### PR TITLE
feat: add show stats on launch setting

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -49,6 +49,8 @@ export interface Settings {
   microphoneDeviceId: string;
   /** Hide stream buttons (mic/fullscreen/end-session) while streaming */
   hideStreamButtons: boolean;
+  /** Show the stats overlay automatically when a stream launches */
+  showStatsOnLaunch: boolean;
   /** Enable controller-first media bar layout for library browsing */
   controllerMode: boolean;
   /** Play subtle sounds in controller library mode */
@@ -101,6 +103,7 @@ const DEFAULT_SETTINGS: Settings = {
   microphoneMode: "disabled",
   microphoneDeviceId: "",
   hideStreamButtons: false,
+  showStatsOnLaunch: false,
   controllerMode: false,
   controllerUiSounds: false,
   controllerBackgroundAnimations: false,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -618,6 +618,7 @@ export function App(): JSX.Element {
     microphoneMode: "disabled",
     microphoneDeviceId: "",
     hideStreamButtons: false,
+    showStatsOnLaunch: false,
     controllerMode: false,
     controllerUiSounds: false,
     controllerBackgroundAnimations: false,
@@ -643,7 +644,7 @@ export function App(): JSX.Element {
   // Stream State
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [streamStatus, setStreamStatus] = useState<StreamStatus>("idle");
-  const [showStatsOverlay, setShowStatsOverlay] = useState(true);
+  const [showStatsOverlay, setShowStatsOverlay] = useState(false);
   const [antiAfkEnabled, setAntiAfkEnabled] = useState(false);
   const [escHoldReleaseIndicator, setEscHoldReleaseIndicator] = useState<{ visible: boolean; progress: number }>({
     visible: false,
@@ -665,6 +666,10 @@ export function App(): JSX.Element {
   const isStreaming = streamStatus === "streaming";
 
   const controllerOverlayOpenRef = useRef(false);
+
+  const resetStatsOverlayToPreference = useCallback((): void => {
+    setShowStatsOverlay(settings.showStatsOnLaunch);
+  }, [settings.showStatsOnLaunch]);
 
   const handleControllerPageNavigate = useCallback((direction: "prev" | "next"): void => {
     if (controllerOverlayOpenRef.current) {
@@ -1084,6 +1089,7 @@ export function App(): JSX.Element {
     setSessionStartedAtMs(null);
     setStreamWarning(null);
     setEscHoldReleaseIndicator({ visible: false, progress: 0 });
+    resetStatsOverlayToPreference();
     diagnosticsStore.set(defaultDiagnostics());
 
     if (!options?.keepStreamingContext) {
@@ -1094,7 +1100,7 @@ export function App(): JSX.Element {
     if (!options?.keepLaunchError) {
       setLaunchError(null);
     }
-  }, [diagnosticsStore]);
+  }, [diagnosticsStore, resetStatsOverlayToPreference]);
 
   // Session ref sync
   useEffect(() => {
@@ -1472,6 +1478,7 @@ export function App(): JSX.Element {
         // Load settings first
         const loadedSettings = await window.openNow.getSettings();
         setSettings(loadedSettings);
+        setShowStatsOverlay(loadedSettings.showStatsOnLaunch);
         setSettingsLoaded(true);
 
         // Load providers and session (refresh only if token is near expiry)
@@ -2108,7 +2115,7 @@ export function App(): JSX.Element {
       signalingServer: claimed.signalingServer,
       signalingUrl: claimed.signalingUrl,
     });
-  }, [authSession, effectiveStreamingBaseUrl, findGameContextForSession, settings]);
+  }, [authSession, effectiveStreamingBaseUrl, findGameContextForSession, resetStatsOverlayToPreference, settings]);
 
   // Play game handler
   const handlePlayGame = useCallback(async (game: GameInfo, options?: { bypassGuards?: boolean }) => {
@@ -2140,6 +2147,7 @@ export function App(): JSX.Element {
     setSessionStartedAtMs(null);
     setStreamWarning(null);
     setLaunchError(null);
+    resetStatsOverlayToPreference();
     const selectedVariantId = variantByGameId[game.id] ?? defaultVariantId(game);
     const selectedVariant = getSelectedVariant(game, selectedVariantId);
     startPlaytimeSession(game.id);
@@ -2398,6 +2406,7 @@ export function App(): JSX.Element {
     effectiveStreamingBaseUrl,
     refreshNavbarActiveSession,
     resetLaunchRuntime,
+    resetStatsOverlayToPreference,
     selectedProvider,
     settings,
     streamStatus,
@@ -2424,6 +2433,7 @@ export function App(): JSX.Element {
     setQueuePosition(undefined);
     setSessionStartedAtMs(null);
     setStreamWarning(null);
+    resetStatsOverlayToPreference();
     const matchedContext = findGameContextForSession(navbarActiveSession);
     if (matchedContext) {
       setStreamingGame(matchedContext.game);
@@ -2455,6 +2465,7 @@ export function App(): JSX.Element {
     findGameContextForSession,
     refreshNavbarActiveSession,
     resetLaunchRuntime,
+    resetStatsOverlayToPreference,
     selectedProvider,
     streamStatus,
   ]);

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1817,6 +1817,21 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
 
             <div className="settings-row">
               <label className="settings-label">
+                Show Stats on Stream Launch
+                <span className="settings-hint">Automatically show the stats overlay when a new stream starts.</span>
+              </label>
+              <label className="settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={settings.showStatsOnLaunch}
+                  onChange={(e) => handleChange("showStatsOnLaunch", e.target.checked)}
+                />
+                <span className="settings-toggle-track" />
+              </label>
+            </div>
+
+            <div className="settings-row">
+              <label className="settings-label">
                 <span className="settings-label-title">
                   Controller Mode Library
                   <span className="settings-inline-badge settings-inline-badge--beta">Beta</span>

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -96,6 +96,7 @@ export interface Settings {
   microphoneMode: MicrophoneMode;
   microphoneDeviceId: string;
   hideStreamButtons: boolean;
+  showStatsOnLaunch: boolean;
   controllerMode: boolean;
   controllerUiSounds: boolean;
   autoLoadControllerLibrary: boolean;


### PR DESCRIPTION
## Description

Adds a persisted `showStatsOnLaunch` Appearance setting (default `false`) that controls whether the stats overlay automatically appears when a new stream launches. The overlay can still be toggled manually during streaming via the existing `F3` shortcut, and each subsequent stream launch resets to the saved preference rather than persisting the prior session's toggle state.

- Added `showStatsOnLaunch` boolean to Settings interface and main-process defaults
- Added Appearance toggle row in SettingsPage
- Updated renderer to reset overlay visibility to saved preference on each new stream launch (`handlePlayGame`, `claimAndConnectSession`, `handleResumeFromNavbar`) and during initialization
- Changed default overlay initial state from `true` to `false` to match new default setting

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/b8c3ebd5-0ef7-4933-9ebf-e9a47c82bd50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-47&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-47"><img alt="OPE-47 · 5.4-Fast" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-47"></picture></a>