### PR TITLE
Merge dev to main

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1298,6 +1298,13 @@ function createStreamingContainer(gameName: string): HTMLElement {
       background: rgba(0,0,0,0.5);
       padding: 5px 10px;
       border-radius: 4px;
+      z-index: 10003;
+    }
+    #streaming-container:fullscreen .stream-stats,
+    #streaming-container:-webkit-full-screen .stream-stats {
+      position: fixed;
+      bottom: 20px;
+      left: 20px;
     }
     .stream-stats span {
       font-family: monospace;


### PR DESCRIPTION
This pull request makes minor adjustments to the streaming container's layout and styling, specifically improving the positioning and stacking of the stream statistics panel, especially when in fullscreen mode.

Styling and layout improvements:

* Added a higher `z-index` to the `.stream-stats` element to ensure it appears above other elements.
* Updated the positioning of `.stream-stats` so that when the streaming container is in fullscreen mode (including WebKit browsers), the stats panel is fixed to the bottom-left corner of the screen.

Structural fixes:

* Fixed the placement of closing and opening `</div>` tags to ensure the DOM structure for the streaming container is correct.