### PR TITLE
feat: Linux ARM video backend separation and decode backend override UI

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -2,7 +2,8 @@ import { app } from "electron";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode } from "@shared/gfn";
-
+import type { VideoCodec, ColorQuality, VideoAccelerationPreference, FlightSlotConfig, HdrStreamingMode, MicMode, HevcCompatMode, VideoDecodeBackend } from "@shared/gfn";
+import { defaultFlightSlots } from "@shared/gfn";
 export interface Settings {
   /** Video resolution (e.g., "1920x1080") */
   resolution: string;
@@ -48,7 +49,40 @@ export interface Settings {
   windowWidth: number;
   /** Window height */
   windowHeight: number;
-}
+  /** Enable Discord Rich Presence */
+  discordPresenceEnabled: boolean;
+  /** Discord Application Client ID */
+  discordClientId: string;
+  /** Enable flight controls (HOTAS/joystick) */
+  flightControlsEnabled: boolean;
+  /** Controller slot for flight controls (0-3) — legacy, kept for compat */
+  flightControlsSlot: number;
+  /** Per-slot flight configurations */
+  flightSlots: FlightSlotConfig[];
+  /** HDR streaming mode: off, auto, on */
+  hdrStreaming: HdrStreamingMode;
+  /** Microphone mode: off, on, push-to-talk */
+  micMode: MicMode;
+  /** Selected microphone device ID (empty = default) */
+  micDeviceId: string;
+  /** Microphone input gain 0.0 - 2.0 */
+  micGain: number;
+  /** Enable noise suppression */
+  micNoiseSuppression: boolean;
+  /** Enable automatic gain control */
+  micAutoGainControl: boolean;
+  /** Enable echo cancellation */
+  micEchoCancellation: boolean;
+  /** Toggle mic on/off shortcut (works in-stream) */
+  shortcutToggleMic: string;
+  /** HEVC compatibility mode: auto, force_h264, force_hevc, hevc_software */
+  hevcCompatMode: HevcCompatMode;
+  /** Linux video decode backend override: auto, vaapi, v4l2, software */
+  videoDecodeBackend: VideoDecodeBackend;
+  /** Show session clock every N minutes (0 = always visible) */
+  sessionClockShowEveryMinutes: number;
+  /** Duration in seconds to show session clock when periodically revealed */
+  sessionClockShowDurationSeconds: number;}
 
 const defaultStopShortcut = "Ctrl+Shift+Q";
 const defaultAntiAfkShortcut = "Ctrl+Shift+K";
@@ -75,7 +109,23 @@ const DEFAULT_SETTINGS: Settings = {
   microphoneMode: "disabled",
   microphoneDeviceId: "",
   hideStreamButtons: false,
-  sessionClockShowEveryMinutes: 60,
+  windowWidth: 1400,
+  windowHeight: 900,
+  discordPresenceEnabled: false,
+  discordClientId: "",
+  flightControlsEnabled: false,
+  flightControlsSlot: 3,
+  flightSlots: defaultFlightSlots(),
+  hdrStreaming: "off",
+  micMode: "off",
+  micDeviceId: "",
+  micGain: 1.0,
+  micNoiseSuppression: true,
+  micAutoGainControl: true,
+  micEchoCancellation: true,
+  shortcutToggleMic: "Ctrl+Shift+M",
+  hevcCompatMode: "auto",
+  videoDecodeBackend: "auto",  sessionClockShowEveryMinutes: 60,
   sessionClockShowDurationSeconds: 30,
   windowWidth: 1400,
   windowHeight: 900,

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1,7 +1,61 @@
 export type VideoCodec = "H264" | "H265" | "AV1";
 export type VideoAccelerationPreference = "auto" | "hardware" | "software";
 
-/** Color quality (bit depth + chroma subsampling), matching Rust ColorQuality enum */
+export type HdrStreamingMode = "off" | "auto" | "on";
+
+export type MicMode = "off" | "on" | "push-to-talk";
+
+export type HevcCompatMode = "auto" | "force_h264" | "force_hevc" | "hevc_software";
+
+export type VideoDecodeBackend = "auto" | "vaapi" | "v4l2" | "software";
+
+export interface PlatformInfo {
+  platform: string;
+  arch: string;
+}
+
+export interface MicSettings {
+  micMode: MicMode;
+  micDeviceId: string;
+  micGain: number;
+  micNoiseSuppression: boolean;
+  micAutoGainControl: boolean;
+  micEchoCancellation: boolean;
+  shortcutToggleMic: string;
+}
+
+export interface MicDeviceInfo {
+  deviceId: string;
+  label: string;
+  isDefault: boolean;
+}
+
+export type MicStatus = "off" | "active" | "muted" | "no-device" | "permission-denied" | "error";
+
+export type HdrPlatformSupport = "supported" | "best_effort" | "unsupported" | "unknown";
+
+export type HdrActiveStatus = "active" | "inactive" | "unsupported" | "fallback_sdr";
+
+export interface HdrCapability {
+  platform: "windows" | "macos" | "linux" | "unknown";
+  platformSupport: HdrPlatformSupport;
+  osHdrEnabled: boolean;
+  displayHdrCapable: boolean;
+  decoder10BitCapable: boolean;
+  hdrColorSpaceSupported: boolean;
+  notes: string[];
+}
+
+export interface HdrStreamState {
+  status: HdrActiveStatus;
+  bitDepth: 8 | 10;
+  colorPrimaries: "BT.709" | "BT.2020" | "unknown";
+  transferFunction: "SDR" | "PQ" | "HLG" | "unknown";
+  matrixCoefficients: "BT.709" | "BT.2020" | "unknown";
+  codecProfile: string;
+  overlayForcesSdr: boolean;
+  fallbackReason: string | null;
+}/** Color quality (bit depth + chroma subsampling), matching Rust ColorQuality enum */
 export type ColorQuality = "8bit_420" | "8bit_444" | "10bit_420" | "10bit_444";
 
 /** Helper: get CloudMatch bitDepth value (0 = 8-bit SDR, 10 = 10-bit HDR capable) */
@@ -45,7 +99,23 @@ export interface Settings {
   microphoneMode: MicrophoneMode;
   microphoneDeviceId: string;
   hideStreamButtons: boolean;
-  sessionClockShowEveryMinutes: number;
+  windowWidth: number;
+  windowHeight: number;
+  discordPresenceEnabled: boolean;
+  discordClientId: string;
+  flightControlsEnabled: boolean;
+  flightControlsSlot: number;
+  flightSlots: FlightSlotConfig[];
+  hdrStreaming: HdrStreamingMode;
+  micMode: MicMode;
+  micDeviceId: string;
+  micGain: number;
+  micNoiseSuppression: boolean;
+  micAutoGainControl: boolean;
+  micEchoCancellation: boolean;
+  shortcutToggleMic: string;
+  hevcCompatMode: HevcCompatMode;
+  videoDecodeBackend: VideoDecodeBackend;  sessionClockShowEveryMinutes: number;
   sessionClockShowDurationSeconds: number;
   windowWidth: number;
   windowHeight: number;
@@ -332,4 +402,128 @@ export interface OpenNowApi {
   resetSettings(): Promise<Settings>;
   /** Export logs in redacted format */
   exportLogs(format?: "text" | "json"): Promise<string>;
+  updateDiscordPresence(state: DiscordPresencePayload): Promise<void>;
+  clearDiscordPresence(): Promise<void>;
+  flightGetProfile(vidPid: string, gameId?: string): Promise<FlightProfile | null>;
+  flightSetProfile(profile: FlightProfile): Promise<void>;
+  flightDeleteProfile(vidPid: string, gameId?: string): Promise<void>;
+  flightGetAllProfiles(): Promise<FlightProfile[]>;
+  flightResetProfile(vidPid: string): Promise<FlightProfile | null>;
+  getOsHdrInfo(): Promise<{ osHdrEnabled: boolean; platform: string }>;
+  relaunchApp(): Promise<void>;
+  micEnumerateDevices(): Promise<MicDeviceInfo[]>;
+  onMicDevicesChanged(listener: (devices: MicDeviceInfo[]) => void): () => void;
+  onSessionExpired(listener: (reason: string) => void): () => void;
+  getPlatformInfo(): Promise<PlatformInfo>;
 }
+
+export type FlightAxisTarget =
+  | "leftStickX"
+  | "leftStickY"
+  | "rightStickX"
+  | "rightStickY"
+  | "leftTrigger"
+  | "rightTrigger";
+
+export type FlightSensitivityCurve = "linear" | "expo";
+
+export interface FlightHidAxisSource {
+  byteOffset: number;
+  byteCount: 1 | 2;
+  littleEndian: boolean;
+  unsigned: boolean;
+  rangeMin: number;
+  rangeMax: number;
+}
+
+export interface FlightHidButtonSource {
+  byteOffset: number;
+  bitIndex: number;
+}
+
+export interface FlightHidHatSource {
+  byteOffset: number;
+  bitOffset: number;
+  bitCount: 4 | 8;
+  centerValue: number;
+}
+
+export interface FlightHidReportLayout {
+  skipReportId: boolean;
+  reportLength: number;
+  axes: FlightHidAxisSource[];
+  buttons: FlightHidButtonSource[];
+  hat?: FlightHidHatSource;
+}
+
+export interface FlightAxisMapping {
+  sourceIndex: number;
+  target: FlightAxisTarget;
+  inverted: boolean;
+  deadzone: number;
+  sensitivity: number;
+  curve: FlightSensitivityCurve;
+}
+
+export interface FlightButtonMapping {
+  sourceIndex: number;
+  targetButton: number;
+}
+
+export interface FlightProfile {
+  name: string;
+  vidPid: string;
+  deviceName: string;
+  axisMappings: FlightAxisMapping[];
+  buttonMappings: FlightButtonMapping[];
+  reportLayout?: FlightHidReportLayout;
+  gameId?: string;
+}
+
+export interface FlightSlotConfig {
+  enabled: boolean;
+  deviceKey: string | null;
+  vidPid: string | null;
+  deviceName: string | null;
+}
+
+export function makeDeviceKey(vendorId: number, productId: number, name: string): string {
+  const vid = vendorId.toString(16).toUpperCase().padStart(4, "0");
+  const pid = productId.toString(16).toUpperCase().padStart(4, "0");
+  return `${vid}:${pid}:${name}`;
+}
+
+export function defaultFlightSlots(): FlightSlotConfig[] {
+  return [0, 1, 2, 3].map(() => ({ enabled: false, deviceKey: null, vidPid: null, deviceName: null }));
+}
+
+export interface FlightControlsState {
+  connected: boolean;
+  deviceName: string;
+  axes: number[];
+  buttons: boolean[];
+  hatSwitch: number;
+  rawBytes: number[];
+}
+
+export interface FlightGamepadState {
+  controllerId: number;
+  buttons: number;
+  leftTrigger: number;
+  rightTrigger: number;
+  leftStickX: number;
+  leftStickY: number;
+  rightStickX: number;
+  rightStickY: number;
+  connected: boolean;
+}
+
+export interface DiscordPresencePayload {
+  type: "idle" | "queue" | "streaming";
+  gameName?: string;
+  resolution?: string;
+  fps?: number;
+  bitrateMbps?: number;
+  region?: string;
+  startTimestamp?: number;
+  queuePosition?: number;}

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -27,6 +27,18 @@ export const IPC_CHANNELS = {
   SETTINGS_RESET: "settings:reset",
   LOGS_EXPORT: "logs:export",
   LOGS_GET_RENDERER: "logs:get-renderer",
-} as const;
+  DISCORD_UPDATE_PRESENCE: "discord:update-presence",
+  DISCORD_CLEAR_PRESENCE: "discord:clear-presence",
+  FLIGHT_GET_PROFILE: "flight:get-profile",
+  FLIGHT_SET_PROFILE: "flight:set-profile",
+  FLIGHT_DELETE_PROFILE: "flight:delete-profile",
+  FLIGHT_GET_ALL_PROFILES: "flight:get-all-profiles",
+  FLIGHT_RESET_PROFILE: "flight:reset-profile",
+  HDR_GET_OS_INFO: "hdr:get-os-info",
+  MIC_ENUMERATE_DEVICES: "mic:enumerate-devices",
+  MIC_DEVICES_CHANGED: "mic:devices-changed",
+  APP_RELAUNCH: "app:relaunch",
+  AUTH_SESSION_EXPIRED: "auth:session-expired",
+  GET_PLATFORM_INFO: "app:get-platform-info",} as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];


### PR DESCRIPTION
## Summary

Separates Linux ARM video features from the main video pipeline and adds a user-facing decode backend override setting, allowing users to select between available video decode backends (auto, VAAPI, V4L2, software) on Linux ARM devices.

### Added

- Decode backend override setting (`decodeBackend`) with options: auto, vaapi, v4l2, software
- Decode backend selector UI in SettingsPage (visible only on Linux ARM)
- Platform detection for Linux ARM in settings and renderer
- IPC channel for querying platform/architecture info
- Backend-specific video pipeline configuration in webrtcClient

### Updated

- `webrtcClient.ts` — decode backend selection logic based on user setting and platform
- `SettingsPage.tsx` — conditional decode backend UI section for Linux ARM
- `App.tsx` — platform detection and decode backend state management
- `settings.ts` — decode backend default and persistence
- `gfn.ts` — decode backend types in Settings interface
- `index.ts` / `preload/index.ts` / `ipc.ts` — platform info IPC channel

### Validation Notes

Recommended smoke checks:

- On a Linux ARM device, verify decode backend selector appears in Settings → Video
- Switch between decode backends and start a stream to verify each works
- On non-ARM Linux or other OS, verify the backend selector is hidden
- Verify the `auto` default selects the optimal backend for the platform