### PR TITLE
fix(controller): prevent duplicate loading states in controller mode

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -2198,7 +2198,7 @@ export function App(): JSX.Element {
             }}
           />
         )}
-        {isSwitchingGame && settings.controllerMode && (
+        {isSwitchingGame && settings.controllerMode && streamStatus !== "connecting" && (
           <ControllerStreamLoading
             gameTitle={pendingSwitchGameTitle ?? streamingGame?.title ?? "Game"}
             gamePoster={pendingSwitchGameCover ?? streamingGame?.imageUrl}
@@ -2284,7 +2284,7 @@ export function App(): JSX.Element {
             />
           </div>
         )}
-        {streamStatus !== "idle" && streamStatus !== "streaming" && settings.controllerMode && (
+        {streamStatus !== "idle" && streamStatus !== "streaming" && streamStatus !== "connecting" && settings.controllerMode && !isSwitchingGame && (
           <ControllerStreamLoading
             gameTitle={streamingGame?.title ?? "Game"}
             gamePoster={streamingGame?.imageUrl}
@@ -2296,7 +2296,7 @@ export function App(): JSX.Element {
             enableBackgroundAnimations={settings.controllerBackgroundAnimations}
           />
         )}
-        {streamStatus !== "idle" && streamStatus !== "streaming" && !settings.controllerMode && (
+        {streamStatus !== "idle" && streamStatus !== "streaming" && !settings.controllerMode && !isSwitchingGame && (
           <StreamLoading
             gameTitle={streamingGame?.title ?? "Game"}
             gameCover={streamingGame?.imageUrl}


### PR DESCRIPTION
This pull request refines the logic for displaying loading components during game streaming and switching, ensuring that loading screens appear only in appropriate scenarios. The changes help prevent overlapping or incorrect loading UI states, especially when switching games or when the stream is connecting.

**Improvements to loading screen logic:**

* The `ControllerStreamLoading` component is now only shown during game switching if the `streamStatus` is not `"connecting"`, preventing duplicate loading screens during stream connection.
* The `ControllerStreamLoading` component for non-idle/non-streaming states now also checks that `streamStatus` is not `"connecting"` and that a game switch is not in progress, further avoiding overlapping loading screens.
* The `StreamLoading` component for non-controller mode now ensures that it is not displayed while switching games, preventing conflicting loading indicators.