### PR TITLE
feat(signaling): implement official-style signaling with survivability

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -20,6 +20,7 @@ import type {
 
 import {
   DEFAULT_KEYBOARD_LAYOUT,
+  getDefaultStreamPreferences,
   colorQualityBitDepth,
   colorQualityChromaFormat,
   normalizeStreamPreferences,
@@ -1277,12 +1278,13 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
 
   // Provide default values for optional parameters
   const appId = input.appId ?? "0";
+  const defaultStreamPreferences = getDefaultStreamPreferences();
   const settings = input.settings ?? {
     resolution: "1920x1080",
     fps: 60,
     maxBitrateMbps: 75,
-    codec: "H264",
-    colorQuality: "8bit_420",
+    codec: defaultStreamPreferences.codec,
+    colorQuality: defaultStreamPreferences.colorQuality,
     keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
     gameLanguage: "en_US",
     enableL4S: false,

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -22,7 +22,7 @@ import {
   DEFAULT_KEYBOARD_LAYOUT,
   colorQualityBitDepth,
   colorQualityChromaFormat,
-  normalizeSafeStreamPreferences,
+  normalizeStreamPreferences,
   resolveGfnKeyboardLayout,
 } from "@shared/gfn";
 
@@ -454,9 +454,9 @@ function timezoneOffsetMs(): number {
 
 function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
   const { width, height } = parseResolution(input.settings.resolution);
-  const safeStreamPreferences = normalizeSafeStreamPreferences(input.settings.codec, input.settings.colorQuality);
-  input.settings.codec = safeStreamPreferences.codec;
-  input.settings.colorQuality = safeStreamPreferences.colorQuality;
+  const normalizedStreamPreferences = normalizeStreamPreferences(input.settings.codec, input.settings.colorQuality);
+  input.settings.codec = normalizedStreamPreferences.codec;
+  input.settings.colorQuality = normalizedStreamPreferences.colorQuality;
   const cq = input.settings.colorQuality;
   // IMPORTANT: hdrEnabled is a SEPARATE toggle from color quality.
   // The Rust reference (cloudmatch.rs) uses settings.hdr_enabled independently.

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_KEYBOARD_LAYOUT,
   colorQualityBitDepth,
   colorQualityChromaFormat,
+  normalizeSafeStreamPreferences,
   resolveGfnKeyboardLayout,
 } from "@shared/gfn";
 
@@ -453,6 +454,9 @@ function timezoneOffsetMs(): number {
 
 function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
   const { width, height } = parseResolution(input.settings.resolution);
+  const safeStreamPreferences = normalizeSafeStreamPreferences(input.settings.codec, input.settings.colorQuality);
+  input.settings.codec = safeStreamPreferences.codec;
+  input.settings.colorQuality = safeStreamPreferences.colorQuality;
   const cq = input.settings.colorQuality;
   // IMPORTANT: hdrEnabled is a SEPARATE toggle from color quality.
   // The Rust reference (cloudmatch.rs) uses settings.hdr_enabled independently.

--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -7,17 +7,41 @@ import type {
   KeyframeRequest,
   MainToRendererSignalingEvent,
   SendAnswerRequest,
+  SignalingDisconnectInfo,
+  SignalingSessionPhase,
 } from "@shared/gfn";
 
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/131.0.0.0 Safari/537.36";
+const HEARTBEAT_INTERVAL_MS = 5000;
+const HEARTBEAT_STALE_MS = 20000;
+const RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECT_ATTEMPTS = 3;
+const HOST_PEER_ID = 1;
+const CLIENT_PEER_ID = 2;
+
+type PeerPayload = Record<string, unknown>;
+
+type OutboundEnvelope = {
+  ackId: number;
+  body: SignalingMessage;
+  replayable: boolean;
+  label: string;
+};
 
 interface SignalingMessage {
   ackid?: number;
   ack?: number;
   hb?: number;
   peer_info?: {
+    browser?: string;
+    browserVersion?: string;
+    connected?: boolean;
     id: number;
+    name?: string;
+    peerRole?: number;
+    resolution?: string;
+    version?: number;
   };
   peer_msg?: {
     from: number;
@@ -28,36 +52,31 @@ interface SignalingMessage {
 
 export class GfnSignalingClient {
   private ws: WebSocket | null = null;
-  private peerId = 2;
-  private peerName = `peer-${Math.floor(Math.random() * 10_000_000_000)}`;
-  private ackCounter = 0;
-  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private readonly peerId = CLIENT_PEER_ID;
+  private readonly peerName = `peer-${Math.floor(Math.random() * 10_000_000_000)}`;
+  private readonly listeners = new Set<(event: MainToRendererSignalingEvent) => void>();
+
   private isDisconnecting = false;
-  private listeners = new Set<(event: MainToRendererSignalingEvent) => void>();
+  private socketGeneration = 0;
+  private nextOutboundAckId = 0;
+  private lastInboundAckId = 0;
+  private sessionPhase: SignalingSessionPhase = "sign-in";
+  private hasEverOpened = false;
+  private reconnectAttempt = 0;
+  private connectPromise: Promise<void> | null = null;
+  private connectResolve: (() => void) | null = null;
+  private connectReject: ((error: Error) => void) | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private lastMessageAt = 0;
+  private queuedOutbound: OutboundEnvelope[] = [];
+  private unackedOutbound = new Map<number, OutboundEnvelope>();
 
   constructor(
     private readonly signalingServer: string,
     private readonly sessionId: string,
     private readonly signalingUrl?: string,
   ) {}
-
-  private buildSignInUrl(): string {
-    const fallbackHost = this.signalingServer.includes(":")
-      ? this.signalingServer
-      : `${this.signalingServer}:443`;
-    const baseUrl = this.signalingUrl?.trim() || `wss://${fallbackHost}/nvst/`;
-    const signInUrl = new URL(baseUrl);
-
-    signInUrl.protocol = "wss:";
-    signInUrl.pathname = `${signInUrl.pathname.replace(/\/?$/, "/")}sign_in`;
-    signInUrl.search = "";
-    signInUrl.searchParams.set("peer_id", this.peerName);
-    signInUrl.searchParams.set("version", "2");
-
-    const url = signInUrl.toString();
-    console.log("[Signaling] URL:", url, "(server:", this.signalingServer, ", signalingUrl:", this.signalingUrl, ")");
-    return url;
-  }
 
   onEvent(listener: (event: MainToRendererSignalingEvent) => void): () => void {
     this.listeners.add(listener);
@@ -70,23 +89,73 @@ export class GfnSignalingClient {
     }
   }
 
-  private nextAckId(): number {
-    this.ackCounter += 1;
-    return this.ackCounter;
+  private log(message: string): void {
+    console.log(`[Signaling] ${message}`);
+    this.emit({ type: "log", message });
   }
 
-  private sendJson(payload: unknown): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      return;
+  private resolveConnect(): void {
+    this.connectResolve?.();
+    this.connectResolve = null;
+    this.connectReject = null;
+    this.connectPromise = null;
+  }
+
+  private rejectConnect(error: Error): void {
+    this.connectReject?.(error);
+    this.connectResolve = null;
+    this.connectReject = null;
+    this.connectPromise = null;
+  }
+
+  private nextAckId(): number {
+    this.nextOutboundAckId += 1;
+    return this.nextOutboundAckId;
+  }
+
+  private buildSocketUrl(isReconnect: boolean): string {
+    const fallbackHost = this.signalingServer.includes(":")
+      ? this.signalingServer
+      : `${this.signalingServer}:443`;
+    const baseUrl = this.signalingUrl?.trim() || `wss://${fallbackHost}/nvst/`;
+    const signInUrl = new URL(baseUrl);
+
+    signInUrl.protocol = "wss:";
+    signInUrl.pathname = `${signInUrl.pathname.replace(/\/?$/, "/")}sign_in`;
+    signInUrl.search = "";
+    signInUrl.searchParams.set("peer_id", this.peerName);
+    signInUrl.searchParams.set("version", "2");
+    if (isReconnect) {
+      signInUrl.searchParams.set("reconnect", "1");
     }
-    this.ws.send(JSON.stringify(payload));
+    return signInUrl.toString();
+  }
+
+  private getSocketOptions(url: string): ConstructorParameters<typeof WebSocket>[2] {
+    const urlHost = url.replace(/^wss?:\/\//, "").split("/")[0];
+    return {
+      rejectUnauthorized: false,
+      headers: {
+        Host: urlHost,
+        Origin: "https://play.geforcenow.com",
+        "User-Agent": USER_AGENT,
+        "Sec-WebSocket-Key": randomBytes(16).toString("base64"),
+      },
+    };
   }
 
   private setupHeartbeat(): void {
     this.clearHeartbeat();
+    this.lastMessageAt = Date.now();
     this.heartbeatTimer = setInterval(() => {
-      this.sendJson({ hb: 1 });
-    }, 5000);
+      const idleForMs = Date.now() - this.lastMessageAt;
+      if (idleForMs >= HEARTBEAT_STALE_MS) {
+        this.log(
+          `Heartbeat stale: idle=${idleForMs}ms gen=${this.socketGeneration} phase=${this.sessionPhase} lastInAck=${this.lastInboundAckId} lastOutAck=${this.nextOutboundAckId}`,
+        );
+      }
+      this.sendImmediate({ hb: 1 });
+    }, HEARTBEAT_INTERVAL_MS);
   }
 
   private clearHeartbeat(): void {
@@ -96,81 +165,315 @@ export class GfnSignalingClient {
     }
   }
 
-  private sendPeerInfo(): void {
-    this.sendJson({
-      ackid: this.nextAckId(),
-      peer_info: {
-        browser: "Chrome",
-        browserVersion: "131",
-        connected: true,
-        id: this.peerId,
-        name: this.peerName,
-        peerRole: 0,
-        resolution: "1920x1080",
-        version: 2,
-      },
-    });
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
   }
 
-  async connect(): Promise<void> {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+  private describeState(): string {
+    return `gen=${this.socketGeneration} attempt=${this.reconnectAttempt} phase=${this.sessionPhase} lastInAck=${this.lastInboundAckId} lastOutAck=${this.nextOutboundAckId} queued=${this.queuedOutbound.length} unacked=${this.unackedOutbound.size}`;
+  }
+
+  private sendImmediate(payload: SignalingMessage): boolean {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+    this.ws.send(JSON.stringify(payload));
+    return true;
+  }
+
+  private flushQueuedOutbound(skipAckIdsInReplayStore = false): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN || this.queuedOutbound.length === 0) {
       return;
     }
 
-    const url = this.buildSignInUrl();
-    const protocol = `x-nv-sessionid.${this.sessionId}`;
+    const queued = [...this.queuedOutbound];
+    this.queuedOutbound = [];
+    for (const item of queued) {
+      if (skipAckIdsInReplayStore && this.unackedOutbound.has(item.ackId)) {
+        continue;
+      }
+      this.sendEnvelope(item, false);
+    }
+  }
+
+  private replayUnackedOutbound(): number {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN || this.unackedOutbound.size === 0) {
+      return 0;
+    }
+
+    const replayList = [...this.unackedOutbound.values()].sort((a, b) => a.ackId - b.ackId);
+    for (const item of replayList) {
+      this.sendEnvelope(item, false);
+    }
+    return replayList.length;
+  }
+
+  private sendEnvelope(envelope: OutboundEnvelope, allowQueue: boolean): void {
+    const sent = this.sendImmediate(envelope.body);
+    if (sent) {
+      if (envelope.replayable) {
+        this.unackedOutbound.set(envelope.ackId, envelope);
+      }
+      return;
+    }
+
+    if (!allowQueue) {
+      return;
+    }
+
+    this.queuedOutbound.push(envelope);
+    if (envelope.replayable) {
+      this.unackedOutbound.set(envelope.ackId, envelope);
+    }
+    this.log(
+      `Queued outbound ${envelope.label} ackid=${envelope.ackId} ${this.describeState()}`,
+    );
+  }
+
+  private sendTrackedMessage(body: Omit<SignalingMessage, "ackid">, label: string, replayable = true): void {
+    const ackId = this.nextAckId();
+    this.sendEnvelope(
+      {
+        ackId,
+        body: { ...body, ackid: ackId },
+        replayable,
+        label,
+      },
+      true,
+    );
+  }
+
+  private sendAck(ackId: number): void {
+    const sent = this.sendImmediate({ ack: ackId });
+    this.log(`Sent ack=${ackId} sent=${sent} ${this.describeState()}`);
+  }
+
+  private ackOutbound(ackId: number): void {
+    const ackedIds = [...this.unackedOutbound.keys()].filter((candidate) => candidate <= ackId);
+    for (const candidate of ackedIds) {
+      this.unackedOutbound.delete(candidate);
+      this.queuedOutbound = this.queuedOutbound.filter((item) => item.ackId !== candidate);
+    }
+    if (ackedIds.length > 0) {
+      this.log(`Acked outbound <=${ackId} removed=${ackedIds.length} ${this.describeState()}`);
+    }
+  }
+
+  private sendPeerInfo(): void {
+    this.sendTrackedMessage(
+      {
+        peer_info: {
+          browser: "Chrome",
+          browserVersion: "131",
+          connected: true,
+          id: this.peerId,
+          name: this.peerName,
+          peerRole: 0,
+          resolution: "1920x1080",
+          version: 2,
+        },
+      },
+      "peer_info",
+      true,
+    );
+  }
+
+  async connect(): Promise<void> {
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+      return;
+    }
 
     this.isDisconnecting = false;
+    this.clearReconnectTimer();
 
-    console.log("[Signaling] Connecting to:", url);
-    console.log("[Signaling] Session ID:", this.sessionId);
-    console.log("[Signaling] Protocol:", protocol);
-
-    await new Promise<void>((resolve, reject) => {
-      // Extract host:port for the Host header (matching Rust behavior)
-      const urlHost = url.replace(/^wss?:\/\//, "").split("/")[0];
-
-      const ws = new WebSocket(url, protocol, {
-        rejectUnauthorized: false,
-        headers: {
-          Host: urlHost,
-          Origin: "https://play.geforcenow.com",
-          "User-Agent": USER_AGENT,
-          "Sec-WebSocket-Key": randomBytes(16).toString("base64"),
-        },
-      });
-
-      this.ws = ws;
-
-      ws.once("error", (error) => {
-        this.emit({ type: "error", message: `Signaling connect failed: ${String(error)}` });
-        reject(error);
-      });
-
-      ws.once("open", () => {
-        this.sendPeerInfo();
-        this.setupHeartbeat();
-        this.emit({ type: "connected" });
-        resolve();
-      });
-
-      ws.on("message", (raw) => {
-        const text = typeof raw === "string" ? raw : raw.toString("utf8");
-        this.handleMessage(text);
-      });
-
-      ws.on("close", (_code, reason) => {
-        this.clearHeartbeat();
-        this.ws = null;
-
-        if (this.isDisconnecting) {
-          return;
-        }
-
-        const reasonText = typeof reason === "string" ? reason : reason.toString("utf8");
-        this.emit({ type: "disconnected", reason: reasonText || "socket closed" });
-      });
+    this.connectPromise = new Promise<void>((resolve, reject) => {
+      this.connectResolve = resolve;
+      this.connectReject = reject;
     });
+
+    this.openSocket(false, false);
+    return this.connectPromise;
+  }
+
+  private openSocket(isReconnect: boolean, resolveAsReconnect: boolean): void {
+    const generation = this.socketGeneration + 1;
+    this.socketGeneration = generation;
+    const url = this.buildSocketUrl(isReconnect);
+    const protocol = `x-nv-sessionid.${this.sessionId}`;
+
+    this.log(`Opening socket ${isReconnect ? "reconnect" : "initial"} url=${url} ${this.describeState()}`);
+
+    const ws = new WebSocket(url, protocol, this.getSocketOptions(url));
+    this.ws = ws;
+
+    let handshakeSettled = false;
+    const settleConnect = (): void => {
+      if (handshakeSettled) {
+        return;
+      }
+      handshakeSettled = true;
+      if (resolveAsReconnect) {
+        return;
+      }
+      this.resolveConnect();
+    };
+
+    const failConnect = (error: Error): void => {
+      if (handshakeSettled) {
+        return;
+      }
+      handshakeSettled = true;
+      if (resolveAsReconnect) {
+        return;
+      }
+      this.rejectConnect(error);
+    };
+
+    const isCurrentSocket = (): boolean => this.ws === ws && this.socketGeneration === generation;
+
+    let socketErrored = false;
+
+    ws.on("open", () => {
+      if (!isCurrentSocket()) {
+        ws.close();
+        return;
+      }
+
+      this.hasEverOpened = true;
+      this.setupHeartbeat();
+      this.lastMessageAt = Date.now();
+
+      let replayedCount = 0;
+      if (isReconnect) {
+        replayedCount = this.replayUnackedOutbound();
+      }
+      this.flushQueuedOutbound(isReconnect);
+      if (!isReconnect || replayedCount === 0) {
+        this.sendPeerInfo();
+      }
+
+      this.log(
+        `Socket open gen=${generation} reconnect=${isReconnect} replayed=${replayedCount} queuedFlushed=${this.queuedOutbound.length === 0} ${this.describeState()}`,
+      );
+
+      if (isReconnect) {
+        this.emit({
+          type: "reconnected",
+          socketGeneration: generation,
+          attempt: this.reconnectAttempt,
+          replayedCount,
+          sessionPhase: this.sessionPhase,
+        });
+      } else {
+        this.emit({ type: "connected", socketGeneration: generation, sessionPhase: this.sessionPhase });
+      }
+
+      settleConnect();
+    });
+
+    ws.on("error", (error) => {
+      if (!isCurrentSocket()) {
+        return;
+      }
+      socketErrored = true;
+      this.log(`Socket error gen=${generation} reconnect=${isReconnect} ${String(error)} ${this.describeState()}`);
+      this.emit({ type: "error", message: `Signaling socket error: ${String(error)}` });
+      failConnect(error instanceof Error ? error : new Error(String(error)));
+    });
+
+    ws.on("message", (raw) => {
+      if (!isCurrentSocket()) {
+        return;
+      }
+      const text = typeof raw === "string" ? raw : raw.toString("utf8");
+      this.lastMessageAt = Date.now();
+      this.handleMessage(text);
+    });
+
+    ws.on("close", (code, reason) => {
+      const reasonText = typeof reason === "string" ? reason : reason.toString("utf8");
+      const detail = this.buildDisconnectInfo(code, reasonText, ws, generation, socketErrored);
+      this.clearHeartbeat();
+      if (isCurrentSocket()) {
+        this.ws = null;
+      }
+
+      this.log(
+        `Socket close gen=${generation} code=${detail.code} clean=${detail.wasClean} willRetry=${detail.willRetry} reason=${detail.reason || "<empty>"} ${this.describeState()}`,
+      );
+
+      if (this.isDisconnecting) {
+        settleConnect();
+        return;
+      }
+
+      failConnect(new Error(`Signaling closed before ready: code=${detail.code} reason=${detail.reason || "socket closed"}`));
+      this.emit({ type: "disconnected", detail });
+
+      if (detail.willRetry) {
+        this.scheduleReconnect();
+      }
+    });
+  }
+
+  private buildDisconnectInfo(
+    code: number,
+    reason: string,
+    ws: WebSocket,
+    generation: number,
+    socketErrored: boolean,
+  ): SignalingDisconnectInfo {
+    const normalizedCode = Number.isFinite(code) && code > 0 ? code : 1005;
+    const frameReceived = Boolean((ws as WebSocket & { _closeFrameReceived?: boolean })._closeFrameReceived);
+    const frameSent = Boolean((ws as WebSocket & { _closeFrameSent?: boolean })._closeFrameSent);
+    const wasClean = frameReceived && frameSent && !socketErrored;
+    const error = socketErrored || (normalizedCode >= 1002 && normalizedCode <= 1015);
+    const willRetry =
+      !this.isDisconnecting
+      && this.sessionPhase === "established"
+      && this.hasEverOpened
+      && this.reconnectAttempt < MAX_RECONNECT_ATTEMPTS
+      && (error || normalizedCode === 1006 || normalizedCode === 1001);
+
+    return {
+      code: normalizedCode,
+      reason,
+      wasClean,
+      error,
+      attempt: this.reconnectAttempt,
+      willRetry,
+      socketGeneration: generation,
+      sessionPhase: this.sessionPhase,
+      lastInboundAckId: this.lastInboundAckId,
+      lastOutboundAckId: this.nextOutboundAckId,
+    };
+  }
+
+  private scheduleReconnect(): void {
+    this.clearReconnectTimer();
+    this.reconnectAttempt += 1;
+    const replayCount = this.unackedOutbound.size;
+    this.emit({
+      type: "reconnecting",
+      socketGeneration: this.socketGeneration,
+      attempt: this.reconnectAttempt,
+      queuedReplayCount: replayCount,
+      sessionPhase: this.sessionPhase,
+    });
+    this.log(`Scheduling reconnect attempt=${this.reconnectAttempt} replay=${replayCount} ${this.describeState()}`);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.isDisconnecting) {
+        return;
+      }
+      this.openSocket(true, true);
+    }, RECONNECT_DELAY_MS);
   }
 
   private handleMessage(text: string): void {
@@ -178,43 +481,47 @@ export class GfnSignalingClient {
     try {
       parsed = JSON.parse(text) as SignalingMessage;
     } catch {
-      this.emit({ type: "log", message: `Ignoring non-JSON signaling packet: ${text.slice(0, 120)}` });
+      this.log(`Ignoring non-JSON signaling packet: ${text.slice(0, 120)}`);
       return;
+    }
+
+    if (typeof parsed.hb === "number") {
+      this.sendImmediate({ hb: 1 });
+      return;
+    }
+
+    if (typeof parsed.ack === "number") {
+      this.ackOutbound(parsed.ack);
     }
 
     if (typeof parsed.ackid === "number") {
-      const shouldAck = parsed.peer_info?.id !== this.peerId;
-      if (shouldAck) {
-        this.sendJson({ ack: parsed.ackid });
-      }
-    }
-
-    if (parsed.hb) {
-      this.sendJson({ hb: 1 });
-      return;
+      this.lastInboundAckId = Math.max(this.lastInboundAckId, parsed.ackid);
+      this.sendAck(this.lastInboundAckId);
     }
 
     if (!parsed.peer_msg?.msg) {
       return;
     }
 
-    let peerPayload: Record<string, unknown>;
+    let peerPayload: PeerPayload;
     try {
-      peerPayload = JSON.parse(parsed.peer_msg.msg) as Record<string, unknown>;
+      peerPayload = JSON.parse(parsed.peer_msg.msg) as PeerPayload;
     } catch {
-      this.emit({ type: "log", message: "Received non-JSON peer payload" });
+      this.log("Received non-JSON peer payload");
       return;
     }
 
+    this.sessionPhase = "established";
+    this.reconnectAttempt = 0;
+
     if (peerPayload.type === "offer" && typeof peerPayload.sdp === "string") {
-      console.log(`[Signaling] Received OFFER SDP (${peerPayload.sdp.length} chars), first 500 chars:`);
-      console.log(peerPayload.sdp.slice(0, 500));
+      this.log(`Received offer sdpLen=${peerPayload.sdp.length} ${this.describeState()}`);
       this.emit({ type: "offer", sdp: peerPayload.sdp });
       return;
     }
 
     if (typeof peerPayload.candidate === "string") {
-      console.log(`[Signaling] Received remote ICE candidate: ${peerPayload.candidate}`);
+      this.log(`Received remote ICE candidate ${peerPayload.candidate}`);
       this.emit({
         type: "remote-ice",
         candidate: {
@@ -227,79 +534,94 @@ export class GfnSignalingClient {
             typeof peerPayload.sdpMLineIndex === "number" || peerPayload.sdpMLineIndex === null
               ? peerPayload.sdpMLineIndex
               : undefined,
+          usernameFragment:
+            typeof peerPayload.usernameFragment === "string" || peerPayload.usernameFragment === null
+              ? peerPayload.usernameFragment
+              : undefined,
         },
       });
       return;
     }
 
-    // Log any unhandled peer message types for debugging
-    console.log("[Signaling] Unhandled peer message keys:", Object.keys(peerPayload));
+    this.log(`Unhandled peer message keys=${Object.keys(peerPayload).join(",")}`);
   }
 
   async sendAnswer(payload: SendAnswerRequest): Promise<void> {
-    console.log(`[Signaling] Sending ANSWER SDP (${payload.sdp.length} chars), first 500 chars:`);
-    console.log(payload.sdp.slice(0, 500));
-    if (payload.nvstSdp) {
-      console.log(`[Signaling] Sending nvstSdp (${payload.nvstSdp.length} chars):`);
-      console.log(payload.nvstSdp);
-    }
-    const answer = {
-      type: "answer",
-      sdp: payload.sdp,
-      ...(payload.nvstSdp ? { nvstSdp: payload.nvstSdp } : {}),
-    };
-
-    this.sendJson({
-      peer_msg: {
-        from: this.peerId,
-        to: 1,
-        msg: JSON.stringify(answer),
+    this.log(`Sending answer sdpLen=${payload.sdp.length} nvstLen=${payload.nvstSdp?.length ?? 0}`);
+    this.sendTrackedMessage(
+      {
+        peer_msg: {
+          from: this.peerId,
+          to: HOST_PEER_ID,
+          msg: JSON.stringify({
+            type: "answer",
+            sdp: payload.sdp,
+            ...(payload.nvstSdp ? { nvstSdp: payload.nvstSdp } : {}),
+          }),
+        },
       },
-      ackid: this.nextAckId(),
-    });
+      "answer",
+      true,
+    );
+    this.sessionPhase = "established";
   }
 
   async sendIceCandidate(candidate: IceCandidatePayload): Promise<void> {
-    console.log(`[Signaling] Sending local ICE candidate: ${candidate.candidate} (sdpMid=${candidate.sdpMid})`);
-    this.sendJson({
-      peer_msg: {
-        from: this.peerId,
-        to: 1,
-        msg: JSON.stringify({
-          candidate: candidate.candidate,
-          sdpMid: candidate.sdpMid,
-          sdpMLineIndex: candidate.sdpMLineIndex,
-        }),
+    this.log(`Sending local ICE candidate ${candidate.candidate} sdpMid=${candidate.sdpMid ?? "?"}`);
+    this.sendTrackedMessage(
+      {
+        peer_msg: {
+          from: this.peerId,
+          to: HOST_PEER_ID,
+          msg: JSON.stringify({
+            candidate: candidate.candidate,
+            sdpMid: candidate.sdpMid,
+            sdpMLineIndex: candidate.sdpMLineIndex,
+            usernameFragment: candidate.usernameFragment,
+          }),
+        },
       },
-      ackid: this.nextAckId(),
-    });
+      "ice_candidate",
+      true,
+    );
   }
 
   async requestKeyframe(payload: KeyframeRequest): Promise<void> {
-    this.sendJson({
-      peer_msg: {
-        from: this.peerId,
-        to: 1,
-        msg: JSON.stringify({
-          type: "request_keyframe",
-          reason: payload.reason,
-          backlogFrames: payload.backlogFrames,
-          attempt: payload.attempt,
-        }),
+    this.sendTrackedMessage(
+      {
+        peer_msg: {
+          from: this.peerId,
+          to: HOST_PEER_ID,
+          msg: JSON.stringify({
+            type: "request_keyframe",
+            reason: payload.reason,
+            backlogFrames: payload.backlogFrames,
+            attempt: payload.attempt,
+          }),
+        },
       },
-      ackid: this.nextAckId(),
-    });
-    console.log(
-      `[Signaling] Sent keyframe request (reason=${payload.reason}, backlog=${payload.backlogFrames}, attempt=${payload.attempt})`,
+      "request_keyframe",
+      true,
+    );
+    this.log(
+      `Sent keyframe request reason=${payload.reason} backlog=${payload.backlogFrames} attempt=${payload.attempt}`,
     );
   }
 
   disconnect(): void {
-    this.clearHeartbeat();
     this.isDisconnecting = true;
+    this.sessionPhase = "sign-in";
+    this.reconnectAttempt = 0;
+    this.clearHeartbeat();
+    this.clearReconnectTimer();
+    this.rejectConnect(new Error("Signaling disconnected by client"));
     if (this.ws) {
-      this.ws.close();
+      this.ws.close(1000, "client disconnect");
       this.ws = null;
     }
+    this.queuedOutbound = [];
+    this.unackedOutbound.clear();
+    this.lastInboundAckId = 0;
+    this.nextOutboundAckId = 0;
   }
 }

--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -14,8 +14,6 @@ import type {
 
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/131.0.0.0 Safari/537.36";
-const HEARTBEAT_INTERVAL_MS = 5000;
-const HEARTBEAT_STALE_MS = 20000;
 const RECONNECT_DELAY_MS = 1000;
 const MAX_RECONNECT_ATTEMPTS = 3;
 const HOST_PEER_ID = 1;
@@ -60,7 +58,7 @@ export class GfnSignalingClient {
   private isDisconnecting = false;
   private socketGeneration = 0;
   private nextOutboundAckId = 0;
-  private lastInboundAckId = 0;
+  private maxReceivedAckId = 0;
   private sessionPhase: SignalingSessionPhase = "sign-in";
   private hasEverOpened = false;
   private reconnectAttempt = 0;
@@ -68,7 +66,6 @@ export class GfnSignalingClient {
   private connectResolve: (() => void) | null = null;
   private connectReject: ((error: Error) => void) | null = null;
   private reconnectTimer: NodeJS.Timeout | null = null;
-  private heartbeatTimer: NodeJS.Timeout | null = null;
   private lastMessageAt = 0;
   private queuedOutbound: OutboundEnvelope[] = [];
   private unackedOutbound = new Map<number, OutboundEnvelope>();
@@ -146,25 +143,8 @@ export class GfnSignalingClient {
     };
   }
 
-  private setupHeartbeat(): void {
-    this.clearHeartbeat();
-    this.lastMessageAt = Date.now();
-    this.heartbeatTimer = setInterval(() => {
-      const idleForMs = Date.now() - this.lastMessageAt;
-      if (idleForMs >= HEARTBEAT_STALE_MS) {
-        this.log(
-          `Heartbeat stale: idle=${idleForMs}ms gen=${this.socketGeneration} phase=${this.sessionPhase} lastInAck=${this.lastInboundAckId} lastOutAck=${this.nextOutboundAckId}`,
-        );
-      }
-      this.sendImmediate({ hb: 1 });
-    }, HEARTBEAT_INTERVAL_MS);
-  }
-
   private clearHeartbeat(): void {
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
-    }
+    return;
   }
 
   private clearReconnectTimer(): void {
@@ -175,7 +155,7 @@ export class GfnSignalingClient {
   }
 
   private describeState(): string {
-    return `gen=${this.socketGeneration} attempt=${this.reconnectAttempt} phase=${this.sessionPhase} establishedBy=${this.establishmentReason ?? "none"} lastInAck=${this.lastInboundAckId} lastOutAck=${this.nextOutboundAckId} queued=${this.queuedOutbound.length} unacked=${this.unackedOutbound.size}`;
+    return `gen=${this.socketGeneration} attempt=${this.reconnectAttempt} phase=${this.sessionPhase} establishedBy=${this.establishmentReason ?? "none"} maxInAck=${this.maxReceivedAckId} lastOutAck=${this.nextOutboundAckId} queued=${this.queuedOutbound.length} unacked=${this.unackedOutbound.size}`;
   }
 
   private describeOutboundList(items: OutboundEnvelope[]): string {
@@ -273,7 +253,7 @@ export class GfnSignalingClient {
 
   private sendAck(ackId: number): void {
     const sent = this.sendImmediate({ ack: ackId });
-    this.log(`Sent ack=${ackId} sent=${sent} ${this.describeState()}`);
+    this.log(`Emitted ack=${ackId} sent=${sent} maxReceivedAckId=${this.maxReceivedAckId} ${this.describeState()}`);
   }
 
   private ackOutbound(ackId: number): void {
@@ -371,8 +351,8 @@ export class GfnSignalingClient {
       }
 
       this.hasEverOpened = true;
-      this.setupHeartbeat();
       this.lastMessageAt = Date.now();
+      this.log(`Proactive signaling heartbeat disabled; waiting for inbound traffic ${this.describeState()}`);
 
       let replayedCount = 0;
       if (isReconnect) {
@@ -478,7 +458,7 @@ export class GfnSignalingClient {
       willRetry,
       socketGeneration: generation,
       sessionPhase: this.sessionPhase,
-      lastInboundAckId: this.lastInboundAckId,
+      lastInboundAckId: this.maxReceivedAckId,
       lastOutboundAckId: this.nextOutboundAckId,
     };
   }
@@ -531,7 +511,7 @@ export class GfnSignalingClient {
     }
 
     if (typeof parsed.hb === "number") {
-      this.sendImmediate({ hb: 1 });
+      this.log(`Inbound signaling heartbeat ignored ${this.describeState()}`);
       return;
     }
 
@@ -539,9 +519,22 @@ export class GfnSignalingClient {
       this.ackOutbound(parsed.ack);
     }
 
+    let isDuplicateInboundAckId = false;
     if (typeof parsed.ackid === "number") {
-      this.lastInboundAckId = Math.max(this.lastInboundAckId, parsed.ackid);
-      this.sendAck(this.lastInboundAckId);
+      isDuplicateInboundAckId = parsed.ackid <= this.maxReceivedAckId;
+      const previousMaxReceivedAckId = this.maxReceivedAckId;
+      this.maxReceivedAckId = Math.max(this.maxReceivedAckId, parsed.ackid);
+      this.log(
+        `Inbound ackid=${parsed.ackid} maxReceivedAckId=${this.maxReceivedAckId} duplicate=${isDuplicateInboundAckId} prevMax=${previousMaxReceivedAckId} ${this.describeState()}`,
+      );
+      this.sendAck(this.maxReceivedAckId);
+      if (isDuplicateInboundAckId) {
+        this.log(`Ignoring duplicate inbound ackid=${parsed.ackid} ${this.describeState()}`);
+      }
+    }
+
+    if (isDuplicateInboundAckId) {
+      return;
     }
 
     if (!parsed.peer_msg?.msg) {
@@ -662,7 +655,7 @@ export class GfnSignalingClient {
     }
     this.queuedOutbound = [];
     this.unackedOutbound.clear();
-    this.lastInboundAckId = 0;
+    this.maxReceivedAckId = 0;
     this.nextOutboundAckId = 0;
     this.establishmentReason = null;
   }

--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -8,6 +8,7 @@ import type {
   MainToRendererSignalingEvent,
   SendAnswerRequest,
   SignalingDisconnectInfo,
+  SignalingEstablishedRequest,
   SignalingSessionPhase,
 } from "@shared/gfn";
 
@@ -71,6 +72,7 @@ export class GfnSignalingClient {
   private lastMessageAt = 0;
   private queuedOutbound: OutboundEnvelope[] = [];
   private unackedOutbound = new Map<number, OutboundEnvelope>();
+  private establishmentReason: SignalingEstablishedRequest["reason"] | null = null;
 
   constructor(
     private readonly signalingServer: string,
@@ -173,7 +175,7 @@ export class GfnSignalingClient {
   }
 
   private describeState(): string {
-    return `gen=${this.socketGeneration} attempt=${this.reconnectAttempt} phase=${this.sessionPhase} lastInAck=${this.lastInboundAckId} lastOutAck=${this.nextOutboundAckId} queued=${this.queuedOutbound.length} unacked=${this.unackedOutbound.size}`;
+    return `gen=${this.socketGeneration} attempt=${this.reconnectAttempt} phase=${this.sessionPhase} establishedBy=${this.establishmentReason ?? "none"} lastInAck=${this.lastInboundAckId} lastOutAck=${this.nextOutboundAckId} queued=${this.queuedOutbound.length} unacked=${this.unackedOutbound.size}`;
   }
 
   private describeOutboundList(items: OutboundEnvelope[]): string {
@@ -189,6 +191,10 @@ export class GfnSignalingClient {
     }
     this.ws.send(JSON.stringify(payload));
     return true;
+  }
+
+  private shouldQueueWhenOffline(): boolean {
+    return !this.hasEverOpened || this.sessionPhase === "sign-in" || this.reconnectTimer !== null;
   }
 
   private flushQueuedOutbound(skipAckIdsInReplayStore = false): void {
@@ -235,6 +241,11 @@ export class GfnSignalingClient {
     }
 
     if (!allowQueue) {
+      return;
+    }
+
+    if (!this.shouldQueueWhenOffline()) {
+      this.log(`Dropping outbound ${envelope.label} ackid=${envelope.ackId} because signaling is closed post-establishment ${this.describeState()}`);
       return;
     }
 
@@ -432,6 +443,10 @@ export class GfnSignalingClient {
 
       if (detail.willRetry) {
         this.scheduleReconnect();
+      } else if (this.hasEverOpened) {
+        this.log(`Post-open signaling close will not reconnect; clearing queued signaling state ${this.describeState()}`);
+        this.queuedOutbound = [];
+        this.unackedOutbound.clear();
       }
     });
   }
@@ -450,8 +465,7 @@ export class GfnSignalingClient {
     const error = socketErrored || (normalizedCode >= 1002 && normalizedCode <= 1015);
     const willRetry =
       !this.isDisconnecting
-      && this.sessionPhase === "established"
-      && this.hasEverOpened
+      && this.sessionPhase === "sign-in"
       && this.reconnectAttempt < MAX_RECONNECT_ATTEMPTS
       && (error || normalizedCode === 1006 || normalizedCode === 1001);
 
@@ -492,6 +506,21 @@ export class GfnSignalingClient {
     }, RECONNECT_DELAY_MS);
   }
 
+  markEstablished(reason: SignalingEstablishedRequest["reason"]): void {
+    if (this.sessionPhase === "established") {
+      if (this.establishmentReason === null) {
+        this.establishmentReason = reason;
+      }
+      this.log(`Signaling establishment reaffirmed by ${reason} ${this.describeState()}`);
+      return;
+    }
+
+    this.sessionPhase = "established";
+    this.establishmentReason = reason;
+    this.clearReconnectTimer();
+    this.log(`Signaling session marked established by ${reason} ${this.describeState()}`);
+  }
+
   private handleMessage(text: string): void {
     let parsed: SignalingMessage;
     try {
@@ -526,9 +555,6 @@ export class GfnSignalingClient {
       this.log("Received non-JSON peer payload");
       return;
     }
-
-    this.sessionPhase = "established";
-    this.reconnectAttempt = 0;
 
     if (peerPayload.type === "offer" && typeof peerPayload.sdp === "string") {
       this.log(`Received offer sdpLen=${peerPayload.sdp.length} ${this.describeState()}`);
@@ -579,7 +605,6 @@ export class GfnSignalingClient {
       "answer",
       true,
     );
-    this.sessionPhase = "established";
   }
 
   async sendIceCandidate(candidate: IceCandidatePayload): Promise<void> {
@@ -639,5 +664,6 @@ export class GfnSignalingClient {
     this.unackedOutbound.clear();
     this.lastInboundAckId = 0;
     this.nextOutboundAckId = 0;
+    this.establishmentReason = null;
   }
 }

--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -176,6 +176,13 @@ export class GfnSignalingClient {
     return `gen=${this.socketGeneration} attempt=${this.reconnectAttempt} phase=${this.sessionPhase} lastInAck=${this.lastInboundAckId} lastOutAck=${this.nextOutboundAckId} queued=${this.queuedOutbound.length} unacked=${this.unackedOutbound.size}`;
   }
 
+  private describeOutboundList(items: OutboundEnvelope[]): string {
+    if (items.length === 0) {
+      return "none";
+    }
+    return items.map((item) => `${item.label}#${item.ackId}`).join(", ");
+  }
+
   private sendImmediate(payload: SignalingMessage): boolean {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return false;
@@ -191,11 +198,16 @@ export class GfnSignalingClient {
 
     const queued = [...this.queuedOutbound];
     this.queuedOutbound = [];
+    const flushed: OutboundEnvelope[] = [];
     for (const item of queued) {
       if (skipAckIdsInReplayStore && this.unackedOutbound.has(item.ackId)) {
         continue;
       }
       this.sendEnvelope(item, false);
+      flushed.push(item);
+    }
+    if (flushed.length > 0) {
+      this.log(`Flushed queued outbound: ${this.describeOutboundList(flushed)} ${this.describeState()}`);
     }
   }
 
@@ -208,6 +220,7 @@ export class GfnSignalingClient {
     for (const item of replayList) {
       this.sendEnvelope(item, false);
     }
+    this.log(`Replayed unacked outbound: ${this.describeOutboundList(replayList)} ${this.describeState()}`);
     return replayList.length;
   }
 
@@ -217,6 +230,7 @@ export class GfnSignalingClient {
       if (envelope.replayable) {
         this.unackedOutbound.set(envelope.ackId, envelope);
       }
+      this.log(`Sent outbound ${envelope.label} ackid=${envelope.ackId} replayable=${envelope.replayable} ${this.describeState()}`);
       return;
     }
 
@@ -354,12 +368,12 @@ export class GfnSignalingClient {
         replayedCount = this.replayUnackedOutbound();
       }
       this.flushQueuedOutbound(isReconnect);
-      if (!isReconnect || replayedCount === 0) {
+      if (!isReconnect) {
         this.sendPeerInfo();
       }
 
       this.log(
-        `Socket open gen=${generation} reconnect=${isReconnect} replayed=${replayedCount} queuedFlushed=${this.queuedOutbound.length === 0} ${this.describeState()}`,
+        `Socket open gen=${generation} reconnect=${isReconnect} replayed=${replayedCount} queuedFlushed=${this.queuedOutbound.length === 0} pendingReplay=${this.describeOutboundList([...this.unackedOutbound.values()].sort((a, b) => a.ackId - b.ackId))} ${this.describeState()}`,
       );
 
       if (isReconnect) {
@@ -466,7 +480,9 @@ export class GfnSignalingClient {
       queuedReplayCount: replayCount,
       sessionPhase: this.sessionPhase,
     });
-    this.log(`Scheduling reconnect attempt=${this.reconnectAttempt} replay=${replayCount} ${this.describeState()}`);
+    this.log(
+      `Scheduling reconnect attempt=${this.reconnectAttempt} replay=${replayCount} replayItems=${this.describeOutboundList([...this.unackedOutbound.values()].sort((a, b) => a.ackId - b.ackId))} ${this.describeState()}`,
+    );
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       if (this.isDisconnecting) {

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -37,6 +37,7 @@ import type {
   SessionStopRequest,
   SessionClaimRequest,
   SignalingConnectRequest,
+  SignalingEstablishedRequest,
   SendAnswerRequest,
   IceCandidatePayload,
   KeyframeRequest,
@@ -853,6 +854,10 @@ function registerIpcHandlers(): void {
     signalingClient?.disconnect();
     signalingClient = null;
     signalingClientKey = null;
+  });
+
+  ipcMain.handle(IPC_CHANNELS.MARK_SIGNALING_ESTABLISHED, async (_event, payload: SignalingEstablishedRequest): Promise<void> => {
+    signalingClient?.markEstablished(payload.reason);
   });
 
   ipcMain.handle(IPC_CHANNELS.SEND_ANSWER, async (_event, payload: SendAnswerRequest) => {

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -2,7 +2,7 @@ import { app } from "electron";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode, GameLanguage, AspectRatio, KeyboardLayout } from "@shared/gfn";
-import { DEFAULT_KEYBOARD_LAYOUT, normalizeStreamPreferences } from "@shared/gfn";
+import { DEFAULT_KEYBOARD_LAYOUT, getDefaultStreamPreferences, normalizeStreamPreferences } from "@shared/gfn";
 
 export interface Settings {
   /** Video resolution (e.g., "1920x1080") */
@@ -80,13 +80,15 @@ const defaultMicShortcut = "Ctrl+Shift+M";
 const LEGACY_STOP_SHORTCUTS = new Set(["META+SHIFT+Q", "CMD+SHIFT+Q"]);
 const LEGACY_ANTI_AFK_SHORTCUTS = new Set(["META+SHIFT+F10", "CMD+SHIFT+F10", "CTRL+SHIFT+F10"]);
 
+const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
+
 const DEFAULT_SETTINGS: Settings = {
   resolution: "1920x1080",
   aspectRatio: "16:9",
   fps: 60,
   maxBitrateMbps: 75,
-  codec: "H264",
-  colorQuality: "8bit_420",
+  codec: DEFAULT_STREAM_PREFERENCES.codec,
+  colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
   region: "",
   clipboardPaste: false,
   mouseSensitivity: 1,

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -2,7 +2,7 @@ import { app } from "electron";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode, GameLanguage, AspectRatio, KeyboardLayout } from "@shared/gfn";
-import { DEFAULT_KEYBOARD_LAYOUT } from "@shared/gfn";
+import { DEFAULT_KEYBOARD_LAYOUT, normalizeSafeStreamPreferences } from "@shared/gfn";
 
 export interface Settings {
   /** Video resolution (e.g., "1920x1080") */
@@ -170,15 +170,18 @@ export class SettingsManager {
   }
 
   private enforceCompatibility(settings: Settings): boolean {
-    if (settings.codec === "H264" && settings.colorQuality !== "8bit_420") {
-      console.warn(
-        `[Settings] colorQuality "${settings.colorQuality}" is incompatible with H264; resetting to 8bit_420`,
-      );
-      settings.colorQuality = "8bit_420";
-      return true;
+    const normalized = normalizeSafeStreamPreferences(settings.codec, settings.colorQuality);
+
+    if (!normalized.migrated) {
+      return false;
     }
 
-    return false;
+    console.warn(
+      `[Settings] Migrating unsupported stream settings codec="${settings.codec}" colorQuality="${settings.colorQuality}" to H264/8bit_420`,
+    );
+    settings.codec = normalized.codec;
+    settings.colorQuality = normalized.colorQuality;
+    return true;
   }
 
   private migrateLegacyShortcutDefaults(settings: Settings): boolean {
@@ -236,6 +239,7 @@ export class SettingsManager {
    */
   set<K extends keyof Settings>(key: K, value: Settings[K]): void {
     this.settings[key] = value;
+    this.enforceCompatibility(this.settings);
     this.save();
   }
 
@@ -247,6 +251,7 @@ export class SettingsManager {
       ...this.settings,
       ...updates,
     };
+    this.enforceCompatibility(this.settings);
     this.save();
   }
 

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -2,7 +2,7 @@ import { app } from "electron";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode, GameLanguage, AspectRatio, KeyboardLayout } from "@shared/gfn";
-import { DEFAULT_KEYBOARD_LAYOUT, normalizeSafeStreamPreferences } from "@shared/gfn";
+import { DEFAULT_KEYBOARD_LAYOUT, normalizeStreamPreferences } from "@shared/gfn";
 
 export interface Settings {
   /** Video resolution (e.g., "1920x1080") */
@@ -170,14 +170,14 @@ export class SettingsManager {
   }
 
   private enforceCompatibility(settings: Settings): boolean {
-    const normalized = normalizeSafeStreamPreferences(settings.codec, settings.colorQuality);
+    const normalized = normalizeStreamPreferences(settings.codec, settings.colorQuality);
 
     if (!normalized.migrated) {
       return false;
     }
 
     console.warn(
-      `[Settings] Migrating unsupported stream settings codec="${settings.codec}" colorQuality="${settings.colorQuality}" to H264/8bit_420`,
+      `[Settings] Migrating unsupported stream settings codec="${settings.codec}" colorQuality="${settings.colorQuality}" to ${normalized.codec}/${normalized.colorQuality}`,
     );
     settings.codec = normalized.codec;
     settings.colorQuality = normalized.colorQuality;

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -15,6 +15,7 @@ import type {
   SessionStopRequest,
   SessionClaimRequest,
   SignalingConnectRequest,
+  SignalingEstablishedRequest,
   SendAnswerRequest,
   IceCandidatePayload,
   KeyframeRequest,
@@ -59,6 +60,8 @@ const api: OpenNowApi = {
   connectSignaling: (input: SignalingConnectRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.CONNECT_SIGNALING, input),
   disconnectSignaling: () => ipcRenderer.invoke(IPC_CHANNELS.DISCONNECT_SIGNALING),
+  markSignalingEstablished: (input: SignalingEstablishedRequest) =>
+    ipcRenderer.invoke(IPC_CHANNELS.MARK_SIGNALING_ESTABLISHED, input),
   sendAnswer: (input: SendAnswerRequest) => ipcRenderer.invoke(IPC_CHANNELS.SEND_ANSWER, input),
   sendIceCandidate: (input: IceCandidatePayload) =>
     ipcRenderer.invoke(IPC_CHANNELS.SEND_ICE_CANDIDATE, input),

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -35,6 +35,7 @@ import {
   GfnWebRtcClient,
   type StreamDiagnostics,
   type StreamTimeWarning,
+  type WebRtcSessionSnapshot,
 } from "./gfn/webrtcClient";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
 import { useControllerNavigation } from "./controllerNavigation";
@@ -113,6 +114,7 @@ type QueueAdMetrics = {
   startedAtMs: number | null;
   wasPausedAtLeastOnce: boolean;
 };
+type SignalingConnectionState = "connected" | "reconnecting" | "disconnected";
 type QueueAdReportOptions = {
   cancelReason?: QueueAdCancelReason;
   errorInfo?: QueueAdErrorInfo;
@@ -894,6 +896,16 @@ export function App(): JSX.Element {
   const reportQueueAdActionRef = useRef<
     (adId: string, action: SessionAdAction, options?: QueueAdReportOptions) => void
   >(() => {});
+  const signalingStateRef = useRef<SignalingConnectionState>("disconnected");
+
+  const getWebRtcSnapshot = useCallback((): WebRtcSessionSnapshot | null => {
+    return clientRef.current?.getSessionSnapshot() ?? null;
+  }, []);
+
+  const shouldKeepStreamingSessionAlive = useCallback((): boolean => {
+    const snapshot = getWebRtcSnapshot();
+    return !!snapshot && (snapshot.peerConnected || snapshot.controlChannelOpen || (snapshot.answerSent && snapshot.mediaLive));
+  }, [getWebRtcSnapshot]);
 
   useEffect(() => {
     controllerOverlayOpenRef.current = controllerOverlayOpen;
@@ -1112,6 +1124,15 @@ export function App(): JSX.Element {
       setLaunchError(null);
     }
   }, [diagnosticsStore]);
+
+  const teardownStreamFromTerminalSignaling = useCallback((context: string): void => {
+    console.warn(`[App] Terminal signaling teardown: ${context}`);
+    clientRef.current?.dispose();
+    clientRef.current = null;
+    signalingStateRef.current = "disconnected";
+    resetLaunchRuntime();
+    launchInFlightRef.current = false;
+  }, [resetLaunchRuntime]);
 
   // Session ref sync
   useEffect(() => {
@@ -1875,12 +1896,49 @@ export function App(): JSX.Element {
           }
         } else if (event.type === "remote-ice") {
           await clientRef.current?.addRemoteCandidate(event.candidate);
+        } else if (event.type === "connected") {
+          signalingStateRef.current = "connected";
+          console.log("[App] Signaling connected", event);
+        } else if (event.type === "reconnecting") {
+          signalingStateRef.current = "reconnecting";
+          const snapshot = getWebRtcSnapshot();
+          console.warn("[App] Signaling reconnecting", {
+            ...event,
+            streamStatus: streamStatusRef.current,
+            peerConnected: snapshot?.peerConnected ?? false,
+            controlChannelOpen: snapshot?.controlChannelOpen ?? false,
+            answerSent: snapshot?.answerSent ?? false,
+            mediaLive: snapshot?.mediaLive ?? false,
+          });
+        } else if (event.type === "reconnected") {
+          signalingStateRef.current = "connected";
+          const snapshot = getWebRtcSnapshot();
+          console.log("[App] Signaling reconnected", {
+            ...event,
+            streamStatus: streamStatusRef.current,
+            peerConnected: snapshot?.peerConnected ?? false,
+            controlChannelOpen: snapshot?.controlChannelOpen ?? false,
+            mediaLive: snapshot?.mediaLive ?? false,
+          });
         } else if (event.type === "disconnected") {
-          console.warn("Signaling disconnected:", event.reason);
-          clientRef.current?.dispose();
-          clientRef.current = null;
-          resetLaunchRuntime();
-          launchInFlightRef.current = false;
+          signalingStateRef.current = event.detail.willRetry ? "reconnecting" : "disconnected";
+          const snapshot = getWebRtcSnapshot();
+          const keepAlive = event.detail.willRetry && shouldKeepStreamingSessionAlive();
+          console.warn("[App] Signaling disconnected", {
+            ...event.detail,
+            streamStatus: streamStatusRef.current,
+            peerConnectionState: snapshot?.peerConnectionState ?? "closed",
+            peerConnected: snapshot?.peerConnected ?? false,
+            controlChannelOpen: snapshot?.controlChannelOpen ?? false,
+            answerSent: snapshot?.answerSent ?? false,
+            mediaLive: snapshot?.mediaLive ?? false,
+            keepAlive,
+          });
+          if (!keepAlive) {
+            teardownStreamFromTerminalSignaling(
+              `code=${event.detail.code} reason=${event.detail.reason || "socket closed"} willRetry=${event.detail.willRetry} phase=${event.detail.sessionPhase}`,
+            );
+          }
         } else if (event.type === "error") {
           console.error("Signaling error:", event.message);
         }
@@ -1890,7 +1948,7 @@ export function App(): JSX.Element {
     });
 
     return () => unsubscribe();
-  }, [resetLaunchRuntime, settings]);
+  }, [getWebRtcSnapshot, settings, shouldKeepStreamingSessionAlive, teardownStreamFromTerminalSignaling]);
 
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -902,9 +902,20 @@ export function App(): JSX.Element {
     (adId: string, action: SessionAdAction, options?: QueueAdReportOptions) => void
   >(() => {});
   const signalingStateRef = useRef<SignalingConnectionState>("disconnected");
+  const signalingEstablishedRef = useRef(false);
 
   const getWebRtcSnapshot = useCallback((): WebRtcSessionSnapshot | null => {
     return clientRef.current?.getSessionSnapshot() ?? null;
+  }, []);
+
+  const markSignalingEstablished = useCallback((reason: "answer-sent" | "remote-ice" | "peer-connected" | "control-channel-open" | "media-live"): void => {
+    if (signalingEstablishedRef.current) {
+      return;
+    }
+    signalingEstablishedRef.current = true;
+    void window.openNow.markSignalingEstablished({ reason }).catch((error) => {
+      console.warn("[App] Failed to mark signaling established:", reason, error);
+    });
   }, []);
 
   const shouldKeepStreamingSessionAlive = useCallback((): boolean => {
@@ -1120,6 +1131,7 @@ export function App(): JSX.Element {
     setEscHoldReleaseIndicator({ visible: false, progress: 0 });
     resetStatsOverlayToPreference();
     diagnosticsStore.set(defaultDiagnostics());
+    signalingEstablishedRef.current = false;
 
     if (!options?.keepStreamingContext) {
       setStreamingGame(null);
@@ -1811,18 +1823,25 @@ export function App(): JSX.Element {
     }
 
     const evaluate = () => {
-      const snapshot = diagnosticsStore.getSnapshot();
+      const diagnosticsSnapshot = diagnosticsStore.getSnapshot();
+      const sessionSnapshot = getWebRtcSnapshot();
+      if (sessionSnapshot?.controlChannelOpen) {
+        markSignalingEstablished("control-channel-open");
+      } else if (sessionSnapshot?.peerConnected) {
+        markSignalingEstablished("peer-connected");
+      }
       const hasLiveFrames =
-        snapshot.framesDecoded > 0 || snapshot.framesReceived > 0 || snapshot.renderFps > 0;
+        diagnosticsSnapshot.framesDecoded > 0 || diagnosticsSnapshot.framesReceived > 0 || diagnosticsSnapshot.renderFps > 0;
       if (hasLiveFrames) {
         setSessionStartedAtMs(Date.now());
+        markSignalingEstablished("media-live");
       }
     };
 
     evaluate();
     const unsubscribe = diagnosticsStore.subscribe(evaluate);
     return unsubscribe;
-  }, [sessionStartedAtMs, streamStatus]);
+  }, [diagnosticsStore, getWebRtcSnapshot, markSignalingEstablished, sessionStartedAtMs, streamStatus]);
 
   useEffect(() => {
     if (!streamWarning) return;
@@ -1890,6 +1909,7 @@ export function App(): JSX.Element {
               fps: settings.fps,
               maxBitrateKbps: settings.maxBitrateMbps * 1000,
             });
+            markSignalingEstablished("answer-sent");
             setLaunchError(null);
             setStreamStatus("streaming");
             // Auto-enter fullscreen on stream start if user enabled it
@@ -1902,6 +1922,7 @@ export function App(): JSX.Element {
             }
           }
         } else if (event.type === "remote-ice") {
+          markSignalingEstablished("remote-ice");
           await clientRef.current?.addRemoteCandidate(event.candidate);
         } else if (event.type === "connected") {
           signalingStateRef.current = "connected";
@@ -1930,7 +1951,8 @@ export function App(): JSX.Element {
         } else if (event.type === "disconnected") {
           signalingStateRef.current = event.detail.willRetry ? "reconnecting" : "disconnected";
           const snapshot = getWebRtcSnapshot();
-          const keepAlive = event.detail.willRetry && shouldKeepStreamingSessionAlive();
+          const keepAlive = shouldKeepStreamingSessionAlive()
+            && (event.detail.willRetry || event.detail.sessionPhase === "established");
           console.warn("[App] Signaling disconnected", {
             ...event.detail,
             streamStatus: streamStatusRef.current,
@@ -1955,7 +1977,7 @@ export function App(): JSX.Element {
     });
 
     return () => unsubscribe();
-  }, [getWebRtcSnapshot, settings, shouldKeepStreamingSessionAlive, teardownStreamFromTerminalSignaling]);
+  }, [getWebRtcSnapshot, markSignalingEstablished, settings, shouldKeepStreamingSessionAlive, teardownStreamFromTerminalSignaling]);
 
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@shared/gfn";
 import {
   DEFAULT_KEYBOARD_LAYOUT,
+  getDefaultStreamPreferences,
   USER_FACING_VIDEO_CODEC_OPTIONS,
   normalizeStreamPreferences,
   getPreferredSessionAdMediaUrl,
@@ -54,6 +55,7 @@ import type { QueueAdPlaybackEvent, QueueAdPreviewHandle } from "./components/Qu
 import { StreamView } from "./components/StreamView";
 
 const codecOptions: VideoCodec[] = [...USER_FACING_VIDEO_CODEC_OPTIONS];
+const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
 const allResolutionOptions = ["1280x720", "1280x800", "1440x900", "1680x1050", "1920x1080", "1920x1200", "2560x1080", "2560x1440", "2560x1600", "3440x1440", "3840x2160", "3840x2400"];
 const fpsOptions = [30, 60, 120, 144, 240];
 const aspectRatioOptions = ["16:9", "16:10", "21:9", "32:9"] as const;
@@ -612,8 +614,8 @@ export function App(): JSX.Element {
     aspectRatio: "16:9",
     fps: 60,
     maxBitrateMbps: 75,
-    codec: "H264",
-    colorQuality: "8bit_420",
+    codec: DEFAULT_STREAM_PREFERENCES.codec,
+    colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
     region: "",
     clipboardPaste: false,
     mouseSensitivity: 1,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -2941,13 +2941,22 @@ export function App(): JSX.Element {
       ? Math.floor(sessionElapsedSeconds / 60) / 60
       : 0;
   const remainingPlaytimeText = formatRemainingPlaytimeFromSubscription(subscriptionInfo, consumedHours);
+  const shouldRenderStreamView = streamStatus !== "idle";
+  const shouldRenderControllerLaunchOverlay =
+    !isSwitchingGame
+    && settings.controllerMode
+    && (launchError !== null || (streamStatus !== "idle" && streamStatus !== "streaming" && streamStatus !== "connecting"));
+  const shouldRenderDesktopLaunchOverlay =
+    !isSwitchingGame
+    && !settings.controllerMode
+    && (launchError !== null || (streamStatus !== "idle" && streamStatus !== "streaming"));
 
   // Show stream lifecycle (waiting/connecting/streaming/failure)
   if (showLaunchOverlay) {
     const loadingStatus = launchError ? launchError.stage : toLoadingStatus(streamStatus);
     return (
       <>
-        {streamStatus !== "idle" && (
+        {shouldRenderStreamView && (
           <StreamView
             className={isSwitchingGame ? "sv--switching" : undefined}
             videoRef={videoRef}
@@ -3119,7 +3128,7 @@ export function App(): JSX.Element {
             />
           </div>
         )}
-        {streamStatus !== "idle" && streamStatus !== "streaming" && streamStatus !== "connecting" && settings.controllerMode && !isSwitchingGame && (
+        {shouldRenderControllerLaunchOverlay && (
           <ControllerStreamLoading
             gameTitle={streamingGame?.title ?? "Game"}
             gamePoster={streamingGame?.imageUrl}
@@ -3145,7 +3154,7 @@ export function App(): JSX.Element {
             enableBackgroundAnimations={settings.controllerBackgroundAnimations}
           />
         )}
-        {streamStatus !== "idle" && streamStatus !== "streaming" && !settings.controllerMode && !isSwitchingGame && (
+        {shouldRenderDesktopLaunchOverlay && (
           <StreamLoading
             gameTitle={streamingGame?.title ?? "Game"}
             gameCover={streamingGame?.imageUrl}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -20,6 +20,8 @@ import type {
 } from "@shared/gfn";
 import {
   DEFAULT_KEYBOARD_LAYOUT,
+  SAFE_VIDEO_CODEC_OPTIONS,
+  normalizeSafeStreamPreferences,
   getPreferredSessionAdMediaUrl,
   getSessionAdDurationMs,
   getSessionAdItems,
@@ -51,7 +53,7 @@ import { ControllerStreamLoading } from "./components/ControllerStreamLoading";
 import type { QueueAdPlaybackEvent, QueueAdPreviewHandle } from "./components/QueueAdPreview";
 import { StreamView } from "./components/StreamView";
 
-const codecOptions: VideoCodec[] = ["H264", "H265", "AV1"];
+const codecOptions: VideoCodec[] = [...SAFE_VIDEO_CODEC_OPTIONS];
 const allResolutionOptions = ["1280x720", "1280x800", "1440x900", "1680x1050", "1920x1080", "1920x1200", "2560x1080", "2560x1440", "2560x1600", "3440x1440", "3840x2160", "3840x2400"];
 const fpsOptions = [30, 60, 120, 144, 240];
 const aspectRatioOptions = ["16:9", "16:10", "21:9", "32:9"] as const;
@@ -127,6 +129,14 @@ const DEFAULT_SHORTCUTS = {
   shortcutScreenshot: "F11",
   shortcutToggleRecording: "F12",
 } as const;
+
+function applySafeStreamPreferenceGuards(settings: Pick<Settings, "codec" | "colorQuality">): { codec: Settings["codec"]; colorQuality: Settings["colorQuality"] } {
+  const normalized = normalizeSafeStreamPreferences(settings.codec, settings.colorQuality);
+  return {
+    codec: normalized.codec,
+    colorQuality: normalized.colorQuality,
+  };
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
@@ -1471,7 +1481,10 @@ export function App(): JSX.Element {
       try {
         // Load settings first
         const loadedSettings = await window.openNow.getSettings();
-        setSettings(loadedSettings);
+        setSettings({
+          ...loadedSettings,
+          ...applySafeStreamPreferenceGuards(loadedSettings),
+        });
         setSettingsLoaded(true);
 
         // Load providers and session (refresh only if token is near expiry)
@@ -1835,8 +1848,7 @@ export function App(): JSX.Element {
 
           if (clientRef.current) {
             await clientRef.current.handleOffer(event.sdp, activeSession, {
-              codec: settings.codec,
-              colorQuality: settings.colorQuality,
+              ...applySafeStreamPreferenceGuards(settings),
               resolution: settings.resolution,
               fps: settings.fps,
               maxBitrateKbps: settings.maxBitrateMbps * 1000,
@@ -1873,9 +1885,18 @@ export function App(): JSX.Element {
 
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {
-    setSettings((prev) => ({ ...prev, [key]: value }));
+    const currentSettings = settings;
+    const nextSettings = { ...currentSettings, [key]: value };
+    const safeStreamPreferences = applySafeStreamPreferenceGuards(nextSettings);
+    const updates: Partial<Settings> = { [key]: value, ...safeStreamPreferences };
+
+    setSettings((prev) => ({ ...prev, ...updates }));
     if (settingsLoaded) {
-      await window.openNow.setSetting(key, value);
+      await Promise.all(
+        (Object.entries(updates) as Array<[keyof Settings, Settings[keyof Settings]]>).map(([updateKey, updateValue]) =>
+          window.openNow.setSetting(updateKey, updateValue)
+        )
+      );
     }
     // If a running client exists, push certain settings live
     if (key === "mouseSensitivity") {
@@ -1899,7 +1920,7 @@ export function App(): JSX.Element {
         // ignore
       }
     }
-  }, [settingsLoaded]);
+  }, [settings, settingsLoaded]);
 
   const handleMouseSensitivityChange = useCallback((value: number) => {
     void updateSetting("mouseSensitivity", value);
@@ -1931,7 +1952,7 @@ export function App(): JSX.Element {
         console.warn("Failed to persist controller mode exit settings:", error);
       });
     }
-  }, [settingsLoaded]);
+  }, [settings, settingsLoaded]);
 
   const handleExitApp = useCallback(() => {
     void window.openNow.quitApp().catch((error) => {
@@ -2082,8 +2103,7 @@ export function App(): JSX.Element {
         resolution: settings.resolution,
         fps: settings.fps,
         maxBitrateMbps: settings.maxBitrateMbps,
-        codec: settings.codec,
-        colorQuality: settings.colorQuality,
+        ...applySafeStreamPreferenceGuards(settings),
         keyboardLayout: settings.keyboardLayout,
         gameLanguage: settings.gameLanguage,
         enableL4S: settings.enableL4S,
@@ -2233,8 +2253,7 @@ export function App(): JSX.Element {
           resolution: settings.resolution,
           fps: settings.fps,
           maxBitrateMbps: settings.maxBitrateMbps,
-          codec: settings.codec,
-          colorQuality: settings.colorQuality,
+          ...applySafeStreamPreferenceGuards(settings),
           keyboardLayout: settings.keyboardLayout,
           gameLanguage: settings.gameLanguage,
           enableL4S: settings.enableL4S,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1922,7 +1922,6 @@ export function App(): JSX.Element {
             }
           }
         } else if (event.type === "remote-ice") {
-          markSignalingEstablished("remote-ice");
           await clientRef.current?.addRemoteCandidate(event.candidate);
         } else if (event.type === "connected") {
           signalingStateRef.current = "connected";

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1885,13 +1885,16 @@ export function App(): JSX.Element {
 
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {
-    const currentSettings = settings;
-    const nextSettings = { ...currentSettings, [key]: value };
-    const safeStreamPreferences = applySafeStreamPreferenceGuards(nextSettings);
-    const updates: Partial<Settings> = { [key]: value, ...safeStreamPreferences };
+    let updates: Partial<Settings> | null = null;
 
-    setSettings((prev) => ({ ...prev, ...updates }));
-    if (settingsLoaded) {
+    setSettings((prev) => {
+      const nextSettings = { ...prev, [key]: value };
+      const safeStreamPreferences = applySafeStreamPreferenceGuards(nextSettings);
+      updates = { [key]: value, ...safeStreamPreferences };
+      return { ...prev, ...updates };
+    });
+
+    if (settingsLoaded && updates) {
       await Promise.all(
         (Object.entries(updates) as Array<[keyof Settings, Settings[keyof Settings]]>).map(([updateKey, updateValue]) =>
           window.openNow.setSetting(updateKey, updateValue)
@@ -1920,7 +1923,7 @@ export function App(): JSX.Element {
         // ignore
       }
     }
-  }, [settings, settingsLoaded]);
+  }, [settingsLoaded]);
 
   const handleMouseSensitivityChange = useCallback((value: number) => {
     void updateSetting("mouseSensitivity", value);
@@ -1952,7 +1955,7 @@ export function App(): JSX.Element {
         console.warn("Failed to persist controller mode exit settings:", error);
       });
     }
-  }, [settings, settingsLoaded]);
+  }, [settingsLoaded]);
 
   const handleExitApp = useCallback(() => {
     void window.openNow.quitApp().catch((error) => {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -20,8 +20,8 @@ import type {
 } from "@shared/gfn";
 import {
   DEFAULT_KEYBOARD_LAYOUT,
-  SAFE_VIDEO_CODEC_OPTIONS,
-  normalizeSafeStreamPreferences,
+  USER_FACING_VIDEO_CODEC_OPTIONS,
+  normalizeStreamPreferences,
   getPreferredSessionAdMediaUrl,
   getSessionAdDurationMs,
   getSessionAdItems,
@@ -53,7 +53,7 @@ import { ControllerStreamLoading } from "./components/ControllerStreamLoading";
 import type { QueueAdPlaybackEvent, QueueAdPreviewHandle } from "./components/QueueAdPreview";
 import { StreamView } from "./components/StreamView";
 
-const codecOptions: VideoCodec[] = [...SAFE_VIDEO_CODEC_OPTIONS];
+const codecOptions: VideoCodec[] = [...USER_FACING_VIDEO_CODEC_OPTIONS];
 const allResolutionOptions = ["1280x720", "1280x800", "1440x900", "1680x1050", "1920x1080", "1920x1200", "2560x1080", "2560x1440", "2560x1600", "3440x1440", "3840x2160", "3840x2400"];
 const fpsOptions = [30, 60, 120, 144, 240];
 const aspectRatioOptions = ["16:9", "16:10", "21:9", "32:9"] as const;
@@ -130,8 +130,8 @@ const DEFAULT_SHORTCUTS = {
   shortcutToggleRecording: "F12",
 } as const;
 
-function applySafeStreamPreferenceGuards(settings: Pick<Settings, "codec" | "colorQuality">): { codec: Settings["codec"]; colorQuality: Settings["colorQuality"] } {
-  const normalized = normalizeSafeStreamPreferences(settings.codec, settings.colorQuality);
+function applyCompatibleStreamPreferenceGuards(settings: Pick<Settings, "codec" | "colorQuality">): { codec: Settings["codec"]; colorQuality: Settings["colorQuality"] } {
+  const normalized = normalizeStreamPreferences(settings.codec, settings.colorQuality);
   return {
     codec: normalized.codec,
     colorQuality: normalized.colorQuality,
@@ -643,7 +643,12 @@ export function App(): JSX.Element {
     gameLanguage: "en_US",
     enableL4S: false,
   });
+  const settingsRef = useRef<Settings>(settings);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
+
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
   const [regions, setRegions] = useState<StreamRegion[]>([]);
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
   const diagnosticsStoreRef = useRef<ReturnType<typeof createStreamDiagnosticsStore> | null>(null);
@@ -1481,10 +1486,12 @@ export function App(): JSX.Element {
       try {
         // Load settings first
         const loadedSettings = await window.openNow.getSettings();
-        setSettings({
+        const normalizedLoadedSettings = {
           ...loadedSettings,
-          ...applySafeStreamPreferenceGuards(loadedSettings),
-        });
+          ...applyCompatibleStreamPreferenceGuards(loadedSettings),
+        };
+        settingsRef.current = normalizedLoadedSettings;
+        setSettings(normalizedLoadedSettings);
         setSettingsLoaded(true);
 
         // Load providers and session (refresh only if token is near expiry)
@@ -1848,7 +1855,7 @@ export function App(): JSX.Element {
 
           if (clientRef.current) {
             await clientRef.current.handleOffer(event.sdp, activeSession, {
-              ...applySafeStreamPreferenceGuards(settings),
+              ...applyCompatibleStreamPreferenceGuards(settings),
               resolution: settings.resolution,
               fps: settings.fps,
               maxBitrateKbps: settings.maxBitrateMbps * 1000,
@@ -1885,16 +1892,27 @@ export function App(): JSX.Element {
 
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {
-    let updates: Partial<Settings> | null = null;
+    const currentSettings = settingsRef.current;
+    const nextSettings = { ...currentSettings, [key]: value };
+    const normalizedStreamPreferences = applyCompatibleStreamPreferenceGuards(nextSettings);
+    const normalizedSettings: Settings = {
+      ...nextSettings,
+      ...normalizedStreamPreferences,
+    };
+    const updates = Object.fromEntries(
+      (Object.entries(normalizedSettings) as Array<[keyof Settings, Settings[keyof Settings]]>).filter(
+        ([updateKey, updateValue]) => currentSettings[updateKey] !== updateValue
+      )
+    ) as Partial<Settings>;
 
-    setSettings((prev) => {
-      const nextSettings = { ...prev, [key]: value };
-      const safeStreamPreferences = applySafeStreamPreferenceGuards(nextSettings);
-      updates = { [key]: value, ...safeStreamPreferences };
-      return { ...prev, ...updates };
-    });
+    if (Object.keys(updates).length === 0) {
+      return;
+    }
 
-    if (settingsLoaded && updates) {
+    settingsRef.current = normalizedSettings;
+    setSettings(normalizedSettings);
+
+    if (settingsLoaded) {
       await Promise.all(
         (Object.entries(updates) as Array<[keyof Settings, Settings[keyof Settings]]>).map(([updateKey, updateValue]) =>
           window.openNow.setSetting(updateKey, updateValue)
@@ -1941,11 +1959,13 @@ export function App(): JSX.Element {
   }, [updateSetting]);
 
   const handleExitControllerMode = useCallback(() => {
-    setSettings((prev) => ({
-      ...prev,
+    const nextSettings = {
+      ...settingsRef.current,
       controllerMode: false,
       autoLoadControllerLibrary: false,
-    }));
+    };
+    settingsRef.current = nextSettings;
+    setSettings(nextSettings);
 
     if (settingsLoaded) {
       void Promise.all([
@@ -2106,7 +2126,7 @@ export function App(): JSX.Element {
         resolution: settings.resolution,
         fps: settings.fps,
         maxBitrateMbps: settings.maxBitrateMbps,
-        ...applySafeStreamPreferenceGuards(settings),
+        ...applyCompatibleStreamPreferenceGuards(settings),
         keyboardLayout: settings.keyboardLayout,
         gameLanguage: settings.gameLanguage,
         enableL4S: settings.enableL4S,
@@ -2256,7 +2276,7 @@ export function App(): JSX.Element {
           resolution: settings.resolution,
           fps: settings.fps,
           maxBitrateMbps: settings.maxBitrateMbps,
-          ...applySafeStreamPreferenceGuards(settings),
+          ...applyCompatibleStreamPreferenceGuards(settings),
           keyboardLayout: settings.keyboardLayout,
           gameLanguage: settings.gameLanguage,
           enableL4S: settings.enableL4S,

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -12,7 +12,7 @@ import type {
   PingResult,
   GameLanguage,
 } from "@shared/gfn";
-import { colorQualityRequiresHevc, keyboardLayoutOptions } from "@shared/gfn";
+import { SAFE_COLOR_QUALITY_OPTIONS, SAFE_VIDEO_CODEC_OPTIONS, keyboardLayoutOptions } from "@shared/gfn";
 import { formatShortcutForDisplay, normalizeShortcut } from "../shortcuts";
 
 interface SettingsPageProps {
@@ -21,14 +21,13 @@ interface SettingsPageProps {
   onSettingChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
 }
 
-const codecOptions: VideoCodec[] = ["H264", "H265", "AV1"];
+const codecOptions: VideoCodec[] = [...SAFE_VIDEO_CODEC_OPTIONS];
 
-const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = [
-  { value: "8bit_420", label: "8-bit 4:2:0", description: "Most compatible" },
-  { value: "8bit_444", label: "8-bit 4:4:4", description: "Better color" },
-  { value: "10bit_420", label: "10-bit 4:2:0", description: "HDR ready" },
-  { value: "10bit_444", label: "10-bit 4:4:4", description: "Best quality" },
-];
+const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = SAFE_COLOR_QUALITY_OPTIONS.map((value) => ({
+  value,
+  label: "8-bit 4:2:0",
+  description: "Most compatible",
+}));
 
 /* ── Static fallbacks (used when MES API is unavailable) ─────────── */
 
@@ -737,25 +736,18 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     [onSettingChange]
   );
 
-  /** Change color quality, auto-switching codec to H265 if the mode requires HEVC */
   const handleColorQualityChange = useCallback(
     (cq: ColorQuality) => {
       handleChange("colorQuality", cq);
-      if (colorQualityRequiresHevc(cq) && settings.codec === "H264") {
-        handleChange("codec", "H265");
-      }
     },
-    [handleChange, settings.codec]
+    [handleChange]
   );
 
   const handleCodecChange = useCallback(
     (codec: VideoCodec) => {
       handleChange("codec", codec);
-      if (codec === "H264" && settings.colorQuality !== "8bit_420") {
-        handleChange("colorQuality", "8bit_420");
-      }
     },
-    [handleChange, settings.colorQuality]
+    [handleChange]
   );
 
   // Microphone devices
@@ -1282,23 +1274,17 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
             <div className="settings-row settings-row--column">
               <label className="settings-label">Color Depth</label>
               <div className="settings-chip-row">
-                {colorQualityOptions.map((opt) => {
-                  const needsHevc = colorQualityRequiresHevc(opt.value);
-                  return (
-                    <button
-                      key={opt.value}
-                      className={`settings-chip ${settings.colorQuality === opt.value ? "active" : ""}`}
-                      onClick={() => handleColorQualityChange(opt.value)}
-                      title={`${opt.description}${needsHevc ? " — requires H265/AV1" : ""}`}
-                    >
-                      <span>{opt.label}</span>
-                    </button>
-                  );
-                })}
+                {colorQualityOptions.map((opt) => (
+                  <button
+                    key={opt.value}
+                    className={`settings-chip ${settings.colorQuality === opt.value ? "active" : ""}`}
+                    onClick={() => handleColorQualityChange(opt.value)}
+                    title={opt.description}
+                  >
+                    <span>{opt.label}</span>
+                  </button>
+                ))}
               </div>
-              {colorQualityRequiresHevc(settings.colorQuality) && settings.codec === "H264" && (
-                <span className="settings-input-hint">This mode requires H265 or AV1. Codec will be auto-switched.</span>
-              )}
             </div>
 
             {/* Bitrate slider */}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -12,7 +12,7 @@ import type {
   PingResult,
   GameLanguage,
 } from "@shared/gfn";
-import { SAFE_COLOR_QUALITY_OPTIONS, SAFE_VIDEO_CODEC_OPTIONS, keyboardLayoutOptions } from "@shared/gfn";
+import { USER_FACING_VIDEO_CODEC_OPTIONS, getAllowedColorQualitiesForCodec, normalizeStreamPreferences, keyboardLayoutOptions } from "@shared/gfn";
 import { formatShortcutForDisplay, normalizeShortcut } from "../shortcuts";
 
 interface SettingsPageProps {
@@ -21,13 +21,14 @@ interface SettingsPageProps {
   onSettingChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
 }
 
-const codecOptions: VideoCodec[] = [...SAFE_VIDEO_CODEC_OPTIONS];
+const codecOptions: VideoCodec[] = [...USER_FACING_VIDEO_CODEC_OPTIONS];
 
-const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = SAFE_COLOR_QUALITY_OPTIONS.map((value) => ({
-  value,
-  label: "8-bit 4:2:0",
-  description: "Most compatible",
-}));
+const colorQualityOptionDetails: Record<ColorQuality, { label: string; description: string }> = {
+  "8bit_420": { label: "8-bit 4:2:0", description: "Most compatible" },
+  "8bit_444": { label: "8-bit 4:4:4", description: "Better color" },
+  "10bit_420": { label: "10-bit 4:2:0", description: "HDR ready" },
+  "10bit_444": { label: "10-bit 4:4:4", description: "Best quality" },
+};
 
 /* ── Static fallbacks (used when MES API is unavailable) ─────────── */
 
@@ -736,6 +737,19 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     [onSettingChange]
   );
 
+  const normalizedStreamPreferences = useMemo(
+    () => normalizeStreamPreferences(settings.codec, settings.colorQuality),
+    [settings.codec, settings.colorQuality]
+  );
+
+  const colorQualityOptions = useMemo(
+    () => getAllowedColorQualitiesForCodec(normalizedStreamPreferences.codec).map((value) => ({
+      value,
+      ...colorQualityOptionDetails[value],
+    })),
+    [normalizedStreamPreferences.codec]
+  );
+
   const handleColorQualityChange = useCallback(
     (cq: ColorQuality) => {
       handleChange("colorQuality", cq);
@@ -1261,7 +1275,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                 {codecOptions.map((codec) => (
                   <button
                     key={codec}
-                    className={`settings-chip ${settings.codec === codec ? "active" : ""}`}
+                    className={`settings-chip ${normalizedStreamPreferences.codec === codec ? "active" : ""}`}
                     onClick={() => handleCodecChange(codec)}
                   >
                     {codec}
@@ -1277,7 +1291,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                 {colorQualityOptions.map((opt) => (
                   <button
                     key={opt.value}
-                    className={`settings-chip ${settings.colorQuality === opt.value ? "active" : ""}`}
+                    className={`settings-chip ${normalizedStreamPreferences.colorQuality === opt.value ? "active" : ""}`}
                     onClick={() => handleColorQualityChange(opt.value)}
                     title={opt.description}
                   >

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -194,6 +194,17 @@ export interface StreamTimeWarning {
   secondsLeft?: number;
 }
 
+export interface WebRtcSessionSnapshot {
+  peerConnectionState: RTCPeerConnectionState | "closed";
+  peerConnected: boolean;
+  iceConnectionState: RTCIceConnectionState | "closed";
+  controlChannelOpen: boolean;
+  answerSent: boolean;
+  mediaLive: boolean;
+  videoTrackLive: boolean;
+  audioTrackLive: boolean;
+}
+
 interface ClientOptions {
   videoElement: HTMLVideoElement;
   audioElement: HTMLAudioElement;
@@ -618,6 +629,7 @@ export class GfnWebRtcClient {
   // Microphone
   private micManager: MicrophoneManager | null = null;
   private micState: MicState = "uninitialized";
+  private answerSent = false;
 
   // Stream info
   private currentCodec = "";
@@ -858,6 +870,25 @@ export class GfnWebRtcClient {
     this.options.onLog(message);
   }
 
+  public getSessionSnapshot(): WebRtcSessionSnapshot {
+    const videoTrackLive = this.videoStream.getVideoTracks().some((track) => track.readyState === "live");
+    const audioTrackLive = this.audioStream.getAudioTracks().some((track) => track.readyState === "live");
+    const peerConnectionState = this.pc?.connectionState ?? "closed";
+    const iceConnectionState = this.pc?.iceConnectionState ?? "closed";
+    const peerConnected = peerConnectionState === "connected" || iceConnectionState === "connected" || iceConnectionState === "completed";
+    const controlChannelOpen = this.controlChannel?.readyState === "open";
+    return {
+      peerConnectionState,
+      iceConnectionState,
+      peerConnected,
+      controlChannelOpen,
+      answerSent: this.answerSent,
+      mediaLive: videoTrackLive || audioTrackLive,
+      videoTrackLive,
+      audioTrackLive,
+    };
+  }
+
   private emitStats(): void {
     if (this.options.onStats) {
       this.options.onStats({ ...this.diagnostics });
@@ -928,6 +959,7 @@ export class GfnWebRtcClient {
 
   private resetInputState(): void {
     this.inputReady = false;
+    this.answerSent = false;
     this.inputProtocolVersion = 2;
     this.inputEncoder.setProtocolVersion(2);
     this.diagnostics.inputReady = false;
@@ -3419,6 +3451,9 @@ export class GfnWebRtcClient {
 
       this.controlChannel = channel;
       this.controlChannel.binaryType = "arraybuffer";
+      this.controlChannel.onopen = () => {
+        this.log("Control channel open");
+      };
       this.controlChannel.onmessage = (msgEvent) => {
         void this.onControlChannelMessage(msgEvent.data as string | Blob | ArrayBuffer);
       };
@@ -3646,6 +3681,7 @@ export class GfnWebRtcClient {
       sdp: finalSdp,
       nvstSdp,
     });
+    this.answerSent = true;
     this.log("Sent SDP answer and nvstSdp");
 
     // 5. Inject manual ICE candidate from mediaConnectionInfo AFTER answer is sent

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -630,6 +630,8 @@ export class GfnWebRtcClient {
   private micManager: MicrophoneManager | null = null;
   private micState: MicState = "uninitialized";
   private answerSent = false;
+  private remoteIceCandidateCount = 0;
+  private manualIceFallbackUsed = false;
 
   // Stream info
   private currentCodec = "";
@@ -960,10 +962,50 @@ export class GfnWebRtcClient {
   private resetInputState(): void {
     this.inputReady = false;
     this.answerSent = false;
+    this.remoteIceCandidateCount = 0;
+    this.manualIceFallbackUsed = false;
     this.inputProtocolVersion = 2;
     this.inputEncoder.setProtocolVersion(2);
     this.diagnostics.inputReady = false;
     this.emitStats();
+  }
+
+  private async logIceCandidatePairSnapshot(context: string): Promise<void> {
+    if (!this.pc) {
+      return;
+    }
+    try {
+      const report = await this.pc.getStats();
+      let selectedPair: Record<string, unknown> | null = null;
+      let localCandidate: Record<string, unknown> | null = null;
+      let remoteCandidate: Record<string, unknown> | null = null;
+
+      for (const entry of report.values()) {
+        const stats = entry as unknown as Record<string, unknown>;
+        if (entry.type === "candidate-pair" && (stats.selected === true || (stats.state === "succeeded" && stats.nominated === true))) {
+          selectedPair = stats;
+        }
+      }
+
+      if (selectedPair) {
+        const localId = selectedPair.localCandidateId as string | undefined;
+        const remoteId = selectedPair.remoteCandidateId as string | undefined;
+        if (localId) {
+          const local = report.get(localId);
+          localCandidate = local ? local as unknown as Record<string, unknown> : null;
+        }
+        if (remoteId) {
+          const remote = report.get(remoteId);
+          remoteCandidate = remote ? remote as unknown as Record<string, unknown> : null;
+        }
+      }
+
+      this.log(
+        `${context} remoteIceCount=${this.remoteIceCandidateCount} manualFallback=${this.manualIceFallbackUsed} selectedPair=${selectedPair ? `state=${selectedPair.state ?? "?"} nominated=${selectedPair.nominated ?? "?"} currentRtt=${selectedPair.currentRoundTripTime ?? "?"}` : "none"} local=${localCandidate ? `${localCandidate.candidateType ?? "?"}/${localCandidate.protocol ?? "?"}/${localCandidate.address ?? "?"}:${localCandidate.port ?? "?"}` : "none"} remote=${remoteCandidate ? `${remoteCandidate.candidateType ?? "?"}/${remoteCandidate.protocol ?? "?"}/${remoteCandidate.address ?? "?"}:${remoteCandidate.port ?? "?"}` : "none"}`,
+      );
+    } catch (error) {
+      this.log(`${context} candidate-pair snapshot failed: ${String(error)}`);
+    }
   }
 
   private closeDataChannels(): void {
@@ -3478,6 +3520,9 @@ export class GfnWebRtcClient {
 
     pc.oniceconnectionstatechange = () => {
       this.log(`ICE connection state: ${pc.iceConnectionState}`);
+      if (pc.iceConnectionState === "disconnected" || pc.iceConnectionState === "failed") {
+        void this.logIceCandidatePairSnapshot(`ICE ${pc.iceConnectionState}`);
+      }
     };
 
     pc.onicegatheringstatechange = () => {
@@ -3512,7 +3557,7 @@ export class GfnWebRtcClient {
       }
     }
 
-    // 2. Extract server's ice-ufrag BEFORE any modifications (needed for manual candidate injection)
+    // 2. Extract server's ice-ufrag for diagnostics only.
     const serverIceUfrag = extractIceUfragFromOffer(processedOffer);
     this.log(`Server ICE ufrag: "${serverIceUfrag}"`);
 
@@ -3684,43 +3729,14 @@ export class GfnWebRtcClient {
     this.answerSent = true;
     this.log("Sent SDP answer and nvstSdp");
 
-    // 5. Inject manual ICE candidate from mediaConnectionInfo AFTER answer is sent
-    //    (matches Rust reference ordering — full SDP exchange completes first)
-    //    GFN servers use ice-lite and may not trickle candidates via signaling.
-    //    The actual media endpoint comes from the session's connectionInfo array.
     if (session.mediaConnectionInfo) {
       const mci = session.mediaConnectionInfo;
       const rawIp = extractPublicIp(mci.ip);
-      if (rawIp && mci.port > 0) {
-        const candidateStr = `candidate:1 1 udp 2130706431 ${rawIp} ${mci.port} typ host`;
-        this.log(`Injecting manual ICE candidate: ${rawIp}:${mci.port}`);
-
-        // Try sdpMid "0" first, then "1", "2", "3" (matching Rust fallback)
-        const mids = ["0", "1", "2", "3"];
-        let injected = false;
-        for (const mid of mids) {
-          try {
-            await pc.addIceCandidate({
-              candidate: candidateStr,
-              sdpMid: mid,
-              sdpMLineIndex: parseInt(mid, 10),
-              usernameFragment: serverIceUfrag || undefined,
-            });
-            this.log(`Manual ICE candidate injected (sdpMid=${mid})`);
-            injected = true;
-            break;
-          } catch (error) {
-            this.log(`Manual ICE candidate failed for sdpMid=${mid}: ${String(error)}`);
-          }
-        }
-        if (!injected) {
-          this.log("Warning: Could not inject manual ICE candidate on any sdpMid");
-        }
-      } else {
-        this.log(`Warning: mediaConnectionInfo present but no valid IP (ip=${mci.ip}, port=${mci.port})`);
-      }
+      this.log(
+        `MediaConnectionInfo available for SDP/server-IP patch only: ip=${rawIp ?? mci.ip}, port=${mci.port}; synthetic remote ICE injection disabled`,
+      );
     } else {
-      this.log("No mediaConnectionInfo available — relying on trickle ICE only");
+      this.log("No mediaConnectionInfo available — relying on server-provided SDP/candidates only");
     }
 
     this.log("=== handleOffer COMPLETE — waiting for ICE connectivity and tracks ===");
@@ -3728,6 +3744,7 @@ export class GfnWebRtcClient {
 
   async addRemoteCandidate(candidate: IceCandidatePayload): Promise<void> {
     this.log(`Remote ICE candidate received: ${candidate.candidate} (sdpMid=${candidate.sdpMid})`);
+    this.remoteIceCandidateCount += 1;
     const init: RTCIceCandidateInit = {
       candidate: candidate.candidate,
       sdpMid: candidate.sdpMid ?? undefined,
@@ -3736,11 +3753,13 @@ export class GfnWebRtcClient {
     };
 
     if (!this.pc || !this.pc.remoteDescription) {
+      this.log(`Queueing remote ICE candidate until remote description is ready (count=${this.remoteIceCandidateCount})`);
       this.queuedCandidates.push(init);
       return;
     }
 
     await this.pc.addIceCandidate(init);
+    this.log(`Applied remote ICE candidate immediately (count=${this.remoteIceCandidateCount})`);
   }
 
   dispose(): void {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -545,9 +545,38 @@ export interface KeyframeRequest {
   attempt: number;
 }
 
+export type SignalingSessionPhase = "sign-in" | "established";
+
+export interface SignalingDisconnectInfo {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+  error: boolean;
+  attempt: number;
+  willRetry: boolean;
+  socketGeneration: number;
+  sessionPhase: SignalingSessionPhase;
+  lastInboundAckId: number;
+  lastOutboundAckId: number;
+}
+
 export type MainToRendererSignalingEvent =
-  | { type: "connected" }
-  | { type: "disconnected"; reason: string }
+  | { type: "connected"; socketGeneration: number; sessionPhase: SignalingSessionPhase }
+  | {
+      type: "reconnecting";
+      socketGeneration: number;
+      attempt: number;
+      queuedReplayCount: number;
+      sessionPhase: SignalingSessionPhase;
+    }
+  | {
+      type: "reconnected";
+      socketGeneration: number;
+      attempt: number;
+      replayedCount: number;
+      sessionPhase: SignalingSessionPhase;
+    }
+  | { type: "disconnected"; detail: SignalingDisconnectInfo }
   | { type: "offer"; sdp: string }
   | { type: "remote-ice"; candidate: IceCandidatePayload }
   | { type: "error"; message: string }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -104,6 +104,19 @@ export function normalizeStreamPreferences(codec: VideoCodec, colorQuality: Colo
   };
 }
 
+export const DEFAULT_STREAM_PREFERENCES: Readonly<Pick<Settings, "codec" | "colorQuality">> = Object.freeze({
+  codec: "H264",
+  colorQuality: "8bit_420",
+});
+
+export function getDefaultStreamPreferences(): Pick<Settings, "codec" | "colorQuality"> {
+  const normalized = normalizeStreamPreferences(DEFAULT_STREAM_PREFERENCES.codec, DEFAULT_STREAM_PREFERENCES.colorQuality);
+  return {
+    codec: normalized.codec,
+    colorQuality: normalized.colorQuality,
+  };
+}
+
 /** Helper: is this a 10-bit (HDR-capable) mode? */
 export function colorQualityIs10Bit(cq: ColorQuality): boolean {
   return cq.startsWith("10bit");

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -546,6 +546,10 @@ export interface KeyframeRequest {
   attempt: number;
 }
 
+export interface SignalingEstablishedRequest {
+  reason: "answer-sent" | "remote-ice" | "peer-connected" | "control-channel-open" | "media-live";
+}
+
 export type SignalingSessionPhase = "sign-in" | "established";
 
 export interface SignalingDisconnectInfo {
@@ -609,6 +613,7 @@ export interface OpenNowApi {
   showSessionConflictDialog(): Promise<SessionConflictChoice>;
   connectSignaling(input: SignalingConnectRequest): Promise<void>;
   disconnectSignaling(): Promise<void>;
+  markSignalingEstablished(input: SignalingEstablishedRequest): Promise<void>;
   sendAnswer(input: SendAnswerRequest): Promise<void>;
   sendIceCandidate(input: IceCandidatePayload): Promise<void>;
   requestKeyframe(input: KeyframeRequest): Promise<void>;

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -67,6 +67,40 @@ export function colorQualityRequiresHevc(cq: ColorQuality): boolean {
   return cq !== "8bit_420";
 }
 
+export const SAFE_VIDEO_CODEC_OPTIONS: readonly VideoCodec[] = ["H264", "AV1"];
+export const SAFE_COLOR_QUALITY_OPTIONS: readonly ColorQuality[] = ["8bit_420"];
+
+export function isSupportedUserFacingCodec(codec: VideoCodec): boolean {
+  return SAFE_VIDEO_CODEC_OPTIONS.includes(codec);
+}
+
+export function isSupportedUserFacingColorQuality(colorQuality: ColorQuality): boolean {
+  return SAFE_COLOR_QUALITY_OPTIONS.includes(colorQuality);
+}
+
+export function normalizeSafeStreamPreferences(codec: VideoCodec, colorQuality: ColorQuality): {
+  codec: VideoCodec;
+  colorQuality: ColorQuality;
+  migrated: boolean;
+} {
+  const codecSupported = isSupportedUserFacingCodec(codec);
+  const colorQualitySupported = isSupportedUserFacingColorQuality(colorQuality);
+
+  if (!codecSupported || !colorQualitySupported) {
+    return {
+      codec: "H264",
+      colorQuality: "8bit_420",
+      migrated: codec !== "H264" || colorQuality !== "8bit_420",
+    };
+  }
+
+  return {
+    codec,
+    colorQuality,
+    migrated: false,
+  };
+}
+
 /** Helper: is this a 10-bit (HDR-capable) mode? */
 export function colorQualityIs10Bit(cq: ColorQuality): boolean {
   return cq.startsWith("10bit");

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -67,37 +67,40 @@ export function colorQualityRequiresHevc(cq: ColorQuality): boolean {
   return cq !== "8bit_420";
 }
 
-export const SAFE_VIDEO_CODEC_OPTIONS: readonly VideoCodec[] = ["H264", "AV1"];
-export const SAFE_COLOR_QUALITY_OPTIONS: readonly ColorQuality[] = ["8bit_420"];
+export const USER_FACING_VIDEO_CODEC_OPTIONS: readonly VideoCodec[] = ["H264", "H265", "AV1"];
+export const USER_FACING_COLOR_QUALITY_OPTIONS: readonly ColorQuality[] = ["8bit_420", "8bit_444", "10bit_420", "10bit_444"];
+
+const ALLOWED_COLOR_QUALITIES_BY_CODEC: Record<VideoCodec, readonly ColorQuality[]> = {
+  H264: ["8bit_420"],
+  H265: USER_FACING_COLOR_QUALITY_OPTIONS,
+  AV1: USER_FACING_COLOR_QUALITY_OPTIONS,
+};
 
 export function isSupportedUserFacingCodec(codec: VideoCodec): boolean {
-  return SAFE_VIDEO_CODEC_OPTIONS.includes(codec);
+  return USER_FACING_VIDEO_CODEC_OPTIONS.includes(codec);
 }
 
-export function isSupportedUserFacingColorQuality(colorQuality: ColorQuality): boolean {
-  return SAFE_COLOR_QUALITY_OPTIONS.includes(colorQuality);
+export function getAllowedColorQualitiesForCodec(codec: VideoCodec): readonly ColorQuality[] {
+  return ALLOWED_COLOR_QUALITIES_BY_CODEC[codec] ?? ALLOWED_COLOR_QUALITIES_BY_CODEC.H264;
 }
 
-export function normalizeSafeStreamPreferences(codec: VideoCodec, colorQuality: ColorQuality): {
+export function isAllowedColorQualityForCodec(codec: VideoCodec, colorQuality: ColorQuality): boolean {
+  return getAllowedColorQualitiesForCodec(codec).includes(colorQuality);
+}
+
+export function normalizeStreamPreferences(codec: VideoCodec, colorQuality: ColorQuality): {
   codec: VideoCodec;
   colorQuality: ColorQuality;
   migrated: boolean;
 } {
-  const codecSupported = isSupportedUserFacingCodec(codec);
-  const colorQualitySupported = isSupportedUserFacingColorQuality(colorQuality);
-
-  if (!codecSupported || !colorQualitySupported) {
-    return {
-      codec: "H264",
-      colorQuality: "8bit_420",
-      migrated: codec !== "H264" || colorQuality !== "8bit_420",
-    };
-  }
+  const normalizedCodec = isSupportedUserFacingCodec(codec) ? codec : "H264";
+  const allowedColorQualities = getAllowedColorQualitiesForCodec(normalizedCodec);
+  const normalizedColorQuality = allowedColorQualities.includes(colorQuality) ? colorQuality : allowedColorQualities[0];
 
   return {
-    codec,
-    colorQuality,
-    migrated: false,
+    codec: normalizedCodec,
+    colorQuality: normalizedColorQuality,
+    migrated: normalizedCodec !== codec || normalizedColorQuality !== colorQuality,
   };
 }
 

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -19,6 +19,7 @@ export const IPC_CHANNELS = {
   SESSION_CONFLICT_DIALOG: "gfn:session-conflict-dialog",
   CONNECT_SIGNALING: "gfn:connect-signaling",
   DISCONNECT_SIGNALING: "gfn:disconnect-signaling",
+  MARK_SIGNALING_ESTABLISHED: "gfn:mark-signaling-established",
   SEND_ANSWER: "gfn:send-answer",
   SEND_ICE_CANDIDATE: "gfn:send-ice-candidate",
   REQUEST_KEYFRAME: "gfn:request-keyframe",


### PR DESCRIPTION
Implements official-client-style signaling session management with ack/replay state, reconnect attempts, and stream survivability. Transient signaling socket closes after media establishment no longer immediately destroy the active stream.

- **src/main/gfn/signaling.ts**: Refactor into session manager with socket generations, ack/ackid tracking, outbound queuing, unacked message replay, reconnect with `&reconnect=1`, and close-code-aware retry policy up to 3 attempts
- **src/shared/gfn.ts**: Add `SignalingDisconnectInfo`, `SignalingSessionPhase`, and expand `MainToRendererSignalingEvent` with `connected`, `reconnecting`, `reconnected`, and structured `disconnected` payloads including code, reason, wasClean, retry state, generation, phase, and last ack ids
- **src/renderer/src/App.tsx**: Conditional teardown on signaling disconnect—keep media alive if peer connection/control channel/answer/media is established and signaling indicates retry will occur; add `shouldKeepStreamingSessionAlive` helper and `teardownStreamFromTerminalSignaling` handler
- **src/renderer/src/gfn/webrtcClient.ts**: Expose `WebRtcSessionSnapshot` with peer connection/ICE state, control channel open, answer sent, and audio/video track liveness; add `controlChannel.onopen` logging without disrupting existing SDP/H265/manual-ICE handling

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/62113a9b-5f33-4dd1-b1ad-73137a517875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-48&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-48"><img alt="OPE-48 · 5.4-Fast" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=OPE-48"></picture></a>