### PR TITLE
Fix session IPC errors losing structured details

### DIFF
--- a/opennow-stable/src/main/gfn/errorCodes.ts
+++ b/opennow-stable/src/main/gfn/errorCodes.ts
@@ -1,3 +1,5 @@
+import type { SessionErrorInfo } from "@shared/sessionError";
+
 /**
  * CloudMatch error codes.
  *
@@ -633,26 +635,6 @@ export const ERROR_MESSAGES: Map<number, ErrorMessageEntry> = new Map([
     },
   ],
 ]);
-
-/** Parsed error information from CloudMatch response */
-export interface SessionErrorInfo {
-  /** HTTP status code (e.g., 403) */
-  httpStatus: number;
-  /** CloudMatch status code from requestStatus.statusCode */
-  statusCode: number;
-  /** Status description from requestStatus.statusDescription */
-  statusDescription?: string;
-  /** Unified error code from requestStatus.unifiedErrorCode */
-  unifiedErrorCode?: number;
-  /** Session error code from session.errorCode */
-  sessionErrorCode?: number;
-  /** Computed service error code */
-  gfnErrorCode: number;
-  /** User-friendly title */
-  title: string;
-  /** User-friendly description */
-  description: string;
-}
 
 /** CloudMatch error response structure */
 interface CloudMatchErrorResponse {

--- a/opennow-stable/src/main/gfn/types.ts
+++ b/opennow-stable/src/main/gfn/types.ts
@@ -1,4 +1,5 @@
-import type { SessionError, SessionErrorInfo } from "./errorCodes";
+import type { SessionError } from "./errorCodes";
+import type { SessionErrorInfo } from "@shared/sessionError";
 
 export interface CloudMatchRequest {
   sessionRequestData: {

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -59,6 +59,7 @@ import type {
   RecordingAbortRequest,
   RecordingDeleteRequest,
 } from "@shared/gfn";
+import { serializeSessionErrorTransport } from "@shared/sessionError";
 
 import { getSettingsManager, type SettingsManager } from "./settings";
 
@@ -591,7 +592,7 @@ function isSessionConflictError(error: unknown): boolean {
 
 function rethrowSerializedSessionError(error: unknown): never {
   if (error instanceof SessionError) {
-    throw error.toJSON();
+    throw new Error(serializeSessionErrorTransport(error.toJSON()));
   }
   throw error;
 }

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -33,6 +33,22 @@ import type {
   RecordingDeleteRequest,
   MediaListingResult,
 } from "@shared/gfn";
+import { parseSerializedSessionErrorTransport } from "@shared/sessionError";
+
+function unwrapSessionInvokeError(error: unknown): never {
+  if (error instanceof Error) {
+    const sessionError = parseSerializedSessionErrorTransport(error.message);
+    if (sessionError) {
+      throw sessionError;
+    }
+  }
+
+  throw error;
+}
+
+function invokeSessionChannel<T>(channel: string, ...args: unknown[]): Promise<T> {
+  return ipcRenderer.invoke(channel, ...args).catch((error: unknown) => unwrapSessionInvokeError(error)) as Promise<T>;
+}
 
 const api: OpenNowApi = {
   getAuthSession: (input: AuthSessionRequest = {}) => ipcRenderer.invoke(IPC_CHANNELS.AUTH_GET_SESSION, input),
@@ -48,13 +64,13 @@ const api: OpenNowApi = {
   fetchPublicGames: () => ipcRenderer.invoke(IPC_CHANNELS.GAMES_FETCH_PUBLIC),
   resolveLaunchAppId: (input: ResolveLaunchIdRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.GAMES_RESOLVE_LAUNCH_ID, input),
-  createSession: (input: SessionCreateRequest) => ipcRenderer.invoke(IPC_CHANNELS.CREATE_SESSION, input),
-  pollSession: (input: SessionPollRequest) => ipcRenderer.invoke(IPC_CHANNELS.POLL_SESSION, input),
-  reportSessionAd: (input: SessionAdReportRequest) => ipcRenderer.invoke(IPC_CHANNELS.REPORT_SESSION_AD, input),
-  stopSession: (input: SessionStopRequest) => ipcRenderer.invoke(IPC_CHANNELS.STOP_SESSION, input),
+  createSession: (input: SessionCreateRequest) => invokeSessionChannel(IPC_CHANNELS.CREATE_SESSION, input),
+  pollSession: (input: SessionPollRequest) => invokeSessionChannel(IPC_CHANNELS.POLL_SESSION, input),
+  reportSessionAd: (input: SessionAdReportRequest) => invokeSessionChannel(IPC_CHANNELS.REPORT_SESSION_AD, input),
+  stopSession: (input: SessionStopRequest) => invokeSessionChannel(IPC_CHANNELS.STOP_SESSION, input),
   getActiveSessions: (token?: string, streamingBaseUrl?: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.GET_ACTIVE_SESSIONS, token, streamingBaseUrl),
-  claimSession: (input: SessionClaimRequest) => ipcRenderer.invoke(IPC_CHANNELS.CLAIM_SESSION, input),
+  claimSession: (input: SessionClaimRequest) => invokeSessionChannel(IPC_CHANNELS.CLAIM_SESSION, input),
   showSessionConflictDialog: () => ipcRenderer.invoke(IPC_CHANNELS.SESSION_CONFLICT_DIALOG),
   connectSignaling: (input: SignalingConnectRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.CONNECT_SIGNALING, input),

--- a/opennow-stable/src/shared/sessionError.ts
+++ b/opennow-stable/src/shared/sessionError.ts
@@ -1,0 +1,65 @@
+export interface SessionErrorInfo {
+  httpStatus: number;
+  statusCode: number;
+  statusDescription?: string;
+  unifiedErrorCode?: number;
+  sessionErrorCode?: number;
+  gfnErrorCode: number;
+  title: string;
+  description: string;
+}
+
+export const SESSION_ERROR_TRANSPORT_KIND = "opennow.session-error" as const;
+const SESSION_ERROR_TRANSPORT_PREFIX = "__OPENNOW_SESSION_ERROR__:";
+
+export interface SerializedSessionError extends SessionErrorInfo {
+  kind: typeof SESSION_ERROR_TRANSPORT_KIND;
+  name: "SessionError";
+  message: string;
+}
+
+export function toSerializedSessionError(info: SessionErrorInfo): SerializedSessionError {
+  return {
+    ...info,
+    kind: SESSION_ERROR_TRANSPORT_KIND,
+    name: "SessionError",
+    message: info.description,
+  };
+}
+
+export function isSerializedSessionError(error: unknown): error is SerializedSessionError {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "kind" in error &&
+      error.kind === SESSION_ERROR_TRANSPORT_KIND &&
+      "name" in error &&
+      error.name === "SessionError" &&
+      "gfnErrorCode" in error &&
+      typeof error.gfnErrorCode === "number" &&
+      "title" in error &&
+      typeof error.title === "string" &&
+      "description" in error &&
+      typeof error.description === "string",
+  );
+}
+
+export function serializeSessionErrorTransport(info: SessionErrorInfo): string {
+  return `${SESSION_ERROR_TRANSPORT_PREFIX}${JSON.stringify(toSerializedSessionError(info))}`;
+}
+
+export function parseSerializedSessionErrorTransport(message: string): SerializedSessionError | null {
+  const markerIndex = message.indexOf(SESSION_ERROR_TRANSPORT_PREFIX);
+  if (markerIndex < 0) {
+    return null;
+  }
+
+  const payload = message.slice(markerIndex + SESSION_ERROR_TRANSPORT_PREFIX.length);
+
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    return isSerializedSessionError(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
This PR fixes the launch failure path where `window.openNow.createSession(...)` rejects in the renderer as `Error invoking remote method 'gfn:create-session': [object Object]` instead of preserving the structured GeForce NOW session error details.

**Changes:**

* Introduced explicit shared transport typing in `src/shared/sessionError.ts` with `SerializedSessionError`, `toSerializedSessionError`, `isSerializedSessionError`, `serializeSessionErrorTransport`, and `parseSerializedSessionErrorTransport` utilities.
* Updated `src/main/index.ts` to use `serializeSessionErrorTransport` in `rethrowSerializedSessionError`, wrapping `SessionError.toJSON()` output in a sentinel-prefixed `Error.message` that survives Electron `ipcRenderer.invoke` serialization.
* Updated `src/preload/index.ts` with `invokeSessionChannel` wrapper that unwraps the sentinel prefix and rethrows the parsed structured object for `createSession`, `pollSession`, `reportSessionAd`, `stopSession`, and `claimSession`.
* Moved `SessionErrorInfo` definition from `src/main/gfn/errorCodes.ts` to `src/shared/sessionError.ts` and updated re-exports in `src/main/gfn/types.ts`.

The renderer's existing `toLaunchErrorState` mapping already consumes structured fields (`title`, `description`, `statusDescription`, `statusCode`, `gfnErrorCode`), so no changes were needed there. The fix restores reliable access to those fields for UI display and diagnostics.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/76649891-2e5a-464b-b408-48db128645ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-51&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-51"><img alt="OPE-51 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-51"></picture></a>