### PR TITLE
fix(streaming): prevent H264 + 10-bit color black screen

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -81,7 +81,7 @@ const DEFAULT_SETTINGS: Settings = {
   fps: 60,
   maxBitrateMbps: 75,
   codec: "H264",
-  colorQuality: "10bit_420",
+  colorQuality: "8bit_420",
   region: "",
   clipboardPaste: false,
   mouseSensitivity: 1,
@@ -125,7 +125,9 @@ export class SettingsManager {
   private load(): Settings {
     try {
       if (!existsSync(this.settingsPath)) {
-        return { ...DEFAULT_SETTINGS };
+        const defaults = { ...DEFAULT_SETTINGS };
+        this.enforceCompatibility(defaults);
+        return defaults;
       }
 
       const content = readFileSync(this.settingsPath, "utf-8");
@@ -138,6 +140,7 @@ export class SettingsManager {
       };
 
       let migrated = this.migrateLegacyShortcutDefaults(merged);
+      migrated = this.enforceCompatibility(merged) || migrated;
 
       // Migrate legacy boolean accelerator setting to percentage slider.
       if (typeof (parsed as { mouseAcceleration?: unknown }).mouseAcceleration === "boolean") {
@@ -153,8 +156,22 @@ export class SettingsManager {
       return merged;
     } catch (error) {
       console.error("Failed to load settings, using defaults:", error);
-      return { ...DEFAULT_SETTINGS };
+      const defaults = { ...DEFAULT_SETTINGS };
+      this.enforceCompatibility(defaults);
+      return defaults;
     }
+  }
+
+  private enforceCompatibility(settings: Settings): boolean {
+    if (settings.codec === "H264" && settings.colorQuality !== "8bit_420") {
+      console.warn(
+        `[Settings] colorQuality "${settings.colorQuality}" is incompatible with H264; resetting to 8bit_420`,
+      );
+      settings.colorQuality = "8bit_420";
+      return true;
+    }
+
+    return false;
   }
 
   private migrateLegacyShortcutDefaults(settings: Settings): boolean {
@@ -231,6 +248,7 @@ export class SettingsManager {
    */
   reset(): Settings {
     this.settings = { ...DEFAULT_SETTINGS };
+    this.enforceCompatibility(this.settings);
     this.save();
     return { ...this.settings };
   }
@@ -239,7 +257,9 @@ export class SettingsManager {
    * Get the default settings
    */
   getDefaults(): Settings {
-    return { ...DEFAULT_SETTINGS };
+    const defaults = { ...DEFAULT_SETTINGS };
+    this.enforceCompatibility(defaults);
+    return defaults;
   }
 }
 

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -399,7 +399,7 @@ export function App(): JSX.Element {
     fps: 60,
     maxBitrateMbps: 75,
     codec: "H264",
-    colorQuality: "10bit_420",
+    colorQuality: "8bit_420",
     region: "",
     clipboardPaste: false,
     mouseSensitivity: 1,

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -745,6 +745,16 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     [handleChange, settings.codec]
   );
 
+  const handleCodecChange = useCallback(
+    (codec: VideoCodec) => {
+      handleChange("codec", codec);
+      if (codec === "H264" && settings.colorQuality !== "8bit_420") {
+        handleChange("colorQuality", "8bit_420");
+      }
+    },
+    [handleChange, settings.colorQuality]
+  );
+
   // Microphone devices
   const [microphoneDevices, setMicrophoneDevices] = useState<MediaDeviceInfo[]>([]);
   const [microphonePermissionError, setMicrophonePermissionError] = useState<string | null>(null);
@@ -1250,7 +1260,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                   <button
                     key={codec}
                     className={`settings-chip ${settings.codec === codec ? "active" : ""}`}
-                    onClick={() => handleChange("codec", codec)}
+                    onClick={() => handleCodecChange(codec)}
                   >
                     {codec}
                   </button>

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -459,7 +459,7 @@ export function buildNvstSdp(params: NvstParams): string {
   const is120Fps = params.fps === 120;
   const is240Fps = params.fps >= 240;
   const isAv1 = params.codec === "AV1";
-  const bitDepth = params.colorQuality.startsWith("10bit") ? 10 : 8;
+  const bitDepth = params.colorQuality.startsWith("10bit") && params.codec !== "H264" ? 10 : 8;
 
   const lines: string[] = [
     "v=0",


### PR DESCRIPTION
## Description

This PR fixes a black-screen issue where the default settings combined `codec: "H264"` with `colorQuality: "10bit_420"`. Since standard WebRTC H264 does not support 10-bit color, this caused the GFN server to send an incompatible stream that Chromium/Electron could not render.

- Change default `colorQuality` from `"10bit_420"` to `"8bit_420"` in `opennow-stable/src/main/settings.ts` (`DEFAULT_SETTINGS`) and `opennow-stable/src/renderer/src/App.tsx` (initial state)
- Add compatibility logic in `SettingsManager.load` to heal existing `H264 + 10bit_*` settings by resetting them to `8bit_420`, logging a warning
- Apply the same guard in `reset()` and `getDefaults()` to prevent the bad combo from returning
- Add `handleCodecChange` in `opennow-stable/src/renderer/src/components/SettingsPage.tsx` to automatically downgrade `colorQuality` to `"8bit_420"` when the user switches to `H264`
- Add a runtime safeguard in `buildNvstSdp` in `opennow-stable/src/renderer/src/gfn/sdp.ts` to clamp `bitDepth` to 8 when `codec === "H264"`, preventing `a=video.bitDepth:10` from being emitted

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/e9caa457-c91a-4edc-bcb8-489342ab1c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-23&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-23"><img alt="OPE-23 · 5.4 Mini" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-23"></picture></a>