### PR TITLE
Fix resolution not being applied to stream

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   forceInputHandshake,
   isInputReady,
   getInputDebugInfo,
+  StreamingOptions,
 } from "./streaming";
 
 // Types
@@ -1089,8 +1090,12 @@ async function launchGame(game: Game) {
     const streamContainer = createStreamingContainer(game.title);
 
     try {
-      // Initialize WebRTC streaming
-      await initializeStreaming(streamingResult, accessToken, streamContainer);
+      // Initialize WebRTC streaming with user's selected resolution/fps
+      const streamingOptions: StreamingOptions = {
+        resolution: currentResolution,
+        fps: currentFps
+      };
+      await initializeStreaming(streamingResult, accessToken, streamContainer, streamingOptions);
 
       // Set up input capture
       const videoElement = document.getElementById("gfn-stream-video") as HTMLVideoElement;

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -133,10 +133,16 @@ let lastBytesTimestamp = 0;
  * - Auth: WebSocket subprotocol x-nv-sessionid.{session_id}
  * - Protocol: JSON peer messaging with ackid, peer_info, peer_msg
  */
+export interface StreamingOptions {
+  resolution: string; // "2560x1440" format
+  fps: number;
+}
+
 export async function initializeStreaming(
   connectionState: StreamingConnectionState,
   accessToken: string,
-  videoContainer: HTMLElement
+  videoContainer: HTMLElement,
+  options?: StreamingOptions
 ): Promise<void> {
   console.log("Initializing streaming with:", connectionState);
 
@@ -202,8 +208,20 @@ export async function initializeStreaming(
   console.log("Stream IP:", streamIp);
   console.log("Session ID:", sessionId);
 
+  // Parse resolution from options or use defaults
+  let streamWidth = window.screen.width;
+  let streamHeight = window.screen.height;
+  if (options?.resolution) {
+    const [w, h] = options.resolution.split('x').map(Number);
+    if (w && h) {
+      streamWidth = w;
+      streamHeight = h;
+      console.log(`Using requested resolution: ${streamWidth}x${streamHeight}`);
+    }
+  }
+
   // Connect using the official GFN browser protocol
-  await connectGfnBrowserSignaling(streamIp, sessionId, webrtcConfig);
+  await connectGfnBrowserSignaling(streamIp, sessionId, webrtcConfig, streamWidth, streamHeight);
 }
 
 // GFN Browser Peer Protocol types
@@ -297,7 +315,9 @@ async function logIceDebugInfo(pc: RTCPeerConnection): Promise<void> {
 async function connectGfnBrowserSignaling(
   serverIp: string,
   sessionId: string,
-  config: WebRtcConfig
+  config: WebRtcConfig,
+  requestedWidth: number,
+  requestedHeight: number
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     // Generate random peer ID suffix (matching GFN browser format)
@@ -357,7 +377,7 @@ async function connectGfnBrowserSignaling(
           id: gfnPeerId,
           name: peerName,
           peer_role: 0, // 0 = client
-          resolution: `${window.screen.width}x${window.screen.height}`,
+          resolution: `${requestedWidth}x${requestedHeight}`,
           version: 2
         }
       };
@@ -893,9 +913,10 @@ async function handleGfnSdpOffer(
   console.log("Our ICE credentials - ufrag:", iceUfrag, "pwd:", icePwd.substring(0, 8) + "...");
   console.log("Our DTLS fingerprint:", fingerprint.substring(0, 30) + "...");
 
-  // Get viewport dimensions
-  const viewportWidth = window.screen.width;
-  const viewportHeight = window.screen.height;
+  // Use requested resolution for viewport dimensions (not screen dimensions)
+  const viewportWidth = requestedWidth;
+  const viewportHeight = requestedHeight;
+  console.log(`nvstSdp viewport: ${viewportWidth}x${viewportHeight}`);
 
   // Use bitrate from config (set by user in settings)
   const maxBitrateKbps = config.max_bitrate_kbps || 100000;


### PR DESCRIPTION
This pull request adds support for user-selectable streaming resolution and frame rate (fps) when initializing a game stream. The changes ensure that the selected resolution and fps are passed through the streaming initialization process and used in the WebRTC signaling protocol, resulting in the stream being set up with the user's preferences.

**Streaming Options Support**

* Introduced a new `StreamingOptions` interface in `src/streaming.ts` to encapsulate user-selected resolution and fps settings.
* Updated `initializeStreaming` in `src/streaming.ts` to accept an optional `StreamingOptions` parameter, parse the resolution, and pass the selected width and height to the signaling layer. [[1]](diffhunk://#diff-8a2752b294fd18f455e03050a76d1fbea6fb833d95e62367377219a3a41bca8cR136-R145) [[2]](diffhunk://#diff-8a2752b294fd18f455e03050a76d1fbea6fb833d95e62367377219a3a41bca8cR211-R224)

**Integration with Game Launch**

* Modified `launchGame` in `src/main.ts` to construct a `StreamingOptions` object using the current resolution and fps, and pass it to `initializeStreaming`.

**WebRTC Signaling Protocol Updates**

* Changed the `connectGfnBrowserSignaling` function in `src/streaming.ts` to accept and use the requested width and height for the stream, ensuring the correct resolution is communicated to the server. [[1]](diffhunk://#diff-8a2752b294fd18f455e03050a76d1fbea6fb833d95e62367377219a3a41bca8cL300-R320) [[2]](diffhunk://#diff-8a2752b294fd18f455e03050a76d1fbea6fb833d95e62367377219a3a41bca8cL360-R380)
* Updated the SDP offer handling to use the requested resolution for the viewport dimensions, rather than the default screen size.

**Other**

* Exported the new `StreamingOptions` type from `src/streaming.ts` and imported it in `src/main.ts`.