### PR TITLE
feat: add persisted session counter disable toggle

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -60,6 +60,8 @@ export interface Settings {
   /** Automatically enter fullscreen when controller-mode triggers it */
   autoFullScreen: boolean;
   favoriteGameIds: string[];
+  /** Enable the live elapsed session counter */
+  sessionCounterEnabled: boolean;
   /** Window width */
   windowWidth: number;
   /** Window height */
@@ -105,6 +107,7 @@ const DEFAULT_SETTINGS: Settings = {
   autoLoadControllerLibrary: false,
   autoFullScreen: false,
   favoriteGameIds: [],
+  sessionCounterEnabled: false,
   sessionClockShowEveryMinutes: 60,
   sessionClockShowDurationSeconds: 30,
   windowWidth: 1400,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -398,6 +398,7 @@ export function App(): JSX.Element {
     autoLoadControllerLibrary: false,
     autoFullScreen: false,
     favoriteGameIds: [],
+    sessionCounterEnabled: false,
     sessionClockShowEveryMinutes: 60,
     sessionClockShowDurationSeconds: 30,
     windowWidth: 1400,
@@ -2120,6 +2121,7 @@ export function App(): JSX.Element {
             escHoldReleaseIndicator={escHoldReleaseIndicator}
             exitPrompt={exitPrompt}
             sessionStartedAtMs={sessionStartedAtMs}
+            sessionCounterEnabled={settings.sessionCounterEnabled}
             sessionClockShowEveryMinutes={settings.sessionClockShowEveryMinutes}
             sessionClockShowDurationSeconds={settings.sessionClockShowDurationSeconds}
             streamWarning={streamWarning}
@@ -2229,6 +2231,7 @@ export function App(): JSX.Element {
               playtimeData={playtime}
               sessionStartedAtMs={sessionStartedAtMs}
               isStreaming={isStreaming}
+              sessionCounterEnabled={settings.sessionCounterEnabled}
               settings={{
                 resolution: settings.resolution,
                 fps: settings.fps,
@@ -2362,6 +2365,7 @@ export function App(): JSX.Element {
               playtimeData={playtime}
               sessionStartedAtMs={sessionStartedAtMs}
               isStreaming={isStreaming}
+              sessionCounterEnabled={settings.sessionCounterEnabled}
               settings={{
                 resolution: settings.resolution,
                 fps: settings.fps,

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -48,6 +48,7 @@ interface ControllerLibraryPageProps {
   onExitControllerMode?: () => void;
   sessionStartedAtMs?: number | null;
   isStreaming?: boolean;
+  sessionCounterEnabled?: boolean;
 }
 
 type Direction = "up" | "down" | "left" | "right";
@@ -126,6 +127,7 @@ export function ControllerLibraryPage({
   onExitControllerMode,
   sessionStartedAtMs = null,
   isStreaming = false,
+  sessionCounterEnabled = false,
 }: ControllerLibraryPageProps): JSX.Element {
   const [isEntering, setIsEntering] = useState(true);
   const initialCategoryIndex = (() => {
@@ -1139,9 +1141,11 @@ export function ControllerLibraryPage({
                     return (
                       <>
                         {storeName && <span className="xmb-game-meta-chip xmb-game-meta-chip--store">{storeName}</span>}
-                        <span className="xmb-game-meta-chip xmb-game-meta-chip--session">
-                          <SessionElapsedIndicator startedAtMs={sessionStartedAtMs ?? null} active={isStreaming} />
-                        </span>
+                        {sessionCounterEnabled && (
+                          <span className="xmb-game-meta-chip xmb-game-meta-chip--session">
+                            <SessionElapsedIndicator startedAtMs={sessionStartedAtMs ?? null} active={isStreaming} />
+                          </span>
+                        )}
                         <span className="xmb-game-meta-chip xmb-game-meta-chip--playtime">
                           <Clock size={10} className="xmb-meta-icon" />
                           {playtimeLabel}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1894,13 +1894,30 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
               </div>
             )}
 
+            <div className="settings-row">
+              <label className="settings-label">
+                Session Elapsed Counter
+                <span className="settings-hint">Enable or disable the live session elapsed counter while streaming.</span>
+              </label>
+              <label className="settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={settings.sessionCounterEnabled}
+                  onChange={(e) => handleChange("sessionCounterEnabled", e.target.checked)}
+                />
+                <span className="settings-toggle-track" />
+              </label>
+            </div>
+
             <div className="settings-row settings-row--column">
               <div className="settings-row-top">
                 <label className="settings-label">Session Timer Reappear</label>
                 <span className="settings-value-badge">
-                  {settings.sessionClockShowEveryMinutes === 0
-                    ? "Off"
-                    : `Every ${settings.sessionClockShowEveryMinutes} min`}
+                  {!settings.sessionCounterEnabled
+                    ? "Disabled"
+                    : settings.sessionClockShowEveryMinutes === 0
+                      ? "Off"
+                      : `Every ${settings.sessionClockShowEveryMinutes} min`}
                 </span>
               </div>
               <input
@@ -1911,6 +1928,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                 step={5}
                 value={settings.sessionClockShowEveryMinutes}
                 onChange={(e) => handleChange("sessionClockShowEveryMinutes", parseInt(e.target.value, 10))}
+                disabled={!settings.sessionCounterEnabled}
               />
               <span className="settings-subtle-hint">
                 How often the session timer pops back up while streaming (0 disables repeats).
@@ -1920,7 +1938,9 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
             <div className="settings-row settings-row--column">
               <div className="settings-row-top">
                 <label className="settings-label">Session Timer Visible Time</label>
-                <span className="settings-value-badge">{settings.sessionClockShowDurationSeconds}s</span>
+                <span className="settings-value-badge">
+                  {settings.sessionCounterEnabled ? `${settings.sessionClockShowDurationSeconds}s` : "Disabled"}
+                </span>
               </div>
               <input
                 type="range"
@@ -1930,9 +1950,16 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                 step={5}
                 value={settings.sessionClockShowDurationSeconds}
                 onChange={(e) => handleChange("sessionClockShowDurationSeconds", parseInt(e.target.value, 10))}
+                disabled={!settings.sessionCounterEnabled}
               />
               <span className="settings-subtle-hint">
                 How long the session timer stays visible each time it appears.
+              </span>
+            </div>
+
+            <div className="settings-row settings-row--column">
+              <span className="settings-subtle-hint">
+                Disabling the session elapsed counter stops the live elapsed timer from rendering at all. Remaining playtime indicators stay unchanged.
               </span>
             </div>
           </div>

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -37,6 +37,7 @@ interface StreamViewProps {
   };
   sessionStartedAtMs: number | null;
   isStreaming: boolean;
+  sessionCounterEnabled: boolean;
   sessionClockShowEveryMinutes: number;
   sessionClockShowDurationSeconds: number;
   streamWarning: {
@@ -283,6 +284,7 @@ export function StreamView({
   exitPrompt,
   sessionStartedAtMs,
   isStreaming,
+  sessionCounterEnabled,
   sessionClockShowEveryMinutes,
   sessionClockShowDurationSeconds,
   streamWarning,
@@ -392,6 +394,11 @@ export function StreamView({
   }, []);
 
   useEffect(() => {
+    if (!sessionCounterEnabled) {
+      setShowSessionClock(false);
+      return;
+    }
+
     if (isConnecting) {
       setShowSessionClock(false);
       return;
@@ -432,7 +439,7 @@ export function StreamView({
         window.clearInterval(periodicTimer);
       }
     };
-  }, [isConnecting, sessionClockShowDurationSeconds, sessionClockShowEveryMinutes]);
+  }, [isConnecting, sessionClockShowDurationSeconds, sessionClockShowEveryMinutes, sessionCounterEnabled]);
 
   const bitrateMbps = (stats.bitrateKbps / 1000).toFixed(1);
   const hasResolution = stats.resolution && stats.resolution !== "";
@@ -1483,7 +1490,7 @@ export function StreamView({
         </div>
       )}
 
-      {!isConnecting && (
+      {sessionCounterEnabled && !isConnecting && (
         <div
           className={`sv-session-clock${showSessionClock ? " is-visible" : ""}`}
           title="Current gaming session elapsed time"

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -104,6 +104,7 @@ export interface Settings {
   /** When true, the app will automatically enter fullscreen when controller mode triggers it */
   autoFullScreen: boolean;
   favoriteGameIds: string[];
+  sessionCounterEnabled: boolean;
   sessionClockShowEveryMinutes: number;
   sessionClockShowDurationSeconds: number;
   windowWidth: number;


### PR DESCRIPTION
This PR adds a persisted setting to disable the live session elapsed counter, defaulting it to off for fresh installs and backward-compatible merged settings. When disabled, the `SessionElapsedIndicator` component is not mounted in any view, and `StreamView` does not run its periodic session-clock scheduling effect, eliminating the 1Hz background rerenders reported during streaming.

- Added `sessionCounterEnabled: boolean` to shared `Settings` interface in `src/shared/gfn.ts`
- Added `sessionCounterEnabled: boolean` to main-process `Settings` interface in `src/main/settings.ts`
- Added `sessionCounterEnabled: false` to `DEFAULT_SETTINGS` in `src/main/settings.ts` so fresh installs and merged legacy settings default to disabled
- In `App.tsx`, threaded `settings.sessionCounterEnabled` into `StreamView` and both `ControllerLibraryPage` mounts (overlay during streaming and standalone library view)
- In `StreamView`, added `sessionCounterEnabled` prop, short-circuited the session-clock scheduling `useEffect` before timer setup when the setting is false, and conditionally renders the `SessionElapsedIndicator` subtree
- In `ControllerLibraryPage`, added `sessionCounterEnabled` prop and conditionally renders `SessionElapsedIndicator`
- In `SettingsPage`, added a toggle labeled "Session Elapsed Counter" near existing session timer controls, disabled both session timer sliders while the toggle is off, and added helper text explaining that disabling stops the live elapsed timer from rendering
- Remaining playtime indicators (`RemainingPlaytimeIndicator`) are unchanged and continue to render regardless of the setting

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/57ee8ba3-2808-4cc4-b2f2-68992238c767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-42&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-42"><img alt="OPE-42 · 5.4-Fast" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-42"></picture></a>