### PR TITLE
fix: Zain alliance partner signaling URL (follow-up)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "opennow"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -189,8 +189,10 @@ export async function initializeStreaming(
   }
 
   // Get WebRTC config from backend
+  // Pass the signaling_url from connectionState to override any stale data in session storage
   const webrtcConfig = await invoke<WebRtcConfig>("get_webrtc_config", {
     sessionId: connectionState.session_id,
+    signalingUrlOverride: connectionState.signaling_url,
   });
 
   console.log("WebRTC config:", webrtcConfig);


### PR DESCRIPTION
## Summary
Follow-up fix for Zain alliance partner streaming issues.

The previous fix (v0.0.22) added validation for malformed URLs, but the session storage wasn't being updated correctly due to a race condition.

## Changes
- **Pass signaling URL directly from frontend** - The `get_webrtc_config` command now accepts a `signalingUrlOverride` parameter
- Frontend passes the correct `signaling_url` from `StreamingConnectionState` (which has the correct URL from polling)
- Added debug logging to trace URL handling

## Root Cause
The session storage update was happening, but `get_webrtc_config` was reading stale data. By passing the URL directly from the frontend (which receives the correct URL from `poll_session_until_ready`), we bypass the stale session storage entirely.