### PR TITLE
Enhance game hub with media captures and session metadata

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -1352,6 +1352,45 @@ function registerIpcHandlers(): void {
     }
   });
 
+  ipcMain.handle(IPC_CHANNELS.MEDIA_DATA_URL, async (_event, payload: { filePath: string }): Promise<string | null> => {
+    const rawFp = payload?.filePath;
+    if (typeof rawFp !== "string") return null;
+    if (rawFp.length > 4096) return null;
+    try {
+      const allowedRoot = resolve(join(app.getPath("pictures"), "OpenNOW"));
+      const fpResolved = resolve(rawFp);
+      const allowedRootReal = await realpath(allowedRoot).catch(() => allowedRoot);
+      const fpReal = await realpath(fpResolved).catch(() => fpResolved);
+      const rel = relative(allowedRootReal, fpReal);
+      if (rel.startsWith("..")) return null;
+
+      const lower = fpReal.toLowerCase();
+      const buf = await readFile(fpReal);
+      if (lower.endsWith(".png") || lower.endsWith(".jpg") || lower.endsWith(".jpeg") || lower.endsWith(".webp")) {
+        const extMatch = /\.([^.]+)$/.exec(fpReal);
+        const ext = (extMatch?.[1] || "png").toLowerCase();
+        const mime = ext === "jpg" || ext === "jpeg" ? "image/jpeg" : ext === "webp" ? "image/webp" : "image/png";
+        return `data:${mime};base64,${buf.toString("base64")}`;
+      }
+
+      if (lower.endsWith(".mp4") || lower.endsWith(".webm") || lower.endsWith(".mkv") || lower.endsWith(".mov")) {
+        const mime = lower.endsWith(".mp4")
+          ? "video/mp4"
+          : lower.endsWith(".webm")
+            ? "video/webm"
+            : lower.endsWith(".mov")
+              ? "video/quicktime"
+              : "video/x-matroska";
+        return `data:${mime};base64,${buf.toString("base64")}`;
+      }
+
+      return null;
+    } catch (err) {
+      console.warn("MEDIA_DATA_URL error:", err);
+      return null;
+    }
+  });
+
   ipcMain.handle(IPC_CHANNELS.MEDIA_SHOW_IN_FOLDER, async (_event, payload: { filePath: string }): Promise<void> => {
     const rawFp = payload?.filePath;
     if (typeof rawFp !== "string") return;

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -56,6 +56,11 @@ import type {
   RecordingFinishRequest,
   RecordingAbortRequest,
   RecordingDeleteRequest,
+  MediaListingResult,
+  MediaExportRequest,
+  MediaExportResult,
+  MediaSessionSnapshot,
+  MediaSessionSummary,
 } from "@shared/gfn";
 
 import { getSettingsManager, type SettingsManager } from "./settings";
@@ -227,6 +232,116 @@ function buildScreenshotDataUrl(ext: string, buffer: Buffer): string {
   return `data:${mime};base64,${buffer.toString("base64")}`;
 }
 
+interface StoredMediaMetadata {
+  version: 1;
+  gameTitle?: string;
+  sessionSnapshot?: MediaSessionSnapshot;
+}
+
+function getMediaMetadataPath(filePath: string): string {
+  return `${filePath}.json`;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeSessionSnapshot(value: unknown): MediaSessionSnapshot | undefined {
+  if (!value || typeof value !== "object") return undefined;
+
+  const source = value as Record<string, unknown>;
+  const snapshot: MediaSessionSnapshot = {};
+
+  const resolution = normalizeOptionalString(source.resolution);
+  if (resolution) snapshot.resolution = resolution;
+
+  const codec = normalizeOptionalString(source.codec);
+  if (codec) snapshot.codec = codec;
+
+  const bitrateKbps = normalizeOptionalNumber(source.bitrateKbps);
+  if (bitrateKbps !== undefined) snapshot.bitrateKbps = bitrateKbps;
+
+  const decodeFps = normalizeOptionalNumber(source.decodeFps);
+  if (decodeFps !== undefined) snapshot.decodeFps = decodeFps;
+
+  const renderFps = normalizeOptionalNumber(source.renderFps);
+  if (renderFps !== undefined) snapshot.renderFps = renderFps;
+
+  const rttMs = normalizeOptionalNumber(source.rttMs);
+  if (rttMs !== undefined) snapshot.rttMs = rttMs;
+
+  const packetLossPercent = normalizeOptionalNumber(source.packetLossPercent);
+  if (packetLossPercent !== undefined) snapshot.packetLossPercent = packetLossPercent;
+
+  const connectedControllers = normalizeOptionalNumber(source.connectedControllers);
+  if (connectedControllers !== undefined) snapshot.connectedControllers = connectedControllers;
+
+  const sessionElapsedSeconds = normalizeOptionalNumber(source.sessionElapsedSeconds);
+  if (sessionElapsedSeconds !== undefined) snapshot.sessionElapsedSeconds = sessionElapsedSeconds;
+
+  const serverRegion = normalizeOptionalString(source.serverRegion);
+  if (serverRegion) snapshot.serverRegion = serverRegion;
+
+  return Object.keys(snapshot).length > 0 ? snapshot : undefined;
+}
+
+function buildStoredMediaMetadata(
+  gameTitle?: string,
+  sessionSnapshot?: MediaSessionSnapshot,
+): StoredMediaMetadata | null {
+  const metadata: StoredMediaMetadata = { version: 1 };
+  const normalizedTitle = normalizeOptionalString(gameTitle);
+  const normalizedSnapshot = normalizeSessionSnapshot(sessionSnapshot);
+
+  if (normalizedTitle) metadata.gameTitle = normalizedTitle;
+  if (normalizedSnapshot) metadata.sessionSnapshot = normalizedSnapshot;
+
+  return metadata.gameTitle || metadata.sessionSnapshot ? metadata : null;
+}
+
+async function readMediaMetadata(filePath: string): Promise<StoredMediaMetadata | null> {
+  try {
+    const raw = await readFile(getMediaMetadataPath(filePath), "utf8");
+    const parsed = JSON.parse(raw) as { gameTitle?: unknown; sessionSnapshot?: unknown } | null;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+
+    return buildStoredMediaMetadata(
+      normalizeOptionalString(parsed.gameTitle),
+      normalizeSessionSnapshot(parsed.sessionSnapshot),
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function writeMediaMetadata(
+  filePath: string,
+  gameTitle?: string,
+  sessionSnapshot?: MediaSessionSnapshot,
+): Promise<void> {
+  const metadata = buildStoredMediaMetadata(gameTitle, sessionSnapshot);
+  const metadataPath = getMediaMetadataPath(filePath);
+
+  if (!metadata) {
+    await unlink(metadataPath).catch(() => undefined);
+    return;
+  }
+
+  await writeFile(metadataPath, JSON.stringify(metadata, null, 2), "utf8");
+}
+
+async function deleteMediaMetadata(filePath: string): Promise<void> {
+  await unlink(getMediaMetadataPath(filePath)).catch(() => undefined);
+}
+
 function assertSafeScreenshotId(id: string): void {
   if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
     throw new Error("Invalid screenshot id");
@@ -247,6 +362,7 @@ async function listScreenshots(): Promise<ScreenshotEntry[]> {
       try {
         const fileStats = await stat(filePath);
         const fileBuffer = await readFile(filePath);
+        const metadata = await readMediaMetadata(filePath);
         const extMatch = /\.([^.]+)$/.exec(fileName);
         const ext = (extMatch?.[1] ?? "png").toLowerCase();
 
@@ -257,6 +373,8 @@ async function listScreenshots(): Promise<ScreenshotEntry[]> {
           createdAtMs: fileStats.birthtimeMs || fileStats.mtimeMs,
           sizeBytes: fileStats.size,
           dataUrl: buildScreenshotDataUrl(ext, fileBuffer),
+          gameTitle: metadata?.gameTitle,
+          sessionSnapshot: metadata?.sessionSnapshot,
         };
       } catch {
         return null;
@@ -279,6 +397,7 @@ async function saveScreenshot(input: ScreenshotSaveRequest): Promise<ScreenshotE
   const filePath = join(dir, fileName);
 
   await writeFile(filePath, buffer);
+  await writeMediaMetadata(filePath, input.gameTitle, input.sessionSnapshot);
 
   return {
     id: fileName,
@@ -287,6 +406,8 @@ async function saveScreenshot(input: ScreenshotSaveRequest): Promise<ScreenshotE
     createdAtMs: Date.now(),
     sizeBytes: buffer.byteLength,
     dataUrl: buildScreenshotDataUrl(ext, buffer),
+    gameTitle: input.gameTitle,
+    sessionSnapshot: normalizeSessionSnapshot(input.sessionSnapshot),
   };
 }
 
@@ -295,6 +416,7 @@ async function deleteScreenshot(input: ScreenshotDeleteRequest): Promise<void> {
   const dir = await ensureScreenshotDirectory();
   const filePath = join(dir, input.id);
   await unlink(filePath);
+  await deleteMediaMetadata(filePath);
 }
 
 async function saveScreenshotAs(input: ScreenshotSaveAsRequest): Promise<ScreenshotSaveAsResult> {
@@ -311,6 +433,37 @@ async function saveScreenshotAs(input: ScreenshotSaveAsRequest): Promise<Screens
       { name: "WebP Image", extensions: ["webp"] },
       { name: "All Files", extensions: ["*"] },
     ],
+  };
+  const target =
+    mainWindow && !mainWindow.isDestroyed()
+      ? await dialog.showSaveDialog(mainWindow, saveDialogOptions)
+      : await dialog.showSaveDialog(saveDialogOptions);
+
+  if (target.canceled || !target.filePath) {
+    return { saved: false };
+  }
+
+  await copyFile(sourcePath, target.filePath);
+  return { saved: true, filePath: target.filePath };
+}
+
+async function exportMedia(input: MediaExportRequest): Promise<MediaExportResult> {
+  const rawPath = input?.filePath;
+  if (typeof rawPath !== "string" || rawPath.length === 0 || rawPath.length > 4096) {
+    throw new Error("Invalid media file path");
+  }
+
+  const sourcePath = resolve(rawPath);
+  const sourceStats = await stat(sourcePath);
+  if (!sourceStats.isFile()) {
+    throw new Error("Media file not found");
+  }
+
+  const defaultName = normalizeOptionalString(input.fileName) ?? sourcePath.split(/[/\\]/).pop() ?? "OpenNOW-media";
+  const saveDialogOptions = {
+    title: "Export Media",
+    defaultPath: join(app.getPath("downloads"), defaultName),
+    filters: [{ name: "All Files", extensions: ["*"] }],
   };
   const target =
     mainWindow && !mainWindow.isDestroyed()
@@ -438,6 +591,7 @@ async function listRecordings(): Promise<RecordingEntry[]> {
       const filePath = join(dir, fileName);
       try {
         const fileStats = await stat(filePath);
+        const metadata = await readMediaMetadata(filePath);
         const stem = fileName.replace(/\.webm$/i, "");
         const thumbName = `${stem}-thumb.jpg`;
         const thumbPath = join(dir, thumbName);
@@ -465,8 +619,9 @@ async function listRecordings(): Promise<RecordingEntry[]> {
           createdAtMs: fileStats.birthtimeMs || fileStats.mtimeMs,
           sizeBytes: fileStats.size,
           durationMs,
-          gameTitle,
+          gameTitle: metadata?.gameTitle ?? gameTitle,
           thumbnailDataUrl,
+          sessionSnapshot: metadata?.sessionSnapshot,
         };
       } catch {
         return null;
@@ -478,6 +633,37 @@ async function listRecordings(): Promise<RecordingEntry[]> {
     .filter((item): item is RecordingEntry => item !== null)
     .sort((a, b) => b.createdAtMs - a.createdAtMs)
     .slice(0, RECORDING_LIMIT);
+}
+
+function buildMediaListingSummary(
+  screenshots: ScreenshotEntry[],
+  videos: RecordingEntry[],
+): MediaSessionSummary | undefined {
+  const combined = [...videos, ...screenshots].sort((left, right) => right.createdAtMs - left.createdAtMs);
+  if (combined.length === 0) {
+    return undefined;
+  }
+
+  const latest = combined[0];
+  const snapshot = latest.sessionSnapshot;
+  const summary: MediaSessionSummary = {
+    totalCaptures: combined.length,
+    screenshots: screenshots.length,
+    videos: videos.length,
+    lastCapturedAtMs: latest.createdAtMs,
+  };
+
+  if (snapshot?.resolution) summary.latestResolution = snapshot.resolution;
+  if (snapshot?.codec) summary.latestCodec = snapshot.codec;
+  if (snapshot?.bitrateKbps !== undefined) summary.latestBitrateKbps = snapshot.bitrateKbps;
+  if (snapshot?.decodeFps !== undefined) summary.latestDecodeFps = snapshot.decodeFps;
+  if (snapshot?.rttMs !== undefined) summary.latestRttMs = snapshot.rttMs;
+  if (snapshot?.packetLossPercent !== undefined) summary.latestPacketLossPercent = snapshot.packetLossPercent;
+  if (snapshot?.connectedControllers !== undefined) summary.latestConnectedControllers = snapshot.connectedControllers;
+  if (snapshot?.sessionElapsedSeconds !== undefined) summary.latestSessionElapsedSeconds = snapshot.sessionElapsedSeconds;
+  if (snapshot?.serverRegion) summary.latestServerRegion = snapshot.serverRegion;
+
+  return summary;
 }
 
 function emitToRenderer(event: MainToRendererSignalingEvent): void {
@@ -836,7 +1022,7 @@ function registerIpcHandlers(): void {
   });
 
   // Media: per-game listing (screenshots + recordings). Best-effort title matching.
-  ipcMain.handle(IPC_CHANNELS.MEDIA_LIST_BY_GAME, async (_event, payload: { gameTitle?: string } = {}) => {
+  ipcMain.handle(IPC_CHANNELS.MEDIA_LIST_BY_GAME, async (_event, payload: { gameTitle?: string } = {}): Promise<MediaListingResult> => {
     const title = (payload?.gameTitle || "").trim().toLowerCase();
     const screenshots = await listScreenshots();
     const recordings = await listRecordings();
@@ -846,19 +1032,20 @@ function registerIpcHandlers(): void {
 
     const matchedScreens = screenshots.filter((s) => {
       if (!needle) return true;
-      const candidate = normalize(s.fileName) + normalize(s.filePath || "");
+      const candidate = normalize(s.gameTitle ?? "") + normalize(s.fileName) + normalize(s.filePath || "");
       return candidate.includes(needle);
     });
 
     const matchedRecordings = recordings.filter((r) => {
       if (!needle) return true;
-      const candidate = normalize(r.gameTitle ?? r.fileName ?? "");
+      const candidate = normalize(r.gameTitle ?? "") + normalize(r.fileName ?? "") + normalize(r.filePath || "");
       return candidate.includes(needle);
     });
 
     return {
       screenshots: matchedScreens,
       videos: matchedRecordings,
+      summary: buildMediaListingSummary(matchedScreens, matchedRecordings),
     };
   });
 
@@ -935,6 +1122,8 @@ function registerIpcHandlers(): void {
       }
     }
 
+    await writeMediaMetadata(finalPath, input.gameTitle, input.sessionSnapshot);
+
     // Enforce recording limit: delete oldest entries beyond RECORDING_LIMIT
     const all = await listRecordings();
     if (all.length > RECORDING_LIMIT) {
@@ -944,6 +1133,7 @@ function registerIpcHandlers(): void {
           await unlink(entry.filePath).catch(() => undefined);
           const stem = entry.fileName.replace(/\.(mp4|webm)$/i, "");
           await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
+          await deleteMediaMetadata(entry.filePath);
         }),
       );
     }
@@ -958,6 +1148,7 @@ function registerIpcHandlers(): void {
       durationMs: input.durationMs,
       gameTitle: input.gameTitle,
       thumbnailDataUrl,
+      sessionSnapshot: normalizeSessionSnapshot(input.sessionSnapshot),
     };
   });
 
@@ -982,6 +1173,7 @@ function registerIpcHandlers(): void {
     await unlink(filePath);
     const stem = input.id.replace(/\.(mp4|webm)$/i, "");
     await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
+    await deleteMediaMetadata(filePath);
   });
 
   ipcMain.handle(IPC_CHANNELS.RECORDING_SHOW_IN_FOLDER, async (_event, id: string): Promise<void> => {
@@ -1056,6 +1248,10 @@ function registerIpcHandlers(): void {
     } catch {
       return;
     }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.MEDIA_EXPORT, async (_event, payload: MediaExportRequest): Promise<MediaExportResult> => {
+    return exportMedia(payload);
   });
 
   ipcMain.handle(IPC_CHANNELS.CACHE_REFRESH_MANUAL, async (): Promise<void> => {

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, session } from "electron";
 import { fileURLToPath } from "node:url";
-import { dirname, join, resolve, relative } from "node:path";
+import { dirname, isAbsolute, join, resolve, relative } from "node:path";
 import { existsSync, readFileSync, createWriteStream } from "node:fs";
 import { copyFile, mkdir, readdir, readFile, rename, stat, unlink, writeFile, realpath } from "node:fs/promises";
 import * as net from "node:net";
@@ -57,6 +57,9 @@ import type {
   RecordingAbortRequest,
   RecordingDeleteRequest,
   MediaListingResult,
+  MediaExportBrowserRequest,
+  MediaExportBrowserResult,
+  MediaExportBrowserLocation,
   MediaExportRequest,
   MediaExportResult,
   MediaSessionSnapshot,
@@ -246,6 +249,30 @@ function normalizeOptionalString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function sanitizeMediaExportFileName(value: string | undefined): string {
+  const raw = normalizeOptionalString(value) ?? "OpenNOW-media";
+  const sanitized = raw
+    .replace(/[<>:"/\\|?*\x00-\x1f]/g, "-")
+    .replace(/\s+/g, " ")
+    .replace(/[. ]+$/g, "")
+    .trim();
+
+  return sanitized.length > 0 ? sanitized.slice(0, 160) : "OpenNOW-media";
+}
+
+function getMediaStorageRoot(): string {
+  return resolve(join(app.getPath("pictures"), "OpenNOW"));
+}
+
+async function isPathWithinDirectory(candidatePath: string, directoryPath: string): Promise<boolean> {
+  const resolvedDirectory = resolve(directoryPath);
+  const resolvedCandidate = resolve(candidatePath);
+  const directoryReal = await realpath(resolvedDirectory).catch(() => resolvedDirectory);
+  const candidateReal = await realpath(resolvedCandidate).catch(() => resolvedCandidate);
+  const rel = relative(directoryReal, candidateReal);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
 function normalizeOptionalNumber(value: unknown): number | undefined {
@@ -459,7 +486,41 @@ async function exportMedia(input: MediaExportRequest): Promise<MediaExportResult
     throw new Error("Media file not found");
   }
 
-  const defaultName = normalizeOptionalString(input.fileName) ?? sourcePath.split(/[/\\]/).pop() ?? "OpenNOW-media";
+  if (!(await isPathWithinDirectory(sourcePath, getMediaStorageRoot()))) {
+    throw new Error("Media file not found");
+  }
+
+  const defaultName = sanitizeMediaExportFileName(
+    normalizeOptionalString(input.fileName) ?? sourcePath.split(/[/\\]/).pop() ?? "OpenNOW-media",
+  );
+
+  const explicitDestinationDirectory = normalizeOptionalString(input.destinationDirectoryPath);
+  if (explicitDestinationDirectory) {
+    const destinationDirectoryPath = resolve(explicitDestinationDirectory);
+    const destinationStats = await stat(destinationDirectoryPath);
+    if (!destinationStats.isDirectory()) {
+      throw new Error("Export directory not found");
+    }
+
+    const targetPath = join(destinationDirectoryPath, defaultName);
+    if (targetPath === sourcePath) {
+      return { saved: false, filePath: targetPath, alreadyExists: true };
+    }
+
+    const existingTarget = await stat(targetPath).catch(() => null);
+    if (existingTarget) {
+      if (!existingTarget.isFile()) {
+        throw new Error("Export target is not a file");
+      }
+      if (!input.overwrite) {
+        return { saved: false, filePath: targetPath, alreadyExists: true };
+      }
+    }
+
+    await copyFile(sourcePath, targetPath);
+    return { saved: true, filePath: targetPath };
+  }
+
   const saveDialogOptions = {
     title: "Export Media",
     defaultPath: join(app.getPath("downloads"), defaultName),
@@ -476,6 +537,63 @@ async function exportMedia(input: MediaExportRequest): Promise<MediaExportResult
 
   await copyFile(sourcePath, target.filePath);
   return { saved: true, filePath: target.filePath };
+}
+
+function getMediaExportQuickLocations(): MediaExportBrowserLocation[] {
+  const candidates: Array<{ id: string; label: string; path: string }> = [
+    { id: "downloads", label: "Downloads", path: app.getPath("downloads") },
+    { id: "desktop", label: "Desktop", path: app.getPath("desktop") },
+    { id: "documents", label: "Documents", path: app.getPath("documents") },
+    { id: "pictures", label: "Pictures", path: app.getPath("pictures") },
+    { id: "videos", label: "Videos", path: app.getPath("videos") },
+    { id: "home", label: "Home", path: app.getPath("home") },
+  ];
+
+  const seen = new Set<string>();
+  return candidates.reduce<MediaExportBrowserLocation[]>((acc, candidate) => {
+    const normalizedPath = normalizeOptionalString(candidate.path);
+    if (!normalizedPath) {
+      return acc;
+    }
+
+    const resolvedPath = resolve(normalizedPath);
+    if (seen.has(resolvedPath)) {
+      return acc;
+    }
+
+    seen.add(resolvedPath);
+    acc.push({ ...candidate, path: resolvedPath });
+    return acc;
+  }, []);
+}
+
+async function browseMediaExportLocations(
+  input: MediaExportBrowserRequest = {},
+): Promise<MediaExportBrowserResult> {
+  const quickLocations = getMediaExportQuickLocations();
+  const fallbackPath = quickLocations[0]?.path ?? resolve(app.getPath("home"));
+  const requestedPath = normalizeOptionalString(input.directoryPath);
+  const currentPath = resolve(requestedPath ?? fallbackPath);
+  const currentStats = await stat(currentPath);
+  if (!currentStats.isDirectory()) {
+    throw new Error("Export directory not found");
+  }
+
+  const entries = (await readdir(currentPath, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .map((entry) => ({
+      name: entry.name,
+      path: join(currentPath, entry.name),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name, undefined, { numeric: true, sensitivity: "base" }));
+
+  const parentPath = resolve(currentPath, "..");
+  return {
+    currentPath,
+    parentPath: parentPath !== currentPath ? parentPath : undefined,
+    entries,
+    quickLocations,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1253,6 +1371,13 @@ function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.MEDIA_EXPORT, async (_event, payload: MediaExportRequest): Promise<MediaExportResult> => {
     return exportMedia(payload);
   });
+
+  ipcMain.handle(
+    IPC_CHANNELS.MEDIA_EXPORT_BROWSE,
+    async (_event, payload: MediaExportBrowserRequest | undefined): Promise<MediaExportBrowserResult> => {
+      return browseMediaExportLocations(payload);
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.CACHE_REFRESH_MANUAL, async (): Promise<void> => {
     await refreshScheduler.manualRefresh();

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -31,6 +31,8 @@ import type {
   RecordingEntry,
   RecordingDeleteRequest,
   MediaListingResult,
+  MediaExportRequest,
+  MediaExportResult,
 } from "@shared/gfn";
 
 const api: OpenNowApi = {
@@ -119,6 +121,8 @@ const api: OpenNowApi = {
   getMediaThumbnail: (input: { filePath: string }) => ipcRenderer.invoke(IPC_CHANNELS.MEDIA_THUMBNAIL, input),
   showMediaInFolder: (input: { filePath: string }): Promise<void> =>
     ipcRenderer.invoke(IPC_CHANNELS.MEDIA_SHOW_IN_FOLDER, input),
+  exportMedia: (input: MediaExportRequest): Promise<MediaExportResult> =>
+    ipcRenderer.invoke(IPC_CHANNELS.MEDIA_EXPORT, input),
   deleteCache: (): Promise<void> =>
     ipcRenderer.invoke(IPC_CHANNELS.CACHE_DELETE_ALL),
 };

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -31,6 +31,8 @@ import type {
   RecordingEntry,
   RecordingDeleteRequest,
   MediaListingResult,
+  MediaExportBrowserRequest,
+  MediaExportBrowserResult,
   MediaExportRequest,
   MediaExportResult,
 } from "@shared/gfn";
@@ -121,6 +123,8 @@ const api: OpenNowApi = {
   getMediaThumbnail: (input: { filePath: string }) => ipcRenderer.invoke(IPC_CHANNELS.MEDIA_THUMBNAIL, input),
   showMediaInFolder: (input: { filePath: string }): Promise<void> =>
     ipcRenderer.invoke(IPC_CHANNELS.MEDIA_SHOW_IN_FOLDER, input),
+  browseMediaExportLocations: (input: MediaExportBrowserRequest = {}): Promise<MediaExportBrowserResult> =>
+    ipcRenderer.invoke(IPC_CHANNELS.MEDIA_EXPORT_BROWSE, input),
   exportMedia: (input: MediaExportRequest): Promise<MediaExportResult> =>
     ipcRenderer.invoke(IPC_CHANNELS.MEDIA_EXPORT, input),
   deleteCache: (): Promise<void> =>

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -121,6 +121,7 @@ const api: OpenNowApi = {
   listMediaByGame: (input: { gameTitle?: string } = {}): Promise<MediaListingResult> =>
     ipcRenderer.invoke(IPC_CHANNELS.MEDIA_LIST_BY_GAME, input),
   getMediaThumbnail: (input: { filePath: string }) => ipcRenderer.invoke(IPC_CHANNELS.MEDIA_THUMBNAIL, input),
+  getMediaDataUrl: (input: { filePath: string }) => ipcRenderer.invoke(IPC_CHANNELS.MEDIA_DATA_URL, input),
   showMediaInFolder: (input: { filePath: string }): Promise<void> =>
     ipcRenderer.invoke(IPC_CHANNELS.MEDIA_SHOW_IN_FOLDER, input),
   browseMediaExportLocations: (input: MediaExportBrowserRequest = {}): Promise<MediaExportBrowserResult> =>

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -589,6 +589,8 @@ export function App(): JSX.Element {
   const [switchingPhase, setSwitchingPhase] = useState<null | "cleaning" | "creating">(null);
   const [pendingSwitchGameTitle, setPendingSwitchGameTitle] = useState<string | null>(null);
   const [pendingSwitchGameCover, setPendingSwitchGameCover] = useState<string | null>(null);
+  const [pendingSwitchGameDescription, setPendingSwitchGameDescription] = useState<string | null>(null);
+  const [pendingSwitchGameId, setPendingSwitchGameId] = useState<string | null>(null);
   const controllerDesktopModeActive = Boolean(authSession)
     && streamStatus === "idle"
     && settings.controllerMode
@@ -1875,6 +1877,8 @@ export function App(): JSX.Element {
     setControllerOverlayOpen(false);
     setPendingSwitchGameTitle(game.title ?? null);
     setPendingSwitchGameCover(game.imageUrl ?? null);
+    setPendingSwitchGameDescription(game.description ?? null);
+    setPendingSwitchGameId(game.id ?? null);
     setIsSwitchingGame(true);
     setSwitchingPhase("cleaning");
     // allow overlay to paint
@@ -1913,6 +1917,8 @@ export function App(): JSX.Element {
     setSwitchingPhase(null);
     setPendingSwitchGameTitle(null);
     setPendingSwitchGameCover(null);
+    setPendingSwitchGameDescription(null);
+    setPendingSwitchGameId(null);
   }, [handleStopStream, handlePlayGame]);
 
   const handleDismissLaunchError = useCallback(async () => {
@@ -2208,11 +2214,11 @@ export function App(): JSX.Element {
           <ControllerStreamLoading
             gameTitle={pendingSwitchGameTitle ?? streamingGame?.title ?? "Game"}
             gamePoster={pendingSwitchGameCover ?? streamingGame?.imageUrl}
-            gameDescription={streamingGame?.description}
+            gameDescription={pendingSwitchGameDescription ?? streamingGame?.description}
             status={switchingPhase === "cleaning" ? "setup" : "starting"}
             queuePosition={queuePosition}
             playtimeData={playtime}
-            gameId={streamingGame?.id}
+            gameId={pendingSwitchGameId ?? streamingGame?.id}
             enableBackgroundAnimations={settings.controllerBackgroundAnimations}
           />
         )}
@@ -2275,6 +2281,7 @@ export function App(): JSX.Element {
                 fps: settings.fps,
                 codec: settings.codec,
                 enableL4S: settings.enableL4S,
+                microphoneDeviceId: settings.microphoneDeviceId,
                 controllerUiSounds: settings.controllerUiSounds,
                 controllerBackgroundAnimations: settings.controllerBackgroundAnimations,
                 autoLoadControllerLibrary: settings.autoLoadControllerLibrary,
@@ -2407,6 +2414,7 @@ export function App(): JSX.Element {
                 fps: settings.fps,
                 codec: settings.codec,
                 enableL4S: settings.enableL4S,
+                microphoneDeviceId: settings.microphoneDeviceId,
                 controllerUiSounds: settings.controllerUiSounds,
                 controllerBackgroundAnimations: settings.controllerBackgroundAnimations,
                 autoLoadControllerLibrary: settings.autoLoadControllerLibrary,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -25,6 +25,7 @@ import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./
 import { useControllerNavigation } from "./controllerNavigation";
 import { usePlaytime } from "./utils/usePlaytime";
 import { createStreamDiagnosticsStore } from "./utils/streamDiagnosticsStore";
+import type { MediaListingEntry } from "@shared/gfn";
 
 // UI Components
 import { LoginScreen } from "./components/LoginScreen";
@@ -386,6 +387,8 @@ export function App(): JSX.Element {
   // Games State
   const [games, setGames] = useState<GameInfo[]>([]);
   const [libraryGames, setLibraryGames] = useState<GameInfo[]>([]);
+  const [mediaPreviewScreenshotId, setMediaPreviewScreenshotId] = useState<string | null>(null);
+  const [mediaPreviewRecordingId, setMediaPreviewRecordingId] = useState<string | null>(null);
   const [source, setSource] = useState<GameSource>("main");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedGameId, setSelectedGameId] = useState("");
@@ -2126,6 +2129,17 @@ export function App(): JSX.Element {
     return libraryGames.filter((g) => g.title.toLowerCase().includes(query));
   }, [libraryGames, searchQuery]);
 
+  const handleOpenMediaAsset = useCallback((asset: MediaListingEntry) => {
+    if (asset.durationMs && asset.durationMs > 0) {
+      setMediaPreviewRecordingId(asset.id);
+      setMediaPreviewScreenshotId(null);
+      return;
+    }
+
+    setMediaPreviewScreenshotId(asset.id);
+    setMediaPreviewRecordingId(null);
+  }, []);
+
   const activeSessionGameTitle = useMemo(() => {
     if (!navbarActiveSession) return null;
     const mappedTitle = gameTitleByAppId.get(navbarActiveSession.appId);
@@ -2228,6 +2242,8 @@ export function App(): JSX.Element {
             onReleasePointerLock={() => {
               void releasePointerLockIfNeeded();
             }}
+            openScreenshotId={mediaPreviewScreenshotId}
+            openRecordingId={mediaPreviewRecordingId}
           />
         )}
         {isSwitchingGame && settings.controllerMode && streamStatus !== "connecting" && (
@@ -2281,6 +2297,7 @@ export function App(): JSX.Element {
               favoriteGameIds={settings.favoriteGameIds}
               onToggleFavoriteGame={handleToggleFavoriteGame}
               onOpenSettings={() => setCurrentPage("settings")}
+              onOpenMediaAsset={handleOpenMediaAsset}
               currentStreamingGame={streamingGame}
               onResumeGame={() => setControllerOverlayOpen(false)}
               onCloseGame={async () => {
@@ -2419,6 +2436,7 @@ export function App(): JSX.Element {
               onSelectGameVariant={handleSelectGameVariant}
               favoriteGameIds={settings.favoriteGameIds}
               onToggleFavoriteGame={handleToggleFavoriteGame}
+              onOpenMediaAsset={handleOpenMediaAsset}
               onOpenSettings={() => setCurrentPage("settings")}
               currentStreamingGame={streamingGame}
               onResumeGame={handlePlayGame}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -546,6 +546,25 @@ export function App(): JSX.Element {
     return false;
   }, [authSession, currentPage, settings.controllerMode, streamStatus]);
 
+  const handleControllerStartInput = useCallback((): boolean => {
+    if (controllerOverlayOpenRef.current) {
+      window.dispatchEvent(new CustomEvent("opennow:controller-start"));
+      return true;
+    }
+    if (!authSession || streamStatus !== "idle") {
+      return false;
+    }
+    if (settings.controllerMode && currentPage === "library") {
+      window.dispatchEvent(new CustomEvent("opennow:controller-start"));
+      return true;
+    }
+    if (settings.controllerMode && currentPage === "settings") {
+      window.dispatchEvent(new CustomEvent("opennow:controller-start"));
+      return true;
+    }
+    return false;
+  }, [authSession, currentPage, settings.controllerMode, streamStatus]);
+
   const handleControllerSecondaryActivateInput = useCallback((): boolean => {
     if (controllerOverlayOpenRef.current) {
       window.dispatchEvent(new CustomEvent("opennow:controller-secondary-activate"));
@@ -603,6 +622,7 @@ export function App(): JSX.Element {
     onBackAction: handleControllerBackAction,
     onDirectionInput: handleControllerDirectionInput,
     onActivateInput: handleControllerActivateInput,
+    onStartInput: handleControllerStartInput,
     onSecondaryActivateInput: handleControllerSecondaryActivateInput,
     onTertiaryActivateInput: handleControllerTertiaryActivateInput,
   });

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -479,17 +479,6 @@ export function ControllerLibraryPage({
   const showCurrentDetail = topCategory === "current" && Boolean(currentStreamingGame);
   const detailVisible = showCurrentDetail || showGameHub;
 
-  const selectedGameVariant = useMemo(() => {
-    if (!selectedGame) return null;
-    return selectedGame.variants.find((variant) => variant.id === selectedVariantId) ?? selectedGame.variants[0] ?? null;
-  }, [selectedGame, selectedVariantId]);
-
-  const selectedGameStoreName = useMemo(() => getStoreDisplayName(selectedGameVariant?.store || ""), [selectedGameVariant]);
-  const selectedGameRecord = useMemo(() => {
-    if (!selectedGame) return undefined;
-    return playtimeData[selectedGame.id];
-  }, [playtimeData, selectedGame]);
-  const selectedGameGenres = useMemo(() => selectedGame?.genres?.slice(0, 3) ?? [], [selectedGame]);
   const selectedCategoryLabel = useMemo(() => getCategoryLabel(topCategory, currentStreamingGame?.title).label, [topCategory, currentStreamingGame?.title]);
   const selectedGameDescription = useMemo(() => {
     if (!selectedGame) return "";
@@ -497,7 +486,8 @@ export function ControllerLibraryPage({
     return description || `${selectedGame.title} is ready to launch from your XMB library.`;
   }, [selectedGame]);
   const selectedGameSessionState = useMemo(() => {
-    if (!selectedGame || !currentStreamingGame) return null;
+    if (!selectedGame) return null;
+    if (!currentStreamingGame) return "Ready To Launch";
     if (currentStreamingGame.id === selectedGame.id) return "Active Session";
     return "Ready To Switch";
   }, [currentStreamingGame, selectedGame]);
@@ -1291,17 +1281,7 @@ export function ControllerLibraryPage({
                 </div>
                 <p className="xmb-game-hub-description">{selectedGameDescription}</p>
                 <div className="xmb-game-meta xmb-game-hub-meta">
-                  {selectedGameStoreName && <span className="xmb-game-meta-chip xmb-game-meta-chip--store">{selectedGameStoreName}</span>}
                   {selectedGameSessionState && <span className="xmb-game-meta-chip xmb-game-meta-chip--session">{selectedGameSessionState}</span>}
-                  <span className="xmb-game-meta-chip xmb-game-meta-chip--playtime">
-                    <Clock size={10} className="xmb-meta-icon" />
-                    {formatPlaytime(selectedGameRecord?.totalSeconds ?? 0)}
-                  </span>
-                  <span className="xmb-game-meta-chip xmb-game-meta-chip--last-played">
-                    <Calendar size={10} className="xmb-meta-icon" />
-                    {formatLastPlayed(selectedGameRecord?.lastPlayedAt ?? null)}
-                  </span>
-                  {selectedGameGenres[0] && <span className="xmb-game-meta-chip xmb-game-meta-chip--genre">{sanitizeGenreName(selectedGameGenres[0])}</span>}
                 </div>
 
                 <div className="xmb-game-hub-captures">
@@ -1323,8 +1303,7 @@ export function ControllerLibraryPage({
                           <div key={item.id} className="xmb-game-hub-capture">
                             {thumb && <img src={thumb} alt={item.fileName} className="xmb-game-hub-capture-image" />}
                             <div className="xmb-game-hub-capture-meta">
-                              <span className="xmb-game-hub-capture-type">{captureLabel}</span>
-                              <div className="xmb-game-hub-capture-name">{item.fileName}</div>
+                              <div className="xmb-game-hub-capture-name">{captureLabel}</div>
                               <div className="xmb-game-hub-capture-date">{new Date(item.createdAtMs).toLocaleDateString(undefined, { month: "short", day: "numeric" })}</div>
                             </div>
                           </div>

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
-import type { GameInfo, MediaListingEntry, MediaSessionSummary, Settings } from "@shared/gfn";
+import type { GameInfo, MediaExportBrowserResult, MediaListingEntry, MediaSessionSummary, Settings } from "@shared/gfn";
 import { Star, Clock, Calendar, Repeat2, FolderOpen, Share2, Trash2 } from "lucide-react";
 import { ButtonA, ButtonB, ButtonX, ButtonY, ButtonPSCross, ButtonPSCircle, ButtonPSSquare, ButtonPSTriangle } from "./ControllerButtons";
 import { getStoreDisplayName } from "./GameCard";
@@ -160,6 +160,7 @@ export function ControllerLibraryPage({
   const currentPosterImgRef = useRef<HTMLImageElement | null>(null);
   const [metaMaxWidth, setMetaMaxWidth] = useState<number | null>(null);
   const posterObserverRef = useRef<ResizeObserver | null>(null);
+  const gameHubExportBrowseRequestIdRef = useRef(0);
   const attachPosterRef = (el: HTMLImageElement | null) => {
     if (posterObserverRef.current) {
       try { posterObserverRef.current.disconnect(); } catch {}
@@ -200,6 +201,11 @@ export function ControllerLibraryPage({
   const [gameHubActionBusy, setGameHubActionBusy] = useState<"reveal" | "export" | "delete" | null>(null);
   const [gameHubActionMessage, setGameHubActionMessage] = useState<string | null>(null);
   const [isGameHubExpanded, setIsGameHubExpanded] = useState(false);
+  const [isGameHubExportBrowserOpen, setIsGameHubExportBrowserOpen] = useState(false);
+  const [gameHubExportBrowser, setGameHubExportBrowser] = useState<MediaExportBrowserResult | null>(null);
+  const [gameHubExportBrowserLoading, setGameHubExportBrowserLoading] = useState(false);
+  const [gameHubExportOverwritePending, setGameHubExportOverwritePending] = useState(false);
+  const [lastGameHubExportDirectoryPath, setLastGameHubExportDirectoryPath] = useState<string | null>(null);
   const [controllerType, setControllerType] = useState<"ps" | "xbox" | "nintendo" | "generic">("generic");
   const [editingBandwidth, setEditingBandwidth] = useState(false);
 
@@ -638,24 +644,97 @@ export function ControllerLibraryPage({
     }
   }, [playUiSound, selectedGameHubMedia]);
 
+  const closeGameHubExportBrowser = useCallback((clearMessage = true) => {
+    gameHubExportBrowseRequestIdRef.current += 1;
+    setIsGameHubExportBrowserOpen(false);
+    setGameHubExportBrowser(null);
+    setGameHubExportBrowserLoading(false);
+    setGameHubExportOverwritePending(false);
+    if (clearMessage) {
+      setGameHubActionMessage(null);
+    }
+  }, []);
+
+  const loadGameHubExportBrowser = useCallback(async (directoryPath?: string) => {
+    if (typeof window.openNow?.browseMediaExportLocations !== "function") {
+      throw new Error("Export browser unavailable");
+    }
+
+    const requestId = gameHubExportBrowseRequestIdRef.current + 1;
+    gameHubExportBrowseRequestIdRef.current = requestId;
+    setGameHubExportBrowserLoading(true);
+    setGameHubActionMessage(null);
+    setGameHubExportOverwritePending(false);
+
+    try {
+      const result = await window.openNow.browseMediaExportLocations(
+        directoryPath ? { directoryPath } : {},
+      );
+      if (gameHubExportBrowseRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      setGameHubExportBrowser(result);
+      setLastGameHubExportDirectoryPath(result.currentPath);
+    } finally {
+      if (gameHubExportBrowseRequestIdRef.current === requestId) {
+        setGameHubExportBrowserLoading(false);
+      }
+    }
+  }, []);
+
   const handleGameHubExport = useCallback(async () => {
-    if (!selectedGameHubMedia || typeof window.openNow?.exportMedia !== "function") return;
+    if (!selectedGameHubMedia) return;
+    setIsGameHubExportBrowserOpen(true);
+    setGameHubExportBrowser(null);
+    try {
+      await loadGameHubExportBrowser(lastGameHubExportDirectoryPath ?? undefined);
+      playUiSound("confirm");
+    } catch {
+      closeGameHubExportBrowser(false);
+      setGameHubActionMessage("Unable to browse export folders.");
+    }
+  }, [closeGameHubExportBrowser, lastGameHubExportDirectoryPath, loadGameHubExportBrowser, playUiSound, selectedGameHubMedia]);
+
+  const handleGameHubExportNavigate = useCallback(async (directoryPath: string) => {
+    try {
+      await loadGameHubExportBrowser(directoryPath);
+      playUiSound("move");
+    } catch {
+      setGameHubActionMessage("Unable to open that folder.");
+    }
+  }, [loadGameHubExportBrowser, playUiSound]);
+
+  const handleGameHubExportSubmit = useCallback(async () => {
+    if (!selectedGameHubMedia || !gameHubExportBrowser || typeof window.openNow?.exportMedia !== "function") return;
+
     setGameHubActionBusy("export");
     setGameHubActionMessage(null);
     try {
       const result = await window.openNow.exportMedia({
         filePath: selectedGameHubMedia.filePath,
         fileName: selectedGameHubMedia.fileName,
+        destinationDirectoryPath: gameHubExportBrowser.currentPath,
+        overwrite: gameHubExportOverwritePending,
       });
+
       if (result.saved) {
+        setLastGameHubExportDirectoryPath(gameHubExportBrowser.currentPath);
+        closeGameHubExportBrowser();
         playUiSound("confirm");
+        return;
+      }
+
+      if (result.alreadyExists) {
+        setGameHubExportOverwritePending(true);
+        setGameHubActionMessage("A file with that name already exists here.");
       }
     } catch {
       setGameHubActionMessage("Unable to export moment.");
     } finally {
       setGameHubActionBusy(null);
     }
-  }, [playUiSound, selectedGameHubMedia]);
+  }, [closeGameHubExportBrowser, gameHubExportBrowser, gameHubExportOverwritePending, playUiSound, selectedGameHubMedia]);
 
   const handleGameHubDelete = useCallback(async () => {
     if (!selectedGameHubMedia) return;
@@ -688,6 +767,10 @@ export function ControllerLibraryPage({
       setSelectedGameHubMediaIndex(0);
       setGameHubActionMessage(null);
       setIsGameHubExpanded(false);
+      setIsGameHubExportBrowserOpen(false);
+      setGameHubExportBrowser(null);
+      setGameHubExportBrowserLoading(false);
+      setGameHubExportOverwritePending(false);
       setGameHubMediaLoading(false);
       return;
     }
@@ -746,7 +829,20 @@ export function ControllerLibraryPage({
     setSelectedGameHubMediaIndex(0);
     setGameHubActionMessage(null);
     setIsGameHubExpanded(false);
+    setIsGameHubExportBrowserOpen(false);
+    setGameHubExportBrowser(null);
+    setGameHubExportBrowserLoading(false);
+    setGameHubExportOverwritePending(false);
   }, [selectedGame?.id]);
+
+  useEffect(() => {
+    if (isGameHubExpanded) return;
+    gameHubExportBrowseRequestIdRef.current += 1;
+    setIsGameHubExportBrowserOpen(false);
+    setGameHubExportBrowser(null);
+    setGameHubExportBrowserLoading(false);
+    setGameHubExportOverwritePending(false);
+  }, [isGameHubExpanded]);
 
 
 
@@ -934,6 +1030,16 @@ export function ControllerLibraryPage({
         playUiSound("confirm");
         return;
       }
+      if (showGameHub && isGameHubExpanded) {
+        const buttons = getGameHubButtons();
+        const activeButton = document.activeElement instanceof HTMLButtonElement && buttons.includes(document.activeElement)
+          ? document.activeElement
+          : buttons[0] ?? null;
+        if (activeButton) {
+          activeButton.click();
+        }
+        return;
+      }
       if (topCategory === "current") {
         const item = displayItems[selectedSettingIndex];
         if (item?.id === "resume" && currentStreamingGame && onResumeGame) {
@@ -1015,6 +1121,11 @@ export function ControllerLibraryPage({
     };
 
     const secondaryActivateHandler = () => {
+      if (showGameHub && isGameHubExpanded && isGameHubExportBrowserOpen) {
+        closeGameHubExportBrowser();
+        playUiSound("move");
+        return;
+      }
       if (showGameHub) {
         setIsGameHubExpanded((prev) => !prev);
         playUiSound("confirm");
@@ -1101,6 +1212,9 @@ export function ControllerLibraryPage({
     };
 
     const tertiaryActivateHandler = () => {
+      if (showGameHub && isGameHubExpanded && isGameHubExportBrowserOpen) {
+        return;
+      }
       if (showGameHub && isGameHubExpanded && selectedGameHubMedia) {
         void handleGameHubDelete();
         return;
@@ -1127,6 +1241,12 @@ export function ControllerLibraryPage({
         return;
       }
       if (showGameHub) {
+        if (isGameHubExportBrowserOpen) {
+          closeGameHubExportBrowser();
+          playUiSound("move");
+          e.preventDefault();
+          return;
+        }
         if (isGameHubExpanded) {
           setIsGameHubExpanded(false);
         }
@@ -1180,6 +1300,10 @@ export function ControllerLibraryPage({
         return;
       }
       if (e.key === "Backspace" || e.key === "Escape") {
+        if (showGameHub && isGameHubExpanded) {
+          cancelHandler(e);
+          return;
+        }
         if (topCategory === "settings" && settingsSubcategory !== "root") {
           cancelHandler(e);
           return;
@@ -1217,7 +1341,7 @@ export function ControllerLibraryPage({
       window.removeEventListener("opennow:controller-cancel", cancelHandler);
       window.removeEventListener("keydown", kbdHandler);
     };
-  }, [isLoading, TOP_CATEGORIES.length, categorizedGames, selectedIndex, selectedGame, selectedVariantId, onPlayGame, onSelectGameVariant, onOpenSettings, playUiSound, throttledOnSelectGame, toggleFavoriteForSelected, topCategory, selectedSettingIndex, selectedMediaIndex, displayItems, mediaAssetItems.length, mediaSubcategory, settings, settingsBySubcategory, settingsSubcategory, lastRootSettingIndex, lastRootMediaIndex, onSettingChange, resolutionOptions, fpsOptions, codecOptions, aspectRatioOptions, currentStreamingGame, onResumeGame, onCloseGame, onExitControllerMode, onExitApp, editingBandwidth, showGameHub, selectedGameHubMedia, handleGameHubReveal, handleGameHubExport, handleGameHubDelete, gameHubMedia.length, selectedGameHubMediaIndex, moveGameHubFocus]);
+  }, [isLoading, TOP_CATEGORIES.length, categorizedGames, selectedIndex, selectedGame, selectedVariantId, onPlayGame, onSelectGameVariant, onOpenSettings, playUiSound, throttledOnSelectGame, toggleFavoriteForSelected, topCategory, selectedSettingIndex, selectedMediaIndex, displayItems, mediaAssetItems.length, mediaSubcategory, settings, settingsBySubcategory, settingsSubcategory, lastRootSettingIndex, lastRootMediaIndex, onSettingChange, resolutionOptions, fpsOptions, codecOptions, aspectRatioOptions, currentStreamingGame, onResumeGame, onCloseGame, onExitControllerMode, onExitApp, editingBandwidth, showGameHub, isGameHubExpanded, isGameHubExportBrowserOpen, selectedGameHubMedia, handleGameHubReveal, handleGameHubExport, handleGameHubDelete, gameHubMedia.length, selectedGameHubMediaIndex, moveGameHubFocus, closeGameHubExportBrowser]);
 
   const renderFaceButton = (kind: "primary" | "secondary" | "tertiary", className: string, size: number): JSX.Element => {
     if (kind === "primary") {
@@ -1545,115 +1669,213 @@ export function ControllerLibraryPage({
           {showGameHub && isGameHubExpanded && selectedGame && (
             <div className="xmb-game-hub">
               <div className="xmb-game-hub-panel">
-                <div className="xmb-game-hub-eyebrow">{topCategory === "all" ? "Game Hub" : selectedCategoryLabel}</div>
-                <div className="xmb-game-hub-title-row">
-                  {favoriteGameIdSet.has(selectedGame.id) && <Star className="xmb-game-hub-favorite" />}
-                  <div className="xmb-game-hub-title">{selectedGame.title}</div>
-                </div>
-                <p className="xmb-game-hub-description">{selectedGameDescription}</p>
-                <div className="xmb-game-meta xmb-game-hub-meta">
-                  {selectedGameSessionState && <span className="xmb-game-meta-chip xmb-game-meta-chip--session">{selectedGameSessionState}</span>}
-                </div>
-
-                {gameHubSummary && (
-                  <div className="xmb-game-hub-snapshot">
-                    <div className="xmb-game-hub-section-title">Session Snapshot</div>
-                    <div className="xmb-game-meta xmb-game-hub-meta">
-                      {gameHubSnapshotChips.map((chip, index) => (
-                        <span key={`${index}-${chip}`} className="xmb-game-meta-chip">
-                          {chip}
-                        </span>
-                      ))}
+                {isGameHubExportBrowserOpen && selectedGameHubMedia ? (
+                  <div className="xmb-export-browser">
+                    <div className="xmb-game-hub-eyebrow">Export Moment</div>
+                    <div className="xmb-game-hub-title-row">
+                      <div className="xmb-game-hub-title">Choose Destination</div>
                     </div>
-                    {gameHubSnapshotCaption && <div className="xmb-game-hub-snapshot-caption">{gameHubSnapshotCaption}</div>}
-                  </div>
-                )}
+                    <div className="xmb-export-browser-file">{selectedGameHubMedia.fileName}</div>
+                    <div className="xmb-export-browser-path">
+                      {gameHubExportBrowser?.currentPath ?? "Loading folders..."}
+                    </div>
 
-                <div className="xmb-game-hub-captures">
-                  {gameHubMediaLoading ? (
-                    <div className="xmb-game-hub-capture-empty">Scanning recent captures...</div>
-                  ) : gameHubMedia.length === 0 ? (
-                    <div className="xmb-game-hub-capture-empty">No recent captures.</div>
-                  ) : (
-                    <>
-                      <div className="xmb-game-hub-section-title">Recent Captures</div>
-                      <div className="xmb-game-hub-capture-grid">
-                        {gameHubMedia.map((item, index) => {
-                        const isActiveMoment = selectedGameHubMedia?.id === item.id;
-                        const thumb = mediaThumbById[item.id] ?? item.thumbnailDataUrl ?? item.dataUrl;
-                        const captureLabel = item.kind === "video"
-                          ? `${Math.max(1, Math.round((item.durationMs ?? 0) / 1000))}s Clip`
-                          : "Screenshot";
-                        const captureStats = [
-                          item.sessionSnapshot?.resolution,
-                          formatMediaBitrate(item.sessionSnapshot?.bitrateKbps),
-                          typeof item.sessionSnapshot?.rttMs === "number" && Number.isFinite(item.sessionSnapshot.rttMs)
-                            ? `${Math.round(item.sessionSnapshot.rttMs)} ms`
-                            : null,
-                        ].filter((value): value is string => Boolean(value));
-
-                        return (
+                    <div className="xmb-export-browser-section">
+                      <div className="xmb-game-hub-section-title">Quick Locations</div>
+                      <div className="xmb-export-browser-quick-grid">
+                        {(gameHubExportBrowser?.quickLocations ?? []).map((location) => (
                           <button
-                            key={item.id}
+                            key={location.id}
                             type="button"
-                            className={`xmb-game-hub-capture ${isActiveMoment ? "active" : ""}`}
-                            data-hub-media-index={index}
-                            onClick={() => {
-                              setSelectedGameHubMediaIndex(gameHubMedia.findIndex((media) => media.id === item.id));
-                              setGameHubActionMessage(null);
-                            }}
+                            className="xmb-export-browser-quick"
+                            onClick={() => { void handleGameHubExportNavigate(location.path); }}
+                            disabled={gameHubExportBrowserLoading || gameHubActionBusy === "export"}
                           >
-                            {thumb && <img src={thumb} alt={item.fileName} className="xmb-game-hub-capture-image" />}
-                            <div className="xmb-game-hub-capture-meta">
-                              <div className="xmb-game-hub-capture-name">{captureLabel}</div>
-                              {captureStats.length > 0 && <div className="xmb-game-hub-capture-stats">{captureStats.join(" • ")}</div>}
-                              <div className="xmb-game-hub-capture-date">{new Date(item.createdAtMs).toLocaleDateString(undefined, { month: "short", day: "numeric" })}</div>
-                            </div>
+                            {location.label}
                           </button>
-                        );
-                      })}
+                        ))}
                       </div>
+                    </div>
 
-                      {selectedGameHubMedia && (
-                        <div className="xmb-game-hub-actions-wrap">
-                          <div className="xmb-game-hub-actions-header">
-                            Selected Moment: {selectedGameHubMedia.gameTitle || selectedGameHubMedia.fileName}
-                          </div>
-                          <div className="xmb-game-hub-actions">
+                    <div className="xmb-export-browser-section">
+                      <div className="xmb-game-hub-section-title">Folders</div>
+                      <div className="xmb-export-browser-directory-list">
+                        {gameHubExportBrowser?.parentPath && (
+                          <button
+                            type="button"
+                            className="xmb-export-browser-directory xmb-export-browser-directory--parent"
+                            onClick={() => { void handleGameHubExportNavigate(gameHubExportBrowser.parentPath!); }}
+                            disabled={gameHubExportBrowserLoading || gameHubActionBusy === "export"}
+                          >
+                            .. Parent Folder
+                          </button>
+                        )}
+                        {gameHubExportBrowserLoading ? (
+                          <div className="xmb-game-hub-capture-empty">Loading folders...</div>
+                        ) : (gameHubExportBrowser?.entries.length ?? 0) === 0 ? (
+                          <div className="xmb-game-hub-capture-empty">No subfolders in this location.</div>
+                        ) : (
+                          gameHubExportBrowser?.entries.map((entry) => (
                             <button
+                              key={entry.path}
                               type="button"
-                              className="xmb-game-hub-action"
-                              onClick={() => { void handleGameHubReveal(); }}
-                              disabled={gameHubActionBusy !== null}
+                              className="xmb-export-browser-directory"
+                              onClick={() => { void handleGameHubExportNavigate(entry.path); }}
+                              disabled={gameHubExportBrowserLoading || gameHubActionBusy === "export"}
                             >
-                              <FolderOpen size={14} />
-                              <span>{gameHubActionBusy === "reveal" ? "Opening..." : "Reveal in Finder"}</span>
+                              {entry.name}
                             </button>
-                            <button
-                              type="button"
-                              className="xmb-game-hub-action"
-                              onClick={() => { void handleGameHubExport(); }}
-                              disabled={gameHubActionBusy !== null}
-                            >
-                              <Share2 size={14} />
-                              <span>{gameHubActionBusy === "export" ? "Exporting..." : "Export / Share"}</span>
-                            </button>
-                            <button
-                              type="button"
-                              className="xmb-game-hub-action xmb-game-hub-action--danger"
-                              onClick={() => { void handleGameHubDelete(); }}
-                              disabled={gameHubActionBusy !== null}
-                            >
-                              <Trash2 size={14} />
-                              <span>{gameHubActionBusy === "delete" ? "Deleting..." : "Delete"}</span>
-                            </button>
-                          </div>
-                          {gameHubActionMessage && <div className="xmb-game-hub-action-message">{gameHubActionMessage}</div>}
+                          ))
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="xmb-game-hub-actions-wrap">
+                      <div className="xmb-game-hub-actions-header">
+                        Exporting to: {gameHubExportBrowser?.currentPath ?? "Loading..."}
+                      </div>
+                      <div className="xmb-game-hub-actions">
+                        <button
+                          type="button"
+                          className="xmb-game-hub-action"
+                          onClick={() => { void handleGameHubExportSubmit(); }}
+                          disabled={gameHubExportBrowserLoading || gameHubActionBusy === "export" || !gameHubExportBrowser}
+                        >
+                          <Share2 size={14} />
+                          <span>
+                            {gameHubActionBusy === "export"
+                              ? "Exporting..."
+                              : gameHubExportOverwritePending
+                                ? "Overwrite Existing"
+                                : "Export Here"}
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          className="xmb-game-hub-action"
+                          onClick={() => { closeGameHubExportBrowser(); }}
+                          disabled={gameHubActionBusy === "export"}
+                        >
+                          <FolderOpen size={14} />
+                          <span>Cancel</span>
+                        </button>
+                      </div>
+                      {gameHubActionMessage && <div className="xmb-game-hub-action-message">{gameHubActionMessage}</div>}
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="xmb-game-hub-eyebrow">{topCategory === "all" ? "Game Hub" : selectedCategoryLabel}</div>
+                    <div className="xmb-game-hub-title-row">
+                      {favoriteGameIdSet.has(selectedGame.id) && <Star className="xmb-game-hub-favorite" />}
+                      <div className="xmb-game-hub-title">{selectedGame.title}</div>
+                    </div>
+                    <p className="xmb-game-hub-description">{selectedGameDescription}</p>
+                    <div className="xmb-game-meta xmb-game-hub-meta">
+                      {selectedGameSessionState && <span className="xmb-game-meta-chip xmb-game-meta-chip--session">{selectedGameSessionState}</span>}
+                    </div>
+
+                    {gameHubSummary && (
+                      <div className="xmb-game-hub-snapshot">
+                        <div className="xmb-game-hub-section-title">Session Snapshot</div>
+                        <div className="xmb-game-meta xmb-game-hub-meta">
+                          {gameHubSnapshotChips.map((chip, index) => (
+                            <span key={`${index}-${chip}`} className="xmb-game-meta-chip">
+                              {chip}
+                            </span>
+                          ))}
                         </div>
+                        {gameHubSnapshotCaption && <div className="xmb-game-hub-snapshot-caption">{gameHubSnapshotCaption}</div>}
+                      </div>
+                    )}
+
+                    <div className="xmb-game-hub-captures">
+                      {gameHubMediaLoading ? (
+                        <div className="xmb-game-hub-capture-empty">Scanning recent captures...</div>
+                      ) : gameHubMedia.length === 0 ? (
+                        <div className="xmb-game-hub-capture-empty">No recent captures.</div>
+                      ) : (
+                        <>
+                          <div className="xmb-game-hub-section-title">Recent Captures</div>
+                          <div className="xmb-game-hub-capture-grid">
+                            {gameHubMedia.map((item, index) => {
+                            const isActiveMoment = selectedGameHubMedia?.id === item.id;
+                            const thumb = mediaThumbById[item.id] ?? item.thumbnailDataUrl ?? item.dataUrl;
+                            const captureLabel = item.kind === "video"
+                              ? `${Math.max(1, Math.round((item.durationMs ?? 0) / 1000))}s Clip`
+                              : "Screenshot";
+                            const captureStats = [
+                              item.sessionSnapshot?.resolution,
+                              formatMediaBitrate(item.sessionSnapshot?.bitrateKbps),
+                              typeof item.sessionSnapshot?.rttMs === "number" && Number.isFinite(item.sessionSnapshot.rttMs)
+                                ? `${Math.round(item.sessionSnapshot.rttMs)} ms`
+                                : null,
+                            ].filter((value): value is string => Boolean(value));
+
+                            return (
+                              <button
+                                key={item.id}
+                                type="button"
+                                className={`xmb-game-hub-capture ${isActiveMoment ? "active" : ""}`}
+                                data-hub-media-index={index}
+                                onClick={() => {
+                                  setSelectedGameHubMediaIndex(gameHubMedia.findIndex((media) => media.id === item.id));
+                                  setGameHubActionMessage(null);
+                                }}
+                              >
+                                {thumb && <img src={thumb} alt={item.fileName} className="xmb-game-hub-capture-image" />}
+                                <div className="xmb-game-hub-capture-meta">
+                                  <div className="xmb-game-hub-capture-name">{captureLabel}</div>
+                                  {captureStats.length > 0 && <div className="xmb-game-hub-capture-stats">{captureStats.join(" • ")}</div>}
+                                  <div className="xmb-game-hub-capture-date">{new Date(item.createdAtMs).toLocaleDateString(undefined, { month: "short", day: "numeric" })}</div>
+                                </div>
+                              </button>
+                            );
+                          })}
+                          </div>
+
+                          {selectedGameHubMedia && (
+                            <div className="xmb-game-hub-actions-wrap">
+                              <div className="xmb-game-hub-actions-header">
+                                Selected Moment: {selectedGameHubMedia.gameTitle || selectedGameHubMedia.fileName}
+                              </div>
+                              <div className="xmb-game-hub-actions">
+                                <button
+                                  type="button"
+                                  className="xmb-game-hub-action"
+                                  onClick={() => { void handleGameHubReveal(); }}
+                                  disabled={gameHubActionBusy !== null}
+                                >
+                                  <FolderOpen size={14} />
+                                  <span>{gameHubActionBusy === "reveal" ? "Opening..." : "Reveal in Finder"}</span>
+                                </button>
+                                <button
+                                  type="button"
+                                  className="xmb-game-hub-action"
+                                  onClick={() => { void handleGameHubExport(); }}
+                                  disabled={gameHubActionBusy !== null}
+                                >
+                                  <Share2 size={14} />
+                                  <span>Browse Export Folder</span>
+                                </button>
+                                <button
+                                  type="button"
+                                  className="xmb-game-hub-action xmb-game-hub-action--danger"
+                                  onClick={() => { void handleGameHubDelete(); }}
+                                  disabled={gameHubActionBusy !== null}
+                                >
+                                  <Trash2 size={14} />
+                                  <span>{gameHubActionBusy === "delete" ? "Deleting..." : "Delete"}</span>
+                                </button>
+                              </div>
+                              {gameHubActionMessage && <div className="xmb-game-hub-action-message">{gameHubActionMessage}</div>}
+                            </div>
+                          )}
+                        </>
                       )}
-                    </>
-                  )}
-                </div>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           )}
@@ -1739,11 +1961,13 @@ export function ControllerLibraryPage({
           </>
         ) : (
           <>
-            <div className="xmb-btn-hint">{renderFaceButton("primary", "xmb-btn-icon", 24)} <span>{currentStreamingGame && selectedGame && currentStreamingGame.id !== selectedGame.id ? "Switch" : "Play"}</span></div>
+            <div className="xmb-btn-hint">{renderFaceButton("primary", "xmb-btn-icon", 24)} <span>{showGameHub && isGameHubExpanded ? "Select" : currentStreamingGame && selectedGame && currentStreamingGame.id !== selectedGame.id ? "Switch" : "Play"}</span></div>
             {showGameHub ? (
               <>
-                <div className="xmb-btn-hint">{renderFaceButton("secondary", "xmb-btn-icon", 24)} <span>{isGameHubExpanded ? "Close Hub" : "Toggle Hub"}</span></div>
-                <div className="xmb-btn-hint">{renderFaceButton("tertiary", "xmb-btn-icon", 24)} <span>{isGameHubExpanded && selectedGameHubMedia ? "Delete Moment" : "Favorite"}</span></div>
+                <div className="xmb-btn-hint">{renderFaceButton("secondary", "xmb-btn-icon", 24)} <span>{isGameHubExportBrowserOpen ? "Close Browser" : isGameHubExpanded ? "Close Hub" : "Toggle Hub"}</span></div>
+                {!isGameHubExportBrowserOpen && (
+                  <div className="xmb-btn-hint">{renderFaceButton("tertiary", "xmb-btn-icon", 24)} <span>{isGameHubExpanded && selectedGameHubMedia ? "Delete Moment" : "Favorite"}</span></div>
+                )}
               </>
             ) : selectedGame?.variants.length && selectedGame.variants.length > 1 ? (
               <div className="xmb-btn-hint">{renderFaceButton("secondary", "xmb-btn-icon", 24)} <span>Variant</span></div>

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
-import type { GameInfo, MediaListingEntry, Settings } from "@shared/gfn";
-import { Star, Clock, Calendar, Repeat2 } from "lucide-react";
+import type { GameInfo, MediaListingEntry, MediaSessionSummary, Settings } from "@shared/gfn";
+import { Star, Clock, Calendar, Repeat2, FolderOpen, Share2, Trash2 } from "lucide-react";
 import { ButtonA, ButtonB, ButtonX, ButtonY, ButtonPSCross, ButtonPSCircle, ButtonPSSquare, ButtonPSTriangle } from "./ControllerButtons";
 import { getStoreDisplayName } from "./GameCard";
 import { type PlaytimeStore, formatPlaytime, formatLastPlayed } from "../utils/usePlaytime";
@@ -95,6 +95,24 @@ function getCategoryLabel(categoryId: string, currentGameTitle?: string): { labe
   return { label: display };
 }
 
+function formatMediaBitrate(kbps: number | undefined): string | null {
+  if (typeof kbps !== "number" || !Number.isFinite(kbps) || kbps <= 0) return null;
+  if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
+  return `${Math.round(kbps)} kbps`;
+}
+
+function formatSessionElapsedCompact(totalSeconds: number | undefined): string | null {
+  if (typeof totalSeconds !== "number" || !Number.isFinite(totalSeconds) || totalSeconds < 0) return null;
+
+  const safe = Math.floor(totalSeconds);
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+
+  if (hours > 0) return `${hours}h ${minutes.toString().padStart(2, "0")}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${safe}s`;
+}
+
 
 export function ControllerLibraryPage({
   games,
@@ -176,7 +194,12 @@ export function ControllerLibraryPage({
   const [mediaScreenshots, setMediaScreenshots] = useState<MediaListingEntry[]>([]);
   const [mediaThumbById, setMediaThumbById] = useState<Record<string, string>>({});
   const [gameHubMedia, setGameHubMedia] = useState<GameHubMediaItem[]>([]);
+  const [gameHubSummary, setGameHubSummary] = useState<MediaSessionSummary | null>(null);
   const [gameHubMediaLoading, setGameHubMediaLoading] = useState(false);
+  const [selectedGameHubMediaIndex, setSelectedGameHubMediaIndex] = useState(0);
+  const [gameHubActionBusy, setGameHubActionBusy] = useState<"reveal" | "export" | "delete" | null>(null);
+  const [gameHubActionMessage, setGameHubActionMessage] = useState<string | null>(null);
+  const [isGameHubExpanded, setIsGameHubExpanded] = useState(false);
   const [controllerType, setControllerType] = useState<"ps" | "xbox" | "nintendo" | "generic">("generic");
   const [editingBandwidth, setEditingBandwidth] = useState(false);
 
@@ -491,55 +514,198 @@ export function ControllerLibraryPage({
     if (currentStreamingGame.id === selectedGame.id) return "Active Session";
     return "Ready To Switch";
   }, [currentStreamingGame, selectedGame]);
+  const handleStartSelectedGame = useCallback((): void => {
+    if (showGameHub && selectedGame) {
+      if (currentStreamingGame && currentStreamingGame.id === selectedGame.id && onResumeGame) {
+        onResumeGame(currentStreamingGame);
+        return;
+      }
+      onPlayGame(selectedGame);
+      return;
+    }
+
+    if (topCategory === "current") {
+      if (currentStreamingGame && onResumeGame) {
+        onResumeGame(currentStreamingGame);
+      }
+      return;
+    }
+
+    if (topCategory !== "settings" && topCategory !== "media" && selectedGame) {
+      onPlayGame(selectedGame);
+    }
+  }, [currentStreamingGame, onPlayGame, onResumeGame, selectedGame, showGameHub, topCategory]);
+  const selectedGameHubMedia = useMemo(
+    () => gameHubMedia[selectedGameHubMediaIndex] ?? null,
+    [gameHubMedia, selectedGameHubMediaIndex],
+  );
+  const gameHubSnapshotChips = useMemo(() => {
+    if (!gameHubSummary) return [];
+
+    const chips: string[] = [`${gameHubSummary.totalCaptures} Moment${gameHubSummary.totalCaptures === 1 ? "" : "s"}`];
+
+    if (gameHubSummary.latestResolution) {
+      const fpsLabel =
+        typeof gameHubSummary.latestDecodeFps === "number" && Number.isFinite(gameHubSummary.latestDecodeFps) && gameHubSummary.latestDecodeFps > 0
+          ? ` @ ${Math.round(gameHubSummary.latestDecodeFps)} FPS`
+          : "";
+      chips.push(`${gameHubSummary.latestResolution}${fpsLabel}`);
+    }
+
+    const bitrateLabel = formatMediaBitrate(gameHubSummary.latestBitrateKbps);
+    if (bitrateLabel) chips.push(bitrateLabel);
+
+    if (
+      typeof gameHubSummary.latestRttMs === "number" &&
+      Number.isFinite(gameHubSummary.latestRttMs) &&
+      gameHubSummary.latestRttMs >= 0
+    ) {
+      chips.push(`${Math.round(gameHubSummary.latestRttMs)} ms RTT`);
+    }
+
+    return chips;
+  }, [gameHubSummary]);
+  const gameHubSnapshotCaption = useMemo(() => {
+    if (!gameHubSummary) return null;
+
+    const parts: string[] = [
+      `${gameHubSummary.videos} clip${gameHubSummary.videos === 1 ? "" : "s"}`,
+      `${gameHubSummary.screenshots} shot${gameHubSummary.screenshots === 1 ? "" : "s"}`,
+    ];
+
+    const elapsedLabel = formatSessionElapsedCompact(gameHubSummary.latestSessionElapsedSeconds);
+    if (elapsedLabel) parts.push(`session ${elapsedLabel}`);
+
+    if (gameHubSummary.lastCapturedAtMs > 0) {
+      parts.push(
+        `updated ${new Date(gameHubSummary.lastCapturedAtMs).toLocaleDateString(undefined, {
+          month: "short",
+          day: "numeric",
+        })}`,
+      );
+    }
+
+    return parts.join(" • ");
+  }, [gameHubSummary]);
+
+  const loadGameHubMedia = useCallback(async (gameTitle: string, cancelled?: () => boolean) => {
+    const listing = await window.openNow.listMediaByGame({ gameTitle });
+    if (cancelled?.()) return;
+
+    const recentItems: GameHubMediaItem[] = [
+      ...(listing.videos ?? []).map((item) => ({ ...item, kind: "video" as const })),
+      ...(listing.screenshots ?? []).map((item) => ({ ...item, kind: "screenshot" as const })),
+    ]
+      .sort((left, right) => right.createdAtMs - left.createdAtMs)
+      .slice(0, 2);
+
+    setGameHubMedia(recentItems);
+    setGameHubSummary(listing.summary ?? null);
+
+    const thumbEntries = await Promise.all(
+      recentItems.map(async (item): Promise<[string, string | null]> => {
+        if (item.thumbnailDataUrl) return [item.id, item.thumbnailDataUrl];
+        if (item.dataUrl) return [item.id, item.dataUrl];
+        if (typeof window.openNow?.getMediaThumbnail === "function") {
+          const generated = await window.openNow.getMediaThumbnail({ filePath: item.filePath });
+          return [item.id, generated];
+        }
+        return [item.id, null];
+      }),
+    );
+
+    if (cancelled?.()) return;
+    setMediaThumbById((prev) => {
+      const next = { ...prev };
+      for (const [id, url] of thumbEntries) {
+        if (url) next[id] = url;
+      }
+      return next;
+    });
+  }, []);
+
+  const handleGameHubReveal = useCallback(async () => {
+    if (!selectedGameHubMedia || typeof window.openNow?.showMediaInFolder !== "function") return;
+    setGameHubActionBusy("reveal");
+    setGameHubActionMessage(null);
+    try {
+      await window.openNow.showMediaInFolder({ filePath: selectedGameHubMedia.filePath });
+      playUiSound("confirm");
+    } catch {
+      setGameHubActionMessage("Unable to reveal moment.");
+    } finally {
+      setGameHubActionBusy(null);
+    }
+  }, [playUiSound, selectedGameHubMedia]);
+
+  const handleGameHubExport = useCallback(async () => {
+    if (!selectedGameHubMedia || typeof window.openNow?.exportMedia !== "function") return;
+    setGameHubActionBusy("export");
+    setGameHubActionMessage(null);
+    try {
+      const result = await window.openNow.exportMedia({
+        filePath: selectedGameHubMedia.filePath,
+        fileName: selectedGameHubMedia.fileName,
+      });
+      if (result.saved) {
+        playUiSound("confirm");
+      }
+    } catch {
+      setGameHubActionMessage("Unable to export moment.");
+    } finally {
+      setGameHubActionBusy(null);
+    }
+  }, [playUiSound, selectedGameHubMedia]);
+
+  const handleGameHubDelete = useCallback(async () => {
+    if (!selectedGameHubMedia) return;
+    setGameHubActionBusy("delete");
+    setGameHubActionMessage(null);
+    try {
+      if (selectedGameHubMedia.kind === "screenshot") {
+        await window.openNow.deleteScreenshot({ id: selectedGameHubMedia.id });
+      } else {
+        await window.openNow.deleteRecording({ id: selectedGameHubMedia.id });
+      }
+
+      if (selectedGame?.title && typeof window.openNow?.listMediaByGame === "function") {
+        await loadGameHubMedia(selectedGame.title);
+      } else {
+        setGameHubMedia((prev) => prev.filter((item) => item.id !== selectedGameHubMedia.id));
+      }
+      playUiSound("confirm");
+    } catch {
+      setGameHubActionMessage("Unable to delete moment.");
+    } finally {
+      setGameHubActionBusy(null);
+    }
+  }, [loadGameHubMedia, playUiSound, selectedGame?.title, selectedGameHubMedia]);
 
   useEffect(() => {
     if (!showGameHub || !selectedGame?.title || typeof window.openNow?.listMediaByGame !== "function") {
       setGameHubMedia([]);
+      setGameHubSummary(null);
+      setSelectedGameHubMediaIndex(0);
+      setGameHubActionMessage(null);
+      setIsGameHubExpanded(false);
       setGameHubMediaLoading(false);
       return;
     }
 
     let cancelled = false;
     setGameHubMedia([]);
+    setGameHubSummary(null);
     setGameHubMediaLoading(true);
 
     const timeoutId = window.setTimeout(() => {
       void (async () => {
         try {
-          const listing = await window.openNow.listMediaByGame({ gameTitle: selectedGame.title });
-          if (cancelled) return;
-
-          const recentItems: GameHubMediaItem[] = [
-            ...(listing.videos ?? []).map((item) => ({ ...item, kind: "video" as const })),
-            ...(listing.screenshots ?? []).map((item) => ({ ...item, kind: "screenshot" as const })),
-          ]
-            .sort((left, right) => right.createdAtMs - left.createdAtMs)
-            .slice(0, 2);
-
-          setGameHubMedia(recentItems);
-
-          const thumbEntries = await Promise.all(
-            recentItems.map(async (item): Promise<[string, string | null]> => {
-              if (item.thumbnailDataUrl) return [item.id, item.thumbnailDataUrl];
-              if (item.dataUrl) return [item.id, item.dataUrl];
-              if (typeof window.openNow?.getMediaThumbnail === "function") {
-                const generated = await window.openNow.getMediaThumbnail({ filePath: item.filePath });
-                return [item.id, generated];
-              }
-              return [item.id, null];
-            }),
-          );
-
-          if (cancelled) return;
-          setMediaThumbById((prev) => {
-            const next = { ...prev };
-            for (const [id, url] of thumbEntries) {
-              if (url) next[id] = url;
-            }
-            return next;
-          });
+          await loadGameHubMedia(selectedGame.title, () => cancelled);
         } catch {
-          if (!cancelled) setGameHubMedia([]);
+          if (!cancelled) {
+            setGameHubMedia([]);
+            setGameHubSummary(null);
+          }
         } finally {
           if (!cancelled) setGameHubMediaLoading(false);
         }
@@ -550,7 +716,37 @@ export function ControllerLibraryPage({
       cancelled = true;
       window.clearTimeout(timeoutId);
     };
-  }, [selectedGame?.id, selectedGame?.title, showGameHub]);
+  }, [loadGameHubMedia, selectedGame?.id, selectedGame?.title, showGameHub]);
+
+  useEffect(() => {
+    setSelectedGameHubMediaIndex((prev) => Math.min(prev, Math.max(0, gameHubMedia.length - 1)));
+  }, [gameHubMedia.length]);
+
+  useEffect(() => {
+    if (!showGameHub || !isGameHubExpanded) {
+      document.querySelectorAll<HTMLElement>(".xmb-game-hub .controller-focus").forEach((node) => {
+        node.classList.remove("controller-focus");
+      });
+      return;
+    }
+
+    const buttons = getGameHubButtons();
+    if (buttons.length === 0) return;
+
+    const active = document.activeElement instanceof HTMLButtonElement && buttons.includes(document.activeElement)
+      ? document.activeElement
+      : null;
+    const selectedCapture = buttons.find((button) => button.dataset.hubMediaIndex === String(selectedGameHubMediaIndex)) ?? null;
+    const nextButton = active ?? selectedCapture ?? buttons[0];
+    focusGameHubButton(nextButton);
+    syncGameHubSelectionFromButton(nextButton);
+  }, [focusGameHubButton, getGameHubButtons, isGameHubExpanded, selectedGameHubMediaIndex, showGameHub, syncGameHubSelectionFromButton, gameHubMedia.length]);
+
+  useEffect(() => {
+    setSelectedGameHubMediaIndex(0);
+    setGameHubActionMessage(null);
+    setIsGameHubExpanded(false);
+  }, [selectedGame?.id]);
 
 
 
@@ -577,6 +773,53 @@ export function ControllerLibraryPage({
     }
   }, [onToggleFavoriteGame, playUiSound, selectedGame]);
 
+  function getGameHubButtons(): HTMLButtonElement[] {
+    return Array.from(document.querySelectorAll<HTMLButtonElement>(".xmb-game-hub button:not([disabled])")).filter((button) => button.offsetParent !== null);
+  }
+
+  function focusGameHubButton(button: HTMLButtonElement): void {
+    document.querySelectorAll<HTMLElement>(".controller-focus").forEach((node) => {
+      node.classList.remove("controller-focus");
+    });
+    button.classList.add("controller-focus");
+    button.focus({ preventScroll: true });
+  }
+
+  function syncGameHubSelectionFromButton(button: HTMLButtonElement): void {
+    const mediaIndex = button.dataset.hubMediaIndex;
+    if (mediaIndex === undefined) return;
+    const nextIndex = Number.parseInt(mediaIndex, 10);
+    if (Number.isFinite(nextIndex)) {
+      setSelectedGameHubMediaIndex(nextIndex);
+    }
+  }
+
+  function moveGameHubFocus(direction: Direction): boolean {
+    const buttons = getGameHubButtons();
+    if (buttons.length === 0) return false;
+
+    const active = document.activeElement instanceof HTMLButtonElement && buttons.includes(document.activeElement)
+      ? document.activeElement
+      : null;
+
+    if (!active) {
+      playUiSound("move");
+      focusGameHubButton(buttons[0]);
+      syncGameHubSelectionFromButton(buttons[0]);
+      return true;
+    }
+
+    const currentIndex = buttons.indexOf(active);
+    const step = direction === "up" || direction === "left" ? -1 : 1;
+    const nextButton = buttons[(currentIndex + step + buttons.length) % buttons.length];
+    if (nextButton === active) return true;
+
+    playUiSound("move");
+    focusGameHubButton(nextButton);
+    syncGameHubSelectionFromButton(nextButton);
+    return true;
+  }
+
   useEffect(() => {
     const applyDirection = (direction: Direction): void => {
       // When editing the bandwidth slider, use left/right to adjust value
@@ -595,6 +838,10 @@ export function ControllerLibraryPage({
           playUiSound("move");
           return;
         }
+      }
+      if (showGameHub && isGameHubExpanded) {
+        moveGameHubFocus(direction);
+        return;
       }
       if (isLoading && topCategory !== "settings" && topCategory !== "current") return;
       if (direction === "left") {
@@ -768,6 +1015,11 @@ export function ControllerLibraryPage({
     };
 
     const secondaryActivateHandler = () => {
+      if (showGameHub) {
+        setIsGameHubExpanded((prev) => !prev);
+        playUiSound("confirm");
+        return;
+      }
         if (topCategory === "current") {
           // X button does nothing on current game menu items
           return;
@@ -843,7 +1095,16 @@ export function ControllerLibraryPage({
       }
     };
 
+    const startHandler = () => {
+      handleStartSelectedGame();
+      playUiSound("confirm");
+    };
+
     const tertiaryActivateHandler = () => {
+      if (showGameHub && isGameHubExpanded && selectedGameHubMedia) {
+        void handleGameHubDelete();
+        return;
+      }
       if (topCategory !== "settings" && topCategory !== "current") {
         toggleFavoriteForSelected();
       }
@@ -861,6 +1122,14 @@ export function ControllerLibraryPage({
         }
         setSettingsSubcategory("root");
         setSelectedSettingIndex(lastRootSettingIndex);
+        playUiSound("move");
+        e.preventDefault();
+        return;
+      }
+      if (showGameHub) {
+        if (isGameHubExpanded) {
+          setIsGameHubExpanded(false);
+        }
         playUiSound("move");
         e.preventDefault();
         return;
@@ -934,6 +1203,7 @@ export function ControllerLibraryPage({
 
     window.addEventListener("opennow:controller-direction", handler);
     window.addEventListener("opennow:controller-activate", activateHandler);
+    window.addEventListener("opennow:controller-start", startHandler);
     window.addEventListener("opennow:controller-secondary-activate", secondaryActivateHandler);
     window.addEventListener("opennow:controller-tertiary-activate", tertiaryActivateHandler);
     window.addEventListener("opennow:controller-cancel", cancelHandler);
@@ -941,12 +1211,13 @@ export function ControllerLibraryPage({
     return () => {
       window.removeEventListener("opennow:controller-direction", handler);
       window.removeEventListener("opennow:controller-activate", activateHandler);
+      window.removeEventListener("opennow:controller-start", startHandler);
       window.removeEventListener("opennow:controller-secondary-activate", secondaryActivateHandler);
       window.removeEventListener("opennow:controller-tertiary-activate", tertiaryActivateHandler);
       window.removeEventListener("opennow:controller-cancel", cancelHandler);
       window.removeEventListener("keydown", kbdHandler);
     };
-  }, [isLoading, TOP_CATEGORIES.length, categorizedGames, selectedIndex, selectedGame, selectedVariantId, onPlayGame, onSelectGameVariant, onOpenSettings, playUiSound, throttledOnSelectGame, toggleFavoriteForSelected, topCategory, selectedSettingIndex, selectedMediaIndex, displayItems, mediaAssetItems.length, mediaSubcategory, settings, settingsBySubcategory, settingsSubcategory, lastRootSettingIndex, lastRootMediaIndex, onSettingChange, resolutionOptions, fpsOptions, codecOptions, aspectRatioOptions, currentStreamingGame, onResumeGame, onCloseGame, onExitControllerMode, onExitApp, editingBandwidth]);
+  }, [isLoading, TOP_CATEGORIES.length, categorizedGames, selectedIndex, selectedGame, selectedVariantId, onPlayGame, onSelectGameVariant, onOpenSettings, playUiSound, throttledOnSelectGame, toggleFavoriteForSelected, topCategory, selectedSettingIndex, selectedMediaIndex, displayItems, mediaAssetItems.length, mediaSubcategory, settings, settingsBySubcategory, settingsSubcategory, lastRootSettingIndex, lastRootMediaIndex, onSettingChange, resolutionOptions, fpsOptions, codecOptions, aspectRatioOptions, currentStreamingGame, onResumeGame, onCloseGame, onExitControllerMode, onExitApp, editingBandwidth, showGameHub, selectedGameHubMedia, handleGameHubReveal, handleGameHubExport, handleGameHubDelete, gameHubMedia.length, selectedGameHubMediaIndex, moveGameHubFocus]);
 
   const renderFaceButton = (kind: "primary" | "secondary" | "tertiary", className: string, size: number): JSX.Element => {
     if (kind === "primary") {
@@ -1271,7 +1542,7 @@ export function ControllerLibraryPage({
               </div>
             </div>
           )}
-          {showGameHub && selectedGame && (
+          {showGameHub && isGameHubExpanded && selectedGame && (
             <div className="xmb-game-hub">
               <div className="xmb-game-hub-panel">
                 <div className="xmb-game-hub-eyebrow">{topCategory === "all" ? "Game Hub" : selectedCategoryLabel}</div>
@@ -1284,6 +1555,20 @@ export function ControllerLibraryPage({
                   {selectedGameSessionState && <span className="xmb-game-meta-chip xmb-game-meta-chip--session">{selectedGameSessionState}</span>}
                 </div>
 
+                {gameHubSummary && (
+                  <div className="xmb-game-hub-snapshot">
+                    <div className="xmb-game-hub-section-title">Session Snapshot</div>
+                    <div className="xmb-game-meta xmb-game-hub-meta">
+                      {gameHubSnapshotChips.map((chip, index) => (
+                        <span key={`${index}-${chip}`} className="xmb-game-meta-chip">
+                          {chip}
+                        </span>
+                      ))}
+                    </div>
+                    {gameHubSnapshotCaption && <div className="xmb-game-hub-snapshot-caption">{gameHubSnapshotCaption}</div>}
+                  </div>
+                )}
+
                 <div className="xmb-game-hub-captures">
                   {gameHubMediaLoading ? (
                     <div className="xmb-game-hub-capture-empty">Scanning recent captures...</div>
@@ -1293,23 +1578,79 @@ export function ControllerLibraryPage({
                     <>
                       <div className="xmb-game-hub-section-title">Recent Captures</div>
                       <div className="xmb-game-hub-capture-grid">
-                      {gameHubMedia.map((item) => {
+                        {gameHubMedia.map((item, index) => {
+                        const isActiveMoment = selectedGameHubMedia?.id === item.id;
                         const thumb = mediaThumbById[item.id] ?? item.thumbnailDataUrl ?? item.dataUrl;
                         const captureLabel = item.kind === "video"
                           ? `${Math.max(1, Math.round((item.durationMs ?? 0) / 1000))}s Clip`
                           : "Screenshot";
+                        const captureStats = [
+                          item.sessionSnapshot?.resolution,
+                          formatMediaBitrate(item.sessionSnapshot?.bitrateKbps),
+                          typeof item.sessionSnapshot?.rttMs === "number" && Number.isFinite(item.sessionSnapshot.rttMs)
+                            ? `${Math.round(item.sessionSnapshot.rttMs)} ms`
+                            : null,
+                        ].filter((value): value is string => Boolean(value));
 
                         return (
-                          <div key={item.id} className="xmb-game-hub-capture">
+                          <button
+                            key={item.id}
+                            type="button"
+                            className={`xmb-game-hub-capture ${isActiveMoment ? "active" : ""}`}
+                            data-hub-media-index={index}
+                            onClick={() => {
+                              setSelectedGameHubMediaIndex(gameHubMedia.findIndex((media) => media.id === item.id));
+                              setGameHubActionMessage(null);
+                            }}
+                          >
                             {thumb && <img src={thumb} alt={item.fileName} className="xmb-game-hub-capture-image" />}
                             <div className="xmb-game-hub-capture-meta">
                               <div className="xmb-game-hub-capture-name">{captureLabel}</div>
+                              {captureStats.length > 0 && <div className="xmb-game-hub-capture-stats">{captureStats.join(" • ")}</div>}
                               <div className="xmb-game-hub-capture-date">{new Date(item.createdAtMs).toLocaleDateString(undefined, { month: "short", day: "numeric" })}</div>
                             </div>
-                          </div>
+                          </button>
                         );
                       })}
                       </div>
+
+                      {selectedGameHubMedia && (
+                        <div className="xmb-game-hub-actions-wrap">
+                          <div className="xmb-game-hub-actions-header">
+                            Selected Moment: {selectedGameHubMedia.gameTitle || selectedGameHubMedia.fileName}
+                          </div>
+                          <div className="xmb-game-hub-actions">
+                            <button
+                              type="button"
+                              className="xmb-game-hub-action"
+                              onClick={() => { void handleGameHubReveal(); }}
+                              disabled={gameHubActionBusy !== null}
+                            >
+                              <FolderOpen size={14} />
+                              <span>{gameHubActionBusy === "reveal" ? "Opening..." : "Reveal in Finder"}</span>
+                            </button>
+                            <button
+                              type="button"
+                              className="xmb-game-hub-action"
+                              onClick={() => { void handleGameHubExport(); }}
+                              disabled={gameHubActionBusy !== null}
+                            >
+                              <Share2 size={14} />
+                              <span>{gameHubActionBusy === "export" ? "Exporting..." : "Export / Share"}</span>
+                            </button>
+                            <button
+                              type="button"
+                              className="xmb-game-hub-action xmb-game-hub-action--danger"
+                              onClick={() => { void handleGameHubDelete(); }}
+                              disabled={gameHubActionBusy !== null}
+                            >
+                              <Trash2 size={14} />
+                              <span>{gameHubActionBusy === "delete" ? "Deleting..." : "Delete"}</span>
+                            </button>
+                          </div>
+                          {gameHubActionMessage && <div className="xmb-game-hub-action-message">{gameHubActionMessage}</div>}
+                        </div>
+                      )}
                     </>
                   )}
                 </div>
@@ -1399,10 +1740,15 @@ export function ControllerLibraryPage({
         ) : (
           <>
             <div className="xmb-btn-hint">{renderFaceButton("primary", "xmb-btn-icon", 24)} <span>{currentStreamingGame && selectedGame && currentStreamingGame.id !== selectedGame.id ? "Switch" : "Play"}</span></div>
-            {selectedGame?.variants.length && selectedGame.variants.length > 1 && (
+            {showGameHub ? (
+              <>
+                <div className="xmb-btn-hint">{renderFaceButton("secondary", "xmb-btn-icon", 24)} <span>{isGameHubExpanded ? "Close Hub" : "Toggle Hub"}</span></div>
+                <div className="xmb-btn-hint">{renderFaceButton("tertiary", "xmb-btn-icon", 24)} <span>{isGameHubExpanded && selectedGameHubMedia ? "Delete Moment" : "Favorite"}</span></div>
+              </>
+            ) : selectedGame?.variants.length && selectedGame.variants.length > 1 ? (
               <div className="xmb-btn-hint">{renderFaceButton("secondary", "xmb-btn-icon", 24)} <span>Variant</span></div>
-            )}
-            {selectedGame && (
+            ) : null}
+            {selectedGame && !showGameHub && (
               <div className="xmb-btn-hint">{renderFaceButton("tertiary", "xmb-btn-icon", 24)} <span>{favoriteGameIdSet.has(selectedGame.id) ? "Unfavorite" : "Favorite"}</span></div>
             )}
           </>

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import type { GameInfo, MediaExportBrowserResult, MediaListingEntry, MediaSessionSummary, Settings } from "@shared/gfn";
-import { Star, Clock, Calendar, Repeat2, FolderOpen, Share2, Trash2 } from "lucide-react";
+import { Star, Clock, Calendar, Repeat2, FolderOpen, Share2, Trash2, X } from "lucide-react";
 import { ButtonA, ButtonB, ButtonX, ButtonY, ButtonPSCross, ButtonPSCircle, ButtonPSSquare, ButtonPSTriangle } from "./ControllerButtons";
 import { getStoreDisplayName } from "./GameCard";
 import { type PlaytimeStore, formatPlaytime, formatLastPlayed } from "../utils/usePlaytime";
@@ -47,6 +47,7 @@ interface ControllerLibraryPageProps {
   onSettingChange?: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
   onExitControllerMode?: () => void;
   sessionElapsedSeconds?: number;
+  onOpenMediaAsset?: (asset: MediaListingEntry) => void;
 }
 
 type Direction = "up" | "down" | "left" | "right";
@@ -59,6 +60,7 @@ type GameHubMediaItem = MediaListingEntry & { kind: "video" | "screenshot" };
 const CATEGORY_STEP_PX = 160;
 const CATEGORY_ACTIVE_HALF_WIDTH_PX = 60;
 const GAME_ACTIVE_CENTER_OFFSET_X_PX = 320;
+const MEDIA_VIDEO_SCRUB_SECONDS = 10;
 
 function sanitizeGenreName(raw: string): string {
   return raw
@@ -113,6 +115,15 @@ function formatSessionElapsedCompact(totalSeconds: number | undefined): string |
   return `${safe}s`;
 }
 
+function toLocalFileUrl(filePath: string | undefined): string | null {
+  if (!filePath) return null;
+  const normalized = filePath.replace(/\\/g, "/");
+  if (!normalized) return null;
+  return normalized.startsWith("/")
+    ? encodeURI(`file://${normalized}`)
+    : encodeURI(`file:///${normalized}`);
+}
+
 
 export function ControllerLibraryPage({
   games,
@@ -143,6 +154,7 @@ export function ControllerLibraryPage({
   onSettingChange,
   onExitControllerMode,
   sessionElapsedSeconds = 0,
+  onOpenMediaAsset,
 }: ControllerLibraryPageProps): JSX.Element {
   const [isEntering, setIsEntering] = useState(true);
   const initialCategoryIndex = (() => {
@@ -161,6 +173,9 @@ export function ControllerLibraryPage({
   const [metaMaxWidth, setMetaMaxWidth] = useState<number | null>(null);
   const posterObserverRef = useRef<ResizeObserver | null>(null);
   const gameHubExportBrowseRequestIdRef = useRef(0);
+  const mediaExportBrowseRequestIdRef = useRef(0);
+  const mediaViewerRequestIdRef = useRef(0);
+  const mediaViewerVideoRef = useRef<HTMLVideoElement | null>(null);
   const attachPosterRef = (el: HTMLImageElement | null) => {
     if (posterObserverRef.current) {
       try { posterObserverRef.current.disconnect(); } catch {}
@@ -194,6 +209,16 @@ export function ControllerLibraryPage({
   const [mediaVideos, setMediaVideos] = useState<MediaListingEntry[]>([]);
   const [mediaScreenshots, setMediaScreenshots] = useState<MediaListingEntry[]>([]);
   const [mediaThumbById, setMediaThumbById] = useState<Record<string, string>>({});
+  const [mediaActionBusy, setMediaActionBusy] = useState<"reveal" | "export" | "delete" | null>(null);
+  const [mediaActionMessage, setMediaActionMessage] = useState<string | null>(null);
+  const [isMediaExportBrowserOpen, setIsMediaExportBrowserOpen] = useState(false);
+  const [mediaViewerAsset, setMediaViewerAsset] = useState<MediaListingEntry | null>(null);
+  const [mediaViewerSource, setMediaViewerSource] = useState<string | null>(null);
+  const [mediaViewerLoading, setMediaViewerLoading] = useState(false);
+  const [mediaExportBrowser, setMediaExportBrowser] = useState<MediaExportBrowserResult | null>(null);
+  const [mediaExportBrowserLoading, setMediaExportBrowserLoading] = useState(false);
+  const [mediaExportOverwritePending, setMediaExportOverwritePending] = useState(false);
+  const [lastMediaExportDirectoryPath, setLastMediaExportDirectoryPath] = useState<string | null>(null);
   const [gameHubMedia, setGameHubMedia] = useState<GameHubMediaItem[]>([]);
   const [gameHubSummary, setGameHubSummary] = useState<MediaSessionSummary | null>(null);
   const [gameHubMediaLoading, setGameHubMediaLoading] = useState(false);
@@ -496,6 +521,23 @@ export function ControllerLibraryPage({
   }, [categorizedGames, selectedGameId]);
 
   const selectedGame = useMemo(() => categorizedGames[selectedIndex] ?? null, [categorizedGames, selectedIndex]);
+  const selectedMediaAsset = useMemo(() => {
+    if (topCategory !== "media" || mediaSubcategory === "root") return null;
+    return mediaAssetItems[selectedMediaIndex] ?? null;
+  }, [topCategory, mediaSubcategory, mediaAssetItems, selectedMediaIndex]);
+  const selectedMediaThumb = useMemo(() => {
+    if (!selectedMediaAsset) return null;
+    return mediaThumbById[selectedMediaAsset.id] ?? selectedMediaAsset.thumbnailDataUrl ?? selectedMediaAsset.dataUrl ?? null;
+  }, [mediaThumbById, selectedMediaAsset]);
+  const isMediaViewerVideo = Boolean(mediaViewerAsset && (mediaViewerAsset.durationMs ?? 0) > 0);
+  const scrubMediaViewerVideo = useCallback((direction: "prev" | "next") => {
+    const video = mediaViewerVideoRef.current;
+    if (!video || !isMediaViewerVideo) return;
+    const delta = direction === "next" ? MEDIA_VIDEO_SCRUB_SECONDS : -MEDIA_VIDEO_SCRUB_SECONDS;
+    const duration = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : Number.POSITIVE_INFINITY;
+    const nextTime = Math.min(Math.max(0, video.currentTime + delta), duration);
+    video.currentTime = nextTime;
+  }, [isMediaViewerVideo]);
 
   const selectedVariantId = useMemo(() => {
     if (!selectedGame) return "";
@@ -506,7 +548,8 @@ export function ControllerLibraryPage({
   const isGameHubCategory = topCategory !== "settings" && topCategory !== "current" && topCategory !== "media";
   const showGameHub = isGameHubCategory && Boolean(selectedGame);
   const showCurrentDetail = topCategory === "current" && Boolean(currentStreamingGame);
-  const detailVisible = showCurrentDetail || showGameHub;
+  const showMediaDetail = topCategory === "media" && mediaSubcategory !== "root" && Boolean(selectedMediaAsset);
+  const detailVisible = showCurrentDetail || showGameHub || showMediaDetail;
 
   const selectedCategoryLabel = useMemo(() => getCategoryLabel(topCategory, currentStreamingGame?.title).label, [topCategory, currentStreamingGame?.title]);
   const selectedGameDescription = useMemo(() => {
@@ -593,6 +636,31 @@ export function ControllerLibraryPage({
 
     return parts.join(" • ");
   }, [gameHubSummary]);
+  const selectedMediaDetailChips = useMemo(() => {
+    if (!selectedMediaAsset) return [] as string[];
+
+    const durationMs = selectedMediaAsset.durationMs ?? 0;
+    return [
+      durationMs > 0 ? `${Math.max(1, Math.round(durationMs / 1000))}s Clip` : "Screenshot",
+      new Date(selectedMediaAsset.createdAtMs).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }),
+      selectedMediaAsset.sessionSnapshot?.resolution,
+      formatMediaBitrate(selectedMediaAsset.sessionSnapshot?.bitrateKbps),
+      typeof selectedMediaAsset.sessionSnapshot?.rttMs === "number" && Number.isFinite(selectedMediaAsset.sessionSnapshot.rttMs)
+        ? `${Math.round(selectedMediaAsset.sessionSnapshot.rttMs)} ms`
+        : null,
+    ].filter((value): value is string => Boolean(value));
+  }, [selectedMediaAsset]);
+  const selectedMediaDetailCaption = useMemo(() => {
+    if (!selectedMediaAsset?.sessionSnapshot) return null;
+
+    return [
+      selectedMediaAsset.sessionSnapshot.codec,
+      typeof selectedMediaAsset.sessionSnapshot.packetLossPercent === "number" && Number.isFinite(selectedMediaAsset.sessionSnapshot.packetLossPercent)
+        ? `${selectedMediaAsset.sessionSnapshot.packetLossPercent.toFixed(1)}% loss`
+        : null,
+      selectedMediaAsset.sessionSnapshot.serverRegion,
+    ].filter((value): value is string => Boolean(value)).join(" • ") || null;
+  }, [selectedMediaAsset]);
 
   const loadGameHubMedia = useCallback(async (gameTitle: string, cancelled?: () => boolean) => {
     const listing = await window.openNow.listMediaByGame({ gameTitle });
@@ -760,6 +828,172 @@ export function ControllerLibraryPage({
     }
   }, [loadGameHubMedia, playUiSound, selectedGame?.title, selectedGameHubMedia]);
 
+  const closeMediaExportBrowser = useCallback((clearMessage = true) => {
+    mediaExportBrowseRequestIdRef.current += 1;
+    setIsMediaExportBrowserOpen(false);
+    setMediaExportBrowser(null);
+    setMediaExportBrowserLoading(false);
+    setMediaExportOverwritePending(false);
+    if (clearMessage) {
+      setMediaActionMessage(null);
+    }
+  }, []);
+
+  const closeMediaViewer = useCallback(() => {
+    mediaViewerRequestIdRef.current += 1;
+    setMediaViewerAsset(null);
+    setMediaViewerSource(null);
+    setMediaViewerLoading(false);
+  }, []);
+
+  const loadMediaExportBrowser = useCallback(async (directoryPath?: string) => {
+    if (typeof window.openNow?.browseMediaExportLocations !== "function") {
+      throw new Error("Export browser unavailable");
+    }
+
+    const requestId = mediaExportBrowseRequestIdRef.current + 1;
+    mediaExportBrowseRequestIdRef.current = requestId;
+    setMediaExportBrowserLoading(true);
+    setMediaActionMessage(null);
+    setMediaExportOverwritePending(false);
+
+    try {
+      const result = await window.openNow.browseMediaExportLocations(directoryPath ? { directoryPath } : {});
+      if (mediaExportBrowseRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      setMediaExportBrowser(result);
+      setLastMediaExportDirectoryPath(result.currentPath);
+    } finally {
+      if (mediaExportBrowseRequestIdRef.current === requestId) {
+        setMediaExportBrowserLoading(false);
+      }
+    }
+  }, []);
+
+  const handleMediaOpen = useCallback(async (asset?: MediaListingEntry | null) => {
+    const targetAsset = asset ?? selectedMediaAsset;
+    if (!targetAsset) return;
+    const requestId = mediaViewerRequestIdRef.current + 1;
+    mediaViewerRequestIdRef.current = requestId;
+    setMediaActionMessage(null);
+    setMediaViewerAsset(targetAsset);
+    setMediaViewerSource(targetAsset.dataUrl ?? null);
+    setMediaViewerLoading(!targetAsset.dataUrl);
+    playUiSound("confirm");
+
+    if (targetAsset.dataUrl) {
+      return;
+    }
+
+    try {
+      const resolvedSource = typeof window.openNow?.getMediaDataUrl === "function"
+        ? await window.openNow.getMediaDataUrl({ filePath: targetAsset.filePath })
+        : toLocalFileUrl(targetAsset.filePath);
+
+      if (mediaViewerRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      if (!resolvedSource) {
+        closeMediaViewer();
+        setMediaActionMessage("Unable to open media.");
+        return;
+      }
+
+      setMediaViewerSource(resolvedSource);
+    } catch {
+      if (mediaViewerRequestIdRef.current === requestId) {
+        closeMediaViewer();
+        setMediaActionMessage("Unable to open media.");
+      }
+    } finally {
+      if (mediaViewerRequestIdRef.current === requestId) {
+        setMediaViewerLoading(false);
+      }
+    }
+  }, [closeMediaViewer, playUiSound, selectedMediaAsset]);
+
+  const handleMediaExport = useCallback(async () => {
+    if (!selectedMediaAsset) return;
+    setIsMediaExportBrowserOpen(true);
+    setMediaExportBrowser(null);
+    try {
+      await loadMediaExportBrowser(lastMediaExportDirectoryPath ?? undefined);
+      playUiSound("confirm");
+    } catch {
+      closeMediaExportBrowser(false);
+      setMediaActionMessage("Unable to browse export folders.");
+    }
+  }, [closeMediaExportBrowser, lastMediaExportDirectoryPath, loadMediaExportBrowser, playUiSound, selectedMediaAsset]);
+
+  const handleMediaExportNavigate = useCallback(async (directoryPath: string) => {
+    try {
+      await loadMediaExportBrowser(directoryPath);
+      playUiSound("move");
+    } catch {
+      setMediaActionMessage("Unable to open that folder.");
+    }
+  }, [loadMediaExportBrowser, playUiSound]);
+
+  const handleMediaExportSubmit = useCallback(async () => {
+    if (!selectedMediaAsset || !mediaExportBrowser || typeof window.openNow?.exportMedia !== "function") return;
+
+    setMediaActionBusy("export");
+    setMediaActionMessage(null);
+    try {
+      const result = await window.openNow.exportMedia({
+        filePath: selectedMediaAsset.filePath,
+        fileName: selectedMediaAsset.fileName,
+        destinationDirectoryPath: mediaExportBrowser.currentPath,
+        overwrite: mediaExportOverwritePending,
+      });
+
+      if (result.saved) {
+        setLastMediaExportDirectoryPath(mediaExportBrowser.currentPath);
+        closeMediaExportBrowser();
+        playUiSound("confirm");
+        return;
+      }
+
+      if (result.alreadyExists) {
+        setMediaExportOverwritePending(true);
+        setMediaActionMessage("A file with that name already exists here.");
+      }
+    } catch {
+      setMediaActionMessage("Unable to export media.");
+    } finally {
+      setMediaActionBusy(null);
+    }
+  }, [closeMediaExportBrowser, mediaExportBrowser, mediaExportOverwritePending, playUiSound, selectedMediaAsset]);
+
+  const handleMediaDelete = useCallback(async () => {
+    if (!selectedMediaAsset) return;
+    setMediaActionBusy("delete");
+    setMediaActionMessage(null);
+    try {
+      if (mediaSubcategory === "Screenshots") {
+        await window.openNow.deleteScreenshot({ id: selectedMediaAsset.id });
+        setMediaScreenshots((prev) => prev.filter((item) => item.id !== selectedMediaAsset.id));
+      } else {
+        await window.openNow.deleteRecording({ id: selectedMediaAsset.id });
+        setMediaVideos((prev) => prev.filter((item) => item.id !== selectedMediaAsset.id));
+      }
+      setMediaThumbById((prev) => {
+        const next = { ...prev };
+        delete next[selectedMediaAsset.id];
+        return next;
+      });
+      closeMediaExportBrowser();
+      playUiSound("confirm");
+    } catch {
+      setMediaActionMessage("Unable to delete media.");
+    } finally {
+      setMediaActionBusy(null);
+    }
+  }, [closeMediaExportBrowser, mediaSubcategory, playUiSound, selectedMediaAsset]);
+
   useEffect(() => {
     if (!showGameHub || !selectedGame?.title || typeof window.openNow?.listMediaByGame !== "function") {
       setGameHubMedia([]);
@@ -806,6 +1040,11 @@ export function ControllerLibraryPage({
   }, [gameHubMedia.length]);
 
   useEffect(() => {
+    if (topCategory !== "media" || mediaSubcategory === "root") return;
+    setSelectedMediaIndex((prev) => Math.min(prev, Math.max(0, mediaAssetItems.length - 1)));
+  }, [mediaAssetItems.length, mediaSubcategory, topCategory]);
+
+  useEffect(() => {
     if (!showGameHub || !isGameHubExpanded) {
       document.querySelectorAll<HTMLElement>(".xmb-game-hub .controller-focus").forEach((node) => {
         node.classList.remove("controller-focus");
@@ -826,6 +1065,29 @@ export function ControllerLibraryPage({
   }, [focusGameHubButton, getGameHubButtons, isGameHubExpanded, selectedGameHubMediaIndex, showGameHub, syncGameHubSelectionFromButton, gameHubMedia.length]);
 
   useEffect(() => {
+    if (!showMediaDetail || !isMediaExportBrowserOpen) {
+      document.querySelectorAll<HTMLElement>(".xmb-media-detail .controller-focus").forEach((node) => {
+        node.classList.remove("controller-focus");
+      });
+      return;
+    }
+
+    const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>(".xmb-media-detail .xmb-export-browser button:not([disabled])"))
+      .filter((button) => button.offsetParent !== null);
+    if (buttons.length === 0) return;
+
+    const active = document.activeElement instanceof HTMLButtonElement && buttons.includes(document.activeElement)
+      ? document.activeElement
+      : null;
+    const nextButton = active ?? buttons[0];
+    document.querySelectorAll<HTMLElement>(".controller-focus").forEach((node) => {
+      node.classList.remove("controller-focus");
+    });
+    nextButton.classList.add("controller-focus");
+    nextButton.focus({ preventScroll: true });
+  }, [showMediaDetail, isMediaExportBrowserOpen, mediaExportBrowserLoading, mediaExportBrowser?.currentPath, mediaExportBrowser?.entries.length]);
+
+  useEffect(() => {
     setSelectedGameHubMediaIndex(0);
     setGameHubActionMessage(null);
     setIsGameHubExpanded(false);
@@ -834,6 +1096,22 @@ export function ControllerLibraryPage({
     setGameHubExportBrowserLoading(false);
     setGameHubExportOverwritePending(false);
   }, [selectedGame?.id]);
+
+  useEffect(() => {
+    if (topCategory === "media" && mediaSubcategory !== "root") return;
+    mediaExportBrowseRequestIdRef.current += 1;
+    setIsMediaExportBrowserOpen(false);
+    closeMediaViewer();
+    setMediaExportBrowser(null);
+    setMediaExportBrowserLoading(false);
+    setMediaExportOverwritePending(false);
+    setMediaActionMessage(null);
+  }, [closeMediaViewer, mediaSubcategory, topCategory]);
+
+  useEffect(() => {
+    setMediaActionMessage(null);
+    setMediaExportOverwritePending(false);
+  }, [selectedMediaAsset?.id]);
 
   useEffect(() => {
     if (isGameHubExpanded) return;
@@ -916,6 +1194,38 @@ export function ControllerLibraryPage({
     return true;
   }
 
+  function moveMediaExportFocus(direction: Direction): boolean {
+    const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>(".xmb-media-detail .xmb-export-browser button:not([disabled])"))
+      .filter((button) => button.offsetParent !== null);
+    if (buttons.length === 0) return false;
+
+    const active = document.activeElement instanceof HTMLButtonElement && buttons.includes(document.activeElement)
+      ? document.activeElement
+      : null;
+    if (!active) {
+      playUiSound("move");
+      document.querySelectorAll<HTMLElement>(".controller-focus").forEach((node) => {
+        node.classList.remove("controller-focus");
+      });
+      buttons[0].classList.add("controller-focus");
+      buttons[0].focus({ preventScroll: true });
+      return true;
+    }
+
+    const currentIndex = buttons.indexOf(active);
+    const step = direction === "up" || direction === "left" ? -1 : 1;
+    const nextButton = buttons[(currentIndex + step + buttons.length) % buttons.length];
+    if (nextButton === active) return true;
+
+    playUiSound("move");
+    document.querySelectorAll<HTMLElement>(".controller-focus").forEach((node) => {
+      node.classList.remove("controller-focus");
+    });
+    nextButton.classList.add("controller-focus");
+    nextButton.focus({ preventScroll: true });
+    return true;
+  }
+
   useEffect(() => {
     const applyDirection = (direction: Direction): void => {
       // When editing the bandwidth slider, use left/right to adjust value
@@ -937,6 +1247,13 @@ export function ControllerLibraryPage({
       }
       if (showGameHub && isGameHubExpanded) {
         moveGameHubFocus(direction);
+        return;
+      }
+      if (showMediaDetail && isMediaExportBrowserOpen) {
+        moveMediaExportFocus(direction);
+        return;
+      }
+      if (mediaViewerAsset) {
         return;
       }
       if (isLoading && topCategory !== "settings" && topCategory !== "current") return;
@@ -1040,6 +1357,20 @@ export function ControllerLibraryPage({
         }
         return;
       }
+      if (showMediaDetail && isMediaExportBrowserOpen) {
+        const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>(".xmb-media-detail .xmb-export-browser button:not([disabled])"))
+          .filter((button) => button.offsetParent !== null);
+        const activeButton = document.activeElement instanceof HTMLButtonElement && buttons.includes(document.activeElement)
+          ? document.activeElement
+          : buttons[0] ?? null;
+        if (activeButton) {
+          activeButton.click();
+        }
+        return;
+      }
+      if (mediaViewerAsset) {
+        return;
+      }
       if (topCategory === "current") {
         const item = displayItems[selectedSettingIndex];
         if (item?.id === "resume" && currentStreamingGame && onResumeGame) {
@@ -1106,9 +1437,8 @@ export function ControllerLibraryPage({
 
         if (mediaSubcategory !== "root") {
           const selectedMedia = mediaAssetItems[selectedMediaIndex];
-          if (selectedMedia && typeof window.openNow?.showMediaInFolder === "function") {
-            void window.openNow.showMediaInFolder({ filePath: selectedMedia.filePath });
-            playUiSound("confirm");
+          if (selectedMedia) {
+            handleMediaOpen(selectedMedia);
             return;
           }
         }
@@ -1121,6 +1451,20 @@ export function ControllerLibraryPage({
     };
 
     const secondaryActivateHandler = () => {
+      if (topCategory === "media" && mediaSubcategory !== "root") {
+        if (mediaViewerAsset) {
+          closeMediaViewer();
+          playUiSound("move");
+          return;
+        }
+        if (isMediaExportBrowserOpen) {
+          closeMediaExportBrowser();
+          playUiSound("move");
+          return;
+        }
+        void handleMediaExport();
+        return;
+      }
       if (showGameHub && isGameHubExpanded && isGameHubExportBrowserOpen) {
         closeGameHubExportBrowser();
         playUiSound("move");
@@ -1212,6 +1556,15 @@ export function ControllerLibraryPage({
     };
 
     const tertiaryActivateHandler = () => {
+      if (topCategory === "media" && mediaSubcategory !== "root") {
+        if (isMediaExportBrowserOpen) {
+          return;
+        }
+        if (selectedMediaAsset) {
+            void handleMediaDelete();
+          }
+        return;
+      }
       if (showGameHub && isGameHubExpanded && isGameHubExportBrowserOpen) {
         return;
       }
@@ -1240,6 +1593,20 @@ export function ControllerLibraryPage({
         e.preventDefault();
         return;
       }
+      if (topCategory === "media" && mediaSubcategory !== "root") {
+        if (mediaViewerAsset) {
+          closeMediaViewer();
+          playUiSound("move");
+          e.preventDefault();
+          return;
+        }
+        if (isMediaExportBrowserOpen) {
+          closeMediaExportBrowser();
+          playUiSound("move");
+          e.preventDefault();
+          return;
+        }
+      }
       if (showGameHub) {
         if (isGameHubExportBrowserOpen) {
           closeGameHubExportBrowser();
@@ -1262,8 +1629,34 @@ export function ControllerLibraryPage({
       }
     };
 
+    const shoulderHandler = (e: Event) => {
+      if (!mediaViewerAsset || !isMediaViewerVideo) {
+        return;
+      }
+      const direction = (e as CustomEvent<{ direction?: "prev" | "next" }>).detail?.direction;
+      if (!direction) {
+        return;
+      }
+      scrubMediaViewerVideo(direction);
+      playUiSound("move");
+    };
+
     const kbdHandler = (e: KeyboardEvent) => {
       if (e.repeat || e.altKey || e.ctrlKey || e.metaKey || isEditableTarget(e.target)) return;
+      if (mediaViewerAsset && isMediaViewerVideo) {
+        if (e.key === "q" || e.key === "Q" || e.key === "[") {
+          e.preventDefault();
+          scrubMediaViewerVideo("prev");
+          playUiSound("move");
+          return;
+        }
+        if (e.key === "e" || e.key === "E" || e.key === "]") {
+          e.preventDefault();
+          scrubMediaViewerVideo("next");
+          playUiSound("move");
+          return;
+        }
+      }
       if (e.key === "ArrowLeft") {
         e.preventDefault();
         applyDirection("left");
@@ -1331,6 +1724,7 @@ export function ControllerLibraryPage({
     window.addEventListener("opennow:controller-secondary-activate", secondaryActivateHandler);
     window.addEventListener("opennow:controller-tertiary-activate", tertiaryActivateHandler);
     window.addEventListener("opennow:controller-cancel", cancelHandler);
+    window.addEventListener("opennow:controller-shoulder", shoulderHandler as EventListener);
     window.addEventListener("keydown", kbdHandler);
     return () => {
       window.removeEventListener("opennow:controller-direction", handler);
@@ -1339,9 +1733,10 @@ export function ControllerLibraryPage({
       window.removeEventListener("opennow:controller-secondary-activate", secondaryActivateHandler);
       window.removeEventListener("opennow:controller-tertiary-activate", tertiaryActivateHandler);
       window.removeEventListener("opennow:controller-cancel", cancelHandler);
+      window.removeEventListener("opennow:controller-shoulder", shoulderHandler as EventListener);
       window.removeEventListener("keydown", kbdHandler);
     };
-  }, [isLoading, TOP_CATEGORIES.length, categorizedGames, selectedIndex, selectedGame, selectedVariantId, onPlayGame, onSelectGameVariant, onOpenSettings, playUiSound, throttledOnSelectGame, toggleFavoriteForSelected, topCategory, selectedSettingIndex, selectedMediaIndex, displayItems, mediaAssetItems.length, mediaSubcategory, settings, settingsBySubcategory, settingsSubcategory, lastRootSettingIndex, lastRootMediaIndex, onSettingChange, resolutionOptions, fpsOptions, codecOptions, aspectRatioOptions, currentStreamingGame, onResumeGame, onCloseGame, onExitControllerMode, onExitApp, editingBandwidth, showGameHub, isGameHubExpanded, isGameHubExportBrowserOpen, selectedGameHubMedia, handleGameHubReveal, handleGameHubExport, handleGameHubDelete, gameHubMedia.length, selectedGameHubMediaIndex, moveGameHubFocus, closeGameHubExportBrowser]);
+  }, [isLoading, TOP_CATEGORIES.length, categorizedGames, selectedIndex, selectedGame, selectedVariantId, onPlayGame, onSelectGameVariant, onOpenSettings, playUiSound, throttledOnSelectGame, toggleFavoriteForSelected, topCategory, selectedSettingIndex, selectedMediaIndex, displayItems, mediaAssetItems.length, mediaSubcategory, settings, settingsBySubcategory, settingsSubcategory, lastRootSettingIndex, lastRootMediaIndex, onSettingChange, resolutionOptions, fpsOptions, codecOptions, aspectRatioOptions, currentStreamingGame, onResumeGame, onCloseGame, onExitControllerMode, onExitApp, editingBandwidth, showGameHub, showMediaDetail, mediaViewerAsset, isMediaViewerVideo, isGameHubExpanded, isGameHubExportBrowserOpen, isMediaExportBrowserOpen, selectedGameHubMedia, selectedMediaAsset, handleGameHubReveal, handleGameHubExport, handleGameHubDelete, handleMediaOpen, handleMediaExport, handleMediaDelete, gameHubMedia.length, selectedGameHubMediaIndex, moveGameHubFocus, closeGameHubExportBrowser, closeMediaExportBrowser, closeMediaViewer, scrubMediaViewerVideo]);
 
   const renderFaceButton = (kind: "primary" | "secondary" | "tertiary", className: string, size: number): JSX.Element => {
     if (kind === "primary") {
@@ -1597,6 +1992,19 @@ export function ControllerLibraryPage({
                 <div className="xmb-game-meta">
                   <span className="xmb-game-meta-chip">{durationLabel}</span>
                   <span className="xmb-game-meta-chip">{dateLabel}</span>
+                </div>
+                <div className="xmb-game-meta xmb-game-meta--expanded">
+                  <button
+                    type="button"
+                    className="xmb-game-meta-chip xmb-game-meta-chip--action"
+                    onClick={() => {
+                      setSelectedMediaIndex(idx);
+                      setMediaActionMessage(null);
+                      handleMediaOpen(item);
+                    }}
+                  >
+                    Open
+                  </button>
                 </div>
               </div>
             </div>
@@ -1879,7 +2287,172 @@ export function ControllerLibraryPage({
               </div>
             </div>
           )}
+          {showMediaDetail && selectedMediaAsset && (
+            <div className="xmb-media-detail">
+              <div className="xmb-current-poster">
+                {selectedMediaThumb ? (
+                  <img src={selectedMediaThumb} alt={selectedMediaAsset.gameTitle || selectedMediaAsset.fileName} />
+                ) : (
+                  <div className="xmb-media-detail-preview-empty">No Preview</div>
+                )}
+              </div>
+              <div className="xmb-game-hub-panel">
+                {isMediaExportBrowserOpen ? (
+                  <div className="xmb-export-browser">
+                    <div className="xmb-game-hub-eyebrow">Export Media</div>
+                    <div className="xmb-game-hub-title-row">
+                      <div className="xmb-game-hub-title">Choose Destination</div>
+                    </div>
+                    <div className="xmb-export-browser-file">{selectedMediaAsset.fileName}</div>
+                    <div className="xmb-export-browser-path">{mediaExportBrowser?.currentPath ?? "Loading folders..."}</div>
+
+                    <div className="xmb-export-browser-section">
+                      <div className="xmb-game-hub-section-title">Quick Locations</div>
+                      <div className="xmb-export-browser-quick-grid">
+                        {(mediaExportBrowser?.quickLocations ?? []).map((location) => (
+                          <button
+                            key={location.id}
+                            type="button"
+                            className="xmb-export-browser-quick"
+                            onClick={() => { void handleMediaExportNavigate(location.path); }}
+                            disabled={mediaExportBrowserLoading || mediaActionBusy === "export"}
+                          >
+                            {location.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="xmb-export-browser-section">
+                      <div className="xmb-game-hub-section-title">Folders</div>
+                      <div className="xmb-export-browser-directory-list">
+                        {mediaExportBrowser?.parentPath && (
+                          <button
+                            type="button"
+                            className="xmb-export-browser-directory xmb-export-browser-directory--parent"
+                            onClick={() => { void handleMediaExportNavigate(mediaExportBrowser.parentPath!); }}
+                            disabled={mediaExportBrowserLoading || mediaActionBusy === "export"}
+                          >
+                            .. Parent Folder
+                          </button>
+                        )}
+                        {mediaExportBrowserLoading ? (
+                          <div className="xmb-game-hub-capture-empty">Loading folders...</div>
+                        ) : (mediaExportBrowser?.entries.length ?? 0) === 0 ? (
+                          <div className="xmb-game-hub-capture-empty">No subfolders in this location.</div>
+                        ) : (
+                          mediaExportBrowser?.entries.map((entry) => (
+                            <button
+                              key={entry.path}
+                              type="button"
+                              className="xmb-export-browser-directory"
+                              onClick={() => { void handleMediaExportNavigate(entry.path); }}
+                              disabled={mediaExportBrowserLoading || mediaActionBusy === "export"}
+                            >
+                              {entry.name}
+                            </button>
+                          ))
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="xmb-game-hub-actions-wrap">
+                      <div className="xmb-game-hub-actions-header">Exporting to: {mediaExportBrowser?.currentPath ?? "Loading..."}</div>
+                      <div className="xmb-game-hub-actions">
+                        <button
+                          type="button"
+                          className="xmb-game-hub-action"
+                          onClick={() => { void handleMediaExportSubmit(); }}
+                          disabled={mediaExportBrowserLoading || mediaActionBusy === "export" || !mediaExportBrowser}
+                        >
+                          <Share2 size={14} />
+                          <span>
+                            {mediaActionBusy === "export"
+                              ? "Exporting..."
+                              : mediaExportOverwritePending
+                                ? "Overwrite Existing"
+                                : "Export Here"}
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          className="xmb-game-hub-action"
+                          onClick={() => { closeMediaExportBrowser(); }}
+                          disabled={mediaActionBusy === "export"}
+                        >
+                          <FolderOpen size={14} />
+                          <span>Cancel</span>
+                        </button>
+                      </div>
+                      {mediaActionMessage && <div className="xmb-game-hub-action-message">{mediaActionMessage}</div>}
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="xmb-game-hub-eyebrow">Media</div>
+                    <div className="xmb-game-hub-title-row">
+                      <div className="xmb-game-hub-title">{selectedMediaAsset.gameTitle || selectedMediaAsset.fileName}</div>
+                    </div>
+                    <div className="xmb-game-meta xmb-game-hub-meta">
+                      {selectedMediaDetailChips.map((chip, index) => (
+                        <span key={`${index}-${chip}`} className="xmb-game-meta-chip">{chip}</span>
+                      ))}
+                    </div>
+                    {selectedMediaDetailCaption && <div className="xmb-game-hub-snapshot-caption">{selectedMediaDetailCaption}</div>}
+                  </>
+                )}
+              </div>
+            </div>
+          )}
           </div>
+
+      {mediaViewerAsset && (
+        <div className="sv-shot-modal" role="dialog" aria-modal="true" aria-label={isMediaViewerVideo ? "Video player" : "Image viewer"}>
+          <button
+            type="button"
+            className="sv-shot-modal-backdrop"
+            onClick={closeMediaViewer}
+            aria-label="Close media viewer"
+          />
+          <div className="sv-shot-modal-card">
+            <div className="sv-shot-modal-head">
+              <h4>{isMediaViewerVideo ? "Video Player" : "Image Viewer"}</h4>
+              <button
+                type="button"
+                className="sv-shot-modal-close"
+                onClick={closeMediaViewer}
+                aria-label="Close media viewer"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            {mediaViewerLoading ? (
+              <div className="sv-shot-modal-loading">Loading media...</div>
+            ) : isMediaViewerVideo && mediaViewerSource ? (
+              <video
+                ref={mediaViewerVideoRef}
+                className="sv-shot-modal-video"
+                src={mediaViewerSource}
+                controls
+                autoPlay
+                playsInline
+                preload="metadata"
+                onLoadedMetadata={(event) => {
+                  void event.currentTarget.play().catch(() => undefined);
+                }}
+              />
+            ) : mediaViewerSource ? (
+              <img
+                className="sv-shot-modal-image"
+                src={mediaViewerSource}
+                alt={mediaViewerAsset.fileName}
+              />
+            ) : (
+              <div className="sv-shot-modal-loading">Unable to load media.</div>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="xmb-footer">
         {topCategory === "current" ? (
@@ -1938,6 +2511,30 @@ export function ControllerLibraryPage({
                 )}
                 <span>Enter</span>
               </div>
+            ) : mediaViewerAsset && isMediaViewerVideo ? (
+              <>
+                <div className="xmb-btn-hint">
+                  <span className="xmb-btn-text-hint">L1 / R1</span>
+                  <span>Scrub 10s</span>
+                </div>
+                <div className="xmb-btn-hint">
+                  {controllerType === "ps" ? (
+                    <ButtonPSCircle className="xmb-btn-icon" size={24} />
+                  ) : (
+                    <ButtonB className="xmb-btn-icon" size={24} />
+                  )}
+                  <span>Close</span>
+                </div>
+              </>
+            ) : mediaViewerAsset ? (
+              <div className="xmb-btn-hint">
+                {controllerType === "ps" ? (
+                  <ButtonPSCircle className="xmb-btn-icon" size={24} />
+                ) : (
+                  <ButtonB className="xmb-btn-icon" size={24} />
+                )}
+                <span>Close</span>
+              </div>
             ) : (
               <>
                 <div className="xmb-btn-hint">
@@ -1946,8 +2543,26 @@ export function ControllerLibraryPage({
                   ) : (
                     <ButtonA className="xmb-btn-icon" size={24} />
                   )}
-                  <span>Open Folder</span>
+                  <span>{isMediaExportBrowserOpen ? "Select" : "Open"}</span>
                 </div>
+                <div className="xmb-btn-hint">
+                  {controllerType === "ps" ? (
+                    <ButtonPSSquare className="xmb-btn-icon" size={24} />
+                  ) : (
+                    <ButtonX className="xmb-btn-icon" size={24} />
+                  )}
+                  <span>{isMediaExportBrowserOpen ? "Close Browser" : "Export"}</span>
+                </div>
+                {!isMediaExportBrowserOpen && (
+                  <div className="xmb-btn-hint">
+                    {controllerType === "ps" ? (
+                      <ButtonPSTriangle className="xmb-btn-icon" size={24} />
+                    ) : (
+                      <ButtonY className="xmb-btn-icon" size={24} />
+                    )}
+                    <span>Delete</span>
+                  </div>
+                )}
                 <div className="xmb-btn-hint">
                   {controllerType === "ps" ? (
                     <ButtonPSCircle className="xmb-btn-icon" size={24} />

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -32,6 +32,7 @@ interface ControllerLibraryPageProps {
     fps?: number;
     codec?: string;
     enableL4S?: boolean;
+    microphoneDeviceId?: string;
     controllerUiSounds?: boolean;
     controllerBackgroundAnimations?: boolean;
     autoLoadControllerLibrary?: boolean;
@@ -53,6 +54,7 @@ type TopCategory = "current" | "all" | "settings" | "media" | "favorites" | `gen
 type SoundKind = "move" | "confirm";
 type SettingsSubcategory = "root" | "Network" | "Audio" | "Video" | "System";
 type MediaSubcategory = "root" | "Videos" | "Screenshots";
+type GameHubMediaItem = MediaListingEntry & { kind: "video" | "screenshot" };
 
 const CATEGORY_STEP_PX = 160;
 const CATEGORY_ACTIVE_HALF_WIDTH_PX = 60;
@@ -173,6 +175,8 @@ export function ControllerLibraryPage({
   const [mediaVideos, setMediaVideos] = useState<MediaListingEntry[]>([]);
   const [mediaScreenshots, setMediaScreenshots] = useState<MediaListingEntry[]>([]);
   const [mediaThumbById, setMediaThumbById] = useState<Record<string, string>>({});
+  const [gameHubMedia, setGameHubMedia] = useState<GameHubMediaItem[]>([]);
+  const [gameHubMediaLoading, setGameHubMediaLoading] = useState(false);
   const [controllerType, setControllerType] = useState<"ps" | "xbox" | "nintendo" | "generic">("generic");
   const [editingBandwidth, setEditingBandwidth] = useState(false);
 
@@ -297,6 +301,7 @@ export function ControllerLibraryPage({
     categories.push({ id: "settings", label: "Settings" });
     categories.push({ id: "all", label: "All" });
     categories.push({ id: "favorites", label: "Favorites" });
+    categories.push({ id: "media", label: "Media" });
     for (const genre of allGenres) categories.push({ id: `genre:${genre}`, label: sanitizeGenreName(genre) });
     return categories;
   }, [allGenres, currentStreamingGame]);
@@ -468,6 +473,94 @@ export function ControllerLibraryPage({
     const current = selectedVariantByGameId[selectedGame.id];
     return current ?? selectedGame.variants[0]?.id ?? "";
   }, [selectedGame, selectedVariantByGameId]);
+
+  const isGameHubCategory = topCategory !== "settings" && topCategory !== "current" && topCategory !== "media";
+  const showGameHub = isGameHubCategory && Boolean(selectedGame);
+  const showCurrentDetail = topCategory === "current" && Boolean(currentStreamingGame);
+  const detailVisible = showCurrentDetail || showGameHub;
+
+  const selectedGameVariant = useMemo(() => {
+    if (!selectedGame) return null;
+    return selectedGame.variants.find((variant) => variant.id === selectedVariantId) ?? selectedGame.variants[0] ?? null;
+  }, [selectedGame, selectedVariantId]);
+
+  const selectedGameStoreName = useMemo(() => getStoreDisplayName(selectedGameVariant?.store || ""), [selectedGameVariant]);
+  const selectedGameRecord = useMemo(() => {
+    if (!selectedGame) return undefined;
+    return playtimeData[selectedGame.id];
+  }, [playtimeData, selectedGame]);
+  const selectedGameGenres = useMemo(() => selectedGame?.genres?.slice(0, 3) ?? [], [selectedGame]);
+  const selectedCategoryLabel = useMemo(() => getCategoryLabel(topCategory, currentStreamingGame?.title).label, [topCategory, currentStreamingGame?.title]);
+  const selectedGameDescription = useMemo(() => {
+    if (!selectedGame) return "";
+    const description = selectedGame.longDescription?.trim() || selectedGame.description?.trim();
+    return description || `${selectedGame.title} is ready to launch from your XMB library.`;
+  }, [selectedGame]);
+  const selectedGameSessionState = useMemo(() => {
+    if (!selectedGame || !currentStreamingGame) return null;
+    if (currentStreamingGame.id === selectedGame.id) return "Active Session";
+    return "Ready To Switch";
+  }, [currentStreamingGame, selectedGame]);
+
+  useEffect(() => {
+    if (!showGameHub || !selectedGame?.title || typeof window.openNow?.listMediaByGame !== "function") {
+      setGameHubMedia([]);
+      setGameHubMediaLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setGameHubMedia([]);
+    setGameHubMediaLoading(true);
+
+    const timeoutId = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const listing = await window.openNow.listMediaByGame({ gameTitle: selectedGame.title });
+          if (cancelled) return;
+
+          const recentItems: GameHubMediaItem[] = [
+            ...(listing.videos ?? []).map((item) => ({ ...item, kind: "video" as const })),
+            ...(listing.screenshots ?? []).map((item) => ({ ...item, kind: "screenshot" as const })),
+          ]
+            .sort((left, right) => right.createdAtMs - left.createdAtMs)
+            .slice(0, 2);
+
+          setGameHubMedia(recentItems);
+
+          const thumbEntries = await Promise.all(
+            recentItems.map(async (item): Promise<[string, string | null]> => {
+              if (item.thumbnailDataUrl) return [item.id, item.thumbnailDataUrl];
+              if (item.dataUrl) return [item.id, item.dataUrl];
+              if (typeof window.openNow?.getMediaThumbnail === "function") {
+                const generated = await window.openNow.getMediaThumbnail({ filePath: item.filePath });
+                return [item.id, generated];
+              }
+              return [item.id, null];
+            }),
+          );
+
+          if (cancelled) return;
+          setMediaThumbById((prev) => {
+            const next = { ...prev };
+            for (const [id, url] of thumbEntries) {
+              if (url) next[id] = url;
+            }
+            return next;
+          });
+        } catch {
+          if (!cancelled) setGameHubMedia([]);
+        } finally {
+          if (!cancelled) setGameHubMediaLoading(false);
+        }
+      })();
+    }, 140);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [selectedGame?.id, selectedGame?.title, showGameHub]);
 
 
 
@@ -865,6 +958,24 @@ export function ControllerLibraryPage({
     };
   }, [isLoading, TOP_CATEGORIES.length, categorizedGames, selectedIndex, selectedGame, selectedVariantId, onPlayGame, onSelectGameVariant, onOpenSettings, playUiSound, throttledOnSelectGame, toggleFavoriteForSelected, topCategory, selectedSettingIndex, selectedMediaIndex, displayItems, mediaAssetItems.length, mediaSubcategory, settings, settingsBySubcategory, settingsSubcategory, lastRootSettingIndex, lastRootMediaIndex, onSettingChange, resolutionOptions, fpsOptions, codecOptions, aspectRatioOptions, currentStreamingGame, onResumeGame, onCloseGame, onExitControllerMode, onExitApp, editingBandwidth]);
 
+  const renderFaceButton = (kind: "primary" | "secondary" | "tertiary", className: string, size: number): JSX.Element => {
+    if (kind === "primary") {
+      return controllerType === "ps"
+        ? <ButtonPSCross className={className} size={size} />
+        : <ButtonA className={className} size={size} />;
+    }
+
+    if (kind === "secondary") {
+      return controllerType === "ps"
+        ? <ButtonPSSquare className={className} size={size} />
+        : <ButtonX className={className} size={size} />;
+    }
+
+    return controllerType === "ps"
+      ? <ButtonPSTriangle className={className} size={size} />
+      : <ButtonY className={className} size={size} />;
+  };
+
   const wrapperClassName = `xmb-wrapper ${settings.controllerBackgroundAnimations ? "xmb-animate" : "xmb-static"} ${isEntering ? "xmb-entering" : "xmb-ready"}`;
 
   if (isLoading && topCategory !== "settings" && topCategory !== "current" && topCategory !== "media") return <div className={wrapperClassName}><div className="xmb-bg-layer"><div className="xmb-bg-gradient" /></div><div style={{display:'flex',justifyContent:'center',alignItems:'center',height:'100vh'}}>Loading...</div></div>;
@@ -1109,7 +1220,7 @@ export function ControllerLibraryPage({
       </div>
       )}
 
-      <div className={`xmb-detail-layer ${selectedGame ? 'visible' : ''}`}>
+      <div className={`xmb-detail-layer ${detailVisible ? 'visible' : ''}`}>
           {topCategory === "current" && (
             <div className="xmb-current-detail">
               <div className="xmb-current-poster">
@@ -1166,6 +1277,62 @@ export function ControllerLibraryPage({
                       </>
                     );
                   })()}
+                </div>
+              </div>
+            </div>
+          )}
+          {showGameHub && selectedGame && (
+            <div className="xmb-game-hub">
+              <div className="xmb-game-hub-panel">
+                <div className="xmb-game-hub-eyebrow">{topCategory === "all" ? "Game Hub" : selectedCategoryLabel}</div>
+                <div className="xmb-game-hub-title-row">
+                  {favoriteGameIdSet.has(selectedGame.id) && <Star className="xmb-game-hub-favorite" />}
+                  <div className="xmb-game-hub-title">{selectedGame.title}</div>
+                </div>
+                <p className="xmb-game-hub-description">{selectedGameDescription}</p>
+                <div className="xmb-game-meta xmb-game-hub-meta">
+                  {selectedGameStoreName && <span className="xmb-game-meta-chip xmb-game-meta-chip--store">{selectedGameStoreName}</span>}
+                  {selectedGameSessionState && <span className="xmb-game-meta-chip xmb-game-meta-chip--session">{selectedGameSessionState}</span>}
+                  <span className="xmb-game-meta-chip xmb-game-meta-chip--playtime">
+                    <Clock size={10} className="xmb-meta-icon" />
+                    {formatPlaytime(selectedGameRecord?.totalSeconds ?? 0)}
+                  </span>
+                  <span className="xmb-game-meta-chip xmb-game-meta-chip--last-played">
+                    <Calendar size={10} className="xmb-meta-icon" />
+                    {formatLastPlayed(selectedGameRecord?.lastPlayedAt ?? null)}
+                  </span>
+                  {selectedGameGenres[0] && <span className="xmb-game-meta-chip xmb-game-meta-chip--genre">{sanitizeGenreName(selectedGameGenres[0])}</span>}
+                </div>
+
+                <div className="xmb-game-hub-captures">
+                  {gameHubMediaLoading ? (
+                    <div className="xmb-game-hub-capture-empty">Scanning recent captures...</div>
+                  ) : gameHubMedia.length === 0 ? (
+                    <div className="xmb-game-hub-capture-empty">No recent captures.</div>
+                  ) : (
+                    <>
+                      <div className="xmb-game-hub-section-title">Recent Captures</div>
+                      <div className="xmb-game-hub-capture-grid">
+                      {gameHubMedia.map((item) => {
+                        const thumb = mediaThumbById[item.id] ?? item.thumbnailDataUrl ?? item.dataUrl;
+                        const captureLabel = item.kind === "video"
+                          ? `${Math.max(1, Math.round((item.durationMs ?? 0) / 1000))}s Clip`
+                          : "Screenshot";
+
+                        return (
+                          <div key={item.id} className="xmb-game-hub-capture">
+                            {thumb && <img src={thumb} alt={item.fileName} className="xmb-game-hub-capture-image" />}
+                            <div className="xmb-game-hub-capture-meta">
+                              <span className="xmb-game-hub-capture-type">{captureLabel}</span>
+                              <div className="xmb-game-hub-capture-name">{item.fileName}</div>
+                              <div className="xmb-game-hub-capture-date">{new Date(item.createdAtMs).toLocaleDateString(undefined, { month: "short", day: "numeric" })}</div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                      </div>
+                    </>
+                  )}
                 </div>
               </div>
             </div>
@@ -1252,20 +1419,13 @@ export function ControllerLibraryPage({
           </>
         ) : (
           <>
-            {
-              (() => {
-                const Primary = controllerType === "ps" ? ButtonPSCross : ButtonA;
-                const Left = controllerType === "ps" ? ButtonPSSquare : ButtonX;
-                const Top = controllerType === "ps" ? ButtonPSTriangle : ButtonY;
-                return (
-                  <>
-                    <div className="xmb-btn-hint"><Primary className="xmb-btn-icon" size={24} /> <span>Play</span></div>
-                    <div className="xmb-btn-hint"><Left className="xmb-btn-icon" size={24} /> <span>Variant</span></div>
-                    <div className="xmb-btn-hint"><Top className="xmb-btn-icon" size={24} /> <span>Favorite</span></div>
-                  </>
-                );
-              })()
-            }
+            <div className="xmb-btn-hint">{renderFaceButton("primary", "xmb-btn-icon", 24)} <span>{currentStreamingGame && selectedGame && currentStreamingGame.id !== selectedGame.id ? "Switch" : "Play"}</span></div>
+            {selectedGame?.variants.length && selectedGame.variants.length > 1 && (
+              <div className="xmb-btn-hint">{renderFaceButton("secondary", "xmb-btn-icon", 24)} <span>Variant</span></div>
+            )}
+            {selectedGame && (
+              <div className="xmb-btn-hint">{renderFaceButton("tertiary", "xmb-btn-icon", 24)} <span>{favoriteGameIdSet.has(selectedGame.id) ? "Unfavorite" : "Favorite"}</span></div>
+            )}
           </>
         )}
       </div>

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -5,9 +5,9 @@ import { Maximize, Minimize, Gamepad2, Loader2, LogOut, Clock3, AlertTriangle, M
 import SideBar from "./SideBar";
 import type { StreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
 import { useStreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
-import type { StreamLagReason } from "../gfn/webrtcClient";
+import type { StreamDiagnostics, StreamLagReason } from "../gfn/webrtcClient";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
-import type { MicrophoneMode, ScreenshotEntry, RecordingEntry } from "@shared/gfn";
+import type { MediaSessionSnapshot, MicrophoneMode, ScreenshotEntry, RecordingEntry } from "@shared/gfn";
 import { isShortcutMatch, normalizeShortcut } from "../shortcuts";
 
 interface StreamViewProps {
@@ -152,6 +152,35 @@ function formatWarningSeconds(value: number | undefined): string | null {
     return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
   }
   return `${seconds}s`;
+}
+
+function buildMediaSessionSnapshot(
+  stats: StreamDiagnostics,
+  serverRegion: string | undefined,
+  sessionElapsedSeconds: number,
+): MediaSessionSnapshot {
+  const snapshot: MediaSessionSnapshot = {};
+
+  if (Number.isFinite(sessionElapsedSeconds) && sessionElapsedSeconds >= 0) {
+    snapshot.sessionElapsedSeconds = Math.floor(sessionElapsedSeconds);
+  }
+  if (stats.resolution) snapshot.resolution = stats.resolution;
+  if (stats.codec) snapshot.codec = stats.codec;
+  if (Number.isFinite(stats.bitrateKbps) && stats.bitrateKbps > 0) snapshot.bitrateKbps = Math.round(stats.bitrateKbps);
+  if (Number.isFinite(stats.decodeFps) && stats.decodeFps > 0) snapshot.decodeFps = Math.round(stats.decodeFps);
+  if (Number.isFinite(stats.renderFps) && stats.renderFps > 0) snapshot.renderFps = Math.round(stats.renderFps);
+  if (Number.isFinite(stats.rttMs) && stats.rttMs >= 0) snapshot.rttMs = Math.round(stats.rttMs * 10) / 10;
+  if (Number.isFinite(stats.packetLossPercent) && stats.packetLossPercent >= 0) {
+    snapshot.packetLossPercent = Number(stats.packetLossPercent.toFixed(2));
+  }
+  if (Number.isFinite(stats.connectedGamepads) && stats.connectedGamepads > 0) {
+    snapshot.connectedControllers = stats.connectedGamepads;
+  }
+
+  const resolvedServerRegion = stats.serverRegion.trim() || serverRegion?.trim() || "";
+  if (resolvedServerRegion) snapshot.serverRegion = resolvedServerRegion;
+
+  return snapshot;
 }
 
 function useMicMeter(
@@ -307,6 +336,7 @@ export function StreamView({
   className,
 }: StreamViewProps): JSX.Element {
   const stats = useStreamDiagnosticsStore(diagnosticsStore);
+  const liveSessionContextRef = useRef({ serverRegion, sessionElapsedSeconds });
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showHints, setShowHints] = useState(true);
   const [showSessionClock, setShowSessionClock] = useState(false);
@@ -338,6 +368,19 @@ export function StreamView({
   const recordingStartTimeRef = useRef<number>(0);
   const recordingTimerRef = useRef<number | undefined>(undefined);
   const thumbnailDataUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    liveSessionContextRef.current = { serverRegion, sessionElapsedSeconds };
+  }, [serverRegion, sessionElapsedSeconds]);
+
+  const captureSessionSnapshot = useCallback((): MediaSessionSnapshot => {
+    const liveContext = liveSessionContextRef.current;
+    return buildMediaSessionSnapshot(
+      diagnosticsStore.getSnapshot(),
+      liveContext.serverRegion,
+      liveContext.sessionElapsedSeconds,
+    );
+  }, [diagnosticsStore]);
   const recCarouselRef = useRef<HTMLDivElement | null>(null);
   const recordingApiAvailable =
     typeof window.openNow?.beginRecording === "function" &&
@@ -585,7 +628,11 @@ export function StreamView({
 
       context.drawImage(video, 0, 0, canvas.width, canvas.height);
       const dataUrl = canvas.toDataURL("image/png");
-      const saved = await window.openNow.saveScreenshot({ dataUrl, gameTitle });
+      const saved = await window.openNow.saveScreenshot({
+        dataUrl,
+        gameTitle,
+        sessionSnapshot: captureSessionSnapshot(),
+      });
       setScreenshots((prev) => [saved, ...prev.filter((item) => item.id !== saved.id)].slice(0, 60));
     } catch (error) {
       console.error("[StreamView] Failed to capture screenshot:", error);
@@ -593,7 +640,7 @@ export function StreamView({
     } finally {
       setIsSavingScreenshot(false);
     }
-  }, [gameTitle, isSavingScreenshot, screenshotApiAvailable]);
+  }, [captureSessionSnapshot, gameTitle, isSavingScreenshot, screenshotApiAvailable]);
 
   const scrollGallery = useCallback((direction: "left" | "right") => {
     const strip = galleryStripRef.current;
@@ -810,6 +857,7 @@ export function StreamView({
           durationMs,
           gameTitle,
           thumbnailDataUrl: thumbnailDataUrlRef.current ?? undefined,
+          sessionSnapshot: captureSessionSnapshot(),
         })
         .then((entry) => {
           setRecordings((prev) => [entry, ...prev].slice(0, 20));
@@ -838,7 +886,7 @@ export function StreamView({
 
     mediaRecorderRef.current = recorder;
     recorder.start(2000);
-  }, [gameTitle, isRecording, micTrack, recordingApiAvailable]);
+  }, [captureSessionSnapshot, gameTitle, isRecording, micTrack, recordingApiAvailable]);
 
   // Cleanup: abort any active recording on unmount
   useEffect(() => {

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -64,6 +64,8 @@ interface StreamViewProps {
   remainingPlaytimeText: string;
   micTrack?: MediaStreamTrack | null;
   className?: string;
+  openScreenshotId?: string | null;
+  openRecordingId?: string | null;
 }
 
 function getRttColor(rttMs: number): string {
@@ -334,6 +336,8 @@ export function StreamView({
   micTrack,
   hideStreamButtons = false,
   className,
+  openScreenshotId,
+  openRecordingId,
 }: StreamViewProps): JSX.Element {
   const stats = useStreamDiagnosticsStore(diagnosticsStore);
   const liveSessionContextRef = useRef({ serverRegion, sessionElapsedSeconds });
@@ -512,6 +516,31 @@ export function StreamView({
     if (!selectedScreenshotId) return null;
     return screenshots.find((item) => item.id === selectedScreenshotId) ?? null;
   }, [screenshots, selectedScreenshotId]);
+
+  useEffect(() => {
+    if (!openScreenshotId) return;
+    if (screenshots.some((item) => item.id === openScreenshotId)) {
+      setSelectedScreenshotId(openScreenshotId);
+      setActiveSidebarTab("preferences");
+      setShowSideBar(true);
+    }
+  }, [openScreenshotId, screenshots]);
+
+  useEffect(() => {
+    if (!openScreenshotId) return;
+    const selected = screenshots.find((item) => item.id === openScreenshotId);
+    if (selected) {
+      setSelectedScreenshotId(selected.id);
+    }
+  }, [openScreenshotId, screenshots]);
+
+  useEffect(() => {
+    if (!openRecordingId) return;
+    if (recordings.some((item) => item.id === openRecordingId)) {
+      setActiveSidebarTab("preferences");
+      setShowSideBar(true);
+    }
+  }, [openRecordingId, recordings]);
 
   useEffect(() => {
     setScreenshotShortcutInput(shortcuts.screenshot);

--- a/opennow-stable/src/renderer/src/controllerNavigation.ts
+++ b/opennow-stable/src/renderer/src/controllerNavigation.ts
@@ -9,6 +9,7 @@ interface UseControllerNavigationOptions {
   onBackAction?: () => boolean;
   onDirectionInput?: (direction: Direction) => boolean;
   onActivateInput?: () => boolean;
+  onStartInput?: () => boolean;
   onSecondaryActivateInput?: () => boolean;
   onTertiaryActivateInput?: () => boolean;
 }
@@ -261,6 +262,7 @@ export function useControllerNavigation({
   onBackAction,
   onDirectionInput,
   onActivateInput,
+  onStartInput,
   onSecondaryActivateInput,
   onTertiaryActivateInput,
 }: UseControllerNavigationOptions): boolean {
@@ -277,6 +279,7 @@ export function useControllerNavigation({
 
   const actionStateRef = useRef({
     a: false,
+    start: false,
     x: false,
     y: false,
     b: false,
@@ -312,7 +315,7 @@ export function useControllerNavigation({
         for (const state of Object.values(directionStateRef.current)) {
           state.pressed = false;
         }
-        actionStateRef.current = { a: false, x: false, y: false, b: false, lb: false, rb: false };
+        actionStateRef.current = { a: false, start: false, x: false, y: false, b: false, lb: false, rb: false };
         frameRef.current = window.requestAnimationFrame(tick);
         return;
       }
@@ -364,7 +367,15 @@ export function useControllerNavigation({
 
       if (a && !actionStateRef.current.a) {
         if (onActivateInput?.()) {
-          actionStateRef.current = { a, x, y, b, lb, rb };
+          actionStateRef.current = { a, start: actionStateRef.current.start, x, y, b, lb, rb };
+          frameRef.current = window.requestAnimationFrame(tick);
+          return;
+        }
+        activateFocusedElement();
+      }
+      if (pad.buttons[9]?.pressed && !actionStateRef.current.start) {
+        if (onStartInput?.()) {
+          actionStateRef.current = { a, start: true, x, y, b, lb, rb };
           frameRef.current = window.requestAnimationFrame(tick);
           return;
         }
@@ -386,7 +397,7 @@ export function useControllerNavigation({
         onNavigatePage?.("next");
       }
 
-      actionStateRef.current = { a, x, y, b, lb, rb };
+      actionStateRef.current = { a, start: Boolean(pad.buttons[9]?.pressed), x, y, b, lb, rb };
       frameRef.current = window.requestAnimationFrame(tick);
     };
 
@@ -400,7 +411,7 @@ export function useControllerNavigation({
         node.classList.remove("controller-focus");
       });
     };
-  }, [enabled, onActivateInput, onBackAction, onDirectionInput, onNavigatePage, onSecondaryActivateInput, onTertiaryActivateInput]);
+  }, [enabled, onActivateInput, onBackAction, onDirectionInput, onNavigatePage, onSecondaryActivateInput, onStartInput, onTertiaryActivateInput]);
 
   return controllerConnected;
 }

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -5807,6 +5807,104 @@ button.game-card-store-chip.active:hover {
   text-align: right;
 }
 
+.xmb-export-browser {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.xmb-export-browser-file {
+  width: 100%;
+  font-size: 0.82rem;
+  font-weight: 800;
+  color: rgba(247, 255, 250, 0.94);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.xmb-export-browser-path {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(205, 255, 220, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.66rem;
+  font-weight: 700;
+  color: rgba(214, 255, 227, 0.72);
+  text-align: right;
+  word-break: break-word;
+}
+
+.xmb-export-browser-section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.xmb-export-browser-quick-grid {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.xmb-export-browser-quick,
+.xmb-export-browser-directory {
+  appearance: none;
+  width: 100%;
+  border: 1px solid rgba(205, 255, 220, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(248, 255, 250, 0.9);
+  border-radius: 14px;
+  padding: 10px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.xmb-export-browser-quick {
+  width: auto;
+  min-width: 116px;
+}
+
+.xmb-export-browser-directory-list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.xmb-export-browser-directory--parent {
+  color: rgba(225, 255, 234, 0.72);
+}
+
+.xmb-export-browser-quick:hover:not(:disabled),
+.xmb-export-browser-directory:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(205, 255, 220, 0.44);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.xmb-export-browser-quick:disabled,
+.xmb-export-browser-directory:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 @media (max-width: 1500px) {
   .xmb-detail-layer {
     max-width: min(30vw, 340px);

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -5477,12 +5477,22 @@ button.game-card-store-chip.active:hover {
   opacity: 0.75;
 }
 
+.xmb-game-meta-chip--session {
+  background: rgba(96, 165, 250, 0.12);
+  border-color: rgba(96, 165, 250, 0.24);
+}
+
+.xmb-game-item.active .xmb-game-meta-chip--session {
+  color: #dbeafe;
+  border-color: rgba(147, 197, 253, 0.42);
+}
+
 
 .xmb-detail-layer {
   position: absolute;
   bottom: 200px;
   right: 5%;
-  width: 35%;
+  width: 30%;
   opacity: 0;
   transform: translateX(40px);
   transition: all 600ms cubic-bezier(0.22, 1, 0.36, 1);
@@ -5497,6 +5507,211 @@ button.game-card-store-chip.active:hover {
 .xmb-detail-layer.visible {
   opacity: 1;
   transform: translateX(0);
+}
+
+.xmb-current-detail,
+.xmb-game-hub {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 14px;
+}
+
+.xmb-current-poster {
+  width: min(100%, 250px);
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(234, 255, 241, 0.16);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.05));
+  box-shadow: 0 28px 56px rgba(0, 0, 0, 0.44);
+}
+
+.xmb-current-poster img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  object-fit: cover;
+}
+
+.xmb-current-info,
+.xmb-game-hub-panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 18px 20px;
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(20, 30, 24, 0.82), rgba(7, 12, 9, 0.72));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(14px);
+}
+
+.xmb-game-hub-eyebrow {
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(199, 255, 217, 0.68);
+}
+
+.xmb-game-hub-title-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.xmb-game-hub-title {
+  font-size: 1.85rem;
+  line-height: 1;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  color: rgba(255, 255, 255, 0.98);
+}
+
+.xmb-game-hub-favorite {
+  width: 22px;
+  height: 22px;
+  color: #ffd700;
+  flex-shrink: 0;
+}
+
+.xmb-game-hub-description {
+  margin: 0;
+  width: 100%;
+  font-size: 0.84rem;
+  line-height: 1.45;
+  color: rgba(243, 255, 247, 0.76);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.xmb-game-hub-meta {
+  justify-content: flex-end;
+}
+
+.xmb-game-hub-capture-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.xmb-game-hub-captures {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.xmb-game-hub-section-title {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(214, 255, 227, 0.72);
+}
+
+.xmb-game-hub-capture,
+.xmb-game-hub-capture-empty {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+}
+
+.xmb-game-hub-capture {
+  position: relative;
+  min-height: 88px;
+}
+
+.xmb-game-hub-capture::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(3, 6, 4, 0.06) 0%, rgba(2, 5, 3, 0.78) 100%);
+}
+
+.xmb-game-hub-capture-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.xmb-game-hub-capture-meta {
+  position: relative;
+  z-index: 1;
+  min-height: 88px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 10px;
+}
+
+.xmb-game-hub-capture-type {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.96);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.xmb-game-hub-capture-name {
+  max-width: 100%;
+  font-size: 0.7rem;
+  font-weight: 800;
+  color: rgba(255, 255, 255, 0.96);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.xmb-game-hub-capture-date {
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(225, 255, 234, 0.68);
+}
+
+.xmb-game-hub-capture-empty {
+  width: 100%;
+  padding: 12px 14px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: rgba(232, 255, 239, 0.72);
+}
+
+@media (max-width: 1500px) {
+  .xmb-detail-layer {
+    width: 34%;
+  }
+}
+
+@media (max-width: 1220px) {
+  .xmb-detail-layer {
+    width: 38%;
+  }
+
+  .xmb-game-hub-capture-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -5599,6 +5599,24 @@ button.game-card-store-chip.active:hover {
   justify-content: flex-end;
 }
 
+.xmb-game-hub-snapshot {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.xmb-game-hub-snapshot-caption {
+  width: 100%;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(214, 255, 227, 0.62);
+  text-align: right;
+}
+
 .xmb-game-hub-capture-grid {
   width: 100%;
   display: grid;
@@ -5631,8 +5649,21 @@ button.game-card-store-chip.active:hover {
 }
 
 .xmb-game-hub-capture {
+  appearance: none;
+  width: 100%;
   position: relative;
   min-height: 76px;
+  padding: 0;
+  text-align: inherit;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.xmb-game-hub-capture:hover,
+.xmb-game-hub-capture.active {
+  border-color: rgba(205, 255, 220, 0.58);
+  box-shadow: 0 0 0 1px rgba(205, 255, 220, 0.28), 0 18px 30px rgba(0, 0, 0, 0.24);
+  transform: translateY(-1px);
 }
 
 .xmb-game-hub-capture::after {
@@ -5672,6 +5703,18 @@ button.game-card-store-chip.active:hover {
   text-overflow: ellipsis;
 }
 
+.xmb-game-hub-capture-stats {
+  max-width: 100%;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(220, 255, 231, 0.72);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .xmb-game-hub-capture-date {
   font-size: 0.58rem;
   font-weight: 700;
@@ -5686,6 +5729,82 @@ button.game-card-store-chip.active:hover {
   font-size: 0.7rem;
   font-weight: 700;
   color: rgba(232, 255, 239, 0.72);
+}
+
+.xmb-game-hub-actions-wrap {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.xmb-game-hub-actions-header {
+  width: 100%;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(220, 255, 231, 0.68);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.xmb-game-hub-actions {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.xmb-game-hub-action {
+  appearance: none;
+  border: 1px solid rgba(205, 255, 220, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(248, 255, 250, 0.9);
+  border-radius: 999px;
+  padding: 8px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, color 180ms ease;
+}
+
+.xmb-game-hub-action:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(205, 255, 220, 0.44);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.xmb-game-hub-action:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.xmb-game-hub-action--danger {
+  border-color: rgba(255, 190, 190, 0.18);
+  color: rgba(255, 222, 222, 0.94);
+}
+
+.xmb-game-hub-action--danger:hover:not(:disabled) {
+  border-color: rgba(255, 160, 160, 0.46);
+  background: rgba(143, 31, 31, 0.16);
+}
+
+.xmb-game-hub-action-message {
+  width: 100%;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: rgba(255, 205, 205, 0.88);
+  text-align: right;
 }
 
 @media (max-width: 1500px) {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -5492,7 +5492,8 @@ button.game-card-store-chip.active:hover {
   position: absolute;
   bottom: 200px;
   right: 5%;
-  width: 30%;
+  width: auto;
+  max-width: min(26vw, 340px);
   opacity: 0;
   transform: translateX(40px);
   transition: all 600ms cubic-bezier(0.22, 1, 0.36, 1);
@@ -5511,7 +5512,8 @@ button.game-card-store-chip.active:hover {
 
 .xmb-current-detail,
 .xmb-game-hub {
-  width: 100%;
+  width: auto;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -5536,7 +5538,8 @@ button.game-card-store-chip.active:hover {
 
 .xmb-current-info,
 .xmb-game-hub-panel {
-  width: 100%;
+  width: auto;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -5599,7 +5602,7 @@ button.game-card-store-chip.active:hover {
 .xmb-game-hub-capture-grid {
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 8px;
 }
 
@@ -5629,7 +5632,7 @@ button.game-card-store-chip.active:hover {
 
 .xmb-game-hub-capture {
   position: relative;
-  min-height: 88px;
+  min-height: 76px;
 }
 
 .xmb-game-hub-capture::after {
@@ -5650,7 +5653,7 @@ button.game-card-store-chip.active:hover {
 .xmb-game-hub-capture-meta {
   position: relative;
   z-index: 1;
-  min-height: 88px;
+  min-height: 76px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -5659,22 +5662,9 @@ button.game-card-store-chip.active:hover {
   padding: 10px;
 }
 
-.xmb-game-hub-capture-type {
-  display: inline-flex;
-  align-items: center;
-  padding: 3px 8px;
-  border-radius: 999px;
-  font-size: 0.62rem;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.96);
-  background: rgba(255, 255, 255, 0.14);
-}
-
 .xmb-game-hub-capture-name {
   max-width: 100%;
-  font-size: 0.7rem;
+  font-size: 0.76rem;
   font-weight: 800;
   color: rgba(255, 255, 255, 0.96);
   white-space: nowrap;
@@ -5700,17 +5690,13 @@ button.game-card-store-chip.active:hover {
 
 @media (max-width: 1500px) {
   .xmb-detail-layer {
-    width: 34%;
+    max-width: min(30vw, 340px);
   }
 }
 
 @media (max-width: 1220px) {
   .xmb-detail-layer {
-    width: 38%;
-  }
-
-  .xmb-game-hub-capture-grid {
-    grid-template-columns: 1fr;
+    max-width: min(36vw, 340px);
   }
 }
 

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -4983,6 +4983,18 @@ button.game-card-store-chip.active:hover {
   gap: 10px;
 }
 
+.sv-shot-modal-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border);
+  background: #050607;
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+}
+
 .sv-shot-modal-head {
   display: flex;
   align-items: center;
@@ -5020,6 +5032,14 @@ button.game-card-store-chip.active:hover {
   width: 100%;
   max-height: calc(100vh - 180px);
   object-fit: contain;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border);
+  background: #050607;
+}
+
+.sv-shot-modal-video {
+  width: 100%;
+  max-height: calc(100vh - 180px);
   border-radius: 10px;
   border: 1px solid var(--panel-border);
   background: #050607;
@@ -5520,6 +5540,15 @@ button.game-card-store-chip.active:hover {
   gap: 14px;
 }
 
+.xmb-media-detail {
+  width: auto;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 14px;
+}
+
 .xmb-current-poster {
   width: min(100%, 250px);
   border-radius: 20px;
@@ -5534,6 +5563,20 @@ button.game-card-store-chip.active:hover {
   width: 100%;
   aspect-ratio: 9 / 16;
   object-fit: cover;
+}
+
+.xmb-media-detail-preview-empty {
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(225, 255, 234, 0.6);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04));
 }
 
 .xmb-current-info,

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -431,6 +431,9 @@ export interface OpenNowApi {
   /** Resolve a thumbnail data URL for a media file path */
   getMediaThumbnail(input: { filePath: string }): Promise<string | null>;
 
+  /** Resolve a media data URL for in-app playback/viewing */
+  getMediaDataUrl(input: { filePath: string }): Promise<string | null>;
+
   /** Reveal a media file path in the system file manager */
   showMediaInFolder(input: { filePath: string }): Promise<void>;
 

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -434,20 +434,48 @@ export interface OpenNowApi {
   /** Reveal a media file path in the system file manager */
   showMediaInFolder(input: { filePath: string }): Promise<void>;
 
-  /** Export a media file to a user-selected path */
+  /** List available export destination folders for the in-app export browser */
+  browseMediaExportLocations(input?: MediaExportBrowserRequest): Promise<MediaExportBrowserResult>;
+
+  /** Export a media file to a destination selected in-app */
   exportMedia(input: MediaExportRequest): Promise<MediaExportResult>;
 
   deleteCache(): Promise<void>;
 }
 
+export interface MediaExportBrowserRequest {
+  directoryPath?: string;
+}
+
+export interface MediaExportBrowserLocation {
+  id: string;
+  label: string;
+  path: string;
+}
+
+export interface MediaExportBrowserEntry {
+  name: string;
+  path: string;
+}
+
+export interface MediaExportBrowserResult {
+  currentPath: string;
+  parentPath?: string;
+  entries: MediaExportBrowserEntry[];
+  quickLocations: MediaExportBrowserLocation[];
+}
+
 export interface MediaExportRequest {
   filePath: string;
   fileName?: string;
+  destinationDirectoryPath?: string;
+  overwrite?: boolean;
 }
 
 export interface MediaExportResult {
   saved: boolean;
   filePath?: string;
+  alreadyExists?: boolean;
 }
 
 export interface ScreenshotSaveRequest {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -434,12 +434,26 @@ export interface OpenNowApi {
   /** Reveal a media file path in the system file manager */
   showMediaInFolder(input: { filePath: string }): Promise<void>;
 
+  /** Export a media file to a user-selected path */
+  exportMedia(input: MediaExportRequest): Promise<MediaExportResult>;
+
   deleteCache(): Promise<void>;
+}
+
+export interface MediaExportRequest {
+  filePath: string;
+  fileName?: string;
+}
+
+export interface MediaExportResult {
+  saved: boolean;
+  filePath?: string;
 }
 
 export interface ScreenshotSaveRequest {
   dataUrl: string;
   gameTitle?: string;
+  sessionSnapshot?: MediaSessionSnapshot;
 }
 
 export interface ScreenshotDeleteRequest {
@@ -462,6 +476,8 @@ export interface ScreenshotEntry {
   createdAtMs: number;
   sizeBytes: number;
   dataUrl: string;
+  gameTitle?: string;
+  sessionSnapshot?: MediaSessionSnapshot;
 }
 
 export interface RecordingEntry {
@@ -473,6 +489,7 @@ export interface RecordingEntry {
   durationMs: number;
   gameTitle?: string;
   thumbnailDataUrl?: string;
+  sessionSnapshot?: MediaSessionSnapshot;
 }
 
 export interface RecordingBeginRequest {
@@ -493,6 +510,7 @@ export interface RecordingFinishRequest {
   durationMs: number;
   gameTitle?: string;
   thumbnailDataUrl?: string;
+  sessionSnapshot?: MediaSessionSnapshot;
 }
 
 export interface RecordingAbortRequest {
@@ -513,9 +531,40 @@ export interface MediaListingEntry {
   durationMs?: number;
   thumbnailDataUrl?: string;
   dataUrl?: string;
+  sessionSnapshot?: MediaSessionSnapshot;
+}
+
+export interface MediaSessionSnapshot {
+  sessionElapsedSeconds?: number;
+  resolution?: string;
+  codec?: string;
+  bitrateKbps?: number;
+  decodeFps?: number;
+  renderFps?: number;
+  rttMs?: number;
+  packetLossPercent?: number;
+  connectedControllers?: number;
+  serverRegion?: string;
+}
+
+export interface MediaSessionSummary {
+  totalCaptures: number;
+  screenshots: number;
+  videos: number;
+  lastCapturedAtMs: number;
+  latestResolution?: string;
+  latestCodec?: string;
+  latestBitrateKbps?: number;
+  latestDecodeFps?: number;
+  latestRttMs?: number;
+  latestPacketLossPercent?: number;
+  latestConnectedControllers?: number;
+  latestSessionElapsedSeconds?: number;
+  latestServerRegion?: string;
 }
 
 export interface MediaListingResult {
   screenshots: MediaListingEntry[];
   videos: MediaListingEntry[];
+  summary?: MediaSessionSummary;
 }

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -49,6 +49,7 @@ export const IPC_CHANNELS = {
   MEDIA_LIST_BY_GAME: "media:list-by-game",
   MEDIA_THUMBNAIL: "media:thumbnail",
   MEDIA_SHOW_IN_FOLDER: "media:show-in-folder",
+  MEDIA_EXPORT: "media:export",
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -48,6 +48,7 @@ export const IPC_CHANNELS = {
   // Media browsing
   MEDIA_LIST_BY_GAME: "media:list-by-game",
   MEDIA_THUMBNAIL: "media:thumbnail",
+  MEDIA_DATA_URL: "media:data-url",
   MEDIA_SHOW_IN_FOLDER: "media:show-in-folder",
   MEDIA_EXPORT_BROWSE: "media:export-browse",
   MEDIA_EXPORT: "media:export",

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -49,6 +49,7 @@ export const IPC_CHANNELS = {
   MEDIA_LIST_BY_GAME: "media:list-by-game",
   MEDIA_THUMBNAIL: "media:thumbnail",
   MEDIA_SHOW_IN_FOLDER: "media:show-in-folder",
+  MEDIA_EXPORT_BROWSE: "media:export-browse",
   MEDIA_EXPORT: "media:export",
 } as const;
 


### PR DESCRIPTION
This pull request introduces comprehensive improvements to media (screenshots and recordings) metadata handling, adds support for exporting media files, and enhances controller input handling and game switching UX in the renderer. The key changes are grouped below:

### Media Metadata and Listing Enhancements

* Introduced functions to read, write, normalize, and delete per-media metadata (including `gameTitle` and session statistics) alongside media files. This metadata is now persisted in `.json` files and associated with both screenshots and recordings. (`opennow-stable/src/main/index.ts`) [[1]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R235-R344) [[2]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R365) [[3]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R376-R377) [[4]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R400) [[5]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R409-R410) [[6]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R419) [[7]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R594) [[8]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1L468-R624) [[9]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R1125-R1126) [[10]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R1136) [[11]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R1151) [[12]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R1176)
* Media listings (screenshots and recordings) now include the associated game title and session snapshot when available. The listing and search logic was updated to match on game titles as well. (`opennow-stable/src/main/index.ts`) [[1]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1L839-R1025) [[2]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1L849-R1048)
* Added a summary object to media listings, aggregating capture counts and the latest session statistics for the UI. (`opennow-stable/src/main/index.ts`)

### Media Export Feature

* Implemented a new IPC handler and supporting logic for exporting media files, allowing users to save screenshots or recordings to a location of their choice. (`opennow-stable/src/main/index.ts`, `opennow-stable/src/preload/index.ts`) [[1]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R450-R480) [[2]](diffhunk://#diff-478a03f7457ec344a5c436234472751591a7542477165bdf613b5691ae4c7aa1R1253-R1256) [[3]](diffhunk://#diff-485219907090ce2b7dff7098e5527ace94cc883ed6f3468470459f590c600081R34-R35) [[4]](diffhunk://#diff-485219907090ce2b7dff7098e5527ace94cc883ed6f3468470459f590c600081R124-R125)

### Renderer/UI Improvements

* Added support for a new controller "Start" input event, integrating it into the controller input handler logic. (`opennow-stable/src/renderer/src/App.tsx`) [[1]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR549-R567) [[2]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR625)
* Enhanced game switching UX by tracking additional pending game information (description and id) during transitions, and ensuring proper cleanup/reset of these fields. (`opennow-stable/src/renderer/src/App.tsx`) [[1]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR611-R612) [[2]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR1900-R1901) [[3]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR1940-R1941)

These changes collectively improve the fidelity and usability of media management in the app, and lay groundwork for richer media-related features in the UI.