### PR TITLE
Add NVIDIA Reflex, improve input latency, and expand resolution options

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,10 +160,36 @@
                   <i data-lucide="chevron-down" class="dropdown-arrow"></i>
                 </div>
                 <div class="dropdown-menu">
+                  <!-- 4:3 / 5:4 Resolutions -->
+                  <div class="dropdown-option" data-value="1024x768">1024x768 (4:3)</div>
+                  <div class="dropdown-option" data-value="1280x1024">1280x1024 (5:4)</div>
+                  <div class="dropdown-option" data-value="1600x1200">1600x1200 (4:3)</div>
+                  <!-- 16:9 Standard -->
                   <div class="dropdown-option" data-value="1280x720">1280x720 (720p)</div>
+                  <div class="dropdown-option" data-value="1366x768">1366x768 (HD)</div>
+                  <div class="dropdown-option" data-value="1600x900">1600x900 (HD+)</div>
                   <div class="dropdown-option selected" data-value="1920x1080">1920x1080 (1080p)</div>
                   <div class="dropdown-option" data-value="2560x1440">2560x1440 (1440p)</div>
                   <div class="dropdown-option" data-value="3840x2160">3840x2160 (4K)</div>
+                  <div class="dropdown-option" data-value="5120x2880">5120x2880 (5K)</div>
+                  <!-- 16:10 Resolutions -->
+                  <div class="dropdown-option" data-value="1280x800">1280x800 (16:10)</div>
+                  <div class="dropdown-option" data-value="1440x900">1440x900 (16:10)</div>
+                  <div class="dropdown-option" data-value="1680x1050">1680x1050 (16:10)</div>
+                  <div class="dropdown-option" data-value="1920x1200">1920x1200 (16:10)</div>
+                  <div class="dropdown-option" data-value="2560x1600">2560x1600 (16:10)</div>
+                  <div class="dropdown-option" data-value="3840x1600">3840x1600 (16:10)</div>
+                  <!-- Ultrawide 21:9 -->
+                  <div class="dropdown-option" data-value="2560x1080">2560x1080 (21:9)</div>
+                  <div class="dropdown-option" data-value="3440x1440">3440x1440 (21:9 UW)</div>
+                  <!-- Super Ultrawide 32:9 -->
+                  <div class="dropdown-option" data-value="3840x1080">3840x1080 (32:9)</div>
+                  <div class="dropdown-option" data-value="5120x1440">5120x1440 (32:9 UW)</div>
+                  <!-- Other -->
+                  <div class="dropdown-option" data-value="1112x834">1112x834 (iPad)</div>
+                  <div class="dropdown-option" data-value="1680x720">1680x720 (21:9 HD)</div>
+                  <div class="dropdown-option" data-value="3456x2160">3456x2160 (16:10 4K)</div>
+                  <div class="dropdown-option" data-value="5120x2160">5120x2160 (21:9 5K)</div>
                 </div>
               </div>
             </div>
@@ -245,6 +271,12 @@
               <label>
                 <input type="checkbox" id="discord-stats-setting" />
                 Show Stats in Discord (resolution, fps, ms)
+              </label>
+            </div>
+            <div class="setting-group">
+              <label>
+                <input type="checkbox" id="reflex-setting" checked />
+                NVIDIA Reflex (Low Latency Mode)
               </label>
             </div>
             <div class="setting-group">

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -33,6 +33,8 @@ pub struct Settings {
     pub start_minimized: bool,
     /// Auto-update games library
     pub auto_refresh_library: bool,
+    /// Enable NVIDIA Reflex low-latency mode (auto-enabled for 120+ FPS)
+    pub reflex: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -85,6 +87,7 @@ impl Default for Settings {
             disable_telemetry: true,
             start_minimized: false,
             auto_refresh_library: true,
+            reflex: true, // Enabled by default for low-latency gaming
         }
     }
 }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -981,10 +981,7 @@ async function handleGfnSdpOffer(
   const viewportHeight = requestedHeight;
   console.log(`nvstSdp viewport: ${viewportWidth}x${viewportHeight}`);
 
-  // Calculate frame timing from requested FPS
-  // minTargetFrameTimeUs is the minimum time between frames in microseconds
-  const minTargetFrameTimeUs = Math.floor(1000000 / requestedFps);
-  console.log(`nvstSdp video.maxFPS: ${requestedFps} (minTargetFrameTimeUs: ${minTargetFrameTimeUs})`);
+  console.log(`nvstSdp video.maxFPS: ${requestedFps}`);
 
   // Use bitrate from config (set by user in settings)
   const maxBitrateKbps = config.max_bitrate_kbps || 100000;
@@ -992,85 +989,106 @@ async function handleGfnSdpOffer(
   const initialBitrateKbps = Math.round(maxBitrateKbps * 0.5); // Start at 50%
   console.log(`Bitrate settings: max=${maxBitrateKbps}kbps, min=${minBitrateKbps}kbps, initial=${initialBitrateKbps}kbps`);
 
-  // Build nvstSdp as a proper SDP-like string (matching official GFN browser client format)
-  // This includes ICE credentials, DTLS fingerprint, and streaming parameters
+  // Build nvstSdp matching official GFN browser client format
+  // Based on Wl function from vendor_beautified.js
+  const isHighFps = requestedFps >= 120;
+  const is120Fps = requestedFps === 120;
+  const is240Fps = requestedFps >= 240;
+
   const nvstSdpString = [
     "v=0",
     "o=SdpTest test_id_13 14 IN IPv4 127.0.0.1",
     "s=-",
     "t=0 0",
-    "a=runtime.serverTraceCapture:2",
-    "a=runtime.maxVerboseEtlSizeMb:45",
     `a=general.icePassword:${icePwd}`,
     `a=general.iceUserNameFragment:${iceUfrag}`,
     `a=general.dtlsFingerprint:${fingerprint}`,
     "m=video 0 RTP/AVP",
     "a=msid:fbc-video-0",
+    // FEC settings
+    "a=vqos.fec.rateDropWindow:10",
     "a=vqos.fec.minRequiredFecPackets:2",
-    "a=vqos.drc.enable:0",
-    "a=vqos.drc.minRequiredBitrateCheckEnabled:0",
+    "a=vqos.fec.repairMinPercent:5",
+    "a=vqos.fec.repairPercent:5",
+    "a=vqos.fec.repairMaxPercent:35",
+    // DRC settings - disable for high FPS, use DFC instead
+    ...(isHighFps ? [
+      "a=vqos.drc.enable:0",
+      "a=vqos.dfc.enable:1",
+      "a=vqos.dfc.decodeFpsAdjPercent:85",
+      "a=vqos.dfc.targetDownCooldownMs:250",
+      "a=vqos.dfc.dfcAlgoVersion:2",
+      `a=vqos.dfc.minTargetFps:${is120Fps ? 100 : 60}`,
+    ] : [
+      "a=vqos.drc.minRequiredBitrateCheckEnabled:1",
+    ]),
+    // Video encoder settings
     "a=video.dx9EnableNv12:1",
     "a=video.dx9EnableHdr:1",
-    "a=vqos.qpg.enable:0",
-    "a=vqos.resControl.enable:0",
-    "a=vqos.resControl.qp.qpg.featureSetting:0",
+    "a=vqos.qpg.enable:1",
+    "a=vqos.resControl.qp.qpg.featureSetting:7",
     "a=bwe.useOwdCongestionControl:1",
+    "a=video.enableRtpNack:1",
+    "a=vqos.bw.txRxLag.minFeedbackTxDeltaMs:200",
+    "a=vqos.drc.bitrateIirFilterFactor:18",
+    "a=video.packetSize:1140",
+    "a=packetPacing.minNumPacketsPerGroup:15",
     // High FPS (120+) optimizations from official GFN client
-    ...(requestedFps >= 120 ? [
+    ...(isHighFps ? [
       "a=bwe.iirFilterFactor:8",
       "a=video.encoderFeatureSetting:47",
       "a=video.encoderPreset:6",
+      "a=vqos.resControl.cpmRtc.badNwSkipFramesCount:600",
+      "a=vqos.resControl.cpmRtc.decodeTimeThresholdMs:9",
+      `a=video.fbcDynamicFpsGrabTimeoutMs:${is120Fps ? 6 : 18}`,
+      `a=vqos.resControl.cpmRtc.serverResolutionUpdateCoolDownCount:${is120Fps ? 6000 : 12000}`,
     ] : []),
     // Ultra high FPS (240+) optimizations
-    ...(requestedFps >= 240 ? [
+    ...(is240Fps ? [
       "a=video.enableNextCaptureMode:1",
+      "a=vqos.maxStreamFpsEstimate:240",
+      "a=video.videoSplitEncodeStripsPerFrame:3",
+      "a=video.updateSplitEncodeStateDynamically:1",
     ] : []),
-    "a=video.enableRtpNack:1",
-    "a=vqos.bw.txRxLag.minFeedbackTxDeltaMs:200",
-    "a=vqos.adjustStreamingFpsDuringOutOfFocus:0",
+    // Out of focus settings
+    "a=vqos.adjustStreamingFpsDuringOutOfFocus:1",
     "a=vqos.resControl.cpmRtc.ignoreOutOfFocusWindowState:1",
     "a=vqos.resControl.perfHistory.rtcIgnoreOutOfFocusWindowState:1",
     "a=vqos.resControl.cpmRtc.featureMask:3",
-    "a=packetPacing.numGroups:5",
+    // Packet pacing
+    `a=packetPacing.numGroups:${is120Fps ? 3 : 5}`,
+    "a=packetPacing.maxDelayUs:1000",
+    "a=packetPacing.minNumPacketsFrame:10",
+    // NACK settings
     "a=video.rtpNackQueueLength:1024",
     "a=video.rtpNackQueueMaxPackets:512",
     "a=video.rtpNackMaxPacketCount:25",
-    "a=vqos.drc.qpMaxResThresholdAdj:0",
-    "a=vqos.grc.qpMaxResThresholdAdj:0",
-    "a=vqos.drc.iirFilterFactor:0",
-    "a=video.videoSplitEncodeStripsPerFrame:63",
-    "a=video.updateSplitEncodeStateDynamically:1",
+    // Resolution/quality settings
+    "a=vqos.drc.qpMaxResThresholdAdj:4",
+    "a=vqos.grc.qpMaxResThresholdAdj:4",
+    "a=vqos.drc.iirFilterFactor:100",
+    // Viewport and FPS
     `a=video.clientViewportWd:${viewportWidth}`,
     `a=video.clientViewportHt:${viewportHeight}`,
     `a=video.maxFPS:${requestedFps}`,
-    // For high FPS modes (120+), set maxStreamFpsEstimate
-    ...(requestedFps >= 120 ? [`a=vqos.maxStreamFpsEstimate:${requestedFps}`] : []),
+    // Bitrate settings
     `a=video.initialBitrateKbps:${initialBitrateKbps}`,
     `a=video.initialPeakBitrateKbps:${initialBitrateKbps}`,
     `a=vqos.bw.maximumBitrateKbps:${maxBitrateKbps}`,
     `a=vqos.bw.minimumBitrateKbps:${minBitrateKbps}`,
+    // Encoder settings
     "a=video.maxNumReferenceFrames:4",
     "a=video.mapRtpTimestampsToFrames:1",
     "a=video.encoderCscMode:3",
     "a=video.scalingFeature1:0",
-    "a=video.prefilterParams.prefilterModel:4",
-    "a=packetPacing.enableAccurateSleep:1",
-    "a=video.adaptiveQuantization.perfAdjEnablement:1",
-    "a=video.adaptiveQuantization.spatialAQSetting:2",
-    "a=video.adaptiveQuantization.temporalAQSetting:2",
-    "a=video.enableAv1RcPrecisionFactor:0",
-    `a=video.framePacing.pid.minTargetFrameTimeUs:${minTargetFrameTimeUs}`,
-    "a=video.parseRtcClientBlobs:1",
-    "a=vqos.grc.enable:0",
-    "a=vqos.qpDelta.qpDeltaIirFactor:60",
-    "a=vqos.qpDelta.qpDeltaSurfaceAdjustmentStrengthPercent:70",
-    "a=vqos.qpDelta.qpDeltaThrottlePercent:100",
-    "a=vqos.sendEndOfSessionQosTelemetry:1",
-    "a=vqos.statsProcessorThread.flags:249",
+    "a=video.prefilterParams.prefilterModel:0",
+    // Audio track
     "m=audio 0 RTP/AVP",
     "a=msid:audio",
+    // Mic track
     "m=mic 0 RTP/AVP",
     "a=msid:mic",
+    // Input/application track
     "m=application 0 RTP/AVP",
     "a=msid:input_1",
     "a=ri.partialReliableThresholdMs:300",
@@ -2106,24 +2124,13 @@ export function sendInputEvent(event: InputEvent): void {
   }
 
   inputEventCount++;
-  const now = Date.now();
 
-  // Log input state periodically (every 5 seconds) or on first input
-  const shouldLogStatus = inputEventCount === 1 || (now - lastInputLogTime > 5000);
-  if (shouldLogStatus) {
-    lastInputLogTime = now;
-    console.log("=== INPUT STATUS ===");
-    console.log(`  Events sent: ${inputEventCount}`);
-    console.log(`  Handshake complete: ${inputHandshakeComplete}`);
-    console.log(`  Handshake attempts: ${inputHandshakeAttempts}`);
-    console.log(`  Stream start time: ${streamStartTime}`);
+  // Log input state only on first input (avoid GC pauses from logging)
+  if (inputEventCount === 1) {
+    console.log("=== FIRST INPUT EVENT ===");
     console.log(`  Input channel: ${inputChannel?.label || 'none'} (${inputChannel?.readyState || 'n/a'})`);
-    console.log(`  Control channel: ${controlChannel?.label || 'none'} (${controlChannel?.readyState || 'n/a'})`);
-    console.log(`  Available channels:`);
-    streamingState.dataChannels.forEach((ch, name) => {
-      console.log(`    ${name}: ${ch.label} (state=${ch.readyState}, id=${ch.id})`);
-    });
-    console.log("====================");
+    console.log(`  Handshake complete: ${inputHandshakeComplete}`);
+    console.log("=========================");
   }
 
   try {
@@ -2671,8 +2678,11 @@ export function setupInputCapture(videoElement: HTMLVideoElement): () => void {
     );
   };
 
-  // Mouse move handler - uses getCoalescedEvents for raw, unsmoothed input
-  const handleMouseMove = (e: MouseEvent) => {
+  // Check if pointerrawupdate is supported (lower latency than pointermove)
+  const supportsRawUpdate = "onpointerrawupdate" in videoElement;
+
+  // Mouse move handler - uses pointerrawupdate for lowest latency when available
+  const handleMouseMove = (e: MouseEvent | PointerEvent) => {
     // In pointer lock mode, require pointer lock OR macOS cursor-hidden workaround
     if (inputCaptureMode === 'pointerlock') {
       // On macOS, use cursor-hidden mode with movementX/movementY (no actual pointer lock)
@@ -2681,13 +2691,23 @@ export function setupInputCapture(videoElement: HTMLVideoElement): () => void {
 
       if (canSendRelative) {
         // Use coalesced events for raw mouse data (no browser smoothing)
-        const events = (e as PointerEvent).getCoalescedEvents?.() || [e];
-        for (const evt of events) {
-          if (evt.movementX !== 0 || evt.movementY !== 0) {
+        // Skip coalescing for pointerrawupdate as it's already raw
+        if (e.type === "pointerrawupdate") {
+          if (e.movementX !== 0 || e.movementY !== 0) {
             sendInputEvent({
               type: "mouse_move",
-              data: { dx: evt.movementX, dy: evt.movementY },
+              data: { dx: e.movementX, dy: e.movementY },
             });
+          }
+        } else {
+          const events = (e as PointerEvent).getCoalescedEvents?.() || [e];
+          for (const evt of events) {
+            if (evt.movementX !== 0 || evt.movementY !== 0) {
+              sendInputEvent({
+                type: "mouse_move",
+                data: { dx: evt.movementX, dy: evt.movementY },
+              });
+            }
           }
         }
       }
@@ -2936,12 +2956,19 @@ export function setupInputCapture(videoElement: HTMLVideoElement): () => void {
   document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
   document.addEventListener("mozfullscreenchange", handleFullscreenChange);
   document.addEventListener("MSFullscreenChange", handleFullscreenChange);
-  document.addEventListener("pointermove", handleMouseMove as EventListener);
+  // Use pointerrawupdate for lowest latency when available, fallback to pointermove
+  if (supportsRawUpdate) {
+    document.addEventListener("pointerrawupdate", handleMouseMove as EventListener);
+    console.log("Using pointerrawupdate for low-latency mouse input");
+  } else {
+    document.addEventListener("pointermove", handleMouseMove as EventListener);
+    console.log("Using pointermove for mouse input (pointerrawupdate not supported)");
+  }
   document.addEventListener("mousedown", handleMouseDown);
   document.addEventListener("mouseup", handleMouseUp);
   document.addEventListener("wheel", handleWheel, { passive: false });
-  document.addEventListener("keydown", handleKeyDown);
-  document.addEventListener("keyup", handleKeyUp);
+  document.addEventListener("keydown", handleKeyDown, { passive: false });
+  document.addEventListener("keyup", handleKeyUp, { passive: false });
   window.addEventListener("blur", handleBlur);
 
   // Start in absolute mode - immediately active
@@ -2967,7 +2994,11 @@ export function setupInputCapture(videoElement: HTMLVideoElement): () => void {
     document.removeEventListener("webkitfullscreenchange", handleFullscreenChange);
     document.removeEventListener("mozfullscreenchange", handleFullscreenChange);
     document.removeEventListener("MSFullscreenChange", handleFullscreenChange);
-    document.removeEventListener("pointermove", handleMouseMove as EventListener);
+    if (supportsRawUpdate) {
+      document.removeEventListener("pointerrawupdate", handleMouseMove as EventListener);
+    } else {
+      document.removeEventListener("pointermove", handleMouseMove as EventListener);
+    }
     document.removeEventListener("mousedown", handleMouseDown);
     document.removeEventListener("mouseup", handleMouseUp);
     document.removeEventListener("wheel", handleWheel);


### PR DESCRIPTION
- Add NVIDIA Reflex low-latency mode with UI toggle (auto-enabled for 120+ FPS)
- Use pointerrawupdate events for lower-latency mouse input in streaming
- Fix session payload to match browser client format (app_id as string, audio_mode 2)
- Switch to DFC (Dynamic Frame Control) for high FPS modes instead of fixed frame timing
- Add 4K, 5K, ultrawide, and super-ultrawide resolution options
