### PR TITLE
Update README structure and add development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <p align="center">
-  <strong>An open-source GeForce NOW client — play your games, your way.</strong>
+  <strong>An open-source desktop client for GeForce NOW.</strong>
 </p>
 
 <p align="center">
-  <img src="img.png" alt="OpenNOW" />
+  Browse the catalog, tune your stream, and launch sessions from a community-built app.
 </p>
 
 <p align="center">
@@ -34,197 +34,124 @@
   <a href="https://github.com/OpenCloudGaming/OpenNOW/releases">
     <img src="https://img.shields.io/github/downloads/OpenCloudGaming/OpenNOW/total?style=flat-square" alt="Downloads">
   </a>
-  <a href="https://github.com/OpenCloudGaming/OpenNOW/blob/dev/LICENSE">
+  <a href="LICENSE">
     <img src="https://img.shields.io/github/license/OpenCloudGaming/OpenNOW?style=flat-square" alt="License">
   </a>
 </p>
 
----
+<p align="center">
+  <img src="img.png" alt="OpenNOW application preview" />
+</p>
 
-> **Warning**  
-> OpenNOW is under active development. Bugs and performance issues are expected while features are finalized.
+> [!WARNING]
+> OpenNOW is under active development. Expect occasional bugs, rough edges, and platform-specific issues while the client matures.
 
-> **Trademark & Affiliation Notice**  
-> OpenNOW is an independent community project and is **not affiliated with, endorsed by, or sponsored by NVIDIA Corporation**.  
-> **NVIDIA** and **GeForce NOW** are trademarks of NVIDIA Corporation. You must use your own GeForce NOW account.
+> [!IMPORTANT]
+> OpenNOW is an independent community project and is not affiliated with, endorsed by, or sponsored by NVIDIA. NVIDIA and GeForce NOW are trademarks of NVIDIA Corporation. You must use your own GeForce NOW account.
 
----
+## Overview
 
-## What is OpenNOW?
+OpenNOW is a community-built Electron app for playing GeForce NOW from an open-source desktop client. The active implementation lives in [`opennow-stable/`](opennow-stable) and uses Electron, React, and TypeScript across the main, preload, and renderer processes.
 
-OpenNOW is an independent, community-built desktop client for [NVIDIA GeForce NOW](https://www.nvidia.com/en-us/geforce-now/), built with Electron and TypeScript. It provides a fully open-source, cross-platform alternative to the official app with zero telemetry, full transparency, and power-user features.
+The project aims to give players a transparent, customizable alternative to the official client without hiding the technical parts from contributors.
 
-- 🔓 **Fully open source** — audit every line, fork it, improve it
-- 🚫 **No telemetry** — OpenNOW collects nothing
-- 🖥️ **Cross-platform** — Windows, macOS, Linux, and ARM64
-- ⚡ **Community-driven** — faster fixes, transparent development
-- 🎮 **Anti-AFK, Stats Overlay, Adjustable Shortcuts** — power-user features built in
+## Highlights
 
-## OpenNOW vs Official GeForce NOW
-
-| Feature | OpenNOW | Official GFN | Notes |
-|---------|:-------:|:------------:|-------|
-| **Streaming** | | | |
-| WebRTC Streaming | ✅ | ✅ | Chromium-based in OpenNOW |
-| H.264 Codec | ✅ | ✅ | |
-| H.265 / HEVC Codec | ✅ | ✅ | Full support |
-| AV1 Codec | ✅ | ✅ | |
-| Up to 1080p | ✅ | ✅ | |
-| Up to 4K | ✅ | ✅ | Configurable in settings |
-| 5K Resolution | ✅ | ✅ | Up to 5K@120fps |
-| 120+ FPS | ✅ | ✅ | Configurable: 30/60/120/144/240 |
-| HDR Streaming | 📋 | ✅ | 10-bit color supported, full HDR pipeline planned |
-| AI-Enhanced Stream Mode | ❌ | ✅ | NVIDIA Cinematic Quality — not available |
-| Adjustable Bitrate | ✅ | ✅ | Up to 200 Mbps in OpenNOW |
-| Color Quality (8/10-bit, 4:2:0/4:4:4) | ✅ | ✅ | Full chroma/bit-depth control |
-| **Input** | | | |
-| Keyboard + Mouse | ✅ | ✅ | Full input over GFN data channels |
-| Gamepad Support | ✅ | ✅ | Up to 4 controllers simultaneously |
-| Flight Controls | ❌ | ✅ | Added in official client v2.0.81 |
-| Mouse Sensitivity | ✅ | ❌ | OpenNOW-exclusive setting |
-| Clipboard Paste | ✅ | ❌ | Paste text into cloud session |
-| **Features** | | | |
-| Authentication + Session Restore | ✅ | ✅ | OAuth PKCE, auto-restore on startup |
-| Game Library + Catalog | ✅ | ✅ | Main catalog, library, and public games |
-| Alliance Partners | ✅ | ✅ | NVIDIA + partner providers |
-| Audio Playback | ✅ | ✅ | |
-| Microphone Support | ✅ | ✅ | Voice chat with mute/unmute toggle |
-| Instant Replay | 📋 | ✅ | Planned for future release |
-| Screenshots | 📋 | ✅ | Planned for future release |
-| Stats Overlay | ✅ | ✅ | Detailed: RTT, decode, render, jitter, loss, input queue |
-| Anti-AFK | ✅ | ❌ | OpenNOW-exclusive — prevents idle disconnects |
-| Adjustable Shortcuts | ✅ | 🚧 | Fully customizable in OpenNOW |
-| Session Conflict Resolution | ✅ | ✅ | Resume / New / Cancel existing sessions |
-| Subscription Info | ✅ | ✅ | Hours, tier, entitled resolutions |
-| Region Selection | ✅ | ✅ | Dynamic region discovery |
-| Install-to-Play | ✅ | ✅ | For games not in standard catalog |
-| Discord Integration | ❌ | ✅ | |
-| **Platform Support** | | | |
-| Windows | ✅ | ✅ | NSIS installer + portable |
-| macOS (x64 + ARM) | ✅ | ✅ | Universal builds |
-| Linux | ✅ | 🚧 | Official client has beta native app |
-| ARM64 / Raspberry Pi | ✅ | ❌ | OpenNOW builds for ARM64 Linux |
-| Steam Deck | 📋 | ✅ | |
-| Android / iOS / TV | ❌ | ✅ | Desktop-only for now |
-| **Privacy & Openness** | | | |
-| Open Source | ✅ | ❌ | MIT licensed |
-| No Telemetry | ✅ | ❌ | Zero data collection |
-| Auditable Code | ✅ | ❌ | |
-
-> 💡 **Legend:** ✅ Working  ·  🚧 In Progress  ·  📋 Planned  ·  ❌ Not Available
-
-## Roadmap
-
-| Priority | Feature | Status | Description |
-|:--------:|---------|:------:|-------------|
-| 🔴 | ~~H.265 codec tuning~~ | ✅ Completed | Full HEVC support implemented |
-| 🔴 | ~~Microphone support~~ | ✅ Completed | Voice chat with mute/unmute toggle |
-| 🟡 | Instant replay | 📋 Planned | Clip and save gameplay moments |
-| 🟡 | Screenshots | 📋 Planned | Capture in-stream screenshots |
-| 🟡 | HDR streaming pipeline | 📋 Planned | Full HDR end-to-end support |
-| 🟢 | Latency optimizations | 🚧 Ongoing | Input and render path improvements |
-| 🟢 | Platform stability | 🚧 Ongoing | Cross-platform bug fixes |
-
-> 🔴 High priority · 🟡 Medium priority · 🟢 Ongoing effort
-
-## Features
-
-**Streaming**
-`H.264` `AV1` `H.265 (WIP)` · Up to 4K@240fps · Adjustable bitrate · 8/10-bit color · 4:2:0/4:4:4 chroma
-
-**Input**
-`Keyboard` `Mouse` `Gamepad ×4` · Mouse sensitivity · Clipboard paste
-
-**Client**
-`Stats Overlay` `Anti-AFK` `Adjustable Shortcuts` · OAuth + session restore · Region selection · Alliance partners
-
-**Platforms**
-`Windows` `macOS` `Linux` `ARM64` · Installer, portable, AppImage, deb, dmg
-
-## Platform Support
-
-| Platform | Status | Builds |
-|----------|:------:|--------|
-| Windows | ✅ Working | NSIS installer + portable |
-| macOS | ✅ Working | dmg + zip (x64 and arm64) |
-| Linux x64 | ✅ Working | AppImage + deb |
-| Linux ARM64 | 🚧 Experimental | AppImage + deb (Raspberry Pi 4/5) |
+- Open-source desktop client for Windows, macOS, and Linux
+- Catalog and public game browsing with search and library-aware session handling
+- Stream controls for codec, resolution, FPS, aspect ratio, region, and quality preferences
+- In-stream diagnostics overlay with latency, packet loss, decode, and render stats
+- Built-in screenshots, recording, microphone controls, and controller-friendly navigation
+- Local settings storage and zero-telemetry project direction
 
 ## Quick Start
 
+### Download
+
+Grab the latest build from [GitHub Releases](https://github.com/OpenCloudGaming/OpenNOW/releases).
+
+Current packaging targets:
+
+| Platform | Formats |
+| --- | --- |
+| Windows | NSIS installer, portable executable |
+| macOS | `dmg`, `zip` |
+| Linux x64 | `AppImage`, `deb` |
+| Linux ARM64 | `AppImage`, `deb` |
+
+### Develop Locally
+
+From the repository root:
+
 ```bash
-git clone https://github.com/OpenCloudGaming/OpenNOW.git
-cd OpenNOW/opennow-stable
+cd opennow-stable
 npm install
+cd ..
 npm run dev
 ```
 
-See [opennow-stable/README.md](./opennow-stable/README.md) for build and packaging details.
+Useful root scripts:
 
-## Download
-
-Grab the latest release for your platform:
-
-👉 **[Download from GitHub Releases](https://github.com/OpenCloudGaming/OpenNOW/releases)**
-
-| Platform | File |
-|----------|------|
-| Windows (installer) | `OpenNOW-v0.2.4-setup-x64.exe` |
-| Windows (portable) | `OpenNOW-v0.2.4-portable-x64.exe` |
-| macOS (x64) | `OpenNOW-v0.2.4-mac-x64.dmg` |
-| macOS (ARM) | `OpenNOW-v0.2.4-mac-arm64.dmg` |
-| Linux (x64) | `OpenNOW-v0.2.4-linux-x86_64.AppImage` |
-| Linux (ARM64) | `OpenNOW-v0.2.4-linux-arm64.AppImage` |
-
-## Architecture
-
-OpenNOW is an Electron app with three processes:
-
-| Layer | Technology | Role |
-|-------|-----------|------|
-| **Main** | Node.js + Electron | OAuth, CloudMatch API, WebSocket signaling, settings |
-| **Renderer** | React 19 + TypeScript | UI, WebRTC streaming, input encoding, stats |
-| **Preload** | Electron contextBridge | Secure IPC between main and renderer |
-
-```
-opennow-stable/src/
-├── main/           # Electron main process
-│   ├── gfn/        # Auth, CloudMatch, signaling, games, subscription
-│   ├── index.ts    # Entry point, IPC handlers, window management
-│   └── settings.ts # Persistent user settings
-├── renderer/src/   # React UI
-│   ├── components/ # Login, Home, Library, Settings, StreamView
-│   ├── gfn/        # WebRTC client, SDP, input protocol
-│   └── App.tsx     # Root component with routing and state
-├── shared/         # Shared types and IPC channel definitions
-│   ├── gfn.ts      # All TypeScript interfaces
-│   └── ipc.ts      # IPC channel constants
-└── preload/        # Context bridge (safe API exposure)
+```bash
+npm run dev
+npm run build
+npm run typecheck
+npm run dist
 ```
 
-## FAQ
+For a fuller setup guide, see [docs/development.md](docs/development.md).
 
-**Is this the official GeForce NOW client?**
-No. OpenNOW is an independent third-party client and is not affiliated with, endorsed by, or sponsored by NVIDIA. NVIDIA and GeForce NOW are trademarks of NVIDIA Corporation.
+## Repository Layout
 
-**Was this project built in Rust before?**
-Yes. OpenNOW originally used Rust/Tauri but switched to Electron for better cross-platform compatibility and faster development.
+```text
+.
+├── opennow-stable/   Electron app workspace
+├── docs/             Local project documentation
+├── .github/          Workflows, templates, contributing docs
+├── logo.png          Project logo
+└── img.png           App preview image
+```
 
-**Does OpenNOW collect any data?**
-No. OpenNOW has zero telemetry. Your credentials are stored locally and only sent to NVIDIA's authentication servers.
+## Documentation
+
+- [Development Guide](docs/development.md)
+- [Contributing Guide](.github/CONTRIBUTING.md)
+- [Project Website](https://opennow.zortos.me)
+
+## Architecture At A Glance
+
+OpenNOW is split into three Electron layers:
+
+| Layer | Tech | Responsibility |
+| --- | --- | --- |
+| Main | Electron + Node.js | OAuth, CloudMatch/session orchestration, signaling, caching, local file handling |
+| Preload | Electron `contextBridge` | Safe IPC bridge between the app shell and UI |
+| Renderer | React + TypeScript | Login flow, browsing, settings, WebRTC playback, diagnostics, controls |
+
+The code lives under [`opennow-stable/src/`](opennow-stable/src), with shared TypeScript types and IPC contracts in [`opennow-stable/src/shared/`](opennow-stable/src/shared).
 
 ## Contributing
 
-Contributions are welcome! Open an issue or PR on [GitHub](https://github.com/OpenCloudGaming/OpenNOW).
+Contributions are welcome. If you want to help:
 
-## Support Me
+1. Read the [contributing guide](.github/CONTRIBUTING.md).
+2. Run `npm run typecheck` and `npm run build` before opening a PR.
+3. Keep changes focused and explain user-facing impact clearly.
 
-<p align="center">
-  <a href="https://github.com/sponsors/zortos293">
-    <img src="https://img.shields.io/badge/Support%20Me-GitHub%20Sponsors-ea4aaa?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Support Me">
-  </a>
-</p>
+## FAQ
+
+### Is this the official GeForce NOW client?
+
+No. OpenNOW is a third-party, community-maintained client.
+
+### Does OpenNOW collect telemetry?
+
+The current project direction is zero telemetry. Settings and media stay on the local machine, and authentication is performed against NVIDIA services.
+
+### What happened to the earlier Tauri/Rust version?
+
+The active client in this repository is the Electron-based app in [`opennow-stable/`](opennow-stable).
 
 ## License
 
-[MIT](./LICENSE) © Zortos
+OpenNOW is licensed under the [MIT License](LICENSE).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,164 @@
+# Development Guide
+
+This guide covers the active Electron-based OpenNOW client in [`opennow-stable/`](../opennow-stable).
+
+## Prerequisites
+
+- Node.js 22 or newer
+- npm
+- A GeForce NOW account for end-to-end testing
+
+## Getting Started
+
+Install app dependencies inside the Electron workspace:
+
+```bash
+cd opennow-stable
+npm install
+```
+
+You can then work either from the app directory or from the repository root.
+
+From the repository root:
+
+```bash
+npm run dev
+npm run typecheck
+npm run build
+npm run dist
+```
+
+Directly inside `opennow-stable/`:
+
+```bash
+npm run dev
+npm run preview
+npm run typecheck
+npm run build
+npm run dist
+npm run dist:signed
+```
+
+## Workspace Layout
+
+```text
+opennow-stable/
+├── src/
+│   ├── main/           Electron main process
+│   │   ├── gfn/        Auth, game catalogs, subscriptions, CloudMatch, signaling
+│   │   └── services/   Cache and refresh helpers
+│   ├── preload/        Safe API exposed to the renderer
+│   ├── renderer/src/   React application
+│   │   ├── components/ Screens, stream UI, settings, library, navigation
+│   │   ├── gfn/        WebRTC client and input protocol
+│   │   └── utils/      Diagnostics and UI helpers
+│   └── shared/         Shared types, IPC channels, logging helpers
+├── electron.vite.config.ts
+├── package.json
+└── tsconfig*.json
+```
+
+## Architecture
+
+### Main process
+
+The main process handles platform and system responsibilities:
+
+- OAuth and session bootstrap
+- Game catalog fetches and cache refresh
+- CloudMatch session creation, polling, claiming, and stopping
+- Signaling and low-level Electron integration
+- Local media management for screenshots and recordings
+- Persistent settings storage
+
+Key entry point:
+
+- [`opennow-stable/src/main/index.ts`](../opennow-stable/src/main/index.ts)
+
+### Preload
+
+The preload layer exposes a narrow IPC surface to the renderer with `contextBridge`.
+
+Key entry point:
+
+- [`opennow-stable/src/preload/index.ts`](../opennow-stable/src/preload/index.ts)
+
+### Renderer
+
+The renderer is a React app responsible for:
+
+- Login and provider selection
+- Browsing the catalog and public listings
+- Managing stream launch state and session recovery
+- Rendering the WebRTC stream
+- Handling controller input, shortcuts, stats overlay, screenshots, recordings, and settings UI
+
+Key entry points:
+
+- [`opennow-stable/src/renderer/src/App.tsx`](../opennow-stable/src/renderer/src/App.tsx)
+- [`opennow-stable/src/renderer/src/components/StreamView.tsx`](../opennow-stable/src/renderer/src/components/StreamView.tsx)
+- [`opennow-stable/src/renderer/src/components/SettingsPage.tsx`](../opennow-stable/src/renderer/src/components/SettingsPage.tsx)
+
+## Common Tasks
+
+### Start the app in development
+
+```bash
+cd opennow-stable
+npm run dev
+```
+
+### Run type checks
+
+```bash
+cd opennow-stable
+npm run typecheck
+```
+
+### Build production bundles
+
+```bash
+cd opennow-stable
+npm run build
+```
+
+### Package release artifacts locally
+
+Unsigned packages:
+
+```bash
+cd opennow-stable
+npm run dist
+```
+
+Signed packages, if your environment is configured for signing:
+
+```bash
+cd opennow-stable
+npm run dist:signed
+```
+
+## CI And Releases
+
+The repository includes two main GitHub Actions workflows:
+
+- [`auto-build.yml`](../.github/workflows/auto-build.yml) builds pull requests and pushes to `main` and `dev`
+- [`release.yml`](../.github/workflows/release.yml) packages and publishes tagged or manually-triggered releases
+
+Current build matrix:
+
+| Target | Output |
+| --- | --- |
+| Windows | NSIS installer, portable executable |
+| macOS x64 | `dmg`, `zip` |
+| macOS arm64 | `dmg`, `zip` |
+| Linux x64 | `AppImage`, `deb` |
+| Linux ARM64 | `AppImage`, `deb` |
+
+## Notes For Contributors
+
+- The active app is the Electron client. If you see older references to previous implementations, prefer `opennow-stable/`.
+- Root-level npm scripts are convenience wrappers around the `opennow-stable` workspace.
+- Before opening a PR, run `npm run typecheck` and `npm run build`.
+
+For contribution workflow details, see [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md).

--- a/opennow-stable/README.md
+++ b/opennow-stable/README.md
@@ -1,52 +1,38 @@
 # OpenNOW Stable (Electron)
 
-> For features, comparison, and downloads, see the [main README](../README.md).
+This directory contains the active Electron-based OpenNOW client.
 
-Developer reference for the Electron-based OpenNOW client.
+For user-facing project information, downloads, and the high-level overview, start with the [main README](../README.md). For local setup and architecture notes, see the [development guide](../docs/development.md).
 
-## Development
+## Quick Commands
 
 ```bash
 npm install
 npm run dev
-```
-
-## Build
-
-```bash
+npm run typecheck
 npm run build
 npm run dist
 ```
 
+## What Lives Here
+
+- `src/main/`: Electron main process, auth, sessions, signaling, caching, media handling
+- `src/preload/`: secure renderer bridge
+- `src/renderer/src/`: React UI, stream playback, controls, diagnostics, settings
+- `src/shared/`: shared types, IPC channels, and utilities
+
 ## Packaging Targets
 
 | Platform | Formats |
-|----------|---------|
-| Windows | NSIS installer + portable |
-| macOS | dmg + zip (x64 and arm64 universal) |
-| Linux x64 | AppImage + deb |
-| Linux ARM64 | AppImage + deb (Raspberry Pi 4/5) |
-
-## CI/CD
-
-Workflow: `.github/workflows/auto-build.yml`
-
-- Triggers on pushes to `dev`/`main` and PRs
-- Builds: Windows, macOS (x64/arm64), Linux x64, Linux arm64
-- Artifacts uploaded to GitHub Releases
-
-## Tagged Releases
-
-Release workflow: `.github/workflows/release.yml`
-
-- Run it manually with `workflow_dispatch`
-- Provide a version like `1.2.3` or `v1.2.3`
-- Optional tag pushes matching `v*.*.*` or `opennow-stable-v*.*.*` also trigger releases
-- The workflow builds all platforms, publishes the GitHub Release, then commits the version bump back to the triggering release branch; manual/tagged runs fall back to `dev` when no branch context is available
+| --- | --- |
+| Windows | NSIS installer, portable executable |
+| macOS | `dmg`, `zip` |
+| Linux x64 | `AppImage`, `deb` |
+| Linux ARM64 | `AppImage`, `deb` |
 
 ## Technical Notes
 
-- `ws` runs in the Electron main process for custom signaling behavior and relaxed TLS handling
-- WebRTC uses Chromium's built-in stack (no external dependencies)
-- OAuth PKCE flow with localhost callback
-- Persistent settings stored via `electron-store`
+- WebRTC relies on Chromium's built-in stack
+- `ws` is used in the main process for custom signaling behavior
+- Authentication uses an OAuth PKCE flow with a localhost callback
+- Settings are persisted locally through `electron-store`


### PR DESCRIPTION
## Summary
- rewrite the root README into a shorter, more maintainable project overview
- add `docs/development.md` with setup, architecture, workflow, and release guidance
- simplify `opennow-stable/README.md` so it points to the main docs and focuses on workspace-specific commands
- remove stale or high-maintenance README content such as hardcoded release artifact names and the large feature comparison matrix

## Testing
- Not run (not requested)