### PR TITLE
Hide stream UI top bar in fullscreen mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1257,6 +1257,20 @@ function createStreamingContainer(gameName: string): HTMLElement {
       height: 18px;
       accent-color: #76b900;
     }
+    /* Hide top bar (header with game name and buttons) in fullscreen mode */
+    #streaming-container:fullscreen .stream-header,
+    #streaming-container:-webkit-full-screen .stream-header,
+    #streaming-container:-moz-full-screen .stream-header,
+    #streaming-container:-ms-fullscreen .stream-header {
+      display: none !important;
+    }
+    /* Also hide settings panel in fullscreen mode */
+    #streaming-container:fullscreen .stream-settings-panel,
+    #streaming-container:-webkit-full-screen .stream-settings-panel,
+    #streaming-container:-moz-full-screen .stream-settings-panel,
+    #streaming-container:-ms-fullscreen .stream-settings-panel {
+      display: none !important;
+    }
   `;
 
   document.head.appendChild(style);


### PR DESCRIPTION
The top bar with game name and control buttons was visible in fullscreen mode when hovering. Now it only shows in windowed mode. The settings panel is also hidden in fullscreen since its toggle button is not accessible.