### PR TITLE
Fix/sidebar pointerlock

### DIFF
--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -886,7 +886,16 @@ export function StreamView({
 
   useEffect(() => {
     if (showSideBar) {
-      document.exitPointerLock();
+      // Mark sidebar open so input auto-lock code can avoid re-requesting.
+      try {
+        document.body.dataset.sidebarOpen = "1";
+      } catch {}
+
+      if (onReleasePointerLock) {
+        void onReleasePointerLock();
+      } else {
+        document.exitPointerLock();
+      }
       void refreshScreenshots();
       void refreshRecordings();
       return;
@@ -899,6 +908,9 @@ export function StreamView({
         localVideoRef.current.focus();
       }
     }, 50);
+    try {
+      delete (document.body.dataset as DOMStringMap).sidebarOpen;
+    } catch {}
     return () => clearTimeout(timer);
   }, [refreshRecordings, refreshScreenshots, showSideBar]);
 

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -2418,6 +2418,12 @@ export class GfnWebRtcClient {
     this.mouseFlushTimer = window.setInterval(flushMouse, this.mouseFlushIntervalMs);
 
     const tryAutoLock = (): void => {
+      try {
+        if (document?.body?.dataset?.sidebarOpen === "1") {
+          return;
+        }
+      } catch {}
+
       if (autoLockPending || isPointerLockActive() || !mouseInStreamView || !this.inputReady) {
         return;
       }
@@ -2540,6 +2546,9 @@ export class GfnWebRtcClient {
     };
 
     const onPointerMove = (event: PointerEvent) => {
+      try {
+        if (document?.body?.dataset?.sidebarOpen === "1") return;
+      } catch {}
       if (this.inputPaused) return;
       if (event.pointerType && event.pointerType !== "mouse") {
         return;
@@ -2570,6 +2579,9 @@ export class GfnWebRtcClient {
     };
 
     const onMouseMove = (event: MouseEvent) => {
+      try {
+        if (document?.body?.dataset?.sidebarOpen === "1") return;
+      } catch {}
       if (this.inputPaused) return;
       if (isPointerLockActive()) {
         queueMouseMovement(event.movementX, event.movementY, event.timeStamp);


### PR DESCRIPTION
## Summary
The client auto-attempts pointer lock on mouse movement. If pointer lock fails or is immediately released, the app repeatedly requests pointerLock (noise in main logs) and can send accidental pointer movement to the remote stream while the settings sidebar is open. This change prevents auto-lock attempts and input forwarding while the sidebar is open.

## Files changed
- [opennow-stable/src/renderer/src/components/StreamView.tsx](opennow-stable/src/renderer/src/components/StreamView.tsx)
  - Set a transient UI flag when sidebar opens (`document.body.dataset.sidebarOpen = "1"`) and clear it when it closes.
  - Call `onReleasePointerLock()` (fallback to `document.exitPointerLock()`) when opening the sidebar.
- [opennow-stable/src/renderer/src/gfn/webrtcClient.ts](opennow-stable/src/renderer/src/gfn/webrtcClient.ts)
  - `tryAutoLock()` returns early if the sidebar flag is set to avoid auto pointer-lock attempts.
  - `onPointerMove` and `onMouseMove` return early when the sidebar flag is set to prevent sending movement to the stream.

## Why
- Stops repeated pointerLock permission requests appearing in the main process logs while the user interacts with the sidebar.
- Prevents unintended remote cursor movement while adjusting settings.
- Minimal, low-risk approach using a transient DOM dataset flag to coordinate between the UI and input path without invasive refactors.