### PR TITLE
fix(gfn): clarify region restriction error message

### DIFF
--- a/opennow-stable/src/main/gfn/errorCodes.ts
+++ b/opennow-stable/src/main/gfn/errorCodes.ts
@@ -441,8 +441,9 @@ export const ERROR_MESSAGES: Map<number, ErrorMessageEntry> = new Map([
   [
     3237093695,
     {
-      title: "Region Not Supported",
-      description: "Streaming is not supported in your region.",
+      title: "GeForce NOW Unavailable in Your Region",
+      description:
+        "GeForce NOW has restricted streaming in your region. This is not an OpenNOW issue — NVIDIA has blocked access from your location. You may need to use a VPN or check GeForce NOW's supported countries list.",
     },
   ],
   [


### PR DESCRIPTION
## Description
- Update the `RegionNotSupportedForStreaming` error (code 3237093695) in `opennow-stable/src/main/gfn/errorCodes.ts` to clearly attribute the restriction to GeForce NOW/NVIDIA
- Explicitly state this is not an OpenNOW issue and provide guidance for users (check supported regions or use a VPN)

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/0e8172cc-e303-4640-83c7-1bc6ba712de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-21&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-21"><img alt="OPE-21 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-21"></picture></a>