### PR TITLE
WinGet manifests and automated winget-pkgs publishing (OPEN-9)

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,24 @@
+name: winget-publish
+
+# Publishes each GitHub release to the Windows Package Manager community repo via PR.
+# Prerequisites:
+# - One-time: merge an initial manifest for OpenCloudGaming.OpenNOW into microsoft/winget-pkgs
+#   (copy from winget/manifests/ in this repo).
+# - Add repo secret WINGET_TOKEN: classic PAT with public_repo; fork microsoft/winget-pkgs under the org/account.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Publish to WinGet
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: OpenCloudGaming.OpenNOW
+          installers-regex: 'setup-x64\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/winget/manifests/o/OpenCloudGaming/OpenNOW/0.3.1/OpenCloudGaming.OpenNOW.installer.yaml
+++ b/winget/manifests/o/OpenCloudGaming/OpenNOW/0.3.1/OpenCloudGaming.OpenNOW.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: OpenCloudGaming.OpenNOW
+PackageVersion: 0.3.1
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: 2026-03-30
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/OpenCloudGaming/OpenNOW/releases/download/v0.3.1/OpenNOW-v0.3.1-setup-x64.exe
+    InstallerSha256: DE76A5832AC94BF40182BC936F40C173CEA844490884C2EE56BCB03BE95DD27F
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/winget/manifests/o/OpenCloudGaming/OpenNOW/0.3.1/OpenCloudGaming.OpenNOW.locale.en-US.yaml
+++ b/winget/manifests/o/OpenCloudGaming/OpenNOW/0.3.1/OpenCloudGaming.OpenNOW.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: OpenCloudGaming.OpenNOW
+PackageVersion: 0.3.1
+PackageLocale: en-US
+Publisher: OpenCloud Gaming
+PublisherUrl: https://github.com/OpenCloudGaming
+Author: zortos293
+PackageName: OpenNOW
+PackageUrl: https://github.com/OpenCloudGaming/OpenNOW
+License: MIT
+LicenseUrl: https://github.com/OpenCloudGaming/OpenNOW/blob/main/LICENSE
+Copyright: Copyright (c) Zortos
+ShortDescription: Open-source desktop client for NVIDIA GeForce NOW
+Description: |-
+  OpenNOW is an independent, community-built desktop client for NVIDIA GeForce NOW.
+  It is built with Electron and TypeScript and is not affiliated with NVIDIA Corporation.
+Moniker: opennow
+Tags:
+  - cloud-gaming
+  - electron
+  - games
+  - geforce-now
+  - nvidia
+  - open-source
+  - streaming
+ReleaseNotesUrl: https://github.com/OpenCloudGaming/OpenNOW/releases/tag/v0.3.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/winget/manifests/o/OpenCloudGaming/OpenNOW/0.3.1/OpenCloudGaming.OpenNOW.yaml
+++ b/winget/manifests/o/OpenCloudGaming/OpenNOW/0.3.1/OpenCloudGaming.OpenNOW.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: OpenCloudGaming.OpenNOW
+PackageVersion: 0.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds **WinGet support** for OpenNOW ([OPEN-9](https://linear.app/OPEN-9)):

1. **Reference manifests** under `/winget/manifests/o/OpenCloudGaming/OpenNOW/0.3.1/` for the current x64 NSIS installer (`OpenNOW-v*-setup-x64.exe`), schema 1.9.0. These can be copied into a PR against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) for the **initial** community submission (required before automation can update the package).

2. **`.github/workflows/winget-publish.yml`** — on `release` `published`, runs [WinGet Releaser](https://github.com/vedantmgoyal9/winget-releaser) to open PRs for new versions. Configure repository secret **`WINGET_TOKEN`** (classic PAT with `public_repo`) and ensure **`microsoft/winget-pkgs` is forked** under the same org/account as the repo.

After the first manifest is merged in winget-pkgs, users can install and upgrade with `winget install OpenCloudGaming.OpenNOW` and `winget upgrade OpenCloudGaming.OpenNOW`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [OPEN-9](https://linear.app/zortos/issue/OPEN-9/winget-support)

<div><a href="https://cursor.com/agents/bc-d8a308b3-6e93-4c9c-b0bd-5e30c49f1c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8a308b3-6e93-4c9c-b0bd-5e30c49f1c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

