### PR TITLE
Fix macOS microphone permission prompt timing

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -58,6 +58,7 @@ import type {
   RecordingFinishRequest,
   RecordingAbortRequest,
   RecordingDeleteRequest,
+  MicrophonePermissionResult,
   ThankYouContributor,
   ThankYouDataResult,
   ThankYouSupporter,
@@ -1164,6 +1165,56 @@ function registerIpcHandlers(): void {
     return settingsManager.reset();
   });
 
+  ipcMain.handle(IPC_CHANNELS.MICROPHONE_PERMISSION_GET, async (): Promise<MicrophonePermissionResult> => {
+    if (process.platform !== "darwin") {
+      return {
+        platform: process.platform,
+        isMacOs: false,
+        status: "not-applicable",
+        granted: false,
+        canRequest: false,
+        shouldUseBrowserApi: true,
+      };
+    }
+
+    const currentStatus = systemPreferences.getMediaAccessStatus("microphone");
+    console.log("[Main] macOS microphone permission status:", currentStatus);
+
+    if (currentStatus === "granted") {
+      return {
+        platform: process.platform,
+        isMacOs: true,
+        status: "granted",
+        granted: true,
+        canRequest: false,
+        shouldUseBrowserApi: true,
+      };
+    }
+
+    if (currentStatus === "not-determined") {
+      const granted = await systemPreferences.askForMediaAccess("microphone");
+      const nextStatus = systemPreferences.getMediaAccessStatus("microphone");
+      console.log("[Main] Requested macOS microphone permission:", granted, nextStatus);
+      return {
+        platform: process.platform,
+        isMacOs: true,
+        status: nextStatus,
+        granted,
+        canRequest: nextStatus === "not-determined",
+        shouldUseBrowserApi: granted,
+      };
+    }
+
+    return {
+      platform: process.platform,
+      isMacOs: true,
+      status: currentStatus,
+      granted: false,
+      canRequest: false,
+      shouldUseBrowserApi: false,
+    };
+  });
+
   // Logs export IPC handler
   ipcMain.handle(IPC_CHANNELS.LOGS_EXPORT, async (_event, format: "text" | "json" = "text"): Promise<string> => {
     return exportLogs(format);
@@ -1503,16 +1554,6 @@ app.whenReady().then(async () => {
   await authService.initialize();
 
   settingsManager = getSettingsManager();
-
-  // Request microphone permission on macOS at startup
-  if (process.platform === "darwin") {
-    const micStatus = systemPreferences.getMediaAccessStatus("microphone");
-    console.log("[Main] macOS microphone permission status:", micStatus);
-    if (micStatus !== "granted") {
-      const granted = await systemPreferences.askForMediaAccess("microphone");
-      console.log("[Main] Requested microphone permission:", granted);
-    }
-  }
 
   // Set up permission handlers for getUserMedia, fullscreen, pointer lock
   session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -108,6 +108,7 @@ const api: OpenNowApi = {
   setSetting: <K extends keyof Settings>(key: K, value: Settings[K]) =>
     ipcRenderer.invoke(IPC_CHANNELS.SETTINGS_SET, key, value),
   resetSettings: () => ipcRenderer.invoke(IPC_CHANNELS.SETTINGS_RESET),
+  getMicrophonePermission: () => ipcRenderer.invoke(IPC_CHANNELS.MICROPHONE_PERMISSION_GET),
   exportLogs: (format?: "text" | "json") => ipcRenderer.invoke(IPC_CHANNELS.LOGS_EXPORT, format),
   pingRegions: (regions: StreamRegion[]) => ipcRenderer.invoke(IPC_CHANNELS.PING_REGIONS, regions),
   saveScreenshot: (input: ScreenshotSaveRequest) => ipcRenderer.invoke(IPC_CHANNELS.SCREENSHOT_SAVE, input),

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -11,6 +11,7 @@ import type {
   MicrophoneMode,
   PingResult,
   GameLanguage,
+  MicrophonePermissionResult,
   ThankYouDataResult,
   ThankYouContributor,
   ThankYouSupporter,
@@ -101,6 +102,19 @@ const microphoneModeOptions: Array<{ value: MicrophoneMode; label: string }> = [
   { value: "push-to-talk", label: "Push-to-Talk" },
   { value: "voice-activity", label: "Voice Activity" },
 ];
+
+function getMicrophonePermissionError(result: MicrophonePermissionResult): string {
+  switch (result.status) {
+    case "denied":
+      return "Microphone access was denied. Enable microphone access for OpenNOW in System Settings → Privacy & Security → Microphone.";
+    case "restricted":
+      return "Microphone access is restricted by macOS and cannot be enabled from OpenNOW.";
+    case "unknown":
+      return "Unable to determine microphone permission status. Check macOS microphone privacy settings for OpenNOW.";
+    default:
+      return "Microphone access is not available.";
+  }
+}
 
 const gameLanguageOptions: Array<{ value: GameLanguage; label: string }> = [
   { value: "en_US", label: "English (US)" },
@@ -776,40 +790,96 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   const [microphoneDeviceDropdownOpen, setMicrophoneDeviceDropdownOpen] = useState(false);
   const microphoneModeDropdownRef = useRef<HTMLDivElement | null>(null);
   const microphoneDeviceDropdownRef = useRef<HTMLDivElement | null>(null);
+  const latestMicrophoneDeviceIdRef = useRef(settings.microphoneDeviceId);
+
+  useEffect(() => {
+    latestMicrophoneDeviceIdRef.current = settings.microphoneDeviceId;
+  }, [settings.microphoneDeviceId]);
 
   // Enumerate microphone devices when mic mode is enabled
   useEffect(() => {
     if (settings.microphoneMode === "disabled") {
       setMicrophoneDevices([]);
+      setMicrophonePermissionError(null);
       return;
     }
 
     let cancelled = false;
 
     async function enumerateDevices(): Promise<void> {
+      const applyDeviceList = (audioInputs: MediaDeviceInfo[]): void => {
+        if (cancelled) {
+          return;
+        }
+
+        setMicrophoneDevices(audioInputs);
+        setMicrophonePermissionError(null);
+
+        if (
+          latestMicrophoneDeviceIdRef.current
+          && !audioInputs.some((device) => device.deviceId === latestMicrophoneDeviceIdRef.current)
+        ) {
+          handleChange("microphoneDeviceId", "");
+        }
+      };
+
       try {
-        // Request permission first to get device labels
+        if (typeof window.openNow?.getMicrophonePermission === "function") {
+          const permission = await window.openNow.getMicrophonePermission();
+          if (cancelled) {
+            return;
+          }
+
+          if (permission.isMacOs && !permission.granted) {
+            setMicrophoneDevices([]);
+            setMicrophonePermissionError(getMicrophonePermissionError(permission));
+            return;
+          }
+        }
+
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        stream.getTracks().forEach(t => t.stop()); // Release the stream immediately
+        stream.getTracks().forEach((track) => track.stop());
 
         const devices = await navigator.mediaDevices.enumerateDevices();
-        if (!cancelled) {
-          const audioInputs = devices.filter(d => d.kind === "audioinput");
-          setMicrophoneDevices(audioInputs);
-          setMicrophonePermissionError(null);
-        }
+        applyDeviceList(devices.filter((device) => device.kind === "audioinput"));
       } catch (err) {
         console.error("[SettingsPage] Failed to enumerate microphone devices:", err);
+
+        try {
+          const devices = await navigator.mediaDevices.enumerateDevices();
+          if (cancelled) {
+            return;
+          }
+
+          const audioInputs = devices.filter((device) => device.kind === "audioinput");
+          if (audioInputs.length > 0) {
+            setMicrophoneDevices(audioInputs);
+            setMicrophonePermissionError("Microphone access is required to show device names and use voice chat. Allow access and try again.");
+            if (
+              latestMicrophoneDeviceIdRef.current
+              && !audioInputs.some((device) => device.deviceId === latestMicrophoneDeviceIdRef.current)
+            ) {
+              handleChange("microphoneDeviceId", "");
+            }
+            return;
+          }
+        } catch {
+          // Ignore secondary enumerate failure and fall through to stable error state.
+        }
+
         if (!cancelled) {
-          setMicrophonePermissionError("Microphone access denied. Please allow microphone permission in your system settings.");
+          const message = err instanceof DOMException && err.name === "NotAllowedError"
+            ? "Microphone access was denied. Allow access for OpenNOW and try again."
+            : "Unable to access microphone devices right now.";
+          setMicrophonePermissionError(message);
           setMicrophoneDevices([]);
         }
       }
     }
 
-    enumerateDevices();
+    void enumerateDevices();
     return () => { cancelled = true; };
-  }, [settings.microphoneMode]);
+  }, [handleChange, settings.microphoneMode]);
 
   const filteredRegions = useMemo(() => {
     const q = regionSearch.trim().toLowerCase();

--- a/opennow-stable/src/renderer/src/gfn/microphoneManager.ts
+++ b/opennow-stable/src/renderer/src/gfn/microphoneManager.ts
@@ -107,7 +107,12 @@ export class MicrophoneManager {
    */
   async enumerateDevices(): Promise<MediaDeviceInfo[]> {
     try {
-      // Request permission first to get labels
+      const permission = await this.checkPermissionState();
+      if (permission === "denied") {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        return devices.filter(device => device.kind === "audioinput");
+      }
+
       const tempStream = await navigator.mediaDevices.getUserMedia({ audio: true });
       tempStream.getTracks().forEach(track => track.stop());
 

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -74,6 +74,30 @@ export function colorQualityIs10Bit(cq: ColorQuality): boolean {
 
 export type MicrophoneMode = "disabled" | "push-to-talk" | "voice-activity";
 export type AspectRatio = "16:9" | "16:10" | "21:9" | "32:9";
+export type RuntimePlatform =
+  | "aix"
+  | "android"
+  | "cygwin"
+  | "darwin"
+  | "freebsd"
+  | "haiku"
+  | "linux"
+  | "netbsd"
+  | "openbsd"
+  | "sunos"
+  | "win32"
+  | "unknown";
+
+export type MacOsMicrophoneAccessStatus = "not-determined" | "granted" | "denied" | "restricted" | "unknown";
+
+export interface MicrophonePermissionResult {
+  platform: RuntimePlatform;
+  isMacOs: boolean;
+  status: MacOsMicrophoneAccessStatus | "not-applicable";
+  granted: boolean;
+  canRequest: boolean;
+  shouldUseBrowserApi: boolean;
+}
 
 export interface Settings {
   resolution: string;
@@ -564,6 +588,7 @@ export interface OpenNowApi {
   getSettings(): Promise<Settings>;
   setSetting<K extends keyof Settings>(key: K, value: Settings[K]): Promise<void>;
   resetSettings(): Promise<Settings>;
+  getMicrophonePermission(): Promise<MicrophonePermissionResult>;
   /** Export logs in redacted format */
   exportLogs(format?: "text" | "json"): Promise<string>;
   /** Ping all regions and return latency results */

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -30,6 +30,7 @@ export const IPC_CHANNELS = {
   SETTINGS_GET: "settings:get",
   SETTINGS_SET: "settings:set",
   SETTINGS_RESET: "settings:reset",
+  MICROPHONE_PERMISSION_GET: "microphone:permission:get",
   LOGS_EXPORT: "logs:export",
   LOGS_GET_RENDERER: "logs:get-renderer",
   SCREENSHOT_SAVE: "screenshot:save",


### PR DESCRIPTION
This PR defers microphone permission prompting on macOS from app startup to when the user explicitly enables a microphone mode in Settings.

**Main Process:**
* Removed startup `askForMediaAccess` call in `src/main/index.ts`
* Added `MICROPHONE_PERMISSION_GET` IPC handler using `getMediaAccessStatus` and `askForMediaAccess` specifically for macOS
* Returns structured `MicrophonePermissionResult` to distinguish granted/denied/restricted states

**IPC & Types:**
* Added `MICROPHONE_PERMISSION_GET` channel in `src/shared/ipc.ts`
* Added `MicrophonePermissionResult`, `MacOsMicrophoneAccessStatus`, and `RuntimePlatform` types in `src/shared/gfn.ts`
* Exposed `getMicrophonePermission` method via `OpenNowApi` in `src/preload/index.ts`

**Renderer:**
* Refactored `SettingsPage.tsx` enumeration flow to call `getMicrophonePermission` before `getUserMedia`
* Clears stale `microphoneDeviceId` if the selected device is missing after enumeration
* Displays specific error messages for denied/restricted macOS permission states
* Added `latestMicrophoneDeviceIdRef` to avoid stale closure dependencies
* Updated `MicrophoneManager.ts` to check existing permission state before requesting access during enumeration

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/7a57c168-0e89-4bdd-a2fa-72474f22ee6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-53&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-53"><img alt="OPE-53 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-53"></picture></a>