### PR TITLE
fix(ci): publish release on main branch pushes [skip ci]

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -114,7 +114,10 @@ jobs:
     name: publish-release
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/opennow-stable-v')
+    if: |
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/tags/v') ||
+      startsWith(github.ref, 'refs/tags/opennow-stable-v')
     permissions:
       contents: write
 
@@ -128,7 +131,8 @@ jobs:
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: OpenNOW ${{ github.ref_name }}
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('nightly-{0}', github.sha) }}
+          name: ${{ github.ref_type == 'tag' && format('OpenNOW {0}', github.ref_name) || format('OpenNOW Nightly ({0})', github.sha) }}
+          prerelease: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') }}
           generate_release_notes: true
           files: release-artifacts/**/*


### PR DESCRIPTION
Updates the release job condition to also trigger on main branch pushes, not just tags. This fixes the issue where the v0.2.4 merge didn't trigger a release.