### PR TITLE
Fix(stream): use selected region URL for session creation

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1195,8 +1195,11 @@ export function App(): JSX.Element {
   }, [providers, providerIdpId, authSession]);
 
   const effectiveStreamingBaseUrl = useMemo(() => {
+    if (settings.region.trim()) {
+      return settings.region;
+    }
     return selectedProvider?.streamingServiceUrl ?? "";
-  }, [selectedProvider]);
+  }, [selectedProvider, settings.region]);
 
   const reportQueueAdAction = useCallback((adId: string, action: SessionAdAction, options?: QueueAdReportOptions): void => {
     const currentSession = sessionRef.current;


### PR DESCRIPTION
This PR applies the region URL selected in user settings when creating a streaming session. Previously, the `effectiveStreamingBaseUrl` hook always defaulted to the provider's generic `streamingServiceUrl`, ignoring the manual region preference stored in `settings.region`. The hook now prioritizes the saved region URL if one is set, ensuring session creation targets the specific endpoint selected by the user.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>