### PR TITLE
fix(gfn): protocol parity, centralized constants and reliable polling

### DIFF
--- a/opennow-stable/src/main/gfn/auth.ts
+++ b/opennow-stable/src/main/gfn/auth.ts
@@ -17,6 +17,16 @@ import type {
   StreamRegion,
   SubscriptionInfo,
 } from "@shared/gfn";
+import {
+  buildGfnHeaders,
+  GFN_CLIENT_STREAMER_WEBRTC,
+  GFN_CLIENT_TYPE_BROWSER,
+  GFN_DEVICE_OS_WINDOWS,
+  GFN_DEVICE_TYPE_DESKTOP,
+  GFN_LCARS_CLIENT_ID,
+  GFN_NVFILE_ORIGIN,
+  GFN_NVFILE_REFERER,
+} from "@shared/gfnClient";
 import { fetchSubscription, fetchDynamicRegions } from "./subscription";
 
 const SERVICE_URLS_ENDPOINT = "https://pcs.geforcenow.com/v1/serviceUrls";
@@ -29,12 +39,19 @@ const CLIENT_ID = "ZU7sPN-miLujMD95LfOQ453IB0AtjM8sMyvgJ9wCXEQ";
 const SCOPES = "openid consent email tk_client age";
 const DEFAULT_IDP_ID = "PDiAhv2kJTFeQ7WOPqiQ2tRZ7lGhR2X11dXvM4TZSxg";
 
-const GFN_USER_AGENT =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/2.0.80.173";
-
 const REDIRECT_PORTS = [2259, 6460, 7119, 8870, 9096];
 const TOKEN_REFRESH_WINDOW_MS = 10 * 60 * 1000;
 const CLIENT_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+const GFN_BROWSER_SERVER_INFO_HEADERS = Object.freeze(
+  buildGfnHeaders({
+    accept: "application/json",
+    clientId: GFN_LCARS_CLIENT_ID,
+    clientType: GFN_CLIENT_TYPE_BROWSER,
+    clientStreamer: GFN_CLIENT_STREAMER_WEBRTC,
+    deviceOs: GFN_DEVICE_OS_WINDOWS,
+    deviceType: GFN_DEVICE_TYPE_DESKTOP,
+  }),
+);
 
 interface PersistedAuthState {
   session: AuthSession | null;
@@ -246,13 +263,12 @@ async function exchangeAuthorizationCode(code: string, verifier: string, port: n
 
   const response = await fetch(TOKEN_ENDPOINT, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-      Origin: "https://nvfile",
-      Referer: "https://nvfile/",
-      Accept: "application/json, text/plain, */*",
-      "User-Agent": GFN_USER_AGENT,
-    },
+    headers: buildGfnHeaders({
+      contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+      origin: GFN_NVFILE_ORIGIN,
+      referer: GFN_NVFILE_REFERER,
+      accept: "application/json, text/plain, */*",
+    }),
     body,
   });
 
@@ -279,12 +295,11 @@ async function refreshAuthTokens(refreshToken: string): Promise<AuthTokens> {
 
   const response = await fetch(TOKEN_ENDPOINT, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-      Origin: "https://nvfile",
-      Accept: "application/json, text/plain, */*",
-      "User-Agent": GFN_USER_AGENT,
-    },
+    headers: buildGfnHeaders({
+      contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+      origin: GFN_NVFILE_ORIGIN,
+      accept: "application/json, text/plain, */*",
+    }),
     body,
   });
 
@@ -308,12 +323,11 @@ async function requestClientToken(accessToken: string): Promise<{
   lifetimeMs: number;
 }> {
   const response = await fetch(CLIENT_TOKEN_ENDPOINT, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Origin: "https://nvfile",
-      Accept: "application/json, text/plain, */*",
-      "User-Agent": GFN_USER_AGENT,
-    },
+    headers: buildGfnHeaders({
+      authorization: { token: accessToken, scheme: "Bearer" },
+      origin: GFN_NVFILE_ORIGIN,
+      accept: "application/json, text/plain, */*",
+    }),
   });
 
   if (!response.ok) {
@@ -340,12 +354,11 @@ async function refreshWithClientToken(clientToken: string, userId: string): Prom
 
   const response = await fetch(TOKEN_ENDPOINT, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-      Origin: "https://nvfile",
-      Accept: "application/json, text/plain, */*",
-      "User-Agent": GFN_USER_AGENT,
-    },
+    headers: buildGfnHeaders({
+      contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+      origin: GFN_NVFILE_ORIGIN,
+      accept: "application/json, text/plain, */*",
+    }),
     body,
   });
 
@@ -401,12 +414,11 @@ async function fetchUserInfo(tokens: AuthTokens): Promise<AuthUser> {
   }
 
   const response = await fetch(USERINFO_ENDPOINT, {
-    headers: {
-      Authorization: `Bearer ${tokens.accessToken}`,
-      Origin: "https://nvfile",
-      Accept: "application/json",
-      "User-Agent": GFN_USER_AGENT,
-    },
+    headers: buildGfnHeaders({
+      authorization: { token: tokens.accessToken, scheme: "Bearer" },
+      origin: GFN_NVFILE_ORIGIN,
+      accept: "application/json",
+    }),
   });
 
   if (!response.ok) {
@@ -513,10 +525,9 @@ export class AuthService {
     let response: Response;
     try {
       response = await fetch(SERVICE_URLS_ENDPOINT, {
-        headers: {
-          Accept: "application/json",
-          "User-Agent": GFN_USER_AGENT,
-        },
+        headers: buildGfnHeaders({
+          accept: "application/json",
+        }),
       });
     } catch (error) {
       console.warn("Failed to fetch providers, using default:", error);
@@ -577,14 +588,7 @@ export class AuthService {
     }
 
     const headers: Record<string, string> = {
-      Accept: "application/json",
-      "nv-client-id": "ec7e38d4-03af-4b58-b131-cfb0495903ab",
-      "nv-client-type": "BROWSER",
-      "nv-client-version": "2.0.80.173",
-      "nv-client-streamer": "WEBRTC",
-      "nv-device-os": "WINDOWS",
-      "nv-device-type": "DESKTOP",
-      "User-Agent": GFN_USER_AGENT,
+      ...GFN_BROWSER_SERVER_INFO_HEADERS,
     };
 
     if (token) {
@@ -731,14 +735,7 @@ export class AuthService {
     }
 
     const headers: Record<string, string> = {
-      Accept: "application/json",
-      "nv-client-id": "ec7e38d4-03af-4b58-b131-cfb0495903ab",
-      "nv-client-type": "BROWSER",
-      "nv-client-version": "2.0.80.173",
-      "nv-client-streamer": "WEBRTC",
-      "nv-device-os": "WINDOWS",
-      "nv-device-type": "DESKTOP",
-      "User-Agent": GFN_USER_AGENT,
+      ...GFN_BROWSER_SERVER_INFO_HEADERS,
     };
 
     if (token) {

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -16,13 +16,33 @@ import {
   colorQualityBitDepth,
   colorQualityChromaFormat,
 } from "@shared/gfn";
+import {
+  buildGfnHeaders,
+  GFN_APP_LAUNCH_MODE,
+  GFN_BROWSER_TYPE_CHROME,
+  GFN_CLIENT_IDENTIFICATION,
+  GFN_CLIENT_PLATFORM_NAME,
+  GFN_CLIENT_STREAMER_CLASSIC,
+  GFN_CLIENT_STREAMER_WEBRTC,
+  GFN_CLIENT_TYPE_NATIVE,
+  GFN_DEVICE_MAKE_UNKNOWN,
+  GFN_DEVICE_MODEL_UNKNOWN,
+  GFN_DEVICE_TYPE_DESKTOP,
+  GFN_ENHANCED_STREAM_MODE,
+  GFN_PLAY_ORIGIN,
+  GFN_PLAY_REFERER,
+  GFN_SDK_VERSION,
+  GFN_SESSION_REQUEST_CLIENT_VERSION,
+  GFN_STREAMER_VERSION,
+  resolveGfnDeviceOs,
+} from "@shared/gfnClient";
 
 import type { CloudMatchRequest, CloudMatchResponse, GetSessionsResponse } from "./types";
 import { SessionError } from "./errorCodes";
 
-const GFN_USER_AGENT =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/2.0.80.173";
-const GFN_CLIENT_VERSION = "2.0.80.173";
+const CLAIM_POLL_TIMEOUT_MS = 60_000;
+const CLAIM_INITIAL_DELAY_MS = 250;
+const CLAIM_MAX_DELAY_MS = 1_500;
 
 async function resolveHostnameWithFallback(hostname: string): Promise<string | null> {
   // Try system resolver first, then fall back to Cloudflare (1.1.1.1) and Google (8.8.8.8)
@@ -378,28 +398,25 @@ function requestHeaders(options: RequestHeadersOptions): Record<string, string> 
   const clientId = options.clientId ?? crypto.randomUUID();
   const deviceId = options.deviceId ?? crypto.randomUUID();
 
-  const headers: Record<string, string> = {
-    "User-Agent": GFN_USER_AGENT,
-    Authorization: `GFNJWT ${options.token}`,
-    "Content-Type": "application/json",
-    "nv-browser-type": "CHROME",
-    "nv-client-id": clientId,
-    "nv-client-streamer": "NVIDIA-CLASSIC",
-    "nv-client-type": "NATIVE",
-    "nv-client-version": GFN_CLIENT_VERSION,
-    "nv-device-make": "UNKNOWN",
-    "nv-device-model": "UNKNOWN",
-    "nv-device-os": process.platform === "win32" ? "WINDOWS" : process.platform === "darwin" ? "MACOS" : "LINUX",
-    "nv-device-type": "DESKTOP",
-    "x-device-id": deviceId,
-  };
-
-  if (options.includeOrigin !== false) {
-    headers["Origin"] = "https://play.geforcenow.com";
-    headers["Referer"] = "https://play.geforcenow.com/";
-  }
-
-  return headers;
+  return buildGfnHeaders({
+    authorization: { token: options.token },
+    contentType: "application/json",
+    clientId,
+    clientStreamer: GFN_CLIENT_STREAMER_CLASSIC,
+    clientType: GFN_CLIENT_TYPE_NATIVE,
+    deviceMake: GFN_DEVICE_MAKE_UNKNOWN,
+    deviceModel: GFN_DEVICE_MODEL_UNKNOWN,
+    deviceOs: resolveGfnDeviceOs(process.platform),
+    deviceType: GFN_DEVICE_TYPE_DESKTOP,
+    browserType: GFN_BROWSER_TYPE_CHROME,
+    deviceId,
+    ...(options.includeOrigin !== false
+      ? {
+          origin: GFN_PLAY_ORIGIN,
+          referer: GFN_PLAY_REFERER,
+        }
+      : {}),
+  });
 }
 
 function parseResolution(input: string): { width: number; height: number } {
@@ -416,6 +433,82 @@ function parseResolution(input: string): { width: number; height: number } {
 
 function timezoneOffsetMs(): number {
   return -new Date().getTimezoneOffset() * 60 * 1000;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function jitterDelayMs(baseMs: number): number {
+  const jitter = 0.2 + Math.random() * 0.2;
+  return Math.round(baseMs * (1 + jitter));
+}
+
+function nextClaimPollDelayMs(previousDelayMs: number): number {
+  return Math.min(CLAIM_MAX_DELAY_MS, Math.max(CLAIM_INITIAL_DELAY_MS, Math.round(previousDelayMs * 1.5)));
+}
+
+function summarizeJsonText(body: string): string {
+  const compact = body.replace(/\s+/g, " ").trim();
+  if (!compact) {
+    return "empty";
+  }
+  return compact.length > 240 ? `${compact.slice(0, 240)}…` : compact;
+}
+
+function summarizeCloudMatchPayload(payload: CloudMatchResponse): string {
+  const queuePosition = extractQueuePosition(payload);
+  const session = payload.session;
+  return [
+    `statusCode=${payload.requestStatus.statusCode}`,
+    `status=${session.status}`,
+    `queue=${queuePosition ?? "n/a"}`,
+    `seatStep=${extractSeatSetupStep(payload) ?? "n/a"}`,
+    `errorCode=${session.errorCode ?? "n/a"}`,
+    `connections=${session.connectionInfo?.length ?? 0}`,
+  ].join(" ");
+}
+
+function isReadySessionStatus(status: number): boolean {
+  return status === 2 || status === 3;
+}
+
+function isTerminalSessionStatus(status: number): boolean {
+  return status > 3 && status !== 6;
+}
+
+function isRetryablePollError(error: unknown): boolean {
+  return error instanceof SessionError ? error.isRetryable() : false;
+}
+
+function buildSessionInfoFromPayload(
+  sessionData: CloudMatchResponse["session"],
+  payload: CloudMatchResponse,
+  effectiveServerIp: string,
+  pairingId: string,
+  iceServers: IceServer[],
+  clientId?: string,
+  deviceId?: string,
+): SessionInfo {
+  const signaling = resolveSignaling(payload);
+  const queuePosition = extractQueuePosition(payload);
+
+  return {
+    sessionId: sessionData.sessionId,
+    status: sessionData.status,
+    queuePosition,
+    zone: "",
+    streamingBaseUrl: `https://${effectiveServerIp}`,
+    serverIp: signaling.serverIp,
+    signalingServer: signaling.signalingServer,
+    signalingUrl: signaling.signalingUrl,
+    pairingId,
+    gpuType: sessionData.gpuType,
+    iceServers,
+    mediaConnectionInfo: signaling.mediaConnectionInfo,
+    clientId,
+    deviceId,
+  };
 }
 
 function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
@@ -438,12 +531,12 @@ function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest
       availableSupportedControllers: [],
       networkTestSessionId: null,
       parentSessionId: null,
-      clientIdentification: "GFN-PC",
+      clientIdentification: GFN_CLIENT_IDENTIFICATION,
       deviceHashId: crypto.randomUUID(),
-      clientVersion: "30.0",
-      sdkVersion: "1.0",
-      streamerVersion: 1,
-      clientPlatformName: "windows",
+      clientVersion: GFN_SESSION_REQUEST_CLIENT_VERSION,
+      sdkVersion: GFN_SDK_VERSION,
+      streamerVersion: GFN_STREAMER_VERSION,
+      clientPlatformName: GFN_CLIENT_PLATFORM_NAME,
       clientRequestMonitorSettings: [
         {
           widthInPixels: width,
@@ -463,7 +556,7 @@ function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest
       metaData: [
         { key: "SubSessionId", value: crypto.randomUUID() },
         { key: "wssignaling", value: "1" },
-        { key: "GSStreamerType", value: "WebRTC" },
+        { key: "GSStreamerType", value: GFN_CLIENT_STREAMER_WEBRTC },
         { key: "networkType", value: "Unknown" },
         { key: "ClientImeSupport", value: "0" },
         {
@@ -483,8 +576,8 @@ function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest
       surroundAudioInfo: 0,
       remoteControllersBitmap: 0,
       clientTimezoneOffset: timezoneOffsetMs(),
-      enhancedStreamMode: 1,
-      appLaunchMode: 1,
+      enhancedStreamMode: GFN_ENHANCED_STREAM_MODE,
+      appLaunchMode: GFN_APP_LAUNCH_MODE,
       secureRTSPSupported: false,
       partnerCustomData: "",
       accountLinked,
@@ -613,24 +706,10 @@ async function toSessionInfo(options: ToSessionInfoOptions): Promise<SessionInfo
   const signaling = resolveSignaling(payload);
   const queuePosition = extractQueuePosition(payload);
   const seatSetupStep = extractSeatSetupStep(payload);
-
-  // Debug logging to trace signaling resolution
-  const connections = payload.session.connectionInfo ?? [];
   console.log(
-    `[CloudMatch] toSessionInfo: status=${payload.session.status}, ` +
-    `seatSetupStep=${seatSetupStep ?? "n/a"}, ` +
-    `queuePosition=${queuePosition ?? "n/a"}, ` +
-    `connectionInfo=${connections.length} entries, ` +
-    `serverIp=${signaling.serverIp}, ` +
-    `signalingServer=${signaling.signalingServer}, ` +
-    `signalingUrl=${signaling.signalingUrl}`,
+    `[CloudMatch] Session info ready ${summarizeCloudMatchPayload(payload)} ` +
+    `serverIp=${signaling.serverIp} signalingHost=${signaling.signalingServer}`,
   );
-  for (const conn of connections) {
-    console.log(
-      `[CloudMatch]   conn: usage=${conn.usage} ip=${conn.ip ?? "null"} port=${conn.port} ` +
-      `resourcePath=${conn.resourcePath ?? "null"}`,
-    );
-  }
 
   return {
     sessionId: payload.session.sessionId,
@@ -642,6 +721,7 @@ async function toSessionInfo(options: ToSessionInfoOptions): Promise<SessionInfo
     serverIp: signaling.serverIp,
     signalingServer: signaling.signalingServer,
     signalingUrl: signaling.signalingUrl,
+    pairingId: payload.session.sessionId,
     gpuType: payload.session.gpuType,
     iceServers: await normalizeIceServers(payload),
     mediaConnectionInfo: signaling.mediaConnectionInfo,
@@ -885,26 +965,26 @@ function buildClaimRequestBody(sessionId: string, appId: string, settings: Strea
       sdrHdrMode: 0,
       networkTestSessionId: null,
       availableSupportedControllers: [],
-      clientVersion: "30.0",
+      clientVersion: GFN_SESSION_REQUEST_CLIENT_VERSION,
       deviceHashId: deviceId,
       internalTitle: null,
-      clientPlatformName: "windows",
+      clientPlatformName: GFN_CLIENT_PLATFORM_NAME,
       metaData: [
         { key: "SubSessionId", value: subSessionId },
         { key: "wssignaling", value: "1" },
-        { key: "GSStreamerType", value: "WebRTC" },
+        { key: "GSStreamerType", value: GFN_CLIENT_STREAMER_WEBRTC },
         { key: "networkType", value: "Unknown" },
         { key: "ClientImeSupport", value: "0" },
       ],
       surroundAudioInfo: 0,
       clientTimezoneOffset: timezoneMs,
-      clientIdentification: "GFN-PC",
+      clientIdentification: GFN_CLIENT_IDENTIFICATION,
       parentSessionId: null,
       appId: parseInt(appId, 10),
-      streamerVersion: 1,
-      appLaunchMode: 1,
-      sdkVersion: "1.0",
-      enhancedStreamMode: 1,
+      streamerVersion: GFN_STREAMER_VERSION,
+      appLaunchMode: GFN_APP_LAUNCH_MODE,
+      sdkVersion: GFN_SDK_VERSION,
+      enhancedStreamMode: GFN_ENHANCED_STREAM_MODE,
       useOps: true,
       clientDisplayHdrCapabilities: null,
       accountLinked: true,
@@ -939,6 +1019,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
 
   const deviceId = crypto.randomUUID();
   const clientId = crypto.randomUUID();
+  const pairingId = input.sessionId;
 
   // Provide default values for optional parameters
   const appId = input.appId ?? "0";
@@ -962,29 +1043,35 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
   // IMPORTANT: We must query the SAME zone LB where the session is hosted (use serverIp),
   // not the provider's generic streamingBaseUrl (which may route to a different zone LB).
   let effectiveServerIp = input.serverIp;
-  console.log(`[CloudMatch] claimSession: input serverIp=${input.serverIp}, isZone=${isZoneHostname(input.serverIp)}`);
+  console.log(
+    `[CloudMatch] claimSession session=${input.sessionId} server=${input.serverIp} zoneHost=${isZoneHostname(input.serverIp)}`,
+  );
   if (isZoneHostname(effectiveServerIp)) {
     const zoneBase = `https://${effectiveServerIp}`;
     const prefetchUrl = `${zoneBase}/v2/session/${input.sessionId}`;
-    console.log(`[CloudMatch] claimSession: pre-flight query ${prefetchUrl}`);
     const prefetchHeaders = requestHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
     try {
       const prefetchResp = await fetch(prefetchUrl, { method: "GET", headers: prefetchHeaders });
-      console.log(`[CloudMatch] claimSession: pre-flight response status=${prefetchResp.status}`);
       if (prefetchResp.ok) {
-        const prefetchPayload = JSON.parse(await prefetchResp.text()) as CloudMatchResponse;
+        const prefetchText = await prefetchResp.text();
+        const prefetchPayload = JSON.parse(prefetchText) as CloudMatchResponse;
         const realIp = streamingServerIp(prefetchPayload);
-        console.log(`[CloudMatch] claimSession: extracted realIp=${realIp}, isZone=${realIp ? isZoneHostname(realIp) : 'N/A'}`);
+        console.log(
+          `[CloudMatch] claimSession preflight ${summarizeCloudMatchPayload(prefetchPayload)} realServer=${realIp ?? "n/a"}`,
+        );
         if (realIp) {
           effectiveServerIp = realIp;
-          const ipType = isZoneHostname(realIp) ? 'zone LB' : 'direct IP';
-          console.log(`[CloudMatch] claimSession: using extracted ${ipType}: ${realIp}`);
+          console.log(
+            `[CloudMatch] claimSession using preflight server ${realIp} direct=${!isZoneHostname(realIp)}`,
+          );
         }
       } else {
-        console.warn(`[CloudMatch] claimSession: pre-flight returned HTTP ${prefetchResp.status}, text=${await prefetchResp.text()}`);
+        console.warn(
+          `[CloudMatch] claimSession preflight HTTP ${prefetchResp.status}: ${summarizeJsonText(await prefetchResp.text())}`,
+        );
       }
-    } catch (e) {
-      console.warn("[CloudMatch] claimSession: pre-flight poll failed, proceeding with zone hostname:", e);
+    } catch (error) {
+      console.warn("[CloudMatch] claimSession preflight failed; proceeding with original server", error);
     }
   }
 
@@ -1001,38 +1088,28 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
       const validationPayload = JSON.parse(validationText) as CloudMatchResponse;
       const sessionStatus = validationPayload.session?.status ?? 0;
       const errorCode = validationPayload.session?.errorCode ?? 0;
-      console.log(`[CloudMatch] claimSession: pre-claim validation status=${sessionStatus}, errorCode=${errorCode}`);
-      console.log(`[CloudMatch] claimSession: validation response (first 1000 chars): ${validationText.slice(0, 1000)}`);
-      if (sessionStatus !== 2 && sessionStatus !== 3) {
-        console.warn(`[CloudMatch] claimSession: session not in ready state (status=${sessionStatus}), claim may fail`);
+      console.log(
+        `[CloudMatch] claimSession validation ${summarizeCloudMatchPayload(validationPayload)} errorCode=${errorCode}`,
+      );
+      if (!isReadySessionStatus(sessionStatus)) {
+        console.warn(
+          `[CloudMatch] claimSession validation not ready yet (status=${sessionStatus}); continuing resume request`,
+        );
       }
     } else {
-      console.warn(`[CloudMatch] claimSession: pre-claim validation returned HTTP ${validationResp.status}`);
+      console.warn(`[CloudMatch] claimSession validation HTTP ${validationResp.status}`);
     }
-  } catch (e) {
-    console.warn("[CloudMatch] claimSession: pre-claim validation failed:", e);
+  } catch (error) {
+    console.warn("[CloudMatch] claimSession validation failed", error);
   }
 
   const payload = buildClaimRequestBody(input.sessionId, appId, settings);
-
-  const headers: Record<string, string> = {
-    "User-Agent": GFN_USER_AGENT,
-    Authorization: `GFNJWT ${input.token}`,
-    "Content-Type": "application/json",
-    Origin: "https://play.geforcenow.com",
-    Referer: "https://play.geforcenow.com/",
-    "nv-client-id": clientId,
-    "nv-client-streamer": "NVIDIA-CLASSIC",
-    "nv-client-type": "NATIVE",
-    "nv-client-version": GFN_CLIENT_VERSION,
-    "nv-device-os": process.platform === "win32" ? "WINDOWS" : process.platform === "darwin" ? "MACOS" : "LINUX",
-    "nv-device-type": "DESKTOP",
-    "x-device-id": deviceId,
-  };
+  const headers = requestHeaders({ token: input.token, clientId, deviceId, includeOrigin: true });
 
   // Send claim request
-  console.log(`[CloudMatch] claimSession PUT ${claimUrl}`);
-  console.log(`[CloudMatch] claimSession body: ${JSON.stringify(payload)}`);
+  console.log(
+    `[CloudMatch] claimSession PUT host=${new URL(claimUrl).host} session=${input.sessionId} language=${languageCode}`,
+  );
   const response = await fetch(claimUrl, {
     method: "PUT",
     headers,
@@ -1040,10 +1117,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
   });
 
   const text = await response.text();
-  
-  // Log full response body for debugging (not truncated)
-  console.log(`[CloudMatch] claimSession response: HTTP ${response.status}`);
-  console.log(`[CloudMatch] claimSession response body FULL: ${text}`);
+  console.log(`[CloudMatch] claimSession response HTTP ${response.status}: ${summarizeJsonText(text)}`);
 
   if (!response.ok) {
     throw SessionError.fromResponse(response.status, text);
@@ -1055,66 +1129,106 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
     throw SessionError.fromResponse(200, text);
   }
 
-  // Poll until session is ready (status 2 or 3)
   const getUrl = `https://${effectiveServerIp}/v2/session/${input.sessionId}`;
-  const maxAttempts = 60;
+  const pollHeaders = requestHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
+  const deadlineAt = Date.now() + CLAIM_POLL_TIMEOUT_MS;
+  let attempt = 0;
+  let nextDelayMs = CLAIM_INITIAL_DELAY_MS;
+  let lastStatus: number | undefined;
+  let lastQueuePosition: number | undefined;
+  let lastRetryableError: SessionError | null = null;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+  while (Date.now() < deadlineAt) {
+    attempt += 1;
     if (attempt > 1) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await sleep(jitterDelayMs(nextDelayMs));
+      nextDelayMs = nextClaimPollDelayMs(nextDelayMs);
     }
 
-    // Build headers without Origin/Referer for polling
-    const pollHeaders: Record<string, string> = { ...headers };
-    delete pollHeaders["Origin"];
-    delete pollHeaders["Referer"];
+    let pollText = "";
+    try {
+      const pollResponse = await fetch(getUrl, {
+        method: "GET",
+        headers: pollHeaders,
+      });
+      pollText = await pollResponse.text();
 
-    const pollResponse = await fetch(getUrl, {
-      method: "GET",
-      headers: pollHeaders,
-    });
-
-    if (!pollResponse.ok) {
-      continue;
+      if (!pollResponse.ok) {
+        const pollError = SessionError.fromResponse(pollResponse.status, pollText);
+        if (pollError.isRetryable()) {
+          lastRetryableError = pollError;
+          console.warn(
+            `[CloudMatch] claim poll retryable HTTP ${pollResponse.status} attempt=${attempt} type=${pollError.errorType}`,
+          );
+          continue;
+        }
+        throw pollError;
+      }
+    } catch (error) {
+      if (isRetryablePollError(error)) {
+        lastRetryableError = error as SessionError;
+        console.warn(
+          `[CloudMatch] claim poll retryable error attempt=${attempt} type=${lastRetryableError.errorType}`,
+        );
+        continue;
+      }
+      throw error;
     }
 
-    const pollText = await pollResponse.text();
     let pollApiResponse: CloudMatchResponse;
-
     try {
       pollApiResponse = JSON.parse(pollText) as CloudMatchResponse;
     } catch {
+      console.warn(`[CloudMatch] claim poll parse failure attempt=${attempt}`);
       continue;
     }
 
-    const sessionData = pollApiResponse.session;
-
-    if (sessionData.status === 2 || sessionData.status === 3) {
-      // Session is ready
-      const signaling = resolveSignaling(pollApiResponse);
-      const queuePosition = extractQueuePosition(pollApiResponse);
-
-      return {
-        sessionId: sessionData.sessionId,
-        status: sessionData.status,
-        queuePosition,
-        zone: "", // Zone not applicable for claimed sessions
-        streamingBaseUrl: `https://${effectiveServerIp}`,
-        serverIp: signaling.serverIp,
-        signalingServer: signaling.signalingServer,
-        signalingUrl: signaling.signalingUrl,
-        gpuType: sessionData.gpuType,
-        iceServers: await normalizeIceServers(pollApiResponse),
-        mediaConnectionInfo: signaling.mediaConnectionInfo,
-      };
+    if (pollApiResponse.requestStatus.statusCode !== 1) {
+      const pollError = SessionError.fromResponse(200, pollText);
+      if (pollError.isRetryable()) {
+        lastRetryableError = pollError;
+        console.warn(
+          `[CloudMatch] claim poll retryable API error attempt=${attempt} type=${pollError.errorType}`,
+        );
+        continue;
+      }
+      throw pollError;
     }
 
-    // Status 1 (setup/launching), 6 (cleaning up), etc. — continue polling for ready state (2 or 3)
-    // Only break if we encounter a terminal error state (status 4, 5, etc.)
-    if (sessionData.status > 3 && sessionData.status !== 6) {
-      break;
+    const sessionData = pollApiResponse.session;
+    const queuePosition = extractQueuePosition(pollApiResponse);
+
+    if (sessionData.status !== lastStatus || queuePosition !== lastQueuePosition || attempt === 1) {
+      console.log(
+        `[CloudMatch] claim poll attempt=${attempt} ${summarizeCloudMatchPayload(pollApiResponse)}`,
+      );
+      lastStatus = sessionData.status;
+      lastQueuePosition = queuePosition;
+    }
+
+    if (isReadySessionStatus(sessionData.status)) {
+      const iceServers = await normalizeIceServers(pollApiResponse);
+      return buildSessionInfoFromPayload(
+        sessionData,
+        pollApiResponse,
+        effectiveServerIp,
+        pairingId,
+        iceServers,
+        clientId,
+        deviceId,
+      );
+    }
+
+    if (isTerminalSessionStatus(sessionData.status)) {
+      throw SessionError.fromResponse(200, pollText);
     }
   }
 
-  throw new Error("Session did not become ready after claiming");
+  const retryDetail = lastRetryableError
+    ? ` lastRetryable=${lastRetryableError.errorType}`
+    : "";
+  throw new Error(
+    `Session did not become ready after claim within ${CLAIM_POLL_TIMEOUT_MS}ms ` +
+    `(attempts=${attempt}, lastStatus=${lastStatus ?? "unknown"}, queue=${lastQueuePosition ?? "n/a"})${retryDetail}`,
+  );
 }

--- a/opennow-stable/src/main/gfn/errorCodes.ts
+++ b/opennow-stable/src/main/gfn/errorCodes.ts
@@ -919,7 +919,15 @@ export class SessionError extends Error {
       GfnErrorCode.PeerNoResponse, // 3237101586
     ];
 
-    return retryableCodes.includes(this.gfnErrorCode);
+    if (retryableCodes.includes(this.gfnErrorCode)) {
+      return true;
+    }
+
+    if (this.httpStatus === 429 || (this.httpStatus >= 500 && this.httpStatus < 600)) {
+      return true;
+    }
+
+    return false;
   }
 
   /**

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -1,16 +1,24 @@
 import type { GameInfo, GameVariant } from "@shared/gfn";
+import {
+  buildGfnHeaders,
+  GFN_BROWSER_TYPE_CHROME,
+  GFN_CLIENT_IDENTIFICATION,
+  GFN_CLIENT_STREAMER_CLASSIC,
+  GFN_CLIENT_TYPE_NATIVE,
+  GFN_DEVICE_MAKE_UNKNOWN,
+  GFN_DEVICE_MODEL_UNKNOWN,
+  GFN_DEVICE_OS_WINDOWS,
+  GFN_DEVICE_TYPE_DESKTOP,
+  GFN_LCARS_CLIENT_ID,
+  GFN_PLAY_ORIGIN,
+  GFN_PLAY_REFERER,
+} from "@shared/gfnClient";
 import { cacheManager } from "../services/cacheManager";
 
 const GRAPHQL_URL = "https://games.geforce.com/graphql";
 const PANELS_QUERY_HASH = "f8e26265a5db5c20e1334a6872cf04b6e3970507697f6ae55a6ddefa5420daf0";
 const APP_METADATA_QUERY_HASH = "39187e85b6dcf60b7279a5f233288b0a8b69a8b1dbcfb5b25555afdcb988f0d7";
 const DEFAULT_LOCALE = "en_US";
-const LCARS_CLIENT_ID = "ec7e38d4-03af-4b58-b131-cfb0495903ab";
-const GFN_CLIENT_VERSION = "2.0.80.173";
-
-const GFN_USER_AGENT =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/2.0.80.173";
-
 interface GraphQlResponse {
   data?: {
     panels: Array<{
@@ -103,24 +111,24 @@ async function getVpcId(token: string, providerStreamingBaseUrl?: string): Promi
 
   const response = await fetch(`${normalizedBase}v2/serverInfo`, {
     headers: {
-      Accept: "application/json",
-      Authorization: `GFNJWT ${token}`,
-      "nv-client-id": LCARS_CLIENT_ID,
-      "nv-client-type": "NATIVE",
-      "nv-client-version": GFN_CLIENT_VERSION,
-      "nv-client-streamer": "NVIDIA-CLASSIC",
-      "nv-device-os": "WINDOWS",
-      "nv-device-type": "DESKTOP",
-      "User-Agent": GFN_USER_AGENT,
+      ...buildGfnHeaders({
+        accept: "application/json",
+        authorization: { token },
+        clientId: GFN_LCARS_CLIENT_ID,
+        clientType: GFN_CLIENT_TYPE_NATIVE,
+        clientStreamer: GFN_CLIENT_STREAMER_CLASSIC,
+        deviceOs: GFN_DEVICE_OS_WINDOWS,
+        deviceType: GFN_DEVICE_TYPE_DESKTOP,
+      }),
     },
   });
 
   if (!response.ok) {
-    return "GFN-PC";
+    return GFN_CLIENT_IDENTIFICATION;
   }
 
   const payload = (await response.json()) as ServerInfoResponse;
-  return payload.requestStatus?.serverId ?? "GFN-PC";
+  return payload.requestStatus?.serverId ?? GFN_CLIENT_IDENTIFICATION;
 }
 
 function appToGame(app: AppData): GameInfo {
@@ -293,21 +301,21 @@ async function fetchAppMetaData(
   try {
     const response = await fetch(`${GRAPHQL_URL}?${params.toString()}`, {
       headers: {
-        Accept: "application/json, text/plain, */*",
-        "Content-Type": "application/graphql",
-        Origin: "https://play.geforcenow.com",
-        Referer: "https://play.geforcenow.com/",
-        Authorization: `GFNJWT ${token}`,
-        "nv-client-id": LCARS_CLIENT_ID,
-        "nv-client-type": "NATIVE",
-        "nv-client-version": GFN_CLIENT_VERSION,
-        "nv-client-streamer": "NVIDIA-CLASSIC",
-        "nv-device-os": "WINDOWS",
-        "nv-device-type": "DESKTOP",
-        "nv-device-make": "UNKNOWN",
-        "nv-device-model": "UNKNOWN",
-        "nv-browser-type": "CHROME",
-        "User-Agent": GFN_USER_AGENT,
+        ...buildGfnHeaders({
+          accept: "application/json, text/plain, */*",
+          contentType: "application/graphql",
+          origin: GFN_PLAY_ORIGIN,
+          referer: GFN_PLAY_REFERER,
+          authorization: { token },
+          clientId: GFN_LCARS_CLIENT_ID,
+          clientType: GFN_CLIENT_TYPE_NATIVE,
+          clientStreamer: GFN_CLIENT_STREAMER_CLASSIC,
+          deviceOs: GFN_DEVICE_OS_WINDOWS,
+          deviceType: GFN_DEVICE_TYPE_DESKTOP,
+          deviceMake: GFN_DEVICE_MAKE_UNKNOWN,
+          deviceModel: GFN_DEVICE_MODEL_UNKNOWN,
+          browserType: GFN_BROWSER_TYPE_CHROME,
+        }),
       },
     });
 
@@ -399,21 +407,21 @@ async function fetchPanels(
 
   const response = await fetch(`${GRAPHQL_URL}?${params.toString()}`, {
     headers: {
-      Accept: "application/json, text/plain, */*",
-      "Content-Type": "application/graphql",
-      Origin: "https://play.geforcenow.com",
-      Referer: "https://play.geforcenow.com/",
-      Authorization: `GFNJWT ${token}`,
-      "nv-client-id": LCARS_CLIENT_ID,
-      "nv-client-type": "NATIVE",
-      "nv-client-version": GFN_CLIENT_VERSION,
-      "nv-client-streamer": "NVIDIA-CLASSIC",
-      "nv-device-os": "WINDOWS",
-      "nv-device-type": "DESKTOP",
-      "nv-device-make": "UNKNOWN",
-      "nv-device-model": "UNKNOWN",
-      "nv-browser-type": "CHROME",
-      "User-Agent": GFN_USER_AGENT,
+      ...buildGfnHeaders({
+        accept: "application/json, text/plain, */*",
+        contentType: "application/graphql",
+        origin: GFN_PLAY_ORIGIN,
+        referer: GFN_PLAY_REFERER,
+        authorization: { token },
+        clientId: GFN_LCARS_CLIENT_ID,
+        clientType: GFN_CLIENT_TYPE_NATIVE,
+        clientStreamer: GFN_CLIENT_STREAMER_CLASSIC,
+        deviceOs: GFN_DEVICE_OS_WINDOWS,
+        deviceType: GFN_DEVICE_TYPE_DESKTOP,
+        deviceMake: GFN_DEVICE_MAKE_UNKNOWN,
+        deviceModel: GFN_DEVICE_MODEL_UNKNOWN,
+        browserType: GFN_BROWSER_TYPE_CHROME,
+      }),
     },
   });
 
@@ -506,7 +514,7 @@ async function fetchPublicGamesUncached(): Promise<GameInfo[]> {
     "https://static.nvidiagrid.net/supported-public-game-list/locales/gfnpc-en-US.json",
     {
       headers: {
-        "User-Agent": GFN_USER_AGENT,
+        ...buildGfnHeaders(),
       },
     },
   );

--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -8,9 +8,13 @@ import type {
   MainToRendererSignalingEvent,
   SendAnswerRequest,
 } from "@shared/gfn";
-
-const USER_AGENT =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/131.0.0.0 Safari/537.36";
+import {
+  buildGfnHeaders,
+  buildGfnSignalingSignInUrl,
+  GFN_PLAY_ORIGIN,
+  GFN_USER_AGENT,
+  isGfnVerboseLoggingEnabled,
+} from "@shared/gfnClient";
 
 interface SignalingMessage {
   ackid?: number;
@@ -33,35 +37,38 @@ export class GfnSignalingClient {
   private ackCounter = 0;
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private listeners = new Set<(event: MainToRendererSignalingEvent) => void>();
+  private readonly verboseLogging = isGfnVerboseLoggingEnabled();
 
   constructor(
     private readonly signalingServer: string,
     private readonly sessionId: string,
     private readonly signalingUrl?: string,
+    private readonly pairingId: string = sessionId,
   ) {}
 
   private buildSignInUrl(): string {
-    // Match Rust behavior: extract host:port from signalingUrl if available,
-    // since the signalingUrl contains the real server address (which may differ
-    // from signalingServer when the resource path was an rtsps:// URL)
-    let serverWithPort: string;
-
-    if (this.signalingUrl) {
-      // Extract host:port from wss://host:port/path
-      const withoutScheme = this.signalingUrl.replace(/^wss?:\/\//, "");
-      const hostPort = withoutScheme.split("/")[0];
-      serverWithPort = hostPort && hostPort.length > 0
-        ? (hostPort.includes(":") ? hostPort : `${hostPort}:443`)
-        : (this.signalingServer.includes(":") ? this.signalingServer : `${this.signalingServer}:443`);
-    } else {
-      serverWithPort = this.signalingServer.includes(":")
-        ? this.signalingServer
-        : `${this.signalingServer}:443`;
-    }
-
-    const url = `wss://${serverWithPort}/nvst/sign_in?peer_id=${this.peerName}&version=2`;
-    console.log("[Signaling] URL:", url, "(server:", this.signalingServer, ", signalingUrl:", this.signalingUrl, ")");
+    const serverWithPort = this.signalingServer.includes(":")
+      ? this.signalingServer
+      : `${this.signalingServer}:443`;
+    const baseUrl = this.signalingUrl?.trim() || `wss://${serverWithPort}/nvst/`;
+    const url = buildGfnSignalingSignInUrl(baseUrl, this.peerName, this.pairingId);
+    const parsedUrl = new URL(url);
+    console.log(
+      `[Signaling] Prepared sign-in URL host=${parsedUrl.host} path=${parsedUrl.pathname} pairing=${this.pairingId.slice(0, 8)}…`,
+    );
     return url;
+  }
+
+  private summarizeSdp(label: string, sdp: string): string {
+    const lineCount = sdp.split(/\r?\n/).filter(Boolean).length;
+    const mediaSections = (sdp.match(/^m=/gm) ?? []).length;
+    return `${label}: ${sdp.length} chars, ${lineCount} lines, ${mediaSections} media sections`;
+  }
+
+  private summarizeCandidate(candidate: string): string {
+    const protocol = candidate.match(/candidate:\S+\s+\d+\s+(\w+)/i)?.[1] ?? "unknown";
+    const type = candidate.match(/\styp\s+(\w+)/i)?.[1] ?? "unknown";
+    return `${protocol.toLowerCase()}/${type} (${candidate.length} chars)`;
   }
 
   onEvent(listener: (event: MainToRendererSignalingEvent) => void): () => void {
@@ -110,7 +117,7 @@ export class GfnSignalingClient {
         connected: true,
         id: this.peerId,
         name: this.peerName,
-        peerRole: 0,
+        peerRole: 1,
         resolution: "1920x1080",
         version: 2,
       },
@@ -124,21 +131,23 @@ export class GfnSignalingClient {
 
     const url = this.buildSignInUrl();
     const protocol = `x-nv-sessionid.${this.sessionId}`;
+    const parsedUrl = new URL(url);
 
-    console.log("[Signaling] Connecting to:", url);
-    console.log("[Signaling] Session ID:", this.sessionId);
-    console.log("[Signaling] Protocol:", protocol);
+    console.log(
+      `[Signaling] Connecting host=${parsedUrl.host} protocol=${protocol} pairing=${this.pairingId.slice(0, 8)}…`,
+    );
 
     await new Promise<void>((resolve, reject) => {
-      // Extract host:port for the Host header (matching Rust behavior)
-      const urlHost = url.replace(/^wss?:\/\//, "").split("/")[0];
+      const urlHost = parsedUrl.host;
 
       const ws = new WebSocket(url, protocol, {
         rejectUnauthorized: false,
         headers: {
+          ...buildGfnHeaders({
+            origin: GFN_PLAY_ORIGIN,
+          }),
           Host: urlHost,
-          Origin: "https://play.geforcenow.com",
-          "User-Agent": USER_AGENT,
+          "User-Agent": GFN_USER_AGENT,
           "Sec-WebSocket-Key": randomBytes(16).toString("base64"),
         },
       });
@@ -204,14 +213,18 @@ export class GfnSignalingClient {
     }
 
     if (peerPayload.type === "offer" && typeof peerPayload.sdp === "string") {
-      console.log(`[Signaling] Received OFFER SDP (${peerPayload.sdp.length} chars), first 500 chars:`);
-      console.log(peerPayload.sdp.slice(0, 500));
+      console.log(`[Signaling] ${this.summarizeSdp("Received offer SDP", peerPayload.sdp)}`);
+      if (this.verboseLogging) {
+        console.debug("[Signaling] Offer SDP preview:", peerPayload.sdp.slice(0, 1000));
+      }
       this.emit({ type: "offer", sdp: peerPayload.sdp });
       return;
     }
 
     if (typeof peerPayload.candidate === "string") {
-      console.log(`[Signaling] Received remote ICE candidate: ${peerPayload.candidate}`);
+      console.log(
+        `[Signaling] Received remote ICE candidate ${this.summarizeCandidate(peerPayload.candidate)}`,
+      );
       this.emit({
         type: "remote-ice",
         candidate: {
@@ -229,17 +242,21 @@ export class GfnSignalingClient {
       return;
     }
 
-    // Log any unhandled peer message types for debugging
     console.log("[Signaling] Unhandled peer message keys:", Object.keys(peerPayload));
   }
 
   async sendAnswer(payload: SendAnswerRequest): Promise<void> {
-    console.log(`[Signaling] Sending ANSWER SDP (${payload.sdp.length} chars), first 500 chars:`);
-    console.log(payload.sdp.slice(0, 500));
+    console.log(`[Signaling] ${this.summarizeSdp("Sending answer SDP", payload.sdp)}`);
     if (payload.nvstSdp) {
-      console.log(`[Signaling] Sending nvstSdp (${payload.nvstSdp.length} chars):`);
-      console.log(payload.nvstSdp);
+      console.log(`[Signaling] ${this.summarizeSdp("Sending nvstSdp", payload.nvstSdp)}`);
     }
+    if (this.verboseLogging) {
+      console.debug("[Signaling] Answer SDP preview:", payload.sdp.slice(0, 1000));
+      if (payload.nvstSdp) {
+        console.debug("[Signaling] nvstSdp preview:", payload.nvstSdp.slice(0, 1000));
+      }
+    }
+
     const answer = {
       type: "answer",
       sdp: payload.sdp,
@@ -257,7 +274,9 @@ export class GfnSignalingClient {
   }
 
   async sendIceCandidate(candidate: IceCandidatePayload): Promise<void> {
-    console.log(`[Signaling] Sending local ICE candidate: ${candidate.candidate} (sdpMid=${candidate.sdpMid})`);
+    console.log(
+      `[Signaling] Sending local ICE candidate ${this.summarizeCandidate(candidate.candidate)} sdpMid=${candidate.sdpMid ?? "?"}`,
+    );
     this.sendJson({
       peer_msg: {
         from: this.peerId,

--- a/opennow-stable/src/main/gfn/subscription.ts
+++ b/opennow-stable/src/main/gfn/subscription.ts
@@ -9,15 +9,19 @@ import type {
   StorageAddon,
   StreamRegion,
 } from "@shared/gfn";
+import {
+  buildGfnHeaders,
+  GFN_CLIENT_STREAMER_CLASSIC,
+  GFN_CLIENT_STREAMER_WEBRTC,
+  GFN_CLIENT_TYPE_BROWSER,
+  GFN_CLIENT_TYPE_NATIVE,
+  GFN_DEVICE_OS_WINDOWS,
+  GFN_DEVICE_TYPE_DESKTOP,
+  GFN_LCARS_CLIENT_ID,
+} from "@shared/gfnClient";
 
 /** MES API endpoint URL */
 const MES_URL = "https://mes.geforcenow.com/v4/subscriptions";
-
-/** LCARS Client ID */
-const LCARS_CLIENT_ID = "ec7e38d4-03af-4b58-b131-cfb0495903ab";
-
-/** GFN client version */
-const GFN_CLIENT_VERSION = "2.0.80.173";
 
 interface SubscriptionResponse {
   firstEntitlementStartDateTime?: string;
@@ -113,16 +117,15 @@ export async function fetchSubscription(
   url.searchParams.append("userId", userId);
 
   const response = await fetch(url.toString(), {
-    headers: {
-      Authorization: `GFNJWT ${token}`,
-      Accept: "application/json",
-      "nv-client-id": LCARS_CLIENT_ID,
-      "nv-client-type": "NATIVE",
-      "nv-client-version": GFN_CLIENT_VERSION,
-      "nv-client-streamer": "NVIDIA-CLASSIC",
-      "nv-device-os": "WINDOWS",
-      "nv-device-type": "DESKTOP",
-    },
+    headers: buildGfnHeaders({
+      authorization: { token },
+      accept: "application/json",
+      clientId: GFN_LCARS_CLIENT_ID,
+      clientType: GFN_CLIENT_TYPE_NATIVE,
+      clientStreamer: GFN_CLIENT_STREAMER_CLASSIC,
+      deviceOs: GFN_DEVICE_OS_WINDOWS,
+      deviceType: GFN_DEVICE_TYPE_DESKTOP,
+    }),
   });
 
   if (!response.ok) {
@@ -253,15 +256,14 @@ export async function fetchDynamicRegions(
     : `${streamingBaseUrl}/`;
   const url = `${base}v2/serverInfo`;
 
-  const headers: Record<string, string> = {
-    Accept: "application/json",
-    "nv-client-id": LCARS_CLIENT_ID,
-    "nv-client-type": "BROWSER",
-    "nv-client-version": GFN_CLIENT_VERSION,
-    "nv-client-streamer": "WEBRTC",
-    "nv-device-os": "WINDOWS",
-    "nv-device-type": "DESKTOP",
-  };
+  const headers: Record<string, string> = buildGfnHeaders({
+    accept: "application/json",
+    clientId: GFN_LCARS_CLIENT_ID,
+    clientType: GFN_CLIENT_TYPE_BROWSER,
+    clientStreamer: GFN_CLIENT_STREAMER_WEBRTC,
+    deviceOs: GFN_DEVICE_OS_WINDOWS,
+    deviceType: GFN_DEVICE_TYPE_DESKTOP,
+  });
 
   if (token) {
     headers.Authorization = `GFNJWT ${token}`;

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -721,7 +721,7 @@ function registerIpcHandlers(): void {
   ipcMain.handle(
     IPC_CHANNELS.CONNECT_SIGNALING,
     async (_event, payload: SignalingConnectRequest): Promise<void> => {
-      const nextKey = `${payload.sessionId}|${payload.signalingServer}|${payload.signalingUrl ?? ""}`;
+      const nextKey = `${payload.sessionId}|${payload.signalingServer}|${payload.signalingUrl ?? ""}|${payload.pairingId ?? ""}`;
       if (signalingClient && signalingClientKey === nextKey) {
         console.log("[Signaling] Reuse existing signaling connection (duplicate connect request ignored)");
         return;
@@ -735,6 +735,7 @@ function registerIpcHandlers(): void {
         payload.signalingServer,
         payload.sessionId,
         payload.signalingUrl,
+        payload.pairingId,
       );
       signalingClientKey = nextKey;
       signalingClient.onEvent(emitToRenderer);

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1529,6 +1529,7 @@ export function App(): JSX.Element {
       sessionId: claimed.sessionId,
       signalingServer: claimed.signalingServer,
       signalingUrl: claimed.signalingUrl,
+      pairingId: claimed.pairingId,
     });
   }, [authSession, effectiveStreamingBaseUrl, findGameContextForSession, settings]);
 
@@ -1736,6 +1737,7 @@ export function App(): JSX.Element {
         sessionId: sessionToConnect.sessionId,
         signalingServer: sessionToConnect.signalingServer,
         signalingUrl: sessionToConnect.signalingUrl,
+        pairingId: sessionToConnect.pairingId,
       });
     } catch (error) {
       console.error("Launch failed:", error);

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -450,7 +450,9 @@ export function mungeAnswerSdp(sdp: string, maxBitrateKbps: number): string {
 
 export function buildNvstSdp(params: NvstParams): string {
   console.log(`[SDP] buildNvstSdp: ${params.width}x${params.height}@${params.fps}fps, codec=${params.codec}, colorQuality=${params.colorQuality}, maxBitrate=${params.maxBitrateKbps}kbps`);
-  console.log(`[SDP] buildNvstSdp: ICE ufrag=${params.credentials.ufrag}, pwd=${params.credentials.pwd.slice(0, 8)}..., fingerprint=${params.credentials.fingerprint.slice(0, 20)}...`);
+  console.log(
+    `[SDP] buildNvstSdp: ICE credential lengths ufrag=${params.credentials.ufrag.length}, pwd=${params.credentials.pwd.length}, fingerprint=${params.credentials.fingerprint.length}`,
+  );
   // Adaptive profile:
   // allow bitrate to scale down under congestion to reduce stutter and input lag.
   const minBitrate = Math.max(5000, Math.floor(params.maxBitrateKbps * 0.35));

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -6,6 +6,7 @@ import type {
   VideoCodec,
   MicrophoneMode,
 } from "@shared/gfn";
+import { isGfnVerboseLoggingEnabled } from "@shared/gfnClient";
 
 import {
   InputEncoder,
@@ -224,8 +225,11 @@ function parsePartialReliableThresholdMs(sdp: string): number | null {
     return null;
   }
   const parsed = Number.parseInt(match[1], 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (!Number.isFinite(parsed) || parsed < 0) {
     return null;
+  }
+  if (parsed === 0) {
+    return 0;
   }
   return Math.max(1, Math.min(5000, parsed));
 }
@@ -448,9 +452,10 @@ export class GfnWebRtcClient {
 
   private pc: RTCPeerConnection | null = null;
   private reliableInputChannel: RTCDataChannel | null = null;
-  private mouseInputChannel: RTCDataChannel | null = null;
+  private gamepadInputChannel: RTCDataChannel | null = null;
   private controlChannel: RTCDataChannel | null = null;
   private audioContext: AudioContext | null = null;
+  private readonly verboseLogging = isGfnVerboseLoggingEnabled();
 
   private inputReady = false;
   public inputPaused = false;
@@ -474,7 +479,7 @@ export class GfnWebRtcClient {
   private static readonly MOUSE_FLUSH_FAST_MS = 4;
   private static readonly MOUSE_FLUSH_NORMAL_MS = 8;
   private static readonly MOUSE_FLUSH_SAFE_MS = 16;
-  private static readonly DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS = 300;
+  private static readonly DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS = 0;
   private static readonly RELIABLE_MOUSE_BACKPRESSURE_BYTES = 64 * 1024;
   private static readonly BACKPRESSURE_LOG_INTERVAL_MS = 2000;
   private static readonly VIDEO_BASE_JITTER_TARGET_MS = 12;
@@ -795,6 +800,18 @@ export class GfnWebRtcClient {
     this.options.onLog(message);
   }
 
+  private summarizeCandidate(candidate: string): string {
+    const protocol = candidate.match(/candidate:\S+\s+\d+\s+(\w+)/i)?.[1] ?? "unknown";
+    const type = candidate.match(/\styp\s+(\w+)/i)?.[1] ?? "unknown";
+    return `${protocol.toLowerCase()}/${type} (${candidate.length} chars)`;
+  }
+
+  private summarizeSdp(label: string, sdp: string): string {
+    const lineCount = sdp.split(/\r?\n/).filter(Boolean).length;
+    const mediaSections = (sdp.match(/^m=/gm) ?? []).length;
+    return `${label}: ${sdp.length} chars, ${lineCount} lines, ${mediaSections} media sections`;
+  }
+
   private emitStats(): void {
     if (this.options.onStats) {
       this.options.onStats({ ...this.diagnostics });
@@ -878,10 +895,10 @@ export class GfnWebRtcClient {
       this.controlChannel.onerror = null;
     }
     this.reliableInputChannel?.close();
-    this.mouseInputChannel?.close();
+    this.gamepadInputChannel?.close();
     this.controlChannel?.close();
     this.reliableInputChannel = null;
-    this.mouseInputChannel = null;
+    this.gamepadInputChannel = null;
     this.controlChannel = null;
   }
 
@@ -1737,8 +1754,8 @@ export class GfnWebRtcClient {
           && (nowMs - this.lastGamepadSendMs) >= GfnWebRtcClient.GAMEPAD_KEEPALIVE_MS;
 
         if (stateChanged || needsKeepalive) {
-          // Determine if we should use the partially reliable channel
-          const usePR = this.mouseInputChannel?.readyState === "open";
+          // Official behavior: gamepad can use the partially reliable channel when negotiated.
+          const usePR = this.gamepadInputChannel?.readyState === "open";
           const bytes = this.inputEncoder.encodeGamepadState(gamepadInput, this.gamepadBitmap, usePR);
           this.sendGamepad(bytes);
           this.lastGamepadSendMs = nowMs;
@@ -1777,7 +1794,7 @@ export class GfnWebRtcClient {
           connected: false,
           timestampUs: timestampUs(),
         };
-        const usePR = this.mouseInputChannel?.readyState === "open";
+        const usePR = this.gamepadInputChannel?.readyState === "open";
         const bytes = this.inputEncoder.encodeGamepadState(disconnectState, this.gamepadBitmap, usePR);
         this.sendGamepad(bytes);
       }
@@ -1886,13 +1903,21 @@ export class GfnWebRtcClient {
       this.onInputHandshakeMessage(bytes);
     };
 
-    this.mouseInputChannel = pc.createDataChannel("input_channel_partially_reliable", {
+    if (this.partialReliableThresholdMs <= 0) {
+      this.log("Gamepad partial reliable channel disabled by negotiation");
+      this.gamepadInputChannel = null;
+      return;
+    }
+
+    this.gamepadInputChannel = pc.createDataChannel("input_channel_partially_reliable", {
       ordered: false,
       maxPacketLifeTime: this.partialReliableThresholdMs,
     });
 
-    this.mouseInputChannel.onopen = () => {
-      this.log(`Mouse channel open (partially reliable, maxPacketLifeTime=${this.partialReliableThresholdMs}ms)`);
+    this.gamepadInputChannel.onopen = () => {
+      this.log(
+        `Gamepad partial reliable channel open (maxPacketLifeTime=${this.partialReliableThresholdMs}ms)`,
+      );
     };
   }
 
@@ -2232,9 +2257,9 @@ export class GfnWebRtcClient {
    *  Falls back to reliable channel if partially reliable isn't available.
    *  Official GFN client uses partially reliable ONLY for gamepad, not mouse. */
   private sendGamepad(payload: Uint8Array): void {
-    if (this.mouseInputChannel?.readyState === "open") {
+    if (this.gamepadInputChannel?.readyState === "open") {
       const safePayload = Uint8Array.from(payload);
-      this.mouseInputChannel.send(safePayload.buffer);
+      this.gamepadInputChannel.send(safePayload.buffer);
       return;
     }
     // Fallback to reliable channel if partially reliable not ready
@@ -2936,23 +2961,25 @@ export class GfnWebRtcClient {
       `Settings: codec=${settings.codec}, colorQuality=${settings.colorQuality}, resolution=${settings.resolution}, fps=${settings.fps}, maxBitrate=${settings.maxBitrateKbps}kbps`,
     );
     this.log(`ICE servers: ${session.iceServers.length} (${session.iceServers.map(s => s.urls.join(",")).join(" | ")})`);
-    this.log(`Offer SDP length: ${offerSdp.length} chars`);
-    // Log full offer SDP for ICE debugging
-    this.log(`=== FULL OFFER SDP START ===`);
-    for (const line of offerSdp.split(/\r?\n/)) {
-      this.log(`  SDP> ${line}`);
+    this.log(this.summarizeSdp("Offer SDP", offerSdp));
+    if (this.verboseLogging) {
+      for (const line of offerSdp.split(/\r?\n/)) {
+        this.log(`  SDP> ${line}`);
+      }
     }
-    this.log(`=== FULL OFFER SDP END ===`);
 
     const negotiatedPartialReliable = parsePartialReliableThresholdMs(offerSdp);
-    this.partialReliableThresholdMs = negotiatedPartialReliable ?? GfnWebRtcClient.DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS;
+    this.partialReliableThresholdMs =
+      negotiatedPartialReliable ?? GfnWebRtcClient.DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS;
     this.negotiatedMaxBitrateKbps = Math.max(
       GfnWebRtcClient.DECODER_MIN_RECOVERY_BITRATE_KBPS,
       Math.floor(settings.maxBitrateKbps),
     );
     this.currentBitrateCeilingKbps = this.negotiatedMaxBitrateKbps;
     this.log(
-      `Input channel policy: partial reliable threshold=${this.partialReliableThresholdMs}ms${negotiatedPartialReliable === null ? " (fallback)" : ""}`,
+      this.partialReliableThresholdMs > 0
+        ? `Input channel policy: gamepad partial reliable enabled (${this.partialReliableThresholdMs}ms)`
+        : "Input channel policy: gamepad partial reliable disabled",
     );
 
     // Extract server region from session
@@ -2995,7 +3022,7 @@ export class GfnWebRtcClient {
       if (!payload.candidate) {
         return;
       }
-      this.log(`Local ICE candidate: ${payload.candidate}`);
+      this.log(`Local ICE candidate: ${this.summarizeCandidate(payload.candidate)}`);
       const candidate: IceCandidatePayload = {
         candidate: payload.candidate,
         sdpMid: payload.sdpMid,
@@ -3136,7 +3163,7 @@ export class GfnWebRtcClient {
     const filteredOffer = preferCodec(processedOffer, effectiveCodec, {
       preferHevcProfileId: preferredHevcProfileId,
     });
-    this.log(`Filtered offer SDP length: ${filteredOffer.length} chars`);
+    this.log(this.summarizeSdp("Filtered offer SDP", filteredOffer));
     this.log("Setting remote description (offer)...");
     await pc.setRemoteDescription({ type: "offer", sdp: filteredOffer });
     this.log("Remote description set successfully");
@@ -3157,7 +3184,7 @@ export class GfnWebRtcClient {
     // 4. Create answer, munge SDP, and set local description
     this.log("Creating answer...");
     const answer = await pc.createAnswer();
-    this.log(`Answer created, SDP length: ${answer.sdp?.length ?? 0} chars`);
+    this.log(`Answer created (${answer.sdp?.length ?? 0} chars before munging)`);
 
     // Munge answer SDP: inject b=AS: bitrate limits and stereo=1 for opus
     if (answer.sdp) {
@@ -3169,7 +3196,7 @@ export class GfnWebRtcClient {
     this.log("Local description set, waiting for ICE gathering...");
 
     const finalSdp = await this.waitForIceGathering(pc, 5000);
-    this.log(`ICE gathering done, final SDP length: ${finalSdp.length} chars`);
+    this.log(this.summarizeSdp("Final local SDP", finalSdp));
 
     // Debug negotiated video codec/fmtp lines from local answer SDP
     {
@@ -3193,7 +3220,7 @@ export class GfnWebRtcClient {
           }
         }
       }
-      if (negotiatedVideoLines.length > 0) {
+      if (negotiatedVideoLines.length > 0 && this.verboseLogging) {
         this.log("Negotiated local video SDP lines:");
         for (const l of negotiatedVideoLines) {
           this.log(`  SDP< ${l}`);
@@ -3206,7 +3233,9 @@ export class GfnWebRtcClient {
     }
 
     const credentials = extractIceCredentials(finalSdp);
-    this.log(`Extracted ICE credentials: ufrag=${credentials.ufrag}, pwd=${credentials.pwd.slice(0, 8)}...`);
+    this.log(
+      `Extracted ICE credentials: ufragLen=${credentials.ufrag.length}, pwdLen=${credentials.pwd.length}, fingerprintLen=${credentials.fingerprint.length}`,
+    );
     const { width, height } = parseResolution(settings.resolution);
     const viewportRect = this.options.videoElement.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
@@ -3289,7 +3318,9 @@ export class GfnWebRtcClient {
   }
 
   async addRemoteCandidate(candidate: IceCandidatePayload): Promise<void> {
-    this.log(`Remote ICE candidate received: ${candidate.candidate} (sdpMid=${candidate.sdpMid})`);
+    this.log(
+      `Remote ICE candidate received: ${this.summarizeCandidate(candidate.candidate)} sdpMid=${candidate.sdpMid ?? "?"}`,
+    );
     const init: RTCIceCandidateInit = {
       candidate: candidate.candidate,
       sdpMid: candidate.sdpMid ?? undefined,

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -285,6 +285,7 @@ export interface SessionInfo {
   serverIp: string;
   signalingServer: string;
   signalingUrl: string;
+  pairingId?: string;
   gpuType?: string;
   iceServers: IceServer[];
   mediaConnectionInfo?: MediaConnectionInfo;
@@ -318,6 +319,7 @@ export interface SignalingConnectRequest {
   sessionId: string;
   signalingServer: string;
   signalingUrl?: string;
+  pairingId?: string;
 }
 
 export interface IceCandidatePayload {

--- a/opennow-stable/src/shared/gfnClient.ts
+++ b/opennow-stable/src/shared/gfnClient.ts
@@ -1,0 +1,163 @@
+export const GFN_CLIENT_VERSION = "2.0.80.173";
+export const GFN_SESSION_REQUEST_CLIENT_VERSION = "30.0";
+export const GFN_USER_AGENT =
+  `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ` +
+  `(KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 ` +
+  `NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/${GFN_CLIENT_VERSION}`;
+
+export const GFN_LCARS_CLIENT_ID = "ec7e38d4-03af-4b58-b131-cfb0495903ab";
+export const GFN_CLIENT_IDENTIFICATION = "GFN-PC";
+export const GFN_CLIENT_PLATFORM_NAME = "windows";
+export const GFN_SDK_VERSION = "1.0";
+export const GFN_STREAMER_VERSION = 1;
+export const GFN_APP_LAUNCH_MODE = 1;
+export const GFN_ENHANCED_STREAM_MODE = 1;
+
+export const GFN_CLIENT_TYPE_NATIVE = "NATIVE";
+export const GFN_CLIENT_TYPE_BROWSER = "BROWSER";
+export const GFN_CLIENT_STREAMER_CLASSIC = "NVIDIA-CLASSIC";
+export const GFN_CLIENT_STREAMER_WEBRTC = "WEBRTC";
+export const GFN_DEVICE_OS_WINDOWS = "WINDOWS";
+export const GFN_DEVICE_OS_MACOS = "MACOS";
+export const GFN_DEVICE_OS_LINUX = "LINUX";
+export const GFN_DEVICE_TYPE_DESKTOP = "DESKTOP";
+export const GFN_DEVICE_MAKE_UNKNOWN = "UNKNOWN";
+export const GFN_DEVICE_MODEL_UNKNOWN = "UNKNOWN";
+export const GFN_BROWSER_TYPE_CHROME = "CHROME";
+export const GFN_PLAY_ORIGIN = "https://play.geforcenow.com";
+export const GFN_PLAY_REFERER = `${GFN_PLAY_ORIGIN}/`;
+export const GFN_NVFILE_ORIGIN = "https://nvfile";
+export const GFN_NVFILE_REFERER = `${GFN_NVFILE_ORIGIN}/`;
+
+type GfnAuthScheme = "Bearer" | "GFNJWT";
+
+export interface GfnHeaderOptions {
+  accept?: string;
+  contentType?: string;
+  authorization?: {
+    token: string;
+    scheme?: GfnAuthScheme;
+  };
+  origin?: string;
+  referer?: string;
+  clientId?: string;
+  clientType?: string;
+  clientStreamer?: string;
+  clientVersion?: string;
+  deviceOs?: string;
+  deviceType?: string;
+  deviceMake?: string;
+  deviceModel?: string;
+  browserType?: string;
+  deviceId?: string;
+}
+
+export function resolveGfnDeviceOs(platform?: string): string {
+  switch (platform) {
+    case "win32":
+      return GFN_DEVICE_OS_WINDOWS;
+    case "darwin":
+      return GFN_DEVICE_OS_MACOS;
+    default:
+      return GFN_DEVICE_OS_LINUX;
+  }
+}
+
+export function buildGfnHeaders(options: GfnHeaderOptions = {}): Record<string, string> {
+  const headers: Record<string, string> = {
+    "User-Agent": GFN_USER_AGENT,
+  };
+
+  if (options.accept) {
+    headers.Accept = options.accept;
+  }
+
+  if (options.contentType) {
+    headers["Content-Type"] = options.contentType;
+  }
+
+  if (options.authorization?.token) {
+    headers.Authorization = `${options.authorization.scheme ?? "GFNJWT"} ${options.authorization.token}`;
+  }
+
+  if (options.origin) {
+    headers.Origin = options.origin;
+  }
+
+  if (options.referer) {
+    headers.Referer = options.referer;
+  }
+
+  if (
+    options.clientId ||
+    options.clientType ||
+    options.clientStreamer ||
+    options.clientVersion
+  ) {
+    if (options.clientId) {
+      headers["nv-client-id"] = options.clientId;
+    }
+    if (options.clientType) {
+      headers["nv-client-type"] = options.clientType;
+    }
+    if (options.clientStreamer) {
+      headers["nv-client-streamer"] = options.clientStreamer;
+    }
+    headers["nv-client-version"] = options.clientVersion ?? GFN_CLIENT_VERSION;
+  }
+
+  if (options.deviceOs) {
+    headers["nv-device-os"] = options.deviceOs;
+  }
+  if (options.deviceType) {
+    headers["nv-device-type"] = options.deviceType;
+  }
+  if (options.deviceMake) {
+    headers["nv-device-make"] = options.deviceMake;
+  }
+  if (options.deviceModel) {
+    headers["nv-device-model"] = options.deviceModel;
+  }
+  if (options.browserType) {
+    headers["nv-browser-type"] = options.browserType;
+  }
+  if (options.deviceId) {
+    headers["x-device-id"] = options.deviceId;
+  }
+
+  return headers;
+}
+
+export function buildGfnSignalingSignInUrl(
+  baseUrl: string,
+  peerId: string,
+  pairingId?: string,
+): string {
+  const url = new URL(baseUrl);
+  const normalizedPath = url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
+  url.pathname = `${normalizedPath}sign_in`;
+  url.search = new URLSearchParams({
+    peer_id: peerId,
+    version: "2",
+    peer_role: "1",
+    ...(pairingId ? { pairing_id: pairingId } : {}),
+  }).toString();
+  return url.toString();
+}
+
+export function isGfnVerboseLoggingEnabled(): boolean {
+  const globalValue = globalThis as {
+    process?: { env?: Record<string, string | undefined> };
+    localStorage?: Storage;
+  };
+
+  if (globalValue.process?.env?.OPENNOW_GFN_VERBOSE_LOGS === "1") {
+    return true;
+  }
+
+  try {
+    return globalValue.localStorage?.getItem("OPENNOW_GFN_VERBOSE_LOGS") === "1";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes GFN protocol gaps and reliability issues by aligning with the official reversed client, centralizing duplicated constants, and improving CloudMatch polling behavior.

## Changes

**Protocol parity**
- `buildSignInUrl` now includes `peer_role=1` and `pairing_id` (default to sessionId) to match official client behavior
- CloudMatch and signaling `peerRole` changed from 0 to 1 in peer-info handshakes

**Partially reliable input**
- Default PR threshold changed from 300ms to 0 (disabled unless negotiated via SDP)
- PR data channel created only when negotiated threshold > 0, matching official client
- Renamed misleading `mouseInputChannel` to `gamepadInputChannel` (official behavior: gamepad uses PR, mouse stays on reliable)
- Updated parse logic to treat SDP value `0` as disabled instead of falling back to 300ms

**Centralized constants**
- Created `src/shared/gfnClient.ts` with shared identity, user-agent, client version, and header construction helpers
- Refactored `auth.ts`, `subscription.ts`, `games.ts`, `cloudmatch.ts` to import from shared module instead of duplicating literals
- Added `buildGfnHeaders()` helper for consistent header construction across all GFN API calls

**Logging and diagnostics**
- Signaling/WebRTC/CloudMatch now log concise summaries by default (e.g., SDP length/line count, ICE candidate protocol/type)
- Full SDP/candidate previews gated behind `OPENNOW_GFN_VERBOSE_LOGS=1` or localStorage flag
- Removed full response body logging from hot paths; kept metadata relevant for debugging

**CloudMatch polling and retry**
- Replaced fixed 1s/60-attempt loop with bounded backoff (250ms→1.5s) and jitter for retryable failures
- Integrated `SessionError.isRetryable()` handling; HTTP 429 and 5xx now treated as retryable
- Improved claim preflight/poll logging with status summaries instead of full JSON
- Added `clientId`/`deviceId` preservation through claim/poll flow for consistent session identification

**Types and interfaces**
- Added `pairingId?: string` to `SessionInfo` and `SignalingConnectRequest`
- Updated claim/create/poll flows to propagate `pairingId` to signaling connection

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/4dba13ec-6a29-4f22-8d10-45da10ee4ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-16&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-16"><img alt="OPE-16 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-16"></picture></a>