### PR TITLE
[Linux] Flatpak support [WIP]

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -40,10 +40,10 @@ jobs:
             builder_args: "--mac dmg zip --arm64"
           - label: linux-x64
             os: blacksmith-4vcpu-ubuntu-2404
-            builder_args: "--linux AppImage deb --x64"
+            builder_args: "--linux AppImage deb flatpak --x64"
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
-            builder_args: "--linux AppImage deb --arm64"
+            builder_args: "--linux AppImage deb flatpak --arm64"
 
     defaults:
       run:
@@ -84,7 +84,8 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y fakeroot rpm
+          sudo apt-get install -y fakeroot rpm flatpak flatpak-builder
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
       - name: Install FPM for arm64 deb builds
         if: matrix.label == 'linux-arm64'
         run: sudo apt-get install -y ruby ruby-dev build-essential && sudo gem install fpm
@@ -108,6 +109,7 @@ jobs:
             opennow-stable/dist-release/*.zip
             opennow-stable/dist-release/*.AppImage
             opennow-stable/dist-release/*.deb
+            opennow-stable/dist-release/*.flatpak
           if-no-files-found: error
 
   release:

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -86,6 +86,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y fakeroot rpm flatpak flatpak-builder
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+      - name: Install Flatpak runtimes
+        if: runner.os == 'Linux'
+        run: |
+          sudo flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+          sudo flatpak install -y flathub org.electronjs.Electron2.BaseApp//24.08
       - name: Install FPM for arm64 deb builds
         if: matrix.label == 'linux-arm64'
         run: sudo apt-get install -y ruby ruby-dev build-essential && sudo gem install fpm

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ OpenNOW is a community-built desktop client for [NVIDIA GeForce NOW](https://www
 `Stats Overlay` `Anti-AFK` `Adjustable Shortcuts` · OAuth + session restore · Region selection · Alliance partners
 
 **Platforms**
-`Windows` `macOS` `Linux` `ARM64` · Installer, portable, AppImage, deb, dmg
+`Windows` `macOS` `Linux` `ARM64` · Installer, portable, AppImage, deb, dmg, Flatpak
 
 ## Platform Support
 
@@ -143,8 +143,8 @@ OpenNOW is a community-built desktop client for [NVIDIA GeForce NOW](https://www
 |----------|:------:|--------|
 | Windows | ✅ Working | NSIS installer + portable |
 | macOS | ✅ Working | dmg + zip (x64 and arm64) |
-| Linux x64 | ✅ Working | AppImage + deb |
-| Linux ARM64 | 🚧 Experimental | AppImage + deb (Raspberry Pi 4/5) |
+| Linux x64 | ✅ Working | AppImage + deb + Flatpak |
+| Linux ARM64 | 🚧 Experimental | AppImage + deb + Flatpak (Raspberry Pi 4/5) |
 
 ## Quick Start
 
@@ -170,7 +170,9 @@ Grab the latest release for your platform:
 | macOS (x64) | `OpenNOW-v0.2.4-mac-x64.dmg` |
 | macOS (ARM) | `OpenNOW-v0.2.4-mac-arm64.dmg` |
 | Linux (x64) | `OpenNOW-v0.2.4-linux-x86_64.AppImage` |
+| Linux (x64 Flatpak) | `OpenNOW-v0.2.4-x86_64.flatpak` |
 | Linux (ARM64) | `OpenNOW-v0.2.4-linux-arm64.AppImage` |
+| Linux (ARM64 Flatpak) | `OpenNOW-v0.2.4-arm64.flatpak` |
 
 ## Architecture
 

--- a/opennow-stable/README.md
+++ b/opennow-stable/README.md
@@ -24,8 +24,8 @@ npm run dist
 |----------|---------|
 | Windows | NSIS installer + portable |
 | macOS | dmg + zip (x64 and arm64 universal) |
-| Linux x64 | AppImage + deb |
-| Linux ARM64 | AppImage + deb (Raspberry Pi 4/5) |
+| Linux x64 | AppImage + deb + Flatpak |
+| Linux ARM64 | AppImage + deb + Flatpak (Raspberry Pi 4/5) |
 
 ## CI/CD
 

--- a/opennow-stable/build/com.zortos.opennow.stable.desktop
+++ b/opennow-stable/build/com.zortos.opennow.stable.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=OpenNOW
+Comment=An open-source GeForce NOW client
+Exec=opennow-stable %U
+Type=Application
+Icon=com.zortos.opennow.stable
+Categories=Game;
+Terminal=false
+StartupWMClass=OpenNOW
+MimeType=x-scheme-handler/opennow;
+X-Flatpak=com.zortos.opennow.stable

--- a/opennow-stable/build/com.zortos.opennow.stable.metainfo.xml
+++ b/opennow-stable/build/com.zortos.opennow.stable.metainfo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.zortos.opennow.stable</id>
+  <name>OpenNOW</name>
+  <summary>An open-source GeForce NOW client</summary>
+  <developer_name>zortos293</developer_name>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>OpenNOW is a community-built desktop client for NVIDIA GeForce NOW, built with Electron and TypeScript. It gives you a fully open-source, cross-platform alternative to the official app — with zero telemetry, full transparency, and features the official client doesn't have.</p>
+    <p>Features:</p>
+    <ul>
+      <li>WebRTC streaming with H.264, H.265, and AV1 codecs</li>
+      <li>Up to 4K@240fps streaming</li>
+      <li>Gamepad support (up to 4 controllers)</li>
+      <li>Microphone support for voice chat</li>
+      <li>Stats overlay with performance metrics</li>
+      <li>Anti-AFK feature</li>
+      <li>Adjustable shortcuts</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">com.zortos.opennow.stable.desktop</launchable>
+  <url type="homepage">https://github.com/OpenCloudGaming/OpenNOW</url>
+  <url type="bugtracker">https://github.com/OpenCloudGaming/OpenNOW/issues</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/OpenCloudGaming/OpenNOW/main/img.png</image>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.2.4" date="2025-02-27"/>
+  </releases>
+</component>

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -87,11 +87,36 @@
     "linux": {
       "target": [
         "AppImage",
-        "deb"
+        "deb",
+        "flatpak"
       ],
       "category": "Game",
       "maintainer": "zortos293 <zortos293@users.noreply.github.com>",
       "artifactName": "OpenNOW-v${version}-linux-${arch}.${ext}"
+    },
+    "flatpak": {
+      "runtime": "org.freedesktop.Platform",
+      "runtimeVersion": "24.08",
+      "sdk": "org.freedesktop.Sdk",
+      "base": "org.electronjs.Electron2.BaseApp",
+      "baseVersion": "24.08",
+      "branch": "stable",
+      "artifactName": "OpenNOW-v${version}-${arch}.flatpak",
+      "finishArgs": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--device=dri",
+        "--device=all",
+        "--filesystem=home",
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.freedesktop.portal.Desktop",
+        "--talk-name=org.freedesktop.portal.Settings",
+        "--talk-name=org.freedesktop.portal.Documents",
+        "--own-name=com.zortos.opennow.stable"
+      ]
     }
   }
 }

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -61,7 +61,15 @@
     "files": [
       "dist/**",
       "dist-electron/**",
-      "package.json"
+      "package.json",
+      "build/**"
+    ],
+    "extraResources": [
+      {
+        "from": "build/",
+        "to": "build/",
+        "filter": ["**/*"]
+      }
     ],
     "asar": true,
     "win": {


### PR DESCRIPTION
## Summary
Add Flatpak packaging support for Linux distributions, providing users with a sandboxed, distribution-agnostic installation method.

## Changes
- **Packaging** (`package.json`): Add `flatpak` target with full configuration
  - Uses Freedesktop runtime 24.08
  - Electron2 BaseApp for proper Electron integration
  - Configured sandbox permissions for streaming, audio, GPU, controllers
- **CI/CD** (`.github/workflows/auto-build.yml`): 
  - Install Flatpak tooling and runtimes in Linux builds
  - Build Flatpak packages for x64 and ARM64
  - Include `.flatpak` artifacts in releases
- **Metadata**: Add required desktop entry and AppStream files
- **Documentation**: Update README with Flatpak download links

## Permissions
| Permission | Purpose |
|------------|---------|
| `--share=network` | WebRTC streaming |
| `--socket=pulseaudio` | Audio playback |
| `--device=dri` | GPU acceleration |
| `--device=all` | Gamepad/controller support |
| `--filesystem=home` | Settings and logs storage |

## Testing
- [x] CI build passes for linux-x64
- [x] CI build passes for linux-arm64
- [x] Flatpak installs locally
- [x] Login flow works (OAuth via browser)
- [ ] Streaming works
- [ ] Audio playback works
- [ ] Microphone works
- [ ] Gamepad detected

## Download Artifacts
Once CI passes, download from the workflow artifacts:
- `OpenNOW-v0.2.4-x86_64.flatpak`
- `OpenNOW-v0.2.4-arm64.flatpak`

## Related
https://www.reddit.com/r/linux_gaming/comments/1reb0yt/comment/o7l3six/
