### PR TITLE
Add Settings thank-you tab for contributors and supporters

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -716,8 +716,10 @@ async function fetchThanksContributors(): Promise<ThankYouContributor[]> {
 }
 
 function parseSupporterName(entryHtml: string): { name: string; isPrivate: boolean } {
+  const privateHrefMatch = entryHtml.match(/href="https:\/\/docs\.github\.com\/sponsors\/sponsoring-open-source-contributors\/managing-your-sponsorship#managing-the-privacy-setting-for-your-sponsorship"/i);
   const privateTooltipMatch = entryHtml.match(/<tool-tip[^>]*>\s*Private Sponsor\s*<\/tool-tip>/i);
-  if (privateTooltipMatch) {
+  const privateAriaMatch = entryHtml.match(/aria-label="Private Sponsor"/i);
+  if (privateHrefMatch || privateTooltipMatch || privateAriaMatch) {
     return { name: "Private", isPrivate: true };
   }
 
@@ -735,6 +737,12 @@ function parseSupporterName(entryHtml: string): { name: string; isPrivate: boole
     return { name: normalizedAria, isPrivate: false };
   }
 
+  const hrefMatch = entryHtml.match(/<a[^>]+href="\/([^"/?#]+)"/i);
+  const normalizedHref = hrefMatch ? decodeHtmlEntities(hrefMatch[1]).trim() : "";
+  if (normalizedHref && !/sponsors/i.test(normalizedHref)) {
+    return { name: normalizedHref.replace(/^@/, ""), isPrivate: false };
+  }
+
   return { name: "Private", isPrivate: true };
 }
 
@@ -745,7 +753,7 @@ function parseSupportersFromHtml(html: string): ThankYouSupporter[] {
   }
 
   const listHtml = sponsorsSectionMatch[1];
-  const entryMatches = listHtml.match(/<div class="d-flex mb-1 mr-1"[^>]*>[\s\S]*?<\/div>\s*<\/div>/gi) ?? [];
+  const entryMatches = listHtml.match(/<div class="d-flex mb-1 mr-1"[^>]*>[\s\S]*?<\/div>/gi) ?? [];
   const supporters: ThankYouSupporter[] = [];
   const seenKeys = new Set<string>();
 

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -703,7 +703,7 @@ async function fetchThanksContributors(): Promise<ThankYouContributor[]> {
     throw new Error("GitHub contributors response was not an array");
   }
 
-  return payload
+  const contributors = payload
     .filter((contributor) => !shouldExcludeContributor(contributor))
     .map((contributor) => ({
       login: contributor.login!.trim(),
@@ -712,6 +712,7 @@ async function fetchThanksContributors(): Promise<ThankYouContributor[]> {
       contributions: typeof contributor.contributions === "number" ? contributor.contributions : 0,
     }))
     .sort((a, b) => b.contributions - a.contributions || a.login.localeCompare(b.login));
+  return contributors;
 }
 
 function parseSupporterName(entryHtml: string): { name: string; isPrivate: boolean } {
@@ -785,7 +786,8 @@ async function fetchThanksSupporters(): Promise<ThankYouSupporter[]> {
   }
 
   const html = await withTimeout(response.text(), THANKS_FETCH_TIMEOUT_MS, "GitHub sponsors response");
-  return parseSupportersFromHtml(html);
+  const supporters = parseSupportersFromHtml(html);
+  return supporters;
 }
 
 async function fetchThanksData(): Promise<ThankYouDataResult> {

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -607,6 +607,7 @@ const THANKS_REQUEST_HEADERS = {
   "User-Agent": "OpenNOW-DesktopClient",
 } as const;
 const THANKS_EXCLUDED_PATTERN = /(copilot|claude|cappy)/i;
+const THANKS_FETCH_TIMEOUT_MS = 8000;
 
 interface GitHubContributorResponse {
   login?: string;
@@ -615,6 +616,43 @@ interface GitHubContributorResponse {
   contributions?: number;
   type?: string;
   name?: string | null;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number, label: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if ((error instanceof Error && error.name === "AbortError") || controller.signal.aborted) {
+      const reason = controller.signal.reason;
+      const message = reason instanceof Error ? reason.message : `${label} timed out after ${timeoutMs}ms`;
+      throw new Error(message);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function decodeHtmlEntities(value: string): string {
@@ -650,12 +688,17 @@ function shouldExcludeContributor(contributor: GitHubContributorResponse): boole
 }
 
 async function fetchThanksContributors(): Promise<ThankYouContributor[]> {
-  const response = await fetch(THANKS_CONTRIBUTORS_URL, { headers: THANKS_REQUEST_HEADERS });
+  const response = await fetchWithTimeout(
+    THANKS_CONTRIBUTORS_URL,
+    { headers: THANKS_REQUEST_HEADERS },
+    THANKS_FETCH_TIMEOUT_MS,
+    "GitHub contributors request",
+  );
   if (!response.ok) {
     throw new Error(`GitHub contributors request failed (${response.status})`);
   }
 
-  const payload = (await response.json()) as GitHubContributorResponse[];
+  const payload = (await withTimeout(response.json() as Promise<GitHubContributorResponse[]>, THANKS_FETCH_TIMEOUT_MS, "GitHub contributors response")) as GitHubContributorResponse[];
   if (!Array.isArray(payload)) {
     throw new Error("GitHub contributors response was not an array");
   }
@@ -726,17 +769,22 @@ function parseSupportersFromHtml(html: string): ThankYouSupporter[] {
 }
 
 async function fetchThanksSupporters(): Promise<ThankYouSupporter[]> {
-  const response = await fetch(THANKS_SUPPORTERS_URL, {
-    headers: {
-      ...THANKS_REQUEST_HEADERS,
-      Accept: "text/html,application/xhtml+xml",
+  const response = await fetchWithTimeout(
+    THANKS_SUPPORTERS_URL,
+    {
+      headers: {
+        ...THANKS_REQUEST_HEADERS,
+        Accept: "text/html,application/xhtml+xml",
+      },
     },
-  });
+    THANKS_FETCH_TIMEOUT_MS,
+    "GitHub sponsors request",
+  );
   if (!response.ok) {
     throw new Error(`GitHub sponsors page request failed (${response.status})`);
   }
 
-  const html = await response.text();
+  const html = await withTimeout(response.text(), THANKS_FETCH_TIMEOUT_MS, "GitHub sponsors response");
   return parseSupportersFromHtml(html);
 }
 

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -58,6 +58,9 @@ import type {
   RecordingFinishRequest,
   RecordingAbortRequest,
   RecordingDeleteRequest,
+  ThankYouContributor,
+  ThankYouDataResult,
+  ThankYouSupporter,
 } from "@shared/gfn";
 import { serializeSessionErrorTransport } from "@shared/sessionError";
 
@@ -595,6 +598,179 @@ function rethrowSerializedSessionError(error: unknown): never {
     throw new Error(serializeSessionErrorTransport(error.toJSON()));
   }
   throw error;
+}
+
+const THANKS_CONTRIBUTORS_URL = "https://api.github.com/repos/OpenCloudGaming/OpenNOW/contributors?per_page=100";
+const THANKS_SUPPORTERS_URL = "https://github.com/sponsors/zortos293";
+const THANKS_REQUEST_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "OpenNOW-DesktopClient",
+} as const;
+const THANKS_EXCLUDED_PATTERN = /(copilot|claude|cappy)/i;
+
+interface GitHubContributorResponse {
+  login?: string;
+  avatar_url?: string;
+  html_url?: string;
+  contributions?: number;
+  type?: string;
+  name?: string | null;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+function stripHtml(value: string): string {
+  return decodeHtmlEntities(value.replace(/<[^>]+>/g, " ")).replace(/\s+/g, " ").trim();
+}
+
+function normalizeUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const decoded = decodeHtmlEntities(value.trim());
+  if (!decoded) return undefined;
+  if (decoded.startsWith("//")) return `https:${decoded}`;
+  if (decoded.startsWith("/")) return `https://github.com${decoded}`;
+  return decoded;
+}
+
+function shouldExcludeContributor(contributor: GitHubContributorResponse): boolean {
+  const login = contributor.login?.trim() ?? "";
+  const name = contributor.name?.trim() ?? "";
+  if (!login || !contributor.avatar_url || !contributor.html_url) return true;
+  if (contributor.type === "Bot") return true;
+  if (/\[bot\]$/i.test(login)) return true;
+  if (THANKS_EXCLUDED_PATTERN.test(login) || THANKS_EXCLUDED_PATTERN.test(name)) return true;
+  return false;
+}
+
+async function fetchThanksContributors(): Promise<ThankYouContributor[]> {
+  const response = await fetch(THANKS_CONTRIBUTORS_URL, { headers: THANKS_REQUEST_HEADERS });
+  if (!response.ok) {
+    throw new Error(`GitHub contributors request failed (${response.status})`);
+  }
+
+  const payload = (await response.json()) as GitHubContributorResponse[];
+  if (!Array.isArray(payload)) {
+    throw new Error("GitHub contributors response was not an array");
+  }
+
+  return payload
+    .filter((contributor) => !shouldExcludeContributor(contributor))
+    .map((contributor) => ({
+      login: contributor.login!.trim(),
+      avatarUrl: contributor.avatar_url!,
+      profileUrl: contributor.html_url!,
+      contributions: typeof contributor.contributions === "number" ? contributor.contributions : 0,
+    }))
+    .sort((a, b) => b.contributions - a.contributions || a.login.localeCompare(b.login));
+}
+
+function parseSupporterName(entryHtml: string): { name: string; isPrivate: boolean } {
+  const privateTooltipMatch = entryHtml.match(/<tool-tip[^>]*>\s*Private Sponsor\s*<\/tool-tip>/i);
+  if (privateTooltipMatch) {
+    return { name: "Private", isPrivate: true };
+  }
+
+  const altMatch = entryHtml.match(/<img[^>]+alt="([^"]+)"/i);
+  const altText = altMatch ? stripHtml(altMatch[1]) : "";
+  const normalizedAlt = altText.replace(/^@/, "").trim();
+  if (normalizedAlt) {
+    return { name: normalizedAlt, isPrivate: false };
+  }
+
+  const ariaMatch = entryHtml.match(/aria-label="([^"]+)"/i);
+  const ariaText = ariaMatch ? stripHtml(ariaMatch[1]) : "";
+  const normalizedAria = ariaText.replace(/^@/, "").trim();
+  if (normalizedAria && !/private sponsor/i.test(normalizedAria)) {
+    return { name: normalizedAria, isPrivate: false };
+  }
+
+  return { name: "Private", isPrivate: true };
+}
+
+function parseSupportersFromHtml(html: string): ThankYouSupporter[] {
+  const sponsorsSectionMatch = html.match(/<div class="tmp-mt-3 tmp-pb-4" id="sponsors">([\s\S]*?)<\/remote-pagination>/i);
+  if (!sponsorsSectionMatch) {
+    return [];
+  }
+
+  const listHtml = sponsorsSectionMatch[1];
+  const entryMatches = listHtml.match(/<div class="d-flex mb-1 mr-1"[^>]*>[\s\S]*?<\/div>\s*<\/div>/gi) ?? [];
+  const supporters: ThankYouSupporter[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const entryHtml of entryMatches) {
+    const { name, isPrivate } = parseSupporterName(entryHtml);
+    const hrefMatch = entryHtml.match(/<a[^>]+href="([^"]+)"/i);
+    const profileUrl = isPrivate ? undefined : normalizeUrl(hrefMatch?.[1]);
+    const avatarMatch = entryHtml.match(/<img[^>]+src="([^"]+)"/i);
+    const avatarUrl = normalizeUrl(avatarMatch?.[1]);
+    const dedupeKey = `${name}|${profileUrl ?? ""}|${avatarUrl ?? ""}`;
+    if (seenKeys.has(dedupeKey)) continue;
+    seenKeys.add(dedupeKey);
+    supporters.push({
+      name: name || "Private",
+      avatarUrl,
+      profileUrl,
+      isPrivate: isPrivate || !name,
+    });
+  }
+
+  return supporters;
+}
+
+async function fetchThanksSupporters(): Promise<ThankYouSupporter[]> {
+  const response = await fetch(THANKS_SUPPORTERS_URL, {
+    headers: {
+      ...THANKS_REQUEST_HEADERS,
+      Accept: "text/html,application/xhtml+xml",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub sponsors page request failed (${response.status})`);
+  }
+
+  const html = await response.text();
+  return parseSupportersFromHtml(html);
+}
+
+async function fetchThanksData(): Promise<ThankYouDataResult> {
+  const result: ThankYouDataResult = {
+    contributors: [],
+    supporters: [],
+  };
+
+  const [contributorsResult, supportersResult] = await Promise.allSettled([
+    fetchThanksContributors(),
+    fetchThanksSupporters(),
+  ]);
+
+  if (contributorsResult.status === "fulfilled") {
+    result.contributors = contributorsResult.value;
+  } else {
+    result.contributorsError = contributorsResult.reason instanceof Error
+      ? contributorsResult.reason.message
+      : "Unable to load contributors right now.";
+  }
+
+  if (supportersResult.status === "fulfilled") {
+    result.supporters = supportersResult.value;
+    if (result.supporters.length === 0) {
+      result.supportersError = "No public supporters were found on GitHub Sponsors.";
+    }
+  } else {
+    result.supportersError = supportersResult.reason instanceof Error
+      ? supportersResult.reason.message
+      : "Unable to load supporters right now.";
+  }
+
+  return result;
 }
 
 function registerIpcHandlers(): void {
@@ -1173,6 +1349,10 @@ function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.CACHE_DELETE_ALL, async (): Promise<void> => {
     await cacheManager.deleteAll();
     console.log("[IPC] Cache deletion completed successfully");
+  });
+
+  ipcMain.handle(IPC_CHANNELS.COMMUNITY_GET_THANKS, async (): Promise<ThankYouDataResult> => {
+    return fetchThanksData();
   });
 
   // TCP-based ping function - more accurate than HTTP as it only measures connection time

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import electron from "electron";
 
 import { IPC_CHANNELS } from "@shared/ipc";
 import type {
@@ -35,6 +35,8 @@ import type {
   ThankYouDataResult,
 } from "@shared/gfn";
 import { parseSerializedSessionErrorTransport } from "@shared/sessionError";
+
+const { contextBridge, ipcRenderer } = electron;
 
 function unwrapSessionInvokeError(error: unknown): never {
   if (error instanceof Error) {
@@ -140,8 +142,7 @@ const api: OpenNowApi = {
     ipcRenderer.invoke(IPC_CHANNELS.MEDIA_SHOW_IN_FOLDER, input),
   deleteCache: (): Promise<void> =>
     ipcRenderer.invoke(IPC_CHANNELS.CACHE_DELETE_ALL),
-  getThanksData: (): Promise<ThankYouDataResult> =>
-    ipcRenderer.invoke(IPC_CHANNELS.COMMUNITY_GET_THANKS),
+  getThanksData: (): Promise<ThankYouDataResult> => ipcRenderer.invoke(IPC_CHANNELS.COMMUNITY_GET_THANKS),
 };
 
 contextBridge.exposeInMainWorld("openNow", api);

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -32,6 +32,7 @@ import type {
   RecordingEntry,
   RecordingDeleteRequest,
   MediaListingResult,
+  ThankYouDataResult,
 } from "@shared/gfn";
 import { parseSerializedSessionErrorTransport } from "@shared/sessionError";
 
@@ -139,6 +140,8 @@ const api: OpenNowApi = {
     ipcRenderer.invoke(IPC_CHANNELS.MEDIA_SHOW_IN_FOLDER, input),
   deleteCache: (): Promise<void> =>
     ipcRenderer.invoke(IPC_CHANNELS.CACHE_DELETE_ALL),
+  getThanksData: (): Promise<ThankYouDataResult> =>
+    ipcRenderer.invoke(IPC_CHANNELS.COMMUNITY_GET_THANKS),
 };
 
 contextBridge.exposeInMainWorld("openNow", api);

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -24,6 +24,8 @@ interface SettingsPageProps {
   onSettingChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
 }
 
+type ThanksLoadState = "idle" | "loading" | "loaded" | "error";
+
 const codecOptions: VideoCodec[] = ["H264", "H265", "AV1"];
 
 const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = [
@@ -521,9 +523,10 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   const [savedIndicator, setSavedIndicator] = useState(false);
   const [activeTab, setActiveTab] = useState<"preferences" | "thanks">("preferences");
   const [thanksData, setThanksData] = useState<ThankYouDataResult | null>(null);
-  const [thanksLoading, setThanksLoading] = useState(false);
+  const [thanksLoadState, setThanksLoadState] = useState<ThanksLoadState>("idle");
   const [thanksFetchError, setThanksFetchError] = useState<string | null>(null);
-  const [thanksRequested, setThanksRequested] = useState(false);
+  const thanksRequestIdRef = useRef(0);
+  const thanksMountedRef = useRef(true);
   const [regionSearch, setRegionSearch] = useState("");
   const [regionDropdownOpen, setRegionDropdownOpen] = useState(false);
 
@@ -959,38 +962,46 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   }, [handleChange, settings]);
 
   useEffect(() => {
-    if (activeTab !== "thanks" || thanksData || thanksLoading || thanksRequested) {
+    return () => {
+      thanksMountedRef.current = false;
+      thanksRequestIdRef.current += 1;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (activeTab !== "thanks") {
+      thanksRequestIdRef.current += 1;
+      setThanksLoadState((current) => (current === "loading" ? "idle" : current));
       return;
     }
 
-    let cancelled = false;
-
-    async function loadThanks(): Promise<void> {
-      setThanksLoading(true);
-      setThanksFetchError(null);
-      setThanksRequested(true);
-      try {
-        const data = await window.openNow.getThanksData();
-        if (!cancelled) {
-          setThanksData(data);
-        }
-      } catch (error) {
-        console.error("[SettingsPage] Failed to load thanks data:", error);
-        if (!cancelled) {
-          setThanksFetchError("Unable to load community acknowledgements right now.");
-        }
-      } finally {
-        if (!cancelled) {
-          setThanksLoading(false);
-        }
-      }
+    if (thanksData || thanksLoadState === "loading") {
+      return;
     }
 
-    void loadThanks();
-    return () => {
-      cancelled = true;
-    };
-  }, [activeTab, thanksData, thanksLoading, thanksRequested]);
+    const requestId = ++thanksRequestIdRef.current;
+    setThanksLoadState("loading");
+    setThanksFetchError(null);
+
+    void window.openNow.getThanksData().then(
+      (data) => {
+        if (!thanksMountedRef.current || requestId !== thanksRequestIdRef.current) {
+          return;
+        }
+        setThanksData(data);
+        setThanksLoadState("loaded");
+      },
+      (error) => {
+        console.error("[SettingsPage] Failed to load thanks data:", error);
+        if (!thanksMountedRef.current || requestId !== thanksRequestIdRef.current) {
+          return;
+        }
+        setThanksData(null);
+        setThanksFetchError("Unable to load community acknowledgements right now.");
+        setThanksLoadState("error");
+      },
+    );
+  }, [activeTab, thanksData, thanksLoadState]);
 
   const renderPersonLink = useCallback((person: ThankYouContributor | ThankYouSupporter, content: JSX.Element) => {
     if (!person.profileUrl) {
@@ -1080,7 +1091,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
               <p className="settings-section-subtitle">People improving OpenNOW in code, fixes, and features.</p>
             </div>
           </div>
-          {thanksLoading && !thanksData ? (
+          {thanksLoadState === "loading" && !thanksData ? (
             <div className="settings-thanks-state">
               <Loader size={16} className="settings-loading-icon" />
               <span>Loading contributors from GitHub…</span>
@@ -1106,7 +1117,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
               <p className="settings-section-subtitle">Public GitHub Sponsors backing the work, plus private supporters when available.</p>
             </div>
           </div>
-          {thanksLoading && !thanksData ? (
+          {thanksLoadState === "loading" && !thanksData ? (
             <div className="settings-thanks-state">
               <Loader size={16} className="settings-loading-icon" />
               <span>Loading supporters from GitHub Sponsors…</span>

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -962,6 +962,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   }, [handleChange, settings]);
 
   useEffect(() => {
+    thanksMountedRef.current = true;
     return () => {
       thanksMountedRef.current = false;
       thanksRequestIdRef.current += 1;
@@ -1009,7 +1010,6 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
         setThanksLoadState("loaded");
       },
       (error) => {
-        console.error("[SettingsPage] Failed to load thanks data:", error);
         if (!thanksMountedRef.current || requestId !== thanksRequestIdRef.current) {
           return;
         }

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -971,11 +971,12 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   useEffect(() => {
     if (activeTab !== "thanks") {
       thanksRequestIdRef.current += 1;
-      setThanksLoadState((current) => (current === "loading" ? "idle" : current));
+      setThanksLoadState((current) => (current === "loading" || current === "error" ? "idle" : current));
+      setThanksFetchError(null);
       return;
     }
 
-    if (thanksData || thanksLoadState === "loading") {
+    if (thanksData || thanksLoadState !== "idle") {
       return;
     }
 
@@ -1034,6 +1035,13 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   const thanksContributors = thanksData?.contributors ?? [];
   const thanksSupporters = thanksData?.supporters ?? [];
   const hasThanksError = Boolean(thanksFetchError || thanksData?.contributorsError || thanksData?.supportersError);
+
+  const handleRetryThanks = useCallback(() => {
+    thanksRequestIdRef.current += 1;
+    setThanksData(null);
+    setThanksFetchError(null);
+    setThanksLoadState("idle");
+  }, []);
 
   const renderContributorCard = useCallback((contributor: ThankYouContributor) => {
     return renderPersonLink(
@@ -1095,6 +1103,11 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
         <section className="settings-section settings-thanks-status settings-thanks-status--error">
           <strong>Community data unavailable</strong>
           <span>{thanksFetchError}</span>
+          <div className="settings-thanks-actions">
+            <button type="button" className="settings-chip settings-thanks-retry-btn" onClick={handleRetryThanks}>
+              Retry
+            </button>
+          </div>
         </section>
       )}
 

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -980,10 +980,26 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     }
 
     const requestId = ++thanksRequestIdRef.current;
+    let requestPromise: Promise<ThankYouDataResult>;
+
+    try {
+      const getThanksData = window.openNow?.getThanksData;
+      if (typeof getThanksData !== "function") {
+        throw new Error("openNow.getThanksData is unavailable");
+      }
+      requestPromise = getThanksData();
+    } catch (error) {
+      console.error("[SettingsPage] Failed to start thanks data request:", error);
+      setThanksData(null);
+      setThanksFetchError("Unable to load community acknowledgements right now.");
+      setThanksLoadState("error");
+      return;
+    }
+
     setThanksLoadState("loading");
     setThanksFetchError(null);
 
-    void window.openNow.getThanksData().then(
+    void requestPromise.then(
       (data) => {
         if (!thanksMountedRef.current || requestId !== thanksRequestIdRef.current) {
           return;

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Globe, Check, Search, X, Loader, Zap, Mic, FileDown, Wifi, Trash2 } from "lucide-react";
+import { Globe, Check, Search, X, Loader, Zap, Mic, FileDown, Wifi, Trash2, Heart, Users, ExternalLink } from "lucide-react";
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import type { JSX } from "react";
 
@@ -11,6 +11,9 @@ import type {
   MicrophoneMode,
   PingResult,
   GameLanguage,
+  ThankYouDataResult,
+  ThankYouContributor,
+  ThankYouSupporter,
 } from "@shared/gfn";
 import { colorQualityRequiresHevc, keyboardLayoutOptions } from "@shared/gfn";
 import { formatShortcutForDisplay, normalizeShortcut } from "../shortcuts";
@@ -516,6 +519,11 @@ async function testCodecSupport(): Promise<CodecTestResult[]> {
 
 export function SettingsPage({ settings, regions, onSettingChange }: SettingsPageProps): JSX.Element {
   const [savedIndicator, setSavedIndicator] = useState(false);
+  const [activeTab, setActiveTab] = useState<"preferences" | "thanks">("preferences");
+  const [thanksData, setThanksData] = useState<ThankYouDataResult | null>(null);
+  const [thanksLoading, setThanksLoading] = useState(false);
+  const [thanksFetchError, setThanksFetchError] = useState<string | null>(null);
+  const [thanksRequested, setThanksRequested] = useState(false);
   const [regionSearch, setRegionSearch] = useState("");
   const [regionDropdownOpen, setRegionDropdownOpen] = useState(false);
 
@@ -950,6 +958,182 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     }
   }, [handleChange, settings]);
 
+  useEffect(() => {
+    if (activeTab !== "thanks" || thanksData || thanksLoading || thanksRequested) {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadThanks(): Promise<void> {
+      setThanksLoading(true);
+      setThanksFetchError(null);
+      setThanksRequested(true);
+      try {
+        const data = await window.openNow.getThanksData();
+        if (!cancelled) {
+          setThanksData(data);
+        }
+      } catch (error) {
+        console.error("[SettingsPage] Failed to load thanks data:", error);
+        if (!cancelled) {
+          setThanksFetchError("Unable to load community acknowledgements right now.");
+        }
+      } finally {
+        if (!cancelled) {
+          setThanksLoading(false);
+        }
+      }
+    }
+
+    void loadThanks();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, thanksData, thanksLoading, thanksRequested]);
+
+  const renderPersonLink = useCallback((person: ThankYouContributor | ThankYouSupporter, content: JSX.Element) => {
+    if (!person.profileUrl) {
+      return <div className="settings-person-card">{content}</div>;
+    }
+
+    return (
+      <a className="settings-person-card settings-person-card--link" href={person.profileUrl} target="_blank" rel="noreferrer">
+        {content}
+      </a>
+    );
+  }, []);
+
+  const thanksContributors = thanksData?.contributors ?? [];
+  const thanksSupporters = thanksData?.supporters ?? [];
+  const hasThanksError = Boolean(thanksFetchError || thanksData?.contributorsError || thanksData?.supportersError);
+
+  const renderContributorCard = useCallback((contributor: ThankYouContributor) => {
+    return renderPersonLink(
+      contributor,
+      <>
+        <img className="settings-person-avatar" src={contributor.avatarUrl} alt={contributor.login} loading="lazy" />
+        <div className="settings-person-body">
+          <div className="settings-person-title-row">
+            <span className="settings-person-name">{contributor.login}</span>
+            <span className="settings-person-badge">Contributor</span>
+          </div>
+          <div className="settings-person-meta">
+            <span>{contributor.contributions} contribution{contributor.contributions === 1 ? "" : "s"}</span>
+            <ExternalLink size={14} />
+          </div>
+        </div>
+      </>,
+    );
+  }, [renderPersonLink]);
+
+  const renderSupporterCard = useCallback((supporter: ThankYouSupporter) => {
+    return renderPersonLink(
+      supporter,
+      <>
+        <div className={`settings-person-avatar settings-person-avatar--fallback ${supporter.avatarUrl ? "" : "is-placeholder"}`.trim()}>
+          {supporter.avatarUrl ? (
+            <img className="settings-person-avatar" src={supporter.avatarUrl} alt={supporter.name} loading="lazy" />
+          ) : (
+            <Heart size={18} />
+          )}
+        </div>
+        <div className="settings-person-body">
+          <div className="settings-person-title-row">
+            <span className="settings-person-name">{supporter.name || "Private"}</span>
+            <span className="settings-person-badge settings-person-badge--supporter">Supporter</span>
+          </div>
+          <div className="settings-person-meta">
+            <span>{supporter.isPrivate ? "Private sponsor" : "GitHub Sponsors"}</span>
+            {supporter.profileUrl && <ExternalLink size={14} />}
+          </div>
+        </div>
+      </>,
+    );
+  }, [renderPersonLink]);
+
+  const thanksTabContent = (
+    <div className="settings-thanks-layout">
+      <section className="settings-section settings-thanks-hero">
+        <div className="settings-thanks-hero-icon">
+          <Heart size={18} />
+        </div>
+        <div className="settings-thanks-hero-copy">
+          <h2>Thanks for helping OpenNOW grow</h2>
+          <p>OpenNOW is shaped by contributors building the client and supporters backing the project behind the scenes.</p>
+        </div>
+      </section>
+
+      {thanksFetchError && (
+        <section className="settings-section settings-thanks-status settings-thanks-status--error">
+          <strong>Community data unavailable</strong>
+          <span>{thanksFetchError}</span>
+        </section>
+      )}
+
+      <div className="settings-thanks-grid">
+        <section className="settings-section">
+          <div className="settings-section-header settings-section-header--thanks">
+            <Users size={18} />
+            <div>
+              <h2>Contributors</h2>
+              <p className="settings-section-subtitle">People improving OpenNOW in code, fixes, and features.</p>
+            </div>
+          </div>
+          {thanksLoading && !thanksData ? (
+            <div className="settings-thanks-state">
+              <Loader size={16} className="settings-loading-icon" />
+              <span>Loading contributors from GitHub…</span>
+            </div>
+          ) : thanksContributors.length > 0 ? (
+            <div className="settings-people-grid">
+              {thanksContributors.map((contributor) => (
+                <div key={contributor.login}>{renderContributorCard(contributor)}</div>
+              ))}
+            </div>
+          ) : (
+            <div className="settings-thanks-state settings-thanks-state--muted">
+              <span>{thanksData?.contributorsError ?? "No contributors could be shown right now."}</span>
+            </div>
+          )}
+        </section>
+
+        <section className="settings-section">
+          <div className="settings-section-header settings-section-header--thanks">
+            <Heart size={18} />
+            <div>
+              <h2>Supporters</h2>
+              <p className="settings-section-subtitle">Public GitHub Sponsors backing the work, plus private supporters when available.</p>
+            </div>
+          </div>
+          {thanksLoading && !thanksData ? (
+            <div className="settings-thanks-state">
+              <Loader size={16} className="settings-loading-icon" />
+              <span>Loading supporters from GitHub Sponsors…</span>
+            </div>
+          ) : thanksSupporters.length > 0 ? (
+            <div className="settings-people-grid">
+              {thanksSupporters.map((supporter, index) => (
+                <div key={`${supporter.name}-${supporter.profileUrl ?? index}`}>{renderSupporterCard(supporter)}</div>
+              ))}
+            </div>
+          ) : (
+            <div className="settings-thanks-state settings-thanks-state--muted">
+              <span>{thanksData?.supportersError ?? "No supporters could be shown right now."}</span>
+            </div>
+          )}
+        </section>
+      </div>
+
+      {hasThanksError && thanksData && (
+        <section className="settings-section settings-thanks-status">
+          {thanksData.contributorsError && <span>Contributors: {thanksData.contributorsError}</span>}
+          {thanksData.supportersError && <span>Supporters: {thanksData.supportersError}</span>}
+        </section>
+      )}
+    </div>
+  );
+
   return (
     <div className="settings-page">
       <header className="settings-header">
@@ -960,8 +1144,30 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
         </div>
       </header>
 
-      <div className="settings-sections">
-        {/* ── Region ────────────────────────────────────── */}
+      <div className="settings-tab-row settings-chip-row" role="tablist" aria-label="Settings sections">
+        <button
+          type="button"
+          className={`settings-chip settings-tab-chip ${activeTab === "preferences" ? "active" : ""}`}
+          onClick={() => setActiveTab("preferences")}
+          role="tab"
+          aria-selected={activeTab === "preferences"}
+        >
+          Preferences
+        </button>
+        <button
+          type="button"
+          className={`settings-chip settings-tab-chip ${activeTab === "thanks" ? "active" : ""}`}
+          onClick={() => setActiveTab("thanks")}
+          role="tab"
+          aria-selected={activeTab === "thanks"}
+        >
+          Thanks
+        </button>
+      </div>
+
+      {activeTab === "preferences" ? (
+        <div className="settings-sections">
+          {/* ── Region ────────────────────────────────────── */}
         <section className="settings-section">
           <div className="settings-section-header">
             <h2>Region</h2>
@@ -2045,7 +2251,12 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
             </div>
           </div>
         </section>
-      </div>
+        </div>
+
+      ) : (
+        thanksTabContent
+      )}
+
 
     </div>
   );

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -2156,6 +2156,21 @@ button.game-card-store-chip.active:hover {
   color: #fecaca;
 }
 
+.settings-thanks-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.settings-thanks-retry-btn {
+  color: var(--ink);
+}
+
+.settings-thanks-retry-btn:hover {
+  color: var(--accent);
+}
+
 /* Sections */
 .settings-sections {
   display: flex;

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1951,6 +1951,211 @@ button.game-card-store-chip.active:hover {
   transform: translateY(0);
 }
 
+.settings-tab-row {
+  gap: 8px;
+}
+
+.settings-tab-chip {
+  min-height: 36px;
+}
+
+.settings-thanks-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.settings-thanks-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.settings-thanks-hero {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  background: linear-gradient(180deg, rgba(88, 217, 138, 0.08), rgba(88, 217, 138, 0.03));
+}
+
+.settings-thanks-hero-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: rgba(88, 217, 138, 0.12);
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.settings-thanks-hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-thanks-hero-copy h2 {
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.settings-thanks-hero-copy p {
+  font-size: 0.88rem;
+  color: var(--ink-soft);
+  line-height: 1.55;
+}
+
+.settings-section-header--thanks {
+  align-items: flex-start;
+}
+
+.settings-section-header--thanks > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-section-subtitle {
+  font-size: 0.78rem;
+  color: var(--ink-muted);
+  line-height: 1.45;
+}
+
+.settings-people-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.settings-person-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 72px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.settings-person-card--link {
+  color: inherit;
+  text-decoration: none;
+  transition: border-color var(--t-fast), background var(--t-fast), transform var(--t-fast);
+}
+
+.settings-person-card--link:hover {
+  border-color: rgba(88, 217, 138, 0.24);
+  background: rgba(88, 217, 138, 0.06);
+  transform: translateY(-1px);
+}
+
+.settings-person-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.settings-person-avatar--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  overflow: hidden;
+}
+
+.settings-person-avatar--fallback.is-placeholder {
+  border: 1px solid rgba(88, 217, 138, 0.18);
+  background: rgba(88, 217, 138, 0.08);
+}
+
+.settings-person-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
+}
+
+.settings-person-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.settings-person-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.settings-person-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.12);
+  color: var(--info);
+  font-size: 0.67rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.settings-person-badge--supporter {
+  background: rgba(88, 217, 138, 0.12);
+  color: var(--accent);
+}
+
+.settings-person-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+  color: var(--ink-muted);
+}
+
+.settings-thanks-state,
+.settings-thanks-status {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--ink-soft);
+  font-size: 0.84rem;
+}
+
+.settings-thanks-state {
+  min-height: 84px;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.settings-thanks-state--muted {
+  color: var(--ink-muted);
+}
+
+.settings-thanks-status {
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.settings-thanks-status--error {
+  border-color: var(--error-border);
+  background: var(--error-bg);
+  color: #fecaca;
+}
+
 /* Sections */
 .settings-sections {
   display: flex;
@@ -6762,7 +6967,21 @@ button.game-card-store-chip.active:hover {
   }
 }
 
+@media (max-width: 900px) {
+  .settings-thanks-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
+  .settings-thanks-hero {
+    flex-direction: column;
+  }
+
+  .settings-person-card {
+    align-items: flex-start;
+  }
+
   .csl-content-wrapper {
     padding: 40px 24px;
   }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -187,6 +187,27 @@ export interface AuthSession {
   user: AuthUser;
 }
 
+export interface ThankYouContributor {
+  login: string;
+  avatarUrl: string;
+  profileUrl: string;
+  contributions: number;
+}
+
+export interface ThankYouSupporter {
+  name: string;
+  avatarUrl?: string;
+  profileUrl?: string;
+  isPrivate: boolean;
+}
+
+export interface ThankYouDataResult {
+  contributors: ThankYouContributor[];
+  supporters: ThankYouSupporter[];
+  contributorsError?: string;
+  supportersError?: string;
+}
+
 export interface AuthLoginRequest {
   providerIdpId?: string;
 }
@@ -594,6 +615,7 @@ export interface OpenNowApi {
   showMediaInFolder(input: { filePath: string }): Promise<void>;
 
   deleteCache(): Promise<void>;
+  getThanksData(): Promise<ThankYouDataResult>;
 }
 
 export interface ScreenshotSaveRequest {

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -46,6 +46,7 @@ export const IPC_CHANNELS = {
   CACHE_REFRESH_MANUAL: "cache:refresh-manual",
   CACHE_STATUS_UPDATE: "cache:status-update",
   CACHE_DELETE_ALL: "cache:delete-all",
+  COMMUNITY_GET_THANKS: "community:get-thanks",
   // Media browsing
   MEDIA_LIST_BY_GAME: "media:list-by-game",
   MEDIA_THUMBNAIL: "media:thumbnail",


### PR DESCRIPTION
This PR introduces a dedicated internal 'Thanks' tab within Settings to display project contributors and GitHub sponsors. Data is fetched from the GitHub REST contributors API and scraped from the public sponsors page, filtered to exclude bots and AI entries, and rendered with polished cards and error handling.

**Settings & UI:**

* Refactored `SettingsPage.tsx` to use internal tabs (`Preferences` / `Thanks`) while preserving all existing settings behavior and the saved indicator
* Added `Thanks` tab that fetches and caches community data on first open using `window.openNow.getThanksData()`
* Rendercontributors and supporters as separate sections with avatars, badges, and external profile links
* Display loading states, empty states, and non-fatal error messages for both lists

**Data Layer:**

* Added `ThankYouContributor`, `ThankYouSupporter`, and `ThankYouDataResult` shared types in `src/shared/gfn.ts`
* Added `COMMUNITY_GET_THANKS` IPC channel in `src/shared/ipc.ts`
* Implemented `getThanksData()` endpoint in `src/preload/index.ts`
* Added main-process handler in `src/main/index.ts` that:
  - `fetchThanksContributors`: queries `OpenCloudGaming/OpenNOW/contributors` with per_page=100
  - Filters out bots (`type === 'Bot'`, `[bot]` suffix) and AI entries matching `copilot|claude|cappy`
  - Sorts by contribution count descending
  - `fetchThanksSupporters`: scrapes `github.com/sponsors/zortos293` with lightweight regex/HTML parsing
  - Normalizes private supporters to `Private`, resolves relative URLs
  - Returns partial results with optional `contributorsError`/`supportersError` fields on failure

**Styling:**

* Added CSS for tab row/chip spacing, thanks hero card, people grids, and avatar cards
* Added contributor/supporter badges with accent colors and responsive layout
* Added media queries for mobile/tablet adjustments in `src/renderer/src/styles.css`

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/2d9f567b-c733-42b6-9632-73d2e2e6cfe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-52&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-52"><img alt="OPE-52 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-52"></picture></a>