### PR TITLE
fix(gfn): macOS frame skipping during stream

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -505,12 +505,29 @@ async function createMainWindow(): Promise<void> {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
+      backgroundThrottling: false,
     },
   });
 
   if (process.platform === "win32") {
     // Keep native window fullscreen in sync with HTML fullscreen so Windows treats
     // stream playback like a real fullscreen window instead of only DOM fullscreen.
+    mainWindow.webContents.on("enter-html-full-screen", () => {
+      if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isFullScreen()) {
+        mainWindow.setFullScreen(true);
+      }
+    });
+
+    mainWindow.webContents.on("leave-html-full-screen", () => {
+      if (mainWindow && !mainWindow.isDestroyed() && mainWindow.isFullScreen()) {
+        mainWindow.setFullScreen(false);
+      }
+    });
+  }
+
+  if (process.platform === "darwin") {
+    // On macOS, sync native window fullscreen with HTML fullscreen to prevent
+    // the compositor hiccup that causes frame drop bursts on fullscreen transitions.
     mainWindow.webContents.on("enter-html-full-screen", () => {
       if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isFullScreen()) {
         mainWindow.setFullScreen(true);

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -32,6 +32,13 @@ import {
 } from "./sdp";
 import { MicrophoneManager, type MicState, type MicStateChange } from "./microphoneManager";
 
+/** Returns true when running on macOS (Electron/Chromium userAgent). */
+function isMacOS(): boolean {
+  const ua = navigator.userAgent?.toLowerCase() ?? "";
+  const platform = navigator.platform?.toLowerCase() ?? "";
+  return platform.includes("mac") || ua.includes("macintosh");
+}
+
 interface OfferSettings {
   codec: VideoCodec;
   colorQuality: ColorQuality;
@@ -478,8 +485,10 @@ export class GfnWebRtcClient {
   private static readonly RELIABLE_MOUSE_BACKPRESSURE_BYTES = 64 * 1024;
   private static readonly BACKPRESSURE_LOG_INTERVAL_MS = 2000;
   private static readonly VIDEO_BASE_JITTER_TARGET_MS = 12;
+  private static readonly VIDEO_BASE_JITTER_TARGET_MAC_MS = 20;
   private static readonly AUDIO_BASE_JITTER_TARGET_MS = 20;
   private static readonly VIDEO_PRESSURE_JITTER_TARGET_MS = 30;
+  private static readonly VIDEO_PRESSURE_JITTER_TARGET_MAC_MS = 38;
   private static readonly AUDIO_PRESSURE_JITTER_TARGET_MS = 32;
   private static readonly DECODER_PRESSURE_CONSECUTIVE_POLLS = 3;
   private static readonly DECODER_STABLE_CONSECUTIVE_POLLS = 6;
@@ -538,6 +547,7 @@ export class GfnWebRtcClient {
   private inputQueueMaxSchedulingDelayMsWindow = 0;
   private inputQueuePressureLoggedAtMs = 0;
   private inputQueueDropCount = 0;
+  private readonly platformIsMac: boolean = isMacOS();
 
   // Decoder pressure detection + recovery state.
   private decoderPressureActive = false;
@@ -549,7 +559,9 @@ export class GfnWebRtcClient {
   private negotiatedMaxBitrateKbps = 0;
   private currentBitrateCeilingKbps = 0;
   private receiverLatencyTargets = {
-    video: GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS,
+    video: isMacOS()
+      ? GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MAC_MS
+      : GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS,
     audio: GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS,
   };
   private activeReceivers: Array<{ receiver: RTCRtpReceiver; kind: "audio" | "video" }> = [];
@@ -782,8 +794,12 @@ export class GfnWebRtcClient {
     this.decoderPressureActive = active;
     this.diagnostics.decoderPressureActive = active;
     this.receiverLatencyTargets.video = active
-      ? GfnWebRtcClient.VIDEO_PRESSURE_JITTER_TARGET_MS
-      : GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS;
+      ? (this.platformIsMac
+          ? GfnWebRtcClient.VIDEO_PRESSURE_JITTER_TARGET_MAC_MS
+          : GfnWebRtcClient.VIDEO_PRESSURE_JITTER_TARGET_MS)
+      : (this.platformIsMac
+          ? GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MAC_MS
+          : GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS);
     this.receiverLatencyTargets.audio = active
       ? GfnWebRtcClient.AUDIO_PRESSURE_JITTER_TARGET_MS
       : GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS;
@@ -812,7 +828,9 @@ export class GfnWebRtcClient {
     this.lastDecoderKeyframeRequestAtMs = 0;
     this.negotiatedMaxBitrateKbps = 0;
     this.currentBitrateCeilingKbps = 0;
-    this.receiverLatencyTargets.video = GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS;
+    this.receiverLatencyTargets.video = this.platformIsMac
+      ? GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MAC_MS
+      : GfnWebRtcClient.VIDEO_BASE_JITTER_TARGET_MS;
     this.receiverLatencyTargets.audio = GfnWebRtcClient.AUDIO_BASE_JITTER_TARGET_MS;
     this.activeReceivers = [];
     this.diagnostics.decoderPressureActive = false;


### PR DESCRIPTION
This PR addresses frame skipping during streaming on macOS (OPEN-16) by adjusting jitter buffer targets for VideoToolbox's higher latency and adding platform-specific Electron settings.

**Changes in `opennow-stable/src/renderer/src/gfn/webrtcClient.ts`**
- Add `isMacOS()` detection helper using `navigator.userAgent`/`navigator.platform`
- Add macOS-specific jitter constants: `VIDEO_BASE_JITTER_TARGET_MAC_MS = 20` and `VIDEO_PRESSURE_JITTER_TARGET_MAC_MS = 38` (vs 12ms/30ms on other platforms)
- Update `receiverLatencyTargets` initialization to use macOS-aware values
- Update `setDecoderPressureMode` and `resetDecoderRecoveryState` to select macOS-specific targets when `platformIsMac` is true

**Changes in `opennow-stable/src/main/index.ts`**
- Add `backgroundThrottling: false` to `webPreferences` to fully suppress renderer throttling beyond CLI switches
- Add fullscreen sync on macOS (`darwin` platform) by handling `enter-html-full-screen` and `leave-html-full-screen` events to prevent compositor hiccups during transitions

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/31c4d55e-0df3-4a4f-a556-29763e7f6f54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-22&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-22"><img alt="OPE-22 · 5.4 Mini" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-22"></picture></a>