### PR TITLE
Allow simultaneous controller, mouse, and keyboard input during streaming

### DIFF
--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -4,6 +4,7 @@ import WebSocket from "ws";
 
 import type {
   IceCandidatePayload,
+  KeyframeRequest,
   MainToRendererSignalingEvent,
   SendAnswerRequest,
 } from "@shared/gfn";
@@ -269,6 +270,25 @@ export class GfnSignalingClient {
       },
       ackid: this.nextAckId(),
     });
+  }
+
+  async requestKeyframe(payload: KeyframeRequest): Promise<void> {
+    this.sendJson({
+      peer_msg: {
+        from: this.peerId,
+        to: 1,
+        msg: JSON.stringify({
+          type: "request_keyframe",
+          reason: payload.reason,
+          backlogFrames: payload.backlogFrames,
+          attempt: payload.attempt,
+        }),
+      },
+      ackid: this.nextAckId(),
+    });
+    console.log(
+      `[Signaling] Sent keyframe request (reason=${payload.reason}, backlog=${payload.backlogFrames}, attempt=${payload.attempt})`,
+    );
   }
 
   disconnect(): void {

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -1,11 +1,13 @@
-import { app, BrowserWindow, ipcMain, dialog, systemPreferences, session } from "electron";
+import { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, session } from "electron";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, createWriteStream } from "node:fs";
+import { copyFile, mkdir, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import * as net from "node:net";
+import { randomUUID } from "node:crypto";
 
 // Keyboard shortcuts reference (matching Rust implementation):
-// F11 - Toggle fullscreen (handled in main process)
+// Screenshot keybind - configurable, handled in renderer
 // F3  - Toggle stats overlay (handled in renderer)
 // Ctrl+Shift+Q - Stop streaming (handled in renderer)
 // F8  - Toggle mouse/pointer lock (handled in main process via IPC)
@@ -26,11 +28,25 @@ import type {
   SignalingConnectRequest,
   SendAnswerRequest,
   IceCandidatePayload,
+  KeyframeRequest,
   Settings,
   SubscriptionFetchRequest,
   SessionConflictChoice,
   PingResult,
   StreamRegion,
+  VideoAccelerationPreference,
+  ScreenshotDeleteRequest,
+  ScreenshotEntry,
+  ScreenshotSaveAsRequest,
+  ScreenshotSaveAsResult,
+  ScreenshotSaveRequest,
+  RecordingEntry,
+  RecordingBeginRequest,
+  RecordingBeginResult,
+  RecordingChunkRequest,
+  RecordingFinishRequest,
+  RecordingAbortRequest,
+  RecordingDeleteRequest,
 } from "@shared/gfn";
 
 import { getSettingsManager, type SettingsManager } from "./settings";
@@ -53,9 +69,12 @@ const __dirname = dirname(__filename);
 // Configure Chromium video and WebRTC behavior before app.whenReady().
 // Video acceleration is always set to "auto" - decoder and encoder preferences removed from settings
 
-const bootstrapVideoPrefs = {
-  decoderPreference: "auto" as const,
-  encoderPreference: "auto" as const,
+const bootstrapVideoPrefs: {
+  decoderPreference: VideoAccelerationPreference;
+  encoderPreference: VideoAccelerationPreference;
+} = {
+  decoderPreference: "auto",
+  encoderPreference: "auto",
 };
 console.log(
   `[Main] Video acceleration: decode=${bootstrapVideoPrefs.decoderPreference}, encode=${bootstrapVideoPrefs.encoderPreference}`,
@@ -102,6 +121,8 @@ if (process.platform === "win32") {
 
 app.commandLine.appendSwitch("enable-features",
   [
+    // --- MP4 recording via MediaRecorder (Chromium 127+) ---
+    "MediaRecorderEnableMp4Muxer",
     // --- AV1 support (cross-platform) ---
     "Dav1dVideoDecoder", // Fast AV1 software fallback via dav1d (if no HW decoder)
     // --- Additional (cross-platform) ---
@@ -157,6 +178,232 @@ let signalingClient: GfnSignalingClient | null = null;
 let signalingClientKey: string | null = null;
 let authService: AuthService;
 let settingsManager: SettingsManager;
+const SCREENSHOT_LIMIT = 60;
+
+function getScreenshotDirectory(): string {
+  return join(app.getPath("pictures"), "OpenNOW", "Screenshots");
+}
+
+async function ensureScreenshotDirectory(): Promise<string> {
+  const dir = getScreenshotDirectory();
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function sanitizeTitleForFileName(value: string | undefined): string {
+  const source = (value ?? "").trim().toLowerCase();
+  const compact = source.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  if (!compact) return "stream";
+  return compact.slice(0, 48);
+}
+
+function dataUrlToBuffer(dataUrl: string): { ext: "png" | "jpg" | "webp"; buffer: Buffer } {
+  const match = /^data:image\/(png|jpeg|jpg|webp);base64,([a-z0-9+/=\s]+)$/i.exec(dataUrl);
+  if (!match || !match[1] || !match[2]) {
+    throw new Error("Invalid screenshot payload");
+  }
+
+  const rawExt = match[1].toLowerCase();
+  const ext: "png" | "jpg" | "webp" = rawExt === "jpeg" ? "jpg" : (rawExt as "png" | "jpg" | "webp");
+  const buffer = Buffer.from(match[2].replace(/\s+/g, ""), "base64");
+  if (!buffer.length) {
+    throw new Error("Empty screenshot payload");
+  }
+
+  return { ext, buffer };
+}
+
+function buildScreenshotDataUrl(ext: string, buffer: Buffer): string {
+  const mime = ext === "jpg" ? "image/jpeg" : ext === "webp" ? "image/webp" : "image/png";
+  return `data:${mime};base64,${buffer.toString("base64")}`;
+}
+
+function assertSafeScreenshotId(id: string): void {
+  if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
+    throw new Error("Invalid screenshot id");
+  }
+}
+
+async function listScreenshots(): Promise<ScreenshotEntry[]> {
+  const dir = await ensureScreenshotDirectory();
+  const entries = await readdir(dir, { withFileTypes: true });
+  const screenshotFiles = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => /\.(png|jpg|jpeg|webp)$/i.test(name));
+
+  const loaded = await Promise.all(
+    screenshotFiles.map(async (fileName): Promise<ScreenshotEntry | null> => {
+      const filePath = join(dir, fileName);
+      try {
+        const fileStats = await stat(filePath);
+        const fileBuffer = await readFile(filePath);
+        const extMatch = /\.([^.]+)$/.exec(fileName);
+        const ext = (extMatch?.[1] ?? "png").toLowerCase();
+
+        return {
+          id: fileName,
+          fileName,
+          filePath,
+          createdAtMs: fileStats.birthtimeMs || fileStats.mtimeMs,
+          sizeBytes: fileStats.size,
+          dataUrl: buildScreenshotDataUrl(ext, fileBuffer),
+        };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return loaded
+    .filter((item): item is ScreenshotEntry => item !== null)
+    .sort((a, b) => b.createdAtMs - a.createdAtMs)
+    .slice(0, SCREENSHOT_LIMIT);
+}
+
+async function saveScreenshot(input: ScreenshotSaveRequest): Promise<ScreenshotEntry> {
+  const { ext, buffer } = dataUrlToBuffer(input.dataUrl);
+  const dir = await ensureScreenshotDirectory();
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const title = sanitizeTitleForFileName(input.gameTitle);
+  const fileName = `${stamp}-${title}-${Math.random().toString(16).slice(2, 8)}.${ext}`;
+  const filePath = join(dir, fileName);
+
+  await writeFile(filePath, buffer);
+
+  return {
+    id: fileName,
+    fileName,
+    filePath,
+    createdAtMs: Date.now(),
+    sizeBytes: buffer.byteLength,
+    dataUrl: buildScreenshotDataUrl(ext, buffer),
+  };
+}
+
+async function deleteScreenshot(input: ScreenshotDeleteRequest): Promise<void> {
+  assertSafeScreenshotId(input.id);
+  const dir = await ensureScreenshotDirectory();
+  const filePath = join(dir, input.id);
+  await unlink(filePath);
+}
+
+async function saveScreenshotAs(input: ScreenshotSaveAsRequest): Promise<ScreenshotSaveAsResult> {
+  assertSafeScreenshotId(input.id);
+  const dir = await ensureScreenshotDirectory();
+  const sourcePath = join(dir, input.id);
+
+  const saveDialogOptions = {
+    title: "Save Screenshot",
+    defaultPath: join(app.getPath("pictures"), input.id),
+    filters: [
+      { name: "PNG Image", extensions: ["png"] },
+      { name: "JPEG Image", extensions: ["jpg", "jpeg"] },
+      { name: "WebP Image", extensions: ["webp"] },
+      { name: "All Files", extensions: ["*"] },
+    ],
+  };
+  const target =
+    mainWindow && !mainWindow.isDestroyed()
+      ? await dialog.showSaveDialog(mainWindow, saveDialogOptions)
+      : await dialog.showSaveDialog(saveDialogOptions);
+
+  if (target.canceled || !target.filePath) {
+    return { saved: false };
+  }
+
+  await copyFile(sourcePath, target.filePath);
+  return { saved: true, filePath: target.filePath };
+}
+
+// ---------------------------------------------------------------------------
+// Recording helpers
+// ---------------------------------------------------------------------------
+
+const RECORDING_LIMIT = 20;
+
+interface ActiveRecording {
+  writeStream: ReturnType<typeof createWriteStream>;
+  tempPath: string;
+  mimeType: string;
+}
+
+const activeRecordings = new Map<string, ActiveRecording>();
+
+function getRecordingsDirectory(): string {
+  return join(app.getPath("pictures"), "OpenNOW", "Recordings");
+}
+
+async function ensureRecordingsDirectory(): Promise<string> {
+  const dir = getRecordingsDirectory();
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function assertSafeRecordingId(id: string): void {
+  if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
+    throw new Error("Invalid recording id");
+  }
+}
+
+function extFromMimeType(mimeType: string): ".mp4" | ".webm" {
+  return mimeType.startsWith("video/mp4") ? ".mp4" : ".webm";
+}
+
+async function listRecordings(): Promise<RecordingEntry[]> {
+  const dir = await ensureRecordingsDirectory();
+  const entries = await readdir(dir, { withFileTypes: true });
+  const webmFiles = entries
+    .filter((e) => e.isFile())
+    .map((e) => e.name)
+    .filter((name) => /\.(mp4|webm)$/i.test(name));
+
+  const loaded = await Promise.all(
+    webmFiles.map(async (fileName): Promise<RecordingEntry | null> => {
+      const filePath = join(dir, fileName);
+      try {
+        const fileStats = await stat(filePath);
+        const stem = fileName.replace(/\.webm$/i, "");
+        const thumbName = `${stem}-thumb.jpg`;
+        const thumbPath = join(dir, thumbName);
+
+        let thumbnailDataUrl: string | undefined;
+        try {
+          const thumbBuf = await readFile(thumbPath);
+          thumbnailDataUrl = `data:image/jpeg;base64,${thumbBuf.toString("base64")}`;
+        } catch {
+          // No thumbnail for this recording — that's fine
+        }
+
+        // Parse durationMs encoded in filename as last numeric segment before extension
+        const durMatch = /-dur(\d+)\.(mp4|webm)$/i.exec(fileName);
+        const durationMs = durMatch ? Number(durMatch[1]) : 0;
+
+        // Parse game title from filename: {stamp}-{title}-{rand}[-dur{ms}].{ext}
+        const titleMatch = /^[^-]+-[^-]+-([^-]+(?:-[^-]+)*?)-[a-f0-9]{6}(?:-dur\d+)?\.(mp4|webm)$/i.exec(fileName);
+        const gameTitle = titleMatch ? titleMatch[1].replace(/-/g, " ") : undefined;
+
+        return {
+          id: fileName,
+          fileName,
+          filePath,
+          createdAtMs: fileStats.birthtimeMs || fileStats.mtimeMs,
+          sizeBytes: fileStats.size,
+          durationMs,
+          gameTitle,
+          thumbnailDataUrl,
+        };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return loaded
+    .filter((item): item is RecordingEntry => item !== null)
+    .sort((a, b) => b.createdAtMs - a.createdAtMs)
+    .slice(0, RECORDING_LIMIT);
+}
 
 function emitToRenderer(event: MainToRendererSignalingEvent): void {
   if (mainWindow && !mainWindow.isDestroyed()) {
@@ -184,18 +431,6 @@ async function createMainWindow(): Promise<void> {
       nodeIntegration: false,
       sandbox: false,
     },
-  });
-
-  // Handle F11 fullscreen toggle — send to renderer so it uses W3C Fullscreen API
-  // (which enables navigator.keyboard.lock for Escape key capture)
-  mainWindow.webContents.on("before-input-event", (event, input) => {
-    if (input.key === "F11" && input.type === "keyDown") {
-      event.preventDefault();
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send("app:toggle-fullscreen");
-      }
-    }
-
   });
 
   if (process.platform === "win32") {
@@ -441,6 +676,13 @@ function registerIpcHandlers(): void {
     return signalingClient.sendIceCandidate(payload);
   });
 
+  ipcMain.handle(IPC_CHANNELS.REQUEST_KEYFRAME, async (_event, payload: KeyframeRequest) => {
+    if (!signalingClient) {
+      throw new Error("Signaling is not connected");
+    }
+    return signalingClient.requestKeyframe(payload);
+  });
+
   // Toggle fullscreen via IPC (for completeness)
   ipcMain.handle(IPC_CHANNELS.TOGGLE_FULLSCREEN, async () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
@@ -472,6 +714,142 @@ function registerIpcHandlers(): void {
   // Logs export IPC handler
   ipcMain.handle(IPC_CHANNELS.LOGS_EXPORT, async (_event, format: "text" | "json" = "text"): Promise<string> => {
     return exportLogs(format);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.SCREENSHOT_SAVE, async (_event, input: ScreenshotSaveRequest): Promise<ScreenshotEntry> => {
+    return saveScreenshot(input);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.SCREENSHOT_LIST, async (): Promise<ScreenshotEntry[]> => {
+    return listScreenshots();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.SCREENSHOT_DELETE, async (_event, input: ScreenshotDeleteRequest): Promise<void> => {
+    return deleteScreenshot(input);
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.SCREENSHOT_SAVE_AS,
+    async (_event, input: ScreenshotSaveAsRequest): Promise<ScreenshotSaveAsResult> => {
+      return saveScreenshotAs(input);
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.RECORDING_BEGIN, async (_event, input: RecordingBeginRequest): Promise<RecordingBeginResult> => {
+    const dir = await ensureRecordingsDirectory();
+    const recordingId = randomUUID();
+    const ext = extFromMimeType(input.mimeType);
+    const tempPath = join(dir, `${recordingId}${ext}.tmp`);
+    const writeStream = createWriteStream(tempPath);
+    activeRecordings.set(recordingId, { writeStream, tempPath, mimeType: input.mimeType });
+    return { recordingId };
+  });
+
+  ipcMain.handle(IPC_CHANNELS.RECORDING_CHUNK, async (_event, input: RecordingChunkRequest): Promise<void> => {
+    const rec = activeRecordings.get(input.recordingId);
+    if (!rec) {
+      throw new Error("Unknown recording id");
+    }
+    await new Promise<void>((resolve, reject) => {
+      rec.writeStream.write(Buffer.from(input.chunk), (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
+  ipcMain.handle(IPC_CHANNELS.RECORDING_FINISH, async (_event, input: RecordingFinishRequest): Promise<RecordingEntry> => {
+    const rec = activeRecordings.get(input.recordingId);
+    if (!rec) {
+      throw new Error("Unknown recording id");
+    }
+    activeRecordings.delete(input.recordingId);
+
+    await new Promise<void>((resolve, reject) => {
+      rec.writeStream.end((err?: Error | null) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    const dir = getRecordingsDirectory();
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const title = sanitizeTitleForFileName(input.gameTitle);
+    const rand = Math.random().toString(16).slice(2, 8);
+    const durSuffix = input.durationMs > 0 ? `-dur${Math.round(input.durationMs)}` : "";
+    const ext = extFromMimeType(rec.mimeType);
+    const fileName = `${stamp}-${title}-${rand}${durSuffix}${ext}`;
+    const finalPath = join(dir, fileName);
+
+    await rename(rec.tempPath, finalPath);
+
+    // Save thumbnail if provided
+    let thumbnailDataUrl: string | undefined;
+    if (input.thumbnailDataUrl) {
+      try {
+        const { buffer } = dataUrlToBuffer(input.thumbnailDataUrl);
+        const stem = fileName.replace(/\.(mp4|webm)$/i, "");
+        const thumbPath = join(dir, `${stem}-thumb.jpg`);
+        await writeFile(thumbPath, buffer);
+        thumbnailDataUrl = input.thumbnailDataUrl;
+      } catch {
+        // Thumbnail save is best-effort — don't fail the recording
+      }
+    }
+
+    // Enforce recording limit: delete oldest entries beyond RECORDING_LIMIT
+    const all = await listRecordings();
+    if (all.length > RECORDING_LIMIT) {
+      const toDelete = all.slice(RECORDING_LIMIT);
+      await Promise.all(
+        toDelete.map(async (entry) => {
+          await unlink(entry.filePath).catch(() => undefined);
+          const stem = entry.fileName.replace(/\.(mp4|webm)$/i, "");
+          await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
+        }),
+      );
+    }
+
+    const fileStats = await stat(finalPath);
+    return {
+      id: fileName,
+      fileName,
+      filePath: finalPath,
+      createdAtMs: Date.now(),
+      sizeBytes: fileStats.size,
+      durationMs: input.durationMs,
+      gameTitle: input.gameTitle,
+      thumbnailDataUrl,
+    };
+  });
+
+  ipcMain.handle(IPC_CHANNELS.RECORDING_ABORT, async (_event, input: RecordingAbortRequest): Promise<void> => {
+    const rec = activeRecordings.get(input.recordingId);
+    if (!rec) {
+      return;
+    }
+    activeRecordings.delete(input.recordingId);
+    rec.writeStream.destroy();
+    await unlink(rec.tempPath).catch(() => undefined);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.RECORDING_LIST, async (): Promise<RecordingEntry[]> => {
+    return listRecordings();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.RECORDING_DELETE, async (_event, input: RecordingDeleteRequest): Promise<void> => {
+    assertSafeRecordingId(input.id);
+    const dir = await ensureRecordingsDirectory();
+    const filePath = join(dir, input.id);
+    await unlink(filePath);
+    const stem = input.id.replace(/\.(mp4|webm)$/i, "");
+    await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.RECORDING_SHOW_IN_FOLDER, async (_event, id: string): Promise<void> => {
+    assertSafeRecordingId(id);
+    const dir = await ensureRecordingsDirectory();
+    shell.showItemInFolder(join(dir, id));
   });
 
   // TCP-based ping function - more accurate than HTTP as it only measures connection time

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -20,6 +20,8 @@ export interface Settings {
   clipboardPaste: boolean;
   /** Mouse sensitivity multiplier */
   mouseSensitivity: number;
+  /** Software mouse acceleration strength percentage (1-150) */
+  mouseAcceleration: number;
   /** Toggle stats overlay shortcut */
   shortcutToggleStats: string;
   /** Toggle pointer lock shortcut */
@@ -30,6 +32,10 @@ export interface Settings {
   shortcutToggleAntiAfk: string;
   /** Toggle microphone shortcut */
   shortcutToggleMicrophone: string;
+  /** Take screenshot shortcut */
+  shortcutScreenshot: string;
+  /** Toggle stream recording shortcut */
+  shortcutToggleRecording: string;
   /** How often to re-show the session timer while streaming (0 = off) */
   sessionClockShowEveryMinutes: number;
   /** How long the session timer stays visible when it appears */
@@ -63,11 +69,14 @@ const DEFAULT_SETTINGS: Settings = {
   region: "",
   clipboardPaste: false,
   mouseSensitivity: 1,
+  mouseAcceleration: 1,
   shortcutToggleStats: "F3",
   shortcutTogglePointerLock: "F8",
   shortcutStopStream: defaultStopShortcut,
   shortcutToggleAntiAfk: defaultAntiAfkShortcut,
   shortcutToggleMicrophone: defaultMicShortcut,
+  shortcutScreenshot: "F11",
+  shortcutToggleRecording: "F12",
   microphoneMode: "disabled",
   microphoneDeviceId: "",
   hideStreamButtons: false,
@@ -105,7 +114,15 @@ export class SettingsManager {
         ...parsed,
       };
 
-      const migrated = this.migrateLegacyShortcutDefaults(merged);
+      let migrated = this.migrateLegacyShortcutDefaults(merged);
+
+      // Migrate legacy boolean accelerator setting to percentage slider.
+      if (typeof (parsed as { mouseAcceleration?: unknown }).mouseAcceleration === "boolean") {
+        merged.mouseAcceleration = (parsed as { mouseAcceleration?: boolean }).mouseAcceleration ? 100 : 1;
+        migrated = true;
+      }
+
+      merged.mouseAcceleration = Math.max(1, Math.min(150, Math.round(merged.mouseAcceleration)));
       if (migrated) {
         writeFileSync(this.settingsPath, JSON.stringify(merged, null, 2), "utf-8");
       }

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -16,9 +16,20 @@ import type {
   SignalingConnectRequest,
   SendAnswerRequest,
   IceCandidatePayload,
+  KeyframeRequest,
   Settings,
   SubscriptionFetchRequest,
   StreamRegion,
+  ScreenshotSaveRequest,
+  ScreenshotDeleteRequest,
+  ScreenshotSaveAsRequest,
+  RecordingBeginRequest,
+  RecordingBeginResult,
+  RecordingChunkRequest,
+  RecordingFinishRequest,
+  RecordingAbortRequest,
+  RecordingEntry,
+  RecordingDeleteRequest,
 } from "@shared/gfn";
 
 // Extend the OpenNowApi interface for internal preload use
@@ -51,6 +62,8 @@ const api: PreloadApi = {
   sendAnswer: (input: SendAnswerRequest) => ipcRenderer.invoke(IPC_CHANNELS.SEND_ANSWER, input),
   sendIceCandidate: (input: IceCandidatePayload) =>
     ipcRenderer.invoke(IPC_CHANNELS.SEND_ICE_CANDIDATE, input),
+  requestKeyframe: (input: KeyframeRequest) =>
+    ipcRenderer.invoke(IPC_CHANNELS.REQUEST_KEYFRAME, input),
   onSignalingEvent: (listener: (event: MainToRendererSignalingEvent) => void) => {
     const wrapped = (_event: Electron.IpcRendererEvent, payload: MainToRendererSignalingEvent) => {
       listener(payload);
@@ -76,6 +89,31 @@ const api: PreloadApi = {
   resetSettings: () => ipcRenderer.invoke(IPC_CHANNELS.SETTINGS_RESET),
   exportLogs: (format?: "text" | "json") => ipcRenderer.invoke(IPC_CHANNELS.LOGS_EXPORT, format),
   pingRegions: (regions: StreamRegion[]) => ipcRenderer.invoke(IPC_CHANNELS.PING_REGIONS, regions),
+  saveScreenshot: (input: ScreenshotSaveRequest) => ipcRenderer.invoke(IPC_CHANNELS.SCREENSHOT_SAVE, input),
+  listScreenshots: () => ipcRenderer.invoke(IPC_CHANNELS.SCREENSHOT_LIST),
+  deleteScreenshot: (input: ScreenshotDeleteRequest) => ipcRenderer.invoke(IPC_CHANNELS.SCREENSHOT_DELETE, input),
+  saveScreenshotAs: (input: ScreenshotSaveAsRequest) => ipcRenderer.invoke(IPC_CHANNELS.SCREENSHOT_SAVE_AS, input),
+  onTriggerScreenshot: (listener: () => void) => {
+    const wrapped = () => listener();
+    ipcRenderer.on("app:trigger-screenshot", wrapped);
+    return () => {
+      ipcRenderer.off("app:trigger-screenshot", wrapped);
+    };
+  },
+  beginRecording: (input: RecordingBeginRequest): Promise<RecordingBeginResult> =>
+    ipcRenderer.invoke(IPC_CHANNELS.RECORDING_BEGIN, input),
+  sendRecordingChunk: (input: RecordingChunkRequest): Promise<void> =>
+    ipcRenderer.invoke(IPC_CHANNELS.RECORDING_CHUNK, input),
+  finishRecording: (input: RecordingFinishRequest): Promise<RecordingEntry> =>
+    ipcRenderer.invoke(IPC_CHANNELS.RECORDING_FINISH, input),
+  abortRecording: (input: RecordingAbortRequest): Promise<void> =>
+    ipcRenderer.invoke(IPC_CHANNELS.RECORDING_ABORT, input),
+  listRecordings: (): Promise<RecordingEntry[]> =>
+    ipcRenderer.invoke(IPC_CHANNELS.RECORDING_LIST),
+  deleteRecording: (input: RecordingDeleteRequest): Promise<void> =>
+    ipcRenderer.invoke(IPC_CHANNELS.RECORDING_DELETE, input),
+  showRecordingInFolder: (id: string): Promise<void> =>
+    ipcRenderer.invoke(IPC_CHANNELS.RECORDING_SHOW_IN_FOLDER, id),
 };
 
 contextBridge.exposeInMainWorld("openNow", api);

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -38,6 +38,7 @@ const resolutionOptions = ["1280x720", "1920x1080", "2560x1440", "3840x2160", "2
 const fpsOptions = [30, 60, 120, 144, 240];
 const SESSION_READY_POLL_INTERVAL_MS = 2000;
 const SESSION_READY_TIMEOUT_MS = 180000;
+const PLAYTIME_RESYNC_INTERVAL_MS = 5 * 60 * 1000;
 
 type GameSource = "main" | "library" | "public";
 type AppPage = "home" | "library" | "settings";
@@ -67,6 +68,8 @@ const DEFAULT_SHORTCUTS = {
   shortcutStopStream: "Ctrl+Shift+Q",
   shortcutToggleAntiAfk: "Ctrl+Shift+K",
   shortcutToggleMicrophone: "Ctrl+Shift+M",
+  shortcutScreenshot: "F11",
+  shortcutToggleRecording: "F12",
 } as const;
 
 function sleep(ms: number): Promise<void> {
@@ -152,6 +155,9 @@ function defaultDiagnostics(): StreamDiagnostics {
     inputQueueMaxSchedulingDelayMs: 0,
     gpuType: "",
     serverRegion: "",
+    decoderPressureActive: false,
+    decoderRecoveryAttempts: 0,
+    decoderRecoveryAction: "none",
     micState: "uninitialized",
     micEnabled: false,
   };
@@ -182,6 +188,29 @@ function warningMessage(code: StreamTimeWarning["code"]): string {
   if (code === 1) return "Session time limit approaching";
   if (code === 2) return "Idle timeout approaching";
   return "Maximum session time approaching";
+}
+
+function formatRemainingPlaytimeFromSubscription(
+  subscription: SubscriptionInfo | null,
+  consumedHours = 0,
+): string {
+  if (!subscription) {
+    return "--";
+  }
+  if (subscription.isUnlimited) {
+    return "Unlimited";
+  }
+
+  const baseHours = Number.isFinite(subscription.remainingHours) ? subscription.remainingHours : 0;
+  const safeHours = Math.max(0, baseHours - Math.max(0, consumedHours));
+  const totalMinutes = Math.round(safeHours * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes.toString().padStart(2, "0")}m`;
+  }
+  return `${minutes}m`;
 }
 
 function toLoadingStatus(status: StreamStatus): StreamLoadingStatus {
@@ -303,11 +332,14 @@ export function App(): JSX.Element {
     region: "",
     clipboardPaste: false,
     mouseSensitivity: 1,
+    mouseAcceleration: 1,
     shortcutToggleStats: DEFAULT_SHORTCUTS.shortcutToggleStats,
     shortcutTogglePointerLock: DEFAULT_SHORTCUTS.shortcutTogglePointerLock,
     shortcutStopStream: DEFAULT_SHORTCUTS.shortcutStopStream,
     shortcutToggleAntiAfk: DEFAULT_SHORTCUTS.shortcutToggleAntiAfk,
     shortcutToggleMicrophone: DEFAULT_SHORTCUTS.shortcutToggleMicrophone,
+    shortcutScreenshot: DEFAULT_SHORTCUTS.shortcutScreenshot,
+    shortcutToggleRecording: DEFAULT_SHORTCUTS.shortcutToggleRecording,
     microphoneMode: "disabled",
     microphoneDeviceId: "",
     hideStreamButtons: false,
@@ -315,6 +347,7 @@ export function App(): JSX.Element {
     sessionClockShowDurationSeconds: 30,
     windowWidth: 1400,
     windowHeight: 900,
+    gameLanguage: "en_US",
   });
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [regions, setRegions] = useState<StreamRegion[]>([]);
@@ -590,13 +623,17 @@ export function App(): JSX.Element {
     const stopStream = parseWithFallback(settings.shortcutStopStream, DEFAULT_SHORTCUTS.shortcutStopStream);
     const toggleAntiAfk = parseWithFallback(settings.shortcutToggleAntiAfk, DEFAULT_SHORTCUTS.shortcutToggleAntiAfk);
     const toggleMicrophone = parseWithFallback(settings.shortcutToggleMicrophone, DEFAULT_SHORTCUTS.shortcutToggleMicrophone);
-    return { toggleStats, togglePointerLock, stopStream, toggleAntiAfk, toggleMicrophone };
+    const screenshot = parseWithFallback(settings.shortcutScreenshot, DEFAULT_SHORTCUTS.shortcutScreenshot);
+    const recording = parseWithFallback(settings.shortcutToggleRecording, DEFAULT_SHORTCUTS.shortcutToggleRecording);
+    return { toggleStats, togglePointerLock, stopStream, toggleAntiAfk, toggleMicrophone, screenshot, recording };
   }, [
     settings.shortcutToggleStats,
     settings.shortcutTogglePointerLock,
     settings.shortcutStopStream,
     settings.shortcutToggleAntiAfk,
     settings.shortcutToggleMicrophone,
+    settings.shortcutScreenshot,
+    settings.shortcutToggleRecording,
   ]);
 
   const requestEscLockedPointerCapture = useCallback(async (target: HTMLVideoElement) => {
@@ -630,6 +667,12 @@ export function App(): JSX.Element {
       })
       .catch(() => {});
   }, []);
+
+  const handleRequestPointerLock = useCallback(() => {
+    if (videoRef.current) {
+      void requestEscLockedPointerCapture(videoRef.current);
+    }
+  }, [requestEscLockedPointerCapture]);
 
   const resolveExitPrompt = useCallback((confirmed: boolean) => {
     const resolver = exitPromptResolverRef.current;
@@ -692,6 +735,35 @@ export function App(): JSX.Element {
 
     return () => clearInterval(interval);
   }, [antiAfkEnabled, streamStatus]);
+
+  // Periodically re-sync subscription playtime from backend while streaming.
+  useEffect(() => {
+    if (streamStatus !== "streaming" || !authSession) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const syncPlaytime = async (): Promise<void> => {
+      try {
+        await loadSubscriptionInfo(authSession);
+      } catch (error) {
+        if (!cancelled) {
+          console.warn("Failed to re-sync subscription playtime:", error);
+        }
+      }
+    };
+
+    void syncPlaytime();
+    const timer = window.setInterval(() => {
+      void syncPlaytime();
+    }, PLAYTIME_RESYNC_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [authSession, loadSubscriptionInfo, streamStatus]);
 
   // Restore focus to video element when navigating away from Settings during streaming
   useEffect(() => {
@@ -777,6 +849,7 @@ export function App(): JSX.Element {
               microphoneMode: settings.microphoneMode,
               microphoneDeviceId: settings.microphoneDeviceId || undefined,
               mouseSensitivity: settings.mouseSensitivity,
+              mouseAcceleration: settings.mouseAcceleration,
               onLog: (line: string) => console.log(`[WebRTC] ${line}`),
               onStats: (stats) => setDiagnostics(stats),
               onEscHoldProgress: (visible, progress) => {
@@ -844,7 +917,36 @@ export function App(): JSX.Element {
         // ignore
       }
     }
+    if (key === "mouseAcceleration") {
+      try {
+        (clientRef.current as any)?.setMouseAccelerationPercent?.(value as number);
+      } catch {
+        // ignore
+      }
+    }
+    if (key === "maxBitrateMbps") {
+      try {
+        void (clientRef.current as any)?.setMaxBitrateKbps?.((value as number) * 1000);
+      } catch {
+        // ignore
+      }
+    }
   }, [settingsLoaded]);
+
+  const handleMouseSensitivityChange = useCallback((value: number) => {
+    void updateSetting("mouseSensitivity", value);
+  }, [updateSetting]);
+
+  const handleMouseAccelerationChange = useCallback((value: number) => {
+    void updateSetting("mouseAcceleration", value);
+  }, [updateSetting]);
+
+  const handleMicrophoneModeChange = useCallback((value: import("@shared/gfn").MicrophoneMode) => {
+    // Keep UI responsive while still surfacing persistence failures.
+    void updateSetting("microphoneMode", value).catch((error) => {
+      console.warn("Failed to persist microphone mode setting:", error);
+    });
+  }, [updateSetting]);
 
   // Login handler
   const handleLogin = useCallback(async () => {
@@ -1274,6 +1376,13 @@ export function App(): JSX.Element {
 
   const releasePointerLockIfNeeded = useCallback(async () => {
     if (document.pointerLockElement) {
+      // Tell the client to suppress synthetic Escape/reactive re-acquisition
+      try {
+        // clientRef is a mutable ref to the GfnWebRtcClient instance; access runtime property
+        (clientRef.current as any).suppressNextSyntheticEscape = true;
+      } catch (e) {
+        // ignore
+      }
       document.exitPointerLock();
       setEscHoldReleaseIndicator({ visible: false, progress: 0 });
       await sleep(75);
@@ -1365,8 +1474,14 @@ export function App(): JSX.Element {
         e.stopPropagation();
         e.stopImmediatePropagation();
         if (streamStatus === "streaming" && videoRef.current) {
-          if (document.pointerLockElement) {
+          if (document.pointerLockElement === videoRef.current) {
+            try {
+              (clientRef.current as any).suppressNextSyntheticEscape = true;
+            } catch {
+              // best-effort — client may not be initialised
+            }
             document.exitPointerLock();
+            setEscHoldReleaseIndicator({ visible: false, progress: 0 });
           } else {
             void requestEscLockedPointerCapture(videoRef.current);
           }
@@ -1493,6 +1608,11 @@ export function App(): JSX.Element {
   }
 
   const showLaunchOverlay = streamStatus !== "idle" || launchError !== null;
+  const consumedHours =
+    streamStatus === "streaming"
+      ? Math.floor(sessionElapsedSeconds / 60) / 60
+      : 0;
+  const remainingPlaytimeText = formatRemainingPlaytimeFromSubscription(subscriptionInfo, consumedHours);
 
   // Show stream lifecycle (waiting/connecting/streaming/failure)
   if (showLaunchOverlay) {
@@ -1510,6 +1630,8 @@ export function App(): JSX.Element {
               togglePointerLock: formatShortcutForDisplay(settings.shortcutTogglePointerLock, isMac),
               stopStream: formatShortcutForDisplay(settings.shortcutStopStream, isMac),
               toggleMicrophone: formatShortcutForDisplay(settings.shortcutToggleMicrophone, isMac),
+              screenshot: shortcuts.screenshot.canonical,
+              recording: shortcuts.recording.canonical,
             }}
             hideStreamButtons={settings.hideStreamButtons}
             serverRegion={session?.serverIp}
@@ -1538,6 +1660,24 @@ export function App(): JSX.Element {
             }}
             onToggleMicrophone={() => {
               clientRef.current?.toggleMicrophone();
+            }}
+            mouseSensitivity={settings.mouseSensitivity}
+            onMouseSensitivityChange={handleMouseSensitivityChange}
+            mouseAcceleration={settings.mouseAcceleration}
+            onMouseAccelerationChange={handleMouseAccelerationChange}
+            microphoneMode={settings.microphoneMode}
+            onMicrophoneModeChange={handleMicrophoneModeChange}
+            onScreenshotShortcutChange={(value) => {
+              void updateSetting("shortcutScreenshot", value);
+            }}
+            onRecordingShortcutChange={(value) => {
+              void updateSetting("shortcutToggleRecording", value);
+            }}
+            remainingPlaytimeText={remainingPlaytimeText}
+            micTrack={clientRef.current?.getMicTrack() ?? null}
+            onRequestPointerLock={handleRequestPointerLock}
+            onReleasePointerLock={() => {
+              void releasePointerLockIfNeeded();
             }}
           />
         )}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -70,6 +70,7 @@ const shortcutDefaults = {
   shortcutStopStream: "Ctrl+Shift+Q",
   shortcutToggleAntiAfk: "Ctrl+Shift+K",
   shortcutToggleMicrophone: "Ctrl+Shift+M",
+  shortcutScreenshot: "F11",
 } as const;
 
 const microphoneModeOptions: Array<{ value: MicrophoneMode; label: string }> = [
@@ -605,11 +606,13 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   const [stopStreamInput, setStopStreamInput] = useState(settings.shortcutStopStream);
   const [toggleAntiAfkInput, setToggleAntiAfkInput] = useState(settings.shortcutToggleAntiAfk);
   const [toggleMicrophoneInput, setToggleMicrophoneInput] = useState(settings.shortcutToggleMicrophone);
+  const [screenshotInput, setScreenshotInput] = useState(settings.shortcutScreenshot);
   const [toggleStatsError, setToggleStatsError] = useState(false);
   const [togglePointerLockError, setTogglePointerLockError] = useState(false);
   const [stopStreamError, setStopStreamError] = useState(false);
   const [toggleAntiAfkError, setToggleAntiAfkError] = useState(false);
   const [toggleMicrophoneError, setToggleMicrophoneError] = useState(false);
+  const [screenshotError, setScreenshotError] = useState(false);
 
   // Game language dropdown state
   const [gameLanguageDropdownOpen, setGameLanguageDropdownOpen] = useState(false);
@@ -638,6 +641,10 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   useEffect(() => {
     setToggleMicrophoneInput(settings.shortcutToggleMicrophone);
   }, [settings.shortcutToggleMicrophone]);
+
+  useEffect(() => {
+    setScreenshotInput(settings.shortcutScreenshot);
+  }, [settings.shortcutScreenshot]);
 
   // Fetch subscription data (cached per account; reload only when account changes)
   useEffect(() => {
@@ -859,13 +866,15 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
       && settings.shortcutTogglePointerLock === shortcutDefaults.shortcutTogglePointerLock
       && settings.shortcutStopStream === shortcutDefaults.shortcutStopStream
       && settings.shortcutToggleAntiAfk === shortcutDefaults.shortcutToggleAntiAfk
-      && settings.shortcutToggleMicrophone === shortcutDefaults.shortcutToggleMicrophone,
+      && settings.shortcutToggleMicrophone === shortcutDefaults.shortcutToggleMicrophone
+      && settings.shortcutScreenshot === shortcutDefaults.shortcutScreenshot,
     [
       settings.shortcutToggleStats,
       settings.shortcutTogglePointerLock,
       settings.shortcutStopStream,
       settings.shortcutToggleAntiAfk,
       settings.shortcutToggleMicrophone,
+      settings.shortcutScreenshot,
     ]
   );
 
@@ -875,11 +884,13 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     setStopStreamInput(shortcutDefaults.shortcutStopStream);
     setToggleAntiAfkInput(shortcutDefaults.shortcutToggleAntiAfk);
     setToggleMicrophoneInput(shortcutDefaults.shortcutToggleMicrophone);
+    setScreenshotInput(shortcutDefaults.shortcutScreenshot);
     setToggleStatsError(false);
     setTogglePointerLockError(false);
     setStopStreamError(false);
     setToggleAntiAfkError(false);
     setToggleMicrophoneError(false);
+    setScreenshotError(false);
 
     const shortcutKeys = [
       "shortcutToggleStats",
@@ -887,6 +898,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
       "shortcutStopStream",
       "shortcutToggleAntiAfk",
       "shortcutToggleMicrophone",
+      "shortcutScreenshot",
     ] as const;
 
     for (const key of shortcutKeys) {
@@ -1501,6 +1513,40 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
 
             <div className="settings-row settings-row--column">
               <div className="settings-row-top">
+                <label className="settings-label">Mouse Accelerator</label>
+                <span className="settings-value-badge">{Math.round(settings.mouseAcceleration)}%</span>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <input
+                  type="range"
+                  className="settings-slider"
+                  min={1}
+                  max={150}
+                  step={1}
+                  value={Math.round(settings.mouseAcceleration)}
+                  onChange={(e) => handleChange("mouseAcceleration", Math.max(1, Math.min(150, Math.round(Number(e.target.value) || 1))))}
+                />
+                <input
+                  type="number"
+                  className="settings-number-input"
+                  style={{ width: 80 }}
+                  min={1}
+                  max={150}
+                  step={1}
+                  value={Math.round(settings.mouseAcceleration)}
+                  onChange={(e) => {
+                    const v = Number(e.target.value || "1");
+                    if (Number.isFinite(v)) {
+                      handleChange("mouseAcceleration", Math.max(1, Math.min(150, Math.round(v))));
+                    }
+                  }}
+                />
+              </div>
+              <span className="settings-subtle-hint">Dynamic turn boost strength (1% = off-like, 150% = strongest).</span>
+            </div>
+
+            <div className="settings-row settings-row--column">
+              <div className="settings-row-top">
                 <label className="settings-label">Shortcuts</label>
                 <div className="settings-shortcut-actions">
                   <span className="settings-value-badge">Editable</span>
@@ -1585,17 +1631,40 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                     spellCheck={false}
                   />
                 </label>
+
+                <label className="settings-shortcut-row">
+                  <span className="settings-shortcut-label">ScreensShot</span>
+                  <input
+                    type="text"
+                    className={`settings-text-input settings-shortcut-input ${screenshotError ? "error" : ""}`}
+                    value={screenshotInput}
+                    onChange={(e) => setScreenshotInput(e.target.value)}
+                    onBlur={() => handleShortcutBlur("shortcutScreenshot", screenshotInput, setScreenshotInput, setScreenshotError)}
+                    onKeyDown={handleShortcutKeyDown}
+                    placeholder="F11"
+                    spellCheck={false}
+                  />
+                </label>
+                <label className="settings-shortcut-row">
+                  <span className="settings-shortcut-label">Toggle Settings Menu</span>
+                  <input
+                    type="text"
+                    value="Cmd+G / Ctrl+Shift+G"
+                    className="settings-text-input settings-shortcut-input settings-shortcut-input--static"
+                    disabled
+                  />
+                </label>
               </div>
 
-              {(toggleStatsError || togglePointerLockError || stopStreamError || toggleAntiAfkError || toggleMicrophoneError) && (
+              {(toggleStatsError || togglePointerLockError || stopStreamError || toggleAntiAfkError || toggleMicrophoneError || screenshotError) && (
                 <span className="settings-input-hint">
                   Invalid shortcut. Use {shortcutExamples}
                 </span>
               )}
 
-              {!toggleStatsError && !togglePointerLockError && !stopStreamError && !toggleAntiAfkError && !toggleMicrophoneError && (
+              {!toggleStatsError && !togglePointerLockError && !stopStreamError && !toggleAntiAfkError && !toggleMicrophoneError && !screenshotError && (
                 <span className="settings-shortcut-hint">
-                  {shortcutExamples}. Stop: {formatShortcutForDisplay(settings.shortcutStopStream, isMac)}. Mic: {formatShortcutForDisplay(settings.shortcutToggleMicrophone, isMac)}.
+                  {shortcutExamples}. Stop: {formatShortcutForDisplay(settings.shortcutStopStream, isMac)}. Mic: {formatShortcutForDisplay(settings.shortcutToggleMicrophone, isMac)}. ScreensShot: {formatShortcutForDisplay(settings.shortcutScreenshot, isMac)}.
                 </span>
               )}
             </div>

--- a/opennow-stable/src/renderer/src/components/SideBar.tsx
+++ b/opennow-stable/src/renderer/src/components/SideBar.tsx
@@ -1,0 +1,42 @@
+import type { JSX, ReactNode } from "react";
+
+interface SideBarProps {
+  title?: string;
+  children?: ReactNode;
+  className?: string;
+  onClose?: () => void;
+}
+
+export default function SideBar({
+  title,
+  children,
+  className = "",
+  onClose,
+}: SideBarProps): JSX.Element {
+  const classNames = ["sidebar", className].filter(Boolean).join(" ");
+
+  return (
+    <aside
+      className={classNames}
+      role="dialog"
+      aria-label={title ?? "Sidebar"}
+    >
+      <div className="sidebar-header">
+        <h3>{title ?? "Sidebar"}</h3>
+        {onClose && (
+          <button
+            type="button"
+            className="sidebar-close"
+            onClick={onClose}
+            aria-label="Close settings"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+      <div className="sidebar-body">
+        {children}
+      </div>
+    </aside>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1,8 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import type { JSX } from "react";
-import { Maximize, Minimize, Gamepad2, Loader2, LogOut, Clock3, AlertTriangle, Mic, MicOff } from "lucide-react";
+import { Maximize, Minimize, Gamepad2, Loader2, LogOut, Clock3, AlertTriangle, Mic, MicOff, Camera, ChevronLeft, ChevronRight, Save, Trash2, X, Circle, Square, Video, FolderOpen } from "lucide-react";
+import SideBar from "./SideBar";
 import type { StreamDiagnostics } from "../gfn/webrtcClient";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
+import type { MicrophoneMode, ScreenshotEntry, RecordingEntry } from "@shared/gfn";
+import { isShortcutMatch, normalizeShortcut } from "../shortcuts";
 
 interface StreamViewProps {
   videoRef: React.Ref<HTMLVideoElement>;
@@ -14,6 +17,8 @@ interface StreamViewProps {
     togglePointerLock: string;
     stopStream: string;
     toggleMicrophone?: string;
+    screenshot: string;
+    recording: string;
   };
   hideStreamButtons?: boolean;
   serverRegion?: string;
@@ -44,6 +49,18 @@ interface StreamViewProps {
   onCancelExit: () => void;
   onEndSession: () => void;
   onToggleMicrophone?: () => void;
+  mouseSensitivity: number;
+  onMouseSensitivityChange: (value: number) => void;
+  mouseAcceleration: number;
+  onMouseAccelerationChange: (value: number) => void;
+  onRequestPointerLock?: () => void;
+  onReleasePointerLock?: () => void;
+  microphoneMode: MicrophoneMode;
+  onMicrophoneModeChange: (value: MicrophoneMode) => void;
+  onScreenshotShortcutChange: (value: string) => void;
+  onRecordingShortcutChange: (value: string) => void;
+  remainingPlaytimeText: string;
+  micTrack?: MediaStreamTrack | null;
 }
 
 function getRttColor(rttMs: number): string {
@@ -83,6 +100,12 @@ function formatElapsed(totalSeconds: number): string {
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 }
 
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 function formatWarningSeconds(value: number | undefined): string | null {
   if (value === undefined || !Number.isFinite(value) || value < 0) {
     return null;
@@ -94,6 +117,125 @@ function formatWarningSeconds(value: number | undefined): string | null {
     return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
   }
   return `${seconds}s`;
+}
+
+/**
+ * Drives a canvas-based segmented level meter from a live MediaStreamTrack.
+ * Uses the Web Audio API AnalyserNode as a read-only tap — audio is never
+ * routed to the speaker. Runs a requestAnimationFrame loop while active;
+ * tears down fully (rAF cancelled, AudioContext closed) on deactivation.
+ */
+function useMicMeter(
+  canvasRef: React.RefObject<HTMLCanvasElement | null>,
+  track: MediaStreamTrack | null,
+  active: boolean,
+): void {
+  const pendingCloseRef = useRef<Promise<void> | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!active || !track || !canvas) return;
+
+    const ctx2d = canvas.getContext("2d");
+    if (!ctx2d) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(canvas.clientWidth * dpr);
+    canvas.height = Math.round(canvas.clientHeight * dpr);
+    const W = canvas.width;
+    const H = canvas.height;
+    if (W <= 0 || H <= 0) {
+      return;
+    }
+
+    let audioCtx: AudioContext | null = null;
+    let source: MediaStreamAudioSourceNode | null = null;
+    let analyser: AnalyserNode | null = null;
+    let raf = 0;
+    let dead = false;
+
+    const start = async () => {
+      if (pendingCloseRef.current) {
+        try {
+          await pendingCloseRef.current;
+        } catch {
+          // Ignore close errors from previous contexts.
+        }
+      }
+      if (dead) {
+        return;
+      }
+
+      try {
+        audioCtx = new AudioContext();
+        await audioCtx.resume().catch(() => undefined);
+        if (dead) {
+          return;
+        }
+
+        analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 512;
+        analyser.smoothingTimeConstant = 0.65;
+        source = audioCtx.createMediaStreamSource(new MediaStream([track]));
+        source.connect(analyser);
+        // NOT connected to destination — monitoring only, no loopback
+
+        const buf = new Uint8Array(analyser.frequencyBinCount);
+        const SEG = 20;
+        const GAP = Math.round(2 * dpr);
+        const bw = (W - GAP * (SEG - 1)) / SEG;
+        const radius = Math.min(3 * dpr, bw / 2);
+
+        const frame = () => {
+          if (dead || !analyser) return;
+          raf = requestAnimationFrame(frame);
+          analyser.getByteTimeDomainData(buf);
+
+          let sum = 0;
+          for (let i = 0; i < buf.length; i++) {
+            const v = ((buf[i] ?? 128) - 128) / 128;
+            sum += v * v;
+          }
+          const rms = Math.sqrt(sum / buf.length);
+          const level = Math.min(1, rms * 5.5);
+          const filled = Math.round(level * SEG);
+
+          ctx2d.clearRect(0, 0, W, H);
+          for (let i = 0; i < SEG; i++) {
+            const x = i * (bw + GAP);
+            if (i < filled) {
+              ctx2d.fillStyle =
+                i < SEG * 0.7 ? "#58d98a" : i < SEG * 0.9 ? "#fbbf24" : "#f87171";
+            } else {
+              ctx2d.fillStyle = "rgba(255,255,255,0.07)";
+            }
+            ctx2d.beginPath();
+            ctx2d.roundRect(x, 0, Math.max(1, bw), H, radius);
+            ctx2d.fill();
+          }
+        };
+
+        frame();
+      } catch (e) {
+        console.warn("[MicMeter]", e);
+      }
+    };
+
+    void start();
+
+    return () => {
+      dead = true;
+      cancelAnimationFrame(raf);
+      source?.disconnect();
+      analyser?.disconnect();
+      if (audioCtx && audioCtx.state !== "closed") {
+        pendingCloseRef.current = audioCtx
+          .close()
+          .catch(() => undefined)
+          .then(() => undefined);
+      }
+    };
+  }, [track, active, canvasRef]);
 }
 
 export function StreamView({
@@ -119,21 +261,87 @@ export function StreamView({
   onCancelExit,
   onEndSession,
   onToggleMicrophone,
+  mouseSensitivity,
+  onMouseSensitivityChange,
+  mouseAcceleration,
+  onMouseAccelerationChange,
+  onRequestPointerLock,
+  onReleasePointerLock,
+  microphoneMode,
+  onMicrophoneModeChange,
+  onScreenshotShortcutChange,
+  onRecordingShortcutChange,
+  remainingPlaytimeText,
+  micTrack,
   hideStreamButtons = false,
 }: StreamViewProps): JSX.Element {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showHints, setShowHints] = useState(true);
   const [showSessionClock, setShowSessionClock] = useState(false);
+  const [showSideBar, setShowSideBar] = useState(false);
+  const [isPointerLocked, setIsPointerLocked] = useState(false);
+  const [screenshots, setScreenshots] = useState<ScreenshotEntry[]>([]);
+  const [isSavingScreenshot, setIsSavingScreenshot] = useState(false);
+  const [galleryError, setGalleryError] = useState<string | null>(null);
+  const [selectedScreenshotId, setSelectedScreenshotId] = useState<string | null>(null);
+  const [screenshotShortcutInput, setScreenshotShortcutInput] = useState(shortcuts.screenshot);
+  const [screenshotShortcutError, setScreenshotShortcutError] = useState<string | null>(null);
+  const [activeSidebarTab, setActiveSidebarTab] = useState<"preferences" | "shortcuts">("preferences");
+  const screenshotApiAvailable =
+    typeof window.openNow?.saveScreenshot === "function" &&
+    typeof window.openNow?.listScreenshots === "function" &&
+    typeof window.openNow?.deleteScreenshot === "function" &&
+    typeof window.openNow?.saveScreenshotAs === "function";
+
+  // Recording state
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordings, setRecordings] = useState<RecordingEntry[]>([]);
+  const [recordingDurationMs, setRecordingDurationMs] = useState(0);
+  const [recordingError, setRecordingError] = useState<string | null>(null);
+  const [usedMimeType, setUsedMimeType] = useState<string | null>(null);
+  const [recordingShortcutInput, setRecordingShortcutInput] = useState(shortcuts.recording);
+  const [recordingShortcutError, setRecordingShortcutError] = useState<string | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const recordingIdRef = useRef<string | null>(null);
+  const recordingStartTimeRef = useRef<number>(0);
+  const recordingTimerRef = useRef<number | undefined>(undefined);
+  const thumbnailDataUrlRef = useRef<string | null>(null);
+  const recCarouselRef = useRef<HTMLDivElement | null>(null);
+  const recordingApiAvailable =
+    typeof window.openNow?.beginRecording === "function" &&
+    typeof window.openNow?.sendRecordingChunk === "function" &&
+    typeof window.openNow?.finishRecording === "function" &&
+    typeof window.openNow?.abortRecording === "function" &&
+    typeof window.openNow?.listRecordings === "function" &&
+    typeof window.openNow?.deleteRecording === "function";
 
   // Microphone state
   const micState = stats.micState ?? "uninitialized";
   const micEnabled = stats.micEnabled ?? false;
   const hasMicrophone = micState === "started" || micState === "stopped";
   const showMicIndicator = hasMicrophone && !isConnecting && !hideStreamButtons;
+  const microphoneModes = useMemo(
+    () => [
+      { value: "disabled" as MicrophoneMode, label: "Disabled", description: "No microphone input" },
+      { value: "push-to-talk" as MicrophoneMode, label: "Push-to-Talk", description: "Hold a key to talk" },
+      { value: "voice-activity" as MicrophoneMode, label: "Voice Activity", description: "Always listen" },
+    ],
+    []
+  );
 
   const handleFullscreenToggle = useCallback(() => {
     onToggleFullscreen();
   }, [onToggleFullscreen]);
+
+  const handlePointerLockToggle = useCallback(() => {
+    if (isPointerLocked) {
+      document.exitPointerLock();
+      return;
+    }
+    if (onRequestPointerLock) {
+      onRequestPointerLock();
+    }
+  }, [isPointerLocked, onRequestPointerLock]);
 
   useEffect(() => {
     const timer = setTimeout(() => setShowHints(false), 5000);
@@ -211,14 +419,415 @@ export function StreamView({
   const sessionTimeText = formatElapsed(sessionElapsedSeconds);
   const platformName = platformStore ? getStoreDisplayName(platformStore) : "";
   const PlatformIcon = platformStore ? getStoreIconComponent(platformStore) : null;
+  const isMacClient = navigator.platform?.toLowerCase().includes("mac") || navigator.userAgent.includes("Macintosh");
 
   // Local ref for video element to manage focus
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
+  // Local ref for audio element (game audio stream)
+  const localAudioRef = useRef<HTMLAudioElement | null>(null);
+  // AudioContext used during an active recording (torn down on stop/error)
+  const audioCtxRef = useRef<AudioContext | null>(null);
 
-  // Combined ref callback that sets both local and forwarded ref
+  // Mic level meter canvas
+  const micMeterRef = useRef<HTMLCanvasElement | null>(null);
+  const galleryStripRef = useRef<HTMLDivElement | null>(null);
+  useMicMeter(micMeterRef, micTrack ?? null, showSideBar && microphoneMode !== "disabled");
+
+  const selectedScreenshot = useMemo(() => {
+    if (!selectedScreenshotId) return null;
+    return screenshots.find((item) => item.id === selectedScreenshotId) ?? null;
+  }, [screenshots, selectedScreenshotId]);
+
+  useEffect(() => {
+    setScreenshotShortcutInput(shortcuts.screenshot);
+    setScreenshotShortcutError(null);
+  }, [shortcuts.screenshot]);
+
+  useEffect(() => {
+    setRecordingShortcutInput(shortcuts.recording);
+    setRecordingShortcutError(null);
+  }, [shortcuts.recording]);
+
+  const getScreenshotShortcutError = useCallback((rawValue: string): string | null => {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return "Shortcut cannot be empty.";
+    }
+
+    const normalized = normalizeShortcut(trimmed);
+    if (!normalized.valid) {
+      return "Invalid shortcut format.";
+    }
+
+    const reserved = [
+      shortcuts.toggleStats,
+      shortcuts.togglePointerLock,
+      shortcuts.stopStream,
+      shortcuts.toggleMicrophone,
+      shortcuts.recording,
+      isMacClient ? "Cmd+G" : "Ctrl+Shift+G",
+    ]
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+      .map((value) => normalizeShortcut(value))
+      .filter((parsed) => parsed.valid)
+      .map((parsed) => parsed.canonical);
+
+    if (reserved.includes(normalized.canonical)) {
+      return "Shortcut conflicts with an existing binding.";
+    }
+
+    return null;
+  }, [isMacClient, shortcuts.recording, shortcuts.stopStream, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
+
+  const getRecordingShortcutError = useCallback((rawValue: string): string | null => {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return "Shortcut cannot be empty.";
+    }
+
+    const normalized = normalizeShortcut(trimmed);
+    if (!normalized.valid) {
+      return "Invalid shortcut format.";
+    }
+
+    const reserved = [
+      shortcuts.toggleStats,
+      shortcuts.togglePointerLock,
+      shortcuts.stopStream,
+      shortcuts.toggleMicrophone,
+      shortcuts.screenshot,
+      isMacClient ? "Cmd+G" : "Ctrl+Shift+G",
+    ]
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+      .map((value) => normalizeShortcut(value))
+      .filter((parsed) => parsed.valid)
+      .map((parsed) => parsed.canonical);
+
+    if (reserved.includes(normalized.canonical)) {
+      return "Shortcut conflicts with an existing binding.";
+    }
+
+    return null;
+  }, [isMacClient, shortcuts.screenshot, shortcuts.stopStream, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
+
+  const refreshScreenshots = useCallback(async () => {
+    setGalleryError(null);
+    if (!screenshotApiAvailable) {
+      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
+      return;
+    }
+    try {
+      const items = await window.openNow.listScreenshots();
+      setScreenshots(items);
+    } catch (error) {
+      console.error("[StreamView] Failed to load screenshots:", error);
+      setGalleryError("Unable to load screenshot gallery.");
+    }
+  }, [screenshotApiAvailable]);
+
+  const captureScreenshot = useCallback(async () => {
+    setGalleryError(null);
+    if (!screenshotApiAvailable) {
+      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable capture.");
+      return;
+    }
+    if (isSavingScreenshot) {
+      return;
+    }
+
+    const video = localVideoRef.current;
+    if (!video || video.videoWidth <= 0 || video.videoHeight <= 0) {
+      setGalleryError("Stream is not ready for screenshots yet.");
+      return;
+    }
+
+    setIsSavingScreenshot(true);
+    try {
+      const canvas = document.createElement("canvas");
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const context = canvas.getContext("2d");
+      if (!context) {
+        throw new Error("Could not acquire 2D context");
+      }
+
+      context.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const dataUrl = canvas.toDataURL("image/png");
+      const saved = await window.openNow.saveScreenshot({ dataUrl, gameTitle });
+      setScreenshots((prev) => [saved, ...prev.filter((item) => item.id !== saved.id)].slice(0, 60));
+    } catch (error) {
+      console.error("[StreamView] Failed to capture screenshot:", error);
+      setGalleryError("Screenshot failed. Try again.");
+    } finally {
+      setIsSavingScreenshot(false);
+    }
+  }, [gameTitle, isSavingScreenshot, screenshotApiAvailable]);
+
+  const scrollGallery = useCallback((direction: "left" | "right") => {
+    const strip = galleryStripRef.current;
+    if (!strip) return;
+    const delta = Math.max(180, Math.round(strip.clientWidth * 0.7));
+    strip.scrollBy({ left: direction === "left" ? -delta : delta, behavior: "smooth" });
+  }, []);
+
+  const handleDeleteScreenshot = useCallback(async () => {
+    setGalleryError(null);
+    if (!screenshotApiAvailable) {
+      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
+      return;
+    }
+    if (!selectedScreenshot) return;
+
+    try {
+      await window.openNow.deleteScreenshot({ id: selectedScreenshot.id });
+      setScreenshots((prev) => prev.filter((item) => item.id !== selectedScreenshot.id));
+      setSelectedScreenshotId(null);
+    } catch (error) {
+      console.error("[StreamView] Failed to delete screenshot:", error);
+      setGalleryError("Unable to delete screenshot.");
+    }
+  }, [screenshotApiAvailable, selectedScreenshot]);
+
+  const handleSaveScreenshotAs = useCallback(async () => {
+    setGalleryError(null);
+    if (!screenshotApiAvailable) {
+      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
+      return;
+    }
+    if (!selectedScreenshot) return;
+
+    try {
+      await window.openNow.saveScreenshotAs({ id: selectedScreenshot.id });
+    } catch (error) {
+      console.error("[StreamView] Failed to save screenshot as:", error);
+      setGalleryError("Unable to save screenshot.");
+    }
+  }, [screenshotApiAvailable, selectedScreenshot]);
+
+  const refreshRecordings = useCallback(async () => {
+    setRecordingError(null);
+    if (!recordingApiAvailable) return;
+    try {
+      const items = await window.openNow.listRecordings();
+      setRecordings(items);
+    } catch (error) {
+      console.error("[StreamView] Failed to load recordings:", error);
+      setRecordingError("Unable to load recordings.");
+    }
+  }, [recordingApiAvailable]);
+
+  const handleDeleteRecording = useCallback(async (id: string) => {
+    setRecordingError(null);
+    if (!recordingApiAvailable) return;
+    try {
+      await window.openNow.deleteRecording({ id });
+      setRecordings((prev) => prev.filter((r) => r.id !== id));
+    } catch (error) {
+      console.error("[StreamView] Failed to delete recording:", error);
+      setRecordingError("Unable to delete recording.");
+    }
+  }, [recordingApiAvailable]);
+
+  const scrollRecCarousel = useCallback((direction: "left" | "right") => {
+    const strip = recCarouselRef.current;
+    if (!strip) return;
+    strip.scrollBy({ left: direction === "left" ? -200 : 200, behavior: "smooth" });
+  }, []);
+
+  const toggleRecording = useCallback(async () => {
+    setRecordingError(null);
+
+    if (isRecording) {
+      mediaRecorderRef.current?.stop();
+      return;
+    }
+
+    if (!recordingApiAvailable) {
+      setRecordingError("Recording API unavailable. Restart OpenNOW to enable recording.");
+      return;
+    }
+
+    const video = localVideoRef.current;
+    if (!video || !video.srcObject) {
+      setRecordingError("Stream is not ready for recording yet.");
+      return;
+    }
+
+    const stream = video.srcObject as MediaStream;
+    const mimeTypes = [
+      "video/mp4;codecs=avc1.42E01E,mp4a.40.2",
+      "video/mp4;codecs=avc1",
+      "video/mp4",
+      "video/webm;codecs=h264",
+      "video/webm;codecs=vp8",
+      "video/webm",
+    ];
+    const mimeType = mimeTypes.find((m) => MediaRecorder.isTypeSupported(m)) ?? "video/webm";
+    setUsedMimeType(mimeType);
+
+    // Build a composed MediaStream: video tracks + mixed audio (game + mic)
+    const audioCtx = new AudioContext();
+    audioCtxRef.current = audioCtx;
+    const audioDest = audioCtx.createMediaStreamDestination();
+
+    // Wire game audio (from the <audio> element's srcObject)
+    const audioEl = localAudioRef.current;
+    const gameAudioStream = audioEl?.srcObject instanceof MediaStream ? audioEl.srcObject : null;
+    if (gameAudioStream && gameAudioStream.getAudioTracks().length > 0) {
+      audioCtx.createMediaStreamSource(gameAudioStream).connect(audioDest);
+    }
+
+    // Wire microphone (if active)
+    if (micTrack && micTrack.readyState === "live") {
+      const micStream = new MediaStream([micTrack]);
+      audioCtx.createMediaStreamSource(micStream).connect(audioDest);
+    }
+
+    // Compose: video tracks from the video element + mixed audio destination track
+    const composed = new MediaStream([
+      ...stream.getVideoTracks(),
+      ...audioDest.stream.getAudioTracks(),
+    ]);
+
+    let recordingId: string;
+    try {
+      const result = await window.openNow.beginRecording({ mimeType });
+      recordingId = result.recordingId;
+    } catch (error) {
+      console.error("[StreamView] Failed to begin recording:", error);
+      audioCtx.close().catch(() => undefined);
+      audioCtxRef.current = null;
+      setRecordingError("Could not start recording.");
+      return;
+    }
+
+    recordingIdRef.current = recordingId;
+    thumbnailDataUrlRef.current = null;
+    recordingStartTimeRef.current = Date.now();
+    setRecordingDurationMs(0);
+    setIsRecording(true);
+
+    recordingTimerRef.current = window.setInterval(() => {
+      setRecordingDurationMs(Date.now() - recordingStartTimeRef.current);
+    }, 500);
+
+    let isFirstChunk = true;
+    const recorder = new MediaRecorder(composed, { mimeType });
+
+    recorder.ondataavailable = (e: BlobEvent) => {
+      if (!e.data || e.data.size === 0) return;
+
+      // Capture thumbnail from the first chunk (frame ~2 s in)
+      if (isFirstChunk) {
+        isFirstChunk = false;
+        const vid = localVideoRef.current;
+        if (vid && vid.videoWidth > 0 && vid.videoHeight > 0) {
+          // create a canvas sized to preserve the video's aspect ratio, but
+          // capped at roughly 320×180 so we don't generate unnecessarily large
+          // thumbnails when the stream resolution is higher than 16:9.
+          const maxW = 320;
+          const maxH = 180;
+          let w = vid.videoWidth;
+          let h = vid.videoHeight;
+
+          // shrink to fit within bounds while keeping aspect ratio
+          if (w > maxW) {
+            h = Math.round((maxW / w) * h);
+            w = maxW;
+          }
+          if (h > maxH) {
+            w = Math.round((maxH / h) * w);
+            h = maxH;
+          }
+
+          const canvas = document.createElement("canvas");
+          canvas.width = w;
+          canvas.height = h;
+          const ctx2d = canvas.getContext("2d");
+          if (ctx2d) {
+            ctx2d.drawImage(vid, 0, 0, w, h);
+            thumbnailDataUrlRef.current = canvas.toDataURL("image/jpeg", 0.72);
+          }
+        }
+      }
+
+      void e.data.arrayBuffer().then((buf) => {
+        const id = recordingIdRef.current;
+        if (!id) return;
+        window.openNow.sendRecordingChunk({ recordingId: id, chunk: buf }).catch((err: unknown) => {
+          console.error("[StreamView] Failed to send recording chunk:", err);
+        });
+      });
+    };
+
+    recorder.onstop = () => {
+      window.clearInterval(recordingTimerRef.current);
+      recordingTimerRef.current = undefined;
+      audioCtxRef.current?.close().catch(() => undefined);
+      audioCtxRef.current = null;
+      const id = recordingIdRef.current;
+      recordingIdRef.current = null;
+      setIsRecording(false);
+
+      if (!id) return;
+
+      const durationMs = Date.now() - recordingStartTimeRef.current;
+      void window.openNow
+        .finishRecording({
+          recordingId: id,
+          durationMs,
+          gameTitle,
+          thumbnailDataUrl: thumbnailDataUrlRef.current ?? undefined,
+        })
+        .then((entry) => {
+          setRecordings((prev) => [entry, ...prev].slice(0, 20));
+          thumbnailDataUrlRef.current = null;
+        })
+        .catch((err: unknown) => {
+          console.error("[StreamView] Failed to finish recording:", err);
+          setRecordingError("Recording could not be saved.");
+        });
+    };
+
+    recorder.onerror = () => {
+      window.clearInterval(recordingTimerRef.current);
+      recordingTimerRef.current = undefined;
+      audioCtxRef.current?.close().catch(() => undefined);
+      audioCtxRef.current = null;
+      const id = recordingIdRef.current;
+      recordingIdRef.current = null;
+      setIsRecording(false);
+      thumbnailDataUrlRef.current = null;
+      if (id) {
+        window.openNow.abortRecording({ recordingId: id }).catch(() => undefined);
+      }
+      setRecordingError("Recording encountered an error.");
+    };
+
+    mediaRecorderRef.current = recorder;
+    recorder.start(2000);
+  }, [gameTitle, isRecording, micTrack, recordingApiAvailable]);
+
+  // Cleanup: abort any active recording on unmount
+  useEffect(() => {
+    return () => {
+      window.clearInterval(recordingTimerRef.current);
+      const recorder = mediaRecorderRef.current;
+      const id = recordingIdRef.current;
+      if (recorder && recorder.state !== "inactive") {
+        recorder.stop();
+      }
+      if (id) {
+        window.openNow.abortRecording({ recordingId: id }).catch(() => undefined);
+        recordingIdRef.current = null;
+      }
+      audioCtxRef.current?.close().catch(() => undefined);
+      audioCtxRef.current = null;
+    };
+  }, []);
+
   const setVideoRef = useCallback((element: HTMLVideoElement | null) => {
     localVideoRef.current = element;
-    // Forward to parent ref
     if (typeof videoRef === "function") {
       videoRef(element);
     } else if (videoRef && "current" in videoRef) {
@@ -226,10 +835,50 @@ export function StreamView({
     }
   }, [videoRef]);
 
-  // Focus video element when stream is ready (not connecting anymore)
+  const setAudioRef = useCallback((element: HTMLAudioElement | null) => {
+    localAudioRef.current = element;
+    if (typeof audioRef === "function") {
+      audioRef(element);
+    } else if (audioRef && "current" in audioRef) {
+      (audioRef as React.MutableRefObject<HTMLAudioElement | null>).current = element;
+    }
+  }, [audioRef]);
+
+  useEffect(() => {
+    const handlePointerLockChange = () => {
+      setIsPointerLocked(document.pointerLockElement === localVideoRef.current);
+    };
+    document.addEventListener("pointerlockchange", handlePointerLockChange);
+    return () => document.removeEventListener("pointerlockchange", handlePointerLockChange);
+  }, []);
+
+  useEffect(() => {
+    if (showSideBar) {
+      document.exitPointerLock();
+      void refreshScreenshots();
+      void refreshRecordings();
+      return;
+    }
+    // Sidebar just closed — restore focus to the video so clicks register
+    // immediately. Without this, focus stays on the last sidebar element and
+    // mousedown's preventDefault() blocks the browser from re-focusing on click.
+    const timer = window.setTimeout(() => {
+      if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
+        localVideoRef.current.focus();
+      }
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [refreshRecordings, refreshScreenshots, showSideBar]);
+
+  useEffect(() => {
+    if (!selectedScreenshotId) return;
+    if (!screenshots.some((item) => item.id === selectedScreenshotId)) {
+      setSelectedScreenshotId(null);
+    }
+  }, [screenshots, selectedScreenshotId]);
+
   useEffect(() => {
     if (!isConnecting && localVideoRef.current && hasResolution) {
-      // Small delay to ensure DOM is ready
       const timer = window.setTimeout(() => {
         if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
           localVideoRef.current.focus();
@@ -240,24 +889,527 @@ export function StreamView({
     }
   }, [isConnecting, hasResolution]);
 
+  const handleToggleSideBar = useCallback(() => {
+    setShowSideBar((s) => {
+      if (!s && document.pointerLockElement) {
+        if (onReleasePointerLock) {
+          onReleasePointerLock();
+        } else {
+          document.exitPointerLock();
+        }
+      }
+      return !s;
+    });
+  }, [onReleasePointerLock]);
+
+  useEffect(() => {
+    const screenshotShortcut = normalizeShortcut(shortcuts.screenshot);
+    const recordingShortcut = normalizeShortcut(shortcuts.recording);
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const isTyping = !!target && (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      );
+      if (isTyping) {
+        return;
+      }
+
+      if (isShortcutMatch(event, screenshotShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void captureScreenshot();
+        return;
+      }
+
+      if (isShortcutMatch(event, recordingShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void toggleRecording();
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (isMacClient) {
+        if (event.metaKey && !event.ctrlKey && !event.shiftKey && key === "g") {
+          event.preventDefault();
+          handleToggleSideBar();
+        }
+      } else if (event.ctrlKey && event.shiftKey && !event.metaKey && key === "g") {
+        event.preventDefault();
+        handleToggleSideBar();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [captureScreenshot, handleToggleSideBar, isMacClient, shortcuts.screenshot, shortcuts.recording, toggleRecording]);
+
   return (
     <div className="sv">
-      {/* Video element */}
-      <video 
-        ref={setVideoRef} 
-        autoPlay 
-        playsInline 
-        muted 
-        tabIndex={0} 
+      <video
+        ref={setVideoRef}
+        autoPlay
+        playsInline
+        muted
+        tabIndex={0}
         className="sv-video"
         onClick={() => {
-          // Ensure video has focus when clicked for pointer lock to work
           if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
             localVideoRef.current.focus();
           }
         }}
       />
-      <audio ref={audioRef} autoPlay playsInline />
+      <audio ref={setAudioRef} autoPlay playsInline />
+
+      {showSideBar && (
+        <>
+          <div
+            className="sv-sidebar-backdrop"
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={() => setShowSideBar(false)}
+          />
+          <SideBar title="Settings" className="sv-sidebar" onClose={() => setShowSideBar(false)}>
+            <div className="sidebar-stat-line" title="Total remaining playtime from subscription">
+              <span className="sidebar-stat-label">Remaining Playtime</span>
+              <span className="settings-value-badge">{remainingPlaytimeText}</span>
+            </div>
+            <div className="sidebar-tabs" role="tablist" aria-label="Sidebar sections">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeSidebarTab === "preferences"}
+                className={`sidebar-tab${activeSidebarTab === "preferences" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveSidebarTab("preferences")}
+              >
+                Preferences
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeSidebarTab === "shortcuts"}
+                className={`sidebar-tab${activeSidebarTab === "shortcuts" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveSidebarTab("shortcuts")}
+              >
+                Shortcuts
+              </button>
+            </div>
+
+            {activeSidebarTab === "preferences" && (
+              <>
+                <div className="sidebar-separator" aria-hidden="true" />
+                <section className="sidebar-section">
+                  <div className="sidebar-section-header">
+                    <span>Mouse Preferences</span>
+                    <span className="sidebar-section-sub">Fine-tune cursor movement</span>
+                  </div>
+                  <div className="sidebar-row sidebar-row--column">
+                    <div className="sidebar-row-top">
+                      <span className="sidebar-label">Mouse Sensitivity</span>
+                      <span className="settings-value-badge">{mouseSensitivity.toFixed(2)}x</span>
+                    </div>
+                    <input
+                      type="range"
+                      className="settings-slider"
+                      min={0.1}
+                      max={4}
+                      step={0.01}
+                      value={mouseSensitivity}
+                      onChange={(event) => {
+                        const next = Number(event.target.value);
+                        if (Number.isFinite(next)) {
+                          onMouseSensitivityChange(Math.max(0.1, Math.min(4, next)));
+                        }
+                      }}
+                    />
+                    <span className="sidebar-hint">Multiplier applied to mouse movement (1.00 = default).</span>
+                  </div>
+                  <div className="sidebar-row sidebar-row--column">
+                    <div className="sidebar-row-top">
+                      <span className="sidebar-label">Mouse Accelerator</span>
+                      <span className="settings-value-badge">{Math.round(mouseAcceleration)}%</span>
+                    </div>
+                    <input
+                      type="range"
+                      className="settings-slider"
+                      min={1}
+                      max={150}
+                      step={1}
+                      value={Math.round(mouseAcceleration)}
+                      onChange={(event) => {
+                        const next = Number(event.target.value);
+                        if (Number.isFinite(next)) {
+                          onMouseAccelerationChange(Math.max(1, Math.min(150, Math.round(next))));
+                        }
+                      }}
+                    />
+                    <span className="sidebar-hint">Dynamic turn boost strength (1% = off-like, 150% = strongest).</span>
+                  </div>
+                </section>
+                <div className="sidebar-separator" aria-hidden="true" />
+                <section className="sidebar-section">
+                  <div className="sidebar-section-header">
+                    <span>Audio</span>
+                    <span className="sidebar-section-sub">Microphone handling</span>
+                  </div>
+                  <div className="sidebar-row sidebar-row--column">
+                    <div className="sidebar-row-top">
+                      <span className="sidebar-label">Microphone Mode</span>
+                      <span className="settings-value-badge">
+                        {microphoneModes.find((option) => option.value === microphoneMode)?.label ?? microphoneMode}
+                      </span>
+                    </div>
+                    <div className="sidebar-chip-row">
+                      {microphoneModes.map((option) => (
+                        <button
+                          key={option.value}
+                          type="button"
+                          className={`sidebar-chip${microphoneMode === option.value ? " sidebar-chip--active" : ""}`}
+                          onClick={() => onMicrophoneModeChange(option.value)}
+                        >
+                          <span>{option.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                    <span className="sidebar-hint">
+                      {microphoneModes.find((option) => option.value === microphoneMode)?.description ?? ""}
+                    </span>
+                  </div>
+                  {microphoneMode !== "disabled" && (
+                    <div className="sidebar-row sidebar-row--column">
+                      <div className="sidebar-row-top">
+                        <span className="sidebar-label">Input Level</span>
+                        {micTrack && !micEnabled && <span className="settings-value-badge">Muted</span>}
+                      </div>
+                      <canvas
+                        ref={micMeterRef}
+                        className="mic-meter-canvas"
+                        aria-label="Microphone input level"
+                      />
+                      {!micTrack && <span className="sidebar-hint">Mic not active — check mode and permissions.</span>}
+                    </div>
+                  )}
+                </section>
+                <div className="sidebar-separator" aria-hidden="true" />
+                <section className="sidebar-section">
+                  <div className="sidebar-section-header">
+                    <span>Gallery</span>
+                    <span className="sidebar-section-sub">ScreensShot key: {shortcuts.screenshot}</span>
+                  </div>
+                  <div className="sidebar-row sidebar-row--aligned">
+                    <span className="sidebar-label">ScreensShot</span>
+                    <button
+                      type="button"
+                      className="sidebar-button sidebar-screenshot-button"
+                      onClick={() => {
+                        void captureScreenshot();
+                      }}
+                      disabled={isSavingScreenshot || !screenshotApiAvailable}
+                    >
+                      <Camera size={14} />
+                      <span>{isSavingScreenshot ? "Capturing..." : "Capture"}</span>
+                    </button>
+                  </div>
+                  <div className="sidebar-gallery-row">
+                    <button
+                      type="button"
+                      className="sidebar-gallery-arrow"
+                      onClick={() => scrollGallery("left")}
+                      aria-label="Scroll gallery left"
+                    >
+                      <ChevronLeft size={16} />
+                    </button>
+                    <div className="sidebar-gallery-strip" ref={galleryStripRef}>
+                      {screenshots.map((shot) => (
+                        <button
+                          key={shot.id}
+                          type="button"
+                          className="sidebar-gallery-item"
+                          onClick={() => setSelectedScreenshotId(shot.id)}
+                          title={new Date(shot.createdAtMs).toLocaleString()}
+                        >
+                          <img src={shot.dataUrl} alt={`Screenshot ${shot.fileName}`} />
+                        </button>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      className="sidebar-gallery-arrow"
+                      onClick={() => scrollGallery("right")}
+                      aria-label="Scroll gallery right"
+                    >
+                      <ChevronRight size={16} />
+                    </button>
+                  </div>
+                  {screenshots.length === 0 && (
+                    <span className="sidebar-hint">No screenshots yet. Press {shortcuts.screenshot} to capture one.</span>
+                  )}
+                  {galleryError && <span className="sidebar-hint sidebar-hint--error">{galleryError}</span>}
+                </section>
+                <div className="sidebar-separator" aria-hidden="true" />
+                <section className="sidebar-section">
+                  <div className="sidebar-section-header">
+                    <span>Recordings</span>
+                    <span className="sidebar-section-sub">Record key: {shortcuts.recording}</span>
+                  </div>
+                  {usedMimeType && (
+                    <span className="sidebar-hint sidebar-hint--codec">Codec: {usedMimeType}</span>
+                  )}
+                  <div className="sidebar-row sidebar-row--aligned">
+                    <span className="sidebar-label">
+                      {isRecording ? `Recording ${formatElapsed(Math.round(recordingDurationMs / 1000))}` : "Record"}
+                    </span>
+                    <button
+                      type="button"
+                      className="sidebar-button sidebar-screenshot-button"
+                      onClick={() => { void toggleRecording(); }}
+                      disabled={!recordingApiAvailable}
+                    >
+                      {isRecording ? <Square size={14} /> : <Circle size={14} />}
+                      <span>{isRecording ? "Stop" : "Start"}</span>
+                    </button>
+                  </div>
+                  {recordingError && (
+                    <span className="sidebar-hint sidebar-hint--error">{recordingError}</span>
+                  )}
+                  {recordings.length === 0 ? (
+                    <span className="sidebar-hint">No recordings yet. Press {shortcuts.recording} to record.</span>
+                  ) : (
+                    <div className="sidebar-gallery-row">
+                      <button
+                        type="button"
+                        className="sidebar-gallery-arrow"
+                        onClick={() => scrollRecCarousel("left")}
+                        aria-label="Scroll recordings left"
+                      >
+                        <ChevronLeft size={16} />
+                      </button>
+                      <div className="sidebar-rec-strip" ref={recCarouselRef}>
+                        {recordings.map((rec) => (
+                          <div key={rec.id} className="sidebar-rec-card">
+                            {rec.thumbnailDataUrl ? (
+                              <img
+                                className="sidebar-rec-card-thumb"
+                                src={rec.thumbnailDataUrl}
+                                alt=""
+                              />
+                            ) : (
+                              <div className="sidebar-rec-card-thumb sidebar-rec-card-thumb--placeholder">
+                                <Video size={20} />
+                              </div>
+                            )}
+                            <div className="sidebar-rec-card-meta">
+                              <span className="sidebar-rec-card-title">{rec.gameTitle ?? "Untitled"}</span>
+                              <span className="sidebar-rec-card-detail">
+                                {formatElapsed(Math.round(rec.durationMs / 1000))} · {formatFileSize(rec.sizeBytes)}
+                              </span>
+                            </div>
+                            <div className="sidebar-rec-card-actions">
+                              <button
+                                type="button"
+                                className="sidebar-rec-card-action"
+                                aria-label="Show in folder"
+                                title="Show in folder"
+                                onClick={() => { void window.openNow.showRecordingInFolder(rec.id); }}
+                                disabled={typeof window.openNow?.showRecordingInFolder !== "function"}
+                              >
+                                <FolderOpen size={11} />
+                              </button>
+                              <button
+                                type="button"
+                                className="sidebar-rec-card-action sidebar-rec-card-action--danger"
+                                aria-label="Delete recording"
+                                title="Delete"
+                                onClick={() => { void handleDeleteRecording(rec.id); }}
+                              >
+                                <Trash2 size={11} />
+                              </button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                      <button
+                        type="button"
+                        className="sidebar-gallery-arrow"
+                        onClick={() => scrollRecCarousel("right")}
+                        aria-label="Scroll recordings right"
+                      >
+                        <ChevronRight size={16} />
+                      </button>
+                    </div>
+                  )}
+                </section>
+              </>
+            )}
+
+            {activeSidebarTab === "shortcuts" && (
+              <>
+                <div className="sidebar-separator" aria-hidden="true" />
+                <section className="sidebar-section">
+                  <div className="sidebar-section-header">
+                    <span>Shortcut Bindings</span>
+                    <span className="sidebar-section-sub">Edit screenshot keybind here</span>
+                  </div>
+                  <div className="sidebar-row sidebar-row--column">
+                    <div className="sidebar-row-top">
+                      <span className="sidebar-label">Screenshot Shortcut</span>
+                    </div>
+                    <input
+                      type="text"
+                      className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${screenshotShortcutError ? "error" : ""}`}
+                      value={screenshotShortcutInput}
+                      onChange={(event) => {
+                        const nextValue = event.target.value;
+                        setScreenshotShortcutInput(nextValue);
+                        setScreenshotShortcutError(getScreenshotShortcutError(nextValue));
+                      }}
+                      onBlur={() => {
+                        const error = getScreenshotShortcutError(screenshotShortcutInput);
+                        if (error) {
+                          setScreenshotShortcutError(error);
+                          return;
+                        }
+                        const normalized = normalizeShortcut(screenshotShortcutInput.trim());
+                        if (!normalized.valid) {
+                          setScreenshotShortcutError("Invalid shortcut format.");
+                          return;
+                        }
+                        setScreenshotShortcutError(null);
+                        setScreenshotShortcutInput(normalized.canonical);
+                        if (normalized.canonical !== shortcuts.screenshot) {
+                          onScreenshotShortcutChange(normalized.canonical);
+                        }
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          (event.target as HTMLInputElement).blur();
+                        }
+                      }}
+                      placeholder="F11"
+                      spellCheck={false}
+                    />
+                  </div>
+                  {screenshotShortcutError && <span className="sidebar-hint sidebar-hint--error">{screenshotShortcutError}</span>}
+                  <div className="sidebar-row sidebar-row--column">
+                    <div className="sidebar-row-top">
+                      <span className="sidebar-label">Recording Shortcut</span>
+                    </div>
+                    <input
+                      type="text"
+                      className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${recordingShortcutError ? "error" : ""}`}
+                      value={recordingShortcutInput}
+                      onChange={(event) => {
+                        const nextValue = event.target.value;
+                        setRecordingShortcutInput(nextValue);
+                        setRecordingShortcutError(getRecordingShortcutError(nextValue));
+                      }}
+                      onBlur={() => {
+                        const error = getRecordingShortcutError(recordingShortcutInput);
+                        if (error) {
+                          setRecordingShortcutError(error);
+                          return;
+                        }
+                        const normalized = normalizeShortcut(recordingShortcutInput.trim());
+                        if (!normalized.valid) {
+                          setRecordingShortcutError("Invalid shortcut format.");
+                          return;
+                        }
+                        setRecordingShortcutError(null);
+                        setRecordingShortcutInput(normalized.canonical);
+                        if (normalized.canonical !== shortcuts.recording) {
+                          onRecordingShortcutChange(normalized.canonical);
+                        }
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          (event.target as HTMLInputElement).blur();
+                        }
+                      }}
+                      placeholder="F12"
+                      spellCheck={false}
+                    />
+                  </div>
+                  {recordingShortcutError && <span className="sidebar-hint sidebar-hint--error">{recordingShortcutError}</span>}
+                  <div className="sidebar-row sidebar-row--aligned">
+                    <span className="sidebar-label">Toggle Stats</span>
+                    <span className="settings-value-badge">{shortcuts.toggleStats}</span>
+                  </div>
+                  <div className="sidebar-row sidebar-row--aligned">
+                    <span className="sidebar-label">Mouse Lock</span>
+                    <span className="settings-value-badge">{shortcuts.togglePointerLock}</span>
+                  </div>
+                  <div className="sidebar-row sidebar-row--aligned">
+                    <span className="sidebar-label">Stop Stream</span>
+                    <span className="settings-value-badge">{shortcuts.stopStream}</span>
+                  </div>
+                  {shortcuts.toggleMicrophone && (
+                    <div className="sidebar-row sidebar-row--aligned">
+                      <span className="sidebar-label">Toggle Microphone</span>
+                      <span className="settings-value-badge">{shortcuts.toggleMicrophone}</span>
+                    </div>
+                  )}
+                  <div className="sidebar-row sidebar-row--aligned">
+                    <span className="sidebar-label">Toggle Sidebar</span>
+                    <span className="settings-value-badge">{isMacClient ? "Cmd+G" : "Ctrl+Shift+G"}</span>
+                  </div>
+                </section>
+              </>
+            )}
+          </SideBar>
+        </>
+      )}
+
+      {selectedScreenshot && (
+        <div className="sv-shot-modal" role="dialog" aria-modal="true" aria-label="Screenshot preview">
+          <button
+            type="button"
+            className="sv-shot-modal-backdrop"
+            onClick={() => setSelectedScreenshotId(null)}
+            aria-label="Close screenshot preview"
+          />
+          <div className="sv-shot-modal-card">
+            <div className="sv-shot-modal-head">
+              <h4>Screenshot</h4>
+              <button
+                type="button"
+                className="sv-shot-modal-close"
+                onClick={() => setSelectedScreenshotId(null)}
+                aria-label="Close screenshot preview"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <img
+              className="sv-shot-modal-image"
+              src={selectedScreenshot.dataUrl}
+              alt={`Screenshot ${selectedScreenshot.fileName}`}
+            />
+            <div className="sv-shot-modal-actions">
+              <button
+                type="button"
+                className="sv-shot-modal-btn"
+                onClick={() => {
+                  void handleSaveScreenshotAs();
+                }}
+              >
+                <Save size={14} />
+                <span>Save</span>
+              </button>
+              <button
+                type="button"
+                className="sv-shot-modal-btn sv-shot-modal-btn--danger"
+                onClick={() => {
+                  void handleDeleteScreenshot();
+                }}
+              >
+                <Trash2 size={14} />
+                <span>Delete</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Gradient background when no video */}
       {!hasResolution && (
@@ -356,6 +1508,12 @@ export function StreamView({
             Input queue peak {(stats.inputQueuePeakBufferedBytes / 1024).toFixed(1)}KB · drops {stats.inputQueueDropCount} · sched {stats.inputQueueMaxSchedulingDelayMs.toFixed(1)}ms
           </div>
 
+          {(stats.decoderPressureActive || stats.decoderRecoveryAttempts > 0) && (
+            <div className="sv-stats-foot">
+              Decoder recovery {stats.decoderPressureActive ? "active" : "idle"} · attempts {stats.decoderRecoveryAttempts} · action {stats.decoderRecoveryAction}
+            </div>
+          )}
+
           {(stats.gpuType || regionLabel) && (
             <div className="sv-stats-foot">
               {[stats.gpuType, regionLabel].filter(Boolean).join(" · ")}
@@ -392,6 +1550,18 @@ export function StreamView({
         <div className={`sv-afk${connectedControllers > 0 ? " sv-afk--stacked" : ""}`} title="Anti-AFK is enabled">
           <span className="sv-afk-dot" />
           <span className="sv-afk-label">ANTI-AFK ON</span>
+        </div>
+      )}
+
+      {/* Recording indicator (top-left, stacked below other badges) */}
+      {isRecording && !isConnecting && (
+        <div
+          className="sv-rec"
+          style={{ top: 14 + 42 * ([connectedControllers > 0, antiAfkEnabled, showMicIndicator].filter(Boolean).length) }}
+          title={`Recording · ${formatElapsed(Math.round(recordingDurationMs / 1000))}`}
+        >
+          <span className="sv-rec-dot" />
+          <span className="sv-rec-label">REC {formatElapsed(Math.round(recordingDurationMs / 1000))}</span>
         </div>
       )}
 

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -166,6 +166,11 @@ export interface StreamDiagnostics {
   gpuType: string;
   serverRegion: string;
 
+  // Decoder recovery status
+  decoderPressureActive: boolean;
+  decoderRecoveryAttempts: number;
+  decoderRecoveryAction: string;
+
   // Microphone state
   micState: MicState;
   micEnabled: boolean;
@@ -185,6 +190,8 @@ interface ClientOptions {
   microphoneDeviceId?: string;
   /** Mouse sensitivity multiplier (1.0 = default) */
   mouseSensitivity?: number;
+  /** Software acceleration strength percentage (1-150) */
+  mouseAcceleration?: number;
   onLog: (line: string) => void;
   onStats?: (stats: StreamDiagnostics) => void;
   onEscHoldProgress?: (visible: boolean, progress: number) => void;
@@ -458,6 +465,16 @@ export class GfnWebRtcClient {
   private static readonly DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS = 300;
   private static readonly RELIABLE_MOUSE_BACKPRESSURE_BYTES = 64 * 1024;
   private static readonly BACKPRESSURE_LOG_INTERVAL_MS = 2000;
+  private static readonly VIDEO_BASE_JITTER_TARGET_MS = 12;
+  private static readonly AUDIO_BASE_JITTER_TARGET_MS = 20;
+  private static readonly VIDEO_PRESSURE_JITTER_TARGET_MS = 30;
+  private static readonly AUDIO_PRESSURE_JITTER_TARGET_MS = 32;
+  private static readonly DECODER_PRESSURE_CONSECUTIVE_POLLS = 3;
+  private static readonly DECODER_STABLE_CONSECUTIVE_POLLS = 6;
+  private static readonly DECODER_RECOVERY_COOLDOWN_MS = 1500;
+  private static readonly DECODER_KEYFRAME_COOLDOWN_MS = 1200;
+  private static readonly DECODER_BITRATE_STEP_FACTOR = 0.85;
+  private static readonly DECODER_MIN_RECOVERY_BITRATE_KBPS = 4000;
 
   // Gamepad bitmap: tracks which gamepads are connected, matching official client's this.nu field.
   // Bit i (0-3) = gamepad i is connected. Sent in every gamepad packet at offset 8.
@@ -500,12 +517,28 @@ export class GfnWebRtcClient {
   private pendingMouseTimestampUs: bigint | null = null;
   private mouseDeltaFilter = new MouseDeltaFilter();
   private mouseSensitivity = 1;
+  private mouseAccelerationPercent = 1;
 
   private partialReliableThresholdMs = GfnWebRtcClient.DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS;
   private inputQueuePeakBufferedBytesWindow = 0;
   private inputQueueMaxSchedulingDelayMsWindow = 0;
   private inputQueuePressureLoggedAtMs = 0;
   private inputQueueDropCount = 0;
+
+  // Decoder pressure detection + recovery state.
+  private decoderPressureActive = false;
+  private decoderPressureConsecutivePolls = 0;
+  private decoderStableConsecutivePolls = 0;
+  private decoderRecoveryAttemptCount = 0;
+  private lastDecoderRecoveryAtMs = 0;
+  private lastDecoderKeyframeRequestAtMs = 0;
+  private negotiatedMaxBitrateKbps = 0;
+  private currentBitrateCeilingKbps = 0;
+  private receiverLatencyTargets = {
+    video: GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS,
+    audio: GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS,
+  };
+  private activeReceivers: Array<{ receiver: RTCRtpReceiver; kind: "audio" | "video" }> = [];
 
   // Microphone
   private micManager: MicrophoneManager | null = null;
@@ -546,6 +579,9 @@ export class GfnWebRtcClient {
     inputQueueMaxSchedulingDelayMs: 0,
     gpuType: "",
     serverRegion: "",
+    decoderPressureActive: false,
+    decoderRecoveryAttempts: 0,
+    decoderRecoveryAction: "none",
     micState: "uninitialized",
     micEnabled: false,
   };
@@ -555,6 +591,7 @@ export class GfnWebRtcClient {
     options.audioElement.srcObject = this.audioStream;
     options.audioElement.muted = true;
     this.mouseSensitivity = options.mouseSensitivity ?? 1;
+    this.mouseAccelerationPercent = Math.max(1, Math.min(150, Math.round(options.mouseAcceleration ?? 1)));
 
     // Configure video element for lowest latency playback
     this.configureVideoElementForLowLatency(options.videoElement);
@@ -610,6 +647,61 @@ export class GfnWebRtcClient {
     this.log(`Mouse sensitivity set to ${this.mouseSensitivity}`);
   }
 
+  /** Update software mouse acceleration strength at runtime (1-150%). */
+  public setMouseAccelerationPercent(value: number): void {
+    const v = Number.isFinite(value) ? value : 1;
+    this.mouseAccelerationPercent = Math.max(1, Math.min(150, Math.round(v)));
+    this.log(`Mouse acceleration set to ${this.mouseAccelerationPercent}%`);
+  }
+
+  /**
+   * Replace the b=AS bandwidth line in video sections of an SDP string.
+   * Unlike mungeAnswerSdp, this is safe to call on an already-munged SDP
+   * because it replaces the existing line rather than injecting a new one.
+   */
+  private replaceVideoBitrateInSdp(sdp: string, maxBitrateKbps: number): string {
+    const lines = sdp.split("\r\n");
+    let inVideoSection = false;
+    let bitrateReplaced = false;
+    const result: string[] = [];
+    for (const line of lines) {
+      if (line.startsWith("m=")) {
+        inVideoSection = line.startsWith("m=video");
+        bitrateReplaced = false;
+      }
+      if (inVideoSection && !bitrateReplaced && line.startsWith("b=AS:")) {
+        result.push(`b=AS:${maxBitrateKbps}`);
+        bitrateReplaced = true;
+        continue;
+      }
+      result.push(line);
+    }
+    return result.join("\r\n");
+  }
+
+  /**
+   * Update the maximum receive bitrate ceiling mid-stream by replacing b=AS
+   * in the local SDP and re-applying it. Chrome/Electron honours this change
+   * without requiring a full ICE renegotiation.
+   */
+  public async setMaxBitrateKbps(kbps: number): Promise<void> {
+    if (!this.pc || !this.pc.localDescription) {
+      return;
+    }
+    const updatedSdp = this.replaceVideoBitrateInSdp(
+      this.pc.localDescription.sdp,
+      kbps,
+    );
+    try {
+      await this.pc.setLocalDescription(
+        new RTCSessionDescription({ type: this.pc.localDescription.type, sdp: updatedSdp }),
+      );
+      this.log(`Bitrate ceiling updated to ${kbps} kbps via local SDP`);
+    } catch (err) {
+      this.log(`setMaxBitrateKbps failed (non-fatal): ${String(err)}`);
+    }
+  }
+
   /**
    * Configure an RTCRtpReceiver for minimum jitter buffer delay.
    *
@@ -624,8 +716,14 @@ export class GfnWebRtcClient {
    *
    */
   private configureReceiverForLowLatency(receiver: RTCRtpReceiver, kind: string): void {
+    if (kind !== "video" && kind !== "audio") {
+      return;
+    }
+
+    this.registerReceiver(receiver, kind);
+
     try {
-      const targetMs = kind === "video" ? 12 : 20;
+      const targetMs = this.receiverLatencyTargets[kind];
       const rawReceiver = receiver as unknown as Record<string, unknown>;
 
       if ("jitterBufferTarget" in receiver) {
@@ -634,7 +732,7 @@ export class GfnWebRtcClient {
       }
 
       if ("playoutDelayHint" in receiver) {
-        const playoutDelaySeconds = kind === "video" ? 0.012 : 0.02;
+        const playoutDelaySeconds = targetMs / 1000;
         rawReceiver.playoutDelayHint = playoutDelaySeconds;
         this.log(`${kind} receiver: playoutDelayHint set to ${playoutDelaySeconds}s`);
       }
@@ -647,6 +745,38 @@ export class GfnWebRtcClient {
     }
   }
 
+  private registerReceiver(receiver: RTCRtpReceiver, kind: "audio" | "video"): void {
+    const alreadyRegistered = this.activeReceivers.some((entry) => entry.receiver === receiver);
+    if (!alreadyRegistered) {
+      this.activeReceivers.push({ receiver, kind });
+    }
+  }
+
+  private applyReceiverLatencyTargets(): void {
+    for (const entry of this.activeReceivers) {
+      this.configureReceiverForLowLatency(entry.receiver, entry.kind);
+    }
+  }
+
+  private setDecoderPressureMode(active: boolean): void {
+    if (this.decoderPressureActive === active) {
+      return;
+    }
+
+    this.decoderPressureActive = active;
+    this.diagnostics.decoderPressureActive = active;
+    this.receiverLatencyTargets.video = active
+      ? GfnWebRtcClient.VIDEO_PRESSURE_JITTER_TARGET_MS
+      : GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS;
+    this.receiverLatencyTargets.audio = active
+      ? GfnWebRtcClient.AUDIO_PRESSURE_JITTER_TARGET_MS
+      : GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS;
+    this.log(
+      `Decoder pressure mode ${active ? "enabled" : "cleared"}; receiver targets video=${this.receiverLatencyTargets.video}ms audio=${this.receiverLatencyTargets.audio}ms`,
+    );
+    this.applyReceiverLatencyTargets();
+  }
+
   private log(message: string): void {
     this.options.onLog(message);
   }
@@ -657,12 +787,30 @@ export class GfnWebRtcClient {
     }
   }
 
+  private resetDecoderRecoveryState(): void {
+    this.decoderPressureActive = false;
+    this.decoderPressureConsecutivePolls = 0;
+    this.decoderStableConsecutivePolls = 0;
+    this.decoderRecoveryAttemptCount = 0;
+    this.lastDecoderRecoveryAtMs = 0;
+    this.lastDecoderKeyframeRequestAtMs = 0;
+    this.negotiatedMaxBitrateKbps = 0;
+    this.currentBitrateCeilingKbps = 0;
+    this.receiverLatencyTargets.video = GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS;
+    this.receiverLatencyTargets.audio = GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS;
+    this.activeReceivers = [];
+    this.diagnostics.decoderPressureActive = false;
+    this.diagnostics.decoderRecoveryAttempts = 0;
+    this.diagnostics.decoderRecoveryAction = "none";
+  }
+
   private resetDiagnostics(): void {
     this.lastStatsSample = null;
     this.currentCodec = "";
     this.currentResolution = "";
     this.isHdr = false;
     this.videoDecodeStallWarningSent = false;
+    this.resetDecoderRecoveryState();
     this.diagnostics = {
       connectionState: this.pc?.connectionState ?? "closed",
       inputReady: false,
@@ -690,6 +838,9 @@ export class GfnWebRtcClient {
       inputQueueMaxSchedulingDelayMs: 0,
       gpuType: this.gpuType,
       serverRegion: this.serverRegion,
+      decoderPressureActive: false,
+      decoderRecoveryAttempts: 0,
+      decoderRecoveryAction: "none",
       micState: this.micState,
       micEnabled: this.micManager?.isEnabled() ?? false,
     };
@@ -767,6 +918,210 @@ export class GfnWebRtcClient {
     }
   }
 
+  private shouldTreatAsDecoderPressure(params: {
+    framesReceived: number;
+    framesDecoded: number;
+    framesDropped: number;
+    decodeTimeMs: number;
+    decodeFps: number;
+    prevSample: {
+      framesReceived: number;
+      framesDecoded: number;
+      framesDropped: number;
+    } | null;
+  }): { active: boolean; reason: string; backlogFrames: number; dropRatePercent: number } {
+    const backlogFrames = Math.max(0, params.framesReceived - params.framesDecoded);
+    const dropRatePercent = params.framesReceived > 0
+      ? (params.framesDropped / params.framesReceived) * 100
+      : 0;
+    const severeStall = params.framesReceived > 120 && params.framesDecoded === 0;
+    const backlogHigh = backlogFrames >= 45;
+    const dropRateHigh = dropRatePercent >= 6;
+
+    let dropBurst = false;
+    if (params.prevSample) {
+      const decodedDelta = params.framesDecoded - params.prevSample.framesDecoded;
+      const droppedDelta = params.framesDropped - params.prevSample.framesDropped;
+      dropBurst = droppedDelta >= 8 && decodedDelta <= 4;
+    }
+
+    let decodeSaturated = false;
+    if (params.decodeFps > 0 && params.decodeTimeMs > 0) {
+      const frameBudgetMs = 1000 / params.decodeFps;
+      decodeSaturated = params.decodeTimeMs >= frameBudgetMs * 0.82;
+    }
+
+    if (severeStall) {
+      return {
+        active: true,
+        reason: "severe_stall",
+        backlogFrames,
+        dropRatePercent,
+      };
+    }
+
+    const active = (backlogHigh && (dropRateHigh || dropBurst || decodeSaturated))
+      || (dropBurst && decodeSaturated);
+    const reason = active
+      ? (backlogHigh
+        ? "backlog_and_drop"
+        : "decode_saturated")
+      : "stable";
+
+    return {
+      active,
+      reason,
+      backlogFrames,
+      dropRatePercent,
+    };
+  }
+
+  private async requestDecoderKeyframe(backlogFrames: number, reason: string): Promise<boolean> {
+    const now = performance.now();
+    if (now - this.lastDecoderKeyframeRequestAtMs < GfnWebRtcClient.DECODER_KEYFRAME_COOLDOWN_MS) {
+      return false;
+    }
+
+    let requestedViaSender = false;
+    if (this.pc) {
+      for (const sender of this.pc.getSenders()) {
+        if (sender.track?.kind !== "video") {
+          continue;
+        }
+        const senderWithKeyframe = sender as RTCRtpSender & {
+          requestKeyFrame?: () => Promise<void>;
+        };
+        if (typeof senderWithKeyframe.requestKeyFrame !== "function") {
+          continue;
+        }
+        try {
+          await senderWithKeyframe.requestKeyFrame();
+          requestedViaSender = true;
+        } catch (error) {
+          this.log(`requestKeyFrame failed on sender (non-fatal): ${String(error)}`);
+        }
+      }
+    }
+
+    if (!requestedViaSender && this.controlChannel?.readyState === "open") {
+      try {
+        this.controlChannel.send(JSON.stringify({
+          type: "request_keyframe",
+          reason,
+          backlogFrames,
+          attempt: this.decoderRecoveryAttemptCount + 1,
+        }));
+        requestedViaSender = true;
+        this.diagnostics.decoderRecoveryAction = "control_channel_keyframe";
+      } catch (error) {
+        this.log(`control_channel keyframe request failed (non-fatal): ${String(error)}`);
+      }
+    }
+
+    if (!requestedViaSender) {
+      try {
+        await window.openNow.requestKeyframe({
+          reason,
+          backlogFrames,
+          attempt: this.decoderRecoveryAttemptCount + 1,
+        });
+        requestedViaSender = true;
+        this.diagnostics.decoderRecoveryAction = "signaling_keyframe";
+      } catch (error) {
+        this.log(`signaling keyframe request failed (non-fatal): ${String(error)}`);
+      }
+    }
+
+    if (requestedViaSender) {
+      this.lastDecoderKeyframeRequestAtMs = now;
+      if (this.diagnostics.decoderRecoveryAction === "none") {
+        this.diagnostics.decoderRecoveryAction = "sender_keyframe";
+      }
+      this.log(
+        `Decoder recovery: keyframe requested (reason=${reason}, backlog=${backlogFrames}, attempt=${this.decoderRecoveryAttemptCount + 1})`,
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  private async reduceBitrateForDecoderRecovery(): Promise<boolean> {
+    if (!this.pc || !this.pc.localDescription) {
+      return false;
+    }
+
+    const current = this.currentBitrateCeilingKbps > 0
+      ? this.currentBitrateCeilingKbps
+      : this.negotiatedMaxBitrateKbps;
+    if (current <= GfnWebRtcClient.DECODER_MIN_RECOVERY_BITRATE_KBPS) {
+      return false;
+    }
+
+    const next = Math.max(
+      GfnWebRtcClient.DECODER_MIN_RECOVERY_BITRATE_KBPS,
+      Math.floor(current * GfnWebRtcClient.DECODER_BITRATE_STEP_FACTOR),
+    );
+    if (next >= current) {
+      return false;
+    }
+
+    await this.setMaxBitrateKbps(next);
+    this.currentBitrateCeilingKbps = next;
+    this.diagnostics.decoderRecoveryAction = "bitrate_step_down";
+    this.log(`Decoder recovery: bitrate ceiling stepped down ${current} -> ${next} kbps`);
+    return true;
+  }
+
+  private async maybeRecoverFromDecoderPressure(signal: {
+    active: boolean;
+    reason: string;
+    backlogFrames: number;
+    dropRatePercent: number;
+  }): Promise<void> {
+    if (!signal.active) {
+      this.decoderPressureConsecutivePolls = 0;
+      this.decoderStableConsecutivePolls++;
+      if (this.decoderStableConsecutivePolls >= GfnWebRtcClient.DECODER_STABLE_CONSECUTIVE_POLLS) {
+        this.decoderRecoveryAttemptCount = 0;
+        this.diagnostics.decoderRecoveryAttempts = 0;
+        this.diagnostics.decoderRecoveryAction = "none";
+        this.setDecoderPressureMode(false);
+      }
+      return;
+    }
+
+    this.decoderStableConsecutivePolls = 0;
+    this.decoderPressureConsecutivePolls++;
+
+    if (this.decoderPressureConsecutivePolls < GfnWebRtcClient.DECODER_PRESSURE_CONSECUTIVE_POLLS) {
+      return;
+    }
+
+    this.setDecoderPressureMode(true);
+
+    const now = performance.now();
+    if (now - this.lastDecoderRecoveryAtMs < GfnWebRtcClient.DECODER_RECOVERY_COOLDOWN_MS) {
+      return;
+    }
+
+    const keyframeRequested = await this.requestDecoderKeyframe(signal.backlogFrames, signal.reason);
+
+    let bitrateReduced = false;
+    if (!keyframeRequested || this.decoderRecoveryAttemptCount >= 1) {
+      bitrateReduced = await this.reduceBitrateForDecoderRecovery();
+    }
+
+    if (keyframeRequested || bitrateReduced) {
+      this.decoderRecoveryAttemptCount++;
+      this.diagnostics.decoderRecoveryAttempts = this.decoderRecoveryAttemptCount;
+      this.lastDecoderRecoveryAtMs = now;
+      this.log(
+        `Decoder pressure detected: reason=${signal.reason}, backlog=${signal.backlogFrames}, dropRate=${signal.dropRatePercent.toFixed(1)}%, recoveryAttempt=${this.decoderRecoveryAttemptCount}`,
+      );
+    }
+  }
+
   private async collectStats(): Promise<void> {
     if (!this.pc) {
       return;
@@ -806,19 +1161,20 @@ export class GfnWebRtcClient {
       const framesDropped = Number(inboundVideo.framesDropped ?? 0);
       const packetsReceived = Number(inboundVideo.packetsReceived ?? 0);
       const packetsLost = Number(inboundVideo.packetsLost ?? 0);
+      const prevSample = this.lastStatsSample;
 
       // Calculate bitrate
-      if (this.lastStatsSample) {
-        const bytesDelta = bytes - this.lastStatsSample.bytesReceived;
-        const timeDeltaMs = now - this.lastStatsSample.atMs;
+      if (prevSample) {
+        const bytesDelta = bytes - prevSample.bytesReceived;
+        const timeDeltaMs = now - prevSample.atMs;
         if (bytesDelta >= 0 && timeDeltaMs > 0) {
           const kbps = (bytesDelta * 8) / (timeDeltaMs / 1000) / 1000;
           this.diagnostics.bitrateKbps = Math.max(0, Math.round(kbps));
         }
 
         // Calculate packet loss percentage over the interval
-        const packetsDelta = packetsReceived - this.lastStatsSample.packetsReceived;
-        const lostDelta = packetsLost - this.lastStatsSample.packetsLost;
+        const packetsDelta = packetsReceived - prevSample.packetsReceived;
+        const lostDelta = packetsLost - prevSample.packetsLost;
         if (packetsDelta > 0) {
           const totalPackets = packetsDelta + lostDelta;
           this.diagnostics.packetLossPercent = totalPackets > 0
@@ -927,6 +1283,16 @@ export class GfnWebRtcClient {
         const avgFrameDelay = totalInterFrameDelay / (framesDecodedForTiming - 1);
         this.diagnostics.renderTimeMs = Math.round(avgFrameDelay * 1000 * 10) / 10;
       }
+
+      const pressureSignal = this.shouldTreatAsDecoderPressure({
+        framesReceived,
+        framesDecoded,
+        framesDropped,
+        decodeTimeMs: this.diagnostics.decodeTimeMs,
+        decodeFps: this.diagnostics.decodeFps,
+        prevSample,
+      });
+      await this.maybeRecoverFromDecoderPressure(pressureSignal);
     }
 
     // RTT from active candidate pair
@@ -1824,9 +2190,21 @@ export class GfnWebRtcClient {
         return;
       }
 
-      // Apply user-configured mouse sensitivity multiplier before queuing
-      this.pendingMouseDx += Math.round(this.mouseDeltaFilter.getX() * this.mouseSensitivity);
-      this.pendingMouseDy += Math.round(this.mouseDeltaFilter.getY() * this.mouseSensitivity);
+      // Apply user-configured sensitivity, then optional software acceleration.
+      let adjustedDx = this.mouseDeltaFilter.getX() * this.mouseSensitivity;
+      let adjustedDy = this.mouseDeltaFilter.getY() * this.mouseSensitivity;
+
+      if (this.mouseAccelerationPercent > 1) {
+        const speed = Math.hypot(adjustedDx, adjustedDy);
+        const strength = (this.mouseAccelerationPercent - 1) / 149;
+        // Gentle curve: low-speed precision, high-speed turn boost (caps at +60% at 150%).
+        const accelFactor = 1 + Math.min(0.6 * strength, (speed / 50) * strength);
+        adjustedDx *= accelFactor;
+        adjustedDy *= accelFactor;
+      }
+
+      this.pendingMouseDx += Math.round(adjustedDx);
+      this.pendingMouseDy += Math.round(adjustedDy);
       this.pendingMouseTimestampUs = timestampUs(eventTimestampMs);
     };
 
@@ -1963,6 +2341,11 @@ export class GfnWebRtcClient {
 
     const onMouseUp = (event: MouseEvent) => {
       if (!this.inputReady) {
+        return;
+      }
+      // When pointer lock is not active, only forward events that originate from
+      // the video element itself to avoid intercepting overlay button clicks.
+      if (!isPointerLockActive() && event.target !== videoElement) {
         return;
       }
       event.preventDefault();
@@ -2127,9 +2510,9 @@ export class GfnWebRtcClient {
     } else {
       window.addEventListener("mousemove", onMouseMove);
     }
-    videoElement.addEventListener("mousedown", onMouseDown);
-    videoElement.addEventListener("mouseup", onMouseUp);
-    videoElement.addEventListener("wheel", onWheel, { passive: false });
+    pointerLockTarget.addEventListener("mousedown", onMouseDown);
+    pointerLockTarget.addEventListener("mouseup", onMouseUp);
+    pointerLockTarget.addEventListener("wheel", onWheel, { passive: false });
     videoElement.addEventListener("click", onClick);
     document.addEventListener("pointerlockchange", onPointerLockChange);
     document.addEventListener("fullscreenchange", onFullscreenChange);
@@ -2150,9 +2533,9 @@ export class GfnWebRtcClient {
     } else {
       this.inputCleanup.push(() => window.removeEventListener("mousemove", onMouseMove));
     }
-    this.inputCleanup.push(() => videoElement.removeEventListener("mousedown", onMouseDown));
-    this.inputCleanup.push(() => videoElement.removeEventListener("mouseup", onMouseUp));
-    this.inputCleanup.push(() => videoElement.removeEventListener("wheel", onWheel));
+    this.inputCleanup.push(() => pointerLockTarget.removeEventListener("mousedown", onMouseDown));
+    this.inputCleanup.push(() => pointerLockTarget.removeEventListener("mouseup", onMouseUp));
+    this.inputCleanup.push(() => pointerLockTarget.removeEventListener("wheel", onWheel));
     this.inputCleanup.push(() => videoElement.removeEventListener("click", onClick));
     this.inputCleanup.push(() => document.removeEventListener("pointerlockchange", onPointerLockChange));
     this.inputCleanup.push(() => document.removeEventListener("fullscreenchange", onFullscreenChange));
@@ -2396,6 +2779,11 @@ export class GfnWebRtcClient {
 
     const negotiatedPartialReliable = parsePartialReliableThresholdMs(offerSdp);
     this.partialReliableThresholdMs = negotiatedPartialReliable ?? GfnWebRtcClient.DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS;
+    this.negotiatedMaxBitrateKbps = Math.max(
+      GfnWebRtcClient.DECODER_MIN_RECOVERY_BITRATE_KBPS,
+      Math.floor(settings.maxBitrateKbps),
+    );
+    this.currentBitrateCeilingKbps = this.negotiatedMaxBitrateKbps;
     this.log(
       `Input channel policy: partial reliable threshold=${this.partialReliableThresholdMs}ms${negotiatedPartialReliable === null ? " (fallback)" : ""}`,
     );
@@ -2833,6 +3221,14 @@ export class GfnWebRtcClient {
    */
   getMicrophoneState(): MicState {
     return this.micState;
+  }
+
+  /**
+   * Return the live audio track from the microphone stream, or null if
+   * the mic has not been started or has been stopped.
+   */
+  getMicTrack(): MediaStreamTrack | null {
+    return this.micManager?.getTrack() ?? null;
   }
 
   /**

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1517,6 +1517,16 @@ button.game-card-store-chip.active:hover {
   min-width: 185px;
   text-align: right;
 }
+.settings-shortcut-input--static {
+  background: var(--bg-e);
+  color: var(--ink);
+  border-color: var(--panel-border);
+  cursor: default;
+}
+.settings-shortcut-input--static:focus {
+  border-color: var(--panel-border);
+  box-shadow: none;
+}
 
 /* Chip row (presets) */
 .settings-chip-row {
@@ -2448,6 +2458,28 @@ button.game-card-store-chip.active:hover {
   letter-spacing: 0.03em;
 }
 
+.sv-rec {
+  position: fixed; left: 14px;
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 7px 11px;
+  background: rgba(10, 10, 12, 0.92);
+  border: 1px solid var(--panel-border); border-radius: var(--r-md);
+  z-index: 1001;
+}
+.sv-rec-dot {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--error);
+  animation: rec-pulse 1.2s ease-in-out infinite;
+}
+.sv-rec-label {
+  font-size: 0.72rem; font-weight: 700; color: var(--error);
+  letter-spacing: 0.06em;
+}
+@keyframes rec-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+}
+
 .sv-mic {
   position: fixed; top: 14px; left: 14px;
   display: inline-flex; align-items: center; justify-content: center;
@@ -2999,6 +3031,483 @@ button.game-card-store-chip.active:hover {
   width: 100%; margin-top: 3px; padding-top: 5px;
   border-top: 1px solid var(--panel-border);
   font-size: 0.65rem; color: var(--ink-muted); text-align: center;
+}
+
+/* Sidebar overlay for settings */
+.sidebar {
+  position: fixed;
+  top: 14px;
+  left: 14px;
+  z-index: 1002;
+  width: min(340px, 92vw);
+  padding: 14px;
+  background: rgba(10, 10, 12, 0.96);
+  border-radius: var(--r-xl);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px);
+}
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.sidebar-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ink);
+}
+.sidebar-close {
+  background: transparent;
+  border: none;
+  color: var(--ink-muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  transition: background var(--t-normal), color var(--t-normal);
+}
+.sidebar-close:hover {
+  background: var(--card-hover);
+  color: var(--ink);
+}
+.sidebar-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.sidebar-body > * {
+  min-width: 0;
+}
+.sidebar-stat-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.sidebar-stat-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.sidebar-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+.sidebar-tab {
+  border-radius: 8px;
+  border: 1px solid var(--panel-border);
+  background: var(--card);
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 7px 10px;
+  cursor: pointer;
+  transition: border-color var(--t-fast), background var(--t-fast), color var(--t-fast);
+}
+.sidebar-tab:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--panel-border));
+  color: var(--ink);
+}
+.sidebar-tab--active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-surface);
+}
+.sidebar-separator {
+  height: 1px;
+  background: var(--panel-border);
+  width: 100%;
+}
+.sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.sidebar-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-muted);
+}
+.sidebar-section-sub {
+  font-size: 0.74rem;
+  letter-spacing: normal;
+  overflow-wrap: anywhere;
+}
+.sidebar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.sidebar-row--column {
+  flex-direction: column;
+  align-items: stretch;
+}
+.sidebar-row--aligned {
+  justify-content: space-between;
+}
+.sidebar-row-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.sidebar-label {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--ink-muted);
+}
+.sidebar-hint {
+  font-size: 0.72rem;
+  color: var(--ink-muted);
+  overflow-wrap: anywhere;
+}
+.sidebar-hint--error {
+  color: #fda4af;
+}
+.sidebar-hint--codec {
+  font-family: monospace;
+  font-size: 0.67rem;
+  color: var(--ink-muted);
+  word-break: break-all;
+  display: block;
+}
+.sidebar-shortcut-input {
+  width: 100%;
+  min-width: 0;
+}
+.sidebar-button {
+  border-radius: 4px;
+  border: 1px solid var(--panel-border);
+  background: var(--card);
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: transform var(--t-normal), background var(--t-normal);
+}
+.sidebar-button:hover {
+  transform: translateY(-1px);
+  background: var(--card-hover);
+}
+.sidebar-button:active {
+  transform: translateY(0);
+}
+.sidebar-screenshot-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.sidebar-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.sidebar-chip {
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--card);
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: transform var(--t-normal), background var(--t-normal), border-color var(--t-normal), color var(--t-normal);
+}
+.sidebar-chip:hover {
+  transform: translateY(-1px);
+  background: var(--card-hover);
+}
+.sidebar-chip--active {
+  border-color: var(--accent);
+  background: rgba(119, 187, 255, 0.12);
+  color: var(--accent);
+}
+.sidebar-gallery-row {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) 24px;
+  gap: 8px;
+  align-items: center;
+}
+.sidebar-gallery-arrow {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: 1px solid var(--panel-border);
+  background: var(--card);
+  color: var(--ink-soft);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background var(--t-fast), border-color var(--t-fast), color var(--t-fast);
+}
+.sidebar-gallery-arrow:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--card-hover);
+}
+.sidebar-gallery-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 2px 2px 6px;
+  scroll-behavior: smooth;
+}
+.sidebar-gallery-item {
+  width: 88px;
+  height: 50px;
+  flex: 0 0 auto;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--panel-border);
+  background: #08090b;
+  padding: 0;
+  cursor: pointer;
+  transition: transform var(--t-fast), border-color var(--t-fast);
+}
+.sidebar-gallery-item:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent);
+}
+.sidebar-gallery-item img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.sidebar-gallery-item-delete {
+  flex: 0 0 auto;
+  display: flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px;
+  border-radius: 4px;
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--ink-dim);
+  cursor: pointer;
+  transition: color var(--t-fast), border-color var(--t-fast), background var(--t-fast);
+}
+.sidebar-gallery-item-delete:hover {
+  color: var(--error);
+  border-color: rgba(255, 80, 80, 0.35);
+  background: rgba(255, 80, 80, 0.08);
+}
+.sidebar-rec-strip {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 2px 2px 6px;
+  scroll-behavior: smooth;
+}
+.sidebar-rec-card {
+  flex: 0 0 auto;
+  width: 110px;
+  display: flex;
+  flex-direction: column;
+  border-radius: 6px;
+  border: 1px solid var(--panel-border);
+  background: #08090b;
+  overflow: hidden;
+  transition: border-color var(--t-fast);
+}
+.sidebar-rec-card:hover {
+  border-color: rgba(255,255,255,0.12);
+}
+.sidebar-rec-card-thumb {
+  /* keep the slot a fixed size so the carousel doesn’t jump around; the
+     thumbnail itself will preserve its own proportions below */
+  width: 110px;
+  height: 62px;
+  display: block;
+
+  /* `contain` ensures <img> contents aren't squashed – wide/portrait
+     recordings will letterbox instead of being warped, which makes them
+     look "correct" even when the source aspect ratio differs from 16:9. */
+  object-fit: contain;
+  background: #08090b;
+}
+.sidebar-rec-card-thumb--placeholder {
+  width: 110px;
+  height: 62px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-dim);
+}
+.sidebar-rec-card-meta {
+  padding: 5px 6px 3px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 auto;
+}
+.sidebar-rec-card-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar-rec-card-detail {
+  font-size: 0.65rem;
+  color: var(--ink-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar-rec-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 6px 5px;
+}
+.sidebar-rec-card-action {
+  flex: 1 1 0;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--ink-dim);
+  cursor: pointer;
+  transition: color var(--t-fast), border-color var(--t-fast), background var(--t-fast);
+}
+.sidebar-rec-card-action:hover {
+  color: var(--ink);
+  border-color: rgba(255,255,255,0.15);
+  background: rgba(255,255,255,0.06);
+}
+.sidebar-rec-card-action--danger:hover {
+  color: var(--error);
+  border-color: rgba(255, 80, 80, 0.35);
+  background: rgba(255, 80, 80, 0.08);
+}
+.sv-sidebar {
+  width: min(360px, 92vw);
+}
+.sv-sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 3, 5, 0.65);
+  z-index: 1000;
+  cursor: pointer;
+}
+.mic-meter-canvas {
+  display: block;
+  width: 100%;
+  height: 14px;
+  border-radius: 3px;
+}
+
+.sv-shot-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+}
+.sv-shot-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  border: none;
+  background: rgba(5, 6, 8, 0.72);
+  backdrop-filter: blur(8px);
+}
+.sv-shot-modal-card {
+  position: relative;
+  z-index: 1;
+  width: min(980px, calc(100vw - 32px));
+  max-height: calc(100vh - 36px);
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--panel-border);
+  background: rgba(10, 10, 12, 0.96);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.sv-shot-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.sv-shot-modal-head h4 {
+  margin: 0;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-soft);
+}
+.sv-shot-modal-close {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  background: var(--card);
+  color: var(--ink-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.sv-shot-modal-close:hover {
+  color: var(--ink);
+  border-color: var(--panel-border-solid);
+}
+.sv-shot-modal-image {
+  width: 100%;
+  max-height: calc(100vh - 180px);
+  object-fit: contain;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border);
+  background: #050607;
+}
+.sv-shot-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.sv-shot-modal-btn {
+  border: 1px solid var(--panel-border);
+  background: var(--card);
+  color: var(--ink);
+  border-radius: 8px;
+  padding: 7px 10px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+.sv-shot-modal-btn:hover {
+  border-color: var(--accent);
+}
+.sv-shot-modal-btn--danger:hover {
+  border-color: rgba(248, 113, 113, 0.55);
+  color: #ffd4d4;
 }
 
 

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -43,11 +43,14 @@ export interface Settings {
   region: string;
   clipboardPaste: boolean;
   mouseSensitivity: number;
+  mouseAcceleration: number;
   shortcutToggleStats: string;
   shortcutTogglePointerLock: string;
   shortcutStopStream: string;
   shortcutToggleAntiAfk: string;
   shortcutToggleMicrophone: string;
+  shortcutScreenshot: string;
+  shortcutToggleRecording: string;
   microphoneMode: MicrophoneMode;
   microphoneDeviceId: string;
   hideStreamButtons: boolean;
@@ -305,6 +308,12 @@ export interface SendAnswerRequest {
   nvstSdp?: string;
 }
 
+export interface KeyframeRequest {
+  reason: string;
+  backlogFrames: number;
+  attempt: number;
+}
+
 export type MainToRendererSignalingEvent =
   | { type: "connected" }
   | { type: "disconnected"; reason: string }
@@ -340,6 +349,7 @@ export interface OpenNowApi {
   disconnectSignaling(): Promise<void>;
   sendAnswer(input: SendAnswerRequest): Promise<void>;
   sendIceCandidate(input: IceCandidatePayload): Promise<void>;
+  requestKeyframe(input: KeyframeRequest): Promise<void>;
   onSignalingEvent(listener: (event: MainToRendererSignalingEvent) => void): () => void;
   /** Listen for F11 fullscreen toggle from main process */
   onToggleFullscreen(listener: () => void): () => void;
@@ -352,4 +362,106 @@ export interface OpenNowApi {
   exportLogs(format?: "text" | "json"): Promise<string>;
   /** Ping all regions and return latency results */
   pingRegions(regions: StreamRegion[]): Promise<PingResult[]>;
+
+  /** Persist a PNG screenshot from a renderer-generated data URL */
+  saveScreenshot(input: ScreenshotSaveRequest): Promise<ScreenshotEntry>;
+
+  /** List recent screenshots from the persistent screenshot directory */
+  listScreenshots(): Promise<ScreenshotEntry[]>;
+
+  /** Delete a screenshot from the persistent screenshot directory */
+  deleteScreenshot(input: ScreenshotDeleteRequest): Promise<void>;
+
+  /** Export a screenshot to a user-selected path */
+  saveScreenshotAs(input: ScreenshotSaveAsRequest): Promise<ScreenshotSaveAsResult>;
+
+  /** Listen for screenshot hotkey events from the main process (F11) */
+  onTriggerScreenshot(listener: () => void): () => void;
+
+  /** Begin a new recording session; returns a recordingId to use for subsequent calls */
+  beginRecording(input: RecordingBeginRequest): Promise<RecordingBeginResult>;
+
+  /** Stream a chunk of recorded video data to the main process */
+  sendRecordingChunk(input: RecordingChunkRequest): Promise<void>;
+
+  /** Finalise a recording; saves the video and optional thumbnail to disk */
+  finishRecording(input: RecordingFinishRequest): Promise<RecordingEntry>;
+
+  /** Abort an in-progress recording and remove the temporary file */
+  abortRecording(input: RecordingAbortRequest): Promise<void>;
+
+  /** List all saved recordings from the recordings directory */
+  listRecordings(): Promise<RecordingEntry[]>;
+
+  /** Delete a saved recording (and its thumbnail if present) */
+  deleteRecording(input: RecordingDeleteRequest): Promise<void>;
+
+  /** Reveal a saved recording in the system file manager */
+  showRecordingInFolder(id: string): Promise<void>;
+}
+
+export interface ScreenshotSaveRequest {
+  dataUrl: string;
+  gameTitle?: string;
+}
+
+export interface ScreenshotDeleteRequest {
+  id: string;
+}
+
+export interface ScreenshotSaveAsRequest {
+  id: string;
+}
+
+export interface ScreenshotSaveAsResult {
+  saved: boolean;
+  filePath?: string;
+}
+
+export interface ScreenshotEntry {
+  id: string;
+  fileName: string;
+  filePath: string;
+  createdAtMs: number;
+  sizeBytes: number;
+  dataUrl: string;
+}
+
+export interface RecordingEntry {
+  id: string;
+  fileName: string;
+  filePath: string;
+  createdAtMs: number;
+  sizeBytes: number;
+  durationMs: number;
+  gameTitle?: string;
+  thumbnailDataUrl?: string;
+}
+
+export interface RecordingBeginRequest {
+  mimeType: string;
+}
+
+export interface RecordingBeginResult {
+  recordingId: string;
+}
+
+export interface RecordingChunkRequest {
+  recordingId: string;
+  chunk: ArrayBuffer;
+}
+
+export interface RecordingFinishRequest {
+  recordingId: string;
+  durationMs: number;
+  gameTitle?: string;
+  thumbnailDataUrl?: string;
+}
+
+export interface RecordingAbortRequest {
+  recordingId: string;
+}
+
+export interface RecordingDeleteRequest {
+  id: string;
 }

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -20,6 +20,7 @@ export const IPC_CHANNELS = {
   DISCONNECT_SIGNALING: "gfn:disconnect-signaling",
   SEND_ANSWER: "gfn:send-answer",
   SEND_ICE_CANDIDATE: "gfn:send-ice-candidate",
+  REQUEST_KEYFRAME: "gfn:request-keyframe",
   SIGNALING_EVENT: "gfn:signaling-event",
   TOGGLE_FULLSCREEN: "window:toggle-fullscreen",
   TOGGLE_POINTER_LOCK: "window:toggle-pointer-lock",
@@ -28,6 +29,17 @@ export const IPC_CHANNELS = {
   SETTINGS_RESET: "settings:reset",
   LOGS_EXPORT: "logs:export",
   LOGS_GET_RENDERER: "logs:get-renderer",
+  SCREENSHOT_SAVE: "screenshot:save",
+  SCREENSHOT_LIST: "screenshot:list",
+  SCREENSHOT_DELETE: "screenshot:delete",
+  SCREENSHOT_SAVE_AS: "screenshot:save-as",
+  RECORDING_BEGIN: "recording:begin",
+  RECORDING_CHUNK: "recording:chunk",
+  RECORDING_FINISH: "recording:finish",
+  RECORDING_ABORT: "recording:abort",
+  RECORDING_LIST: "recording:list",
+  RECORDING_DELETE: "recording:delete",
+  RECORDING_SHOW_IN_FOLDER: "recording:showInFolder",
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];


### PR DESCRIPTION
## Problem

When a controller was connected and in use during a stream, mouse and keyboard input would be locked out (suppressed). Similarly, controller input would be blocked when mouse/keyboard was active. This made it impossible to use multiple input methods simultaneously.

## Root Cause

The `GfnWebRtcClient` had an exclusive `activeInputMode` property that toggled between `"mkb"` (mouse+keyboard) and `"gamepad"` modes. When mode switched to `"gamepad"`, all keyboard, mouse movement, mouse button, and mouse wheel events were silently dropped. A 3-second lockout (`GAMEPAD_MODE_LOCKOUT_MS`) prevented switching back to `"mkb"` even after putting down the controller.

## Solution

Remove the exclusive input mode switching system entirely and allow all input types to operate concurrently:

- **Removed** `activeInputMode` property and `GAMEPAD_MODE_LOCKOUT_MS` constant
- **Removed** `ensureKeyboardInputMode()` method
- **Removed** input mode checks from `onKeyDown`, `onKeyUp`, `onMouseDown`, `onMouseUp`, `onWheel`, `queueMouseMovement`, and the mouse flush timer
- **Modified** gamepad keepalive to send continuously while a controller is connected (previously only sent in `"gamepad"` mode)

## Result

All input methods — controller, mouse, and keyboard — now work simultaneously during active streaming sessions.