### PR TITLE
Fix 1Hz renderer-wide rerenders during streaming

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -260,29 +260,6 @@ function warningMessage(code: StreamTimeWarning["code"]): string {
   return "Maximum session time approaching";
 }
 
-function formatRemainingPlaytimeFromSubscription(
-  subscription: SubscriptionInfo | null,
-  consumedHours = 0,
-): string {
-  if (!subscription) {
-    return "--";
-  }
-  if (subscription.isUnlimited) {
-    return "Unlimited";
-  }
-
-  const baseHours = Number.isFinite(subscription.remainingHours) ? subscription.remainingHours : 0;
-  const safeHours = Math.max(0, baseHours - Math.max(0, consumedHours));
-  const totalMinutes = Math.round(safeHours * 60);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-
-  if (hours > 0) {
-    return `${hours}h ${minutes.toString().padStart(2, "0")}m`;
-  }
-  return `${minutes}m`;
-}
-
 function toLoadingStatus(status: StreamStatus): StreamLoadingStatus {
   switch (status) {
     case "queue":
@@ -453,10 +430,10 @@ export function App(): JSX.Element {
   const [isResumingNavbarSession, setIsResumingNavbarSession] = useState(false);
   const [launchError, setLaunchError] = useState<LaunchErrorState | null>(null);
   const [sessionStartedAtMs, setSessionStartedAtMs] = useState<number | null>(null);
-  const [sessionElapsedSeconds, setSessionElapsedSeconds] = useState(0);
   const [streamWarning, setStreamWarning] = useState<StreamWarningState | null>(null);
 
   const { playtime, startSession: startPlaytimeSession, endSession: endPlaytimeSession } = usePlaytime();
+  const isStreaming = streamStatus === "streaming";
 
   const controllerOverlayOpenRef = useRef(false);
 
@@ -705,7 +682,6 @@ export function App(): JSX.Element {
     setStreamStatus("idle");
     setQueuePosition(undefined);
     setSessionStartedAtMs(null);
-    setSessionElapsedSeconds(0);
     setStreamWarning(null);
     setEscHoldReleaseIndicator({ visible: false, progress: 0 });
     diagnosticsStore.set(defaultDiagnostics());
@@ -1171,21 +1147,6 @@ export function App(): JSX.Element {
     }
   }, [currentPage, streamStatus]);
 
-  useEffect(() => {
-    if (streamStatus === "idle" || sessionStartedAtMs === null) {
-      setSessionElapsedSeconds(0);
-      return;
-    }
-
-    const updateElapsed = () => {
-      const elapsed = Math.max(0, Math.floor((Date.now() - sessionStartedAtMs) / 1000));
-      setSessionElapsedSeconds(elapsed);
-    };
-
-    updateElapsed();
-    const timer = window.setInterval(updateElapsed, 1000);
-    return () => window.clearInterval(timer);
-  }, [sessionStartedAtMs, streamStatus]);
 
   useEffect(() => {
     if (streamStatus !== "streaming" || sessionStartedAtMs !== null) {
@@ -1570,7 +1531,6 @@ export function App(): JSX.Element {
     };
 
     setSessionStartedAtMs(null);
-    setSessionElapsedSeconds(0);
     setStreamWarning(null);
     setLaunchError(null);
     const selectedVariantId = variantByGameId[game.id] ?? defaultVariantId(game);
@@ -1803,7 +1763,6 @@ export function App(): JSX.Element {
     setLaunchError(null);
     setQueuePosition(undefined);
     setSessionStartedAtMs(null);
-    setSessionElapsedSeconds(0);
     setStreamWarning(null);
     const matchedContext = findGameContextForSession(navbarActiveSession);
     if (matchedContext) {
@@ -2135,12 +2094,6 @@ export function App(): JSX.Element {
   }
 
   const showLaunchOverlay = streamStatus !== "idle" || launchError !== null || isSwitchingGame;
-  const consumedHours =
-    streamStatus === "streaming"
-      ? Math.floor(sessionElapsedSeconds / 60) / 60
-      : 0;
-  const remainingPlaytimeText = formatRemainingPlaytimeFromSubscription(subscriptionInfo, consumedHours);
-
   // Show stream lifecycle (waiting/connecting/streaming/failure)
   if (showLaunchOverlay) {
     const loadingStatus = launchError ? launchError.stage : toLoadingStatus(streamStatus);
@@ -2166,11 +2119,12 @@ export function App(): JSX.Element {
             antiAfkEnabled={antiAfkEnabled}
             escHoldReleaseIndicator={escHoldReleaseIndicator}
             exitPrompt={exitPrompt}
-            sessionElapsedSeconds={sessionElapsedSeconds}
+            sessionStartedAtMs={sessionStartedAtMs}
             sessionClockShowEveryMinutes={settings.sessionClockShowEveryMinutes}
             sessionClockShowDurationSeconds={settings.sessionClockShowDurationSeconds}
             streamWarning={streamWarning}
             isConnecting={streamStatus === "connecting"}
+            isStreaming={isStreaming}
             gameTitle={streamingGame?.title ?? "Game"}
             platformStore={streamingStore ?? undefined}
             onToggleFullscreen={() => {
@@ -2200,7 +2154,7 @@ export function App(): JSX.Element {
             onRecordingShortcutChange={(value) => {
               void updateSetting("shortcutToggleRecording", value);
             }}
-            remainingPlaytimeText={remainingPlaytimeText}
+            subscriptionInfo={subscriptionInfo}
             micTrack={clientRef.current?.getMicTrack() ?? null}
             onRequestPointerLock={handleRequestPointerLock}
             onReleasePointerLock={() => {
@@ -2271,9 +2225,10 @@ export function App(): JSX.Element {
               pendingSwitchGameCover={pendingSwitchGameCover}
               userName={authSession?.user.displayName}
               userAvatarUrl={authSession?.user.avatarUrl}
-              remainingPlaytimeText={remainingPlaytimeText}
+              subscriptionInfo={subscriptionInfo}
               playtimeData={playtime}
-              sessionElapsedSeconds={sessionElapsedSeconds}
+              sessionStartedAtMs={sessionStartedAtMs}
+              isStreaming={isStreaming}
               settings={{
                 resolution: settings.resolution,
                 fps: settings.fps,
@@ -2403,9 +2358,10 @@ export function App(): JSX.Element {
               pendingSwitchGameCover={pendingSwitchGameCover}
               userName={authSession?.user.displayName}
               userAvatarUrl={authSession?.user.avatarUrl}
-              remainingPlaytimeText={remainingPlaytimeText}
+              subscriptionInfo={subscriptionInfo}
               playtimeData={playtime}
-              sessionElapsedSeconds={sessionElapsedSeconds}
+              sessionStartedAtMs={sessionStartedAtMs}
+              isStreaming={isStreaming}
               settings={{
                 resolution: settings.resolution,
                 fps: settings.fps,

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -4,6 +4,7 @@ import type { GameInfo, MediaListingEntry, Settings } from "@shared/gfn";
 import { Star, Clock, Calendar, Repeat2 } from "lucide-react";
 import { ButtonA, ButtonB, ButtonX, ButtonY, ButtonPSCross, ButtonPSCircle, ButtonPSSquare, ButtonPSTriangle } from "./ControllerButtons";
 import { getStoreDisplayName } from "./GameCard";
+import { SessionElapsedIndicator, RemainingPlaytimeIndicator, CurrentClock } from "./ElapsedSessionIndicators";
 import { type PlaytimeStore, formatPlaytime, formatLastPlayed } from "../utils/usePlaytime";
 
 interface ControllerLibraryPageProps {
@@ -15,7 +16,7 @@ interface ControllerLibraryPageProps {
   favoriteGameIds: string[];
   userName?: string;
   userAvatarUrl?: string;
-  remainingPlaytimeText?: string;
+  subscriptionInfo: import("@shared/gfn").SubscriptionInfo | null;
   playtimeData?: PlaytimeStore;
   onSelectGame: (id: string) => void;
   onSelectGameVariant: (gameId: string, variantId: string) => void;
@@ -45,7 +46,8 @@ interface ControllerLibraryPageProps {
   aspectRatioOptions?: string[];
   onSettingChange?: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
   onExitControllerMode?: () => void;
-  sessionElapsedSeconds?: number;
+  sessionStartedAtMs?: number | null;
+  isStreaming?: boolean;
 }
 
 type Direction = "up" | "down" | "left" | "right";
@@ -113,7 +115,7 @@ export function ControllerLibraryPage({
   pendingSwitchGameCover,
   userName = "Player One",
   userAvatarUrl,
-  remainingPlaytimeText = "--",
+  subscriptionInfo,
   playtimeData = {},
   settings = {},
   resolutionOptions = [],
@@ -122,7 +124,8 @@ export function ControllerLibraryPage({
   aspectRatioOptions = [],
   onSettingChange,
   onExitControllerMode,
-  sessionElapsedSeconds = 0,
+  sessionStartedAtMs = null,
+  isStreaming = false,
 }: ControllerLibraryPageProps): JSX.Element {
   const [isEntering, setIsEntering] = useState(true);
   const initialCategoryIndex = (() => {
@@ -160,7 +163,6 @@ export function ControllerLibraryPage({
   };
   const [listTranslateY, setListTranslateY] = useState(0);
   const favoriteGameIdSet = useMemo(() => new Set(favoriteGameIds), [favoriteGameIds]);
-  const [time, setTime] = useState(new Date());
   const [selectedSettingIndex, setSelectedSettingIndex] = useState(0);
   const [microphoneDevices, setMicrophoneDevices] = useState<{ deviceId: string; label: string }[]>([]);
   const [settingsSubcategory, setSettingsSubcategory] = useState<SettingsSubcategory>("root");
@@ -196,10 +198,6 @@ export function ControllerLibraryPage({
     };
   }, []);
 
-  useEffect(() => {
-    const timer = setInterval(() => setTime(new Date()), 1000);
-    return () => clearInterval(timer);
-  }, []);
 
   // poster measurement handled by `attachPosterRef` callback ref
 
@@ -878,8 +876,8 @@ export function ControllerLibraryPage({
 
       <div className="xmb-top-right">
         <div className="xmb-clock-wrap">
-          <div className="xmb-clock">{formatTime(time)}</div>
-          <div className="xmb-remaining-playtime">{remainingPlaytimeText} left</div>
+          <CurrentClock className="xmb-clock" />
+          <div className="xmb-remaining-playtime"><RemainingPlaytimeIndicator subscriptionInfo={subscriptionInfo} startedAtMs={sessionStartedAtMs} active={isStreaming} className="xmb-remaining-playtime-text" /></div>
         </div>
         <div className="xmb-user-badge">
           {userAvatarUrl ? (
@@ -1142,8 +1140,7 @@ export function ControllerLibraryPage({
                       <>
                         {storeName && <span className="xmb-game-meta-chip xmb-game-meta-chip--store">{storeName}</span>}
                         <span className="xmb-game-meta-chip xmb-game-meta-chip--session">
-                          <Clock size={12} className="xmb-meta-icon" />
-                          {formatElapsed(sessionElapsedSeconds)}
+                          <SessionElapsedIndicator startedAtMs={sessionStartedAtMs ?? null} active={isStreaming} />
                         </span>
                         <span className="xmb-game-meta-chip xmb-game-meta-chip--playtime">
                           <Clock size={10} className="xmb-meta-icon" />

--- a/opennow-stable/src/renderer/src/components/ElapsedSessionIndicators.tsx
+++ b/opennow-stable/src/renderer/src/components/ElapsedSessionIndicators.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import type { JSX } from "react";
+import { Calendar, Clock3, Clock } from "lucide-react";
+
+import type { SubscriptionInfo } from "@shared/gfn";
+
+import { formatRemainingPlaytimeFromSubscription } from "../utils/usePlaytime";
+
+function formatElapsed(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const seconds = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+  }
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+interface SessionElapsedIndicatorProps {
+  startedAtMs: number | null;
+  active: boolean;
+  className?: string;
+  iconSize?: number;
+}
+
+export function SessionElapsedIndicator({ startedAtMs, active, className, iconSize = 14 }: SessionElapsedIndicatorProps): JSX.Element {
+  const nowMs = useTicker(1000);
+  const elapsedSeconds = active && startedAtMs != null ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1000)) : 0;
+
+  return (
+    <span className={className}>
+      <Clock3 size={iconSize} />
+      <span>Session {formatElapsed(elapsedSeconds)}</span>
+    </span>
+  );
+}
+
+
+interface CurrentClockProps {
+  className?: string;
+}
+
+function useTicker(tickMs: number): number {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setNowMs(Date.now());
+    }, tickMs);
+    return () => window.clearInterval(timer);
+  }, [tickMs]);
+
+  return nowMs;
+}
+
+export function CurrentClock({ className }: CurrentClockProps): JSX.Element {
+  const nowMs = useTicker(1000);
+  return (
+    <span className={className}>
+      <Clock size={16} />
+      <span>{new Date(nowMs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
+    </span>
+  );
+}
+
+interface RemainingPlaytimeIndicatorProps {
+  subscriptionInfo: SubscriptionInfo | null;
+  startedAtMs: number | null;
+  active: boolean;
+  className?: string;
+}
+
+export function RemainingPlaytimeIndicator({ subscriptionInfo, startedAtMs, active, className }: RemainingPlaytimeIndicatorProps): JSX.Element {
+  const nowMs = useTicker(60_000);
+  const elapsedSeconds = active && startedAtMs != null ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1000)) : 0;
+  const consumedHours = active ? Math.floor(elapsedSeconds / 60) / 60 : 0;
+  const remainingPlaytimeText = formatRemainingPlaytimeFromSubscription(subscriptionInfo, consumedHours);
+
+  return (
+    <span className={className}>
+      <Calendar size={10} />
+      <span>{remainingPlaytimeText} left</span>
+    </span>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -7,7 +7,8 @@ import type { StreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
 import { useStreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
 import type { StreamLagReason } from "../gfn/webrtcClient";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
-import type { MicrophoneMode, ScreenshotEntry, RecordingEntry } from "@shared/gfn";
+import { RemainingPlaytimeIndicator, SessionElapsedIndicator } from "./ElapsedSessionIndicators";
+import type { MicrophoneMode, ScreenshotEntry, RecordingEntry, SubscriptionInfo } from "@shared/gfn";
 import { isShortcutMatch, normalizeShortcut } from "../shortcuts";
 
 interface StreamViewProps {
@@ -34,7 +35,8 @@ interface StreamViewProps {
     open: boolean;
     gameTitle: string;
   };
-  sessionElapsedSeconds: number;
+  sessionStartedAtMs: number | null;
+  isStreaming: boolean;
   sessionClockShowEveryMinutes: number;
   sessionClockShowDurationSeconds: number;
   streamWarning: {
@@ -61,7 +63,7 @@ interface StreamViewProps {
   onMicrophoneModeChange: (value: MicrophoneMode) => void;
   onScreenshotShortcutChange: (value: string) => void;
   onRecordingShortcutChange: (value: string) => void;
-  remainingPlaytimeText: string;
+  subscriptionInfo: SubscriptionInfo | null;
   micTrack?: MediaStreamTrack | null;
   className?: string;
 }
@@ -279,7 +281,8 @@ export function StreamView({
   antiAfkEnabled,
   escHoldReleaseIndicator,
   exitPrompt,
-  sessionElapsedSeconds,
+  sessionStartedAtMs,
+  isStreaming,
   sessionClockShowEveryMinutes,
   sessionClockShowDurationSeconds,
   streamWarning,
@@ -301,7 +304,7 @@ export function StreamView({
   onMicrophoneModeChange,
   onScreenshotShortcutChange,
   onRecordingShortcutChange,
-  remainingPlaytimeText,
+  subscriptionInfo,
   micTrack,
   hideStreamButtons = false,
   className,
@@ -448,7 +451,6 @@ export function StreamView({
   const inputQueueColor = getInputQueueColor(stats.inputQueueBufferedBytes, stats.inputQueueDropCount);
   const inputQueueText = `${(stats.inputQueueBufferedBytes / 1024).toFixed(1)}KB`;
   const warningSeconds = formatWarningSeconds(streamWarning?.secondsLeft);
-  const sessionTimeText = formatElapsed(sessionElapsedSeconds);
   const platformName = platformStore ? getStoreDisplayName(platformStore) : "";
   const PlatformIcon = platformStore ? getStoreIconComponent(platformStore) : null;
   const isMacClient = navigator.platform?.toLowerCase().includes("mac") || navigator.userAgent.includes("Macintosh");
@@ -1017,7 +1019,7 @@ export function StreamView({
           <SideBar title="Settings" className="sv-sidebar" onClose={() => setShowSideBar(false)}>
             <div className="sidebar-stat-line" title="Total remaining playtime from subscription">
               <span className="sidebar-stat-label">Remaining Playtime</span>
-              <span className="settings-value-badge">{remainingPlaytimeText}</span>
+              <RemainingPlaytimeIndicator subscriptionInfo={subscriptionInfo} startedAtMs={sessionStartedAtMs} active={isStreaming} className="settings-value-badge" />
             </div>
             <div className="sidebar-tabs" role="tablist" aria-label="Sidebar sections">
               <button
@@ -1487,8 +1489,7 @@ export function StreamView({
           title="Current gaming session elapsed time"
           aria-hidden={!showSessionClock}
         >
-          <Clock3 size={14} />
-          <span>Session {sessionTimeText}</span>
+          <SessionElapsedIndicator startedAtMs={sessionStartedAtMs} active={isStreaming} />
         </div>
       )}
 

--- a/opennow-stable/src/renderer/src/utils/useElapsedSeconds.ts
+++ b/opennow-stable/src/renderer/src/utils/useElapsedSeconds.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+function computeElapsedSeconds(startedAtMs: number | null): number {
+  if (startedAtMs == null) return 0;
+  return Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000));
+}
+
+export function useElapsedSeconds(startedAtMs: number | null, active: boolean, tickMs = 1000): number {
+  const [elapsedSeconds, setElapsedSeconds] = useState(() => computeElapsedSeconds(startedAtMs));
+
+  useEffect(() => {
+    if (!active || startedAtMs == null) {
+      setElapsedSeconds(0);
+      return;
+    }
+
+    let intervalId: number | null = null;
+    let timeoutId: number | null = null;
+    let cancelled = false;
+
+    const update = () => {
+      if (!cancelled) {
+        setElapsedSeconds(computeElapsedSeconds(startedAtMs));
+      }
+    };
+
+    update();
+
+    const remainder = (Date.now() - startedAtMs) % tickMs;
+    const initialDelay = remainder === 0 ? tickMs : tickMs - remainder;
+
+    timeoutId = window.setTimeout(() => {
+      update();
+      intervalId = window.setInterval(update, tickMs);
+    }, initialDelay);
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, [active, startedAtMs, tickMs]);
+
+  return elapsedSeconds;
+}

--- a/opennow-stable/src/renderer/src/utils/usePlaytime.ts
+++ b/opennow-stable/src/renderer/src/utils/usePlaytime.ts
@@ -62,6 +62,29 @@ export function formatLastPlayed(isoString: string | null): string {
   return `${Math.floor(diffDays / 365)} yr ago`;
 }
 
+export function formatRemainingPlaytimeFromSubscription(
+  subscription: { isUnlimited: boolean; remainingHours: number } | null,
+  consumedHours = 0,
+): string {
+  if (!subscription) {
+    return "--";
+  }
+  if (subscription.isUnlimited) {
+    return "Unlimited";
+  }
+
+  const baseHours = Number.isFinite(subscription.remainingHours) ? subscription.remainingHours : 0;
+  const safeHours = Math.max(0, baseHours - Math.max(0, consumedHours));
+  const totalMinutes = Math.round(safeHours * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes.toString().padStart(2, "0")}m`;
+  }
+  return `${minutes}m`;
+}
+
 export interface UsePlaytimeReturn {
   playtime: PlaytimeStore;
   startSession: (gameId: string) => void;


### PR DESCRIPTION
This pull request contains changes generated by Capy

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/39368a55-6110-40b8-905b-edaa6b99f73f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-38&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-38"><img alt="OPE-38 · 5.4 Mini" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-mini&task=OPE-38"></picture></a>