### PR TITLE
fix(gfn): windowed decoder lag detection

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -151,12 +151,11 @@ if (process.platform === "linux" && !isLinuxArm) {
 }
 app.commandLine.appendSwitch("disable-features", disableFeatures.join(","));
 
-app.commandLine.appendSwitch("force-fieldtrials",
-  [
-    // Disable send-side pacing — we are receive-only, pacing adds latency to RTCP feedback
-    "WebRTC-Video-Pacing/Disabled/",
-  ].join("/"),
-);
+// Keep Chromium's default WebRTC pacing enabled.
+// Disabling WebRTC-Video-Pacing made receive-side playback more bursty in practice, which
+// lines up with the quantized presentation gaps and dropped-presented-frame bursts seen in
+// stream diagnostics on high-FPS profiles. OpenNOW is primarily a receive path here, so
+// there is no strong reason to override Chromium's pacing behavior at startup.
 
 if (bootstrapVideoPrefs.decoderPreference === "hardware") {
   app.commandLine.appendSwitch("enable-accelerated-video-decode");

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1522,7 +1522,7 @@ export function StreamView({
             <span className="sv-stats-chip" title="D = decode time">
               D <span className="sv-stats-chip-val" style={{ color: decodeColor }}>{dText}</span>
             </span>
-            <span className="sv-stats-chip" title="R = render time">
+            <span className="sv-stats-chip" title="R = recent presentation cadence">
               R <span className="sv-stats-chip-val" style={{ color: renderColor }}>{rText}</span>
             </span>
             <span className="sv-stats-chip" title="JB = jitter buffer delay">

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -327,7 +327,6 @@ export function preferCodec(sdp: string, codec: VideoCodec, options?: PreferCode
     : preferredPayloads;
 
   const preferred = new Set(orderedPreferredPayloads);
-
   const allowed = new Set<string>(preferred);
 
   // Keep RTX payloads linked to preferred payloads (apt mapping)
@@ -337,9 +336,15 @@ export function preferCodec(sdp: string, codec: VideoCodec, options?: PreferCode
     }
   }
 
-  // Do NOT keep FLEXFEC/RED/ULPFEC during hard codec filtering.
-  // Chromium can otherwise negotiate a "video" m-line with only FEC payloads
-  // when primary codec intersection fails, causing black video with live audio.
+  // Keep FEC helper payloads alongside the preferred primary codec. Stripping
+  // them entirely makes the stream more brittle under modest packet loss and
+  // can show up as repeated short freezes followed by forward jumps.
+  const fecCodecs = ["RED", "ULPFEC", "FLEXFEC", "FLEXFEC-03"];
+  for (const fecCodec of fecCodecs) {
+    for (const pt of payloadTypesByCodec.get(fecCodec) ?? []) {
+      allowed.add(pt);
+    }
+  }
 
   console.log(`[SDP] preferCodec: preferred ordered payloads [${orderedPreferredPayloads.join(", ")}] for ${codec}`);
   console.log(`[SDP] preferCodec: keeping payload types [${Array.from(allowed).join(", ")}] for ${codec}`);

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -498,7 +498,6 @@ export function buildNvstSdp(params: NvstParams): string {
     "a=vqos.bw.txRxLag.minFeedbackTxDeltaMs:200",
     "a=vqos.drc.bitrateIirFilterFactor:18",
     "a=video.packetSize:1140",
-    "a=packetPacing.minNumPacketsPerGroup:15",
   );
 
   // High FPS optimizations
@@ -509,7 +508,6 @@ export function buildNvstSdp(params: NvstParams): string {
       "a=video.encoderPreset:6",
       "a=vqos.resControl.cpmRtc.badNwSkipFramesCount:600",
       "a=vqos.resControl.cpmRtc.decodeTimeThresholdMs:9",
-      `a=video.fbcDynamicFpsGrabTimeoutMs:${is120Fps ? 6 : 18}`,
       `a=vqos.resControl.cpmRtc.serverResolutionUpdateCoolDownCount:${is120Fps ? 6000 : 12000}`,
     );
   }
@@ -531,14 +529,6 @@ export function buildNvstSdp(params: NvstParams): string {
     "a=vqos.adjustStreamingFpsDuringOutOfFocus:1",
     "a=vqos.resControl.cpmRtc.ignoreOutOfFocusWindowState:1",
     "a=vqos.resControl.perfHistory.rtcIgnoreOutOfFocusWindowState:1",
-    // Packet pacing
-    `a=packetPacing.numGroups:${is120Fps ? 3 : 5}`,
-    "a=packetPacing.maxDelayUs:1000",
-    "a=packetPacing.minNumPacketsFrame:10",
-    // NACK queue settings
-    "a=video.rtpNackQueueLength:1024",
-    "a=video.rtpNackQueueMaxPackets:512",
-    "a=video.rtpNackMaxPacketCount:25",
   );
 
   // AV1-specific DRC/GRC tuning (mirrors official client intent):
@@ -589,7 +579,6 @@ export function buildNvstSdp(params: NvstParams): string {
     "a=vqos.grc.enable:1",
     // Encoder settings
     "a=video.maxNumReferenceFrames:4",
-    "a=video.mapRtpTimestampsToFrames:1",
     "a=video.encoderCscMode:3",
     "a=video.dynamicRangeMode:0",
     `a=video.bitDepth:${bitDepth}`,

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -477,12 +477,10 @@ export function buildNvstSdp(params: NvstParams): string {
     "a=vqos.fec.repairMinPercent:5",
     "a=vqos.fec.repairPercent:5",
     "a=vqos.fec.repairMaxPercent:35",
-    // DRC — always disabled to allow full bitrate
-    "a=vqos.drc.enable:0",
+    "a=vqos.drc.enable:1",
   ];
 
-  // Force-disable dynamic frame control to avoid server-side FPS/resolution adaptation.
-  lines.push("a=vqos.dfc.enable:0");
+  lines.push("a=vqos.dfc.enable:1");
 
   // Video encoder settings
   lines.push(
@@ -521,18 +519,13 @@ export function buildNvstSdp(params: NvstParams): string {
     );
   }
 
-  // Out-of-focus handling + disable ALL dynamic resolution control
+  // Keep the out-of-focus hints, but do not hard-disable the server's adaptive
+  // resolution / frame-control policy. Our previous "never scale / never adapt"
+  // stance made playback more brittle and stutter-prone than the official client.
   lines.push(
     "a=vqos.adjustStreamingFpsDuringOutOfFocus:1",
     "a=vqos.resControl.cpmRtc.ignoreOutOfFocusWindowState:1",
     "a=vqos.resControl.perfHistory.rtcIgnoreOutOfFocusWindowState:1",
-    // Disable CPM-based resolution changes (prevents SSRC switches)
-    "a=vqos.resControl.cpmRtc.featureMask:0",
-    "a=vqos.resControl.cpmRtc.enable:0",
-    // Never scale down resolution
-    "a=vqos.resControl.cpmRtc.minResolutionPercent:100",
-    // Infinite cooldown to prevent resolution changes
-    "a=vqos.resControl.cpmRtc.resolutionChangeHoldonMs:999999",
     // Packet pacing
     `a=packetPacing.numGroups:${is120Fps ? 3 : 5}`,
     "a=packetPacing.maxDelayUs:1000",
@@ -541,10 +534,6 @@ export function buildNvstSdp(params: NvstParams): string {
     "a=video.rtpNackQueueLength:1024",
     "a=video.rtpNackQueueMaxPackets:512",
     "a=video.rtpNackMaxPacketCount:25",
-    // Resolution/quality thresholds — high values prevent downscaling
-    "a=vqos.drc.qpMaxResThresholdAdj:4",
-    "a=vqos.grc.qpMaxResThresholdAdj:4",
-    "a=vqos.drc.iirFilterFactor:100",
   );
 
   // AV1-specific DRC/GRC tuning (mirrors official client intent):
@@ -590,16 +579,15 @@ export function buildNvstSdp(params: NvstParams): string {
     `a=vqos.bw.serverPeakBitrateKbps:${params.maxBitrateKbps}`,
     "a=vqos.bw.enableBandwidthEstimation:1",
     "a=vqos.bw.disableBitrateLimit:0",
-    // GRC — disabled
+    // Keep server-side adaptation enabled instead of pinning a rigid quality target.
     `a=vqos.grc.maximumBitrateKbps:${params.maxBitrateKbps}`,
-    "a=vqos.grc.enable:0",
+    "a=vqos.grc.enable:1",
     // Encoder settings
     "a=video.maxNumReferenceFrames:4",
     "a=video.mapRtpTimestampsToFrames:1",
     "a=video.encoderCscMode:3",
     "a=video.dynamicRangeMode:0",
     `a=video.bitDepth:${bitDepth}`,
-    // Disable server-side scaling and prefilter (prevents resolution downgrade)
     `a=video.scalingFeature1:${isAv1 ? 1 : 0}`,
     "a=video.prefilterParams.prefilterModel:0",
     // Audio track (receive-only from server)

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -256,6 +256,46 @@ interface DecoderPressureSignal {
   detail: string;
 }
 
+interface VideoPlaybackQualitySample {
+  totalVideoFrames: number;
+  droppedVideoFrames: number;
+}
+
+interface RecentPresentationSample {
+  intervalMs: number;
+  presentedFramesDelta: number;
+  droppedFramesDelta: number;
+  cadenceSampleCount: number;
+  cadenceIntervalSumMs: number;
+  maxCadenceIntervalMs: number;
+  paused: boolean;
+  readyState: number;
+  atMs: number;
+}
+
+interface RecentPresentationWindowMetrics {
+  intervalMs: number;
+  pollCount: number;
+  presentedFrames: number;
+  droppedFrames: number;
+  presentedFps: number;
+  dropRatePercent: number;
+  avgCadenceIntervalMs: number;
+  maxCadenceIntervalMs: number;
+  pausedPolls: number;
+  underflowPolls: number;
+}
+
+interface RenderPressureSignal {
+  active: boolean;
+  detail: string;
+}
+
+interface LagReasonSignals {
+  decoder: DecoderPressureSignal;
+  render: RenderPressureSignal;
+}
+
 function timestampUs(sourceTimestampMs?: number): bigint {
   const base =
     typeof sourceTimestampMs === "number" && Number.isFinite(sourceTimestampMs) && sourceTimestampMs >= 0
@@ -532,6 +572,9 @@ export class GfnWebRtcClient {
   private static readonly DECODER_STALL_MIN_RECEIVED_FRAMES = 24;
   private static readonly DECODER_RECENT_DEFICIT_MIN_FRAMES = 12;
   private static readonly DECODER_RECENT_DROP_BURST_MIN_FRAMES = 6;
+  private static readonly RECENT_PRESENTATION_WINDOW_MS = 1600;
+  private static readonly RENDER_STALL_MIN_WINDOW_MS = 900;
+  private static readonly VIDEO_PLAYBACK_RECOVERY_COOLDOWN_MS = 1500;
   private static readonly DECODER_PRESSURE_CONSECUTIVE_POLLS = 3;
   private static readonly DECODER_STABLE_CONSECUTIVE_POLLS = 6;
   private static readonly DECODER_RECOVERY_COOLDOWN_MS = 1500;
@@ -546,7 +589,18 @@ export class GfnWebRtcClient {
   // Stats tracking
   private lastStatsSample: CumulativeVideoStatsSample | null = null;
   private recentVideoIntervalSamples: RecentVideoIntervalSample[] = [];
-  private renderFpsCounter = { frames: 0, lastUpdate: 0, fps: 0 };
+  private lastPlaybackQualitySample: VideoPlaybackQualitySample | null = null;
+  private recentPresentationSamples: RecentPresentationSample[] = [];
+  private lastPresentationStatsAtMs = 0;
+  private presentationCadenceSincePoll = {
+    presentedFrames: 0,
+    sampleCount: 0,
+    intervalSumMs: 0,
+    maxIntervalMs: 0,
+    lastPresentedAtMs: 0,
+  };
+  private videoFrameCallbackId: number | null = null;
+  private lastVideoPlaybackRecoveryAttemptAtMs = 0;
   private connectedGamepads: Set<number> = new Set();
   private previousGamepadStates: Map<number, GamepadInput> = new Map();
 
@@ -867,6 +921,7 @@ export class GfnWebRtcClient {
   private resetDiagnostics(): void {
     this.lastStatsSample = null;
     this.recentVideoIntervalSamples = [];
+    this.resetPresentationTracking();
     this.currentCodec = "";
     this.currentResolution = "";
     this.isHdr = false;
@@ -967,18 +1022,189 @@ export class GfnWebRtcClient {
     }, 500);
   }
 
-  private updateRenderFps(): void {
-    const now = performance.now();
-    this.renderFpsCounter.frames++;
-
-    // Update FPS every 500ms
-    if (now - this.renderFpsCounter.lastUpdate >= 500) {
-      const elapsed = (now - this.renderFpsCounter.lastUpdate) / 1000;
-      this.renderFpsCounter.fps = Math.round(this.renderFpsCounter.frames / elapsed);
-      this.renderFpsCounter.frames = 0;
-      this.renderFpsCounter.lastUpdate = now;
-      this.diagnostics.renderFps = this.renderFpsCounter.fps;
+  private resetPresentationTracking(): void {
+    const video = this.options.videoElement as HTMLVideoElement & {
+      cancelVideoFrameCallback?: (handle: number) => void;
+    };
+    if (this.videoFrameCallbackId !== null && typeof video.cancelVideoFrameCallback === "function") {
+      video.cancelVideoFrameCallback(this.videoFrameCallbackId);
     }
+    this.videoFrameCallbackId = null;
+    this.lastVideoPlaybackRecoveryAttemptAtMs = 0;
+    this.lastPlaybackQualitySample = null;
+    this.recentPresentationSamples = [];
+    this.lastPresentationStatsAtMs = 0;
+    this.presentationCadenceSincePoll = {
+      presentedFrames: 0,
+      sampleCount: 0,
+      intervalSumMs: 0,
+      maxIntervalMs: 0,
+      lastPresentedAtMs: 0,
+    };
+  }
+
+  private startPresentationTracking(video: HTMLVideoElement): void {
+    this.resetPresentationTracking();
+    if (typeof video.requestVideoFrameCallback !== "function") {
+      return;
+    }
+
+    // requestVideoFrameCallback runs when Chromium is actually handing a frame to
+    // the video element for presentation. This is a stronger presentation signal
+    // than our old local counter because it reflects browser display cadence.
+
+    const frameCallback = (now: number, metadata?: VideoFrameCallbackMetadata) => {
+      this.presentationCadenceSincePoll.presentedFrames++;
+      const presentedAtMs = metadata?.expectedDisplayTime ?? now;
+      const lastPresentedAtMs = this.presentationCadenceSincePoll.lastPresentedAtMs;
+      if (lastPresentedAtMs > 0) {
+        const intervalMs = presentedAtMs - lastPresentedAtMs;
+        if (intervalMs > 0 && intervalMs < 1000) {
+          this.presentationCadenceSincePoll.sampleCount++;
+          this.presentationCadenceSincePoll.intervalSumMs += intervalMs;
+          this.presentationCadenceSincePoll.maxIntervalMs = Math.max(
+            this.presentationCadenceSincePoll.maxIntervalMs,
+            intervalMs,
+          );
+        }
+      }
+      this.presentationCadenceSincePoll.lastPresentedAtMs = presentedAtMs;
+      if (this.videoStream.active) {
+        this.videoFrameCallbackId = video.requestVideoFrameCallback(frameCallback);
+      } else {
+        this.videoFrameCallbackId = null;
+      }
+    };
+
+    this.videoFrameCallbackId = video.requestVideoFrameCallback(frameCallback);
+  }
+
+  private readVideoPlaybackQuality(): VideoPlaybackQualitySample | null {
+    const video = this.options.videoElement as HTMLVideoElement & {
+      getVideoPlaybackQuality?: () => VideoPlaybackQuality;
+    };
+
+    // getVideoPlaybackQuality exposes browser-maintained lifetime presentation
+    // counters, including drops at the HTML video element/compositor layer.
+    // We still window them via deltas so old drops do not stick forever.
+    if (typeof video.getVideoPlaybackQuality !== "function") {
+      return null;
+    }
+    const quality = video.getVideoPlaybackQuality();
+    return {
+      totalVideoFrames: Number(quality.totalVideoFrames ?? 0),
+      droppedVideoFrames: Number(quality.droppedVideoFrames ?? 0),
+    };
+  }
+
+  private appendRecentPresentationSample(sample: RecentPresentationSample): void {
+    this.recentPresentationSamples.push(sample);
+    const cutoffMs = sample.atMs - GfnWebRtcClient.RECENT_PRESENTATION_WINDOW_MS;
+    this.recentPresentationSamples = this.recentPresentationSamples.filter((entry) => entry.atMs > cutoffMs);
+  }
+
+  private ensureVideoPlaybackActive(reason: string): void {
+    const video = this.options.videoElement;
+    const now = performance.now();
+    if (!this.videoStream.active || !video.paused) {
+      return;
+    }
+    if (now - this.lastVideoPlaybackRecoveryAttemptAtMs < GfnWebRtcClient.VIDEO_PLAYBACK_RECOVERY_COOLDOWN_MS) {
+      return;
+    }
+    this.lastVideoPlaybackRecoveryAttemptAtMs = now;
+    void video.play()
+      .then(() => {
+        this.log(`Video playback resumed (${reason})`);
+      })
+      .catch((error) => {
+        this.log(`Video playback resume failed (${reason}): ${String(error)}`);
+      });
+  }
+
+  private captureRecentPresentationWindow(now: number): RecentPresentationWindowMetrics | null {
+    const playbackQuality = this.readVideoPlaybackQuality();
+    const video = this.options.videoElement;
+    if (this.lastPresentationStatsAtMs > 0) {
+      const intervalMs = now - this.lastPresentationStatsAtMs;
+      if (intervalMs > 0) {
+        const presentedFramesDelta = playbackQuality && this.lastPlaybackQualitySample
+          ? Math.max(
+            this.presentationCadenceSincePoll.presentedFrames,
+            Math.max(0, playbackQuality.totalVideoFrames - this.lastPlaybackQualitySample.totalVideoFrames),
+          )
+          : this.presentationCadenceSincePoll.presentedFrames;
+        const droppedFramesDelta = playbackQuality && this.lastPlaybackQualitySample
+          ? Math.max(0, playbackQuality.droppedVideoFrames - this.lastPlaybackQualitySample.droppedVideoFrames)
+          : 0;
+        this.appendRecentPresentationSample({
+          intervalMs,
+          presentedFramesDelta,
+          droppedFramesDelta,
+          cadenceSampleCount: this.presentationCadenceSincePoll.sampleCount,
+          cadenceIntervalSumMs: this.presentationCadenceSincePoll.intervalSumMs,
+          maxCadenceIntervalMs: this.presentationCadenceSincePoll.maxIntervalMs,
+          paused: video.paused,
+          readyState: video.readyState,
+          atMs: now,
+        });
+      }
+    }
+    this.lastPresentationStatsAtMs = now;
+    this.lastPlaybackQualitySample = playbackQuality;
+    this.presentationCadenceSincePoll.presentedFrames = 0;
+    this.presentationCadenceSincePoll.sampleCount = 0;
+    this.presentationCadenceSincePoll.intervalSumMs = 0;
+    this.presentationCadenceSincePoll.maxIntervalMs = 0;
+    return this.summarizeRecentPresentationWindow();
+  }
+
+  private summarizeRecentPresentationWindow(): RecentPresentationWindowMetrics | null {
+    if (this.recentPresentationSamples.length === 0) {
+      return null;
+    }
+
+    let intervalMs = 0;
+    let presentedFrames = 0;
+    let droppedFrames = 0;
+    let cadenceSampleCount = 0;
+    let cadenceIntervalSumMs = 0;
+    let maxCadenceIntervalMs = 0;
+    let pausedPolls = 0;
+    let underflowPolls = 0;
+
+    for (const sample of this.recentPresentationSamples) {
+      intervalMs += sample.intervalMs;
+      presentedFrames += sample.presentedFramesDelta;
+      droppedFrames += sample.droppedFramesDelta;
+      cadenceSampleCount += sample.cadenceSampleCount;
+      cadenceIntervalSumMs += sample.cadenceIntervalSumMs;
+      maxCadenceIntervalMs = Math.max(maxCadenceIntervalMs, sample.maxCadenceIntervalMs);
+      if (sample.paused) {
+        pausedPolls++;
+      }
+      if (sample.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) {
+        underflowPolls++;
+      }
+    }
+
+    if (intervalMs <= 0) {
+      return null;
+    }
+
+    const renderedFrameTotal = presentedFrames + droppedFrames;
+    return {
+      intervalMs,
+      pollCount: this.recentPresentationSamples.length,
+      presentedFrames,
+      droppedFrames,
+      presentedFps: (presentedFrames * 1000) / intervalMs,
+      dropRatePercent: renderedFrameTotal > 0 ? (droppedFrames / renderedFrameTotal) * 100 : 0,
+      avgCadenceIntervalMs: cadenceSampleCount > 0 ? cadenceIntervalSumMs / cadenceSampleCount : 0,
+      maxCadenceIntervalMs,
+      pausedPolls,
+      underflowPolls,
+    };
   }
 
   private appendRecentVideoIntervalSample(sample: RecentVideoIntervalSample): void {
@@ -1120,6 +1346,47 @@ export class GfnWebRtcClient {
     };
   }
 
+  private shouldTreatAsRenderPressure(params: {
+    decodeFps: number;
+    recentPresentation: RecentPresentationWindowMetrics | null;
+    decoderPressure: DecoderPressureSignal;
+  }): RenderPressureSignal {
+    const recent = params.recentPresentation;
+    if (!recent || recent.intervalMs < 400 || params.decoderPressure.active || params.decodeFps <= 0) {
+      return {
+        active: false,
+        detail: "No recent presentation pressure",
+      };
+    }
+
+    const fpsGap = Math.max(0, params.decodeFps - recent.presentedFps);
+    const cadenceUnstable =
+      recent.maxCadenceIntervalMs >= Math.max(34, recent.avgCadenceIntervalMs * 1.8) ||
+      recent.underflowPolls >= 2;
+    const dropBurst = recent.droppedFrames >= 3 || recent.dropRatePercent >= 3;
+    const presentStall =
+      recent.intervalMs >= GfnWebRtcClient.RENDER_STALL_MIN_WINDOW_MS &&
+      recent.presentedFrames <= Math.max(1, Math.round(params.decodeFps * 0.1)) &&
+      recent.pausedPolls === 0;
+    const fpsShortfall = recent.presentedFps > 0 && (fpsGap >= 10 || recent.presentedFps < params.decodeFps * 0.75);
+
+    if (presentStall || (fpsShortfall && (cadenceUnstable || dropBurst)) || (dropBurst && cadenceUnstable)) {
+      const detailParts = [`present ${recent.presentedFps.toFixed(0)}fps vs decode ${params.decodeFps.toFixed(0)}fps`];
+      if (recent.dropRatePercent > 0) detailParts.push(`video drops ${recent.dropRatePercent.toFixed(1)}%`);
+      if (recent.maxCadenceIntervalMs > 0) detailParts.push(`max gap ${recent.maxCadenceIntervalMs.toFixed(1)}ms`);
+      if (recent.underflowPolls > 0) detailParts.push("video underflow");
+      return {
+        active: true,
+        detail: detailParts.join(" · "),
+      };
+    }
+
+    return {
+      active: false,
+      detail: "No recent presentation pressure",
+    };
+  }
+
   private classifyLagReason(params: {
     decodeFps: number;
     renderFps: number;
@@ -1130,7 +1397,7 @@ export class GfnWebRtcClient {
     inputQueueBufferedBytes: number;
     inputQueueDropCount: number;
     inputQueueMaxSchedulingDelayMs: number;
-    decoderPressure: DecoderPressureSignal;
+    lagSignals: LagReasonSignals;
   }): { reason: StreamLagReason; detail: string } {
     const networkSignals: string[] = [];
     if (params.packetLossPercent >= 1) networkSignals.push(`${params.packetLossPercent.toFixed(1)}% loss`);
@@ -1144,10 +1411,10 @@ export class GfnWebRtcClient {
       };
     }
 
-    if (params.decoderPressure.active) {
+    if (params.lagSignals.decoder.active) {
       return {
         reason: "decoder",
-        detail: params.decoderPressure.detail,
+        detail: params.lagSignals.decoder.detail,
       };
     }
 
@@ -1170,14 +1437,11 @@ export class GfnWebRtcClient {
       };
     }
 
-    if (params.renderFps > 0 && params.decodeFps > 0) {
-      const renderGap = params.decodeFps - params.renderFps;
-      if (renderGap >= 8 || params.renderFps < 24) {
-        return {
-          reason: "render",
-          detail: `render ${params.renderFps}fps vs decode ${params.decodeFps}fps`,
-        };
-      }
+    if (params.lagSignals.render.active) {
+      return {
+        reason: "render",
+        detail: params.lagSignals.render.detail,
+      };
     }
 
     return {
@@ -1356,6 +1620,10 @@ export class GfnWebRtcClient {
       recentDeficitFrames: 0,
       dropRatePercent: 0,
       detail: "No recent decoder pressure",
+    };
+    let renderPressureSignal: RenderPressureSignal = {
+      active: false,
+      detail: "No recent presentation pressure",
     };
 
     for (const entry of report.values()) {
@@ -1546,6 +1814,24 @@ export class GfnWebRtcClient {
       await this.maybeRecoverFromDecoderPressure(decoderPressureSignal);
     }
 
+    const recentPresentation = this.captureRecentPresentationWindow(now);
+    if (recentPresentation) {
+      this.diagnostics.renderFps = Math.round(recentPresentation.presentedFps);
+      if (recentPresentation.avgCadenceIntervalMs > 0) {
+        // renderTimeMs now reflects recent presentation cadence at the video
+        // element, not RTP inter-frame timing from decoder stats.
+        this.diagnostics.renderTimeMs = Math.round(recentPresentation.avgCadenceIntervalMs * 10) / 10;
+      }
+      if (recentPresentation.pausedPolls > 0) {
+        this.ensureVideoPlaybackActive("paused_during_stream");
+      }
+      renderPressureSignal = this.shouldTreatAsRenderPressure({
+        decodeFps: this.diagnostics.decodeFps,
+        recentPresentation,
+        decoderPressure: decoderPressureSignal,
+      });
+    }
+
     // RTT from active candidate pair
     if (activePair?.currentRoundTripTime !== undefined) {
       const rtt = Number(activePair.currentRoundTripTime);
@@ -1573,7 +1859,10 @@ export class GfnWebRtcClient {
       inputQueueBufferedBytes: reliableBufferedAmount,
       inputQueueDropCount: this.inputQueueDropCount,
       inputQueueMaxSchedulingDelayMs: this.diagnostics.inputQueueMaxSchedulingDelayMs,
-      decoderPressure: decoderPressureSignal,
+      lagSignals: {
+        decoder: decoderPressureSignal,
+        render: renderPressureSignal,
+      },
     });
     this.diagnostics.lagReason = lagClassification.reason;
     this.diagnostics.lagReasonDetail = lagClassification.detail;
@@ -1621,6 +1910,7 @@ export class GfnWebRtcClient {
     this.clearTimers();
     this.detachInputCapture();
     this.closeDataChannels();
+    this.resetPresentationTracking();
     if (this.audioContext) {
       void this.audioContext.close();
       this.audioContext = null;
@@ -1668,15 +1958,8 @@ export class GfnWebRtcClient {
     if (track.kind === "video") {
       this.replaceTrackInStream(this.videoStream, track);
 
-      // Set up render FPS tracking using video element
       const video = this.options.videoElement;
-      const frameCallback = () => {
-        this.updateRenderFps();
-        if (this.videoStream.active) {
-          video.requestVideoFrameCallback(frameCallback);
-        }
-      };
-      video.requestVideoFrameCallback(frameCallback);
+      this.startPresentationTracking(video);
 
       this.log(
         `Video element before play: paused=${video.paused}, readyState=${video.readyState}, size=${video.videoWidth}x${video.videoHeight}`,

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -210,6 +210,52 @@ interface ClientOptions {
   onMicStateChange?: (state: MicStateChange) => void;
 }
 
+interface CumulativeVideoStatsSample {
+  bytesReceived: number;
+  framesReceived: number;
+  framesDecoded: number;
+  framesDropped: number;
+  packetsReceived: number;
+  packetsLost: number;
+  totalDecodeTime: number;
+  atMs: number;
+}
+
+interface RecentVideoIntervalSample {
+  intervalMs: number;
+  receivedDelta: number;
+  decodedDelta: number;
+  droppedDelta: number;
+  packetsReceivedDelta: number;
+  packetsLostDelta: number;
+  decodeTimeDelta: number;
+  atMs: number;
+}
+
+interface RecentVideoWindowMetrics {
+  intervalMs: number;
+  pollCount: number;
+  receivedFrames: number;
+  decodedFrames: number;
+  droppedFrames: number;
+  packetsReceived: number;
+  packetsLost: number;
+  receiveFps: number;
+  decodeOutputFps: number;
+  recentDecodeTimeMs: number;
+  decodeDeficitFrames: number;
+  dropRatePercent: number;
+  idleDecodePollsWhileReceiving: number;
+}
+
+interface DecoderPressureSignal {
+  active: boolean;
+  reason: string;
+  recentDeficitFrames: number;
+  dropRatePercent: number;
+  detail: string;
+}
+
 function timestampUs(sourceTimestampMs?: number): bigint {
   const base =
     typeof sourceTimestampMs === "number" && Number.isFinite(sourceTimestampMs) && sourceTimestampMs >= 0
@@ -481,6 +527,11 @@ export class GfnWebRtcClient {
   private static readonly AUDIO_BASE_JITTER_TARGET_MS = 20;
   private static readonly VIDEO_PRESSURE_JITTER_TARGET_MS = 30;
   private static readonly AUDIO_PRESSURE_JITTER_TARGET_MS = 32;
+  private static readonly RECENT_VIDEO_WINDOW_MS = 1600;
+  private static readonly DECODER_STALL_MIN_WINDOW_MS = 900;
+  private static readonly DECODER_STALL_MIN_RECEIVED_FRAMES = 24;
+  private static readonly DECODER_RECENT_DEFICIT_MIN_FRAMES = 12;
+  private static readonly DECODER_RECENT_DROP_BURST_MIN_FRAMES = 6;
   private static readonly DECODER_PRESSURE_CONSECUTIVE_POLLS = 3;
   private static readonly DECODER_STABLE_CONSECUTIVE_POLLS = 6;
   private static readonly DECODER_RECOVERY_COOLDOWN_MS = 1500;
@@ -493,15 +544,8 @@ export class GfnWebRtcClient {
   private gamepadBitmap = 0;
 
   // Stats tracking
-  private lastStatsSample: {
-    bytesReceived: number;
-    framesReceived: number;
-    framesDecoded: number;
-    framesDropped: number;
-    packetsReceived: number;
-    packetsLost: number;
-    atMs: number;
-  } | null = null;
+  private lastStatsSample: CumulativeVideoStatsSample | null = null;
+  private recentVideoIntervalSamples: RecentVideoIntervalSample[] = [];
   private renderFpsCounter = { frames: 0, lastUpdate: 0, fps: 0 };
   private connectedGamepads: Set<number> = new Set();
   private previousGamepadStates: Map<number, GamepadInput> = new Map();
@@ -822,6 +866,7 @@ export class GfnWebRtcClient {
 
   private resetDiagnostics(): void {
     this.lastStatsSample = null;
+    this.recentVideoIntervalSamples = [];
     this.currentCodec = "";
     this.currentResolution = "";
     this.isHdr = false;
@@ -936,69 +981,146 @@ export class GfnWebRtcClient {
     }
   }
 
+  private appendRecentVideoIntervalSample(sample: RecentVideoIntervalSample): void {
+    this.recentVideoIntervalSamples.push(sample);
+    const cutoffMs = sample.atMs - GfnWebRtcClient.RECENT_VIDEO_WINDOW_MS;
+    this.recentVideoIntervalSamples = this.recentVideoIntervalSamples.filter((entry) => entry.atMs > cutoffMs);
+  }
+
+  private summarizeRecentVideoWindow(): RecentVideoWindowMetrics | null {
+    if (this.recentVideoIntervalSamples.length === 0) {
+      return null;
+    }
+
+    let intervalMs = 0;
+    let receivedFrames = 0;
+    let decodedFrames = 0;
+    let droppedFrames = 0;
+    let packetsReceived = 0;
+    let packetsLost = 0;
+    let decodeTimeDelta = 0;
+    let idleDecodePollsWhileReceiving = 0;
+
+    for (const sample of this.recentVideoIntervalSamples) {
+      intervalMs += sample.intervalMs;
+      receivedFrames += sample.receivedDelta;
+      decodedFrames += sample.decodedDelta;
+      droppedFrames += sample.droppedDelta;
+      packetsReceived += sample.packetsReceivedDelta;
+      packetsLost += sample.packetsLostDelta;
+      decodeTimeDelta += sample.decodeTimeDelta;
+      if (sample.receivedDelta >= 4 && sample.decodedDelta === 0) {
+        idleDecodePollsWhileReceiving++;
+      }
+    }
+
+    if (intervalMs <= 0) {
+      return null;
+    }
+
+    return {
+      intervalMs,
+      pollCount: this.recentVideoIntervalSamples.length,
+      receivedFrames,
+      decodedFrames,
+      droppedFrames,
+      packetsReceived,
+      packetsLost,
+      receiveFps: (receivedFrames * 1000) / intervalMs,
+      decodeOutputFps: (decodedFrames * 1000) / intervalMs,
+      recentDecodeTimeMs: decodedFrames > 0 ? (decodeTimeDelta / decodedFrames) * 1000 : 0,
+      decodeDeficitFrames: Math.max(0, receivedFrames - decodedFrames),
+      dropRatePercent: receivedFrames > 0 ? (droppedFrames / receivedFrames) * 100 : 0,
+      idleDecodePollsWhileReceiving,
+    };
+  }
+
   private shouldTreatAsDecoderPressure(params: {
-    framesReceived: number;
-    framesDecoded: number;
-    framesDropped: number;
     decodeTimeMs: number;
     decodeFps: number;
-    prevSample: {
-      framesReceived: number;
-      framesDecoded: number;
-      framesDropped: number;
-    } | null;
-  }): { active: boolean; reason: string; backlogFrames: number; dropRatePercent: number } {
-    const backlogFrames = Math.max(0, params.framesReceived - params.framesDecoded);
-    const dropRatePercent = params.framesReceived > 0
-      ? (params.framesDropped / params.framesReceived) * 100
-      : 0;
-    const severeStall = params.framesReceived > 120 && params.framesDecoded === 0;
-    const backlogHigh = backlogFrames >= 45;
-    const dropRateHigh = dropRatePercent >= 6;
-
-    let dropBurst = false;
-    if (params.prevSample) {
-      const decodedDelta = params.framesDecoded - params.prevSample.framesDecoded;
-      const droppedDelta = params.framesDropped - params.prevSample.framesDropped;
-      dropBurst = droppedDelta >= 8 && decodedDelta <= 4;
+    recentVideo: RecentVideoWindowMetrics | null;
+  }): DecoderPressureSignal {
+    const recent = params.recentVideo;
+    if (!recent || recent.intervalMs < 400 || recent.receivedFrames <= 0) {
+      return {
+        active: false,
+        reason: "stable",
+        recentDeficitFrames: 0,
+        dropRatePercent: 0,
+        detail: "No recent decoder pressure",
+      };
     }
 
-    let decodeSaturated = false;
-    if (params.decodeFps > 0 && params.decodeTimeMs > 0) {
-      const frameBudgetMs = 1000 / params.decodeFps;
-      decodeSaturated = params.decodeTimeMs >= frameBudgetMs * 0.82;
-    }
+    const recentDeficitFrames = recent.decodeDeficitFrames;
+    const referenceFps = Math.max(params.decodeFps, recent.receiveFps, recent.decodeOutputFps);
+    const frameBudgetMs = referenceFps > 0 ? 1000 / referenceFps : 0;
+    const decodeTimeMs = recent.recentDecodeTimeMs > 0 ? recent.recentDecodeTimeMs : params.decodeTimeMs;
+    const decodeSaturated =
+      frameBudgetMs > 0 &&
+      decodeTimeMs > 0 &&
+      decodeTimeMs >= frameBudgetMs * 0.82;
+    const severeStall =
+      recent.pollCount >= 2 &&
+      recent.intervalMs >= GfnWebRtcClient.DECODER_STALL_MIN_WINDOW_MS &&
+      recent.receivedFrames >= GfnWebRtcClient.DECODER_STALL_MIN_RECEIVED_FRAMES &&
+      recent.decodedFrames === 0 &&
+      recent.idleDecodePollsWhileReceiving >= 2;
+    const deficitHigh =
+      recentDeficitFrames >= Math.max(
+        GfnWebRtcClient.DECODER_RECENT_DEFICIT_MIN_FRAMES,
+        Math.round(recent.receiveFps * 0.2),
+      );
+    const dropBurst =
+      recent.droppedFrames >= Math.max(
+        GfnWebRtcClient.DECODER_RECENT_DROP_BURST_MIN_FRAMES,
+        Math.round(recent.receiveFps * 0.12),
+      ) ||
+      (recent.dropRatePercent >= 8 && recent.droppedFrames >= 4);
+    const lowDecodeOutput = recent.decodedFrames <= Math.max(4, Math.round(recent.receivedFrames * 0.4));
 
     if (severeStall) {
       return {
         active: true,
-        reason: "severe_stall",
-        backlogFrames,
-        dropRatePercent,
+        reason: "recent_stall",
+        recentDeficitFrames,
+        dropRatePercent: recent.dropRatePercent,
+        detail: `no decodes for ${recent.intervalMs.toFixed(0)}ms while receiving ${recent.receivedFrames} frames`,
       };
     }
 
-    const active = (backlogHigh && (dropRateHigh || dropBurst || decodeSaturated))
-      || (dropBurst && decodeSaturated);
-    const reason = active
-      ? (backlogHigh
-        ? "backlog_and_drop"
-        : "decode_saturated")
-      : "stable";
+    if (decodeSaturated && (deficitHigh || dropBurst)) {
+      const detailParts = [`decode ${decodeTimeMs.toFixed(1)}ms`];
+      if (recentDeficitFrames > 0) detailParts.push(`recent deficit ${recentDeficitFrames}`);
+      if (recent.droppedFrames > 0) detailParts.push(`recent drops ${recent.droppedFrames}`);
+      return {
+        active: true,
+        reason: "recent_saturation",
+        recentDeficitFrames,
+        dropRatePercent: recent.dropRatePercent,
+        detail: detailParts.join(" · "),
+      };
+    }
+
+    if (dropBurst && lowDecodeOutput) {
+      return {
+        active: true,
+        reason: "recent_drop_burst",
+        recentDeficitFrames,
+        dropRatePercent: recent.dropRatePercent,
+        detail: `recent drops ${recent.droppedFrames} (${recent.dropRatePercent.toFixed(1)}%) · decoded ${recent.decodedFrames}/${recent.receivedFrames}`,
+      };
+    }
 
     return {
-      active,
-      reason,
-      backlogFrames,
-      dropRatePercent,
+      active: false,
+      reason: "stable",
+      recentDeficitFrames,
+      dropRatePercent: recent.dropRatePercent,
+      detail: "No recent decoder pressure",
     };
   }
 
   private classifyLagReason(params: {
-    framesReceived: number;
-    framesDecoded: number;
-    framesDropped: number;
-    decodeTimeMs: number;
     decodeFps: number;
     renderFps: number;
     rttMs: number;
@@ -1008,6 +1130,7 @@ export class GfnWebRtcClient {
     inputQueueBufferedBytes: number;
     inputQueueDropCount: number;
     inputQueueMaxSchedulingDelayMs: number;
+    decoderPressure: DecoderPressureSignal;
   }): { reason: StreamLagReason; detail: string } {
     const networkSignals: string[] = [];
     if (params.packetLossPercent >= 1) networkSignals.push(`${params.packetLossPercent.toFixed(1)}% loss`);
@@ -1021,22 +1144,10 @@ export class GfnWebRtcClient {
       };
     }
 
-    const frameBudgetMs = params.decodeFps > 0 ? 1000 / params.decodeFps : 0;
-    const decodeSaturated =
-      frameBudgetMs > 0 &&
-      params.decodeTimeMs > 0 &&
-      params.decodeTimeMs >= frameBudgetMs * 0.82;
-    const severeDecoderStall = params.framesReceived > 100 && params.framesDecoded === 0;
-    const decoderBacklog = Math.max(0, params.framesReceived - params.framesDecoded);
-    if (severeDecoderStall || decodeSaturated || decoderBacklog >= 45 || params.framesDropped >= 8) {
-      const detailParts: string[] = [];
-      if (severeDecoderStall) detailParts.push("frames received but not decoded");
-      if (decodeSaturated) detailParts.push(`decode ${params.decodeTimeMs.toFixed(1)}ms`);
-      if (decoderBacklog >= 45) detailParts.push(`backlog ${decoderBacklog}`);
-      if (params.framesDropped >= 8) detailParts.push(`drops ${params.framesDropped}`);
+    if (params.decoderPressure.active) {
       return {
         reason: "decoder",
-        detail: detailParts.join(" · ") || "decode saturation",
+        detail: params.decoderPressure.detail,
       };
     }
 
@@ -1077,7 +1188,7 @@ export class GfnWebRtcClient {
     };
   }
 
-  private async requestDecoderKeyframe(backlogFrames: number, reason: string): Promise<boolean> {
+  private async requestDecoderKeyframe(recentDeficitFrames: number, reason: string): Promise<boolean> {
     const now = performance.now();
     if (now - this.lastDecoderKeyframeRequestAtMs < GfnWebRtcClient.DECODER_KEYFRAME_COOLDOWN_MS) {
       return false;
@@ -1109,7 +1220,9 @@ export class GfnWebRtcClient {
         this.controlChannel.send(JSON.stringify({
           type: "request_keyframe",
           reason,
-          backlogFrames,
+          // Kept as backlogFrames for signaling compatibility; this is a recent
+          // short-window decode deficit estimate, not lifetime framesReceived - framesDecoded.
+          backlogFrames: recentDeficitFrames,
           attempt: this.decoderRecoveryAttemptCount + 1,
         }));
         requestedViaSender = true;
@@ -1123,7 +1236,7 @@ export class GfnWebRtcClient {
       try {
         await window.openNow.requestKeyframe({
           reason,
-          backlogFrames,
+          backlogFrames: recentDeficitFrames,
           attempt: this.decoderRecoveryAttemptCount + 1,
         });
         requestedViaSender = true;
@@ -1139,7 +1252,7 @@ export class GfnWebRtcClient {
         this.diagnostics.decoderRecoveryAction = "sender_keyframe";
       }
       this.log(
-        `Decoder recovery: keyframe requested (reason=${reason}, backlog=${backlogFrames}, attempt=${this.decoderRecoveryAttemptCount + 1})`,
+        `Decoder recovery: keyframe requested (reason=${reason}, recentDeficit=${recentDeficitFrames}, attempt=${this.decoderRecoveryAttemptCount + 1})`,
       );
       return true;
     }
@@ -1177,8 +1290,9 @@ export class GfnWebRtcClient {
   private async maybeRecoverFromDecoderPressure(signal: {
     active: boolean;
     reason: string;
-    backlogFrames: number;
+    recentDeficitFrames: number;
     dropRatePercent: number;
+    detail: string;
   }): Promise<void> {
     if (!signal.active) {
       this.decoderPressureConsecutivePolls = 0;
@@ -1206,7 +1320,7 @@ export class GfnWebRtcClient {
       return;
     }
 
-    const keyframeRequested = await this.requestDecoderKeyframe(signal.backlogFrames, signal.reason);
+    const keyframeRequested = await this.requestDecoderKeyframe(signal.recentDeficitFrames, signal.reason);
 
     let bitrateReduced = false;
     if (!keyframeRequested || this.decoderRecoveryAttemptCount >= 1) {
@@ -1218,7 +1332,7 @@ export class GfnWebRtcClient {
       this.diagnostics.decoderRecoveryAttempts = this.decoderRecoveryAttemptCount;
       this.lastDecoderRecoveryAtMs = now;
       this.log(
-        `Decoder pressure detected: reason=${signal.reason}, backlog=${signal.backlogFrames}, dropRate=${signal.dropRatePercent.toFixed(1)}%, recoveryAttempt=${this.decoderRecoveryAttemptCount}`,
+        `Decoder pressure detected: reason=${signal.reason}, recentDeficit=${signal.recentDeficitFrames}, dropRate=${signal.dropRatePercent.toFixed(1)}%, recoveryAttempt=${this.decoderRecoveryAttemptCount}`,
       );
     }
   }
@@ -1236,6 +1350,13 @@ export class GfnWebRtcClient {
     let framesReceived = 0;
     let framesDecoded = 0;
     let framesDropped = 0;
+    let decoderPressureSignal: DecoderPressureSignal = {
+      active: false,
+      reason: "stable",
+      recentDeficitFrames: 0,
+      dropRatePercent: 0,
+      detail: "No recent decoder pressure",
+    };
 
     for (const entry of report.values()) {
       const stats = entry as unknown as Record<string, unknown>;
@@ -1265,29 +1386,57 @@ export class GfnWebRtcClient {
       framesDropped = Number(inboundVideo.framesDropped ?? 0);
       const packetsReceived = Number(inboundVideo.packetsReceived ?? 0);
       const packetsLost = Number(inboundVideo.packetsLost ?? 0);
+      const totalDecodeTime = Number(inboundVideo.totalDecodeTime ?? 0);
       const prevSample = this.lastStatsSample;
+      let recentVideo = this.summarizeRecentVideoWindow();
 
-      // Calculate bitrate
       if (prevSample) {
-        const bytesDelta = bytes - prevSample.bytesReceived;
+        const countersReset =
+          bytes < prevSample.bytesReceived ||
+          framesReceived < prevSample.framesReceived ||
+          framesDecoded < prevSample.framesDecoded ||
+          framesDropped < prevSample.framesDropped ||
+          packetsReceived < prevSample.packetsReceived ||
+          packetsLost < prevSample.packetsLost;
         const timeDeltaMs = now - prevSample.atMs;
-        if (bytesDelta >= 0 && timeDeltaMs > 0) {
-          const kbps = (bytesDelta * 8) / (timeDeltaMs / 1000) / 1000;
-          this.diagnostics.bitrateKbps = Math.max(0, Math.round(kbps));
-        }
 
-        // Calculate packet loss percentage over the interval
-        const packetsDelta = packetsReceived - prevSample.packetsReceived;
-        const lostDelta = packetsLost - prevSample.packetsLost;
-        if (packetsDelta > 0) {
+        // WebRTC inbound video counters are cumulative for the life of the RTP
+        // stream. Use interval deltas plus a short rolling window so historical
+        // drops or decode deficits do not stick around as fake decoder backlog.
+        if (countersReset) {
+          this.recentVideoIntervalSamples = [];
+          recentVideo = null;
+        } else if (timeDeltaMs > 0) {
+          const bytesDelta = bytes - prevSample.bytesReceived;
+          const packetsDelta = packetsReceived - prevSample.packetsReceived;
+          const lostDelta = packetsLost - prevSample.packetsLost;
+          const decodeTimeDelta = Math.max(0, totalDecodeTime - prevSample.totalDecodeTime);
+
+          this.appendRecentVideoIntervalSample({
+            intervalMs: timeDeltaMs,
+            receivedDelta: framesReceived - prevSample.framesReceived,
+            decodedDelta: framesDecoded - prevSample.framesDecoded,
+            droppedDelta: framesDropped - prevSample.framesDropped,
+            packetsReceivedDelta: packetsDelta,
+            packetsLostDelta: lostDelta,
+            decodeTimeDelta,
+            atMs: now,
+          });
+          recentVideo = this.summarizeRecentVideoWindow();
+
+          if (bytesDelta >= 0) {
+            const kbps = (bytesDelta * 8) / (timeDeltaMs / 1000) / 1000;
+            this.diagnostics.bitrateKbps = Math.max(0, Math.round(kbps));
+          }
+
           const totalPackets = packetsDelta + lostDelta;
-          this.diagnostics.packetLossPercent = totalPackets > 0
-            ? (lostDelta / totalPackets) * 100
-            : 0;
+          if (totalPackets > 0) {
+            this.diagnostics.packetLossPercent = (lostDelta / totalPackets) * 100;
+          }
         }
       }
 
-      // Store current values for next delta calculation
+      // Store current values for next interval derivation.
       this.lastStatsSample = {
         bytesReceived: bytes,
         framesReceived,
@@ -1295,22 +1444,14 @@ export class GfnWebRtcClient {
         framesDropped,
         packetsReceived,
         packetsLost,
+        totalDecodeTime,
         atMs: now,
       };
 
-      // Frame counters
+      // Keep raw cumulative counters visible in diagnostics.
       this.diagnostics.framesReceived = framesReceived;
       this.diagnostics.framesDecoded = framesDecoded;
       this.diagnostics.framesDropped = framesDropped;
-
-      if (
-        !this.videoDecodeStallWarningSent &&
-        framesReceived > 100 &&
-        framesDecoded === 0
-      ) {
-        this.videoDecodeStallWarningSent = true;
-        this.log("Warning: inbound video packets received but 0 frames decoded (decoder stall)");
-      }
 
       // Decode FPS
       this.diagnostics.decodeFps = Math.round(Number(inboundVideo.framesPerSecond ?? 0));
@@ -1374,7 +1515,6 @@ export class GfnWebRtcClient {
       }
 
       // Get decode timing if available
-      const totalDecodeTime = Number(inboundVideo.totalDecodeTime ?? 0);
       const totalInterFrameDelay = Number(inboundVideo.totalInterFrameDelay ?? 0);
       const framesDecodedForTiming = Number(inboundVideo.framesDecoded ?? 1);
 
@@ -1388,15 +1528,22 @@ export class GfnWebRtcClient {
         this.diagnostics.renderTimeMs = Math.round(avgFrameDelay * 1000 * 10) / 10;
       }
 
-      const pressureSignal = this.shouldTreatAsDecoderPressure({
-        framesReceived,
-        framesDecoded,
-        framesDropped,
+      decoderPressureSignal = this.shouldTreatAsDecoderPressure({
         decodeTimeMs: this.diagnostics.decodeTimeMs,
         decodeFps: this.diagnostics.decodeFps,
-        prevSample,
+        recentVideo,
       });
-      await this.maybeRecoverFromDecoderPressure(pressureSignal);
+
+      if (decoderPressureSignal.reason === "recent_stall") {
+        if (!this.videoDecodeStallWarningSent) {
+          this.videoDecodeStallWarningSent = true;
+          this.log(`Warning: recent decoder stall detected (${decoderPressureSignal.detail})`);
+        }
+      } else {
+        this.videoDecodeStallWarningSent = false;
+      }
+
+      await this.maybeRecoverFromDecoderPressure(decoderPressureSignal);
     }
 
     // RTT from active candidate pair
@@ -1417,10 +1564,6 @@ export class GfnWebRtcClient {
       Math.round(this.inputQueueMaxSchedulingDelayMsWindow * 10) / 10;
 
     const lagClassification = this.classifyLagReason({
-      framesReceived,
-      framesDecoded,
-      framesDropped,
-      decodeTimeMs: this.diagnostics.decodeTimeMs,
       decodeFps: this.diagnostics.decodeFps,
       renderFps: this.diagnostics.renderFps,
       rttMs: this.diagnostics.rttMs,
@@ -1430,6 +1573,7 @@ export class GfnWebRtcClient {
       inputQueueBufferedBytes: reliableBufferedAmount,
       inputQueueDropCount: this.inputQueueDropCount,
       inputQueueMaxSchedulingDelayMs: this.diagnostics.inputQueueMaxSchedulingDelayMs,
+      decoderPressure: decoderPressureSignal,
     });
     this.diagnostics.lagReason = lagClassification.reason;
     this.diagnostics.lagReasonDetail = lagClassification.detail;

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -40,6 +40,12 @@ interface OfferSettings {
   maxBitrateKbps: number;
 }
 
+interface ClientRuntimeInfo {
+  isMacOs: boolean;
+  isElectron: boolean;
+  isMacElectron: boolean;
+}
+
 interface KeyStrokeSpec {
   vk: number;
   scancode: number;
@@ -154,6 +160,46 @@ function applyPresentationSafetyGuardrails(settings: OfferSettings): {
     safeMaxBitrateKbps,
     reason,
   };
+}
+
+function getClientRuntimeInfo(): ClientRuntimeInfo {
+  const platform = navigator.platform?.toLowerCase() ?? "";
+  const ua = navigator.userAgent ?? "";
+  const isMacOs = platform.includes("mac") || ua.includes("Macintosh");
+  const isElectron = /\bElectron\/\d+/i.test(ua);
+  return {
+    isMacOs,
+    isElectron,
+    isMacElectron: isMacOs && isElectron,
+  };
+}
+
+function choosePlaybackParityCodec(
+  settings: OfferSettings,
+  supportedCodecs: string[],
+  runtime: ClientRuntimeInfo,
+): { codec: VideoCodec; reason: string | null } {
+  if (!runtime.isMacElectron || settings.codec !== "AV1") {
+    return { codec: settings.codec, reason: null };
+  }
+
+  // Official GFN web on the same Macs is smoother than our Electron path, while
+  // OpenNOW shows bursty presentation drops on AV1. Treat this as a macOS/Electron
+  // parity issue and prefer a VideoToolbox-backed codec instead of forcing AV1.
+  if (supportedCodecs.includes("H265")) {
+    return {
+      codec: "H265",
+      reason: "mac_electron_av1_fallback_h265",
+    };
+  }
+  if (supportedCodecs.includes("H264")) {
+    return {
+      codec: "H264",
+      reason: "mac_electron_av1_fallback_h264",
+    };
+  }
+
+  return { codec: settings.codec, reason: null };
 }
 
 export interface StreamDiagnostics {
@@ -3753,6 +3799,7 @@ export class GfnWebRtcClient {
     this.cleanupPeerConnection();
     const guardedProfile = applyPresentationSafetyGuardrails(settings);
     const effectiveMaxBitrateKbps = guardedProfile.safeMaxBitrateKbps;
+    const runtimeInfo = getClientRuntimeInfo();
 
     this.log("=== handleOffer START ===");
     this.log(`Session: id=${session.sessionId}, status=${session.status}, serverIp=${session.serverIp}`);
@@ -3915,14 +3962,22 @@ export class GfnWebRtcClient {
     const serverIceUfrag = extractIceUfragFromOffer(processedOffer);
     this.log(`Server ICE ufrag: "${serverIceUfrag}"`);
 
-    const preferredHevcProfileId = hevcPreferredProfileId(settings.colorQuality);
-
     // 3. Filter to preferred codec — but only if the browser actually supports it
-    let effectiveCodec = settings.codec;
     const supported = this.getSupportedVideoCodecs();
     this.log(`Browser supported video codecs: ${supported.join(", ") || "unknown"}`);
+    this.log(
+      `Client runtime: platform=${navigator.platform || "unknown"}, userAgentElectron=${runtimeInfo.isElectron ? "yes" : "no"}, macOS=${runtimeInfo.isMacOs ? "yes" : "no"}`,
+    );
+    const playbackParityCodec = choosePlaybackParityCodec(settings, supported, runtimeInfo);
+    let effectiveCodec = playbackParityCodec.codec;
+    if (playbackParityCodec.reason) {
+      this.log(
+        `Playback parity guardrail applied: ${playbackParityCodec.reason}, codec ${settings.codec} -> ${effectiveCodec}`,
+      );
+    }
+    const preferredHevcProfileId = hevcPreferredProfileId(settings.colorQuality);
 
-    if (settings.codec === "H265") {
+    if (effectiveCodec === "H265") {
       const hevcProfiles = this.getSupportedHevcProfiles();
       if (hevcProfiles.size > 0) {
         this.log(`Browser HEVC profile-id support: ${Array.from(hevcProfiles).join(", ")}`);
@@ -3955,13 +4010,13 @@ export class GfnWebRtcClient {
       }
       if (hevcProfiles.size > 0 && !hevcProfiles.has(String(preferredHevcProfileId))) {
         this.log(
-          `Warning: requested H265 profile-id=${preferredHevcProfileId} not reported in browser capabilities; forcing H265 anyway per user preference`,
+          `Warning: requested H265 profile-id=${preferredHevcProfileId} not reported in browser capabilities; forcing H265 anyway`,
         );
       }
     }
 
-    if (supported.length > 0 && !supported.includes(settings.codec)) {
-      this.log(`Warning: ${settings.codec} not reported in browser codec list; forcing requested codec anyway`);
+    if (supported.length > 0 && !supported.includes(effectiveCodec)) {
+      this.log(`Warning: ${effectiveCodec} not reported in browser codec list; forcing requested codec anyway`);
     }
     this.log(`Effective codec: ${effectiveCodec} (preferred HEVC profile-id=${preferredHevcProfileId})`);
     const filteredOffer = preferCodec(processedOffer, effectiveCodec, {

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -125,6 +125,37 @@ function hevcPreferredProfileId(colorQuality: ColorQuality): 1 | 2 {
   return colorQuality.startsWith("10bit") ? 2 : 1;
 }
 
+function applyPresentationSafetyGuardrails(settings: OfferSettings): {
+  width: number;
+  height: number;
+  safeMaxBitrateKbps: number;
+  reason: string | null;
+} {
+  const { width, height } = parseResolution(settings.resolution);
+  const pixelCount = width * height;
+  let safeMaxBitrateKbps = settings.maxBitrateKbps;
+  let reason: string | null = null;
+
+  // Electron/Chromium is showing very high presented-frame drop rates on the
+  // AV1 120fps high-resolution path even when decoder/underflow telemetry looks
+  // nominal. Cap the initial bitrate for that profile so we do not overwhelm
+  // compositor presentation with an unsustainably dense frame stream.
+  if (settings.codec === "AV1" && settings.fps >= 120 && pixelCount >= 3_686_400) {
+    const guardedCapKbps = 80_000;
+    if (safeMaxBitrateKbps > guardedCapKbps) {
+      safeMaxBitrateKbps = guardedCapKbps;
+      reason = `presentation_guardrail_av1_${width}x${height}_${settings.fps}fps`;
+    }
+  }
+
+  return {
+    width,
+    height,
+    safeMaxBitrateKbps,
+    reason,
+  };
+}
+
 export interface StreamDiagnostics {
   // Connection state
   connectionState: RTCPeerConnectionState | "closed";
@@ -3720,6 +3751,8 @@ export class GfnWebRtcClient {
 
   async handleOffer(offerSdp: string, session: SessionInfo, settings: OfferSettings): Promise<void> {
     this.cleanupPeerConnection();
+    const guardedProfile = applyPresentationSafetyGuardrails(settings);
+    const effectiveMaxBitrateKbps = guardedProfile.safeMaxBitrateKbps;
 
     this.log("=== handleOffer START ===");
     this.log(`Session: id=${session.sessionId}, status=${session.status}, serverIp=${session.serverIp}`);
@@ -3728,6 +3761,11 @@ export class GfnWebRtcClient {
     this.log(
       `Settings: codec=${settings.codec}, colorQuality=${settings.colorQuality}, resolution=${settings.resolution}, fps=${settings.fps}, maxBitrate=${settings.maxBitrateKbps}kbps`,
     );
+    if (guardedProfile.reason) {
+      this.log(
+        `Presentation safety guardrail applied: ${guardedProfile.reason}, bitrate ${settings.maxBitrateKbps} -> ${effectiveMaxBitrateKbps} kbps`,
+      );
+    }
     this.log(`ICE servers: ${session.iceServers.length} (${session.iceServers.map(s => s.urls.join(",")).join(" | ")})`);
     this.log(`Offer SDP length: ${offerSdp.length} chars`);
     // Log full offer SDP for ICE debugging
@@ -3741,7 +3779,7 @@ export class GfnWebRtcClient {
     this.partialReliableThresholdMs = negotiatedPartialReliable ?? GfnWebRtcClient.DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS;
     this.negotiatedMaxBitrateKbps = Math.max(
       GfnWebRtcClient.DECODER_MIN_RECOVERY_BITRATE_KBPS,
-      Math.floor(settings.maxBitrateKbps),
+      Math.floor(effectiveMaxBitrateKbps),
     );
     this.currentBitrateCeilingKbps = this.negotiatedMaxBitrateKbps;
     this.log(
@@ -3954,8 +3992,8 @@ export class GfnWebRtcClient {
 
     // Munge answer SDP: inject b=AS: bitrate limits and stereo=1 for opus
     if (answer.sdp) {
-      answer.sdp = mungeAnswerSdp(answer.sdp, settings.maxBitrateKbps);
-      this.log(`Answer SDP munged (b=AS:${settings.maxBitrateKbps}, stereo=1)`);
+      answer.sdp = mungeAnswerSdp(answer.sdp, effectiveMaxBitrateKbps);
+      this.log(`Answer SDP munged (b=AS:${effectiveMaxBitrateKbps}, stereo=1)`);
     }
 
     await pc.setLocalDescription(answer);
@@ -4000,7 +4038,7 @@ export class GfnWebRtcClient {
 
     const credentials = extractIceCredentials(finalSdp);
     this.log(`Extracted ICE credentials: ufrag=${credentials.ufrag}, pwd=${credentials.pwd.slice(0, 8)}...`);
-    const { width, height } = parseResolution(settings.resolution);
+    const { width, height } = guardedProfile;
     const viewportRect = this.options.videoElement.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
     const baseCssViewportWidth = Math.max(viewportRect.width, window.innerWidth || 0);
@@ -4026,7 +4064,7 @@ export class GfnWebRtcClient {
       clientViewportWidth,
       clientViewportHeight,
       fps: settings.fps,
-      maxBitrateKbps: settings.maxBitrateKbps,
+      maxBitrateKbps: effectiveMaxBitrateKbps,
       partialReliableThresholdMs: this.partialReliableThresholdMs,
       codec: effectiveCodec,
       colorQuality: settings.colorQuality,

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -259,12 +259,16 @@ interface DecoderPressureSignal {
 interface VideoPlaybackQualitySample {
   totalVideoFrames: number;
   droppedVideoFrames: number;
+  freezeCount: number;
+  totalFreezesDurationMs: number;
 }
 
 interface RecentPresentationSample {
   intervalMs: number;
   presentedFramesDelta: number;
   droppedFramesDelta: number;
+  freezeCountDelta: number;
+  freezesDurationDeltaMs: number;
   cadenceSampleCount: number;
   cadenceIntervalSumMs: number;
   maxCadenceIntervalMs: number;
@@ -278,6 +282,8 @@ interface RecentPresentationWindowMetrics {
   pollCount: number;
   presentedFrames: number;
   droppedFrames: number;
+  freezeCount: number;
+  freezesDurationMs: number;
   presentedFps: number;
   dropRatePercent: number;
   avgCadenceIntervalMs: number;
@@ -1061,6 +1067,8 @@ export class GfnWebRtcClient {
     return {
       totalVideoFrames: Number(quality.totalVideoFrames ?? 0),
       droppedVideoFrames: Number(quality.droppedVideoFrames ?? 0),
+      freezeCount: Number((quality as VideoPlaybackQuality & { freezeCount?: number }).freezeCount ?? 0),
+      totalFreezesDurationMs: Number((quality as VideoPlaybackQuality & { totalFreezesDuration?: number }).totalFreezesDuration ?? 0) * 1000,
     };
   }
 
@@ -1104,10 +1112,18 @@ export class GfnWebRtcClient {
         const droppedFramesDelta = playbackQuality && this.lastPlaybackQualitySample
           ? Math.max(0, playbackQuality.droppedVideoFrames - this.lastPlaybackQualitySample.droppedVideoFrames)
           : 0;
+        const freezeCountDelta = playbackQuality && this.lastPlaybackQualitySample
+          ? Math.max(0, playbackQuality.freezeCount - this.lastPlaybackQualitySample.freezeCount)
+          : 0;
+        const freezesDurationDeltaMs = playbackQuality && this.lastPlaybackQualitySample
+          ? Math.max(0, playbackQuality.totalFreezesDurationMs - this.lastPlaybackQualitySample.totalFreezesDurationMs)
+          : 0;
         this.appendRecentPresentationSample({
           intervalMs,
           presentedFramesDelta,
           droppedFramesDelta,
+          freezeCountDelta,
+          freezesDurationDeltaMs,
           cadenceSampleCount: this.presentationCadenceSincePoll.sampleCount,
           cadenceIntervalSumMs: this.presentationCadenceSincePoll.intervalSumMs,
           maxCadenceIntervalMs: this.presentationCadenceSincePoll.maxIntervalMs,
@@ -1134,6 +1150,8 @@ export class GfnWebRtcClient {
     let intervalMs = 0;
     let presentedFrames = 0;
     let droppedFrames = 0;
+    let freezeCount = 0;
+    let freezesDurationMs = 0;
     let cadenceSampleCount = 0;
     let cadenceIntervalSumMs = 0;
     let maxCadenceIntervalMs = 0;
@@ -1144,6 +1162,8 @@ export class GfnWebRtcClient {
       intervalMs += sample.intervalMs;
       presentedFrames += sample.presentedFramesDelta;
       droppedFrames += sample.droppedFramesDelta;
+      freezeCount += sample.freezeCountDelta;
+      freezesDurationMs += sample.freezesDurationDeltaMs;
       cadenceSampleCount += sample.cadenceSampleCount;
       cadenceIntervalSumMs += sample.cadenceIntervalSumMs;
       maxCadenceIntervalMs = Math.max(maxCadenceIntervalMs, sample.maxCadenceIntervalMs);
@@ -1165,6 +1185,8 @@ export class GfnWebRtcClient {
       pollCount: this.recentPresentationSamples.length,
       presentedFrames,
       droppedFrames,
+      freezeCount,
+      freezesDurationMs,
       presentedFps: (presentedFrames * 1000) / intervalMs,
       dropRatePercent: renderedFrameTotal > 0 ? (droppedFrames / renderedFrameTotal) * 100 : 0,
       avgCadenceIntervalMs: cadenceSampleCount > 0 ? cadenceIntervalSumMs / cadenceSampleCount : 0,
@@ -1331,15 +1353,18 @@ export class GfnWebRtcClient {
       recent.maxCadenceIntervalMs >= Math.max(34, recent.avgCadenceIntervalMs * 1.8) ||
       recent.underflowPolls >= 2;
     const dropBurst = recent.droppedFrames >= 3 || recent.dropRatePercent >= 3;
+    const freezeBurst = recent.freezeCount > 0 || recent.freezesDurationMs >= 80;
     const presentStall =
       recent.intervalMs >= GfnWebRtcClient.RENDER_STALL_MIN_WINDOW_MS &&
       recent.presentedFrames <= Math.max(1, Math.round(params.decodeFps * 0.1)) &&
       recent.pausedPolls === 0;
     const fpsShortfall = recent.presentedFps > 0 && (fpsGap >= 10 || recent.presentedFps < params.decodeFps * 0.75);
 
-    if (presentStall || (fpsShortfall && (cadenceUnstable || dropBurst)) || (dropBurst && cadenceUnstable)) {
+    if (presentStall || freezeBurst || (fpsShortfall && (cadenceUnstable || dropBurst)) || (dropBurst && cadenceUnstable)) {
       const detailParts = [`present ${recent.presentedFps.toFixed(0)}fps vs decode ${params.decodeFps.toFixed(0)}fps`];
       if (recent.dropRatePercent > 0) detailParts.push(`video drops ${recent.dropRatePercent.toFixed(1)}%`);
+      if (recent.freezeCount > 0) detailParts.push(`freezes ${recent.freezeCount}`);
+      if (recent.freezesDurationMs > 0) detailParts.push(`freeze ${recent.freezesDurationMs.toFixed(0)}ms`);
       if (recent.maxCadenceIntervalMs > 0) detailParts.push(`max gap ${recent.maxCadenceIntervalMs.toFixed(1)}ms`);
       if (recent.underflowPolls > 0) detailParts.push("video underflow");
       return {
@@ -1797,6 +1822,15 @@ export class GfnWebRtcClient {
         recentPresentation,
         decoderPressure: decoderPressureSignal,
       });
+      if (
+        recentPresentation.freezeCount > 0 ||
+        recentPresentation.freezesDurationMs >= 80 ||
+        recentPresentation.maxCadenceIntervalMs >= 120
+      ) {
+        this.log(
+          `Video hitch evidence: present=${recentPresentation.presentedFps.toFixed(1)}fps drops=${recentPresentation.dropRatePercent.toFixed(1)}% freezes=${recentPresentation.freezeCount}/${recentPresentation.freezesDurationMs.toFixed(0)}ms maxGap=${recentPresentation.maxCadenceIntervalMs.toFixed(1)}ms underflow=${recentPresentation.underflowPolls}`,
+        );
+      }
     }
 
     // RTT from active candidate pair

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -1254,6 +1254,7 @@ export class GfnWebRtcClient {
     decodeTimeMs: number;
     decodeFps: number;
     recentVideo: RecentVideoWindowMetrics | null;
+    recentPresentation: RecentPresentationWindowMetrics | null;
   }): DecoderPressureSignal {
     const recent = params.recentVideo;
     if (!recent || recent.intervalMs < 400 || recent.receivedFrames <= 0) {
@@ -1292,6 +1293,15 @@ export class GfnWebRtcClient {
       ) ||
       (recent.dropRatePercent >= 8 && recent.droppedFrames >= 4);
     const lowDecodeOutput = recent.decodedFrames <= Math.max(4, Math.round(recent.receivedFrames * 0.4));
+    const recentPresentation = params.recentPresentation;
+    const likelyPresentationCadenceIssue =
+      !!recentPresentation &&
+      recentPresentation.intervalMs >= 400 &&
+      recentPresentation.maxCadenceIntervalMs >= 100 &&
+      recentPresentation.underflowPolls === 0 &&
+      recentPresentation.freezeCount === 0 &&
+      recentPresentation.presentedFps > 0 &&
+      recentPresentation.presentedFps < Math.max(30, params.decodeFps * 0.9);
 
     if (severeStall) {
       return {
@@ -1300,6 +1310,16 @@ export class GfnWebRtcClient {
         recentDeficitFrames,
         dropRatePercent: recent.dropRatePercent,
         detail: `no decodes for ${recent.intervalMs.toFixed(0)}ms while receiving ${recent.receivedFrames} frames`,
+      };
+    }
+
+    if (likelyPresentationCadenceIssue) {
+      return {
+        active: false,
+        reason: "stable",
+        recentDeficitFrames,
+        dropRatePercent: recent.dropRatePercent,
+        detail: "Presentation cadence issue dominating over decoder pressure",
       };
     }
 
@@ -1606,6 +1626,7 @@ export class GfnWebRtcClient {
     let framesReceived = 0;
     let framesDecoded = 0;
     let framesDropped = 0;
+    const recentPresentation = this.captureRecentPresentationWindow(now);
     let playoutTelemetry: {
       targetDelayMs?: number;
       currentDelayMs?: number;
@@ -1811,6 +1832,7 @@ export class GfnWebRtcClient {
         decodeTimeMs: this.diagnostics.decodeTimeMs,
         decodeFps: this.diagnostics.decodeFps,
         recentVideo,
+        recentPresentation,
       });
 
       if (decoderPressureSignal.reason === "recent_stall") {
@@ -1825,7 +1847,6 @@ export class GfnWebRtcClient {
       await this.maybeRecoverFromDecoderPressure(decoderPressureSignal);
     }
 
-    const recentPresentation = this.captureRecentPresentationWindow(now);
     if (recentPresentation) {
       this.diagnostics.renderFps = Math.round(recentPresentation.presentedFps);
       if (recentPresentation.avgCadenceIntervalMs > 0) {

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -1606,6 +1606,12 @@ export class GfnWebRtcClient {
     let framesReceived = 0;
     let framesDecoded = 0;
     let framesDropped = 0;
+    let playoutTelemetry: {
+      targetDelayMs?: number;
+      currentDelayMs?: number;
+      minPlayoutDelayMs?: number;
+      timingFrameInfo?: string;
+    } | null = null;
     let decoderPressureSignal: DecoderPressureSignal = {
       active: false,
       reason: "stable",
@@ -1732,6 +1738,19 @@ export class GfnWebRtcClient {
         this.diagnostics.jitterBufferDelayMs = Math.round((jbDelay / jbEmitted) * 1000 * 10) / 10;
       }
 
+      const targetDelayMs = Number(inboundVideo.googTargetDelayMs);
+      const currentDelayMs = Number(inboundVideo.googCurrentDelayMs);
+      const minPlayoutDelayMs = Number(inboundVideo.googMinPlayoutDelayMs);
+      const timingFrameInfo = typeof inboundVideo.googTimingFrameInfo === "string"
+        ? inboundVideo.googTimingFrameInfo
+        : undefined;
+      playoutTelemetry = {
+        targetDelayMs: Number.isFinite(targetDelayMs) && targetDelayMs > 0 ? targetDelayMs : undefined,
+        currentDelayMs: Number.isFinite(currentDelayMs) && currentDelayMs > 0 ? currentDelayMs : undefined,
+        minPlayoutDelayMs: Number.isFinite(minPlayoutDelayMs) && minPlayoutDelayMs >= 0 ? minPlayoutDelayMs : undefined,
+        timingFrameInfo,
+      };
+
       // Get codec information
       const codecId = inboundVideo.codecId as string;
       if (codecId && codecs.has(codecId)) {
@@ -1827,8 +1846,13 @@ export class GfnWebRtcClient {
         recentPresentation.freezesDurationMs >= 80 ||
         recentPresentation.maxCadenceIntervalMs >= 120
       ) {
+        const telemetryParts: string[] = [];
+        if (playoutTelemetry?.targetDelayMs !== undefined) telemetryParts.push(`targetDelay=${playoutTelemetry.targetDelayMs.toFixed(0)}ms`);
+        if (playoutTelemetry?.currentDelayMs !== undefined) telemetryParts.push(`currentDelay=${playoutTelemetry.currentDelayMs.toFixed(0)}ms`);
+        if (playoutTelemetry?.minPlayoutDelayMs !== undefined) telemetryParts.push(`minDelay=${playoutTelemetry.minPlayoutDelayMs.toFixed(0)}ms`);
+        if (playoutTelemetry?.timingFrameInfo) telemetryParts.push(`timing=${playoutTelemetry.timingFrameInfo}`);
         this.log(
-          `Video hitch evidence: present=${recentPresentation.presentedFps.toFixed(1)}fps drops=${recentPresentation.dropRatePercent.toFixed(1)}% freezes=${recentPresentation.freezeCount}/${recentPresentation.freezesDurationMs.toFixed(0)}ms maxGap=${recentPresentation.maxCadenceIntervalMs.toFixed(1)}ms underflow=${recentPresentation.underflowPolls}`,
+          `Video hitch evidence: present=${recentPresentation.presentedFps.toFixed(1)}fps drops=${recentPresentation.dropRatePercent.toFixed(1)}% freezes=${recentPresentation.freezeCount}/${recentPresentation.freezesDurationMs.toFixed(0)}ms maxGap=${recentPresentation.maxCadenceIntervalMs.toFixed(1)}ms underflow=${recentPresentation.underflowPolls}${telemetryParts.length > 0 ? ` · ${telemetryParts.join(" · ")}` : ""}`,
         );
       }
     }

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -563,10 +563,6 @@ export class GfnWebRtcClient {
   private static readonly DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS = 300;
   private static readonly RELIABLE_MOUSE_BACKPRESSURE_BYTES = 64 * 1024;
   private static readonly BACKPRESSURE_LOG_INTERVAL_MS = 2000;
-  private static readonly VIDEO_BASE_JITTER_TARGET_MS = 12;
-  private static readonly AUDIO_BASE_JITTER_TARGET_MS = 20;
-  private static readonly VIDEO_PRESSURE_JITTER_TARGET_MS = 30;
-  private static readonly AUDIO_PRESSURE_JITTER_TARGET_MS = 32;
   private static readonly RECENT_VIDEO_WINDOW_MS = 1600;
   private static readonly DECODER_STALL_MIN_WINDOW_MS = 900;
   private static readonly DECODER_STALL_MIN_RECEIVED_FRAMES = 24;
@@ -646,10 +642,6 @@ export class GfnWebRtcClient {
   private lastDecoderKeyframeRequestAtMs = 0;
   private negotiatedMaxBitrateKbps = 0;
   private currentBitrateCeilingKbps = 0;
-  private receiverLatencyTargets = {
-    video: GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS,
-    audio: GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS,
-  };
   private activeReceivers: Array<{ receiver: RTCRtpReceiver; kind: "audio" | "video" }> = [];
 
   // Microphone
@@ -817,17 +809,13 @@ export class GfnWebRtcClient {
   }
 
   /**
-   * Configure an RTCRtpReceiver for minimum jitter buffer delay.
+   * Register receiver-side hints without overriding Chromium's default playout
+   * buffering policy.
    *
-   * jitterBufferTarget controls how long Chrome holds decoded frames before
-   * displaying them. Setting to 0 tells the browser to use the absolute
-   * minimum buffer — effectively "display as soon as decoded". This is
-   * aggressive but correct for cloud gaming where we prioritize latency
-   * over smoothness.
-   *
-   * The official GFN browser client doesn't set this at all (defaulting to
-   * ~100-200ms). As an Electron app we can be more aggressive.
-   *
+   * Forcing ultra-low jitterBufferTarget/playoutDelayHint made OpenNOW more
+   * aggressive than the official GFN web client and produced visible cadence
+   * jumps under modest packet-arrival variance. We now leave receiver playout
+   * buffering browser-managed and only apply safe track hints.
    */
   private configureReceiverForLowLatency(receiver: RTCRtpReceiver, kind: string): void {
     if (kind !== "video" && kind !== "audio") {
@@ -837,22 +825,9 @@ export class GfnWebRtcClient {
     this.registerReceiver(receiver, kind);
 
     try {
-      const targetMs = this.receiverLatencyTargets[kind];
-      const rawReceiver = receiver as unknown as Record<string, unknown>;
-
-      if ("jitterBufferTarget" in receiver) {
-        rawReceiver.jitterBufferTarget = targetMs;
-        this.log(`${kind} receiver: jitterBufferTarget set to ${targetMs}ms`);
-      }
-
-      if ("playoutDelayHint" in receiver) {
-        const playoutDelaySeconds = targetMs / 1000;
-        rawReceiver.playoutDelayHint = playoutDelaySeconds;
-        this.log(`${kind} receiver: playoutDelayHint set to ${playoutDelaySeconds}s`);
-      }
-
       if (kind === "video" && "contentHint" in receiver.track) {
         receiver.track.contentHint = "motion";
+        this.log("video receiver: leaving browser playout buffering at default policy");
       }
     } catch (error) {
       this.log(`Warning: could not apply ${kind} low-latency receiver tuning: ${String(error)}`);
@@ -879,14 +854,8 @@ export class GfnWebRtcClient {
 
     this.decoderPressureActive = active;
     this.diagnostics.decoderPressureActive = active;
-    this.receiverLatencyTargets.video = active
-      ? GfnWebRtcClient.VIDEO_PRESSURE_JITTER_TARGET_MS
-      : GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS;
-    this.receiverLatencyTargets.audio = active
-      ? GfnWebRtcClient.AUDIO_PRESSURE_JITTER_TARGET_MS
-      : GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS;
     this.log(
-      `Decoder pressure mode ${active ? "enabled" : "cleared"}; receiver targets video=${this.receiverLatencyTargets.video}ms audio=${this.receiverLatencyTargets.audio}ms`,
+      `Decoder pressure mode ${active ? "enabled" : "cleared"}; keeping browser-managed receiver playout policy`,
     );
     this.applyReceiverLatencyTargets();
   }
@@ -910,8 +879,6 @@ export class GfnWebRtcClient {
     this.lastDecoderKeyframeRequestAtMs = 0;
     this.negotiatedMaxBitrateKbps = 0;
     this.currentBitrateCeilingKbps = 0;
-    this.receiverLatencyTargets.video = GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS;
-    this.receiverLatencyTargets.audio = GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS;
     this.activeReceivers = [];
     this.diagnostics.decoderPressureActive = false;
     this.diagnostics.decoderRecoveryAttempts = 0;

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -334,6 +334,7 @@ export interface SendAnswerRequest {
 
 export interface KeyframeRequest {
   reason: string;
+  /** Recent short-window decode deficit estimate kept as backlogFrames for signaling compatibility. */
   backlogFrames: number;
   attempt: number;
 }


### PR DESCRIPTION
Fix false-positive decoder lag classification and recovery churn by replacing cumulative WebRTC counters with a short rolling window of interval deltas.

- Add `CumulativeVideoStatsSample`, `RecentVideoIntervalSample`, `RecentVideoWindowMetrics` and `DecoderPressureSignal` helper types to `opennow-stable/src/renderer/src/gfn/webrtcClient.ts`.
- Implement `appendRecentVideoIntervalSample` and `summarizeRecentVideoWindow` to aggregate interval deltas (`receivedDelta`, `decodedDelta`, `droppedDelta`, `decodeTimeDelta`) over ~1.6s.
- Rewrite `collectStats` to derive interval metrics and detect counter resets/stream restarts so old session drops do not poison future backlog detection.
- Rewrite `shouldTreatAsDecoderPressure` to trigger only on recent windowed evidence (recent stalls, saturation, drop bursts) instead of raw `framesReceived - framesDecoded` or lifetime drop thresholds.
- Update `classifyLagReason` to consume the new `DecoderPressureSignal`, removing redundant cumulative lag calculations.
- Drive `requestDecoderKeyframe` and `maybeRecoverFromDecoderPressure` with `recentDeficitFrames` from the window instead of misleading cumulative counters.
- Document `KeyframeRequest.backlogFrames` in `opennow-stable/src/shared/gfn.ts` as a recent short-window deficit estimate kept for signaling compatibility.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/c7b82bd9-bf17-47c1-923f-4b5a02c0b3b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-19&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-19"><img alt="OPE-19 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-19"></picture></a>