### PR TITLE
feat(ci): add manual release workflow with version bump

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -10,9 +10,6 @@ on:
     branches:
       - main
       - dev
-    tags:
-      - "v*"
-      - "opennow-stable-v*"
     paths:
       - "opennow-stable/**"
       - ".github/workflows/auto-build.yml"
@@ -109,30 +106,3 @@ jobs:
             opennow-stable/dist-release/*.AppImage
             opennow-stable/dist-release/*.deb
           if-no-files-found: error
-
-  release:
-    name: publish-release
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    needs: build
-    if: |
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/tags/v') ||
-      startsWith(github.ref, 'refs/tags/opennow-stable-v')
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: release-artifacts
-          merge-multiple: true
-
-      - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('nightly-{0}', github.sha) }}
-          name: ${{ github.ref_type == 'tag' && format('OpenNOW {0}', github.ref_name) || format('OpenNOW Nightly ({0})', github.sha) }}
-          prerelease: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') }}
-          generate_release_notes: true
-          files: release-artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,260 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release, e.g. 1.2.3 or v1.2.3
+        required: true
+        type: string
+  push:
+    tags:
+      - "v*.*.*"
+      - "opennow-stable-v*.*.*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: preflight
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      make_latest: ${{ steps.release.outputs.make_latest }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: opennow-stable/package-lock.json
+
+      - name: Install dependencies
+        working-directory: opennow-stable
+        run: npm ci --prefer-offline --no-audit --progress=false
+
+      - name: Typecheck
+        working-directory: opennow-stable
+        run: npm run typecheck --if-present
+
+      - name: Resolve release metadata
+        id: release
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          raw="${INPUT_VERSION:-$REF_NAME}"
+          case "$raw" in
+            opennow-stable-v*) version="${raw#opennow-stable-v}" ;;
+            v*) version="${raw#v}" ;;
+            *) version="$raw" ;;
+          esac
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid semver version: $raw" >&2
+            exit 1
+          fi
+
+          prerelease=false
+          if [[ "$version" == *-* ]]; then
+            prerelease=true
+          fi
+
+          make_latest=true
+          if [[ "$prerelease" == true ]]; then
+            make_latest=false
+          fi
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            release_tag="v${version}"
+          else
+            release_tag="$raw"
+          fi
+
+          {
+            echo "version=$version"
+            echo "prerelease=$prerelease"
+            echo "make_latest=$make_latest"
+            echo "release_tag=$release_tag"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    needs: preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: windows
+            os: blacksmith-4vcpu-windows-2025
+            builder_args: "--win nsis portable"
+          - label: macos-x64
+            os: macos-latest
+            builder_args: "--mac dmg zip --x64"
+          - label: macos-arm64
+            os: macos-latest
+            builder_args: "--mac dmg zip --arm64"
+          - label: linux-x64
+            os: blacksmith-4vcpu-ubuntu-2404
+            builder_args: "--linux AppImage deb --x64"
+          - label: linux-arm64
+            os: blacksmith-4vcpu-ubuntu-2404-arm
+            builder_args: "--linux AppImage deb --arm64"
+
+    defaults:
+      run:
+        working-directory: opennow-stable
+
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"
+      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+      npm_config_audit: "false"
+      npm_config_fund: "false"
+      RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+      USE_SYSTEM_FPM: ${{ matrix.label == 'linux-arm64' && 'true' || 'false' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Cache Electron binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.cache/electron
+            ${{ github.workspace }}/.cache/electron-builder
+          key: ${{ runner.os }}-electron-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+
+      - name: Install Linux packaging tools
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fakeroot rpm
+
+      - name: Install FPM for arm64 deb builds
+        if: matrix.label == 'linux-arm64'
+        run: sudo apt-get install -y ruby ruby-dev build-essential && sudo gem install fpm
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --progress=false
+
+      - name: Update package version
+        run: node -e "const fs=require('fs'); const path='package.json'; const pkg=JSON.parse(fs.readFileSync(path,'utf8')); pkg.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');"
+
+      - name: Build app bundles
+        run: npm run build
+
+      - name: Package installers
+        run: npx electron-builder --publish never ${{ matrix.builder_args }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: opennow-stable-${{ matrix.label }}
+          path: |
+            opennow-stable/dist-release/*.exe
+            opennow-stable/dist-release/*.dmg
+            opennow-stable/dist-release/*.zip
+            opennow-stable/dist-release/*.AppImage
+            opennow-stable/dist-release/*.deb
+          if-no-files-found: error
+
+  release:
+    name: publish-release
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs:
+      - preflight
+      - build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.preflight.outputs.release_tag }}
+          name: OpenNOW v${{ needs.preflight.outputs.version }}
+          prerelease: ${{ needs.preflight.outputs.prerelease }}
+          make_latest: ${{ needs.preflight.outputs.make_latest }}
+          generate_release_notes: true
+          files: release-artifacts/**/*
+
+  finalize:
+    name: finalize-version-bump
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs:
+      - preflight
+      - release
+    permissions:
+      contents: write
+
+    steps:
+      - name: Resolve release branch
+        id: branch
+        shell: bash
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF_TYPE" == "branch" ]]; then
+            branch="$REF_NAME"
+          else
+            branch="dev"
+          fi
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Update package version
+        working-directory: opennow-stable
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+        run: node -e "const fs=require('fs'); const path='package.json'; const pkg=JSON.parse(fs.readFileSync(path,'utf8')); pkg.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');"
+
+      - name: Commit and push
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add opennow-stable/package.json
+          if git diff --cached --quiet; then
+            echo "No version bump changes to commit."
+            exit 0
+          fi
+          git commit -m "chore(release): prepare v${{ needs.preflight.outputs.version }}"
+          git push origin HEAD:${{ steps.branch.outputs.branch }}

--- a/opennow-stable/README.md
+++ b/opennow-stable/README.md
@@ -37,14 +37,12 @@ Workflow: `.github/workflows/auto-build.yml`
 
 ## Tagged Releases
 
-Format: `opennow-stable-vX.Y.Z` (e.g., `opennow-stable-v0.2.4`)
+Release workflow: `.github/workflows/release.yml`
 
-```bash
-git tag opennow-stable-v0.2.4
-git push origin opennow-stable-v0.2.4
-```
-
-The workflow automatically builds all platforms and creates/updates the GitHub Release.
+- Run it manually with `workflow_dispatch`
+- Provide a version like `1.2.3` or `v1.2.3`
+- Optional tag pushes matching `v*.*.*` or `opennow-stable-v*.*.*` also trigger releases
+- The workflow builds all platforms, publishes the GitHub Release, then commits the version bump back to the triggering release branch; manual/tagged runs fall back to `dev` when no branch context is available
 
 ## Technical Notes
 


### PR DESCRIPTION
## Summary

Introduces a manual release workflow that replaces automated releases triggered on branch pushes or tags. The new workflow provides controlled versioned releases with GitHub-generated release notes and automatically commits the version bump back to the triggering branch.

## Changes

**Release workflow**
- Created `.github/workflows/release.yml` with `workflow_dispatch` trigger requiring version input (e.g., `1.2.3` or `v1.2.3`)
- Added optional tag triggers for `v*.*.*` and `opennow-stable-v*.*.*` patterns
- Preflight job validates semver format, detects prerelease status (hyphenated versions), and sets `make_latest` flag appropriately
- Pre-flight runs `npm run typecheck` in `opennow-stable` before proceeding

**Build matrix**
- Windows: NSIS installer + portable on `blacksmith-4vcpu-windows-2025`
- macOS x64/arm64: dmg + zip on `macos-latest`
- Linux x64/arm64: AppImage + deb on Blacksmith Ubuntu runners
- Updated `opennow-stable/package.json` version at build time using Node.js script
- Uploaded artifacts as `opennow-stable-{platform}` with pattern matching `.exe`, `.dmg`, `.zip`, `.AppImage`, `.deb`

**Release publishing**
- Publishes to GitHub Releases using `softprops/action-gh-release@v2`
- Release name format: `OpenNOW v{version}`
- Sets `prerelease` and `make_latest` based on preflight job outputs
- Uses `generate_release_notes: true` for auto-generated changelog

**Version bump finalization**
- Finalize job checks out the triggering branch and updates `opennow-stable/package.json` version
- Commits with message `chore(release): prepare v{version}` and pushes back to the same branch
- For tag/manual workflows without branch context, falls back to `dev`

**Deprecated auto-release**
- Removed `publish-release` job from `.github/workflows/auto-build.yml`
- Removed tag triggers (`v*` and `opennow-stable-v*`) from auto-build workflow
- Auto-build workflow now only builds on PRs and branch pushes for validation

**Documentation**
- Updated `opennow-stable/README.md` Tagged Releases section to document `workflow_dispatch` usage and version input
- Removed outdated git tag example and clarified version bump committal behavior (to triggering branch or `dev` fallback)

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/f8af98f7-414b-4dcc-9983-8c9866f061bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-14&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-14"><img alt="OPE-14 · 5.4 Mini" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-14"></picture></a>