### PR TITLE
test(gfn): add resilient core test suite for streaming helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ gfn_tokens.json
 
 # Test files
 test/
+!opennow-stable/test/
+!opennow-stable/test/**
 
 package-lock.json
 !opennow-stable/package-lock.json

--- a/opennow-stable/package-lock.json
+++ b/opennow-stable/package-lock.json
@@ -23,9 +23,72 @@
         "electron": "^40.4.1",
         "electron-builder": "^25.1.8",
         "electron-vite": "^2.3.0",
+        "jsdom": "^29.0.1",
         "typescript": "^5.7.2",
-        "vite": "^5.4.11"
+        "vite": "^5.4.11",
+        "vitest": "^4.1.2"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
+      "integrity": "sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -324,6 +387,161 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -712,6 +930,17 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1001,6 +1230,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1018,6 +1264,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1033,6 +1296,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1101,6 +1381,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@gar/promisify": {
@@ -1248,6 +1546,25 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@npmcli/fs": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
@@ -1290,6 +1607,16 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1299,6 +1626,261 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1671,6 +2253,13 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -1692,6 +2281,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1752,6 +2352,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1761,6 +2372,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1904,6 +2522,92 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -2241,6 +2945,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2328,6 +3042,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bl": {
@@ -2699,6 +3423,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3216,12 +3950,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3240,6 +4002,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -3829,6 +4598,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -3865,6 +4647,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3966,6 +4755,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -4027,6 +4836,24 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/filelist": {
@@ -4535,6 +5362,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -4742,6 +5582,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -4834,6 +5681,58 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -4955,6 +5854,268 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lodash": {
@@ -5158,6 +6319,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime": {
       "version": "2.6.0",
@@ -5571,6 +6739,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5670,6 +6849,19 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -5724,6 +6916,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -5753,6 +6952,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -5769,9 +6982,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -5979,6 +7192,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resedit": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
@@ -6077,6 +7300,47 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -6170,6 +7434,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -6240,6 +7517,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -6396,6 +7680,13 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -6405,6 +7696,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -6499,6 +7797,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tar": {
       "version": "6.2.1",
@@ -6602,6 +7907,70 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -6622,6 +7991,32 @@
         "tmp": "^0.2.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -6631,6 +8026,14 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
@@ -6658,6 +8061,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -6835,6 +8248,598 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -6843,6 +8848,41 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -6859,6 +8899,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -6936,6 +8993,16 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -6945,6 +9012,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -20,7 +20,9 @@
     "preview": "electron-vite preview",
     "dist": "npm run build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
     "dist:signed": "npm run build && electron-builder",
-    "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "lucide-react": "^0.563.0",
@@ -38,8 +40,10 @@
     "electron": "^40.4.1",
     "electron-builder": "^25.1.8",
     "electron-vite": "^2.3.0",
+    "jsdom": "^29.0.1",
     "typescript": "^5.7.2",
-    "vite": "^5.4.11"
+    "vite": "^5.4.11",
+    "vitest": "^4.1.2"
   },
   "build": {
     "appId": "com.zortos.opennow.stable",

--- a/opennow-stable/src/main/gfn/auth.ts
+++ b/opennow-stable/src/main/gfn/auth.ts
@@ -1,10 +1,7 @@
 import { createServer } from "node:http";
-import { createHash, randomBytes } from "node:crypto";
+import { createHash } from "node:crypto";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import net from "node:net";
-import os from "node:os";
-
 import { shell } from "electron";
 
 import type {
@@ -18,21 +15,26 @@ import type {
   SubscriptionInfo,
 } from "@shared/gfn";
 import { fetchSubscription, fetchDynamicRegions } from "./subscription";
+import {
+  buildAuthUrl,
+  CLIENT_ID,
+  findAvailablePort,
+  generatePkce,
+  isExpired,
+  isNearExpiry,
+  normalizeProvider,
+  parseJwtPayload,
+  toExpiresAt,
+} from "./authHelpers";
 
 const SERVICE_URLS_ENDPOINT = "https://pcs.geforcenow.com/v1/serviceUrls";
 const TOKEN_ENDPOINT = "https://login.nvidia.com/token";
 const CLIENT_TOKEN_ENDPOINT = "https://login.nvidia.com/client_token";
 const USERINFO_ENDPOINT = "https://login.nvidia.com/userinfo";
-const AUTH_ENDPOINT = "https://login.nvidia.com/authorize";
-
-const CLIENT_ID = "ZU7sPN-miLujMD95LfOQ453IB0AtjM8sMyvgJ9wCXEQ";
-const SCOPES = "openid consent email tk_client age";
 const DEFAULT_IDP_ID = "PDiAhv2kJTFeQ7WOPqiQ2tRZ7lGhR2X11dXvM4TZSxg";
-
 const GFN_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/2.0.80.173";
 
-const REDIRECT_PORTS = [2259, 6460, 7119, 8870, 9096];
 const TOKEN_REFRESH_WINDOW_MS = 10 * 60 * 1000;
 const CLIENT_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
 
@@ -87,117 +89,6 @@ function defaultProvider(): LoginProvider {
     streamingServiceUrl: "https://prod.cloudmatchbeta.nvidiagrid.net/",
     priority: 0,
   };
-}
-
-function normalizeProvider(provider: LoginProvider): LoginProvider {
-  return {
-    ...provider,
-    streamingServiceUrl: provider.streamingServiceUrl.endsWith("/")
-      ? provider.streamingServiceUrl
-      : `${provider.streamingServiceUrl}/`,
-  };
-}
-
-function decodeBase64Url(value: string): string {
-  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = normalized.length % 4;
-  const padded = padding === 0 ? normalized : `${normalized}${"=".repeat(4 - padding)}`;
-  return Buffer.from(padded, "base64").toString("utf8");
-}
-
-function parseJwtPayload<T>(token: string): T | null {
-  const parts = token.split(".");
-  if (parts.length !== 3) {
-    return null;
-  }
-  try {
-    const payload = decodeBase64Url(parts[1]);
-    return JSON.parse(payload) as T;
-  } catch {
-    return null;
-  }
-}
-
-function toExpiresAt(expiresInSeconds: number | undefined, defaultSeconds = 86400): number {
-  return Date.now() + (expiresInSeconds ?? defaultSeconds) * 1000;
-}
-
-function isExpired(expiresAt: number | undefined): boolean {
-  if (!expiresAt) {
-    return true;
-  }
-  return expiresAt <= Date.now();
-}
-
-function isNearExpiry(expiresAt: number | undefined, windowMs: number): boolean {
-  if (!expiresAt) {
-    return true;
-  }
-  return expiresAt - Date.now() < windowMs;
-}
-
-function generateDeviceId(): string {
-  const host = os.hostname();
-  const username = os.userInfo().username;
-  return createHash("sha256").update(`${host}:${username}:opennow-stable`).digest("hex");
-}
-
-function generatePkce(): { verifier: string; challenge: string } {
-  const verifier = randomBytes(64)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "")
-    .slice(0, 86);
-
-  const challenge = createHash("sha256")
-    .update(verifier)
-    .digest("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
-
-  return { verifier, challenge };
-}
-
-function buildAuthUrl(provider: LoginProvider, challenge: string, port: number): string {
-  const redirectUri = `http://localhost:${port}`;
-  const nonce = randomBytes(16).toString("hex");
-  const params = new URLSearchParams({
-    response_type: "code",
-    device_id: generateDeviceId(),
-    scope: SCOPES,
-    client_id: CLIENT_ID,
-    redirect_uri: redirectUri,
-    ui_locales: "en_US",
-    nonce,
-    prompt: "select_account",
-    code_challenge: challenge,
-    code_challenge_method: "S256",
-    idp_id: provider.idpId,
-  });
-  return `${AUTH_ENDPOINT}?${params.toString()}`;
-}
-
-async function isPortAvailable(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once("error", () => resolve(false));
-    server.once("listening", () => {
-      server.close(() => resolve(true));
-    });
-    server.listen(port, "127.0.0.1");
-  });
-}
-
-async function findAvailablePort(): Promise<number> {
-  for (const port of REDIRECT_PORTS) {
-    if (await isPortAvailable(port)) {
-      return port;
-    }
-  }
-
-  throw new Error("No available OAuth callback ports");
 }
 
 async function waitForAuthorizationCode(port: number, timeoutMs: number): Promise<string> {
@@ -629,7 +520,7 @@ export class AuthService {
 
     const { verifier, challenge } = generatePkce();
     const port = await findAvailablePort();
-    const authUrl = buildAuthUrl(this.selectedProvider, challenge, port);
+    const authUrl = buildAuthUrl(this.selectedProvider, { challenge, port });
 
     const codePromise = waitForAuthorizationCode(port, 120000);
     await shell.openExternal(authUrl);

--- a/opennow-stable/src/main/gfn/authHelpers.ts
+++ b/opennow-stable/src/main/gfn/authHelpers.ts
@@ -1,0 +1,131 @@
+import { createHash, randomBytes } from "node:crypto";
+import net from "node:net";
+import os from "node:os";
+
+import type { LoginProvider } from "@shared/gfn";
+
+export const AUTH_ENDPOINT = "https://login.nvidia.com/authorize";
+export const CLIENT_ID = "ZU7sPN-miLujMD95LfOQ453IB0AtjM8sMyvgJ9wCXEQ";
+export const SCOPES = "openid consent email tk_client age";
+export const REDIRECT_PORTS = [2259, 6460, 7119, 8870, 9096];
+
+export function normalizeProvider(provider: LoginProvider): LoginProvider {
+  return {
+    ...provider,
+    streamingServiceUrl: provider.streamingServiceUrl.endsWith("/")
+      ? provider.streamingServiceUrl
+      : `${provider.streamingServiceUrl}/`,
+  };
+}
+
+export function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4;
+  const padded = padding === 0 ? normalized : `${normalized}${"=".repeat(4 - padding)}`;
+  return Buffer.from(padded, "base64").toString("utf8");
+}
+
+export function parseJwtPayload<T>(token: string): T | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return null;
+  }
+  try {
+    const payload = decodeBase64Url(parts[1]);
+    return JSON.parse(payload) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function toExpiresAt(expiresInSeconds: number | undefined, defaultSeconds = 86400): number {
+  return Date.now() + (expiresInSeconds ?? defaultSeconds) * 1000;
+}
+
+export function isExpired(expiresAt: number | undefined): boolean {
+  if (!expiresAt) {
+    return true;
+  }
+  return expiresAt <= Date.now();
+}
+
+export function isNearExpiry(expiresAt: number | undefined, windowMs: number): boolean {
+  if (!expiresAt) {
+    return true;
+  }
+  return expiresAt - Date.now() < windowMs;
+}
+
+export function generateDeviceId(host = os.hostname(), username = os.userInfo().username): string {
+  return createHash("sha256").update(`${host}:${username}:opennow-stable`).digest("hex");
+}
+
+export function generatePkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(64)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "")
+    .slice(0, 86);
+
+  const challenge = createHash("sha256")
+    .update(verifier)
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+
+  return { verifier, challenge };
+}
+
+export interface BuildAuthUrlOptions {
+  challenge: string;
+  port: number;
+  nonce?: string;
+  deviceId?: string;
+}
+
+export function buildAuthUrl(provider: LoginProvider, options: BuildAuthUrlOptions): string {
+  const redirectUri = `http://localhost:${options.port}`;
+  const nonce = options.nonce ?? randomBytes(16).toString("hex");
+  const params = new URLSearchParams({
+    response_type: "code",
+    device_id: options.deviceId ?? generateDeviceId(),
+    scope: SCOPES,
+    client_id: CLIENT_ID,
+    redirect_uri: redirectUri,
+    ui_locales: "en_US",
+    nonce,
+    prompt: "select_account",
+    code_challenge: options.challenge,
+    code_challenge_method: "S256",
+    idp_id: provider.idpId,
+  });
+  return `${AUTH_ENDPOINT}?${params.toString()}`;
+}
+
+export type PortAvailabilityCheck = (port: number) => Promise<boolean>;
+
+export async function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+export async function findAvailablePort(
+  ports: readonly number[] = REDIRECT_PORTS,
+  checkPort: PortAvailabilityCheck = isPortAvailable,
+): Promise<number> {
+  for (const port of ports) {
+    if (await checkPort(port)) {
+      return port;
+    }
+  }
+
+  throw new Error("No available OAuth callback ports");
+}

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -12,17 +12,20 @@ import type {
   StreamSettings,
 } from "@shared/gfn";
 
-import {
-  colorQualityBitDepth,
-  colorQualityChromaFormat,
-} from "@shared/gfn";
-
-import type { CloudMatchRequest, CloudMatchResponse, GetSessionsResponse } from "./types";
+import type { CloudMatchResponse, GetSessionsResponse } from "./types";
 import { SessionError } from "./errorCodes";
-
-const GFN_USER_AGENT =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/2.0.80.173";
-const GFN_CLIENT_VERSION = "2.0.80.173";
+import {
+  buildSessionRequestBody,
+  buildSignalingUrl,
+  extractHostFromUrl,
+  GFN_CLIENT_VERSION,
+  GFN_USER_AGENT,
+  isZoneHostname,
+  requestHeaders,
+  resolvePollStopBase,
+  resolveStreamingBaseUrl,
+  streamingServerIp,
+} from "./cloudmatchHelpers";
 
 async function resolveHostnameWithFallback(hostname: string): Promise<string | null> {
   // Try system resolver first, then fall back to Cloudflare (1.1.1.1) and Google (8.8.8.8)
@@ -128,71 +131,6 @@ async function normalizeIceServers(response: CloudMatchResponse): Promise<IceSer
   }
 
   return out;
-}
-
-/**
- * Extract the streaming server IP from the CloudMatch response, matching Rust's
- * `streaming_server_ip()` priority chain:
- *   1. connectionInfo[usage==14].ip (direct IP)
- *   2. Host extracted from connectionInfo[usage==14].resourcePath (for rtsps:// URLs)
- *   3. sessionControlInfo.ip (fallback)
- */
-function streamingServerIp(response: CloudMatchResponse): string | null {
-  const connections = response.session.connectionInfo ?? [];
-  const sigConn = connections.find((conn) => conn.usage === 14);
-
-  if (sigConn) {
-    // Priority 1: Direct IP field
-    const rawIp = sigConn.ip;
-    const directIp = Array.isArray(rawIp) ? rawIp[0] : rawIp;
-    if (directIp && directIp.length > 0) {
-      return directIp;
-    }
-
-    // Priority 2: Extract host from resourcePath (Alliance format: rtsps://host:port)
-    if (sigConn.resourcePath) {
-      const host = extractHostFromUrl(sigConn.resourcePath);
-      if (host) return host;
-    }
-  }
-
-  // Priority 3: sessionControlInfo.ip
-  const controlIp = response.session.sessionControlInfo?.ip;
-  if (controlIp && controlIp.length > 0) {
-    return Array.isArray(controlIp) ? controlIp[0] : controlIp;
-  }
-
-  return null;
-}
-
-/**
- * Extract host from a URL string (handles rtsps://, rtsp://, wss://, https://).
- * Matches Rust's extract_host_from_url().
- */
-function extractHostFromUrl(url: string): string | null {
-  const prefixes = ["rtsps://", "rtsp://", "wss://", "https://"];
-  let afterProto: string | null = null;
-  for (const prefix of prefixes) {
-    if (url.startsWith(prefix)) {
-      afterProto = url.slice(prefix.length);
-      break;
-    }
-  }
-  if (!afterProto) return null;
-
-  // Get host (before port or path)
-  const host = afterProto.split(":")[0]?.split("/")[0];
-  if (!host || host.length === 0 || host.startsWith(".")) return null;
-  return host;
-}
-
-/**
- * Check if a given IP/hostname is a CloudMatch zone load balancer hostname
- * (not a real game server IP). Zone hostnames look like:
- *   np-ams-06.cloudmatchbeta.nvidiagrid.net
- */
-function isZoneHostname(ip: string): boolean {
-  return ip.includes("cloudmatchbeta.nvidiagrid.net") || ip.includes("cloudmatch.nvidiagrid.net");
 }
 
 function resolveSignaling(response: CloudMatchResponse): {
@@ -317,228 +255,6 @@ function resolveMediaConnectionInfo(
 
   console.log("[CloudMatch] resolveMediaConnectionInfo: NO valid media connection info found");
   return undefined;
-}
-
-/**
- * Build signaling WSS URL from the resourcePath, matching Rust implementation.
- * Returns the URL and optionally the extracted host (if different from serverIp).
- */
-function buildSignalingUrl(
-  raw: string,
-  serverIp: string,
-): { signalingUrl: string; signalingHost: string | null } {
-  if (raw.startsWith("rtsps://") || raw.startsWith("rtsp://")) {
-    // Extract hostname from RTSP URL, convert to wss://
-    const withoutScheme = raw.startsWith("rtsps://")
-      ? raw.slice("rtsps://".length)
-      : raw.slice("rtsp://".length);
-    const host = withoutScheme.split(":")[0]?.split("/")[0];
-    if (host && host.length > 0 && !host.startsWith(".")) {
-      return {
-        signalingUrl: `wss://${host}/nvst/`,
-        signalingHost: host,
-      };
-    }
-    return {
-      signalingUrl: `wss://${serverIp}:443/nvst/`,
-      signalingHost: null,
-    };
-  }
-
-  if (raw.startsWith("wss://")) {
-    // Already a full WSS URL, use as-is; extract host
-    const withoutScheme = raw.slice("wss://".length);
-    const host = withoutScheme.split("/")[0] ?? null;
-    return { signalingUrl: raw, signalingHost: host };
-  }
-
-  if (raw.startsWith("/")) {
-    // Relative path
-    return {
-      signalingUrl: `wss://${serverIp}:443${raw}`,
-      signalingHost: null,
-    };
-  }
-
-  // Fallback
-  return {
-    signalingUrl: `wss://${serverIp}:443/nvst/`,
-    signalingHost: null,
-  };
-}
-
-interface RequestHeadersOptions {
-  token: string;
-  clientId?: string;
-  deviceId?: string;
-  includeOrigin?: boolean;
-}
-
-function requestHeaders(options: RequestHeadersOptions): Record<string, string> {
-  const clientId = options.clientId ?? crypto.randomUUID();
-  const deviceId = options.deviceId ?? crypto.randomUUID();
-
-  const headers: Record<string, string> = {
-    "User-Agent": GFN_USER_AGENT,
-    Authorization: `GFNJWT ${options.token}`,
-    "Content-Type": "application/json",
-    "nv-browser-type": "CHROME",
-    "nv-client-id": clientId,
-    "nv-client-streamer": "NVIDIA-CLASSIC",
-    "nv-client-type": "NATIVE",
-    "nv-client-version": GFN_CLIENT_VERSION,
-    "nv-device-make": "UNKNOWN",
-    "nv-device-model": "UNKNOWN",
-    "nv-device-os": process.platform === "win32" ? "WINDOWS" : process.platform === "darwin" ? "MACOS" : "LINUX",
-    "nv-device-type": "DESKTOP",
-    "x-device-id": deviceId,
-  };
-
-  if (options.includeOrigin !== false) {
-    headers["Origin"] = "https://play.geforcenow.com";
-    headers["Referer"] = "https://play.geforcenow.com/";
-  }
-
-  return headers;
-}
-
-function parseResolution(input: string): { width: number; height: number } {
-  const [rawWidth, rawHeight] = input.split("x");
-  const width = Number.parseInt(rawWidth ?? "", 10);
-  const height = Number.parseInt(rawHeight ?? "", 10);
-
-  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
-    return { width: 1920, height: 1080 };
-  }
-
-  return { width, height };
-}
-
-function timezoneOffsetMs(): number {
-  return -new Date().getTimezoneOffset() * 60 * 1000;
-}
-
-function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
-  const { width, height } = parseResolution(input.settings.resolution);
-  const cq = input.settings.colorQuality;
-  // IMPORTANT: hdrEnabled is a SEPARATE toggle from color quality.
-  // The Rust reference (cloudmatch.rs) uses settings.hdr_enabled independently.
-  // 10-bit color depth does NOT mean HDR — you can have 10-bit SDR.
-  // Conflating them caused the server to set up an HDR pipeline, which
-  // dynamically downscaled resolution to ~540p.
-  const hdrEnabled = false; // No HDR toggle implemented yet; hardcode off like claim body
-  const bitDepth = colorQualityBitDepth(cq);
-  const chromaFormat = colorQualityChromaFormat(cq);
-  const accountLinked = input.accountLinked ?? true;
-
-  return {
-    sessionRequestData: {
-      appId: input.appId,
-      internalTitle: input.internalTitle || null,
-      availableSupportedControllers: [],
-      networkTestSessionId: null,
-      parentSessionId: null,
-      clientIdentification: "GFN-PC",
-      deviceHashId: crypto.randomUUID(),
-      clientVersion: "30.0",
-      sdkVersion: "1.0",
-      streamerVersion: 1,
-      clientPlatformName: "windows",
-      clientRequestMonitorSettings: [
-        {
-          widthInPixels: width,
-          heightInPixels: height,
-          framesPerSecond: input.settings.fps,
-          sdrHdrMode: hdrEnabled ? 1 : 0,
-          displayData: {
-            desiredContentMaxLuminance: hdrEnabled ? 1000 : 0,
-            desiredContentMinLuminance: 0,
-            desiredContentMaxFrameAverageLuminance: hdrEnabled ? 500 : 0,
-          },
-          dpi: 100,
-        },
-      ],
-      useOps: true,
-      audioMode: 2,
-      metaData: [
-        { key: "SubSessionId", value: crypto.randomUUID() },
-        { key: "wssignaling", value: "1" },
-        { key: "GSStreamerType", value: "WebRTC" },
-        { key: "networkType", value: "Unknown" },
-        { key: "ClientImeSupport", value: "0" },
-        {
-          key: "clientPhysicalResolution",
-          value: JSON.stringify({ horizontalPixels: width, verticalPixels: height }),
-        },
-        { key: "surroundAudioInfo", value: "2" },
-      ],
-      sdrHdrMode: hdrEnabled ? 1 : 0,
-      clientDisplayHdrCapabilities: hdrEnabled
-        ? {
-            version: 1,
-            hdrEdrSupportedFlagsInUint32: 1,
-            staticMetadataDescriptorId: 0,
-          }
-        : null,
-      surroundAudioInfo: 0,
-      remoteControllersBitmap: 0,
-      clientTimezoneOffset: timezoneOffsetMs(),
-      enhancedStreamMode: 1,
-      appLaunchMode: 1,
-      secureRTSPSupported: false,
-      partnerCustomData: "",
-      accountLinked,
-      enablePersistingInGameSettings: true,
-      userAge: 26,
-      requestedStreamingFeatures: {
-        reflex: input.settings.fps >= 120,
-        bitDepth,
-        cloudGsync: false,
-        enabledL4S: input.settings.enableL4S,
-        mouseMovementFlags: 0,
-        trueHdr: hdrEnabled,
-        supportedHidDevices: 0,
-        profile: 0,
-        fallbackToLogicalResolution: false,
-        hidDevices: null,
-        chromaFormat,
-        prefilterMode: 0,
-        prefilterSharpness: 0,
-        prefilterNoiseReduction: 0,
-        hudStreamingMode: 0,
-        sdrColorSpace: 2,
-        hdrColorSpace: hdrEnabled ? 4 : 0,
-      },
-    },
-  };
-}
-
-function cloudmatchUrl(zone: string): string {
-  return `https://${zone}.cloudmatchbeta.nvidiagrid.net`;
-}
-
-function resolveStreamingBaseUrl(zone: string, provided?: string): string {
-  if (provided && provided.trim()) {
-    const trimmed = provided.trim();
-    return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
-  }
-  return cloudmatchUrl(zone);
-}
-
-function shouldUseServerIp(baseUrl: string): boolean {
-  return baseUrl.includes("cloudmatchbeta.nvidiagrid.net");
-}
-
-function resolvePollStopBase(zone: string, provided?: string, serverIp?: string): string {
-  const base = resolveStreamingBaseUrl(zone, provided);
-  // Only use serverIp if it's a real server IP (not a zone hostname).
-  // The Rust version checks: if we're NOT an alliance partner AND we have a server_ip, use it.
-  // But if the "serverIp" is actually the zone hostname (from an early poll when connectionInfo
-  // was empty), using it is circular and doesn't help.
-  if (serverIp && shouldUseServerIp(base) && !isZoneHostname(serverIp)) {
-    return `https://${serverIp}`;
-  }
-  return base;
 }
 
 function toPositiveInt(value: unknown): number | undefined {
@@ -866,6 +582,10 @@ export async function getActiveSessions(
 /**
  * Build claim/resume request payload
  */
+function timezoneOffsetMs(): number {
+  return -new Date().getTimezoneOffset() * 60 * 1000;
+}
+
 function buildClaimRequestBody(sessionId: string, appId: string, settings: StreamSettings): unknown {
   // For RESUME claims, we must NOT attempt to renegotiate streaming parameters.
   // The session is already configured on the server side. Sending different fps, resolution,

--- a/opennow-stable/src/main/gfn/cloudmatchHelpers.ts
+++ b/opennow-stable/src/main/gfn/cloudmatchHelpers.ts
@@ -1,0 +1,270 @@
+import crypto from "node:crypto";
+
+import type { SessionCreateRequest } from "@shared/gfn";
+import {
+  colorQualityBitDepth,
+  colorQualityChromaFormat,
+} from "@shared/gfn";
+
+import type { CloudMatchRequest, CloudMatchResponse } from "./types";
+
+export const GFN_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/2.0.80.173";
+export const GFN_CLIENT_VERSION = "2.0.80.173";
+
+export interface RequestHeadersOptions {
+  token: string;
+  clientId?: string;
+  deviceId?: string;
+  includeOrigin?: boolean;
+  platform?: NodeJS.Platform;
+}
+
+export function streamingServerIp(response: CloudMatchResponse): string | null {
+  const connections = response.session.connectionInfo ?? [];
+  const sigConn = connections.find((conn) => conn.usage === 14);
+
+  if (sigConn) {
+    const rawIp = sigConn.ip;
+    const directIp = Array.isArray(rawIp) ? rawIp[0] : rawIp;
+    if (directIp && directIp.length > 0) {
+      return directIp;
+    }
+
+    if (sigConn.resourcePath) {
+      const host = extractHostFromUrl(sigConn.resourcePath);
+      if (host) return host;
+    }
+  }
+
+  const controlIp = response.session.sessionControlInfo?.ip;
+  if (controlIp && controlIp.length > 0) {
+    return Array.isArray(controlIp) ? controlIp[0] : controlIp;
+  }
+
+  return null;
+}
+
+export function extractHostFromUrl(url: string): string | null {
+  const prefixes = ["rtsps://", "rtsp://", "wss://", "https://"];
+  let afterProto: string | null = null;
+  for (const prefix of prefixes) {
+    if (url.startsWith(prefix)) {
+      afterProto = url.slice(prefix.length);
+      break;
+    }
+  }
+  if (!afterProto) return null;
+
+  const host = afterProto.split(":")[0]?.split("/")[0];
+  if (!host || host.length === 0 || host.startsWith(".")) return null;
+  return host;
+}
+
+export function isZoneHostname(ip: string): boolean {
+  return ip.includes("cloudmatchbeta.nvidiagrid.net") || ip.includes("cloudmatch.nvidiagrid.net");
+}
+
+export function buildSignalingUrl(
+  raw: string,
+  serverIp: string,
+): { signalingUrl: string; signalingHost: string | null } {
+  if (raw.startsWith("rtsps://") || raw.startsWith("rtsp://")) {
+    const withoutScheme = raw.startsWith("rtsps://")
+      ? raw.slice("rtsps://".length)
+      : raw.slice("rtsp://".length);
+    const host = withoutScheme.split(":")[0]?.split("/")[0];
+    if (host && host.length > 0 && !host.startsWith(".")) {
+      return {
+        signalingUrl: `wss://${host}/nvst/`,
+        signalingHost: host,
+      };
+    }
+    return {
+      signalingUrl: `wss://${serverIp}:443/nvst/`,
+      signalingHost: null,
+    };
+  }
+
+  if (raw.startsWith("wss://")) {
+    const withoutScheme = raw.slice("wss://".length);
+    const host = withoutScheme.split("/")[0] ?? null;
+    return { signalingUrl: raw, signalingHost: host };
+  }
+
+  if (raw.startsWith("/")) {
+    return {
+      signalingUrl: `wss://${serverIp}:443${raw}`,
+      signalingHost: null,
+    };
+  }
+
+  return {
+    signalingUrl: `wss://${serverIp}:443/nvst/`,
+    signalingHost: null,
+  };
+}
+
+export function requestHeaders(options: RequestHeadersOptions): Record<string, string> {
+  const clientId = options.clientId ?? crypto.randomUUID();
+  const deviceId = options.deviceId ?? crypto.randomUUID();
+  const platform = options.platform ?? process.platform;
+
+  const headers: Record<string, string> = {
+    "User-Agent": GFN_USER_AGENT,
+    Authorization: `GFNJWT ${options.token}`,
+    "Content-Type": "application/json",
+    "nv-browser-type": "CHROME",
+    "nv-client-id": clientId,
+    "nv-client-streamer": "NVIDIA-CLASSIC",
+    "nv-client-type": "NATIVE",
+    "nv-client-version": GFN_CLIENT_VERSION,
+    "nv-device-make": "UNKNOWN",
+    "nv-device-model": "UNKNOWN",
+    "nv-device-os": platform === "win32" ? "WINDOWS" : platform === "darwin" ? "MACOS" : "LINUX",
+    "nv-device-type": "DESKTOP",
+    "x-device-id": deviceId,
+  };
+
+  if (options.includeOrigin !== false) {
+    headers["Origin"] = "https://play.geforcenow.com";
+    headers["Referer"] = "https://play.geforcenow.com/";
+  }
+
+  return headers;
+}
+
+export function parseResolution(input: string): { width: number; height: number } {
+  const [rawWidth, rawHeight] = input.split("x");
+  const width = Number.parseInt(rawWidth ?? "", 10);
+  const height = Number.parseInt(rawHeight ?? "", 10);
+
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return { width: 1920, height: 1080 };
+  }
+
+  return { width, height };
+}
+
+interface BuildSessionRequestBodyOptions {
+  deviceHashId?: string;
+  subSessionId?: string;
+  now?: Date;
+}
+
+export function buildSessionRequestBody(
+  input: SessionCreateRequest,
+  options: BuildSessionRequestBodyOptions = {},
+): CloudMatchRequest {
+  const { width, height } = parseResolution(input.settings.resolution);
+  const cq = input.settings.colorQuality;
+  const hdrEnabled = false;
+  const bitDepth = colorQualityBitDepth(cq);
+  const chromaFormat = colorQualityChromaFormat(cq);
+  const accountLinked = input.accountLinked ?? true;
+
+  return {
+    sessionRequestData: {
+      appId: input.appId,
+      internalTitle: input.internalTitle || null,
+      availableSupportedControllers: [],
+      networkTestSessionId: null,
+      parentSessionId: null,
+      clientIdentification: "GFN-PC",
+      deviceHashId: options.deviceHashId ?? crypto.randomUUID(),
+      clientVersion: "30.0",
+      sdkVersion: "1.0",
+      streamerVersion: 1,
+      clientPlatformName: "windows",
+      clientRequestMonitorSettings: [
+        {
+          widthInPixels: width,
+          heightInPixels: height,
+          framesPerSecond: input.settings.fps,
+          sdrHdrMode: hdrEnabled ? 1 : 0,
+          displayData: {
+            desiredContentMaxLuminance: hdrEnabled ? 1000 : 0,
+            desiredContentMinLuminance: 0,
+            desiredContentMaxFrameAverageLuminance: hdrEnabled ? 500 : 0,
+          },
+          dpi: 100,
+        },
+      ],
+      useOps: true,
+      audioMode: 2,
+      metaData: [
+        { key: "SubSessionId", value: options.subSessionId ?? crypto.randomUUID() },
+        { key: "wssignaling", value: "1" },
+        { key: "GSStreamerType", value: "WebRTC" },
+        { key: "networkType", value: "Unknown" },
+        { key: "ClientImeSupport", value: "0" },
+        {
+          key: "clientPhysicalResolution",
+          value: JSON.stringify({ horizontalPixels: width, verticalPixels: height }),
+        },
+        { key: "surroundAudioInfo", value: "2" },
+      ],
+      sdrHdrMode: hdrEnabled ? 1 : 0,
+      clientDisplayHdrCapabilities: hdrEnabled
+        ? {
+            version: 1,
+            hdrEdrSupportedFlagsInUint32: 1,
+            staticMetadataDescriptorId: 0,
+          }
+        : null,
+      surroundAudioInfo: 0,
+      remoteControllersBitmap: 0,
+      clientTimezoneOffset: -(options.now ?? new Date()).getTimezoneOffset() * 60 * 1000,
+      enhancedStreamMode: 1,
+      appLaunchMode: 1,
+      secureRTSPSupported: false,
+      partnerCustomData: "",
+      accountLinked,
+      enablePersistingInGameSettings: true,
+      userAge: 26,
+      requestedStreamingFeatures: {
+        reflex: input.settings.fps >= 120,
+        bitDepth,
+        cloudGsync: false,
+        enabledL4S: input.settings.enableL4S,
+        mouseMovementFlags: 0,
+        trueHdr: hdrEnabled,
+        supportedHidDevices: 0,
+        profile: 0,
+        fallbackToLogicalResolution: false,
+        hidDevices: null,
+        chromaFormat,
+        prefilterMode: 0,
+        prefilterSharpness: 0,
+        prefilterNoiseReduction: 0,
+        hudStreamingMode: 0,
+        sdrColorSpace: 2,
+        hdrColorSpace: hdrEnabled ? 4 : 0,
+      },
+    },
+  };
+}
+
+export function cloudmatchUrl(zone: string): string {
+  return `https://${zone}.cloudmatchbeta.nvidiagrid.net`;
+}
+
+export function resolveStreamingBaseUrl(zone: string, provided?: string): string {
+  if (provided && provided.trim()) {
+    const trimmed = provided.trim();
+    return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+  }
+  return cloudmatchUrl(zone);
+}
+
+export function shouldUseServerIp(baseUrl: string): boolean {
+  return baseUrl.includes("cloudmatchbeta.nvidiagrid.net");
+}
+
+export function resolvePollStopBase(zone: string, provided?: string, serverIp?: string): string {
+  const base = resolveStreamingBaseUrl(zone, provided);
+  if (serverIp && shouldUseServerIp(base) && !isZoneHostname(serverIp)) {
+    return `https://${serverIp}`;
+  }
+  return base;
+}

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -518,7 +518,7 @@ export function mapKeyboardEvent(event: KeyboardEvent): { vk: number; scancode: 
   const key = event.key;
   if (key.length === 1) {
     const upper = key.toUpperCase();
-    if (upper >= "A" && upper <= "Z") {
+    if (upper.length === 1 && upper >= "A" && upper <= "Z") {
       return { vk: upper.charCodeAt(0), scancode: 0 };
     }
     if (key >= "0" && key <= "9") {

--- a/opennow-stable/src/renderer/src/shortcuts.ts
+++ b/opennow-stable/src/renderer/src/shortcuts.ts
@@ -24,7 +24,7 @@ function normalizeKeyToken(token: string): string | null {
   if (alias[upper]) {
     return alias[upper];
   }
-  if (upper.length === 1) {
+  if (upper.length === 1 && /^[A-Z0-9]$/.test(upper)) {
     return upper;
   }
   if (/^F\d{1,2}$/.test(upper)) {

--- a/opennow-stable/src/renderer/src/utils/playtimeStore.ts
+++ b/opennow-stable/src/renderer/src/utils/playtimeStore.ts
@@ -1,0 +1,100 @@
+export const PLAYTIME_STORAGE_KEY = "opennow:playtime";
+
+export interface PlaytimeRecord {
+  totalSeconds: number;
+  lastPlayedAt: string | null;
+  sessionCount: number;
+}
+
+export type PlaytimeStore = Record<string, PlaytimeRecord>;
+
+export function loadPlaytimeStore(storage: Pick<Storage, "getItem">, key = PLAYTIME_STORAGE_KEY): PlaytimeStore {
+  try {
+    const raw = storage.getItem(key);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") return parsed as PlaytimeStore;
+    }
+  } catch {
+  }
+  return {};
+}
+
+export function savePlaytimeStore(storage: Pick<Storage, "setItem">, store: PlaytimeStore, key = PLAYTIME_STORAGE_KEY): void {
+  try {
+    storage.setItem(key, JSON.stringify(store));
+  } catch {
+  }
+}
+
+export function emptyPlaytimeRecord(): PlaytimeRecord {
+  return { totalSeconds: 0, lastPlayedAt: null, sessionCount: 0 };
+}
+
+export function formatPlaytime(totalSeconds: number): string {
+  if (totalSeconds < 60) {
+    return totalSeconds <= 0 ? "Never played" : "< 1 min";
+  }
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  if (h === 0) return `${m} m`;
+  if (m === 0) return `${h} h`;
+  return `${h} h ${m} m`;
+}
+
+export function formatLastPlayed(isoString: string | null, now = new Date()): string {
+  if (!isoString) return "Never";
+  const then = new Date(isoString);
+
+  const thenDay = new Date(then.getFullYear(), then.getMonth(), then.getDate()).getTime();
+  const todayDay = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const diffDays = Math.round((todayDay - thenDay) / 86_400_000);
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} wk ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} mo ago`;
+  return `${Math.floor(diffDays / 365)} yr ago`;
+}
+
+export function startPlaytimeSession(
+  store: PlaytimeStore,
+  gameId: string,
+  nowMs: number,
+): PlaytimeStore {
+  const existing = store[gameId] ?? emptyPlaytimeRecord();
+  return {
+    ...store,
+    [gameId]: {
+      ...existing,
+      lastPlayedAt: new Date(nowMs).toISOString(),
+      sessionCount: existing.sessionCount + 1,
+    },
+  };
+}
+
+export function endPlaytimeSession(
+  store: PlaytimeStore,
+  gameId: string,
+  startMs: number | undefined,
+  nowMs: number,
+): PlaytimeStore {
+  if (startMs == null) {
+    return store;
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((nowMs - startMs) / 1000));
+  if (elapsedSeconds === 0) {
+    return store;
+  }
+
+  const existing = store[gameId] ?? emptyPlaytimeRecord();
+  return {
+    ...store,
+    [gameId]: {
+      ...existing,
+      totalSeconds: existing.totalSeconds + elapsedSeconds,
+    },
+  };
+}

--- a/opennow-stable/src/renderer/src/utils/usePlaytime.ts
+++ b/opennow-stable/src/renderer/src/utils/usePlaytime.ts
@@ -1,66 +1,17 @@
 import { useCallback, useRef, useState } from "react";
 
-const STORAGE_KEY = "opennow:playtime";
+import {
+  endPlaytimeSession,
+  formatLastPlayed,
+  formatPlaytime,
+  loadPlaytimeStore,
+  savePlaytimeStore,
+  startPlaytimeSession,
+  type PlaytimeStore,
+} from "./playtimeStore";
 
-export interface PlaytimeRecord {
-  totalSeconds: number;
-  lastPlayedAt: string | null;
-  sessionCount: number;
-}
-
-export type PlaytimeStore = Record<string, PlaytimeRecord>;
-
-function loadStore(): PlaytimeStore {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === "object") return parsed as PlaytimeStore;
-    }
-  } catch {
-  }
-  return {};
-}
-
-function saveStore(store: PlaytimeStore): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
-  } catch {
-  }
-}
-
-function emptyRecord(): PlaytimeRecord {
-  return { totalSeconds: 0, lastPlayedAt: null, sessionCount: 0 };
-}
-
-export function formatPlaytime(totalSeconds: number): string {
-  if (totalSeconds < 60) {
-    return totalSeconds <= 0 ? "Never played" : "< 1 min";
-  }
-  const h = Math.floor(totalSeconds / 3600);
-  const m = Math.floor((totalSeconds % 3600) / 60);
-  if (h === 0) return `${m} m`;
-  if (m === 0) return `${h} h`;
-  return `${h} h ${m} m`;
-}
-
-export function formatLastPlayed(isoString: string | null): string {
-  if (!isoString) return "Never";
-  const then = new Date(isoString);
-  const now = new Date();
-
-  const thenDay = new Date(then.getFullYear(), then.getMonth(), then.getDate()).getTime();
-  const todayDay = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-
-  const diffDays = Math.round((todayDay - thenDay) / 86_400_000);
-
-  if (diffDays === 0) return "Today";
-  if (diffDays === 1) return "Yesterday";
-  if (diffDays < 7) return `${diffDays} days ago`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} wk ago`;
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)} mo ago`;
-  return `${Math.floor(diffDays / 365)} yr ago`;
-}
+export { formatLastPlayed, formatPlaytime };
+export type { PlaytimeRecord, PlaytimeStore } from "./playtimeStore";
 
 export interface UsePlaytimeReturn {
   playtime: PlaytimeStore;
@@ -69,22 +20,15 @@ export interface UsePlaytimeReturn {
 }
 
 export function usePlaytime(): UsePlaytimeReturn {
-  const [playtime, setPlaytime] = useState<PlaytimeStore>(loadStore);
+  const [playtime, setPlaytime] = useState<PlaytimeStore>(() => loadPlaytimeStore(localStorage));
   const sessionStartRef = useRef<Record<string, number>>({});
 
   const startSession = useCallback((gameId: string): void => {
-    sessionStartRef.current[gameId] = Date.now();
+    const nowMs = Date.now();
+    sessionStartRef.current[gameId] = nowMs;
     setPlaytime((prev) => {
-      const existing = prev[gameId] ?? emptyRecord();
-      const next: PlaytimeStore = {
-        ...prev,
-        [gameId]: {
-          ...existing,
-          lastPlayedAt: new Date().toISOString(),
-          sessionCount: existing.sessionCount + 1,
-        },
-      };
-      saveStore(next);
+      const next = startPlaytimeSession(prev, gameId, nowMs);
+      savePlaytimeStore(localStorage, next);
       return next;
     });
   }, []);
@@ -94,19 +38,13 @@ export function usePlaytime(): UsePlaytimeReturn {
     if (startMs == null) return;
     delete sessionStartRef.current[gameId];
 
-    const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startMs) / 1000));
-    if (elapsedSeconds === 0) return;
-
+    const nowMs = Date.now();
     setPlaytime((prev) => {
-      const existing = prev[gameId] ?? emptyRecord();
-      const next: PlaytimeStore = {
-        ...prev,
-        [gameId]: {
-          ...existing,
-          totalSeconds: existing.totalSeconds + elapsedSeconds,
-        },
-      };
-      saveStore(next);
+      const next = endPlaytimeSession(prev, gameId, startMs, nowMs);
+      if (Object.is(next, prev)) {
+        return prev;
+      }
+      savePlaytimeStore(localStorage, next);
       return next;
     });
   }, []);

--- a/opennow-stable/test/fixtures/cloudmatch.ts
+++ b/opennow-stable/test/fixtures/cloudmatch.ts
@@ -1,0 +1,50 @@
+import type { SessionCreateRequest } from "@shared/gfn";
+
+import type { CloudMatchResponse } from "../../src/main/gfn/types";
+
+export function buildCloudMatchResponse(
+  overrides: Partial<CloudMatchResponse> = {},
+  sessionOverrides: Partial<CloudMatchResponse["session"]> = {},
+): CloudMatchResponse {
+  return {
+    requestStatus: {
+      statusCode: 1,
+      ...overrides.requestStatus,
+    },
+    session: {
+      sessionId: "session-1",
+      status: 2,
+      connectionInfo: [],
+      sessionControlInfo: {},
+      iceServerConfiguration: {
+        iceServers: [],
+      },
+      ...overrides.session,
+      ...sessionOverrides,
+    },
+  };
+}
+
+export function buildSessionCreateRequest(
+  overrides: Partial<SessionCreateRequest> = {},
+  settingsOverrides: Partial<SessionCreateRequest["settings"]> = {},
+): SessionCreateRequest {
+  return {
+    token: "token",
+    zone: "np-ams-06",
+    appId: "12345",
+    internalTitle: "OpenNOW Test",
+    streamingBaseUrl: "https://np-ams-06.cloudmatchbeta.nvidiagrid.net/",
+    settings: {
+      resolution: "2560x1440",
+      fps: 120,
+      maxBitrateMbps: 75,
+      codec: "H264",
+      colorQuality: "10bit_444",
+      gameLanguage: "en_US",
+      enableL4S: true,
+      ...settingsOverrides,
+    },
+    ...overrides,
+  };
+}

--- a/opennow-stable/test/fixtures/sdp.ts
+++ b/opennow-stable/test/fixtures/sdp.ts
@@ -1,0 +1,34 @@
+export function joinSdpLines(lines: string[], lineEnding: "\n" | "\r\n" = "\r\n"): string {
+  return `${lines.join(lineEnding)}${lineEnding}`;
+}
+
+export function buildOfferSdp(lineEnding: "\n" | "\r\n" = "\r\n"): string {
+  return joinSdpLines(
+    [
+      "v=0",
+      "o=- 0 0 IN IP4 127.0.0.1",
+      "s=-",
+      "t=0 0",
+      "a=ice-ufrag:offerUfrag",
+      "a=ice-pwd:offerPwd",
+      "a=fingerprint:sha-256 AA:BB:CC:DD",
+      "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+      "c=IN IP4 0.0.0.0",
+      "a=rtpmap:111 opus/48000/2",
+      "a=fmtp:111 minptime=10;useinbandfec=1;tier-flag=1;profile-id=1;level-id=93",
+      "a=candidate:1 1 udp 2113937151 0.0.0.0 54400 typ host",
+      "m=video 9 UDP/TLS/RTP/SAVPF 96 98 100",
+      "c=IN IP4 0.0.0.0",
+      "a=rtpmap:96 H264/90000",
+      "a=fmtp:96 profile-level-id=42e01f;tier-flag=1",
+      "a=rtpmap:98 H265/90000",
+      "a=fmtp:98 profile-id=1;level-id=120;tier-flag=1",
+      "a=rtpmap:100 HEVC/90000",
+      "a=fmtp:100 profile-id=2;level-id=150;tier-flag=1",
+      "a=candidate:2 1 udp 2113937151 0.0.0.0 54402 typ host",
+      "m=application 9 UDP/DTLS/SCTP webrtc-datachannel",
+      "c=IN IP4 0.0.0.0",
+    ],
+    lineEnding,
+  );
+}

--- a/opennow-stable/test/main/gfn/authHelpers.test.ts
+++ b/opennow-stable/test/main/gfn/authHelpers.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { LoginProvider } from "@shared/gfn";
+
+import {
+  buildAuthUrl,
+  decodeBase64Url,
+  findAvailablePort,
+  isExpired,
+  isNearExpiry,
+  normalizeProvider,
+  parseJwtPayload,
+  toExpiresAt,
+} from "../../../src/main/gfn/authHelpers";
+
+const provider: LoginProvider = {
+  idpId: "provider-1",
+  code: "NVIDIA",
+  displayName: "NVIDIA",
+  streamingServiceUrl: "https://prod.cloudmatchbeta.nvidiagrid.net",
+  priority: 0,
+};
+
+function createJwt(payload: object): string {
+  const encode = (value: object): string => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.signature`;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("authHelpers", () => {
+  it("normalizes provider urls with a trailing slash", () => {
+    expect(normalizeProvider(provider).streamingServiceUrl).toBe("https://prod.cloudmatchbeta.nvidiagrid.net/");
+    expect(normalizeProvider({ ...provider, streamingServiceUrl: "https://already.example/" }).streamingServiceUrl).toBe(
+      "https://already.example/",
+    );
+  });
+
+  it("parses base64url and jwt payloads", () => {
+    expect(decodeBase64Url(Buffer.from('{"sub":"123"}').toString("base64url"))).toBe('{"sub":"123"}');
+    expect(parseJwtPayload<{ sub: string; tier: string }>(createJwt({ sub: "123", tier: "ULTIMATE" }))).toEqual({
+      sub: "123",
+      tier: "ULTIMATE",
+    });
+  });
+
+  it("returns null for invalid jwt payloads", () => {
+    expect(parseJwtPayload("not-a-jwt")).toBeNull();
+    expect(parseJwtPayload("a.invalid-json.c")).toBeNull();
+  });
+
+  it("applies expiry and near-expiry boundaries", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-29T12:00:00.000Z"));
+    const now = Date.now();
+
+    expect(toExpiresAt(60)).toBe(now + 60_000);
+    expect(isExpired(now)).toBe(true);
+    expect(isExpired(now + 1)).toBe(false);
+    expect(isNearExpiry(now + 59_999, 60_000)).toBe(true);
+    expect(isNearExpiry(now + 60_000, 60_000)).toBe(false);
+    expect(isNearExpiry(undefined, 60_000)).toBe(true);
+  });
+
+  it("builds auth urls with required oauth query params", () => {
+    const url = new URL(
+      buildAuthUrl(provider, {
+        challenge: "challenge-value",
+        port: 2259,
+        deviceId: "device-123",
+        nonce: "nonce-456",
+      }),
+    );
+
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("device_id")).toBe("device-123");
+    expect(url.searchParams.get("scope")).toBe("openid consent email tk_client age");
+    expect(url.searchParams.get("client_id")).toBe("ZU7sPN-miLujMD95LfOQ453IB0AtjM8sMyvgJ9wCXEQ");
+    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:2259");
+    expect(url.searchParams.get("nonce")).toBe("nonce-456");
+    expect(url.searchParams.get("code_challenge")).toBe("challenge-value");
+    expect(url.searchParams.get("idp_id")).toBe("provider-1");
+  });
+
+  it("selects the first available redirect port using an injected availability check", async () => {
+    const checked: number[] = [];
+    const port = await findAvailablePort([2259, 6460, 7119], async (candidate) => {
+      checked.push(candidate);
+      return candidate === 6460;
+    });
+
+    expect(port).toBe(6460);
+    expect(checked).toEqual([2259, 6460]);
+  });
+
+  it("throws when no redirect ports are available", async () => {
+    await expect(findAvailablePort([2259, 6460], async () => false)).rejects.toThrow(
+      "No available OAuth callback ports",
+    );
+  });
+});

--- a/opennow-stable/test/main/gfn/cloudmatchHelpers.test.ts
+++ b/opennow-stable/test/main/gfn/cloudmatchHelpers.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSessionRequestBody,
+  buildSignalingUrl,
+  extractHostFromUrl,
+  requestHeaders,
+  resolvePollStopBase,
+  resolveStreamingBaseUrl,
+  streamingServerIp,
+} from "../../../src/main/gfn/cloudmatchHelpers";
+import { buildCloudMatchResponse, buildSessionCreateRequest } from "../../fixtures/cloudmatch";
+
+describe("cloudmatchHelpers", () => {
+  it("selects signaling host with the expected priority", () => {
+    const directIpResponse = buildCloudMatchResponse({}, {
+      connectionInfo: [
+        { usage: 14, port: 443, ip: "203.0.113.10", resourcePath: "rtsps://ignored.example:48010/stream" },
+      ],
+      sessionControlInfo: { ip: "198.51.100.5" as never },
+    });
+    const resourcePathResponse = buildCloudMatchResponse({}, {
+      connectionInfo: [{ usage: 14, port: 48010, resourcePath: "rtsps://signal.example:48010/stream" }],
+    });
+    const fallbackResponse = buildCloudMatchResponse({}, {
+      connectionInfo: [{ usage: 14, port: 48010, resourcePath: "invalid" }],
+      sessionControlInfo: { ip: "198.51.100.25" as never },
+    });
+
+    expect(streamingServerIp(directIpResponse)).toBe("203.0.113.10");
+    expect(streamingServerIp(resourcePathResponse)).toBe("signal.example");
+    expect(streamingServerIp(fallbackResponse)).toBe("198.51.100.25");
+  });
+
+  it("extracts hosts and safely handles malformed urls", () => {
+    expect(extractHostFromUrl("rtsps://stream.example:48010/foo")).toBe("stream.example");
+    expect(extractHostFromUrl("wss://signal.example/nvst/")).toBe("signal.example");
+    expect(extractHostFromUrl("https://api.example/v2/session")).toBe("api.example");
+    expect(extractHostFromUrl("relative/path")).toBeNull();
+    expect(extractHostFromUrl("rtsps://.broken:48010/foo")).toBeNull();
+  });
+
+  it("derives signaling urls from rtsp, wss, relative, and malformed paths", () => {
+    expect(buildSignalingUrl("rtsps://stream.example:47998/some/path", "198.51.100.3")).toEqual({
+      signalingUrl: "wss://stream.example/nvst/",
+      signalingHost: "stream.example",
+    });
+    expect(buildSignalingUrl("wss://signal.example/custom", "198.51.100.3")).toEqual({
+      signalingUrl: "wss://signal.example/custom",
+      signalingHost: "signal.example",
+    });
+    expect(buildSignalingUrl("/nvst/", "198.51.100.3")).toEqual({
+      signalingUrl: "wss://198.51.100.3:443/nvst/",
+      signalingHost: null,
+    });
+    expect(buildSignalingUrl("rtsps://.broken:47998/path", "198.51.100.3")).toEqual({
+      signalingUrl: "wss://198.51.100.3:443/nvst/",
+      signalingHost: null,
+    });
+  });
+
+  it("builds request headers with expected auth, platform, and origin behavior", () => {
+    const defaultHeaders = requestHeaders({
+      token: "jwt-token",
+      clientId: "client-1",
+      deviceId: "device-1",
+      platform: "win32",
+    });
+    const noOriginHeaders = requestHeaders({
+      token: "jwt-token",
+      includeOrigin: false,
+      clientId: "client-1",
+      deviceId: "device-1",
+      platform: "linux",
+    });
+
+    expect(defaultHeaders).toMatchObject({
+      Authorization: "GFNJWT jwt-token",
+      "nv-client-id": "client-1",
+      "x-device-id": "device-1",
+      "nv-client-type": "NATIVE",
+      "nv-device-type": "DESKTOP",
+      "nv-device-os": "WINDOWS",
+      Origin: "https://play.geforcenow.com",
+      Referer: "https://play.geforcenow.com/",
+    });
+    expect(noOriginHeaders.Origin).toBeUndefined();
+    expect(noOriginHeaders.Referer).toBeUndefined();
+    expect(noOriginHeaders["nv-device-os"]).toBe("LINUX");
+  });
+
+  it("builds session payloads with resolution fallback and feature derivation", () => {
+    const highFps = buildSessionRequestBody(buildSessionCreateRequest(), {
+      deviceHashId: "device-hash",
+      subSessionId: "sub-session",
+      now: new Date("2026-03-29T12:00:00.000Z"),
+    });
+    const fallback = buildSessionRequestBody(
+      buildSessionCreateRequest({}, {
+        resolution: "broken",
+        fps: 60,
+        colorQuality: "8bit_420",
+        enableL4S: false,
+      }),
+      {
+        deviceHashId: "device-hash",
+        subSessionId: "sub-session",
+      },
+    );
+
+    expect(highFps.sessionRequestData.clientRequestMonitorSettings[0]).toMatchObject({
+      widthInPixels: 2560,
+      heightInPixels: 1440,
+      framesPerSecond: 120,
+    });
+    expect(highFps.sessionRequestData.requestedStreamingFeatures).toMatchObject({
+      reflex: true,
+      bitDepth: 10,
+      chromaFormat: 2,
+      enabledL4S: true,
+    });
+    expect(highFps.sessionRequestData.metaData).toContainEqual({ key: "SubSessionId", value: "sub-session" });
+    expect(fallback.sessionRequestData.clientRequestMonitorSettings[0]).toMatchObject({
+      widthInPixels: 1920,
+      heightInPixels: 1080,
+      framesPerSecond: 60,
+    });
+    expect(fallback.sessionRequestData.requestedStreamingFeatures).toMatchObject({
+      reflex: false,
+      bitDepth: 0,
+      chromaFormat: 0,
+      enabledL4S: false,
+    });
+  });
+
+  it("trims provided streaming base urls and overrides only zone hosts with real server ips", () => {
+    expect(resolveStreamingBaseUrl("np-ams-06", " https://partner.example/base/ ")).toBe("https://partner.example/base");
+    expect(resolvePollStopBase("np-ams-06", undefined, "203.0.113.5")).toBe("https://203.0.113.5");
+    expect(resolvePollStopBase("np-ams-06", "https://partner.example/base/", "203.0.113.5")).toBe("https://partner.example/base");
+    expect(resolvePollStopBase("np-ams-06", undefined, "np-ams-07.cloudmatchbeta.nvidiagrid.net")).toBe(
+      "https://np-ams-06.cloudmatchbeta.nvidiagrid.net",
+    );
+  });
+});

--- a/opennow-stable/test/renderer/gfn/inputProtocol.test.ts
+++ b/opennow-stable/test/renderer/gfn/inputProtocol.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GAMEPAD_A,
+  GAMEPAD_BACK,
+  GAMEPAD_DPAD_LEFT,
+  GAMEPAD_DPAD_UP,
+  GAMEPAD_GUIDE,
+  GAMEPAD_LB,
+  GAMEPAD_LS,
+  GAMEPAD_RB,
+  GAMEPAD_RS,
+  GAMEPAD_START,
+  GAMEPAD_X,
+  GAMEPAD_Y,
+  applyDeadzone,
+  mapGamepadButtons,
+  mapKeyboardEvent,
+  modifierFlags,
+  normalizeToInt16,
+  normalizeToUint8,
+  readGamepadAxes,
+  toMouseButton,
+} from "../../../src/renderer/src/gfn/inputProtocol";
+
+function keyboardEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  const modifierState = new Map<string, boolean>([
+    ["CapsLock", false],
+    ["NumLock", false],
+  ]);
+
+  return {
+    key: "",
+    code: "",
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    getModifierState: (key: string) => modifierState.get(key) ?? false,
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+function gamepadButton(value = 0): GamepadButton {
+  return {
+    value,
+    pressed: value > 0,
+    touched: value > 0,
+  };
+}
+
+function gamepad(overrides: Partial<Gamepad> = {}): Gamepad {
+  return {
+    id: "pad",
+    index: 0,
+    connected: true,
+    mapping: "standard",
+    timestamp: 0,
+    axes: [],
+    buttons: [],
+    vibrationActuator: null,
+    hapticActuators: [],
+    ...overrides,
+  } as Gamepad;
+}
+
+describe("inputProtocol helpers", () => {
+  it("builds modifier bitmasks including lock states", () => {
+    const event = keyboardEvent({
+      ctrlKey: true,
+      altKey: true,
+      shiftKey: true,
+      metaKey: true,
+      getModifierState: (key) => key === "CapsLock" || key === "NumLock",
+    });
+
+    expect(modifierFlags(event)).toBe(0x3f);
+  });
+
+  it("maps keyboard events via code map, fallback map, alphanumerics, and unsupported cases", () => {
+    expect(mapKeyboardEvent(keyboardEvent({ code: "KeyA", key: "a" }))).toEqual({ vk: 0x41, scancode: 0x04 });
+    expect(mapKeyboardEvent(keyboardEvent({ code: "", key: "Esc" }))).toEqual({ vk: 0x1b, scancode: 0x29 });
+    expect(mapKeyboardEvent(keyboardEvent({ code: "", key: "b" }))).toEqual({ vk: 0x42, scancode: 0 });
+    expect(mapKeyboardEvent(keyboardEvent({ code: "", key: "7" }))).toEqual({ vk: 0x37, scancode: 0 });
+    expect(mapKeyboardEvent(keyboardEvent({ code: "", key: "ß" }))).toBeNull();
+  });
+
+  it("maps browser mouse buttons to protocol offsets", () => {
+    expect(toMouseButton(0)).toBe(1);
+    expect(toMouseButton(4)).toBe(5);
+  });
+
+  it("applies radial deadzones and rescales values", () => {
+    expect(applyDeadzone(0.1, 0.1, 0.2)).toEqual({ x: 0, y: 0 });
+    expect(applyDeadzone(0.2, 0, 0.2)).toEqual({ x: 0, y: 0 });
+    const scaled = applyDeadzone(0.5, 0, 0.2);
+    expect(scaled.x).toBeCloseTo(0.375, 6);
+    expect(scaled.y).toBe(0);
+  });
+
+  it("normalizes int16 and uint8 values with clamping", () => {
+    expect(normalizeToInt16(1)).toBe(32767);
+    expect(normalizeToInt16(-2)).toBe(-32768);
+    expect(normalizeToInt16(0.5)).toBe(16384);
+    expect(normalizeToUint8(0.5)).toBe(128);
+    expect(normalizeToUint8(2)).toBe(255);
+    expect(normalizeToUint8(-1)).toBe(0);
+  });
+
+  it("maps standard gamepad buttons to xinput flags using button values", () => {
+    const pad = gamepad({
+      buttons: [
+        gamepadButton(1),
+        gamepadButton(0),
+        gamepadButton(1),
+        gamepadButton(1),
+        gamepadButton(1),
+        gamepadButton(1),
+        gamepadButton(0),
+        gamepadButton(0),
+        gamepadButton(1),
+        gamepadButton(1),
+        gamepadButton(1),
+        gamepadButton(1),
+        gamepadButton(1),
+        gamepadButton(0),
+        gamepadButton(1),
+        gamepadButton(0),
+        gamepadButton(1),
+      ],
+    });
+
+    expect(mapGamepadButtons(pad)).toBe(
+      GAMEPAD_A |
+        GAMEPAD_X |
+        GAMEPAD_Y |
+        GAMEPAD_LB |
+        GAMEPAD_RB |
+        GAMEPAD_BACK |
+        GAMEPAD_START |
+        GAMEPAD_LS |
+        GAMEPAD_RS |
+        GAMEPAD_DPAD_UP |
+        GAMEPAD_DPAD_LEFT |
+        GAMEPAD_GUIDE,
+    );
+  });
+
+  it("reads sticks with deadzone and inverts y axes", () => {
+    const pad = gamepad({
+      axes: [0.5, 0.5, -0.5, -0.5, 0.6, 0.7],
+      buttons: [gamepadButton(), gamepadButton(), gamepadButton(), gamepadButton(), gamepadButton(), gamepadButton()],
+    });
+
+    const axes = readGamepadAxes(pad);
+
+    expect(axes.leftStickX).toBeCloseTo(0.4634517, 6);
+    expect(axes.leftStickY).toBeCloseTo(-0.4634517, 6);
+    expect(axes.rightStickX).toBeCloseTo(-0.4634517, 6);
+    expect(axes.rightStickY).toBeCloseTo(0.4634517, 6);
+    expect(axes.leftTrigger).toBe(0.6);
+    expect(axes.rightTrigger).toBe(0.7);
+  });
+
+  it("falls back to trigger axes only when trigger buttons are absent", () => {
+    const withButtonObjects = gamepad({
+      axes: [0, 0, 0, 0, 0.9, 0.8],
+      buttons: [
+        gamepadButton(),
+        gamepadButton(),
+        gamepadButton(),
+        gamepadButton(),
+        gamepadButton(),
+        gamepadButton(),
+        gamepadButton(0),
+        gamepadButton(0),
+      ],
+    });
+    const withoutTriggerButtons = gamepad({
+      axes: [0, 0, 0, 0, 0.9, 0.8],
+      buttons: [gamepadButton(), gamepadButton(), gamepadButton(), gamepadButton(), gamepadButton(), gamepadButton()],
+    });
+
+    expect(readGamepadAxes(withButtonObjects)).toMatchObject({ leftTrigger: 0, rightTrigger: 0 });
+    expect(readGamepadAxes(withoutTriggerButtons)).toMatchObject({ leftTrigger: 0.9, rightTrigger: 0.8 });
+  });
+});

--- a/opennow-stable/test/renderer/gfn/sdp.test.ts
+++ b/opennow-stable/test/renderer/gfn/sdp.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractIceCredentials,
+  extractIceUfragFromOffer,
+  extractPublicIp,
+  fixServerIp,
+  rewriteH265LevelIdByProfile,
+  rewriteH265TierFlag,
+} from "../../../src/renderer/src/gfn/sdp";
+import { buildOfferSdp } from "../../fixtures/sdp";
+
+describe("sdp helpers", () => {
+  it("extracts public ip from dotted ips and dash hostnames", () => {
+    expect(extractPublicIp("203.0.113.7")).toBe("203.0.113.7");
+    expect(extractPublicIp("80-250-97-40.cloudmatchbeta.nvidiagrid.net")).toBe("80.250.97.40");
+    expect(extractPublicIp("161-248-11-132.bpc.geforcenow.nvidiagrid.net")).toBe("161.248.11.132");
+    expect(extractPublicIp("not-an-ip.example.com")).toBeNull();
+  });
+
+  it("replaces all connection lines and candidate ips when a valid public ip is available", () => {
+    const source = buildOfferSdp("\r\n");
+    const fixed = fixServerIp(source, "80-250-97-40.cloudmatchbeta.nvidiagrid.net");
+
+    expect(fixed).toContain("c=IN IP4 80.250.97.40\r\n");
+    expect(fixed).not.toContain("c=IN IP4 0.0.0.0");
+    expect(fixed).toContain("a=candidate:1 1 udp 2113937151 80.250.97.40 54400 typ host");
+    expect(fixed).toContain("a=candidate:2 1 udp 2113937151 80.250.97.40 54402 typ host");
+    expect(fixed).toContain("\r\nm=video");
+  });
+
+  it("returns the original sdp when no valid public ip can be extracted", () => {
+    const source = buildOfferSdp("\n");
+    expect(fixServerIp(source, "invalid-host")).toBe(source);
+  });
+
+  it("extracts ice credentials and fingerprint from offers", () => {
+    const source = buildOfferSdp("\r\n");
+
+    expect(extractIceUfragFromOffer(source)).toBe("offerUfrag");
+    expect(extractIceCredentials(source)).toEqual({
+      ufrag: "offerUfrag",
+      pwd: "offerPwd",
+      fingerprint: "AA:BB:CC:DD",
+    });
+  });
+
+  it("rewrites only h265 payload fmtp lines and preserves line endings", () => {
+    const source = buildOfferSdp("\r\n");
+    const { sdp, replacements } = rewriteH265TierFlag(source, 0);
+
+    expect(replacements).toBe(2);
+    expect(sdp).toContain("a=fmtp:98 profile-id=1;level-id=120;tier-flag=0\r\n");
+    expect(sdp).toContain("a=fmtp:100 profile-id=2;level-id=150;tier-flag=0\r\n");
+    expect(sdp).toContain("a=fmtp:96 profile-level-id=42e01f;tier-flag=1\r\n");
+    expect(sdp).toContain("a=fmtp:111 minptime=10;useinbandfec=1;tier-flag=1;profile-id=1;level-id=93\r\n");
+  });
+
+  it("rewrites h265 level-id only when payload profile and level conditions match", () => {
+    const source = buildOfferSdp("\n");
+    const { sdp, replacements } = rewriteH265LevelIdByProfile(source, { 1: 93, 2: 120 });
+
+    expect(replacements).toBe(2);
+    expect(sdp).toContain("a=fmtp:98 profile-id=1;level-id=93;tier-flag=1\n");
+    expect(sdp).toContain("a=fmtp:100 profile-id=2;level-id=120;tier-flag=1\n");
+    expect(sdp).toContain("a=fmtp:96 profile-level-id=42e01f;tier-flag=1\n");
+  });
+
+  it("does not rewrite when payloads do not match conditions", () => {
+    const source = [
+      "v=0",
+      "m=video 9 UDP/TLS/RTP/SAVPF 98",
+      "a=rtpmap:98 H265/90000",
+      "a=fmtp:98 profile-id=1;level-id=93;tier-flag=1",
+      "",
+    ].join("\n");
+
+    expect(rewriteH265LevelIdByProfile(source, { 1: 93 })).toEqual({ sdp: source, replacements: 0 });
+    expect(rewriteH265TierFlag(source, 1)).toEqual({ sdp: source, replacements: 0 });
+  });
+});

--- a/opennow-stable/test/renderer/shortcuts.test.ts
+++ b/opennow-stable/test/renderer/shortcuts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatShortcutForDisplay,
+  isShortcutMatch,
+  normalizeShortcut,
+} from "../../src/renderer/src/shortcuts";
+
+function keyboardEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    key: "",
+    code: "",
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+describe("shortcuts", () => {
+  it("normalizes aliases and canonical modifier ordering", () => {
+    expect(normalizeShortcut("Esc")).toMatchObject({ valid: true, key: "ESCAPE", canonical: "ESCAPE" });
+    expect(normalizeShortcut("Return")).toMatchObject({ valid: true, key: "ENTER", canonical: "ENTER" });
+    expect(normalizeShortcut("Del")).toMatchObject({ valid: true, key: "DELETE", canonical: "DELETE" });
+    expect(normalizeShortcut("PgUp")).toMatchObject({ valid: true, key: "PAGEUP", canonical: "PAGEUP" });
+    expect(normalizeShortcut("PgDn")).toMatchObject({ valid: true, key: "PAGEDOWN", canonical: "PAGEDOWN" });
+    expect(normalizeShortcut("Spacebar")).toMatchObject({ valid: true, key: "SPACE", canonical: "SPACE" });
+    expect(normalizeShortcut("shift + cmd + alt + ctrl + esc").canonical).toBe("Ctrl+Alt+Shift+Meta+ESCAPE");
+  });
+
+  it("rejects invalid shortcut definitions", () => {
+    expect(normalizeShortcut("Ctrl+Shift")).toMatchObject({ valid: false, key: "" });
+    expect(normalizeShortcut("Ctrl+A+B")).toMatchObject({ valid: false, key: "" });
+    expect(normalizeShortcut("Ctrl+?")).toMatchObject({ valid: false, key: "" });
+  });
+
+  it("matches shortcuts by key and falls back to code", () => {
+    const shortcut = normalizeShortcut("Ctrl+Shift+A");
+
+    expect(isShortcutMatch(keyboardEvent({ key: "a", code: "KeyA", ctrlKey: true, shiftKey: true }), shortcut)).toBe(true);
+    expect(isShortcutMatch(keyboardEvent({ key: "Dead", code: "KeyA", ctrlKey: true, shiftKey: true }), shortcut)).toBe(true);
+    expect(isShortcutMatch(keyboardEvent({ key: "a", code: "KeyA", ctrlKey: true, shiftKey: false }), shortcut)).toBe(false);
+  });
+
+  it("treats numpad enter as enter", () => {
+    const shortcut = normalizeShortcut("Enter");
+    expect(isShortcutMatch(keyboardEvent({ key: "Enter", code: "NumpadEnter" }), shortcut)).toBe(true);
+  });
+
+  it("formats shortcuts differently for mac and non-mac labels", () => {
+    expect(formatShortcutForDisplay("Ctrl+Alt+Meta+Spacebar", false)).toBe("Ctrl+Alt+Meta+SPACE");
+    expect(formatShortcutForDisplay("Ctrl+Alt+Meta+Spacebar", true)).toBe("Ctrl+Option+Cmd+SPACE");
+    expect(formatShortcutForDisplay("Ctrl+?", true)).toBe("Ctrl+?");
+  });
+});

--- a/opennow-stable/test/renderer/utils/playtimeStore.test.ts
+++ b/opennow-stable/test/renderer/utils/playtimeStore.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  endPlaytimeSession,
+  formatLastPlayed,
+  formatPlaytime,
+  loadPlaytimeStore,
+  startPlaytimeSession,
+} from "../../../src/renderer/src/utils/playtimeStore";
+
+describe("playtime store helpers", () => {
+  it("formats playtime durations", () => {
+    expect(formatPlaytime(0)).toBe("Never played");
+    expect(formatPlaytime(59)).toBe("< 1 min");
+    expect(formatPlaytime(60)).toBe("1 m");
+    expect(formatPlaytime(3600)).toBe("1 h");
+    expect(formatPlaytime(3660)).toBe("1 h 1 m");
+  });
+
+  it("formats last played dates relative to a provided current date", () => {
+    const now = new Date("2026-03-29T12:00:00.000Z");
+
+    expect(formatLastPlayed(null, now)).toBe("Never");
+    expect(formatLastPlayed("2026-03-29T01:00:00.000Z", now)).toBe("Today");
+    expect(formatLastPlayed("2026-03-28T01:00:00.000Z", now)).toBe("Yesterday");
+    expect(formatLastPlayed("2026-03-25T01:00:00.000Z", now)).toBe("4 days ago");
+    expect(formatLastPlayed("2026-03-01T01:00:00.000Z", now)).toBe("4 wk ago");
+  });
+
+  it("parses invalid storage payloads safely", () => {
+    expect(loadPlaytimeStore({ getItem: () => null })).toEqual({});
+    expect(loadPlaytimeStore({ getItem: () => "{invalid" })).toEqual({});
+  });
+
+  it("accumulates session metadata and elapsed time deterministically", () => {
+    const started = startPlaytimeSession({}, "game-1", Date.parse("2026-03-29T12:00:00.000Z"));
+
+    expect(started).toEqual({
+      "game-1": {
+        totalSeconds: 0,
+        lastPlayedAt: "2026-03-29T12:00:00.000Z",
+        sessionCount: 1,
+      },
+    });
+
+    expect(endPlaytimeSession(started, "game-1", 1_000, 4_999)).toEqual({
+      "game-1": {
+        totalSeconds: 3,
+        lastPlayedAt: "2026-03-29T12:00:00.000Z",
+        sessionCount: 1,
+      },
+    });
+    expect(endPlaytimeSession(started, "game-1", 1_000, 1_999)).toBe(started);
+  });
+});

--- a/opennow-stable/test/renderer/utils/streamDiagnosticsStore.test.ts
+++ b/opennow-stable/test/renderer/utils/streamDiagnosticsStore.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createStreamDiagnosticsStore } from "../../../src/renderer/src/utils/streamDiagnosticsStore";
+
+const diagnostics = {
+  connectionState: "connected",
+  inputReady: true,
+  connectedGamepads: 1,
+  resolution: "1920x1080",
+  codec: "H264",
+  isHdr: false,
+  bitrateKbps: 25000,
+  decodeFps: 60,
+  renderFps: 60,
+  packetsLost: 0,
+  packetsReceived: 100,
+  packetLossPercent: 0,
+  jitterMs: 1,
+  rttMs: 20,
+  framesReceived: 100,
+  framesDecoded: 99,
+  framesDropped: 1,
+  decodeTimeMs: 4,
+  renderTimeMs: 4,
+  jitterBufferDelayMs: 0,
+  inputQueueBufferedBytes: 0,
+  inputQueuePeakBufferedBytes: 0,
+  inputQueueDropCount: 0,
+  inputQueueMaxSchedulingDelayMs: 0,
+  lagReason: "none",
+  lagReasonDetail: "",
+} as const;
+
+describe("streamDiagnosticsStore", () => {
+  it("subscribes and emits only for new references", () => {
+    const store = createStreamDiagnosticsStore(diagnostics as never);
+    const listener = vi.fn();
+
+    const unsubscribe = store.subscribe(listener);
+
+    expect(store.getSnapshot()).toBe(diagnostics);
+    expect(store.getServerSnapshot()).toBe(diagnostics);
+
+    store.set(diagnostics as never);
+    expect(listener).not.toHaveBeenCalled();
+
+    const next = { ...diagnostics, bitrateKbps: 30000 };
+    store.set(next as never);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot()).toBe(next);
+
+    unsubscribe();
+    store.set({ ...next, bitrateKbps: 32000 } as never);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/opennow-stable/test/shared/gfn.test.ts
+++ b/opennow-stable/test/shared/gfn.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  colorQualityBitDepth,
+  colorQualityChromaFormat,
+  colorQualityIs10Bit,
+  colorQualityRequiresHevc,
+} from "../../src/shared/gfn";
+
+describe("shared gfn helpers", () => {
+  it("derives bit depth, chroma format, codec requirements, and 10-bit state", () => {
+    expect(colorQualityBitDepth("8bit_420")).toBe(0);
+    expect(colorQualityBitDepth("10bit_444")).toBe(10);
+    expect(colorQualityChromaFormat("8bit_420")).toBe(0);
+    expect(colorQualityChromaFormat("8bit_444")).toBe(2);
+    expect(colorQualityRequiresHevc("8bit_420")).toBe(false);
+    expect(colorQualityRequiresHevc("8bit_444")).toBe(true);
+    expect(colorQualityIs10Bit("10bit_420")).toBe(true);
+    expect(colorQualityIs10Bit("8bit_444")).toBe(false);
+  });
+});

--- a/opennow-stable/test/shared/logger.test.ts
+++ b/opennow-stable/test/shared/logger.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createRedactedLogExport,
+  formatLogEntry,
+  redactSensitiveData,
+} from "../../src/shared/logger";
+
+describe("logger utilities", () => {
+  it("redacts sensitive values including tokens, emails, ips, and passwords", () => {
+    const redacted = redactSensitiveData(
+      'user=test@example.com Authorization: Bearer abcdefghijklmnopqrstuvwxyz password=secret123 ip=203.0.113.5',
+    );
+
+    expect(redacted).toContain("[Redacted for privacy]");
+    expect(redacted).toContain("Authorization: [Redacted for privacy]");
+    expect(redacted).toContain("password: [Redacted for privacy]");
+    expect(redacted).toContain("[Redacted IP]");
+    expect(redacted).not.toContain("test@example.com");
+    expect(redacted).not.toContain("203.0.113.5");
+  });
+
+  it("formats log entries and produces redacted exports", () => {
+    const entry = {
+      timestamp: Date.parse("2026-03-29T12:00:00.000Z"),
+      level: "warn" as const,
+      prefix: "Auth",
+      message: "session created",
+      args: [{ client_token: "abcdefghijklmnopqrstuvwxyz123456" }, "user@example.com"],
+    };
+
+    expect(formatLogEntry(entry)).toBe(
+      '2026-03-29T12:00:00.000Z  WARN [Auth] session created {"client_token":"abcdefghijklmnopqrstuvwxyz123456"} user@example.com',
+    );
+
+    const exported = createRedactedLogExport([entry]);
+    expect(exported).toContain("2026-03-29T12:00:00.000Z  WARN [Auth] session created");
+    expect(exported).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
+    expect(exported).not.toContain("user@example.com");
+  });
+});

--- a/opennow-stable/vitest.config.ts
+++ b/opennow-stable/vitest.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@shared": resolve(__dirname, "src/shared"),
+    },
+  },
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    environmentMatchGlobs: [["test/renderer/**/*.test.ts", "jsdom"]],
+    restoreMocks: true,
+    clearMocks: true,
+  },
+});


### PR DESCRIPTION
This PR introduces a deterministic Vitest-based unit test suite for OpenNOW's core streaming, authentication, and input helpers, with 41 tests covering SDP/WebRTC compatibility, keyboard shortcuts, gamepad input, CloudMatch signaling, auth OAuth flow, and utility helpers.

**Test infrastructure**
- Added Vitest with `@shared` alias support and node/jsdom split in `vitest.config.ts`
- Added `npm test`/`npm run test:run` scripts in `package.json`
- Unignored `opennow-stable/test/` tree in root `.gitignore` so test files are tracked

**Helper extractions for testability**
- `cloudmatchHelpers.ts`: extracted `streamingServerIp`, `buildSignalingUrl`, `extractHostFromUrl`, `requestHeaders`, `buildSessionRequestBody`, and URL/base resolution logic
- `authHelpers.ts`: extracted `normalizeProvider`, `parseJwtPayload`, `isExpired`, `isNearExpiry`, `generatePkce`, `buildAuthUrl`, and `findAvailablePort`
- `playtimeStore.ts`: extracted formatting, parsing, session accumulation, and storage helpers; updated `usePlaytime.ts` to consume them
- Tightened keyboard normalization fallback in `shortcuts.ts` and `inputProtocol.ts` to reject unsupported tokens/punctuation
- Updated `cloudmatch.ts` and `auth.ts` to consume extracted helpers; preserved public behavior

**Coverage highlights**
- SDP helpers: dash-IP conversion, `fixServerIp`, ICE credential extraction, H265 `tier-flag`/`level-id` rewriting with line-ending preservation
- Shortcuts: alias normalization (Esc/Return/PgUp), canonical modifier ordering, match by key/code fallback, Mac vs non-Mac display labels
- Input mapping: `modifierFlags` bitmasks with lock states, keyboard code map/fallback, deadzone scaling, int16/uint8 normalization, gamepad button/axes with Y-inversion and trigger fallback
- CloudMatch helpers: signaling host priority, RTSP→WSS URL derivation, header auth/platform/Origin behavior, resolution fallback to 1920×1080, session payload derivation; reflex at 120+ FPS; base URL trimming; server-IP override safety
- Auth helpers: provider URL normalization, JWT base64url parsing, expiry/near-expiry boundaries, auth URL with required query params; port selection with injectable availability mock
- Shared utilities: color quality mapping, logger redaction/exports, playtime formatting/last-played/accumulation, stream diagnostics store subscription/set/no-op

**Fixtures**
- `test/fixtures/cloudmatch.ts`: `buildCloudMatchResponse`, `buildSessionCreateRequest`
- `test/fixtures/sdp.ts`: `buildOfferSdp` with `
`/`
` line ending support

**Checks**
- `npm run typecheck`: passing
- `npm run test:run`: 9 test files, 41 tests, all passing

This provides a maintainable regression guard for the protocol and input logic most likely to silently break in future updates.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/2c107962-168a-4175-8204-e812b336af07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-15&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-15"><img alt="OPE-15 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-15"></picture></a>