### PR TITLE
Fix(stream): restrict codec and color options to safe H264/8-bit 4:2:0

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -564,17 +564,10 @@ function shouldUseServerIp(baseUrl: string): boolean {
 
 function resolvePollStopBase(zone: string, provided?: string, serverIp?: string): string {
   const base = resolveStreamingBaseUrl(zone, provided);
-  // CloudMatch queue/ad/session endpoints are host-pinned once the session control
-  // host is known. Official captures show `/v2/session/<id>` moving from generic
-  // provider hosts like `prod.cloudmatchbeta...` onto specific zone hosts such as
-  // `np-mia-04.cloudmatchbeta...` before ad updates are sent. Keep the provider
-  // base only until CloudMatch gives us a different host.
-  if (serverIp && shouldUseServerIp(base)) {
-    const baseHost = extractHostFromUrl(base) ?? base.replace(/^https?:\/\//, "").split("/")[0] ?? "";
-    if (serverIp !== baseHost) {
-      return `https://${serverIp}`;
-    }
-  }
+  // Only use serverIp if it's a real server IP (not a zone hostname).
+  // The Rust version checks: if we're NOT an alliance partner AND we have a server_ip, use it.
+  // But if the "serverIp" is actually the zone hostname (from an early poll when connectionInfo
+  // was empty), using it is circular and doesn't help.
   if (serverIp && shouldUseServerIp(base) && !isZoneHostname(serverIp)) {
     return `https://${serverIp}`;
   }

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -22,6 +22,8 @@ import {
   DEFAULT_KEYBOARD_LAYOUT,
   colorQualityBitDepth,
   colorQualityChromaFormat,
+  getDefaultStreamPreferences,
+  normalizeStreamPreferences,
   resolveGfnKeyboardLayout,
 } from "@shared/gfn";
 
@@ -452,8 +454,12 @@ function timezoneOffsetMs(): number {
 }
 
 function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
+  const normalizedStreamPreferences = normalizeStreamPreferences(
+    input.settings.codec,
+    input.settings.colorQuality,
+  );
   const { width, height } = parseResolution(input.settings.resolution);
-  const cq = input.settings.colorQuality;
+  const cq = normalizedStreamPreferences.colorQuality;
   // IMPORTANT: hdrEnabled is a SEPARATE toggle from color quality.
   // The Rust reference (cloudmatch.rs) uses settings.hdr_enabled independently.
   // 10-bit color depth does NOT mean HDR — you can have 10-bit SDR.
@@ -1273,16 +1279,20 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
 
   // Provide default values for optional parameters
   const appId = input.appId ?? "0";
+  const defaultStreamPreferences = getDefaultStreamPreferences();
   const settings = input.settings ?? {
     resolution: "1920x1080",
     fps: 60,
     maxBitrateMbps: 75,
-    codec: "H264",
-    colorQuality: "8bit_420",
+    codec: defaultStreamPreferences.codec,
+    colorQuality: defaultStreamPreferences.colorQuality,
     keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
     gameLanguage: "en_US",
     enableL4S: false,
   };
+  const normalizedStreamPreferences = normalizeStreamPreferences(settings.codec, settings.colorQuality);
+  settings.codec = normalizedStreamPreferences.codec;
+  settings.colorQuality = normalizedStreamPreferences.colorQuality;
 
   const keyboardLayout = resolveGfnKeyboardLayout(settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = settings.gameLanguage ?? "en_US";

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -22,8 +22,6 @@ import {
   DEFAULT_KEYBOARD_LAYOUT,
   colorQualityBitDepth,
   colorQualityChromaFormat,
-  getDefaultStreamPreferences,
-  normalizeStreamPreferences,
   resolveGfnKeyboardLayout,
 } from "@shared/gfn";
 
@@ -454,12 +452,8 @@ function timezoneOffsetMs(): number {
 }
 
 function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
-  const normalizedStreamPreferences = normalizeStreamPreferences(
-    input.settings.codec,
-    input.settings.colorQuality,
-  );
   const { width, height } = parseResolution(input.settings.resolution);
-  const cq = normalizedStreamPreferences.colorQuality;
+  const cq = input.settings.colorQuality;
   // IMPORTANT: hdrEnabled is a SEPARATE toggle from color quality.
   // The Rust reference (cloudmatch.rs) uses settings.hdr_enabled independently.
   // 10-bit color depth does NOT mean HDR — you can have 10-bit SDR.
@@ -1279,21 +1273,16 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
 
   // Provide default values for optional parameters
   const appId = input.appId ?? "0";
-  const defaultStreamPreferences = getDefaultStreamPreferences();
   const settings = input.settings ?? {
     resolution: "1920x1080",
     fps: 60,
     maxBitrateMbps: 75,
-    codec: defaultStreamPreferences.codec,
-    colorQuality: defaultStreamPreferences.colorQuality,
+    codec: "H264",
+    colorQuality: "8bit_420",
     keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
     gameLanguage: "en_US",
     enableL4S: false,
   };
-  const normalizedStreamPreferences = normalizeStreamPreferences(settings.codec, settings.colorQuality);
-  settings.codec = normalizedStreamPreferences.codec;
-  settings.colorQuality = normalizedStreamPreferences.colorQuality;
-
   const keyboardLayout = resolveGfnKeyboardLayout(settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = settings.gameLanguage ?? "en_US";
 

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -83,17 +83,43 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Configure Chromium video and WebRTC behavior before app.whenReady().
-// Video acceleration is always set to "auto" - decoder and encoder preferences removed from settings
 
-const bootstrapVideoPrefs: {
+interface BootstrapVideoPreferences {
   decoderPreference: VideoAccelerationPreference;
   encoderPreference: VideoAccelerationPreference;
-} = {
-  decoderPreference: "auto",
-  encoderPreference: "auto",
-};
+}
+
+function isAccelerationPreference(value: unknown): value is VideoAccelerationPreference {
+  return value === "auto" || value === "hardware" || value === "software";
+}
+
+function loadBootstrapVideoPreferences(): BootstrapVideoPreferences {
+  const defaults: BootstrapVideoPreferences = {
+    decoderPreference: "auto",
+    encoderPreference: "auto",
+  };
+  try {
+    const settingsPath = join(app.getPath("userData"), "settings.json");
+    if (!existsSync(settingsPath)) {
+      return defaults;
+    }
+    const parsed = JSON.parse(readFileSync(settingsPath, "utf-8")) as Partial<BootstrapVideoPreferences>;
+    return {
+      decoderPreference: isAccelerationPreference(parsed.decoderPreference)
+        ? parsed.decoderPreference
+        : defaults.decoderPreference,
+      encoderPreference: isAccelerationPreference(parsed.encoderPreference)
+        ? parsed.encoderPreference
+        : defaults.encoderPreference,
+    };
+  } catch {
+    return defaults;
+  }
+}
+
+const bootstrapVideoPrefs = loadBootstrapVideoPreferences();
 console.log(
-  `[Main] Video acceleration: decode=${bootstrapVideoPrefs.decoderPreference}, encode=${bootstrapVideoPrefs.encoderPreference}`,
+  `[Main] Video acceleration preference: decode=${bootstrapVideoPrefs.decoderPreference}, encode=${bootstrapVideoPrefs.encoderPreference}`,
 );
 
 // --- Platform-specific HW video decode features ---

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -2,7 +2,7 @@ import { app } from "electron";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode, GameLanguage, AspectRatio, KeyboardLayout } from "@shared/gfn";
-import { DEFAULT_KEYBOARD_LAYOUT } from "@shared/gfn";
+import { DEFAULT_KEYBOARD_LAYOUT, getDefaultStreamPreferences, normalizeStreamPreferences } from "@shared/gfn";
 
 export interface Settings {
   /** Video resolution (e.g., "1920x1080") */
@@ -81,14 +81,15 @@ const defaultAntiAfkShortcut = "Ctrl+Shift+K";
 const defaultMicShortcut = "Ctrl+Shift+M";
 const LEGACY_STOP_SHORTCUTS = new Set(["META+SHIFT+Q", "CMD+SHIFT+Q"]);
 const LEGACY_ANTI_AFK_SHORTCUTS = new Set(["META+SHIFT+F10", "CMD+SHIFT+F10", "CTRL+SHIFT+F10"]);
+const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
 
 const DEFAULT_SETTINGS: Settings = {
   resolution: "1920x1080",
   aspectRatio: "16:9",
   fps: 60,
   maxBitrateMbps: 75,
-  codec: "H264",
-  colorQuality: "8bit_420",
+  codec: DEFAULT_STREAM_PREFERENCES.codec,
+  colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
   region: "",
   clipboardPaste: false,
   mouseSensitivity: 1,
@@ -173,15 +174,17 @@ export class SettingsManager {
   }
 
   private enforceCompatibility(settings: Settings): boolean {
-    if (settings.codec === "H264" && settings.colorQuality !== "8bit_420") {
-      console.warn(
-        `[Settings] colorQuality "${settings.colorQuality}" is incompatible with H264; resetting to 8bit_420`,
-      );
-      settings.colorQuality = "8bit_420";
-      return true;
+    const normalized = normalizeStreamPreferences(settings.codec, settings.colorQuality);
+    if (!normalized.migrated) {
+      return false;
     }
 
-    return false;
+    console.warn(
+      `[Settings] Migrating unsupported stream settings codec="${settings.codec}" colorQuality="${settings.colorQuality}" to ${normalized.codec}/${normalized.colorQuality}`,
+    );
+    settings.codec = normalized.codec;
+    settings.colorQuality = normalized.colorQuality;
+    return true;
   }
 
   private migrateLegacyShortcutDefaults(settings: Settings): boolean {
@@ -239,6 +242,7 @@ export class SettingsManager {
    */
   set<K extends keyof Settings>(key: K, value: Settings[K]): void {
     this.settings[key] = value;
+    this.enforceCompatibility(this.settings);
     this.save();
   }
 
@@ -250,6 +254,7 @@ export class SettingsManager {
       ...this.settings,
       ...updates,
     };
+    this.enforceCompatibility(this.settings);
     this.save();
   }
 

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -15,6 +15,10 @@ export interface Settings {
   maxBitrateMbps: number;
   /** Preferred video codec */
   codec: VideoCodec;
+  /** Preferred video decode acceleration mode */
+  decoderPreference: VideoAccelerationPreference;
+  /** Preferred video encode acceleration mode */
+  encoderPreference: VideoAccelerationPreference;
   /** Color quality (bit depth + chroma subsampling) */
   colorQuality: ColorQuality;
   /** Preferred region URL (empty = auto) */
@@ -89,6 +93,8 @@ const DEFAULT_SETTINGS: Settings = {
   fps: 60,
   maxBitrateMbps: 75,
   codec: DEFAULT_STREAM_PREFERENCES.codec,
+  decoderPreference: "auto",
+  encoderPreference: "auto",
   colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
   region: "",
   clipboardPaste: false,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -21,7 +21,6 @@ import type {
 import {
   DEFAULT_KEYBOARD_LAYOUT,
   getDefaultStreamPreferences,
-  normalizeStreamPreferences,
   USER_FACING_VIDEO_CODEC_OPTIONS,
   getPreferredSessionAdMediaUrl,
   getSessionAdDurationMs,
@@ -132,16 +131,6 @@ const DEFAULT_SHORTCUTS = {
   shortcutToggleRecording: "F12",
 } as const;
 
-function applyNormalizedStreamPreferences(settings: Pick<Settings, "codec" | "colorQuality">): {
-  codec: Settings["codec"];
-  colorQuality: Settings["colorQuality"];
-} {
-  const normalized = normalizeStreamPreferences(settings.codec, settings.colorQuality);
-  return {
-    codec: normalized.codec,
-    colorQuality: normalized.colorQuality,
-  };
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
@@ -618,6 +607,8 @@ export function App(): JSX.Element {
     fps: 60,
     maxBitrateMbps: 75,
     codec: DEFAULT_STREAM_PREFERENCES.codec,
+    decoderPreference: "auto",
+    encoderPreference: "auto",
     colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
     region: "",
     clipboardPaste: false,
@@ -1492,10 +1483,7 @@ export function App(): JSX.Element {
       try {
         // Load settings first
         const loadedSettings = await window.openNow.getSettings();
-        setSettings({
-          ...loadedSettings,
-          ...applyNormalizedStreamPreferences(loadedSettings),
-        });
+        setSettings(loadedSettings);
         setShowStatsOverlay(loadedSettings.showStatsOnLaunch);
         setSettingsLoaded(true);
 
@@ -1859,10 +1847,9 @@ export function App(): JSX.Element {
           }
 
           if (clientRef.current) {
-            const normalizedStreamPreferences = applyNormalizedStreamPreferences(settings);
             await clientRef.current.handleOffer(event.sdp, activeSession, {
-              codec: normalizedStreamPreferences.codec,
-              colorQuality: normalizedStreamPreferences.colorQuality,
+              codec: settings.codec,
+              colorQuality: settings.colorQuality,
               resolution: settings.resolution,
               fps: settings.fps,
               maxBitrateKbps: settings.maxBitrateMbps * 1000,
@@ -1899,21 +1886,9 @@ export function App(): JSX.Element {
 
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {
-    const nextSettings = { ...settings, [key]: value };
-    const normalizedStreamPreferences = applyNormalizedStreamPreferences(nextSettings);
-    const updates: Partial<Settings> = {
-      [key]: value,
-      codec: normalizedStreamPreferences.codec,
-      colorQuality: normalizedStreamPreferences.colorQuality,
-    };
-
-    setSettings((prev) => ({ ...prev, ...updates }));
+    setSettings((prev) => ({ ...prev, [key]: value }));
     if (settingsLoaded) {
-      await Promise.all(
-        (Object.entries(updates) as Array<[keyof Settings, Settings[keyof Settings]]>).map(([updateKey, updateValue]) =>
-          window.openNow.setSetting(updateKey, updateValue),
-        ),
-      );
+      await window.openNow.setSetting(key, value);
     }
     // If a running client exists, push certain settings live
     if (key === "mouseSensitivity") {
@@ -1937,7 +1912,7 @@ export function App(): JSX.Element {
         // ignore
       }
     }
-  }, [settings, settingsLoaded]);
+  }, [settingsLoaded]);
 
   const handleMouseSensitivityChange = useCallback((value: number) => {
     void updateSetting("mouseSensitivity", value);
@@ -2120,7 +2095,8 @@ export function App(): JSX.Element {
         resolution: settings.resolution,
         fps: settings.fps,
         maxBitrateMbps: settings.maxBitrateMbps,
-        ...applyNormalizedStreamPreferences(settings),
+        codec: settings.codec,
+        colorQuality: settings.colorQuality,
         keyboardLayout: settings.keyboardLayout,
         gameLanguage: settings.gameLanguage,
         enableL4S: settings.enableL4S,
@@ -2271,7 +2247,8 @@ export function App(): JSX.Element {
           resolution: settings.resolution,
           fps: settings.fps,
           maxBitrateMbps: settings.maxBitrateMbps,
-          ...applyNormalizedStreamPreferences(settings),
+          codec: settings.codec,
+          colorQuality: settings.colorQuality,
           keyboardLayout: settings.keyboardLayout,
           gameLanguage: settings.gameLanguage,
           enableL4S: settings.enableL4S,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -20,6 +20,9 @@ import type {
 } from "@shared/gfn";
 import {
   DEFAULT_KEYBOARD_LAYOUT,
+  getDefaultStreamPreferences,
+  normalizeStreamPreferences,
+  USER_FACING_VIDEO_CODEC_OPTIONS,
   getPreferredSessionAdMediaUrl,
   getSessionAdDurationMs,
   getSessionAdItems,
@@ -51,7 +54,8 @@ import { ControllerStreamLoading } from "./components/ControllerStreamLoading";
 import type { QueueAdPlaybackEvent, QueueAdPreviewHandle } from "./components/QueueAdPreview";
 import { StreamView } from "./components/StreamView";
 
-const codecOptions: VideoCodec[] = ["H264", "H265", "AV1"];
+const codecOptions: VideoCodec[] = [...USER_FACING_VIDEO_CODEC_OPTIONS];
+const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
 const allResolutionOptions = ["1280x720", "1280x800", "1440x900", "1680x1050", "1920x1080", "1920x1200", "2560x1080", "2560x1440", "2560x1600", "3440x1440", "3840x2160", "3840x2400"];
 const fpsOptions = [30, 60, 120, 144, 240];
 const aspectRatioOptions = ["16:9", "16:10", "21:9", "32:9"] as const;
@@ -127,6 +131,17 @@ const DEFAULT_SHORTCUTS = {
   shortcutScreenshot: "F11",
   shortcutToggleRecording: "F12",
 } as const;
+
+function applyNormalizedStreamPreferences(settings: Pick<Settings, "codec" | "colorQuality">): {
+  codec: Settings["codec"];
+  colorQuality: Settings["colorQuality"];
+} {
+  const normalized = normalizeStreamPreferences(settings.codec, settings.colorQuality);
+  return {
+    codec: normalized.codec,
+    colorQuality: normalized.colorQuality,
+  };
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
@@ -602,8 +617,8 @@ export function App(): JSX.Element {
     aspectRatio: "16:9",
     fps: 60,
     maxBitrateMbps: 75,
-    codec: "H264",
-    colorQuality: "8bit_420",
+    codec: DEFAULT_STREAM_PREFERENCES.codec,
+    colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
     region: "",
     clipboardPaste: false,
     mouseSensitivity: 1,
@@ -1477,7 +1492,10 @@ export function App(): JSX.Element {
       try {
         // Load settings first
         const loadedSettings = await window.openNow.getSettings();
-        setSettings(loadedSettings);
+        setSettings({
+          ...loadedSettings,
+          ...applyNormalizedStreamPreferences(loadedSettings),
+        });
         setShowStatsOverlay(loadedSettings.showStatsOnLaunch);
         setSettingsLoaded(true);
 
@@ -1841,9 +1859,10 @@ export function App(): JSX.Element {
           }
 
           if (clientRef.current) {
+            const normalizedStreamPreferences = applyNormalizedStreamPreferences(settings);
             await clientRef.current.handleOffer(event.sdp, activeSession, {
-              codec: settings.codec,
-              colorQuality: settings.colorQuality,
+              codec: normalizedStreamPreferences.codec,
+              colorQuality: normalizedStreamPreferences.colorQuality,
               resolution: settings.resolution,
               fps: settings.fps,
               maxBitrateKbps: settings.maxBitrateMbps * 1000,
@@ -1880,9 +1899,21 @@ export function App(): JSX.Element {
 
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {
-    setSettings((prev) => ({ ...prev, [key]: value }));
+    const nextSettings = { ...settings, [key]: value };
+    const normalizedStreamPreferences = applyNormalizedStreamPreferences(nextSettings);
+    const updates: Partial<Settings> = {
+      [key]: value,
+      codec: normalizedStreamPreferences.codec,
+      colorQuality: normalizedStreamPreferences.colorQuality,
+    };
+
+    setSettings((prev) => ({ ...prev, ...updates }));
     if (settingsLoaded) {
-      await window.openNow.setSetting(key, value);
+      await Promise.all(
+        (Object.entries(updates) as Array<[keyof Settings, Settings[keyof Settings]]>).map(([updateKey, updateValue]) =>
+          window.openNow.setSetting(updateKey, updateValue),
+        ),
+      );
     }
     // If a running client exists, push certain settings live
     if (key === "mouseSensitivity") {
@@ -1906,7 +1937,7 @@ export function App(): JSX.Element {
         // ignore
       }
     }
-  }, [settingsLoaded]);
+  }, [settings, settingsLoaded]);
 
   const handleMouseSensitivityChange = useCallback((value: number) => {
     void updateSetting("mouseSensitivity", value);
@@ -2089,8 +2120,7 @@ export function App(): JSX.Element {
         resolution: settings.resolution,
         fps: settings.fps,
         maxBitrateMbps: settings.maxBitrateMbps,
-        codec: settings.codec,
-        colorQuality: settings.colorQuality,
+        ...applyNormalizedStreamPreferences(settings),
         keyboardLayout: settings.keyboardLayout,
         gameLanguage: settings.gameLanguage,
         enableL4S: settings.enableL4S,
@@ -2241,8 +2271,7 @@ export function App(): JSX.Element {
           resolution: settings.resolution,
           fps: settings.fps,
           maxBitrateMbps: settings.maxBitrateMbps,
-          codec: settings.codec,
-          colorQuality: settings.colorQuality,
+          ...applyNormalizedStreamPreferences(settings),
           keyboardLayout: settings.keyboardLayout,
           gameLanguage: settings.gameLanguage,
           enableL4S: settings.enableL4S,

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -48,8 +48,7 @@ const allColorQualityOptions: { value: ColorQuality; label: string; description:
   { value: "10bit_444", label: "10-bit 4:4:4", description: "Highest chroma and bit depth" },
 ];
 
-const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = allColorQualityOptions
-  .filter((option) => USER_FACING_COLOR_QUALITY_OPTIONS.includes(option.value));
+const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = [...allColorQualityOptions];
 
 /* ── Static fallbacks (used when MES API is unavailable) ─────────── */
 

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -16,7 +16,13 @@ import type {
   ThankYouContributor,
   ThankYouSupporter,
 } from "@shared/gfn";
-import { colorQualityRequiresHevc, keyboardLayoutOptions } from "@shared/gfn";
+import {
+  getAllowedColorQualitiesForCodec,
+  keyboardLayoutOptions,
+  normalizeStreamPreferences,
+  USER_FACING_COLOR_QUALITY_OPTIONS,
+  USER_FACING_VIDEO_CODEC_OPTIONS,
+} from "@shared/gfn";
 import { formatShortcutForDisplay, normalizeShortcut } from "../shortcuts";
 
 interface SettingsPageProps {
@@ -27,14 +33,14 @@ interface SettingsPageProps {
 
 type ThanksLoadState = "idle" | "loading" | "loaded" | "error";
 
-const codecOptions: VideoCodec[] = ["H264", "H265", "AV1"];
+const codecOptions: VideoCodec[] = [...USER_FACING_VIDEO_CODEC_OPTIONS];
 
-const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = [
+const allColorQualityOptions: { value: ColorQuality; label: string; description: string }[] = [
   { value: "8bit_420", label: "8-bit 4:2:0", description: "Most compatible" },
-  { value: "8bit_444", label: "8-bit 4:4:4", description: "Better color" },
-  { value: "10bit_420", label: "10-bit 4:2:0", description: "HDR ready" },
-  { value: "10bit_444", label: "10-bit 4:4:4", description: "Best quality" },
 ];
+
+const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = allColorQualityOptions
+  .filter((option) => USER_FACING_COLOR_QUALITY_OPTIONS.includes(option.value));
 
 /* ── Static fallbacks (used when MES API is unavailable) ─────────── */
 
@@ -762,26 +768,14 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     [onSettingChange]
   );
 
-  /** Change color quality, auto-switching codec to H265 if the mode requires HEVC */
-  const handleColorQualityChange = useCallback(
-    (cq: ColorQuality) => {
-      handleChange("colorQuality", cq);
-      if (colorQualityRequiresHevc(cq) && settings.codec === "H264") {
-        handleChange("codec", "H265");
-      }
-    },
-    [handleChange, settings.codec]
+  const normalizedStreamPreferences = useMemo(
+    () => normalizeStreamPreferences(settings.codec, settings.colorQuality),
+    [settings.codec, settings.colorQuality]
   );
-
-  const handleCodecChange = useCallback(
-    (codec: VideoCodec) => {
-      handleChange("codec", codec);
-      if (codec === "H264" && settings.colorQuality !== "8bit_420") {
-        handleChange("colorQuality", "8bit_420");
-      }
-    },
-    [handleChange, settings.colorQuality]
-  );
+  const availableColorQualityOptions = useMemo(() => {
+    const allowed = new Set(getAllowedColorQualitiesForCodec(normalizedStreamPreferences.codec));
+    return colorQualityOptions.filter((option) => allowed.has(option.value));
+  }, [normalizedStreamPreferences.codec]);
 
   // Microphone devices
   const [microphoneDevices, setMicrophoneDevices] = useState<MediaDeviceInfo[]>([]);
@@ -1585,8 +1579,8 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                 {codecOptions.map((codec) => (
                   <button
                     key={codec}
-                    className={`settings-chip ${settings.codec === codec ? "active" : ""}`}
-                    onClick={() => handleCodecChange(codec)}
+                    className={`settings-chip ${normalizedStreamPreferences.codec === codec ? "active" : ""}`}
+                    onClick={() => handleChange("codec", codec)}
                   >
                     {codec}
                   </button>
@@ -1598,23 +1592,17 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
             <div className="settings-row settings-row--column">
               <label className="settings-label">Color Depth</label>
               <div className="settings-chip-row">
-                {colorQualityOptions.map((opt) => {
-                  const needsHevc = colorQualityRequiresHevc(opt.value);
-                  return (
-                    <button
-                      key={opt.value}
-                      className={`settings-chip ${settings.colorQuality === opt.value ? "active" : ""}`}
-                      onClick={() => handleColorQualityChange(opt.value)}
-                      title={`${opt.description}${needsHevc ? " — requires H265/AV1" : ""}`}
-                    >
-                      <span>{opt.label}</span>
-                    </button>
-                  );
-                })}
+                {availableColorQualityOptions.map((opt) => (
+                  <button
+                    key={opt.value}
+                    className={`settings-chip ${normalizedStreamPreferences.colorQuality === opt.value ? "active" : ""}`}
+                    onClick={() => handleChange("colorQuality", opt.value)}
+                    title={opt.description}
+                  >
+                    <span>{opt.label}</span>
+                  </button>
+                ))}
               </div>
-              {colorQualityRequiresHevc(settings.colorQuality) && settings.codec === "H264" && (
-                <span className="settings-input-hint">This mode requires H265 or AV1. Codec will be auto-switched.</span>
-              )}
             </div>
 
             {/* Bitrate slider */}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -37,6 +37,9 @@ const codecOptions: VideoCodec[] = [...USER_FACING_VIDEO_CODEC_OPTIONS];
 
 const allColorQualityOptions: { value: ColorQuality; label: string; description: string }[] = [
   { value: "8bit_420", label: "8-bit 4:2:0", description: "Most compatible" },
+  { value: "8bit_444", label: "8-bit 4:4:4", description: "Sharper chroma" },
+  { value: "10bit_420", label: "10-bit 4:2:0", description: "Higher bit depth" },
+  { value: "10bit_444", label: "10-bit 4:4:4", description: "Highest chroma and bit depth" },
 ];
 
 const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = allColorQualityOptions

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -8,6 +8,7 @@ import type {
   VideoCodec,
   ColorQuality,
   EntitledResolution,
+  VideoAccelerationPreference,
   MicrophoneMode,
   PingResult,
   GameLanguage,
@@ -17,9 +18,8 @@ import type {
   ThankYouSupporter,
 } from "@shared/gfn";
 import {
-  getAllowedColorQualitiesForCodec,
+  colorQualityRequiresHevc,
   keyboardLayoutOptions,
-  normalizeStreamPreferences,
   USER_FACING_COLOR_QUALITY_OPTIONS,
   USER_FACING_VIDEO_CODEC_OPTIONS,
 } from "@shared/gfn";
@@ -34,6 +34,12 @@ interface SettingsPageProps {
 type ThanksLoadState = "idle" | "loading" | "loaded" | "error";
 
 const codecOptions: VideoCodec[] = [...USER_FACING_VIDEO_CODEC_OPTIONS];
+
+const accelerationOptions: { value: VideoAccelerationPreference; label: string }[] = [
+  { value: "auto", label: "Auto" },
+  { value: "hardware", label: "Hardware" },
+  { value: "software", label: "Software (CPU)" },
+];
 
 const allColorQualityOptions: { value: ColorQuality; label: string; description: string }[] = [
   { value: "8bit_420", label: "8-bit 4:2:0", description: "Most compatible" },
@@ -771,14 +777,25 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
     [onSettingChange]
   );
 
-  const normalizedStreamPreferences = useMemo(
-    () => normalizeStreamPreferences(settings.codec, settings.colorQuality),
-    [settings.codec, settings.colorQuality]
+  const handleColorQualityChange = useCallback(
+    (cq: ColorQuality) => {
+      handleChange("colorQuality", cq);
+      if (colorQualityRequiresHevc(cq) && settings.codec === "H264") {
+        handleChange("codec", "H265");
+      }
+    },
+    [handleChange, settings.codec]
   );
-  const availableColorQualityOptions = useMemo(() => {
-    const allowed = new Set(getAllowedColorQualitiesForCodec(normalizedStreamPreferences.codec));
-    return colorQualityOptions.filter((option) => allowed.has(option.value));
-  }, [normalizedStreamPreferences.codec]);
+
+  const handleCodecChange = useCallback(
+    (codec: VideoCodec) => {
+      handleChange("codec", codec);
+      if (codec === "H264" && settings.colorQuality !== "8bit_420") {
+        handleChange("colorQuality", "8bit_420");
+      }
+    },
+    [handleChange, settings.colorQuality]
+  );
 
   // Microphone devices
   const [microphoneDevices, setMicrophoneDevices] = useState<MediaDeviceInfo[]>([]);
@@ -1582,8 +1599,8 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
                 {codecOptions.map((codec) => (
                   <button
                     key={codec}
-                    className={`settings-chip ${normalizedStreamPreferences.codec === codec ? "active" : ""}`}
-                    onClick={() => handleChange("codec", codec)}
+                    className={`settings-chip ${settings.codec === codec ? "active" : ""}`}
+                    onClick={() => handleCodecChange(codec)}
                   >
                     {codec}
                   </button>
@@ -1591,21 +1608,59 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
               </div>
             </div>
 
+            <div className="settings-row settings-row--column">
+              <label className="settings-label">Decoder</label>
+              <div className="settings-chip-row">
+                {accelerationOptions.map((option) => (
+                  <button
+                    key={`decoder-${option.value}`}
+                    className={`settings-chip ${settings.decoderPreference === option.value ? "active" : ""}`}
+                    onClick={() => handleChange("decoderPreference", option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+              <span className="settings-subtle-hint">Applies after app restart.</span>
+            </div>
+
+            <div className="settings-row settings-row--column">
+              <label className="settings-label">Encoder</label>
+              <div className="settings-chip-row">
+                {accelerationOptions.map((option) => (
+                  <button
+                    key={`encoder-${option.value}`}
+                    className={`settings-chip ${settings.encoderPreference === option.value ? "active" : ""}`}
+                    onClick={() => handleChange("encoderPreference", option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+              <span className="settings-subtle-hint">Applies after app restart.</span>
+            </div>
+
             {/* Color Quality */}
             <div className="settings-row settings-row--column">
               <label className="settings-label">Color Depth</label>
               <div className="settings-chip-row">
-                {availableColorQualityOptions.map((opt) => (
-                  <button
-                    key={opt.value}
-                    className={`settings-chip ${normalizedStreamPreferences.colorQuality === opt.value ? "active" : ""}`}
-                    onClick={() => handleChange("colorQuality", opt.value)}
-                    title={opt.description}
-                  >
-                    <span>{opt.label}</span>
-                  </button>
-                ))}
+                {colorQualityOptions.map((opt) => {
+                  const needsHevc = colorQualityRequiresHevc(opt.value);
+                  return (
+                    <button
+                      key={opt.value}
+                      className={`settings-chip ${settings.colorQuality === opt.value ? "active" : ""}`}
+                      onClick={() => handleColorQualityChange(opt.value)}
+                      title={`${opt.description}${needsHevc ? " — requires H265/AV1" : ""}`}
+                    >
+                      <span>{opt.label}</span>
+                    </button>
+                  );
+                })}
               </div>
+              {colorQualityRequiresHevc(settings.colorQuality) && settings.codec === "H264" && (
+                <span className="settings-input-hint">This mode requires H265 or AV1. Codec will be auto-switched.</span>
+              )}
             </div>
 
             {/* Bitrate slider */}

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -397,8 +397,6 @@ export function preferCodec(sdp: string, codec: VideoCodec, options?: PreferCode
 interface NvstParams {
   width: number;
   height: number;
-  clientViewportWidth: number;
-  clientViewportHeight: number;
   fps: number;
   maxBitrateKbps: number;
   partialReliableThresholdMs: number;
@@ -579,8 +577,8 @@ export function buildNvstSdp(params: NvstParams): string {
 
   // Viewport, FPS, and bitrate
   lines.push(
-    `a=video.clientViewportWd:${params.clientViewportWidth}`,
-    `a=video.clientViewportHt:${params.clientViewportHeight}`,
+    `a=video.clientViewportWd:${params.width}`,
+    `a=video.clientViewportHt:${params.height}`,
     `a=video.maxFPS:${params.fps}`,
     `a=video.initialBitrateKbps:${initialBitrate}`,
     `a=video.initialPeakBitrateKbps:${params.maxBitrateKbps}`,

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -459,7 +459,7 @@ export function buildNvstSdp(params: NvstParams): string {
   const is120Fps = params.fps === 120;
   const is240Fps = params.fps >= 240;
   const isAv1 = params.codec === "AV1";
-  const bitDepth = params.colorQuality.startsWith("10bit") && params.codec !== "H264" ? 10 : 8;
+  const bitDepth = params.colorQuality.startsWith("10bit") ? 10 : 8;
 
   const lines: string[] = [
     "v=0",

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -441,46 +441,6 @@ function normalizeCodecName(codecId: string): string {
   return codecId;
 }
 
-function extractNegotiatedVideoCodec(sdp: string): VideoCodec | undefined {
-  const lines = sdp.split(/\r?\n/);
-  const payloadToCodec = new Map<string, VideoCodec>();
-  let videoPayloadOrder: string[] = [];
-  let inVideoSection = false;
-
-  for (const line of lines) {
-    if (line.startsWith("m=video")) {
-      inVideoSection = true;
-      videoPayloadOrder = line.split(/\s+/).slice(3);
-      continue;
-    }
-    if (line.startsWith("m=") && inVideoSection) {
-      break;
-    }
-    if (!inVideoSection || !line.startsWith("a=rtpmap:")) {
-      continue;
-    }
-
-    const match = line.match(/^a=rtpmap:(\d+)\s+([^/\s]+)/i);
-    if (!match) {
-      continue;
-    }
-
-    const normalized = normalizeCodecName(match[2]);
-    if (normalized === "H264" || normalized === "H265" || normalized === "AV1") {
-      payloadToCodec.set(match[1], normalized);
-    }
-  }
-
-  for (const payload of videoPayloadOrder) {
-    const codec = payloadToCodec.get(payload);
-    if (codec) {
-      return codec;
-    }
-  }
-
-  return undefined;
-}
-
 export class GfnWebRtcClient {
   private readonly videoStream = new MediaStream();
   private readonly audioStream = new MediaStream();
@@ -3581,36 +3541,11 @@ export class GfnWebRtcClient {
 
     const credentials = extractIceCredentials(finalSdp);
     this.log(`Extracted ICE credentials: ufrag=${credentials.ufrag}, pwd=${credentials.pwd.slice(0, 8)}...`);
-    const negotiatedVideoCodec = extractNegotiatedVideoCodec(finalSdp);
-    if (negotiatedVideoCodec) {
-      effectiveCodec = negotiatedVideoCodec;
-      this.log(`Negotiated video codec from local SDP: ${effectiveCodec}`);
-    }
     const { width, height } = parseResolution(settings.resolution);
-    const viewportRect = this.options.videoElement.getBoundingClientRect();
-    const dpr = window.devicePixelRatio || 1;
-    const baseCssViewportWidth = Math.max(viewportRect.width, window.innerWidth || 0);
-    const baseCssViewportHeight = Math.max(viewportRect.height, window.innerHeight || 0);
-    const screenCssWidth = window.screen?.width ?? baseCssViewportWidth;
-    const screenCssHeight = window.screen?.height ?? baseCssViewportHeight;
-    const shouldUseScreenViewportHint = dpr > 1 && (width >= 3840 || height >= 2160);
-    const resolvedCssViewportWidth = shouldUseScreenViewportHint
-      ? Math.max(baseCssViewportWidth, screenCssWidth)
-      : baseCssViewportWidth;
-    const resolvedCssViewportHeight = shouldUseScreenViewportHint
-      ? Math.max(baseCssViewportHeight, screenCssHeight)
-      : baseCssViewportHeight;
-    const clientViewportWidth = Math.max(1, Math.round(resolvedCssViewportWidth * dpr));
-    const clientViewportHeight = Math.max(1, Math.round(resolvedCssViewportHeight * dpr));
-    this.log(
-      `Client viewport for NVST: ${clientViewportWidth}x${clientViewportHeight} (CSS base ${Math.round(baseCssViewportWidth)}x${Math.round(baseCssViewportHeight)}, screen ${Math.round(screenCssWidth)}x${Math.round(screenCssHeight)}, mode=${shouldUseScreenViewportHint ? "screen-hidpi-4k" : "window"} @ DPR ${dpr.toFixed(2)})`,
-    );
 
     const nvstSdp = buildNvstSdp({
       width,
       height,
-      clientViewportWidth,
-      clientViewportHeight,
       fps: settings.fps,
       maxBitrateKbps: settings.maxBitrateKbps,
       partialReliableThresholdMs: this.partialReliableThresholdMs,
@@ -3633,39 +3568,27 @@ export class GfnWebRtcClient {
       const mci = session.mediaConnectionInfo;
       const rawIp = extractPublicIp(mci.ip);
       if (rawIp && mci.port > 0) {
-        // Try UDP host candidate first, then a TCP host candidate as a fallback.
-        // Some GFN endpoints advertise rtsps (TCP/TLS) ports; injecting a TCP
-        // candidate can help when UDP is blocked but the server accepts TCP.
-        const candidateUdp = `candidate:1 1 udp 2130706431 ${rawIp} ${mci.port} typ host`;
-        const candidateTcp = `candidate:1 1 tcp 1518149375 ${rawIp} ${mci.port} typ host tcptype active`;
-        const candidatesToTry = [candidateUdp, candidateTcp];
-
-        this.log(`Injecting manual ICE candidates: ${rawIp}:${mci.port} (udp,tcp)`);
+        const candidateStr = `candidate:1 1 udp 2130706431 ${rawIp} ${mci.port} typ host`;
+        this.log(`Injecting manual ICE candidate: ${rawIp}:${mci.port}`);
 
         // Try sdpMid "0" first, then "1", "2", "3" (matching Rust fallback)
         const mids = ["0", "1", "2", "3"];
         let injected = false;
-
-        for (const cand of candidatesToTry) {
-          const proto = cand.includes("udp") ? "udp" : "tcp";
-          for (const mid of mids) {
-            try {
-              await pc.addIceCandidate({
-                candidate: cand,
-                sdpMid: mid,
-                sdpMLineIndex: parseInt(mid, 10),
-                usernameFragment: serverIceUfrag || undefined,
-              });
-              this.log(`Manual ICE candidate injected (sdpMid=${mid}, proto=${proto})`);
-              injected = true;
-              break;
-            } catch (error) {
-              this.log(`Manual ICE candidate failed for sdpMid=${mid}, proto=${proto}: ${String(error)}`);
-            }
+        for (const mid of mids) {
+          try {
+            await pc.addIceCandidate({
+              candidate: candidateStr,
+              sdpMid: mid,
+              sdpMLineIndex: parseInt(mid, 10),
+              usernameFragment: serverIceUfrag || undefined,
+            });
+            this.log(`Manual ICE candidate injected (sdpMid=${mid})`);
+            injected = true;
+            break;
+          } catch (error) {
+            this.log(`Manual ICE candidate failed for sdpMid=${mid}: ${String(error)}`);
           }
-          if (injected) break;
         }
-
         if (!injected) {
           this.log("Warning: Could not inject manual ICE candidate on any sdpMid");
         }
@@ -3677,170 +3600,6 @@ export class GfnWebRtcClient {
     }
 
     this.log("=== handleOffer COMPLETE — waiting for ICE connectivity and tracks ===");
-
-    // Relay/TURN fallback: if ICE never reaches connected (or fails), and
-    // the session-provided ICE servers include TURN server URLs, attempt to
-    // recreate the PeerConnection with `iceTransportPolicy: 'relay'` to force
-    // use of TURN relays. This helps clients behind restrictive NAT/firewalls.
-    let triedRelay = false;
-    const relayFallbackTimeoutMs = 7000;
-
-    const attemptRelayFallback = async (): Promise<void> => {
-      if (triedRelay) return;
-      triedRelay = true;
-
-      try {
-        const hasTurn = (session.iceServers ?? []).some((s) =>
-          (s.urls ?? []).some((u) => typeof u === "string" && (u.startsWith("turn:") || u.startsWith("turns:"))),
-        );
-        if (!hasTurn) {
-          this.log("Relay fallback: no TURN servers present in session. Skipping relay attempt.");
-          return;
-        }
-
-        this.log("Relay fallback: starting relay/TURN retry (iceTransportPolicy=relay)");
-
-        // Tear down any existing peer connection and create a new one configured
-        // to use only relays.
-        this.cleanupPeerConnection();
-
-        const relayRtcConfig: RTCConfiguration = {
-          iceServers: toRtcIceServers(session.iceServers),
-          bundlePolicy: "max-bundle",
-          rtcpMuxPolicy: "require",
-          iceTransportPolicy: "relay",
-        } as RTCConfiguration;
-
-        const relayPc = new RTCPeerConnection(relayRtcConfig);
-        this.pc = relayPc;
-        this.diagnostics.connectionState = relayPc.connectionState;
-        this.diagnostics.serverRegion = this.serverRegion;
-        this.diagnostics.gpuType = this.gpuType;
-        this.emitStats();
-
-        this.resetInputState();
-        this.resetDiagnostics();
-        this.createDataChannels(relayPc);
-        this.installInputCapture(this.options.videoElement);
-        this.setupStatsPolling();
-
-        relayPc.onicecandidate = (event) => {
-          if (!event.candidate) return;
-          const payload = event.candidate.toJSON();
-          if (!payload.candidate) return;
-          this.log(`Relay PC local ICE candidate: ${payload.candidate}`);
-          const candidate: IceCandidatePayload = {
-            candidate: payload.candidate,
-            sdpMid: payload.sdpMid,
-            sdpMLineIndex: payload.sdpMLineIndex,
-            usernameFragment: payload.usernameFragment,
-          };
-          window.openNow.sendIceCandidate(candidate).catch((error) => {
-            this.log(`Relay PC failed to send local ICE candidate: ${String(error)}`);
-          });
-        };
-
-        relayPc.ontrack = (evt) => {
-          this.log(`Relay PC track received: kind=${evt.track.kind}, id=${evt.track.id}`);
-          this.attachTrack(evt.track);
-          this.configureReceiverForLowLatency(evt.receiver, evt.track.kind);
-        };
-
-        relayPc.onconnectionstatechange = () => {
-          this.diagnostics.connectionState = relayPc.connectionState;
-          this.emitStats();
-          this.log(`Relay PC connection state: ${relayPc.connectionState}`);
-        };
-
-        relayPc.oniceconnectionstatechange = () => {
-          this.log(`Relay PC ICE connection state: ${relayPc.iceConnectionState}`);
-        };
-
-        // Re-run the SDP answer flow against the same (filtered) offer.
-        await relayPc.setRemoteDescription({ type: "offer", sdp: filteredOffer });
-        await this.flushQueuedCandidates();
-
-        if (this.micManager) {
-          this.micManager.setPeerConnection(relayPc);
-          await this.micManager.attachTrackToPeerConnection();
-        }
-
-        // Re-apply codec preferences on the new PC
-        this.applyCodecPreferences(relayPc, effectiveCodec, preferredHevcProfileId);
-
-        const relayAnswer = await relayPc.createAnswer();
-        if (relayAnswer.sdp) {
-          relayAnswer.sdp = mungeAnswerSdp(relayAnswer.sdp, settings.maxBitrateKbps);
-        }
-        await relayPc.setLocalDescription(relayAnswer);
-        this.log("Relay PC local description set, waiting for ICE gathering...");
-
-        const finalRelaySdp = await this.waitForIceGathering(relayPc, 5000);
-        this.log(`Relay ICE gathering done, final SDP length: ${finalRelaySdp.length} chars`);
-
-        const relayCredentials = extractIceCredentials(finalRelaySdp);
-        const nvstSdpRelay = buildNvstSdp({
-          width,
-          height,
-          clientViewportWidth,
-          clientViewportHeight,
-          fps: settings.fps,
-          maxBitrateKbps: settings.maxBitrateKbps,
-          partialReliableThresholdMs: this.partialReliableThresholdMs,
-          codec: effectiveCodec,
-          colorQuality: settings.colorQuality,
-          credentials: relayCredentials,
-        });
-
-        await window.openNow.sendAnswer({ sdp: finalRelaySdp, nvstSdp: nvstSdpRelay });
-        this.log("Relay fallback: sent relay answer to signaling");
-
-        // Attempt manual mediaConnectionInfo injection again (UDP/TCP) — server may
-        // accept TCP connections even when UDP fails.
-        if (session.mediaConnectionInfo) {
-          const mci = session.mediaConnectionInfo;
-          const rawIp = extractPublicIp(mci.ip);
-          if (rawIp && mci.port > 0) {
-            const candidateUdp = `candidate:1 1 udp 2130706431 ${rawIp} ${mci.port} typ host`;
-            const candidateTcp = `candidate:1 1 tcp 1518149375 ${rawIp} ${mci.port} typ host tcptype active`;
-            const candidatesToTry = [candidateUdp, candidateTcp];
-            const mids = ["0", "1", "2", "3"];
-            let injectedRelay = false;
-            for (const cand of candidatesToTry) {
-              const proto = cand.includes("udp") ? "udp" : "tcp";
-              for (const mid of mids) {
-                try {
-                  await relayPc.addIceCandidate({ candidate: cand, sdpMid: mid, sdpMLineIndex: parseInt(mid, 10), usernameFragment: relayCredentials.ufrag || undefined });
-                  this.log(`Relay PC manual ICE candidate injected (sdpMid=${mid}, proto=${proto})`);
-                  injectedRelay = true;
-                  break;
-                } catch (e) {
-                  this.log(`Relay PC manual ICE candidate failed for sdpMid=${mid}, proto=${proto}: ${String(e)}`);
-                }
-              }
-              if (injectedRelay) break;
-            }
-            if (!injectedRelay) this.log("Relay PC: could not inject manual media candidate on any sdpMid");
-          }
-        }
-      } catch (e) {
-        this.log(`Relay fallback failed: ${String(e)}`);
-      }
-    };
-
-    // Trigger fallback on ICE failure or timeout
-    pc.oniceconnectionstatechange = () => {
-      this.log(`ICE connection state: ${pc.iceConnectionState}`);
-      if ((pc.iceConnectionState === "failed" || pc.iceConnectionState === "disconnected") && !triedRelay) {
-        void attemptRelayFallback();
-      }
-    };
-
-    setTimeout(() => {
-      if (!triedRelay && this.pc && this.pc.connectionState !== "connected" && this.pc.iceConnectionState !== "connected") {
-        void attemptRelayFallback();
-      }
-    }, relayFallbackTimeoutMs);
   }
 
   async addRemoteCandidate(candidate: IceCandidatePayload): Promise<void> {

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -2,12 +2,10 @@ import type {
   IceCandidatePayload,
   ColorQuality,
   IceServer,
-  NegotiatedStreamProfile,
   SessionInfo,
   VideoCodec,
   MicrophoneMode,
 } from "@shared/gfn";
-import { colorQualityRequiresHevc } from "@shared/gfn";
 
 import {
   InputEncoder,
@@ -441,25 +439,6 @@ function normalizeCodecName(codecId: string): string {
   }
 
   return codecId;
-}
-
-function resolveOfferSettings(settings: OfferSettings, negotiated?: NegotiatedStreamProfile): OfferSettings {
-  if (!negotiated) {
-    return settings;
-  }
-
-  const resolved: OfferSettings = {
-    ...settings,
-    resolution: negotiated.resolution ?? settings.resolution,
-    fps: negotiated.fps ?? settings.fps,
-    colorQuality: negotiated.colorQuality ?? settings.colorQuality,
-  };
-
-  if (colorQualityRequiresHevc(resolved.colorQuality) && resolved.codec === "H264") {
-    resolved.codec = "H265";
-  }
-
-  return resolved;
 }
 
 function extractNegotiatedVideoCodec(sdp: string): VideoCodec | undefined {
@@ -3320,14 +3299,12 @@ export class GfnWebRtcClient {
 
   async handleOffer(offerSdp: string, session: SessionInfo, settings: OfferSettings): Promise<void> {
     this.cleanupPeerConnection();
-    const effectiveSettings = resolveOfferSettings(settings, session.negotiatedStreamProfile);
-
     this.log("=== handleOffer START ===");
     this.log(`Session: id=${session.sessionId}, status=${session.status}, serverIp=${session.serverIp}`);
     this.log(`Signaling: server=${session.signalingServer}, url=${session.signalingUrl}`);
     this.log(`MediaConnectionInfo: ${session.mediaConnectionInfo ? `ip=${session.mediaConnectionInfo.ip}, port=${session.mediaConnectionInfo.port}` : "NONE"}`);
     this.log(
-      `Settings: codec=${effectiveSettings.codec}, colorQuality=${effectiveSettings.colorQuality}, resolution=${effectiveSettings.resolution}, fps=${effectiveSettings.fps}, maxBitrate=${effectiveSettings.maxBitrateKbps}kbps`,
+      `Settings: codec=${settings.codec}, colorQuality=${settings.colorQuality}, resolution=${settings.resolution}, fps=${settings.fps}, maxBitrate=${settings.maxBitrateKbps}kbps`,
     );
     if (session.negotiatedStreamProfile) {
       this.log(`Negotiated stream profile override: ${JSON.stringify(session.negotiatedStreamProfile)}`);
@@ -3345,7 +3322,7 @@ export class GfnWebRtcClient {
     this.partialReliableThresholdMs = negotiatedPartialReliable ?? GfnWebRtcClient.DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS;
     this.negotiatedMaxBitrateKbps = Math.max(
       GfnWebRtcClient.DECODER_MIN_RECOVERY_BITRATE_KBPS,
-      Math.floor(effectiveSettings.maxBitrateKbps),
+      Math.floor(settings.maxBitrateKbps),
     );
     this.currentBitrateCeilingKbps = this.negotiatedMaxBitrateKbps;
     this.log(
@@ -3481,14 +3458,14 @@ export class GfnWebRtcClient {
     const serverIceUfrag = extractIceUfragFromOffer(processedOffer);
     this.log(`Server ICE ufrag: "${serverIceUfrag}"`);
 
-    const preferredHevcProfileId = hevcPreferredProfileId(effectiveSettings.colorQuality);
+    const preferredHevcProfileId = hevcPreferredProfileId(settings.colorQuality);
 
     // 3. Filter to preferred codec — but only if the browser actually supports it
-    let effectiveCodec = effectiveSettings.codec;
+    let effectiveCodec = settings.codec;
     const supported = this.getSupportedVideoCodecs();
     this.log(`Browser supported video codecs: ${supported.join(", ") || "unknown"}`);
 
-    if (effectiveSettings.codec === "H265") {
+    if (settings.codec === "H265") {
       const hevcProfiles = this.getSupportedHevcProfiles();
       if (hevcProfiles.size > 0) {
         this.log(`Browser HEVC profile-id support: ${Array.from(hevcProfiles).join(", ")}`);
@@ -3526,8 +3503,8 @@ export class GfnWebRtcClient {
       }
     }
 
-    if (supported.length > 0 && !supported.includes(effectiveSettings.codec)) {
-      this.log(`Warning: ${effectiveSettings.codec} not reported in browser codec list; forcing requested codec anyway`);
+    if (supported.length > 0 && !supported.includes(settings.codec)) {
+      this.log(`Warning: ${settings.codec} not reported in browser codec list; forcing requested codec anyway`);
     }
     this.log(`Effective codec: ${effectiveCodec} (preferred HEVC profile-id=${preferredHevcProfileId})`);
     const filteredOffer = preferCodec(processedOffer, effectiveCodec, {
@@ -3558,8 +3535,8 @@ export class GfnWebRtcClient {
 
     // Munge answer SDP: inject b=AS: bitrate limits and stereo=1 for opus
     if (answer.sdp) {
-      answer.sdp = mungeAnswerSdp(answer.sdp, effectiveSettings.maxBitrateKbps);
-      this.log(`Answer SDP munged (b=AS:${effectiveSettings.maxBitrateKbps}, stereo=1)`);
+      answer.sdp = mungeAnswerSdp(answer.sdp, settings.maxBitrateKbps);
+      this.log(`Answer SDP munged (b=AS:${settings.maxBitrateKbps}, stereo=1)`);
     }
 
     await pc.setLocalDescription(answer);
@@ -3609,7 +3586,7 @@ export class GfnWebRtcClient {
       effectiveCodec = negotiatedVideoCodec;
       this.log(`Negotiated video codec from local SDP: ${effectiveCodec}`);
     }
-    const { width, height } = parseResolution(effectiveSettings.resolution);
+    const { width, height } = parseResolution(settings.resolution);
     const viewportRect = this.options.videoElement.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
     const baseCssViewportWidth = Math.max(viewportRect.width, window.innerWidth || 0);
@@ -3634,11 +3611,11 @@ export class GfnWebRtcClient {
       height,
       clientViewportWidth,
       clientViewportHeight,
-      fps: effectiveSettings.fps,
-      maxBitrateKbps: effectiveSettings.maxBitrateKbps,
+      fps: settings.fps,
+      maxBitrateKbps: settings.maxBitrateKbps,
       partialReliableThresholdMs: this.partialReliableThresholdMs,
       codec: effectiveCodec,
-      colorQuality: effectiveSettings.colorQuality,
+      colorQuality: settings.colorQuality,
       credentials,
     });
 
@@ -3793,7 +3770,7 @@ export class GfnWebRtcClient {
 
         const relayAnswer = await relayPc.createAnswer();
         if (relayAnswer.sdp) {
-          relayAnswer.sdp = mungeAnswerSdp(relayAnswer.sdp, effectiveSettings.maxBitrateKbps);
+          relayAnswer.sdp = mungeAnswerSdp(relayAnswer.sdp, settings.maxBitrateKbps);
         }
         await relayPc.setLocalDescription(relayAnswer);
         this.log("Relay PC local description set, waiting for ICE gathering...");
@@ -3807,11 +3784,11 @@ export class GfnWebRtcClient {
           height,
           clientViewportWidth,
           clientViewportHeight,
-          fps: effectiveSettings.fps,
-          maxBitrateKbps: effectiveSettings.maxBitrateKbps,
+          fps: settings.fps,
+          maxBitrateKbps: settings.maxBitrateKbps,
           partialReliableThresholdMs: this.partialReliableThresholdMs,
           codec: effectiveCodec,
-          colorQuality: effectiveSettings.colorQuality,
+          colorQuality: settings.colorQuality,
           credentials: relayCredentials,
         });
 

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -70,22 +70,8 @@ export function colorQualityRequiresHevc(cq: ColorQuality): boolean {
 export const USER_FACING_VIDEO_CODEC_OPTIONS: readonly VideoCodec[] = ["H264", "H265", "AV1"];
 export const USER_FACING_COLOR_QUALITY_OPTIONS: readonly ColorQuality[] = ["8bit_420", "8bit_444", "10bit_420", "10bit_444"];
 
-const ALLOWED_COLOR_QUALITIES_BY_CODEC: Record<VideoCodec, readonly ColorQuality[]> = {
-  H264: USER_FACING_COLOR_QUALITY_OPTIONS,
-  H265: USER_FACING_COLOR_QUALITY_OPTIONS,
-  AV1: USER_FACING_COLOR_QUALITY_OPTIONS,
-};
-
 export function isSupportedUserFacingCodec(codec: VideoCodec): boolean {
   return USER_FACING_VIDEO_CODEC_OPTIONS.includes(codec);
-}
-
-export function getAllowedColorQualitiesForCodec(codec: VideoCodec): readonly ColorQuality[] {
-  return ALLOWED_COLOR_QUALITIES_BY_CODEC[codec] ?? USER_FACING_COLOR_QUALITY_OPTIONS;
-}
-
-export function isAllowedColorQualityForCodec(codec: VideoCodec, colorQuality: ColorQuality): boolean {
-  return getAllowedColorQualitiesForCodec(codec).includes(colorQuality);
 }
 
 export function normalizeStreamPreferences(codec: VideoCodec, colorQuality: ColorQuality): {
@@ -96,10 +82,9 @@ export function normalizeStreamPreferences(codec: VideoCodec, colorQuality: Colo
   const normalizedCodec = isSupportedUserFacingCodec(codec)
     ? codec
     : USER_FACING_VIDEO_CODEC_OPTIONS[0];
-  const allowedColorQualities = getAllowedColorQualitiesForCodec(normalizedCodec);
-  const normalizedColorQuality = isAllowedColorQualityForCodec(normalizedCodec, colorQuality)
+  const normalizedColorQuality = USER_FACING_COLOR_QUALITY_OPTIONS.includes(colorQuality)
     ? colorQuality
-    : allowedColorQualities[0];
+    : USER_FACING_COLOR_QUALITY_OPTIONS[0];
 
   return {
     codec: normalizedCodec,

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -67,6 +67,47 @@ export function colorQualityRequiresHevc(cq: ColorQuality): boolean {
   return cq !== "8bit_420";
 }
 
+export const USER_FACING_VIDEO_CODEC_OPTIONS: readonly VideoCodec[] = ["H264"];
+export const USER_FACING_COLOR_QUALITY_OPTIONS: readonly ColorQuality[] = ["8bit_420"];
+
+const ALLOWED_COLOR_QUALITIES_BY_CODEC: Record<VideoCodec, readonly ColorQuality[]> = {
+  H264: USER_FACING_COLOR_QUALITY_OPTIONS,
+  H265: USER_FACING_COLOR_QUALITY_OPTIONS,
+  AV1: USER_FACING_COLOR_QUALITY_OPTIONS,
+};
+
+export function isSupportedUserFacingCodec(codec: VideoCodec): boolean {
+  return USER_FACING_VIDEO_CODEC_OPTIONS.includes(codec);
+}
+
+export function getAllowedColorQualitiesForCodec(codec: VideoCodec): readonly ColorQuality[] {
+  return ALLOWED_COLOR_QUALITIES_BY_CODEC[codec] ?? USER_FACING_COLOR_QUALITY_OPTIONS;
+}
+
+export function isAllowedColorQualityForCodec(codec: VideoCodec, colorQuality: ColorQuality): boolean {
+  return getAllowedColorQualitiesForCodec(codec).includes(colorQuality);
+}
+
+export function normalizeStreamPreferences(codec: VideoCodec, colorQuality: ColorQuality): {
+  codec: VideoCodec;
+  colorQuality: ColorQuality;
+  migrated: boolean;
+} {
+  const normalizedCodec = isSupportedUserFacingCodec(codec)
+    ? codec
+    : USER_FACING_VIDEO_CODEC_OPTIONS[0];
+  const allowedColorQualities = getAllowedColorQualitiesForCodec(normalizedCodec);
+  const normalizedColorQuality = isAllowedColorQualityForCodec(normalizedCodec, colorQuality)
+    ? colorQuality
+    : allowedColorQualities[0];
+
+  return {
+    codec: normalizedCodec,
+    colorQuality: normalizedColorQuality,
+    migrated: normalizedCodec !== codec || normalizedColorQuality !== colorQuality,
+  };
+}
+
 /** Helper: is this a 10-bit (HDR-capable) mode? */
 export function colorQualityIs10Bit(cq: ColorQuality): boolean {
   return cq.startsWith("10bit");
@@ -140,6 +181,22 @@ export interface Settings {
   gameLanguage: GameLanguage;
   /** Experimental request for Low Latency, Low Loss, Scalable throughput on new sessions */
   enableL4S: boolean;
+}
+
+export const DEFAULT_STREAM_PREFERENCES: Readonly<Pick<Settings, "codec" | "colorQuality">> = Object.freeze({
+  codec: "H264",
+  colorQuality: "8bit_420",
+});
+
+export function getDefaultStreamPreferences(): Pick<Settings, "codec" | "colorQuality"> {
+  const normalized = normalizeStreamPreferences(
+    DEFAULT_STREAM_PREFERENCES.codec,
+    DEFAULT_STREAM_PREFERENCES.colorQuality,
+  );
+  return {
+    codec: normalized.codec,
+    colorQuality: normalized.colorQuality,
+  };
 }
 
 export interface LoginProvider {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -71,9 +71,9 @@ export const USER_FACING_VIDEO_CODEC_OPTIONS: readonly VideoCodec[] = ["H264", "
 export const USER_FACING_COLOR_QUALITY_OPTIONS: readonly ColorQuality[] = ["8bit_420", "8bit_444", "10bit_420", "10bit_444"];
 
 const ALLOWED_COLOR_QUALITIES_BY_CODEC: Record<VideoCodec, readonly ColorQuality[]> = {
-  H264: ["8bit_420"],
-  H265: ["8bit_420", "8bit_444", "10bit_420", "10bit_444"],
-  AV1: ["8bit_420", "10bit_420"],
+  H264: USER_FACING_COLOR_QUALITY_OPTIONS,
+  H265: USER_FACING_COLOR_QUALITY_OPTIONS,
+  AV1: USER_FACING_COLOR_QUALITY_OPTIONS,
 };
 
 export function isSupportedUserFacingCodec(codec: VideoCodec): boolean {
@@ -146,6 +146,8 @@ export interface Settings {
   fps: number;
   maxBitrateMbps: number;
   codec: VideoCodec;
+  decoderPreference: VideoAccelerationPreference;
+  encoderPreference: VideoAccelerationPreference;
   colorQuality: ColorQuality;
   region: string;
   clipboardPaste: boolean;
@@ -185,7 +187,7 @@ export interface Settings {
 
 export const DEFAULT_STREAM_PREFERENCES: Readonly<Pick<Settings, "codec" | "colorQuality">> = Object.freeze({
   codec: "H264",
-  colorQuality: "8bit_420",
+  colorQuality: "10bit_420",
 });
 
 export function getDefaultStreamPreferences(): Pick<Settings, "codec" | "colorQuality"> {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -67,13 +67,13 @@ export function colorQualityRequiresHevc(cq: ColorQuality): boolean {
   return cq !== "8bit_420";
 }
 
-export const USER_FACING_VIDEO_CODEC_OPTIONS: readonly VideoCodec[] = ["H264"];
-export const USER_FACING_COLOR_QUALITY_OPTIONS: readonly ColorQuality[] = ["8bit_420"];
+export const USER_FACING_VIDEO_CODEC_OPTIONS: readonly VideoCodec[] = ["H264", "H265", "AV1"];
+export const USER_FACING_COLOR_QUALITY_OPTIONS: readonly ColorQuality[] = ["8bit_420", "8bit_444", "10bit_420", "10bit_444"];
 
 const ALLOWED_COLOR_QUALITIES_BY_CODEC: Record<VideoCodec, readonly ColorQuality[]> = {
-  H264: USER_FACING_COLOR_QUALITY_OPTIONS,
-  H265: USER_FACING_COLOR_QUALITY_OPTIONS,
-  AV1: USER_FACING_COLOR_QUALITY_OPTIONS,
+  H264: ["8bit_420"],
+  H265: ["8bit_420", "8bit_444", "10bit_420", "10bit_444"],
+  AV1: ["8bit_420", "10bit_420"],
 };
 
 export function isSupportedUserFacingCodec(codec: VideoCodec): boolean {


### PR DESCRIPTION
This PR restricts video codec and color quality options to the stable H264/8-bit 4:2:0 combination. It removes user-facing H265/AV1 and higher color-depth modes, migrates persisted unsupported values to safe defaults, and normalizes stream preferences across all session creation paths to ensure no stale unsafe values leak through.

**Shared Types & Helpers:**
* Restricted `USER_FACING_VIDEO_CODEC_OPTIONS` to `H264` only in `src/shared/gfn.ts`
* Restricted `USER_FACING_COLOR_QUALITY_OPTIONS` to `8bit_420` only
* Added `normalizeStreamPreferences` to canonicalize codec/color-color pairs and report migration status
* Added `getDefaultStreamPreferences` to provide centralized safe defaults
* Added `getAllowedColorQualitiesForCodec` and `isAllowedColorQualityForCodec` helpers

**Main Process:**
* Updated `src/main/settings.ts` to use `getDefaultStreamPreferences` for default `codec`/`colorQuality` in `DEFAULT_SETTINGS`
* Strengthened `enforceCompatibility` to use `normalizeStreamPreferences` and migrate H265/AV1 or non-8bit_420 values to H264/8bit_420
* Added enforcement guards in `set()`, `setMultiple()`, and `reset()` to re-validate before saving
* Updated `src/main/gfn/cloudmatch.ts` to normalize codec/color in `buildSessionRequestBody` before CloudMatch request
* Updated `claimSession` fallback defaults to use `getDefaultStreamPreferences` and normalize

**Renderer:**
* Updated `src/renderer/src/App.tsx` to use `USER_FACING_VIDEO_CODEC_OPTIONS` for options list
* Added `DEFAULT_STREAM_PREFERENCES` and applied it to local default state
* Added `applyNormalizedStreamPreferences` wrapper and normalized loaded settings on startup
* Updated `updateSetting` to normalize codec/color and persist migrated values atomically
* Passed normalized codec/color in `offer`, `claimSession`, and `createSession` paths
* Updated `src/renderer/src/components/SettingsPage.tsx` to render from safe-only exported user-facing codec and color options
* Removed `handleColorQualityChange` HEVC auto-switch logic and H265/AV1 helper text
* Added `normalizedStreamPreferences` memo to reflect normalized active state for proper chip highlighting

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/8569a40d-855d-4395-9b6a-ce5c1daa4434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-55&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-55"><img alt="OPE-55 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-55"></picture></a>