### PR TITLE
perf(stream): Adaptive polling, diagnostics optimization, and lag classification

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import {
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
 import { useControllerNavigation } from "./controllerNavigation";
 import { usePlaytime } from "./utils/usePlaytime";
+import { createStreamDiagnosticsStore } from "./utils/streamDiagnosticsStore";
 
 // UI Components
 import { LoginScreen } from "./components/LoginScreen";
@@ -196,6 +197,8 @@ function defaultDiagnostics(): StreamDiagnostics {
     inputQueuePeakBufferedBytes: 0,
     inputQueueDropCount: 0,
     inputQueueMaxSchedulingDelayMs: 0,
+    lagReason: "unknown",
+    lagReasonDetail: "Waiting for stream stats",
     gpuType: "",
     serverRegion: "",
     decoderPressureActive: false,
@@ -403,11 +406,13 @@ export function App(): JSX.Element {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [regions, setRegions] = useState<StreamRegion[]>([]);
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
+  const diagnosticsStoreRef = useRef<ReturnType<typeof createStreamDiagnosticsStore> | null>(null);
+  const diagnosticsStore =
+    diagnosticsStoreRef.current ?? (diagnosticsStoreRef.current = createStreamDiagnosticsStore(defaultDiagnostics()));
 
   // Stream State
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [streamStatus, setStreamStatus] = useState<StreamStatus>("idle");
-  const [diagnostics, setDiagnostics] = useState<StreamDiagnostics>(defaultDiagnostics());
   const [showStatsOverlay, setShowStatsOverlay] = useState(true);
   const [antiAfkEnabled, setAntiAfkEnabled] = useState(false);
   const [escHoldReleaseIndicator, setEscHoldReleaseIndicator] = useState<{ visible: boolean; progress: number }>({
@@ -668,7 +673,7 @@ export function App(): JSX.Element {
     setSessionElapsedSeconds(0);
     setStreamWarning(null);
     setEscHoldReleaseIndicator({ visible: false, progress: 0 });
-    setDiagnostics(defaultDiagnostics());
+    diagnosticsStore.set(defaultDiagnostics());
 
     if (!options?.keepStreamingContext) {
       setStreamingGame(null);
@@ -678,7 +683,7 @@ export function App(): JSX.Element {
     if (!options?.keepLaunchError) {
       setLaunchError(null);
     }
-  }, []);
+  }, [diagnosticsStore]);
 
   // Session ref sync
   useEffect(() => {
@@ -1121,19 +1126,19 @@ export function App(): JSX.Element {
       return;
     }
 
-    const hasLiveFrames = diagnostics.framesDecoded > 0 || diagnostics.framesReceived > 0 || diagnostics.renderFps > 0;
-    if (!hasLiveFrames) {
-      return;
-    }
+    const evaluate = () => {
+      const snapshot = diagnosticsStore.getSnapshot();
+      const hasLiveFrames =
+        snapshot.framesDecoded > 0 || snapshot.framesReceived > 0 || snapshot.renderFps > 0;
+      if (hasLiveFrames) {
+        setSessionStartedAtMs(Date.now());
+      }
+    };
 
-    setSessionStartedAtMs(Date.now());
-  }, [
-    diagnostics.framesDecoded,
-    diagnostics.framesReceived,
-    diagnostics.renderFps,
-    sessionStartedAtMs,
-    streamStatus,
-  ]);
+    evaluate();
+    const unsubscribe = diagnosticsStore.subscribe(evaluate);
+    return unsubscribe;
+  }, [sessionStartedAtMs, streamStatus]);
 
   useEffect(() => {
     if (!streamWarning) return;
@@ -1172,7 +1177,7 @@ export function App(): JSX.Element {
               mouseSensitivity: settings.mouseSensitivity,
               mouseAcceleration: settings.mouseAcceleration,
               onLog: (line: string) => console.log(`[WebRTC] ${line}`),
-              onStats: (stats) => setDiagnostics(stats),
+              onStats: (stats) => diagnosticsStore.set(stats),
               onEscHoldProgress: (visible, progress) => {
                 setEscHoldReleaseIndicator({ visible, progress });
               },
@@ -2019,7 +2024,7 @@ export function App(): JSX.Element {
             className={isSwitchingGame ? "sv--switching" : undefined}
             videoRef={videoRef}
             audioRef={audioRef}
-            stats={diagnostics}
+            diagnosticsStore={diagnosticsStore}
             showStats={showStatsOverlay}
             shortcuts={{
               toggleStats: formatShortcutForDisplay(settings.shortcutToggleStats, isMac),
@@ -2031,7 +2036,6 @@ export function App(): JSX.Element {
             }}
             hideStreamButtons={settings.hideStreamButtons}
             serverRegion={session?.serverIp}
-            connectedControllers={diagnostics.connectedGamepads}
             antiAfkEnabled={antiAfkEnabled}
             escHoldReleaseIndicator={escHoldReleaseIndicator}
             exitPrompt={exitPrompt}

--- a/opennow-stable/src/renderer/src/components/StatsOverlay.tsx
+++ b/opennow-stable/src/renderer/src/components/StatsOverlay.tsx
@@ -82,6 +82,13 @@ export function StatsOverlay({
           </div>
         )}
 
+        {stats.lagReason !== "stable" && stats.lagReason !== "unknown" && (
+          <div className="sovl-pill sovl-pill--warn" title={stats.lagReasonDetail}>
+            <AlertTriangle size={13} className="sovl-icon" />
+            <span className="sovl-val">{stats.lagReason}</span>
+          </div>
+        )}
+
         {/* Controller Status */}
         {connectedControllers > 0 && (
           <div className="sovl-pill">

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -3,7 +3,9 @@ import { createPortal } from "react-dom";
 import type { JSX } from "react";
 import { Maximize, Minimize, Gamepad2, Loader2, LogOut, Clock3, AlertTriangle, Mic, MicOff, Camera, ChevronLeft, ChevronRight, Save, Trash2, X, Circle, Square, Video, FolderOpen } from "lucide-react";
 import SideBar from "./SideBar";
-import type { StreamDiagnostics } from "../gfn/webrtcClient";
+import type { StreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
+import { useStreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
+import type { StreamLagReason } from "../gfn/webrtcClient";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import type { MicrophoneMode, ScreenshotEntry, RecordingEntry } from "@shared/gfn";
 import { isShortcutMatch, normalizeShortcut } from "../shortcuts";
@@ -11,7 +13,7 @@ import { isShortcutMatch, normalizeShortcut } from "../shortcuts";
 interface StreamViewProps {
   videoRef: React.Ref<HTMLVideoElement>;
   audioRef: React.Ref<HTMLAudioElement>;
-  stats: StreamDiagnostics;
+  diagnosticsStore: StreamDiagnosticsStore;
   showStats: boolean;
   shortcuts: {
     toggleStats: string;
@@ -23,7 +25,6 @@ interface StreamViewProps {
   };
   hideStreamButtons?: boolean;
   serverRegion?: string;
-  connectedControllers: number;
   antiAfkEnabled: boolean;
   escHoldReleaseIndicator: {
     visible: boolean;
@@ -91,6 +92,38 @@ function getInputQueueColor(bufferedBytes: number, dropCount: number): string {
   return "var(--success)";
 }
 
+function getLagReasonLabel(reason: StreamLagReason): string {
+  switch (reason) {
+    case "network":
+      return "Network";
+    case "decoder":
+      return "Decode";
+    case "input_backpressure":
+      return "Input";
+    case "render":
+      return "Render";
+    case "stable":
+      return "Stable";
+    default:
+      return "Unknown";
+  }
+}
+
+function getLagReasonColor(reason: StreamLagReason): string {
+  switch (reason) {
+    case "network":
+    case "decoder":
+      return "var(--error)";
+    case "input_backpressure":
+    case "render":
+      return "var(--warning)";
+    case "stable":
+      return "var(--success)";
+    default:
+      return "var(--ink-muted)";
+  }
+}
+
 function formatElapsed(totalSeconds: number): string {
   const safe = Math.max(0, Math.floor(totalSeconds));
   const hours = Math.floor(safe / 3600);
@@ -121,12 +154,6 @@ function formatWarningSeconds(value: number | undefined): string | null {
   return `${seconds}s`;
 }
 
-/**
- * Drives a canvas-based segmented level meter from a live MediaStreamTrack.
- * Uses the Web Audio API AnalyserNode as a read-only tap — audio is never
- * routed to the speaker. Runs a requestAnimationFrame loop while active;
- * tears down fully (rAF cancelled, AudioContext closed) on deactivation.
- */
 function useMicMeter(
   canvasRef: React.RefObject<HTMLCanvasElement | null>,
   track: MediaStreamTrack | null,
@@ -153,7 +180,7 @@ function useMicMeter(
     let audioCtx: AudioContext | null = null;
     let source: MediaStreamAudioSourceNode | null = null;
     let analyser: AnalyserNode | null = null;
-    let raf = 0;
+    let tickTimer: number | null = null;
     let dead = false;
 
     const start = async () => {
@@ -176,21 +203,21 @@ function useMicMeter(
         }
 
         analyser = audioCtx.createAnalyser();
-        analyser.fftSize = 512;
+        analyser.fftSize = 256;
         analyser.smoothingTimeConstant = 0.65;
         source = audioCtx.createMediaStreamSource(new MediaStream([track]));
         source.connect(analyser);
-        // NOT connected to destination — monitoring only, no loopback
 
         const buf = new Uint8Array(analyser.frequencyBinCount);
         const SEG = 20;
         const GAP = Math.round(2 * dpr);
         const bw = (W - GAP * (SEG - 1)) / SEG;
         const radius = Math.min(3 * dpr, bw / 2);
+        const frameIntervalMs = 33;
 
         const frame = () => {
           if (dead || !analyser) return;
-          raf = requestAnimationFrame(frame);
+          tickTimer = window.setTimeout(frame, frameIntervalMs);
           analyser.getByteTimeDomainData(buf);
 
           let sum = 0;
@@ -227,7 +254,9 @@ function useMicMeter(
 
     return () => {
       dead = true;
-      cancelAnimationFrame(raf);
+      if (tickTimer !== null) {
+        window.clearTimeout(tickTimer);
+      }
       source?.disconnect();
       analyser?.disconnect();
       if (audioCtx && audioCtx.state !== "closed") {
@@ -243,11 +272,10 @@ function useMicMeter(
 export function StreamView({
   videoRef,
   audioRef,
-  stats,
+  diagnosticsStore,
   showStats,
   shortcuts,
   serverRegion,
-  connectedControllers,
   antiAfkEnabled,
   escHoldReleaseIndicator,
   exitPrompt,
@@ -278,6 +306,7 @@ export function StreamView({
   hideStreamButtons = false,
   className,
 }: StreamViewProps): JSX.Element {
+  const stats = useStreamDiagnosticsStore(diagnosticsStore);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showHints, setShowHints] = useState(true);
   const [showSessionClock, setShowSessionClock] = useState(false);
@@ -1505,6 +1534,11 @@ export function StreamView({
             <span className="sv-stats-chip" title="Input queue pressure (buffered bytes and delayed flush)">
               IQ <span className="sv-stats-chip-val" style={{ color: inputQueueColor }}>{inputQueueText}</span>
             </span>
+            {stats.lagReason !== "stable" && stats.lagReason !== "unknown" && (
+              <span className="sv-stats-chip" title={stats.lagReasonDetail}>
+                Lag <span className="sv-stats-chip-val" style={{ color: getLagReasonColor(stats.lagReason) }}>{getLagReasonLabel(stats.lagReason)}</span>
+              </span>
+            )}
           </div>
 
           <div className="sv-stats-foot">
@@ -1522,14 +1556,20 @@ export function StreamView({
               {[stats.gpuType, regionLabel].filter(Boolean).join(" · ")}
             </div>
           )}
+
+          {stats.lagReason !== "stable" && stats.lagReason !== "unknown" && (
+            <div className="sv-stats-foot">
+              Lag source {getLagReasonLabel(stats.lagReason).toLowerCase()} · {stats.lagReasonDetail}
+            </div>
+          )}
         </div>
       )}
 
       {/* Controller indicator (top-left) */}
-      {connectedControllers > 0 && !isConnecting && (
-        <div className="sv-ctrl" title={`${connectedControllers} controller(s) connected`}>
+      {stats.connectedGamepads > 0 && !isConnecting && (
+        <div className="sv-ctrl" title={`${stats.connectedGamepads} controller(s) connected`}>
           <Gamepad2 size={18} />
-          {connectedControllers > 1 && <span className="sv-ctrl-n">{connectedControllers}</span>}
+          {stats.connectedGamepads > 1 && <span className="sv-ctrl-n">{stats.connectedGamepads}</span>}
         </div>
       )}
 
@@ -1537,7 +1577,7 @@ export function StreamView({
       {showMicIndicator && onToggleMicrophone && (
         <button
           type="button"
-          className={`sv-mic${connectedControllers > 0 || antiAfkEnabled ? " sv-mic--stacked" : ""}`}
+          className={`sv-mic${stats.connectedGamepads > 0 || antiAfkEnabled ? " sv-mic--stacked" : ""}`}
           onClick={onToggleMicrophone}
           data-enabled={micEnabled}
           title={micEnabled ? "Mute microphone" : "Unmute microphone"}
@@ -1550,7 +1590,7 @@ export function StreamView({
 
       {/* Anti-AFK indicator (top-left, below controller badge when present) */}
       {antiAfkEnabled && !isConnecting && (
-        <div className={`sv-afk${connectedControllers > 0 ? " sv-afk--stacked" : ""}`} title="Anti-AFK is enabled">
+        <div className={`sv-afk${stats.connectedGamepads > 0 ? " sv-afk--stacked" : ""}`} title="Anti-AFK is enabled">
           <span className="sv-afk-dot" />
           <span className="sv-afk-label">ANTI-AFK ON</span>
         </div>
@@ -1560,7 +1600,7 @@ export function StreamView({
       {isRecording && !isConnecting && (
         <div
           className="sv-rec"
-          style={{ top: 14 + 42 * ([connectedControllers > 0, antiAfkEnabled, showMicIndicator].filter(Boolean).length) }}
+          style={{ top: 14 + 42 * ([stats.connectedGamepads > 0, antiAfkEnabled, showMicIndicator].filter(Boolean).length) }}
           title={`Recording · ${formatElapsed(Math.round(recordingDurationMs / 1000))}`}
         >
           <span className="sv-rec-dot" />

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -162,6 +162,9 @@ export interface StreamDiagnostics {
   inputQueueDropCount: number;
   inputQueueMaxSchedulingDelayMs: number;
 
+  lagReason: StreamLagReason;
+  lagReasonDetail: string;
+
   // System info
   gpuType: string;
   serverRegion: string;
@@ -175,6 +178,14 @@ export interface StreamDiagnostics {
   micState: MicState;
   micEnabled: boolean;
 }
+
+export type StreamLagReason =
+  | "unknown"
+  | "stable"
+  | "network"
+  | "decoder"
+  | "input_backpressure"
+  | "render";
 
 export interface StreamTimeWarning {
   code: 1 | 2 | 3;
@@ -578,6 +589,8 @@ export class GfnWebRtcClient {
     inputQueuePeakBufferedBytes: 0,
     inputQueueDropCount: 0,
     inputQueueMaxSchedulingDelayMs: 0,
+    lagReason: "unknown",
+    lagReasonDetail: "Waiting for stream stats",
     gpuType: "",
     serverRegion: "",
     decoderPressureActive: false,
@@ -837,6 +850,8 @@ export class GfnWebRtcClient {
       inputQueuePeakBufferedBytes: 0,
       inputQueueDropCount: 0,
       inputQueueMaxSchedulingDelayMs: 0,
+      lagReason: "unknown",
+      lagReasonDetail: "Waiting for stream stats",
       gpuType: this.gpuType,
       serverRegion: this.serverRegion,
       decoderPressureActive: false,
@@ -884,7 +899,7 @@ export class GfnWebRtcClient {
       this.statsTimer = null;
     }
     if (this.gamepadPollTimer !== null) {
-      window.clearInterval(this.gamepadPollTimer);
+      window.clearTimeout(this.gamepadPollTimer);
       this.gamepadPollTimer = null;
     }
   }
@@ -974,6 +989,89 @@ export class GfnWebRtcClient {
       reason,
       backlogFrames,
       dropRatePercent,
+    };
+  }
+
+  private classifyLagReason(params: {
+    framesReceived: number;
+    framesDecoded: number;
+    framesDropped: number;
+    decodeTimeMs: number;
+    decodeFps: number;
+    renderFps: number;
+    rttMs: number;
+    packetLossPercent: number;
+    jitterMs: number;
+    jitterBufferDelayMs: number;
+    inputQueueBufferedBytes: number;
+    inputQueueDropCount: number;
+    inputQueueMaxSchedulingDelayMs: number;
+  }): { reason: StreamLagReason; detail: string } {
+    const networkSignals: string[] = [];
+    if (params.packetLossPercent >= 1) networkSignals.push(`${params.packetLossPercent.toFixed(1)}% loss`);
+    if (params.rttMs >= 75) networkSignals.push(`RTT ${params.rttMs.toFixed(0)}ms`);
+    if (params.jitterMs >= 12) networkSignals.push(`jitter ${params.jitterMs.toFixed(1)}ms`);
+    if (params.jitterBufferDelayMs >= 20) networkSignals.push(`buffer ${params.jitterBufferDelayMs.toFixed(1)}ms`);
+    if (networkSignals.length > 0) {
+      return {
+        reason: "network",
+        detail: networkSignals.join(" · "),
+      };
+    }
+
+    const frameBudgetMs = params.decodeFps > 0 ? 1000 / params.decodeFps : 0;
+    const decodeSaturated =
+      frameBudgetMs > 0 &&
+      params.decodeTimeMs > 0 &&
+      params.decodeTimeMs >= frameBudgetMs * 0.82;
+    const severeDecoderStall = params.framesReceived > 100 && params.framesDecoded === 0;
+    const decoderBacklog = Math.max(0, params.framesReceived - params.framesDecoded);
+    if (severeDecoderStall || decodeSaturated || decoderBacklog >= 45 || params.framesDropped >= 8) {
+      const detailParts: string[] = [];
+      if (severeDecoderStall) detailParts.push("frames received but not decoded");
+      if (decodeSaturated) detailParts.push(`decode ${params.decodeTimeMs.toFixed(1)}ms`);
+      if (decoderBacklog >= 45) detailParts.push(`backlog ${decoderBacklog}`);
+      if (params.framesDropped >= 8) detailParts.push(`drops ${params.framesDropped}`);
+      return {
+        reason: "decoder",
+        detail: detailParts.join(" · ") || "decode saturation",
+      };
+    }
+
+    if (
+      params.inputQueueDropCount > 0 ||
+      params.inputQueueBufferedBytes >= GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES ||
+      params.inputQueueMaxSchedulingDelayMs >= 4
+    ) {
+      const detailParts: string[] = [];
+      if (params.inputQueueDropCount > 0) detailParts.push(`drops ${params.inputQueueDropCount}`);
+      if (params.inputQueueBufferedBytes >= GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES) {
+        detailParts.push(`buffered ${(params.inputQueueBufferedBytes / 1024).toFixed(1)}KB`);
+      }
+      if (params.inputQueueMaxSchedulingDelayMs >= 4) {
+        detailParts.push(`sched ${params.inputQueueMaxSchedulingDelayMs.toFixed(1)}ms`);
+      }
+      return {
+        reason: "input_backpressure",
+        detail: detailParts.join(" · "),
+      };
+    }
+
+    if (params.renderFps > 0 && params.decodeFps > 0) {
+      const renderGap = params.decodeFps - params.renderFps;
+      if (renderGap >= 8 || params.renderFps < 24) {
+        return {
+          reason: "render",
+          detail: `render ${params.renderFps}fps vs decode ${params.decodeFps}fps`,
+        };
+      }
+    }
+
+    return {
+      reason: params.decodeFps > 0 || params.renderFps > 0 ? "stable" : "unknown",
+      detail: params.decodeFps > 0 || params.renderFps > 0
+        ? "No dominant lag source detected"
+        : "Waiting for stream stats",
     };
   }
 
@@ -1133,6 +1231,9 @@ export class GfnWebRtcClient {
     let inboundVideo: Record<string, unknown> | null = null;
     let activePair: Record<string, unknown> | null = null;
     const codecs = new Map<string, Record<string, unknown>>();
+    let framesReceived = 0;
+    let framesDecoded = 0;
+    let framesDropped = 0;
 
     for (const entry of report.values()) {
       const stats = entry as unknown as Record<string, unknown>;
@@ -1157,9 +1258,9 @@ export class GfnWebRtcClient {
     // Process video track stats
     if (inboundVideo) {
       const bytes = Number(inboundVideo.bytesReceived ?? 0);
-      const framesReceived = Number(inboundVideo.framesReceived ?? 0);
-      const framesDecoded = Number(inboundVideo.framesDecoded ?? 0);
-      const framesDropped = Number(inboundVideo.framesDropped ?? 0);
+      framesReceived = Number(inboundVideo.framesReceived ?? 0);
+      framesDecoded = Number(inboundVideo.framesDecoded ?? 0);
+      framesDropped = Number(inboundVideo.framesDropped ?? 0);
       const packetsReceived = Number(inboundVideo.packetsReceived ?? 0);
       const packetsLost = Number(inboundVideo.packetsLost ?? 0);
       const prevSample = this.lastStatsSample;
@@ -1312,6 +1413,24 @@ export class GfnWebRtcClient {
     this.diagnostics.inputQueueDropCount = this.inputQueueDropCount;
     this.diagnostics.inputQueueMaxSchedulingDelayMs =
       Math.round(this.inputQueueMaxSchedulingDelayMsWindow * 10) / 10;
+
+    const lagClassification = this.classifyLagReason({
+      framesReceived,
+      framesDecoded,
+      framesDropped,
+      decodeTimeMs: this.diagnostics.decodeTimeMs,
+      decodeFps: this.diagnostics.decodeFps,
+      renderFps: this.diagnostics.renderFps,
+      rttMs: this.diagnostics.rttMs,
+      packetLossPercent: this.diagnostics.packetLossPercent,
+      jitterMs: this.diagnostics.jitterMs,
+      jitterBufferDelayMs: this.diagnostics.jitterBufferDelayMs,
+      inputQueueBufferedBytes: reliableBufferedAmount,
+      inputQueueDropCount: this.inputQueueDropCount,
+      inputQueueMaxSchedulingDelayMs: this.diagnostics.inputQueueMaxSchedulingDelayMs,
+    });
+    this.diagnostics.lagReason = lagClassification.reason;
+    this.diagnostics.lagReasonDetail = lagClassification.detail;
 
     const shouldLogQueuePressure =
       reliableBufferedAmount > GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES / 2
@@ -1541,20 +1660,40 @@ export class GfnWebRtcClient {
 
   private setupGamepadPolling(): void {
     if (this.gamepadPollTimer !== null) {
-      window.clearInterval(this.gamepadPollTimer);
+      window.clearTimeout(this.gamepadPollTimer);
     }
 
-    this.log("Gamepad polling started (250Hz)");
+    this.log("Gamepad polling started (adaptive)");
+    this.scheduleGamepadPolling();
+  }
 
-    // Poll at 250Hz (4ms interval) — the practical minimum for setInterval in browsers.
-    // The Rust reference polls at 1000Hz; browser timers can't go below ~4ms reliably.
-    // Previous 60Hz (16.6ms) added up to 1-2 frames of input lag at 120fps.
-    this.gamepadPollTimer = window.setInterval(() => {
+  private scheduleGamepadPolling(): void {
+    if (this.gamepadPollTimer !== null) {
+      window.clearTimeout(this.gamepadPollTimer);
+    }
+
+    const nextDelay = this.getGamepadPollIntervalMs();
+    this.gamepadPollTimer = window.setTimeout(() => {
+      this.gamepadPollTimer = null;
       if (!this.inputReady) {
+        this.scheduleGamepadPolling();
         return;
       }
       this.pollGamepads();
-    }, 4);
+      this.scheduleGamepadPolling();
+    }, nextDelay);
+  }
+
+  private getGamepadPollIntervalMs(): number {
+    if (!this.inputReady || this.inputPaused || document.visibilityState !== "visible") {
+      return 100;
+    }
+
+    if (this.connectedGamepads.size === 0) {
+      return 100;
+    }
+
+    return 4;
   }
 
   private gamepadSendCount = 0;

--- a/opennow-stable/src/renderer/src/utils/streamDiagnosticsStore.ts
+++ b/opennow-stable/src/renderer/src/utils/streamDiagnosticsStore.ts
@@ -1,0 +1,41 @@
+import { useSyncExternalStore } from "react";
+
+import type { StreamDiagnostics } from "../gfn/webrtcClient";
+
+export interface StreamDiagnosticsStore {
+  getSnapshot: () => StreamDiagnostics;
+  getServerSnapshot: () => StreamDiagnostics;
+  subscribe: (listener: () => void) => () => void;
+  set: (value: StreamDiagnostics) => void;
+}
+
+export function createStreamDiagnosticsStore(initial: StreamDiagnostics): StreamDiagnosticsStore {
+  let current = initial;
+  const listeners = new Set<() => void>();
+
+  const emit = () => {
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+
+  return {
+    getSnapshot: () => current,
+    getServerSnapshot: () => current,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    set: (value) => {
+      if (Object.is(value, current)) {
+        return;
+      }
+      current = value;
+      emit();
+    },
+  };
+}
+
+export function useStreamDiagnosticsStore(store: StreamDiagnosticsStore): StreamDiagnostics {
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getServerSnapshot);
+}


### PR DESCRIPTION
## Summary

Optimizes streaming performance through adaptive input polling, decoupled diagnostics, and real-time lag classification.

### Performance Improvements

**Adaptive polling**
- Gamepad polling now dynamically adjusts between 4ms (active controllers, visible document) and 100ms (idle or no controllers)
- Microphone meter uses 33ms timer interval instead of per-frame rAF loop, with reduced analyser FFT size (256)

**Decoupled diagnostics**
- Moved stream diagnostics to external store using `useSyncExternalStore` to eliminate React re-renders from 500ms stats polling
- `StreamView` and `App` subscribe directly to the store instead of props drilling stats through the component tree

**Lag classification**
- Added comprehensive lag reason analyzer detecting: network congestion, decoder saturation, input backpressure, and render bottlenecks
- Classifies signals into reasons: network, decoder, input_backpressure, render, stable, or unknown
- Surfaces lag reason and detail strings in the in-game stats overlay for actionable feedback

### Changes

**src/renderer/src/gfn/webrtcClient.ts**
- Added `StreamLagReason` type and `lagReason`/`lagReasonDetail` to `StreamDiagnostics`
- Implemented `classifyLagReason()` for automatic bottleneck detection
- Converted gamepad polling to adaptive via `scheduleGamepadPolling()` and `getGamepadPollIntervalMs()`
- Integrated lag classification into stats collection loop

**src/renderer/src/utils/streamDiagnosticsStore.ts** (new)
- External store for stream diagnostics with `createStreamDiagnosticsStore()` and `useStreamDiagnosticsStore()` hook
- Uses `useSyncExternalStore` for efficient subscriptions without React re-renders

**src/renderer/src/App.tsx**
- Replaced `setDiagnostics` state with `diagnosticsStore` external store
- Removed stats prop from `StreamView`; components now subscribe directly

**src/renderer/src/components/StreamView.tsx**
- Subscribes to diagnostics via `useStreamDiagnosticsStore()` hook
- Added lag reason display in stats HUD with color-coded badges
- Switched microphone meter to 33ms `setTimeout` loop with reduced FFT size

**src/renderer/src/components/StatsOverlay.tsx**
- Added lag reason indicator in overlay for compact diagnostics view

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/cd97bbbc-bb73-4f81-8ec9-5229d5289bb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-12&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-12"><img alt="OPE-12 · 5.4 Mini" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-12"></picture></a>