### PR TITLE
fix: queue loading Cancel button and launch abort (OPEN-10)

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -648,6 +648,7 @@ export function App(): JSX.Element {
   const hasInitializedRef = useRef(false);
   const regionsRequestRef = useRef(0);
   const launchInFlightRef = useRef(false);
+  const launchAbortRef = useRef(false);
   const streamStatusRef = useRef<StreamStatus>(streamStatus);
   const exitPromptResolverRef = useRef<((confirmed: boolean) => void) | null>(null);
 
@@ -1552,6 +1553,7 @@ export function App(): JSX.Element {
     }
 
     launchInFlightRef.current = true;
+    launchAbortRef.current = false;
     let loadingStep: StreamLoadingStatus = "queue";
     const updateLoadingStep = (next: StreamLoadingStatus): void => {
       loadingStep = next;
@@ -1674,6 +1676,10 @@ export function App(): JSX.Element {
         attempt++;
         await sleep(SESSION_READY_POLL_INTERVAL_MS);
 
+        if (launchAbortRef.current) {
+          return;
+        }
+
         const polled = await window.openNow.pollSession({
           token: token || undefined,
           streamingBaseUrl: newSession.streamingBaseUrl ?? effectiveStreamingBaseUrl,
@@ -1683,6 +1689,10 @@ export function App(): JSX.Element {
           clientId: newSession.clientId,
           deviceId: newSession.deviceId,
         });
+
+        if (launchAbortRef.current) {
+          return;
+        }
 
         setSession(polled);
         setQueuePosition(polled.queuePosition);
@@ -1821,6 +1831,10 @@ export function App(): JSX.Element {
   const handleStopStream = useCallback(async () => {
     try {
       resolveExitPrompt(false);
+      const status = streamStatusRef.current;
+      if (status !== "idle" && status !== "streaming") {
+        launchAbortRef.current = true;
+      }
       await window.openNow.disconnectSignaling();
 
       const current = sessionRef.current;
@@ -1921,6 +1935,13 @@ export function App(): JSX.Element {
     }
 
     await releasePointerLockIfNeeded();
+
+    const loadingPhases: StreamStatus[] = ["queue", "setup", "starting", "connecting"];
+    if (loadingPhases.includes(streamStatus)) {
+      launchAbortRef.current = true;
+      await handleStopStream();
+      return;
+    }
 
     const gameName = (streamingGame?.title || "this game").trim();
     const shouldExit = await requestExitPrompt(gameName);

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1748,6 +1748,9 @@ export function App(): JSX.Element {
         signalingUrl: sessionToConnect.signalingUrl,
       });
     } catch (error) {
+      if (launchAbortRef.current) {
+        return;
+      }
       console.error("Launch failed:", error);
       setLaunchError(toLaunchErrorState(error, loadingStep));
       await window.openNow.disconnectSignaling().catch(() => {});

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -4068,7 +4068,8 @@ button.game-card-store-chip.active:hover {
 .sload {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  /* Above StreamView (.sv, z-index 1000) so queue/setup Cancel receives clicks */
+  z-index: 1100;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes the queue/setup **Cancel** flow in `handlePlayGame` to avoid showing a false launch failure after an intentional cancel.

**Cause:** if cancel stops the server-side session while `pollSession` is in-flight, `pollSession` can throw. That exception reached the outer `catch` path, which unconditionally set launch error state and displayed "Launch Failed".

**Changes:**
- Keep existing abort checks around polling loop returns.
- Add an abort-aware early return at the top of `handlePlayGame`'s `catch` block (`if (launchAbortRef.current) return;`).
- Preserve existing error handling for genuine launch failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [OPEN-10](https://linear.app/zortos/issue/OPEN-10/game-launch-failed-on-free-tier)

<div><a href="https://cursor.com/agents/bc-8d64ae26-f556-410e-9fd2-5dd63c297333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d64ae26-f556-410e-9fd2-5dd63c297333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

