### PR TITLE
feat: add negotiated stream profile handling

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -3,6 +3,8 @@ import dns from "node:dns";
 
 import type {
   ActiveSessionInfo,
+  ColorQuality,
+  NegotiatedStreamProfile,
   IceServer,
   SessionClaimRequest,
   SessionCreateRequest,
@@ -594,6 +596,63 @@ function extractSeatSetupStep(payload: CloudMatchResponse): number | undefined {
   return undefined;
 }
 
+function toColorQuality(bitDepth?: number, chromaFormat?: number): ColorQuality | undefined {
+  if (bitDepth !== 0 && bitDepth !== 10) {
+    return undefined;
+  }
+  if (chromaFormat !== 0 && chromaFormat !== 2) {
+    return undefined;
+  }
+
+  if (bitDepth === 10) {
+    return chromaFormat === 2 ? "10bit_444" : "10bit_420";
+  }
+
+  return chromaFormat === 2 ? "8bit_444" : "8bit_420";
+}
+
+function extractNegotiatedStreamProfile(payload: CloudMatchResponse): NegotiatedStreamProfile | undefined {
+  const monitor = payload.session.sessionRequestData?.clientRequestMonitorSettings?.[0];
+  const finalizedFeatures = payload.session.finalizedStreamingFeatures;
+  const requestedFeatures = payload.session.sessionRequestData?.requestedStreamingFeatures;
+
+  const width = monitor?.widthInPixels;
+  const height = monitor?.heightInPixels;
+  const fps = monitor?.framesPerSecond;
+  const colorQuality = toColorQuality(
+    finalizedFeatures?.bitDepth ?? requestedFeatures?.bitDepth,
+    finalizedFeatures?.chromaFormat ?? requestedFeatures?.chromaFormat,
+  );
+  const enabledL4S = finalizedFeatures?.enabledL4S ?? requestedFeatures?.enabledL4S;
+
+  const profile: NegotiatedStreamProfile = {};
+
+  if (
+    typeof width === "number" &&
+    Number.isFinite(width) &&
+    width > 0 &&
+    typeof height === "number" &&
+    Number.isFinite(height) &&
+    height > 0
+  ) {
+    profile.resolution = `${Math.trunc(width)}x${Math.trunc(height)}`;
+  }
+
+  if (typeof fps === "number" && Number.isFinite(fps) && fps > 0) {
+    profile.fps = Math.trunc(fps);
+  }
+
+  if (colorQuality) {
+    profile.colorQuality = colorQuality;
+  }
+
+  if (typeof enabledL4S === "boolean") {
+    profile.enableL4S = enabledL4S;
+  }
+
+  return Object.keys(profile).length > 0 ? profile : undefined;
+}
+
 interface ToSessionInfoOptions {
   zone: string;
   streamingBaseUrl: string;
@@ -645,6 +704,7 @@ async function toSessionInfo(options: ToSessionInfoOptions): Promise<SessionInfo
     gpuType: payload.session.gpuType,
     iceServers: await normalizeIceServers(payload),
     mediaConnectionInfo: signaling.mediaConnectionInfo,
+    negotiatedStreamProfile: extractNegotiatedStreamProfile(payload),
     clientId,
     deviceId,
   };
@@ -1106,6 +1166,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
         gpuType: sessionData.gpuType,
         iceServers: await normalizeIceServers(pollApiResponse),
         mediaConnectionInfo: signaling.mediaConnectionInfo,
+        negotiatedStreamProfile: extractNegotiatedStreamProfile(pollApiResponse),
       };
     }
 

--- a/opennow-stable/src/main/gfn/types.ts
+++ b/opennow-stable/src/main/gfn/types.ts
@@ -112,6 +112,23 @@ export interface CloudMatchResponse {
         credential?: string;
       }>;
     };
+    sessionRequestData?: {
+      clientRequestMonitorSettings?: Array<{
+        widthInPixels?: number;
+        heightInPixels?: number;
+        framesPerSecond?: number;
+      }>;
+      requestedStreamingFeatures?: {
+        bitDepth?: number;
+        chromaFormat?: number;
+        enabledL4S?: boolean;
+      };
+    };
+    finalizedStreamingFeatures?: {
+      bitDepth?: number;
+      chromaFormat?: number;
+      enabledL4S?: boolean;
+    };
   };
 }
 

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -2,10 +2,12 @@ import type {
   IceCandidatePayload,
   ColorQuality,
   IceServer,
+  NegotiatedStreamProfile,
   SessionInfo,
   VideoCodec,
   MicrophoneMode,
 } from "@shared/gfn";
+import { colorQualityRequiresHevc } from "@shared/gfn";
 
 import {
   InputEncoder,
@@ -439,6 +441,65 @@ function normalizeCodecName(codecId: string): string {
   }
 
   return codecId;
+}
+
+function resolveOfferSettings(settings: OfferSettings, negotiated?: NegotiatedStreamProfile): OfferSettings {
+  if (!negotiated) {
+    return settings;
+  }
+
+  const resolved: OfferSettings = {
+    ...settings,
+    resolution: negotiated.resolution ?? settings.resolution,
+    fps: negotiated.fps ?? settings.fps,
+    colorQuality: negotiated.colorQuality ?? settings.colorQuality,
+  };
+
+  if (colorQualityRequiresHevc(resolved.colorQuality) && resolved.codec === "H264") {
+    resolved.codec = "H265";
+  }
+
+  return resolved;
+}
+
+function extractNegotiatedVideoCodec(sdp: string): VideoCodec | undefined {
+  const lines = sdp.split(/\r?\n/);
+  const payloadToCodec = new Map<string, VideoCodec>();
+  let videoPayloadOrder: string[] = [];
+  let inVideoSection = false;
+
+  for (const line of lines) {
+    if (line.startsWith("m=video")) {
+      inVideoSection = true;
+      videoPayloadOrder = line.split(/\s+/).slice(3);
+      continue;
+    }
+    if (line.startsWith("m=") && inVideoSection) {
+      break;
+    }
+    if (!inVideoSection || !line.startsWith("a=rtpmap:")) {
+      continue;
+    }
+
+    const match = line.match(/^a=rtpmap:(\d+)\s+([^/\s]+)/i);
+    if (!match) {
+      continue;
+    }
+
+    const normalized = normalizeCodecName(match[2]);
+    if (normalized === "H264" || normalized === "H265" || normalized === "AV1") {
+      payloadToCodec.set(match[1], normalized);
+    }
+  }
+
+  for (const payload of videoPayloadOrder) {
+    const codec = payloadToCodec.get(payload);
+    if (codec) {
+      return codec;
+    }
+  }
+
+  return undefined;
 }
 
 export class GfnWebRtcClient {
@@ -3259,14 +3320,18 @@ export class GfnWebRtcClient {
 
   async handleOffer(offerSdp: string, session: SessionInfo, settings: OfferSettings): Promise<void> {
     this.cleanupPeerConnection();
+    const effectiveSettings = resolveOfferSettings(settings, session.negotiatedStreamProfile);
 
     this.log("=== handleOffer START ===");
     this.log(`Session: id=${session.sessionId}, status=${session.status}, serverIp=${session.serverIp}`);
     this.log(`Signaling: server=${session.signalingServer}, url=${session.signalingUrl}`);
     this.log(`MediaConnectionInfo: ${session.mediaConnectionInfo ? `ip=${session.mediaConnectionInfo.ip}, port=${session.mediaConnectionInfo.port}` : "NONE"}`);
     this.log(
-      `Settings: codec=${settings.codec}, colorQuality=${settings.colorQuality}, resolution=${settings.resolution}, fps=${settings.fps}, maxBitrate=${settings.maxBitrateKbps}kbps`,
+      `Settings: codec=${effectiveSettings.codec}, colorQuality=${effectiveSettings.colorQuality}, resolution=${effectiveSettings.resolution}, fps=${effectiveSettings.fps}, maxBitrate=${effectiveSettings.maxBitrateKbps}kbps`,
     );
+    if (session.negotiatedStreamProfile) {
+      this.log(`Negotiated stream profile override: ${JSON.stringify(session.negotiatedStreamProfile)}`);
+    }
     this.log(`ICE servers: ${session.iceServers.length} (${session.iceServers.map(s => s.urls.join(",")).join(" | ")})`);
     this.log(`Offer SDP length: ${offerSdp.length} chars`);
     // Log full offer SDP for ICE debugging
@@ -3280,7 +3345,7 @@ export class GfnWebRtcClient {
     this.partialReliableThresholdMs = negotiatedPartialReliable ?? GfnWebRtcClient.DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS;
     this.negotiatedMaxBitrateKbps = Math.max(
       GfnWebRtcClient.DECODER_MIN_RECOVERY_BITRATE_KBPS,
-      Math.floor(settings.maxBitrateKbps),
+      Math.floor(effectiveSettings.maxBitrateKbps),
     );
     this.currentBitrateCeilingKbps = this.negotiatedMaxBitrateKbps;
     this.log(
@@ -3416,14 +3481,14 @@ export class GfnWebRtcClient {
     const serverIceUfrag = extractIceUfragFromOffer(processedOffer);
     this.log(`Server ICE ufrag: "${serverIceUfrag}"`);
 
-    const preferredHevcProfileId = hevcPreferredProfileId(settings.colorQuality);
+    const preferredHevcProfileId = hevcPreferredProfileId(effectiveSettings.colorQuality);
 
     // 3. Filter to preferred codec — but only if the browser actually supports it
-    let effectiveCodec = settings.codec;
+    let effectiveCodec = effectiveSettings.codec;
     const supported = this.getSupportedVideoCodecs();
     this.log(`Browser supported video codecs: ${supported.join(", ") || "unknown"}`);
 
-    if (settings.codec === "H265") {
+    if (effectiveSettings.codec === "H265") {
       const hevcProfiles = this.getSupportedHevcProfiles();
       if (hevcProfiles.size > 0) {
         this.log(`Browser HEVC profile-id support: ${Array.from(hevcProfiles).join(", ")}`);
@@ -3461,8 +3526,8 @@ export class GfnWebRtcClient {
       }
     }
 
-    if (supported.length > 0 && !supported.includes(settings.codec)) {
-      this.log(`Warning: ${settings.codec} not reported in browser codec list; forcing requested codec anyway`);
+    if (supported.length > 0 && !supported.includes(effectiveSettings.codec)) {
+      this.log(`Warning: ${effectiveSettings.codec} not reported in browser codec list; forcing requested codec anyway`);
     }
     this.log(`Effective codec: ${effectiveCodec} (preferred HEVC profile-id=${preferredHevcProfileId})`);
     const filteredOffer = preferCodec(processedOffer, effectiveCodec, {
@@ -3493,8 +3558,8 @@ export class GfnWebRtcClient {
 
     // Munge answer SDP: inject b=AS: bitrate limits and stereo=1 for opus
     if (answer.sdp) {
-      answer.sdp = mungeAnswerSdp(answer.sdp, settings.maxBitrateKbps);
-      this.log(`Answer SDP munged (b=AS:${settings.maxBitrateKbps}, stereo=1)`);
+      answer.sdp = mungeAnswerSdp(answer.sdp, effectiveSettings.maxBitrateKbps);
+      this.log(`Answer SDP munged (b=AS:${effectiveSettings.maxBitrateKbps}, stereo=1)`);
     }
 
     await pc.setLocalDescription(answer);
@@ -3539,7 +3604,12 @@ export class GfnWebRtcClient {
 
     const credentials = extractIceCredentials(finalSdp);
     this.log(`Extracted ICE credentials: ufrag=${credentials.ufrag}, pwd=${credentials.pwd.slice(0, 8)}...`);
-    const { width, height } = parseResolution(settings.resolution);
+    const negotiatedVideoCodec = extractNegotiatedVideoCodec(finalSdp);
+    if (negotiatedVideoCodec) {
+      effectiveCodec = negotiatedVideoCodec;
+      this.log(`Negotiated video codec from local SDP: ${effectiveCodec}`);
+    }
+    const { width, height } = parseResolution(effectiveSettings.resolution);
     const viewportRect = this.options.videoElement.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
     const baseCssViewportWidth = Math.max(viewportRect.width, window.innerWidth || 0);
@@ -3564,11 +3634,11 @@ export class GfnWebRtcClient {
       height,
       clientViewportWidth,
       clientViewportHeight,
-      fps: settings.fps,
-      maxBitrateKbps: settings.maxBitrateKbps,
+      fps: effectiveSettings.fps,
+      maxBitrateKbps: effectiveSettings.maxBitrateKbps,
       partialReliableThresholdMs: this.partialReliableThresholdMs,
       codec: effectiveCodec,
-      colorQuality: settings.colorQuality,
+      colorQuality: effectiveSettings.colorQuality,
       credentials,
     });
 

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -275,6 +275,13 @@ export interface MediaConnectionInfo {
   port: number;
 }
 
+export interface NegotiatedStreamProfile {
+  resolution?: string;
+  fps?: number;
+  colorQuality?: ColorQuality;
+  enableL4S?: boolean;
+}
+
 export interface SessionInfo {
   sessionId: string;
   status: number;
@@ -288,6 +295,7 @@ export interface SessionInfo {
   gpuType?: string;
   iceServers: IceServer[];
   mediaConnectionInfo?: MediaConnectionInfo;
+  negotiatedStreamProfile?: NegotiatedStreamProfile;
   clientId?: string;
   deviceId?: string;
 }


### PR DESCRIPTION
This pull request enhances the negotiation and handling of streaming session parameters between the cloud backend and the WebRTC client, improving how video quality and codec settings are determined and logged. The main focus is on extracting, propagating, and using a new `NegotiatedStreamProfile` object, which allows the client to better align its video stream settings with what was actually negotiated with the server.

**Negotiated stream profile extraction and propagation:**

- Added extraction logic for a new `NegotiatedStreamProfile` from the backend response, capturing negotiated resolution, FPS, color quality, and L4S enablement. This profile is now included in the `SessionInfo` object and propagated throughout the session setup flow. [[1]](diffhunk://#diff-01df11ee193582e2e6ccb59c6ae0cbc276382511dfa988f49cdfd2c47a2adb11R599-R655) [[2]](diffhunk://#diff-01df11ee193582e2e6ccb59c6ae0cbc276382511dfa988f49cdfd2c47a2adb11R707) [[3]](diffhunk://#diff-01df11ee193582e2e6ccb59c6ae0cbc276382511dfa988f49cdfd2c47a2adb11R1169) [[4]](diffhunk://#diff-e21ccf956d30017091203ef0273aeabb57a63f8c24105e8439fe7cf90265bba6R278-R284) [[5]](diffhunk://#diff-e21ccf956d30017091203ef0273aeabb57a63f8c24105e8439fe7cf90265bba6R298) [[6]](diffhunk://#diff-5fc8e28d0ee9da8c0c8768365a9029d2348e819c0ce5f26b42a4af2498a4cc33R115-R131)

**WebRTC client settings resolution and logging:**

- Implemented `resolveOfferSettings` to merge user-requested settings with the negotiated stream profile, ensuring the client uses the most accurate parameters for codec, color quality, resolution, and FPS. This also automatically upgrades the codec to H265 if required by color quality.
- Updated the `GfnWebRtcClient` to consistently use these resolved settings throughout the offer/answer process, including logging, bitrate management, and SDP munging. [[1]](diffhunk://#diff-7cf3b2dd2ed102795a365cd9c588cf6c5ff79ec57cd84878f697464a945067bcR3323-R3334) [[2]](diffhunk://#diff-7cf3b2dd2ed102795a365cd9c588cf6c5ff79ec57cd84878f697464a945067bcL3283-R3348) [[3]](diffhunk://#diff-7cf3b2dd2ed102795a365cd9c588cf6c5ff79ec57cd84878f697464a945067bcL3419-R3491) [[4]](diffhunk://#diff-7cf3b2dd2ed102795a365cd9c588cf6c5ff79ec57cd84878f697464a945067bcL3464-R3530) [[5]](diffhunk://#diff-7cf3b2dd2ed102795a365cd9c588cf6c5ff79ec57cd84878f697464a945067bcL3496-R3562) [[6]](diffhunk://#diff-7cf3b2dd2ed102795a365cd9c588cf6c5ff79ec57cd84878f697464a945067bcL3567-R3641)

**Codec negotiation improvements:**

- Added logic to parse the actual negotiated video codec from the local SDP, updating the effective codec if the server selects a different one, and logging this information for debugging. [[1]](diffhunk://#diff-7cf3b2dd2ed102795a365cd9c588cf6c5ff79ec57cd84878f697464a945067bcR446-R504) [[2]](diffhunk://#diff-7cf3b2dd2ed102795a365cd9c588cf6c5ff79ec57cd84878f697464a945067bcL3542-R3612)

These changes improve the accuracy and transparency of stream parameter handling, making the client more robust to backend negotiation outcomes and simplifying debugging.