### PR TITLE
feat: add Nix Flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ package-lock.json
 # AI Agent guidelines (local only)
 AGENTS.md
 release-notes.md
+opennow-stable/result
+result

--- a/README.md
+++ b/README.md
@@ -81,6 +81,54 @@ Current packaging targets:
 | Linux x64 | `AppImage`, `deb` |
 | Linux ARM64 | `AppImage`, `deb` |
 
+## Nix
+
+You'll need to add this repo into your flake.nix:
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    
+    opennow.url = "github:OpenCloudGaming/OpenNOW"; 
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    opennow,
+    ... }@inputs: {
+  };
+}
+```
+Then add the package to your configuration:
+
+```nix
+# Home-manager
+{
+  pkgs,
+  inputs,
+  ...
+}: {
+  home.packages = with pkgs; [
+    inputs.opennow.packages.${pkgs.system}.default
+  ];
+}
+```
+
+```nix
+# Nixos configuraion
+{
+  pkgs,
+  inputs,
+  ...
+}: {
+  environment.systemPackages = with pkgs; [
+    inputs.opennow.packages.${pkgs.system}.default
+  ];
+}
+```
+
+
 ### Develop Locally
 
 From the repository root:

--- a/README.md
+++ b/README.md
@@ -142,100 +142,11 @@ npm run dev
 
 Useful root scripts:
 
-<<<<<<< HEAD
 ```bash
 npm run dev
 npm run build
 npm run typecheck
 npm run dist
-=======
-## Download
-
-Grab the latest release for your platform:
-
-👉 **[Download from GitHub Releases](https://github.com/OpenCloudGaming/OpenNOW/releases)**
-
-| Platform | File |
-|----------|------|
-| Windows (installer) | `OpenNOW-v0.2.4-setup-x64.exe` |
-| Windows (portable) | `OpenNOW-v0.2.4-portable-x64.exe` |
-| macOS (x64) | `OpenNOW-v0.2.4-mac-x64.dmg` |
-| macOS (ARM) | `OpenNOW-v0.2.4-mac-arm64.dmg` |
-| Linux (x64) | `OpenNOW-v0.2.4-linux-x86_64.AppImage` |
-| Linux (ARM64) | `OpenNOW-v0.2.4-linux-arm64.AppImage` |
-
-## Nix
-
-You'll need to add this repo into your flake.nix:
-```nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    
-    opennow.url = "github:OpenCloudGaming/OpenNOW"; 
-  };
-
-  outputs = {
-    self,
-    nixpkgs,
-    opennow,
-    ... }@inputs: {
-  };
-}
-```
-Then add the package to your configuration:
-```nix
-# Home-manager
-{
-  pkgs,
-  inputs,
-  ...
-}: {
-  home.packages = with pkgs; [
-    inputs.opennow.packages.${pkgs.system}.default
-  ];
-}
-```
-
-```nix
-# Nixos configuraion
-{
-  pkgs,
-  inputs,
-  ...
-}: {
-  environment.systemPackages = with pkgs; [
-    inputs.opennow.packages.${pkgs.system}.default
-  ];
-}
-```
-
-
-## Architecture
-
-OpenNOW is an Electron app with three processes:
-
-| Layer | Technology | Role |
-|-------|-----------|------|
-| **Main** | Node.js + Electron | OAuth, CloudMatch API, WebSocket signaling, settings |
-| **Renderer** | React 19 + TypeScript | UI, WebRTC streaming, input encoding, stats |
-| **Preload** | Electron contextBridge | Secure IPC between main and renderer |
-
-```
-opennow-stable/src/
-├── main/           # Electron main process
-│   ├── gfn/        # Auth, CloudMatch, signaling, games, subscription
-│   ├── index.ts    # Entry point, IPC handlers, window management
-│   └── settings.ts # Persistent user settings
-├── renderer/src/   # React UI
-│   ├── components/ # Login, Home, Library, Settings, StreamView
-│   ├── gfn/        # WebRTC client, SDP, input protocol
-│   └── App.tsx     # Root component with routing and state
-├── shared/         # Shared types and IPC channel definitions
-│   ├── gfn.ts      # All TypeScript interfaces
-│   └── ipc.ts      # IPC channel constants
-└── preload/        # Context bridge (safe API exposure)
->>>>>>> bf6734b (Add Nix installation instructions in README and fix app links in flake)
 ```
 
 For a fuller setup guide, see [docs/development.md](docs/development.md).

--- a/README.md
+++ b/README.md
@@ -142,11 +142,100 @@ npm run dev
 
 Useful root scripts:
 
+<<<<<<< HEAD
 ```bash
 npm run dev
 npm run build
 npm run typecheck
 npm run dist
+=======
+## Download
+
+Grab the latest release for your platform:
+
+👉 **[Download from GitHub Releases](https://github.com/OpenCloudGaming/OpenNOW/releases)**
+
+| Platform | File |
+|----------|------|
+| Windows (installer) | `OpenNOW-v0.2.4-setup-x64.exe` |
+| Windows (portable) | `OpenNOW-v0.2.4-portable-x64.exe` |
+| macOS (x64) | `OpenNOW-v0.2.4-mac-x64.dmg` |
+| macOS (ARM) | `OpenNOW-v0.2.4-mac-arm64.dmg` |
+| Linux (x64) | `OpenNOW-v0.2.4-linux-x86_64.AppImage` |
+| Linux (ARM64) | `OpenNOW-v0.2.4-linux-arm64.AppImage` |
+
+## Nix
+
+You'll need to add this repo into your flake.nix:
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    
+    opennow.url = "github:OpenCloudGaming/OpenNOW"; 
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    opennow,
+    ... }@inputs: {
+  };
+}
+```
+Then add the package to your configuration:
+```nix
+# Home-manager
+{
+  pkgs,
+  inputs,
+  ...
+}: {
+  home.packages = with pkgs; [
+    inputs.opennow.packages.${pkgs.system}.default
+  ];
+}
+```
+
+```nix
+# Nixos configuraion
+{
+  pkgs,
+  inputs,
+  ...
+}: {
+  environment.systemPackages = with pkgs; [
+    inputs.opennow.packages.${pkgs.system}.default
+  ];
+}
+```
+
+
+## Architecture
+
+OpenNOW is an Electron app with three processes:
+
+| Layer | Technology | Role |
+|-------|-----------|------|
+| **Main** | Node.js + Electron | OAuth, CloudMatch API, WebSocket signaling, settings |
+| **Renderer** | React 19 + TypeScript | UI, WebRTC streaming, input encoding, stats |
+| **Preload** | Electron contextBridge | Secure IPC between main and renderer |
+
+```
+opennow-stable/src/
+├── main/           # Electron main process
+│   ├── gfn/        # Auth, CloudMatch, signaling, games, subscription
+│   ├── index.ts    # Entry point, IPC handlers, window management
+│   └── settings.ts # Persistent user settings
+├── renderer/src/   # React UI
+│   ├── components/ # Login, Home, Library, Settings, StreamView
+│   ├── gfn/        # WebRTC client, SDP, input protocol
+│   └── App.tsx     # Root component with routing and state
+├── shared/         # Shared types and IPC channel definitions
+│   ├── gfn.ts      # All TypeScript interfaces
+│   └── ipc.ts      # IPC channel constants
+└── preload/        # Context bridge (safe API exposure)
+>>>>>>> bf6734b (Add Nix installation instructions in README and fix app links in flake)
 ```
 
 For a fuller setup guide, see [docs/development.md](docs/development.md).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,103 @@
+{
+  description = "Custom GeForce Now Client Named OpenNOW";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        electron = pkgs.electron;
+
+        nativeDeps = [
+          pkgs.pkg-config
+          pkgs.python3
+          pkgs.gcc
+          pkgs.makeWrapper
+        ];
+
+        runtimeDeps = [
+          pkgs.openssl
+          pkgs.zlib
+        ]
+        ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (
+          with pkgs.darwin.apple_sdk.frameworks;
+          [
+            CoreGraphics
+            CoreVideo
+            AppKit
+            IOKit
+          ]
+        );
+
+      in
+      {
+        packages.default = pkgs.buildNpmPackage {
+          pname = "opennow";
+          version = "1.0.0";
+
+          src = ./opennow-stable;
+
+          npmDepsHash = "sha256-l2ZC4lUztIv2kq5QHKV1KSiwXqSvFH1x3CuT9RGa28o=";
+
+          ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+          nativeBuildInputs = nativeDeps;
+          buildInputs = runtimeDeps;
+
+          npmBuild = "npm run build";
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/lib/opennow
+            cp -r . $out/lib/opennow
+
+            mkdir -p $out/bin
+
+            for path in "out/main/index.js" "dist/main/index.js" "dist-electron/main.js"; do
+              if [ -f "$out/lib/opennow/$path" ]; then
+                MAIN_SCRIPT="$out/lib/opennow/$path"
+                break
+              fi
+            done
+
+            : ''${MAIN_SCRIPT:="$out/lib/opennow"}
+
+            makeWrapper ${electron}/bin/electron $out/bin/opennow \
+              --add-flags "$MAIN_SCRIPT" \
+              --set NODE_ENV production \
+              --inherit-argv0 \
+              --add-flags "--enable-features=WaylandWindowDecorations --platform-hint=auto"
+
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            description = "OpenCloudGaming OpenNOW Client";
+            homepage = "https://github.com/OpenCloudGaming/OpenNOW";
+            license = licenses.mit;
+            platforms = platforms.linux ++ platforms.darwin;
+            mainProgram = "opennow";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.default ];
+
+          shellHook = ''
+            export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
           pkgs.python3
           pkgs.gcc
           pkgs.makeWrapper
+          pkgs.copyDesktopItems
         ];
 
         runtimeDeps = [
@@ -54,6 +55,21 @@
           nativeBuildInputs = nativeDeps;
           buildInputs = runtimeDeps;
 
+          desktopItems = [
+            (pkgs.makeDesktopItem {
+              name = "opennow";
+              exec = "opennow %U";
+              icon = "opennow";
+              desktopName = "OpenNOW";
+              genericName = "Cloud Gaming Client";
+              categories = [
+                "Game"
+                "Network"
+              ];
+              terminal = false;
+            })
+          ];
+
           npmBuild = "npm run build";
 
           installPhase = ''
@@ -79,6 +95,11 @@
               --inherit-argv0 \
               --add-flags "--enable-features=WaylandWindowDecorations --platform-hint=auto"
 
+            mkdir -p $out/share/icons/hicolor/512x512/apps
+            if [ -f "src/renderer/src/assets/opennow-logo.png" ]; then
+              cp src/renderer/src/assets/opennow-logo.png $out/share/icons/hicolor/512x512/apps/opennow.png
+            fi
+
             runHook postInstall
           '';
 
@@ -93,7 +114,6 @@
 
         devShells.default = pkgs.mkShell {
           inputsFrom = [ self.packages.${system}.default ];
-
           shellHook = ''
             export ELECTRON_SKIP_BINARY_DOWNLOAD=1
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
 
           src = ./opennow-stable;
 
-          npmDepsHash = "sha256-l2ZC4lUztIv2kq5QHKV1KSiwXqSvFH1x3CuT9RGa28o=";
+          npmDepsHash = "sha256-rd6DcBubFSl2MFWdkVlj+2WGI7vxhr361sMzyjcrst0=";
 
           ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 

--- a/opennow-stable/README.md
+++ b/opennow-stable/README.md
@@ -36,3 +36,4 @@ npm run dist
 - `ws` is used in the main process for custom signaling behavior
 - Authentication uses an OAuth PKCE flow with a localhost callback
 - Settings are persisted locally through `electron-store`
+- React Scan is available in renderer development builds for performance debugging

--- a/opennow-stable/package-lock.json
+++ b/opennow-stable/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opennow-stable",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opennow-stable",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
@@ -23,6 +23,7 @@
         "electron": "^41.1.1",
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
+        "react-scan": "^0.5.3",
         "typescript": "^6.0.2",
         "vite": "^7.3.1"
       }
@@ -58,6 +59,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1542,10 +1544,68 @@
         "node": ">=14"
       }
     },
+    "node_modules/@preact/signals": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
+      "integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": "10.x"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
       "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2062,6 +2122,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2163,6 +2224,20 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2179,6 +2254,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2354,7 +2430,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2370,7 +2445,6 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2534,6 +2608,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bippy": {
+      "version": "0.5.39",
+      "resolved": "https://registry.npmjs.org/bippy/-/bippy-0.5.39.tgz",
+      "integrity": "sha512-8hE8rKSl8JWyeaY+JjpnmceWAZPpLEyzOZQpWXM5Rc7861c5WotMJHy2aRZKZrGA8nMpvLNF01t4yQQ+HcZG3w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0.1"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -2588,6 +2672,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3331,6 +3416,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -3881,6 +3967,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -4760,6 +4856,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
@@ -4772,8 +4878,7 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -5505,7 +5610,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5585,6 +5689,18 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -5617,6 +5733,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/proper-lockfile": {
@@ -5670,6 +5800,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5679,6 +5810,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5694,6 +5826,58 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-scan": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/react-scan/-/react-scan-0.5.3.tgz",
+      "integrity": "sha512-qde9PupmUf0L3MU1H6bjmoukZNbCXdMyTEwP4Gh8RQ4rZPd2GGNBgEKWszwLm96E8k+sGtMpc0B9P0KyFDP6Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.26.0",
+        "@babel/generator": "^7.26.2",
+        "@babel/types": "^7.26.0",
+        "@preact/signals": "^1.3.1",
+        "@rollup/pluginutils": "^5.1.3",
+        "@types/node": "^20.17.9",
+        "bippy": "^0.5.30",
+        "commander": "^14.0.0",
+        "esbuild": "^0.25.0",
+        "estree-walker": "^3.0.3",
+        "picocolors": "^1.1.1",
+        "preact": "^10.25.1",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "react-scan": "bin/cli.js"
+      },
+      "optionalDependencies": {
+        "unplugin": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-scan/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/react-scan/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/read-binary-file-arch": {
@@ -5835,6 +6019,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6018,6 +6203,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
@@ -6460,6 +6652,21 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unplugin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.1.0.tgz",
+      "integrity": "sha512-us4j03/499KhbGP8BU7Hrzrgseo+KdfJYWcbcajCOqsAyb8Gk0Yn2kiUIcZISYCb1JFaZfIuG3b42HmguVOKCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -6537,6 +6744,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7099,6 +7307,14 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -38,6 +38,7 @@
     "electron": "^41.1.1",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
+    "react-scan": "^0.5.3",
     "typescript": "^6.0.2",
     "vite": "^7.3.1"
   },

--- a/opennow-stable/result
+++ b/opennow-stable/result
@@ -1,0 +1,1 @@
+/nix/store/zrl1irgx2hby58a3szyw58grhl0sfiqq-opennow-1.0.0

--- a/opennow-stable/src/renderer/src/main.tsx
+++ b/opennow-stable/src/renderer/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { scan } from "react-scan";
 
 import { initLogCapture } from "@shared/logger";
 import { App } from "./App";
@@ -7,6 +8,10 @@ import "./styles.css";
 
 // Initialize log capture for renderer process
 initLogCapture("renderer");
+
+if (import.meta.env.DEV) {
+  scan();
+}
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/x1i0nw0qyd7k427ing7l0i3fbbd86rpx-opennow-1.0.0


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
I've created a working flake.nix file for Nix users USING THE GEMINI AI, and it works on my machine and should work just as well for anyone else running NixOS x86-64, so you can just take this flake and push it to nixpkgs, So, I think I’ve added support for Darwin, which means there should be support for macOS, but I can’t verify it because I don’t use macOS. If anyone can, please test it as well with aarch64 Linux.