### PR TITLE
chore: add Buy Me a Coffee funding option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 
 github: [zortos293]
-
+buy_me_a_coffee: zortos


### PR DESCRIPTION
This PR adds Buy Me a Coffee as a funding platform in the GitHub repository configuration. Adding `buy_me_a_coffee: zortos` to `.github/FUNDING.yml` enables a sponsor button in the repository's sidebar alongside the existing GitHub Sponsors option.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/1637be13-490d-45b9-a868-e4c70161cab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-35&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-35"><img alt="OPE-35 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-35"></picture></a>