### PR TITLE
feat(stream): redesign escape-hold overlay into centered circular countdown

### DIFF
--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -791,7 +791,13 @@ export function StreamView({
   }, [isConnecting, sessionClockShowDurationSeconds, sessionClockShowEveryMinutes, sessionCounterEnabled]);
 
   const escHoldProgress = Math.max(0, Math.min(1, escHoldReleaseIndicator.progress));
-  const escHoldSecondsLeft = Math.max(0, 5 - Math.floor(escHoldProgress * 5));
+  const escHoldCountdownSeconds = Math.max(0, 5 * (1 - escHoldProgress));
+  const escHoldCountdownLabel = escHoldCountdownSeconds > 0
+    ? `${escHoldCountdownSeconds.toFixed(1)}s`
+    : "0.0s";
+  const escHoldRingRadius = 54;
+  const escHoldRingCircumference = 2 * Math.PI * escHoldRingRadius;
+  const escHoldRingOffset = escHoldRingCircumference * escHoldProgress;
   const warningSeconds = formatWarningSeconds(streamWarning?.secondsLeft);
   const platformName = platformStore ? getStoreDisplayName(platformStore) : "";
   const PlatformIcon = platformStore ? getStoreIconComponent(platformStore) : null;
@@ -1872,19 +1878,38 @@ export function StreamView({
         recordingDurationMs={recordingDurationMs}
       />
 
-      {/* Hold-Esc release indicator (appears after 1s hold) */}
+      {/* Hold-Esc release indicator */}
       {escHoldReleaseIndicator.visible && !isConnecting && (
         <>
           <div className="sv-esc-hold-backdrop" />
-          <div className="sv-esc-hold" title="Keep holding Escape to release mouse lock">
-            <div className="sv-esc-hold-title">Hold Escape to Release Mouse</div>
-            <div className="sv-esc-hold-head">
-              <span>Keep holding…</span>
-              <span>{escHoldSecondsLeft}s</span>
+          <div
+            className="sv-esc-hold"
+            role="status"
+            aria-label="Hold Escape to release mouse lock. Keep holding until the timer reaches zero."
+            title="Keep holding Escape to release mouse lock"
+          >
+            <div className="sv-esc-hold-kicker">Mouse lock</div>
+            <div className="sv-esc-hold-ring" aria-hidden="true">
+              <svg className="sv-esc-hold-ring-svg" viewBox="0 0 140 140">
+                <circle className="sv-esc-hold-ring-track" cx="70" cy="70" r={escHoldRingRadius} />
+                <circle
+                  className="sv-esc-hold-ring-progress"
+                  cx="70"
+                  cy="70"
+                  r={escHoldRingRadius}
+                  style={{
+                    strokeDasharray: escHoldRingCircumference,
+                    strokeDashoffset: escHoldRingOffset,
+                  }}
+                />
+              </svg>
+              <div className="sv-esc-hold-ring-core">
+                <span className="sv-esc-hold-time">{escHoldCountdownLabel}</span>
+                <span className="sv-esc-hold-caption">to release</span>
+              </div>
             </div>
-            <div className="sv-esc-hold-track">
-              <span className="sv-esc-hold-fill" style={{ transform: `scaleX(${escHoldProgress})` }} />
-            </div>
+            <div className="sv-esc-hold-title">Hold Escape</div>
+            <p className="sv-esc-hold-text">Keep holding until the timer reaches zero.</p>
           </div>
         </>
       )}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3688,61 +3688,160 @@ button.game-card-store-chip.active:hover {
   inset: 0;
   z-index: 1200;
   pointer-events: none;
-  background: rgba(8, 9, 10, 0.24);
-  backdrop-filter: blur(7px) saturate(110%);
+  background:
+    radial-gradient(circle at 50% 50%, rgba(88, 217, 138, 0.08), transparent 38%),
+    rgba(5, 6, 7, 0.42);
+  backdrop-filter: blur(12px) saturate(130%);
   animation: fade-in 140ms var(--ease);
 }
 
 .sv-esc-hold {
   position: fixed;
-  top: 20%;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   z-index: 1201;
-  width: min(520px, calc(100vw - 40px));
-  padding: 16px 18px;
-  background: rgba(10, 10, 12, 0.92);
-  border: 1px solid var(--panel-border);
-  border-radius: calc(var(--r-md) + 2px);
-  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.45);
-  animation: fade-in 180ms var(--ease), float-a 8s ease-in-out infinite;
+  width: min(320px, calc(100vw - 32px));
+  padding: clamp(20px, 4vw, 28px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  pointer-events: none;
+  text-align: center;
+  border-radius: var(--r-xl);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)),
+    rgba(14, 16, 18, 0.86);
+  backdrop-filter: blur(20px) saturate(140%);
+  box-shadow: var(--shadow-lg), 0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+  animation: fade-in 180ms var(--ease);
+}
+
+.sv-esc-hold::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: calc(var(--r-xl) - 1px);
+  background: linear-gradient(180deg, rgba(88, 217, 138, 0.08), rgba(255, 255, 255, 0));
+  opacity: 0.65;
+}
+
+.sv-esc-hold > * {
+  position: relative;
+  z-index: 1;
+}
+
+.sv-esc-hold-kicker {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.sv-esc-hold-ring {
+  position: relative;
+  width: clamp(148px, 32vw, 184px);
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  filter: drop-shadow(0 0 18px rgba(88, 217, 138, 0.14));
+}
+
+.sv-esc-hold-ring::before {
+  content: "";
+  position: absolute;
+  inset: 16%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 40%, rgba(88, 217, 138, 0.18), rgba(88, 217, 138, 0.02) 58%, rgba(9, 11, 12, 0.9) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 0 24px rgba(88, 217, 138, 0.08);
+}
+
+.sv-esc-hold-ring-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.sv-esc-hold-ring-track,
+.sv-esc-hold-ring-progress {
+  fill: none;
+  stroke-width: 10;
+}
+
+.sv-esc-hold-ring-track {
+  stroke: rgba(255, 255, 255, 0.08);
+}
+
+.sv-esc-hold-ring-progress {
+  stroke: var(--accent);
+  stroke-linecap: round;
+  transition: stroke-dashoffset 50ms linear;
+  filter: drop-shadow(0 0 10px var(--accent-glow));
+}
+
+.sv-esc-hold-ring-core {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.sv-esc-hold-time {
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+  line-height: 1;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.34);
+}
+
+.sv-esc-hold-caption {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
 }
 
 .sv-esc-hold-title {
-  font-size: 1.02rem;
+  font-size: 1.12rem;
   font-weight: 800;
-  letter-spacing: 0.01em;
+  letter-spacing: -0.02em;
   color: var(--ink);
 }
 
-.sv-esc-hold-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  margin-top: 6px;
-  font-size: 0.82rem;
+.sv-esc-hold-text {
+  max-width: 24ch;
+  font-size: 0.84rem;
+  line-height: 1.45;
   color: var(--ink-soft);
-  font-weight: 700;
 }
 
-.sv-esc-hold-track {
-  margin-top: 10px;
-  height: 10px;
-  border-radius: 999px;
-  overflow: hidden;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
+@media (max-width: 640px) {
+  .sv-esc-hold {
+    width: min(280px, calc(100vw - 24px));
+    padding: 18px;
+    gap: 8px;
+  }
 
-.sv-esc-hold-fill {
-  display: block;
-  width: 100%;
-  height: 100%;
-  transform-origin: left center;
-  transform: scaleX(0);
-  transition: transform 50ms linear;
-  background: linear-gradient(90deg, #e6b64c 0%, #f07b3f 55%, #f05050 100%);
+  .sv-esc-hold-ring {
+    width: min(160px, 48vw);
+  }
+
+  .sv-esc-hold-title {
+    font-size: 1rem;
+  }
+
+  .sv-esc-hold-text {
+    font-size: 0.78rem;
+  }
 }
 
 .sv-exit {


### PR DESCRIPTION
This PR replaces the top-aligned rectangular progress bar with a centered, polished circular countdown ring that aligns with the OpenNOW visual language. The overlay now features a dark glassy card with an accent-colored SVG ring, a prominent numeric timer (trending from 5.0s to 0.0s), and concise instruction text. It remains lightweight and non-interactive, preserving existing hold-to-release behavior without WebRTC contract changes.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/5975d100-c2a1-4a23-8dd0-8675394bbf0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-45&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-45"><img alt="OPE-45 · 5.4-Fast" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-45"></picture></a>