### PR TITLE
feat: add configurable keyboard layout setting

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -15,8 +15,10 @@ import type {
 } from "@shared/gfn";
 
 import {
+  DEFAULT_KEYBOARD_LAYOUT,
   colorQualityBitDepth,
   colorQualityChromaFormat,
+  resolveGfnKeyboardLayout,
 } from "@shared/gfn";
 
 import type { CloudMatchRequest, CloudMatchResponse, GetSessionsResponse } from "./types";
@@ -726,8 +728,9 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
   const body = buildSessionRequestBody(input);
 
   const base = resolveStreamingBaseUrl(input.zone, input.streamingBaseUrl);
+  const keyboardLayout = resolveGfnKeyboardLayout(input.settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = input.settings.gameLanguage ?? "en_US";
-  const url = `${base}/v2/session?keyboardLayout=en-US&languageCode=${languageCode}`;
+  const url = `${base}/v2/session?${new URLSearchParams({ keyboardLayout, languageCode }).toString()}`;
   const response = await fetch(url, {
     method: "POST",
     headers: requestHeaders({ token: input.token, clientId, deviceId, includeOrigin: true }),
@@ -1008,10 +1011,12 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
     maxBitrateMbps: 75,
     codec: "H264",
     colorQuality: "8bit_420",
+    keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
     gameLanguage: "en_US",
     enableL4S: false,
   };
 
+  const keyboardLayout = resolveGfnKeyboardLayout(settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = settings.gameLanguage ?? "en_US";
 
   // The session list endpoint returns the zone LB hostname in sessionControlInfo.ip.
@@ -1048,7 +1053,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
     }
   }
 
-  const claimUrl = `https://${effectiveServerIp}/v2/session/${input.sessionId}?keyboardLayout=en-US&languageCode=${languageCode}`;
+  const claimUrl = `https://${effectiveServerIp}/v2/session/${input.sessionId}?${new URLSearchParams({ keyboardLayout, languageCode }).toString()}`;
 
   // Pre-claim validation: verify the session is still alive and in ready state before attempting claim
   // This prevents sending a claim to an expired/dead session

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -1,7 +1,8 @@
 import { app } from "electron";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode, GameLanguage, AspectRatio } from "@shared/gfn";
+import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode, GameLanguage, AspectRatio, KeyboardLayout } from "@shared/gfn";
+import { DEFAULT_KEYBOARD_LAYOUT } from "@shared/gfn";
 
 export interface Settings {
   /** Video resolution (e.g., "1920x1080") */
@@ -63,6 +64,8 @@ export interface Settings {
   windowWidth: number;
   /** Window height */
   windowHeight: number;
+  /** Keyboard layout for mapping physical keys inside the remote session */
+  keyboardLayout: KeyboardLayout;
   /** In-game language setting (sent to GFN servers via languageCode parameter) */
   gameLanguage: GameLanguage;
   /** Experimental request for Low Latency, Low Loss, Scalable throughput on new sessions */
@@ -106,6 +109,7 @@ const DEFAULT_SETTINGS: Settings = {
   sessionClockShowDurationSeconds: 30,
   windowWidth: 1400,
   windowHeight: 900,
+  keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
   gameLanguage: "en_US",
   enableL4S: false,
 };

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import type {
   StreamRegion,
   VideoCodec,
 } from "@shared/gfn";
+import { DEFAULT_KEYBOARD_LAYOUT } from "@shared/gfn";
 
 import {
   GfnWebRtcClient,
@@ -424,6 +425,7 @@ export function App(): JSX.Element {
     sessionClockShowDurationSeconds: 30,
     windowWidth: 1400,
     windowHeight: 900,
+    keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
     gameLanguage: "en_US",
     enableL4S: false,
   });
@@ -1514,6 +1516,7 @@ export function App(): JSX.Element {
         maxBitrateMbps: settings.maxBitrateMbps,
         codec: settings.codec,
         colorQuality: settings.colorQuality,
+        keyboardLayout: settings.keyboardLayout,
         gameLanguage: settings.gameLanguage,
         enableL4S: settings.enableL4S,
       },
@@ -1661,6 +1664,7 @@ export function App(): JSX.Element {
           maxBitrateMbps: settings.maxBitrateMbps,
           codec: settings.codec,
           colorQuality: settings.colorQuality,
+          keyboardLayout: settings.keyboardLayout,
           gameLanguage: settings.gameLanguage,
           enableL4S: settings.enableL4S,
         },

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1564,12 +1564,12 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
               </label>
             </div>
 
-            <div className="settings-row">
-              <label className="settings-label">
+            <div className="settings-row settings-row--top-aligned">
+              <label className="settings-label settings-label--wrap">
                 Keyboard Layout
                 <span className="settings-hint">Controls how your physical keyboard is mapped inside the remote session. Separate from the in-game language setting.</span>
               </label>
-              <div className="settings-dropdown" ref={keyboardLayoutDropdownRef}>
+              <div className="settings-dropdown settings-dropdown--constrained" ref={keyboardLayoutDropdownRef}>
                 <button
                   type="button"
                   className={`settings-dropdown-selected ${keyboardLayoutDropdownOpen ? "open" : ""}`}
@@ -1581,7 +1581,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                   </svg>
                 </button>
                 {keyboardLayoutDropdownOpen && (
-                  <div className="settings-dropdown-menu">
+                  <div className="settings-dropdown-menu settings-dropdown-menu--tall">
                     {keyboardLayoutOptions.map((option) => (
                       <button
                         key={option.value}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -12,7 +12,7 @@ import type {
   PingResult,
   GameLanguage,
 } from "@shared/gfn";
-import { colorQualityRequiresHevc } from "@shared/gfn";
+import { colorQualityRequiresHevc, keyboardLayoutOptions } from "@shared/gfn";
 import { formatShortcutForDisplay, normalizeShortcut } from "../shortcuts";
 
 interface SettingsPageProps {
@@ -632,6 +632,9 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   const [toggleMicrophoneError, setToggleMicrophoneError] = useState(false);
   const [screenshotError, setScreenshotError] = useState(false);
 
+  const [keyboardLayoutDropdownOpen, setKeyboardLayoutDropdownOpen] = useState(false);
+  const keyboardLayoutDropdownRef = useRef<HTMLDivElement | null>(null);
+
   // Game language dropdown state
   const [gameLanguageDropdownOpen, setGameLanguageDropdownOpen] = useState(false);
   const gameLanguageDropdownRef = useRef<HTMLDivElement | null>(null);
@@ -843,6 +846,10 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     return gameLanguageOptions.find((option) => option.value === settings.gameLanguage)?.label ?? "English (US)";
   }, [settings.gameLanguage]);
 
+  const selectedKeyboardLayoutName = useMemo(() => {
+    return keyboardLayoutOptions.find((option) => option.value === settings.keyboardLayout)?.label ?? "English (US)";
+  }, [settings.keyboardLayout]);
+
   useEffect(() => {
     if (settings.microphoneMode === "disabled") {
       setMicrophoneDeviceDropdownOpen(false);
@@ -857,6 +864,9 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
       }
       if (microphoneDeviceDropdownRef.current && !microphoneDeviceDropdownRef.current.contains(target)) {
         setMicrophoneDeviceDropdownOpen(false);
+      }
+      if (keyboardLayoutDropdownRef.current && !keyboardLayoutDropdownRef.current.contains(target)) {
+        setKeyboardLayoutDropdownOpen(false);
       }
       if (gameLanguageDropdownRef.current && !gameLanguageDropdownRef.current.contains(target)) {
         setGameLanguageDropdownOpen(false);
@@ -1552,6 +1562,43 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                 />
                 <span className="settings-toggle-track" />
               </label>
+            </div>
+
+            <div className="settings-row">
+              <label className="settings-label">
+                Keyboard Layout
+                <span className="settings-hint">Controls how your physical keyboard is mapped inside the remote session. Separate from the in-game language setting.</span>
+              </label>
+              <div className="settings-dropdown" ref={keyboardLayoutDropdownRef}>
+                <button
+                  type="button"
+                  className={`settings-dropdown-selected ${keyboardLayoutDropdownOpen ? "open" : ""}`}
+                  onClick={() => setKeyboardLayoutDropdownOpen((open) => !open)}
+                >
+                  <span className="settings-dropdown-selected-name">{selectedKeyboardLayoutName}</span>
+                  <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className={`settings-dropdown-chevron ${keyboardLayoutDropdownOpen ? "flipped" : ""}`}>
+                    <path d="M4.47 5.97a.75.75 0 0 1 1.06 0L8 8.44l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
+                  </svg>
+                </button>
+                {keyboardLayoutDropdownOpen && (
+                  <div className="settings-dropdown-menu">
+                    {keyboardLayoutOptions.map((option) => (
+                      <button
+                        key={option.value}
+                        type="button"
+                        className={`settings-dropdown-item ${settings.keyboardLayout === option.value ? "active" : ""}`}
+                        onClick={() => {
+                          handleChange("keyboardLayout", option.value);
+                          setKeyboardLayoutDropdownOpen(false);
+                        }}
+                      >
+                        <span>{option.label}</span>
+                        {settings.keyboardLayout === option.value && <Check size={14} className="settings-dropdown-check" />}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* Mouse Sensitivity */}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -2011,6 +2011,10 @@ button.game-card-store-chip.active:hover {
   align-items: stretch;
 }
 
+.settings-row--top-aligned {
+  align-items: flex-start;
+}
+
 .settings-row-top {
   display: flex;
   align-items: center;
@@ -2392,6 +2396,12 @@ button.game-card-store-chip.active:hover {
 .settings-dropdown {
   position: relative;
   width: 100%;
+  min-width: 0;
+}
+
+.settings-dropdown--constrained {
+  flex: 0 1 320px;
+  width: min(320px, 100%);
 }
 
 .settings-dropdown-selected {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -12,6 +12,46 @@ export type GameLanguage =
   | "el_GR" | "hu_HU" | "ro_RO" | "uk_UA" | "nl_NL" | "sv_SE" | "da_DK"
   | "fi_FI" | "no_NO";
 
+/** Keyboard layout codes for physical key mapping in remote sessions */
+export type KeyboardLayout =
+  | "en-US" | "en-GB" | "tr-TR" | "de-DE" | "fr-FR" | "es-ES" | "es-MX" | "it-IT"
+  | "pt-PT" | "pt-BR" | "pl-PL" | "ru-RU" | "ja-JP" | "ko-KR" | "zh-CN" | "zh-TW";
+
+export interface KeyboardLayoutOption {
+  value: KeyboardLayout;
+  label: string;
+  macValue?: string;
+}
+
+export const DEFAULT_KEYBOARD_LAYOUT: KeyboardLayout = "en-US";
+
+export const keyboardLayoutOptions: readonly KeyboardLayoutOption[] = [
+  { value: "en-US", label: "English (US)", macValue: "m-us" },
+  { value: "en-GB", label: "English (UK)", macValue: "m-brit" },
+  { value: "tr-TR", label: "Turkish Q", macValue: "m-tr-qty" },
+  { value: "de-DE", label: "German" },
+  { value: "fr-FR", label: "French" },
+  { value: "es-ES", label: "Spanish" },
+  { value: "es-MX", label: "Spanish (Latin America)" },
+  { value: "it-IT", label: "Italian" },
+  { value: "pt-PT", label: "Portuguese (Portugal)" },
+  { value: "pt-BR", label: "Portuguese (Brazil)" },
+  { value: "pl-PL", label: "Polish" },
+  { value: "ru-RU", label: "Russian" },
+  { value: "ja-JP", label: "Japanese" },
+  { value: "ko-KR", label: "Korean" },
+  { value: "zh-CN", label: "Chinese (Simplified)" },
+  { value: "zh-TW", label: "Chinese (Traditional)" },
+] as const;
+
+export function resolveGfnKeyboardLayout(layout: KeyboardLayout, platform: string): string {
+  const option = keyboardLayoutOptions.find((candidate) => candidate.value === layout);
+  if (platform === "darwin" && option?.macValue) {
+    return option.macValue;
+  }
+  return option?.value ?? DEFAULT_KEYBOARD_LAYOUT;
+}
+
 /** Helper: get CloudMatch bitDepth value (0 = 8-bit SDR, 10 = 10-bit HDR capable) */
 export function colorQualityBitDepth(cq: ColorQuality): number {
   return cq.startsWith("10bit") ? 10 : 0;
@@ -68,6 +108,8 @@ export interface Settings {
   sessionClockShowDurationSeconds: number;
   windowWidth: number;
   windowHeight: number;
+  /** Keyboard layout for mapping physical keys inside the remote session */
+  keyboardLayout: KeyboardLayout;
   /** In-game language setting (sent to GFN servers via languageCode parameter) */
   gameLanguage: GameLanguage;
   /** Experimental request for Low Latency, Low Loss, Scalable throughput on new sessions */
@@ -228,6 +270,8 @@ export interface StreamSettings {
   maxBitrateMbps: number;
   codec: VideoCodec;
   colorQuality: ColorQuality;
+  /** Keyboard layout for mapping physical keys inside the remote session */
+  keyboardLayout: KeyboardLayout;
   /** In-game language setting (sent to GFN servers via languageCode parameter) */
   gameLanguage: GameLanguage;
   /** Experimental request for Low Latency, Low Loss, Scalable throughput on new sessions */


### PR DESCRIPTION
This PR adds a persisted `keyboardLayout` setting to allow users to select their physical keyboard mapping, replacing the hardcoded `en-US` value that was sent to GeForce Now. The new setting is separate from the existing `gameLanguage` (in-game localization) setting and persists across sessions.


- Added `KeyboardLayout` type, curated options with mac-specific variants, and `resolveGfnKeyboardLayout` for platform-aware GFN code mapping [[src/shared/gfn.ts](src/shared/gfn.ts)]
- Extended `Settings` and `StreamSettings` with `keyboardLayout` field; kept `gameLanguage` unchanged [[src/shared/gfn.ts](src/shared/gfn.ts)]
- Added `keyboardLayout` to main process defaults; old settings files auto-inherit via existing default merge behavior [[src/main/settings.ts](src/main/settings.ts)]
- Replaced hardcoded `keyboardLayout=en-US` in session create/claim URLs with the selected setting, URL-encoded via `URLSearchParams`; updated claim fallback defaults [[src/main/gfn/cloudmatch.ts](src/main/gfn/cloudmatch.ts)]
- Added renderer boot-state default and wired `keyboardLayout` into both `createSession` and `claimSession` payloads [[src/renderer/src/App.tsx](src/renderer/src/App.tsx)]
- Added `Keyboard Layout` dropdown under Input section with hint clarifying it controls physical key mapping separately from in-game language [[src/renderer/src/components/SettingsPage.tsx](src/renderer/src/components/SettingsPage.tsx)]

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/5d7f4b53-15c5-43c5-97bf-a80b3da8762b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-32&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-32"><img alt="OPE-32 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-32"></picture></a>