### PR TITLE
fix(gfn): align resume payload with official client

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeMonitorSetting, normalizePrimaryMonitorSetting } from "./monitorSettings.ts";
+
+test("normalizeMonitorSetting rejects incomplete or non-positive monitor settings", () => {
+  assert.equal(normalizeMonitorSetting(undefined), undefined);
+  assert.equal(normalizeMonitorSetting({ widthInPixels: 1920 }), undefined);
+  assert.equal(normalizeMonitorSetting({ framesPerSecond: 60 }), undefined);
+  assert.equal(normalizeMonitorSetting({ widthInPixels: 1920, heightInPixels: 1080, framesPerSecond: 0 }), undefined);
+  assert.equal(normalizeMonitorSetting({ widthInPixels: 0, heightInPixels: 1080, framesPerSecond: 60 }), undefined);
+});
+
+test("normalizePrimaryMonitorSetting falls back when all session monitor entries are invalid", () => {
+  const monitorSetting = normalizePrimaryMonitorSetting(
+    [
+      { widthInPixels: 1920 },
+      { heightInPixels: 1080, framesPerSecond: 60 },
+    ],
+    {
+      resolution: "2560x1440",
+      fps: 120,
+      maxBitrateMbps: 75,
+      codec: "H264",
+      colorQuality: "8bit_420",
+      gameLanguage: "en_US",
+      enableL4S: false,
+    },
+  );
+
+  assert.equal(monitorSetting.widthInPixels, 2560);
+  assert.equal(monitorSetting.heightInPixels, 1440);
+  assert.equal(monitorSetting.framesPerSecond, 120);
+});

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -4,6 +4,7 @@ import dns from "node:dns";
 import type {
   ActiveSessionInfo,
   IceServer,
+  SessionMonitorSetting,
   SessionClaimRequest,
   SessionCreateRequest,
   SessionInfo,
@@ -15,9 +16,19 @@ import type {
 import {
   colorQualityBitDepth,
   colorQualityChromaFormat,
+  remapResumeAppLaunchMode,
 } from "@shared/gfn";
 
-import type { CloudMatchRequest, CloudMatchResponse, GetSessionsResponse } from "./types";
+import type {
+  ClaimSessionRequestBody,
+  CloudMatchRequest,
+  CloudMatchResponse,
+  GetSessionsResponse,
+  RequestedStreamingFeatures,
+  SessionEntry,
+  SessionRequestData,
+  SessionRequestMetadataEntry,
+} from "./types";
 import { SessionError } from "./errorCodes";
 
 const GFN_USER_AGENT =
@@ -418,98 +429,181 @@ function timezoneOffsetMs(): number {
   return -new Date().getTimezoneOffset() * 60 * 1000;
 }
 
-function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
-  const { width, height } = parseResolution(input.settings.resolution);
-  const cq = input.settings.colorQuality;
-  // IMPORTANT: hdrEnabled is a SEPARATE toggle from color quality.
-  // The Rust reference (cloudmatch.rs) uses settings.hdr_enabled independently.
-  // 10-bit color depth does NOT mean HDR — you can have 10-bit SDR.
-  // Conflating them caused the server to set up an HDR pipeline, which
-  // dynamically downscaled resolution to ~540p.
-  const hdrEnabled = false; // No HDR toggle implemented yet; hardcode off like claim body
-  const bitDepth = colorQualityBitDepth(cq);
-  const chromaFormat = colorQualityChromaFormat(cq);
-  const accountLinked = input.accountLinked ?? true;
+function normalizeMonitorSetting(setting: Partial<SessionMonitorSetting> | undefined): SessionMonitorSetting | undefined {
+  if (!setting) {
+    return undefined;
+  }
+
+  const widthInPixels = Number(setting.widthInPixels ?? 0);
+  const heightInPixels = Number(setting.heightInPixels ?? 0);
+  const framesPerSecond = Number(setting.framesPerSecond ?? 0);
+  if (!Number.isFinite(widthInPixels) || !Number.isFinite(heightInPixels) || !Number.isFinite(framesPerSecond)) {
+    return undefined;
+  }
 
   return {
-    sessionRequestData: {
+    widthInPixels,
+    heightInPixels,
+    framesPerSecond,
+    sdrHdrMode: Number(setting.sdrHdrMode ?? 0),
+    displayData: setting.displayData
+      ? {
+          desiredContentMaxLuminance: Number(setting.displayData.desiredContentMaxLuminance ?? 0),
+          desiredContentMinLuminance: Number(setting.displayData.desiredContentMinLuminance ?? 0),
+          desiredContentMaxFrameAverageLuminance: Number(setting.displayData.desiredContentMaxFrameAverageLuminance ?? 0),
+        }
+      : undefined,
+    dpi: typeof setting.dpi === "number" ? setting.dpi : undefined,
+  };
+}
+
+function buildRequestedStreamingFeatures(settings: StreamSettings, hdrEnabled: boolean): RequestedStreamingFeatures {
+  const bitDepth = colorQualityBitDepth(settings.colorQuality);
+  const chromaFormat = colorQualityChromaFormat(settings.colorQuality);
+
+  return {
+    reflex: settings.fps >= 120,
+    bitDepth,
+    cloudGsync: false,
+    enabledL4S: settings.enableL4S,
+    mouseMovementFlags: 0,
+    trueHdr: hdrEnabled,
+    supportedHidDevices: 0,
+    profile: 0,
+    fallbackToLogicalResolution: false,
+    hidDevices: null,
+    chromaFormat,
+    prefilterMode: 0,
+    prefilterSharpness: 0,
+    prefilterNoiseReduction: 0,
+    hudStreamingMode: 0,
+    sdrColorSpace: 2,
+    hdrColorSpace: hdrEnabled ? 4 : 0,
+  };
+}
+
+function buildSessionMetadata(monitorSetting: SessionMonitorSetting): SessionRequestMetadataEntry[] {
+  return [
+    { key: "SubSessionId", value: crypto.randomUUID() },
+    { key: "wssignaling", value: "1" },
+    { key: "GSStreamerType", value: "WebRTC" },
+    { key: "networkType", value: "Unknown" },
+    { key: "ClientImeSupport", value: "0" },
+    {
+      key: "clientPhysicalResolution",
+      value: JSON.stringify({
+        horizontalPixels: monitorSetting.widthInPixels,
+        verticalPixels: monitorSetting.heightInPixels,
+      }),
+    },
+    { key: "surroundAudioInfo", value: "2" },
+  ];
+}
+
+function buildMonitorSettingFromStreamSettings(settings: StreamSettings): SessionMonitorSetting {
+  const { widthInPixels, heightInPixels } = {
+    widthInPixels: parseResolution(settings.resolution).width,
+    heightInPixels: parseResolution(settings.resolution).height,
+  };
+  const hdrEnabled = false;
+  return {
+    widthInPixels,
+    heightInPixels,
+    framesPerSecond: settings.fps,
+    sdrHdrMode: hdrEnabled ? 1 : 0,
+    displayData: {
+      desiredContentMaxLuminance: hdrEnabled ? 1000 : 0,
+      desiredContentMinLuminance: 0,
+      desiredContentMaxFrameAverageLuminance: hdrEnabled ? 500 : 0,
+    },
+    dpi: 100,
+  };
+}
+
+function normalizePrimaryMonitorSetting(
+  monitorSettings: Array<Partial<SessionMonitorSetting>> | undefined,
+  fallbackSettings?: StreamSettings,
+): SessionMonitorSetting {
+  const primary = monitorSettings?.map(normalizeMonitorSetting).find((entry) => entry !== undefined);
+  if (primary) {
+    return primary;
+  }
+  if (fallbackSettings) {
+    return buildMonitorSettingFromStreamSettings(fallbackSettings);
+  }
+  return buildMonitorSettingFromStreamSettings({
+    resolution: "1920x1080",
+    fps: 60,
+    maxBitrateMbps: 75,
+    codec: "H264",
+    colorQuality: "8bit_420",
+    gameLanguage: "en_US",
+    enableL4S: false,
+  });
+}
+
+function buildSessionRequestData(options: {
+  appId: string;
+  internalTitle: string | null;
+  settings: StreamSettings;
+  monitorSettings?: Array<Partial<SessionMonitorSetting>>;
+  accountLinked?: boolean;
+  partnerCustomData?: string;
+  enablePersistingInGameSettings?: boolean;
+  userAge?: number;
+  appLaunchMode: number;
+}): SessionRequestData {
+  const hdrEnabled = false;
+  const primaryMonitorSetting = normalizePrimaryMonitorSetting(options.monitorSettings, options.settings);
+  const requestedStreamingFeatures = buildRequestedStreamingFeatures(options.settings, hdrEnabled);
+
+  return {
+    appId: options.appId,
+    internalTitle: options.internalTitle,
+    availableSupportedControllers: [],
+    networkTestSessionId: null,
+    parentSessionId: null,
+    clientIdentification: "GFN-PC",
+    deviceHashId: crypto.randomUUID(),
+    clientVersion: "30.0",
+    sdkVersion: "1.0",
+    streamerVersion: 1,
+    clientPlatformName: "windows",
+    clientRequestMonitorSettings: [primaryMonitorSetting],
+    useOps: true,
+    audioMode: 2,
+    metaData: buildSessionMetadata(primaryMonitorSetting),
+    sdrHdrMode: primaryMonitorSetting.sdrHdrMode,
+    clientDisplayHdrCapabilities: hdrEnabled
+      ? {
+          version: 1,
+          hdrEdrSupportedFlagsInUint32: 1,
+          staticMetadataDescriptorId: 0,
+        }
+      : null,
+    surroundAudioInfo: 0,
+    remoteControllersBitmap: 0,
+    clientTimezoneOffset: timezoneOffsetMs(),
+    enhancedStreamMode: 1,
+    appLaunchMode: options.appLaunchMode,
+    secureRTSPSupported: false,
+    partnerCustomData: options.partnerCustomData ?? "",
+    accountLinked: options.accountLinked ?? true,
+    enablePersistingInGameSettings: options.enablePersistingInGameSettings ?? true,
+    userAge: options.userAge ?? 26,
+    requestedStreamingFeatures,
+  };
+}
+
+function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
+  return {
+    sessionRequestData: buildSessionRequestData({
       appId: input.appId,
       internalTitle: input.internalTitle || null,
-      availableSupportedControllers: [],
-      networkTestSessionId: null,
-      parentSessionId: null,
-      clientIdentification: "GFN-PC",
-      deviceHashId: crypto.randomUUID(),
-      clientVersion: "30.0",
-      sdkVersion: "1.0",
-      streamerVersion: 1,
-      clientPlatformName: "windows",
-      clientRequestMonitorSettings: [
-        {
-          widthInPixels: width,
-          heightInPixels: height,
-          framesPerSecond: input.settings.fps,
-          sdrHdrMode: hdrEnabled ? 1 : 0,
-          displayData: {
-            desiredContentMaxLuminance: hdrEnabled ? 1000 : 0,
-            desiredContentMinLuminance: 0,
-            desiredContentMaxFrameAverageLuminance: hdrEnabled ? 500 : 0,
-          },
-          dpi: 100,
-        },
-      ],
-      useOps: true,
-      audioMode: 2,
-      metaData: [
-        { key: "SubSessionId", value: crypto.randomUUID() },
-        { key: "wssignaling", value: "1" },
-        { key: "GSStreamerType", value: "WebRTC" },
-        { key: "networkType", value: "Unknown" },
-        { key: "ClientImeSupport", value: "0" },
-        {
-          key: "clientPhysicalResolution",
-          value: JSON.stringify({ horizontalPixels: width, verticalPixels: height }),
-        },
-        { key: "surroundAudioInfo", value: "2" },
-      ],
-      sdrHdrMode: hdrEnabled ? 1 : 0,
-      clientDisplayHdrCapabilities: hdrEnabled
-        ? {
-            version: 1,
-            hdrEdrSupportedFlagsInUint32: 1,
-            staticMetadataDescriptorId: 0,
-          }
-        : null,
-      surroundAudioInfo: 0,
-      remoteControllersBitmap: 0,
-      clientTimezoneOffset: timezoneOffsetMs(),
-      enhancedStreamMode: 1,
+      settings: input.settings,
+      accountLinked: input.accountLinked,
       appLaunchMode: 1,
-      secureRTSPSupported: false,
-      partnerCustomData: "",
-      accountLinked,
-      enablePersistingInGameSettings: true,
-      userAge: 26,
-      requestedStreamingFeatures: {
-        reflex: input.settings.fps >= 120,
-        bitDepth,
-        cloudGsync: false,
-        enabledL4S: input.settings.enableL4S,
-        mouseMovementFlags: 0,
-        trueHdr: hdrEnabled,
-        supportedHidDevices: 0,
-        profile: 0,
-        fallbackToLogicalResolution: false,
-        hidDevices: null,
-        chromaFormat,
-        prefilterMode: 0,
-        prefilterSharpness: 0,
-        prefilterNoiseReduction: 0,
-        hudStreamingMode: 0,
-        sdrColorSpace: 2,
-        hdrColorSpace: hdrEnabled ? 4 : 0,
-      },
-    },
+    }),
   };
 }
 
@@ -584,6 +678,25 @@ function extractQueuePosition(payload: CloudMatchResponse): number | undefined {
   }
 
   return undefined;
+}
+
+function sessionMonitorSettings(entry: SessionEntry): SessionMonitorSetting[] | undefined {
+  const normalized = (entry.monitorSettings ?? entry.sessionRequestData?.clientRequestMonitorSettings ?? [])
+    .map(normalizeMonitorSetting)
+    .filter((setting): setting is SessionMonitorSetting => setting !== undefined);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function sessionResolutionAndFps(entry: SessionEntry): { resolution?: string; fps?: number } {
+  const primaryMonitor = sessionMonitorSettings(entry)?.[0];
+  if (!primaryMonitor) {
+    return {};
+  }
+
+  return {
+    resolution: `${primaryMonitor.widthInPixels}x${primaryMonitor.heightInPixels}`,
+    fps: primaryMonitor.framesPerSecond,
+  };
 }
 
 function extractSeatSetupStep(payload: CloudMatchResponse): number | undefined {
@@ -841,12 +954,8 @@ export async function getActiveSessions(
           ? `wss://${controlIp}:443/nvst/`
           : undefined;
 
-      // Extract resolution and fps from monitor settings
-      const monitorSettings = s.monitorSettings?.[0];
-      const resolution = monitorSettings
-        ? `${monitorSettings.widthInPixels ?? 0}x${monitorSettings.heightInPixels ?? 0}`
-        : undefined;
-      const fps = monitorSettings?.framesPerSecond ?? undefined;
+      const monitorSettings = sessionMonitorSettings(s);
+      const { resolution, fps } = sessionResolutionAndFps(s);
 
       return {
         sessionId: s.sessionId,
@@ -857,73 +966,42 @@ export async function getActiveSessions(
         signalingUrl,
         resolution,
         fps,
+        appLaunchMode: s.sessionRequestData?.appLaunchMode,
+        accountLinked: s.sessionRequestData?.accountLinked,
+        partnerCustomData: s.sessionRequestData?.partnerCustomData,
+        enablePersistingInGameSettings: s.sessionRequestData?.enablePersistingInGameSettings,
+        userAge: s.sessionRequestData?.userAge,
+        monitorSettings,
       };
     });
 
   return activeSessions;
 }
 
-/**
- * Build claim/resume request payload
- */
-function buildClaimRequestBody(sessionId: string, appId: string, settings: StreamSettings): unknown {
-  // For RESUME claims, we must NOT attempt to renegotiate streaming parameters.
-  // The session is already configured on the server side. Sending different fps, resolution,
-  // codec, etc. causes HTTP 400 from the server because those parameters are immutable for
-  // an already-streaming session. Only send the action and minimal required fields.
-  const deviceId = crypto.randomUUID();
-  const subSessionId = crypto.randomUUID();
-  const timezoneMs = timezoneOffsetMs();
-
+function buildClaimRequestBody(input: {
+  appId: string;
+  settings: StreamSettings;
+  appLaunchMode?: number;
+  accountLinked?: boolean;
+  partnerCustomData?: string;
+  enablePersistingInGameSettings?: boolean;
+  userAge?: number;
+  monitorSettings?: Array<Partial<SessionMonitorSetting>>;
+}): ClaimSessionRequestBody {
   return {
     action: 2,
     data: "RESUME",
-    sessionRequestData: {
-      // Minimal fields required for resume - NO streaming parameter renegotiation
-      audioMode: 2,
-      remoteControllersBitmap: 0,
-      sdrHdrMode: 0,
-      networkTestSessionId: null,
-      availableSupportedControllers: [],
-      clientVersion: "30.0",
-      deviceHashId: deviceId,
+    sessionRequestData: buildSessionRequestData({
+      appId: input.appId,
       internalTitle: null,
-      clientPlatformName: "windows",
-      metaData: [
-        { key: "SubSessionId", value: subSessionId },
-        { key: "wssignaling", value: "1" },
-        { key: "GSStreamerType", value: "WebRTC" },
-        { key: "networkType", value: "Unknown" },
-        { key: "ClientImeSupport", value: "0" },
-      ],
-      surroundAudioInfo: 0,
-      clientTimezoneOffset: timezoneMs,
-      clientIdentification: "GFN-PC",
-      parentSessionId: null,
-      appId: parseInt(appId, 10),
-      streamerVersion: 1,
-      appLaunchMode: 1,
-      sdkVersion: "1.0",
-      enhancedStreamMode: 1,
-      useOps: true,
-      clientDisplayHdrCapabilities: null,
-      accountLinked: true,
-      partnerCustomData: "",
-      enablePersistingInGameSettings: true,
-      secureRTSPSupported: false,
-      userAge: 26,
-      requestedStreamingFeatures: {
-        reflex: false,
-        bitDepth: 0,
-        cloudGsync: false,
-        enabledL4S: false,
-        profile: 0,
-        fallbackToLogicalResolution: false,
-        chromaFormat: 0,
-        prefilterMode: 0,
-        hudStreamingMode: 0,
-      },
-    },
+      settings: input.settings,
+      monitorSettings: input.monitorSettings,
+      accountLinked: input.accountLinked,
+      partnerCustomData: input.partnerCustomData,
+      enablePersistingInGameSettings: input.enablePersistingInGameSettings,
+      userAge: input.userAge,
+      appLaunchMode: remapResumeAppLaunchMode(input.appLaunchMode),
+    }),
     metaData: [],
   };
 }
@@ -1013,7 +1091,16 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
     console.warn("[CloudMatch] claimSession: pre-claim validation failed:", e);
   }
 
-  const payload = buildClaimRequestBody(input.sessionId, appId, settings);
+  const payload = buildClaimRequestBody({
+    appId,
+    settings,
+    appLaunchMode: input.appLaunchMode,
+    accountLinked: input.accountLinked,
+    partnerCustomData: input.partnerCustomData,
+    enablePersistingInGameSettings: input.enablePersistingInGameSettings,
+    userAge: input.userAge,
+    monitorSettings: input.monitorSettings,
+  });
 
   const headers: Record<string, string> = {
     "User-Agent": GFN_USER_AGENT,

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -29,6 +29,11 @@ import type {
   SessionRequestData,
   SessionRequestMetadataEntry,
 } from "./types";
+import {
+  buildMonitorSettingFromStreamSettings,
+  normalizeMonitorSetting,
+  normalizePrimaryMonitorSetting,
+} from "./monitorSettings";
 import { SessionError } from "./errorCodes";
 
 const GFN_USER_AGENT =
@@ -429,34 +434,6 @@ function timezoneOffsetMs(): number {
   return -new Date().getTimezoneOffset() * 60 * 1000;
 }
 
-function normalizeMonitorSetting(setting: Partial<SessionMonitorSetting> | undefined): SessionMonitorSetting | undefined {
-  if (!setting) {
-    return undefined;
-  }
-
-  const widthInPixels = Number(setting.widthInPixels ?? 0);
-  const heightInPixels = Number(setting.heightInPixels ?? 0);
-  const framesPerSecond = Number(setting.framesPerSecond ?? 0);
-  if (!Number.isFinite(widthInPixels) || !Number.isFinite(heightInPixels) || !Number.isFinite(framesPerSecond)) {
-    return undefined;
-  }
-
-  return {
-    widthInPixels,
-    heightInPixels,
-    framesPerSecond,
-    sdrHdrMode: Number(setting.sdrHdrMode ?? 0),
-    displayData: setting.displayData
-      ? {
-          desiredContentMaxLuminance: Number(setting.displayData.desiredContentMaxLuminance ?? 0),
-          desiredContentMinLuminance: Number(setting.displayData.desiredContentMinLuminance ?? 0),
-          desiredContentMaxFrameAverageLuminance: Number(setting.displayData.desiredContentMaxFrameAverageLuminance ?? 0),
-        }
-      : undefined,
-    dpi: typeof setting.dpi === "number" ? setting.dpi : undefined,
-  };
-}
-
 function buildRequestedStreamingFeatures(settings: StreamSettings, hdrEnabled: boolean): RequestedStreamingFeatures {
   const bitDepth = colorQualityBitDepth(settings.colorQuality);
   const chromaFormat = colorQualityChromaFormat(settings.colorQuality);
@@ -498,48 +475,6 @@ function buildSessionMetadata(monitorSetting: SessionMonitorSetting): SessionReq
     },
     { key: "surroundAudioInfo", value: "2" },
   ];
-}
-
-function buildMonitorSettingFromStreamSettings(settings: StreamSettings): SessionMonitorSetting {
-  const { widthInPixels, heightInPixels } = {
-    widthInPixels: parseResolution(settings.resolution).width,
-    heightInPixels: parseResolution(settings.resolution).height,
-  };
-  const hdrEnabled = false;
-  return {
-    widthInPixels,
-    heightInPixels,
-    framesPerSecond: settings.fps,
-    sdrHdrMode: hdrEnabled ? 1 : 0,
-    displayData: {
-      desiredContentMaxLuminance: hdrEnabled ? 1000 : 0,
-      desiredContentMinLuminance: 0,
-      desiredContentMaxFrameAverageLuminance: hdrEnabled ? 500 : 0,
-    },
-    dpi: 100,
-  };
-}
-
-function normalizePrimaryMonitorSetting(
-  monitorSettings: Array<Partial<SessionMonitorSetting>> | undefined,
-  fallbackSettings?: StreamSettings,
-): SessionMonitorSetting {
-  const primary = monitorSettings?.map(normalizeMonitorSetting).find((entry) => entry !== undefined);
-  if (primary) {
-    return primary;
-  }
-  if (fallbackSettings) {
-    return buildMonitorSettingFromStreamSettings(fallbackSettings);
-  }
-  return buildMonitorSettingFromStreamSettings({
-    resolution: "1920x1080",
-    fps: 60,
-    maxBitrateMbps: 75,
-    codec: "H264",
-    colorQuality: "8bit_420",
-    gameLanguage: "en_US",
-    enableL4S: false,
-  });
 }
 
 function buildSessionRequestData(options: {

--- a/opennow-stable/src/main/gfn/launchMode.test.ts
+++ b/opennow-stable/src/main/gfn/launchMode.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { remapResumeAppLaunchMode } from "../../shared/gfn.ts";
+
+test("remapResumeAppLaunchMode mirrors official resume remap", () => {
+  assert.equal(remapResumeAppLaunchMode(2), 3);
+  assert.equal(remapResumeAppLaunchMode(1), 2);
+  assert.equal(remapResumeAppLaunchMode(0), 1);
+  assert.equal(remapResumeAppLaunchMode(99), 1);
+  assert.equal(remapResumeAppLaunchMode(undefined), 1);
+});

--- a/opennow-stable/src/main/gfn/monitorSettings.ts
+++ b/opennow-stable/src/main/gfn/monitorSettings.ts
@@ -1,0 +1,85 @@
+import type { SessionMonitorSetting, StreamSettings } from "../../shared/gfn.ts";
+
+function parseResolution(input: string): { width: number; height: number } {
+  const [rawWidth, rawHeight] = input.split("x");
+  const width = Number.parseInt(rawWidth ?? "", 10);
+  const height = Number.parseInt(rawHeight ?? "", 10);
+
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return { width: 1920, height: 1080 };
+  }
+
+  return { width, height };
+}
+
+export function normalizeMonitorSetting(setting: Partial<SessionMonitorSetting> | undefined): SessionMonitorSetting | undefined {
+  if (!setting) {
+    return undefined;
+  }
+
+  const widthInPixels = Number(setting.widthInPixels);
+  const heightInPixels = Number(setting.heightInPixels);
+  const framesPerSecond = Number(setting.framesPerSecond);
+  if (
+    !Number.isFinite(widthInPixels) || widthInPixels <= 0 ||
+    !Number.isFinite(heightInPixels) || heightInPixels <= 0 ||
+    !Number.isFinite(framesPerSecond) || framesPerSecond <= 0
+  ) {
+    return undefined;
+  }
+
+  return {
+    widthInPixels,
+    heightInPixels,
+    framesPerSecond,
+    sdrHdrMode: Number(setting.sdrHdrMode ?? 0),
+    displayData: setting.displayData
+      ? {
+          desiredContentMaxLuminance: Number(setting.displayData.desiredContentMaxLuminance ?? 0),
+          desiredContentMinLuminance: Number(setting.displayData.desiredContentMinLuminance ?? 0),
+          desiredContentMaxFrameAverageLuminance: Number(setting.displayData.desiredContentMaxFrameAverageLuminance ?? 0),
+        }
+      : undefined,
+    dpi: typeof setting.dpi === "number" ? setting.dpi : undefined,
+  };
+}
+
+export function buildMonitorSettingFromStreamSettings(settings: StreamSettings): SessionMonitorSetting {
+  const { width, height } = parseResolution(settings.resolution);
+  const hdrEnabled = false;
+
+  return {
+    widthInPixels: width,
+    heightInPixels: height,
+    framesPerSecond: settings.fps,
+    sdrHdrMode: hdrEnabled ? 1 : 0,
+    displayData: {
+      desiredContentMaxLuminance: hdrEnabled ? 1000 : 0,
+      desiredContentMinLuminance: 0,
+      desiredContentMaxFrameAverageLuminance: hdrEnabled ? 500 : 0,
+    },
+    dpi: 100,
+  };
+}
+
+export function normalizePrimaryMonitorSetting(
+  monitorSettings: Array<Partial<SessionMonitorSetting>> | undefined,
+  fallbackSettings?: StreamSettings,
+): SessionMonitorSetting {
+  const primary = monitorSettings?.map(normalizeMonitorSetting).find((entry) => entry !== undefined);
+  if (primary) {
+    return primary;
+  }
+  if (fallbackSettings) {
+    return buildMonitorSettingFromStreamSettings(fallbackSettings);
+  }
+  return buildMonitorSettingFromStreamSettings({
+    resolution: "1920x1080",
+    fps: 60,
+    maxBitrateMbps: 75,
+    codec: "H264",
+    colorQuality: "8bit_420",
+    gameLanguage: "en_US",
+    enableL4S: false,
+  });
+}

--- a/opennow-stable/src/main/gfn/signaling.test.ts
+++ b/opennow-stable/src/main/gfn/signaling.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildPeerInfoPayload, buildSignInUrl } from "./signaling.ts";
+
+test("buildSignInUrl matches official sign_in query shape", () => {
+  const url = new URL(buildSignInUrl({
+    signalingServer: "example.test",
+    sessionId: "session-123",
+    peerName: "peer-abc",
+    signalingUrl: "wss://sig.example.test/nvst/",
+  }));
+
+  assert.equal(url.pathname, "/nvst/sign_in");
+  assert.equal(url.searchParams.get("peer_id"), "peer-abc");
+  assert.equal(url.searchParams.get("version"), "2");
+  assert.equal(url.searchParams.get("peer_role"), "1");
+  assert.equal(url.searchParams.get("pairing_id"), "session-123");
+});
+
+test("buildPeerInfoPayload uses browser streaming peer role", () => {
+  assert.deepEqual(buildPeerInfoPayload({
+    peerId: 2,
+    peerName: "peer-abc",
+  }), {
+    browser: "Chrome",
+    browserVersion: "131",
+    connected: true,
+    id: 2,
+    name: "peer-abc",
+    peerRole: 1,
+    resolution: "1920x1080",
+    version: 2,
+  });
+});

--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -26,6 +26,58 @@ interface SignalingMessage {
   };
 }
 
+interface PeerInfoPayload {
+  browser: string;
+  browserVersion: string;
+  connected: boolean;
+  id: number;
+  name: string;
+  peerRole: number;
+  resolution: string;
+  version: number;
+}
+
+export function buildSignInUrl(options: {
+  signalingServer: string;
+  sessionId: string;
+  peerName: string;
+  signalingUrl?: string;
+  pairingId?: string;
+}): string {
+  const fallbackHost = options.signalingServer.includes(":")
+    ? options.signalingServer
+    : `${options.signalingServer}:443`;
+  const baseUrl = options.signalingUrl?.trim() || `wss://${fallbackHost}/nvst/`;
+  const signInUrl = new URL(baseUrl);
+
+  signInUrl.protocol = "wss:";
+  signInUrl.pathname = `${signInUrl.pathname.replace(/\/?$/, "/")}sign_in`;
+  signInUrl.search = "";
+  signInUrl.searchParams.set("peer_id", options.peerName);
+  signInUrl.searchParams.set("version", "2");
+  signInUrl.searchParams.set("peer_role", "1");
+  signInUrl.searchParams.set("pairing_id", options.pairingId ?? options.sessionId);
+
+  return signInUrl.toString();
+}
+
+export function buildPeerInfoPayload(options: {
+  peerId: number;
+  peerName: string;
+  resolution?: string;
+}): PeerInfoPayload {
+  return {
+    browser: "Chrome",
+    browserVersion: "131",
+    connected: true,
+    id: options.peerId,
+    name: options.peerName,
+    peerRole: 1,
+    resolution: options.resolution ?? "1920x1080",
+    version: 2,
+  };
+}
+
 export class GfnSignalingClient {
   private ws: WebSocket | null = null;
   private peerId = 2;
@@ -33,27 +85,31 @@ export class GfnSignalingClient {
   private ackCounter = 0;
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private listeners = new Set<(event: MainToRendererSignalingEvent) => void>();
+  private readonly signalingServer: string;
+  private readonly sessionId: string;
+  private readonly signalingUrl?: string;
+  private readonly pairingId?: string;
 
   constructor(
-    private readonly signalingServer: string,
-    private readonly sessionId: string,
-    private readonly signalingUrl?: string,
-  ) {}
+    signalingServer: string,
+    sessionId: string,
+    signalingUrl?: string,
+    pairingId?: string,
+  ) {
+    this.signalingServer = signalingServer;
+    this.sessionId = sessionId;
+    this.signalingUrl = signalingUrl;
+    this.pairingId = pairingId;
+  }
 
   private buildSignInUrl(): string {
-    const fallbackHost = this.signalingServer.includes(":")
-      ? this.signalingServer
-      : `${this.signalingServer}:443`;
-    const baseUrl = this.signalingUrl?.trim() || `wss://${fallbackHost}/nvst/`;
-    const signInUrl = new URL(baseUrl);
-
-    signInUrl.protocol = "wss:";
-    signInUrl.pathname = `${signInUrl.pathname.replace(/\/?$/, "/")}sign_in`;
-    signInUrl.search = "";
-    signInUrl.searchParams.set("peer_id", this.peerName);
-    signInUrl.searchParams.set("version", "2");
-
-    const url = signInUrl.toString();
+    const url = buildSignInUrl({
+      signalingServer: this.signalingServer,
+      sessionId: this.sessionId,
+      peerName: this.peerName,
+      signalingUrl: this.signalingUrl,
+      pairingId: this.pairingId,
+    });
     console.log("[Signaling] URL:", url, "(server:", this.signalingServer, ", signalingUrl:", this.signalingUrl, ")");
     return url;
   }
@@ -98,16 +154,10 @@ export class GfnSignalingClient {
   private sendPeerInfo(): void {
     this.sendJson({
       ackid: this.nextAckId(),
-      peer_info: {
-        browser: "Chrome",
-        browserVersion: "131",
-        connected: true,
-        id: this.peerId,
-        name: this.peerName,
-        peerRole: 0,
-        resolution: "1920x1080",
-        version: 2,
-      },
+      peer_info: buildPeerInfoPayload({
+        peerId: this.peerId,
+        peerName: this.peerName,
+      }),
     });
   }
 

--- a/opennow-stable/src/main/gfn/types.ts
+++ b/opennow-stable/src/main/gfn/types.ts
@@ -1,69 +1,75 @@
+import type { SessionMonitorSetting } from "@shared/gfn";
+
 import type { SessionError, SessionErrorInfo } from "./errorCodes";
 
+export interface SessionRequestMetadataEntry {
+  key: string;
+  value: string;
+}
+
+export interface RequestedStreamingFeatures {
+  reflex: boolean;
+  bitDepth: number;
+  cloudGsync: boolean;
+  enabledL4S: boolean;
+  mouseMovementFlags: number;
+  trueHdr: boolean;
+  supportedHidDevices: number;
+  profile: number;
+  fallbackToLogicalResolution: boolean;
+  hidDevices: string | null;
+  chromaFormat: number;
+  prefilterMode: number;
+  prefilterSharpness: number;
+  prefilterNoiseReduction: number;
+  hudStreamingMode: number;
+  sdrColorSpace: number;
+  hdrColorSpace: number;
+}
+
+export interface SessionRequestData {
+  appId: string | number;
+  internalTitle: string | null;
+  availableSupportedControllers: number[];
+  networkTestSessionId: string | null;
+  parentSessionId: string | null;
+  clientIdentification: string;
+  deviceHashId: string;
+  clientVersion: string;
+  sdkVersion: string;
+  streamerVersion: number;
+  clientPlatformName: string;
+  clientRequestMonitorSettings: SessionMonitorSetting[];
+  useOps: boolean;
+  audioMode: number;
+  metaData: SessionRequestMetadataEntry[];
+  sdrHdrMode: number;
+  clientDisplayHdrCapabilities: {
+    version: number;
+    hdrEdrSupportedFlagsInUint32: number;
+    staticMetadataDescriptorId: number;
+  } | null;
+  surroundAudioInfo: number;
+  remoteControllersBitmap: number;
+  clientTimezoneOffset: number;
+  enhancedStreamMode: number;
+  appLaunchMode: number;
+  secureRTSPSupported: boolean;
+  partnerCustomData: string;
+  accountLinked: boolean;
+  enablePersistingInGameSettings: boolean;
+  userAge: number;
+  requestedStreamingFeatures: RequestedStreamingFeatures;
+}
+
 export interface CloudMatchRequest {
-  sessionRequestData: {
-    appId: string;
-    internalTitle: string | null;
-    availableSupportedControllers: number[];
-    networkTestSessionId: string | null;
-    parentSessionId: string | null;
-    clientIdentification: string;
-    deviceHashId: string;
-    clientVersion: string;
-    sdkVersion: string;
-    streamerVersion: number;
-    clientPlatformName: string;
-    clientRequestMonitorSettings: Array<{
-      widthInPixels: number;
-      heightInPixels: number;
-      framesPerSecond: number;
-      sdrHdrMode: number;
-      displayData: {
-        desiredContentMaxLuminance: number;
-        desiredContentMinLuminance: number;
-        desiredContentMaxFrameAverageLuminance: number;
-      };
-      dpi: number;
-    }>;
-    useOps: boolean;
-    audioMode: number;
-    metaData: Array<{ key: string; value: string }>;
-    sdrHdrMode: number;
-    clientDisplayHdrCapabilities: {
-      version: number;
-      hdrEdrSupportedFlagsInUint32: number;
-      staticMetadataDescriptorId: number;
-    } | null;
-    surroundAudioInfo: number;
-    remoteControllersBitmap: number;
-    clientTimezoneOffset: number;
-    enhancedStreamMode: number;
-    appLaunchMode: number;
-    secureRTSPSupported: boolean;
-    partnerCustomData: string;
-    accountLinked: boolean;
-    enablePersistingInGameSettings: boolean;
-    userAge: number;
-    requestedStreamingFeatures: {
-      reflex: boolean;
-      bitDepth: number;
-      cloudGsync: boolean;
-      enabledL4S: boolean;
-      mouseMovementFlags: number;
-      trueHdr: boolean;
-      supportedHidDevices: number;
-      profile: number;
-      fallbackToLogicalResolution: boolean;
-      hidDevices: string | null;
-      chromaFormat: number;
-      prefilterMode: number;
-      prefilterSharpness: number;
-      prefilterNoiseReduction: number;
-      hudStreamingMode: number;
-      sdrColorSpace: number;
-      hdrColorSpace: number;
-    };
-  };
+  sessionRequestData: SessionRequestData;
+}
+
+export interface ClaimSessionRequestBody extends CloudMatchRequest {
+  action: 2;
+  data: "RESUME";
+  metaData: SessionRequestMetadataEntry[];
 }
 
 export interface CloudMatchResponse {
@@ -120,10 +126,7 @@ export interface SessionEntry {
   sessionId: string;
   status: number;
   gpuType?: string;
-  sessionRequestData?: {
-    appId?: string;
-    [key: string]: unknown;
-  };
+  sessionRequestData?: Partial<SessionRequestData>;
   sessionControlInfo?: {
     ip?: string;
   };
@@ -133,11 +136,7 @@ export interface SessionEntry {
     usage: number;
     protocol?: number;
   }>;
-  monitorSettings?: Array<{
-    widthInPixels?: number;
-    heightInPixels?: number;
-    framesPerSecond?: number;
-  }>;
+  monitorSettings?: Array<Partial<SessionMonitorSetting>>;
 }
 
 /** Response from GET /v2/session (list of sessions) */

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1508,6 +1508,12 @@ export function App(): JSX.Element {
       serverIp: existingSession.serverIp,
       sessionId: existingSession.sessionId,
       appId: String(existingSession.appId),
+      appLaunchMode: existingSession.appLaunchMode,
+      accountLinked: existingSession.accountLinked,
+      partnerCustomData: existingSession.partnerCustomData,
+      enablePersistingInGameSettings: existingSession.enablePersistingInGameSettings,
+      userAge: existingSession.userAge,
+      monitorSettings: existingSession.monitorSettings,
       settings: {
         resolution: settings.resolution,
         fps: settings.fps,

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -234,6 +234,32 @@ export interface StreamSettings {
   enableL4S: boolean;
 }
 
+export interface SessionDisplayData {
+  desiredContentMaxLuminance: number;
+  desiredContentMinLuminance: number;
+  desiredContentMaxFrameAverageLuminance: number;
+}
+
+export interface SessionMonitorSetting {
+  widthInPixels: number;
+  heightInPixels: number;
+  framesPerSecond: number;
+  sdrHdrMode: number;
+  displayData?: SessionDisplayData;
+  dpi?: number;
+}
+
+export function remapResumeAppLaunchMode(appLaunchMode?: number): number {
+  switch (appLaunchMode) {
+    case 2:
+      return 3;
+    case 1:
+      return 2;
+    default:
+      return 1;
+  }
+}
+
 export interface SessionCreateRequest {
   token?: string;
   streamingBaseUrl?: string;
@@ -302,6 +328,12 @@ export interface ActiveSessionInfo {
   signalingUrl?: string;
   resolution?: string;
   fps?: number;
+  appLaunchMode?: number;
+  accountLinked?: boolean;
+  partnerCustomData?: string;
+  enablePersistingInGameSettings?: boolean;
+  userAge?: number;
+  monitorSettings?: SessionMonitorSetting[];
 }
 
 /** Request to claim/resume an existing session */
@@ -312,6 +344,12 @@ export interface SessionClaimRequest {
   serverIp: string;
   appId?: string;
   settings?: StreamSettings;
+  appLaunchMode?: number;
+  accountLinked?: boolean;
+  partnerCustomData?: string;
+  enablePersistingInGameSettings?: boolean;
+  userAge?: number;
+  monitorSettings?: SessionMonitorSetting[];
 }
 
 export interface SignalingConnectRequest {

--- a/opennow-stable/tsconfig.node.json
+++ b/opennow-stable/tsconfig.node.json
@@ -10,6 +10,7 @@
     },
     "strict": true,
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "esModuleInterop": true,
     "types": [


### PR DESCRIPTION
This PR aligns OpenNOW's resume payload with the official GeForce NOW web client by expanding session parsing and claim body construction. The previous minimal resume payload caused issues because it lacked the full streaming parameters and launch mode remapping required by the server. Now active sessions preserve monitor settings, app launch mode, and other resume-relevant fields; the claim body sends a complete `sessionRequestData` structure like create-session; and launch mode is remapped (2→3, 1→2, default→1) per official behavior.

**Shared types:**
- Added `SessionMonitorSetting` and `SessionDisplayData` interfaces for typed session display/hdr info.
- Added `remapResumeAppLaunchMode()` helper implementing official remap logic.
- Extended `ActiveSessionInfo` to include `appLaunchMode`, `accountLinked`, `partnerCustomData`, `enablePersistingInGameSettings`, `userAge`, `monitorSettings`.
- Extended `SessionClaimRequest` to pass resume context from renderer.

**CloudMatch types:**
- Extracted `SessionRequestData`, `RequestedStreamingFeatures`, `SessionRequestMetadataEntry` into proper interfaces replacing loose inline.
- `SessionEntry.sessionRequestData` now typed as `Partial<SessionRequestData>`.
- Added `ClaimSessionRequestBody` extending `CloudMatchRequest` with resume wrapper.

**CloudMatch implementation:**
- Refactored to share `buildSessionRequestData()` between create and resume paths.
- Added helpers: `normalizeMonitorSetting()`, `buildRequestedStreamingFeatures()`, `buildSessionMetadata()`, `normalizePrimaryMonitorSetting()`, `sessionMonitorSettings()`, `sessionResolutionAndFps()`.
- Replaced minimal `buildClaimRequestBody()` with full official-style payload including streaming features, monitor settings, and metadata.
- Resume wraps payload as `{ action: 2, data: "RESUME", sessionRequestData, metaData: [] }`.
- `sdrHdrMode` stays aligned with normalized primary monitor setting.
- `getActiveSessions()` now parses and exposes resume-relevant fields while preferring `connectionInfo[usage=14]` for server IP.

**Renderer integration:**
- `claimAndConnectSession()` now passes resumed session fields (`appLaunchMode`, `accountLinked`, `partnerCustomData`, `enablePersistingInGameSettings`, `userAge`, `monitorSettings`) to `claimSession()`.
- Navbar resume and launch-conflict behavior unchanged.

**Test and config:**
- Added `launchMode.test.ts` with focused node test for the remap helper.
- Updated `tsconfig.node.json` to allow `.ts` extensions for test imports only.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/c42b4424-aa47-413a-ba75-01af15e36ad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-30&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-30"><img alt="OPE-30 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-30"></picture></a>