### PR TITLE
feat: automatically run codec diagnostics on startup and show decode badges

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -40,6 +40,7 @@ import { useControllerNavigation } from "./controllerNavigation";
 import { useElapsedSeconds } from "./utils/useElapsedSeconds";
 import { usePlaytime } from "./utils/usePlaytime";
 import { createStreamDiagnosticsStore } from "./utils/streamDiagnosticsStore";
+import { loadStoredCodecResults, saveStoredCodecResults, testCodecSupport, type CodecTestResult } from "./lib/codecDiagnostics";
 
 // UI Components
 import { LoginScreen } from "./components/LoginScreen";
@@ -641,6 +642,8 @@ export function App(): JSX.Element {
     enableL4S: false,
   });
   const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [codecResults, setCodecResults] = useState<CodecTestResult[] | null>(() => loadStoredCodecResults());
+  const [codecTesting, setCodecTesting] = useState(false);
   const [regions, setRegions] = useState<StreamRegion[]>([]);
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
   const diagnosticsStoreRef = useRef<ReturnType<typeof createStreamDiagnosticsStore> | null>(null);
@@ -672,10 +675,37 @@ export function App(): JSX.Element {
   const isStreaming = streamStatus === "streaming";
 
   const controllerOverlayOpenRef = useRef(false);
+  const codecTestPromiseRef = useRef<Promise<CodecTestResult[] | null> | null>(null);
 
   const resetStatsOverlayToPreference = useCallback((): void => {
     setShowStatsOverlay(settings.showStatsOnLaunch);
   }, [settings.showStatsOnLaunch]);
+
+  const runCodecTest = useCallback(async (): Promise<void> => {
+    if (codecTestPromiseRef.current) {
+      await codecTestPromiseRef.current;
+      return;
+    }
+
+    const testPromise = (async (): Promise<CodecTestResult[] | null> => {
+      setCodecTesting(true);
+      try {
+        const results = await testCodecSupport();
+        setCodecResults(results);
+        saveStoredCodecResults(results);
+        return results;
+      } catch (error) {
+        console.error("Codec test failed:", error);
+        return null;
+      } finally {
+        setCodecTesting(false);
+        codecTestPromiseRef.current = null;
+      }
+    })();
+
+    codecTestPromiseRef.current = testPromise;
+    await testPromise;
+  }, []);
 
   const handleControllerPageNavigate = useCallback((direction: "prev" | "next"): void => {
     if (controllerOverlayOpenRef.current) {
@@ -1595,6 +1625,17 @@ export function App(): JSX.Element {
 
     void initialize();
   }, []);
+
+  useEffect(() => {
+    saveStoredCodecResults(codecResults);
+  }, [codecResults]);
+
+  useEffect(() => {
+    if (codecResults || codecTesting) {
+      return;
+    }
+    void runCodecTest();
+  }, [codecResults, codecTesting, runCodecTest]);
 
   // Auto-load controller library at startup if enabled
   useEffect(() => {
@@ -3188,6 +3229,9 @@ export function App(): JSX.Element {
           <SettingsPage
             settings={settings}
             regions={regions}
+            codecResults={codecResults}
+            codecTesting={codecTesting}
+            onRunCodecTest={runCodecTest}
             onSettingChange={updateSetting}
           />
         )}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -676,6 +676,7 @@ export function App(): JSX.Element {
 
   const controllerOverlayOpenRef = useRef(false);
   const codecTestPromiseRef = useRef<Promise<CodecTestResult[] | null> | null>(null);
+  const codecStartupTestAttemptedRef = useRef(false);
 
   const resetStatsOverlayToPreference = useCallback((): void => {
     setShowStatsOverlay(settings.showStatsOnLaunch);
@@ -1631,9 +1632,10 @@ export function App(): JSX.Element {
   }, [codecResults]);
 
   useEffect(() => {
-    if (codecResults || codecTesting) {
+    if (codecResults || codecTesting || codecStartupTestAttemptedRef.current) {
       return;
     }
+    codecStartupTestAttemptedRef.current = true;
     void runCodecTest();
   }, [codecResults, codecTesting, runCodecTest]);
 

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -24,10 +24,14 @@ import {
   USER_FACING_VIDEO_CODEC_OPTIONS,
 } from "@shared/gfn";
 import { formatShortcutForDisplay, normalizeShortcut } from "../shortcuts";
+import { getCodecDecodeBadgeState, type CodecTestResult } from "../lib/codecDiagnostics";
 
 interface SettingsPageProps {
   settings: Settings;
   regions: StreamRegion[];
+  codecResults: CodecTestResult[] | null;
+  codecTesting: boolean;
+  onRunCodecTest: () => Promise<void>;
   onSettingChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
 }
 
@@ -253,88 +257,12 @@ function getFpsForResolution(entitled: EntitledResolution[], resolution: string)
   return [...new Set(fpsList)].sort((a, b) => a - b);
 }
 
-/* ── Codec diagnostics ────────────────────────────────────────────── */
-
-interface CodecTestResult {
-  codec: string;
-  /** Whether WebRTC can negotiate this codec at all */
-  webrtcSupported: boolean;
-  /** Whether MediaCapabilities reports decode support */
-  decodeSupported: boolean;
-  /** Whether MediaCapabilities says HW-accelerated (powerEfficient) */
-  hwAccelerated: boolean;
-  /** Whether encode is supported */
-  encodeSupported: boolean;
-  /** Whether encode is HW-accelerated */
-  encodeHwAccelerated: boolean;
-  /** Human-readable decode method (e.g. "D3D11", "VAAPI", "VideoToolbox", "Software") */
-  decodeVia: string;
-  /** Human-readable encode method */
-  encodeVia: string;
-  /** Profiles found in WebRTC capabilities */
-  profiles: string[];
-}
-
-/** Map of codec name to MediaCapabilities contentType and profile strings */
-const CODEC_TEST_CONFIGS: {
-  name: string;
-  webrtcMime: string;
-  decodeContentType: string;
-  encodeContentType: string;
-  profiles: { label: string; contentType: string }[];
-}[] = [
-  {
-    name: "H264",
-    webrtcMime: "video/H264",
-    decodeContentType: "video/mp4; codecs=\"avc1.42E01E\"",
-    encodeContentType: "video/mp4; codecs=\"avc1.42E01E\"",
-    profiles: [
-      { label: "Baseline", contentType: "video/mp4; codecs=\"avc1.42E01E\"" },
-      { label: "Main", contentType: "video/mp4; codecs=\"avc1.4D401E\"" },
-      { label: "High", contentType: "video/mp4; codecs=\"avc1.64001E\"" },
-    ],
-  },
-  {
-    name: "H265",
-    webrtcMime: "video/H265",
-    decodeContentType: "video/mp4; codecs=\"hev1.1.6.L93.B0\"",
-    encodeContentType: "video/mp4; codecs=\"hev1.1.6.L93.B0\"",
-    profiles: [
-      { label: "Main", contentType: "video/mp4; codecs=\"hev1.1.6.L93.B0\"" },
-      { label: "Main 10", contentType: "video/mp4; codecs=\"hev1.2.4.L93.B0\"" },
-    ],
-  },
-  {
-    name: "AV1",
-    webrtcMime: "video/AV1",
-    decodeContentType: "video/mp4; codecs=\"av01.0.08M.08\"",
-    encodeContentType: "video/mp4; codecs=\"av01.0.08M.08\"",
-    profiles: [
-      { label: "Main 8-bit", contentType: "video/mp4; codecs=\"av01.0.08M.08\"" },
-      { label: "Main 10-bit", contentType: "video/mp4; codecs=\"av01.0.08M.10\"" },
-    ],
-  },
-];
-
-const CODEC_TEST_RESULTS_STORAGE_KEY = "opennow.codec-test-results.v1";
 const PING_RESULTS_STORAGE_KEY = "opennow.ping-results.v1";
 const ENTITLED_RESOLUTIONS_STORAGE_KEY = "opennow.entitled-resolutions.v1";
 
 interface EntitledResolutionsCache {
   userId: string;
   entitledResolutions: EntitledResolution[];
-}
-
-function loadStoredCodecResults(): CodecTestResult[] | null {
-  try {
-    const raw = window.sessionStorage.getItem(CODEC_TEST_RESULTS_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return null;
-    return parsed as CodecTestResult[];
-  } catch {
-    return null;
-  }
 }
 
 interface PingCacheEntry {
@@ -395,159 +323,9 @@ function saveCachedEntitledResolutions(cache: EntitledResolutionsCache): void {
   }
 }
 
-function isLinuxArmClient(): boolean {
-  const platform = navigator.platform?.toLowerCase() ?? "";
-  const ua = navigator.userAgent?.toLowerCase() ?? "";
-  const linux = platform.includes("linux") || ua.includes("linux");
-  const arm = /(aarch64|arm64|armv\d|arm)/.test(platform) || /(aarch64|arm64|armv\d|arm)/.test(ua);
-  return linux && arm;
-}
-
-function guessDecodeBackend(hwAccelerated: boolean): string {
-  if (!hwAccelerated) return "Software (CPU)";
-  const platform = navigator.platform?.toLowerCase() ?? "";
-  const ua = navigator.userAgent?.toLowerCase() ?? "";
-  if (platform.includes("win") || ua.includes("windows")) return "D3D11 (GPU)";
-  if (platform.includes("mac") || ua.includes("macintosh")) return "VideoToolbox (GPU)";
-  if (platform.includes("linux") || ua.includes("linux")) {
-    return isLinuxArmClient() ? "V4L2 (GPU)" : "VA-API (GPU)";
-  }
-  return "Hardware (GPU)";
-}
-
-function guessEncodeBackend(hwAccelerated: boolean): string {
-  if (!hwAccelerated) return "Software (CPU)";
-  const platform = navigator.platform?.toLowerCase() ?? "";
-  const ua = navigator.userAgent?.toLowerCase() ?? "";
-  if (platform.includes("win") || ua.includes("windows")) return "Media Foundation (GPU)";
-  if (platform.includes("mac") || ua.includes("macintosh")) return "VideoToolbox (GPU)";
-  if (platform.includes("linux") || ua.includes("linux")) {
-    return isLinuxArmClient() ? "V4L2 (GPU)" : "VA-API (GPU)";
-  }
-  return "Hardware (GPU)";
-}
-
-async function testCodecSupport(): Promise<CodecTestResult[]> {
-  const results: CodecTestResult[] = [];
-
-  // Get WebRTC receiver capabilities once
-  const webrtcCaps = RTCRtpReceiver.getCapabilities?.("video");
-  const webrtcCodecMimes = new Set(
-    webrtcCaps?.codecs.map((c) => c.mimeType.toLowerCase()) ?? [],
-  );
-
-  // Collect WebRTC profiles per codec
-  const webrtcProfiles = new Map<string, string[]>();
-  if (webrtcCaps) {
-    for (const c of webrtcCaps.codecs) {
-      const mime = c.mimeType.toLowerCase();
-      const sdpLine = (c as unknown as Record<string, string>).sdpFmtpLine ?? "";
-      if (!mime.includes("rtx") && !mime.includes("red") && !mime.includes("ulpfec")) {
-        const existing = webrtcProfiles.get(mime) ?? [];
-        if (sdpLine) existing.push(sdpLine);
-        webrtcProfiles.set(mime, existing);
-      }
-    }
-  }
-
-  for (const config of CODEC_TEST_CONFIGS) {
-    const webrtcSupported = webrtcCodecMimes.has(config.webrtcMime.toLowerCase());
-    const profiles = webrtcProfiles.get(config.webrtcMime.toLowerCase()) ?? [];
-
-    // Test decode via MediaCapabilities API
-    let decodeSupported = false;
-    let hwAccelerated = false;
-    try {
-      const decodeResult = await navigator.mediaCapabilities.decodingInfo({
-        type: "webrtc",
-        video: {
-          contentType: config.webrtcMime === "video/H265" ? "video/h265" : config.webrtcMime.toLowerCase(),
-          width: 1920,
-          height: 1080,
-          framerate: 60,
-          bitrate: 20_000_000,
-        },
-      });
-      decodeSupported = decodeResult.supported;
-      hwAccelerated = decodeResult.powerEfficient;
-    } catch {
-      // webrtc type may not be supported, fall back to file type
-      try {
-        const decodeResult = await navigator.mediaCapabilities.decodingInfo({
-          type: "file",
-          video: {
-            contentType: config.decodeContentType,
-            width: 1920,
-            height: 1080,
-            framerate: 60,
-            bitrate: 20_000_000,
-          },
-        });
-        decodeSupported = decodeResult.supported;
-        hwAccelerated = decodeResult.powerEfficient;
-      } catch {
-        // Codec not recognized at all
-      }
-    }
-
-    // Test encode via MediaCapabilities API
-    let encodeSupported = false;
-    let encodeHwAccelerated = false;
-    try {
-      const encodeResult = await navigator.mediaCapabilities.encodingInfo({
-        type: "webrtc",
-        video: {
-          contentType: config.webrtcMime === "video/H265" ? "video/h265" : config.webrtcMime.toLowerCase(),
-          width: 1920,
-          height: 1080,
-          framerate: 60,
-          bitrate: 20_000_000,
-        },
-      });
-      encodeSupported = encodeResult.supported;
-      encodeHwAccelerated = encodeResult.powerEfficient;
-    } catch {
-      try {
-        const encodeResult = await navigator.mediaCapabilities.encodingInfo({
-          type: "record",
-          video: {
-            contentType: config.encodeContentType,
-            width: 1920,
-            height: 1080,
-            framerate: 60,
-            bitrate: 20_000_000,
-          },
-        });
-        encodeSupported = encodeResult.supported;
-        encodeHwAccelerated = encodeResult.powerEfficient;
-      } catch {
-        // Codec not recognized at all
-      }
-    }
-
-    results.push({
-      codec: config.name,
-      webrtcSupported,
-      decodeSupported: decodeSupported || webrtcSupported, // WebRTC support implies decode
-      hwAccelerated,
-      encodeSupported,
-      encodeHwAccelerated,
-      decodeVia: (decodeSupported || webrtcSupported)
-        ? guessDecodeBackend(hwAccelerated)
-        : "Unsupported",
-      encodeVia: encodeSupported
-        ? guessEncodeBackend(encodeHwAccelerated)
-        : "Unsupported",
-      profiles,
-    });
-  }
-
-  return results;
-}
-
 /* ── Component ────────────────────────────────────────────────────── */
 
-export function SettingsPage({ settings, regions, onSettingChange }: SettingsPageProps): JSX.Element {
+export function SettingsPage({ settings, regions, onSettingChange, codecResults, codecTesting, onRunCodecTest }: SettingsPageProps): JSX.Element {
   const [savedIndicator, setSavedIndicator] = useState(false);
   const [activeTab, setActiveTab] = useState<"preferences" | "thanks">("preferences");
   const [thanksData, setThanksData] = useState<ThankYouDataResult | null>(null);
@@ -558,11 +336,7 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
   const [regionSearch, setRegionSearch] = useState("");
   const [regionDropdownOpen, setRegionDropdownOpen] = useState(false);
 
-  // Codec diagnostics
-  const initialCodecResults = useMemo(() => loadStoredCodecResults(), []);
-  const [codecResults, setCodecResults] = useState<CodecTestResult[] | null>(initialCodecResults);
-  const [codecTesting, setCodecTesting] = useState(false);
-  const [codecTestOpen, setCodecTestOpen] = useState(() => initialCodecResults !== null);
+  const codecTestOpen = codecResults !== null || codecTesting;
 
   // Region ping state
   const initialPingResults = useMemo(() => loadStoredPingResults(), []);
@@ -632,31 +406,6 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
       runPingTest();
     }
   }, [regions, pingResults.size, isPinging, runPingTest]);
-
-  const runCodecTest = useCallback(async () => {
-    setCodecTesting(true);
-    setCodecTestOpen(true);
-    try {
-      const results = await testCodecSupport();
-      setCodecResults(results);
-    } catch (err) {
-      console.error("Codec test failed:", err);
-    } finally {
-      setCodecTesting(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    try {
-      if (codecResults && codecResults.length > 0) {
-        window.sessionStorage.setItem(CODEC_TEST_RESULTS_STORAGE_KEY, JSON.stringify(codecResults));
-      } else {
-        window.sessionStorage.removeItem(CODEC_TEST_RESULTS_STORAGE_KEY);
-      }
-    } catch {
-      // Ignore storage failures (private mode / denied storage)
-    }
-  }, [codecResults]);
 
   const [toggleStatsInput, setToggleStatsInput] = useState(settings.shortcutToggleStats);
   const [togglePointerLockInput, setTogglePointerLockInput] = useState(settings.shortcutTogglePointerLock);
@@ -1595,15 +1344,25 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
             <div className="settings-row">
               <label className="settings-label">Codec</label>
               <div className="settings-chip-row">
-                {codecOptions.map((codec) => (
-                  <button
-                    key={codec}
-                    className={`settings-chip ${settings.codec === codec ? "active" : ""}`}
-                    onClick={() => handleCodecChange(codec)}
-                  >
-                    {codec}
-                  </button>
-                ))}
+                {codecOptions.map((codec) => {
+                  const badgeState = getCodecDecodeBadgeState(codec, codecResults, codecTesting);
+                  return (
+                    <button
+                      key={codec}
+                      className={`settings-chip settings-chip--codec ${settings.codec === codec ? "active" : ""}`}
+                      onClick={() => handleCodecChange(codec)}
+                    >
+                      <span>{codec}</span>
+                      {badgeState && (
+                        <span
+                          className={`settings-inline-badge settings-inline-badge--codec settings-inline-badge--codec-${badgeState}`}
+                        >
+                          {badgeState === "gpu" ? "GPU" : badgeState === "cpu" ? "CPU" : "Testing…"}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
               </div>
             </div>
 
@@ -1716,7 +1475,9 @@ export function SettingsPage({ settings, regions, onSettingChange }: SettingsPag
               </label>
               <button
                 className="codec-test-btn"
-                onClick={runCodecTest}
+                onClick={() => {
+                  void onRunCodecTest();
+                }}
                 disabled={codecTesting}
                 type="button"
               >

--- a/opennow-stable/src/renderer/src/lib/codecDiagnostics.ts
+++ b/opennow-stable/src/renderer/src/lib/codecDiagnostics.ts
@@ -1,0 +1,217 @@
+import type { VideoCodec } from "@shared/gfn";
+
+export interface CodecTestResult {
+  codec: string;
+  webrtcSupported: boolean;
+  decodeSupported: boolean;
+  hwAccelerated: boolean;
+  encodeSupported: boolean;
+  encodeHwAccelerated: boolean;
+  decodeVia: string;
+  encodeVia: string;
+  profiles: string[];
+}
+
+const CODEC_TEST_CONFIGS: {
+  name: VideoCodec;
+  webrtcMime: string;
+  decodeContentType: string;
+  encodeContentType: string;
+}[] = [
+  {
+    name: "H264",
+    webrtcMime: "video/H264",
+    decodeContentType: 'video/mp4; codecs="avc1.42E01E"',
+    encodeContentType: 'video/mp4; codecs="avc1.42E01E"',
+  },
+  {
+    name: "H265",
+    webrtcMime: "video/H265",
+    decodeContentType: 'video/mp4; codecs="hev1.1.6.L93.B0"',
+    encodeContentType: 'video/mp4; codecs="hev1.1.6.L93.B0"',
+  },
+  {
+    name: "AV1",
+    webrtcMime: "video/AV1",
+    decodeContentType: 'video/mp4; codecs="av01.0.08M.08"',
+    encodeContentType: 'video/mp4; codecs="av01.0.08M.08"',
+  },
+];
+
+export const CODEC_TEST_RESULTS_STORAGE_KEY = "opennow.codec-test-results.v1";
+
+export function loadStoredCodecResults(): CodecTestResult[] | null {
+  try {
+    const raw = window.sessionStorage.getItem(CODEC_TEST_RESULTS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    return parsed as CodecTestResult[];
+  } catch {
+    return null;
+  }
+}
+
+export function saveStoredCodecResults(results: CodecTestResult[] | null): void {
+  try {
+    if (results && results.length > 0) {
+      window.sessionStorage.setItem(CODEC_TEST_RESULTS_STORAGE_KEY, JSON.stringify(results));
+      return;
+    }
+    window.sessionStorage.removeItem(CODEC_TEST_RESULTS_STORAGE_KEY);
+  } catch {
+  }
+}
+
+function isLinuxArmClient(): boolean {
+  const platform = navigator.platform?.toLowerCase() ?? "";
+  const ua = navigator.userAgent?.toLowerCase() ?? "";
+  const linux = platform.includes("linux") || ua.includes("linux");
+  const arm = /(aarch64|arm64|armv\d|arm)/.test(platform) || /(aarch64|arm64|armv\d|arm)/.test(ua);
+  return linux && arm;
+}
+
+function guessDecodeBackend(hwAccelerated: boolean): string {
+  if (!hwAccelerated) return "Software (CPU)";
+  const platform = navigator.platform?.toLowerCase() ?? "";
+  const ua = navigator.userAgent?.toLowerCase() ?? "";
+  if (platform.includes("win") || ua.includes("windows")) return "D3D11 (GPU)";
+  if (platform.includes("mac") || ua.includes("macintosh")) return "VideoToolbox (GPU)";
+  if (platform.includes("linux") || ua.includes("linux")) {
+    return isLinuxArmClient() ? "V4L2 (GPU)" : "VA-API (GPU)";
+  }
+  return "Hardware (GPU)";
+}
+
+function guessEncodeBackend(hwAccelerated: boolean): string {
+  if (!hwAccelerated) return "Software (CPU)";
+  const platform = navigator.platform?.toLowerCase() ?? "";
+  const ua = navigator.userAgent?.toLowerCase() ?? "";
+  if (platform.includes("win") || ua.includes("windows")) return "Media Foundation (GPU)";
+  if (platform.includes("mac") || ua.includes("macintosh")) return "VideoToolbox (GPU)";
+  if (platform.includes("linux") || ua.includes("linux")) {
+    return isLinuxArmClient() ? "V4L2 (GPU)" : "VA-API (GPU)";
+  }
+  return "Hardware (GPU)";
+}
+
+export async function testCodecSupport(): Promise<CodecTestResult[]> {
+  const results: CodecTestResult[] = [];
+  const webrtcCaps = RTCRtpReceiver.getCapabilities?.("video");
+  const webrtcCodecMimes = new Set(webrtcCaps?.codecs.map((codec) => codec.mimeType.toLowerCase()) ?? []);
+  const webrtcProfiles = new Map<string, string[]>();
+
+  if (webrtcCaps) {
+    for (const codec of webrtcCaps.codecs) {
+      const mime = codec.mimeType.toLowerCase();
+      const sdpLine = (codec as unknown as Record<string, string>).sdpFmtpLine ?? "";
+      if (!mime.includes("rtx") && !mime.includes("red") && !mime.includes("ulpfec")) {
+        const existing = webrtcProfiles.get(mime) ?? [];
+        if (sdpLine) existing.push(sdpLine);
+        webrtcProfiles.set(mime, existing);
+      }
+    }
+  }
+
+  for (const config of CODEC_TEST_CONFIGS) {
+    const webrtcSupported = webrtcCodecMimes.has(config.webrtcMime.toLowerCase());
+    const profiles = webrtcProfiles.get(config.webrtcMime.toLowerCase()) ?? [];
+
+    let decodeSupported = false;
+    let hwAccelerated = false;
+    try {
+      const decodeResult = await navigator.mediaCapabilities.decodingInfo({
+        type: "webrtc",
+        video: {
+          contentType: config.webrtcMime === "video/H265" ? "video/h265" : config.webrtcMime.toLowerCase(),
+          width: 1920,
+          height: 1080,
+          framerate: 60,
+          bitrate: 20_000_000,
+        },
+      });
+      decodeSupported = decodeResult.supported;
+      hwAccelerated = decodeResult.powerEfficient;
+    } catch {
+      try {
+        const decodeResult = await navigator.mediaCapabilities.decodingInfo({
+          type: "file",
+          video: {
+            contentType: config.decodeContentType,
+            width: 1920,
+            height: 1080,
+            framerate: 60,
+            bitrate: 20_000_000,
+          },
+        });
+        decodeSupported = decodeResult.supported;
+        hwAccelerated = decodeResult.powerEfficient;
+      } catch {
+      }
+    }
+
+    let encodeSupported = false;
+    let encodeHwAccelerated = false;
+    try {
+      const encodeResult = await navigator.mediaCapabilities.encodingInfo({
+        type: "webrtc",
+        video: {
+          contentType: config.webrtcMime === "video/H265" ? "video/h265" : config.webrtcMime.toLowerCase(),
+          width: 1920,
+          height: 1080,
+          framerate: 60,
+          bitrate: 20_000_000,
+        },
+      });
+      encodeSupported = encodeResult.supported;
+      encodeHwAccelerated = encodeResult.powerEfficient;
+    } catch {
+      try {
+        const encodeResult = await navigator.mediaCapabilities.encodingInfo({
+          type: "record",
+          video: {
+            contentType: config.encodeContentType,
+            width: 1920,
+            height: 1080,
+            framerate: 60,
+            bitrate: 20_000_000,
+          },
+        });
+        encodeSupported = encodeResult.supported;
+        encodeHwAccelerated = encodeResult.powerEfficient;
+      } catch {
+      }
+    }
+
+    results.push({
+      codec: config.name,
+      webrtcSupported,
+      decodeSupported,
+      hwAccelerated,
+      encodeSupported,
+      encodeHwAccelerated,
+      decodeVia: decodeSupported ? guessDecodeBackend(hwAccelerated) : "Unsupported",
+      encodeVia: encodeSupported ? guessEncodeBackend(encodeHwAccelerated) : "Unsupported",
+      profiles,
+    });
+  }
+
+  return results;
+}
+
+export type CodecDecodeBadgeState = "gpu" | "cpu" | "testing" | null;
+
+export function getCodecDecodeBadgeState(
+  codec: VideoCodec,
+  codecResults: CodecTestResult[] | null,
+  codecTesting: boolean,
+): CodecDecodeBadgeState {
+  const result = codecResults?.find((entry) => entry.codec === codec);
+  if (!result) {
+    return codecTesting ? "testing" : null;
+  }
+  if (!result.decodeSupported) {
+    return null;
+  }
+  return result.hwAccelerated ? "gpu" : "cpu";
+}

--- a/opennow-stable/src/renderer/src/lib/codecDiagnostics.ts
+++ b/opennow-stable/src/renderer/src/lib/codecDiagnostics.ts
@@ -183,14 +183,16 @@ export async function testCodecSupport(): Promise<CodecTestResult[]> {
       }
     }
 
+    const effectiveDecodeSupported = decodeSupported || webrtcSupported;
+
     results.push({
       codec: config.name,
       webrtcSupported,
-      decodeSupported,
+      decodeSupported: effectiveDecodeSupported,
       hwAccelerated,
       encodeSupported,
       encodeHwAccelerated,
-      decodeVia: decodeSupported ? guessDecodeBackend(hwAccelerated) : "Unsupported",
+      decodeVia: effectiveDecodeSupported ? guessDecodeBackend(hwAccelerated) : "Unsupported",
       encodeVia: encodeSupported ? guessEncodeBackend(encodeHwAccelerated) : "Unsupported",
       profiles,
     });

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -2318,6 +2318,28 @@ button.game-card-store-chip.active:hover {
   border-color: rgba(88, 217, 138, 0.24);
 }
 
+.settings-inline-badge--codec {
+  margin-left: 2px;
+}
+
+.settings-inline-badge--codec-gpu {
+  color: var(--accent);
+  background: var(--accent-surface);
+  border-color: rgba(88, 217, 138, 0.24);
+}
+
+.settings-inline-badge--codec-cpu {
+  color: var(--warning);
+  background: rgba(251, 191, 36, 0.1);
+  border-color: rgba(251, 191, 36, 0.22);
+}
+
+.settings-inline-badge--codec-testing {
+  color: var(--ink-soft);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--panel-border);
+}
+
 .settings-hint {
   display: block;
   margin-top: 2px;
@@ -2460,6 +2482,15 @@ button.game-card-store-chip.active:hover {
   background: var(--accent-surface-strong);
   color: var(--accent);
   border-color: rgba(88, 217, 138, 0.25);
+}
+
+.settings-chip--codec {
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.settings-chip--codec .settings-inline-badge {
+  max-width: 100%;
 }
 
 /* Tier indicator on preset chips */


### PR DESCRIPTION
This PR automatically runs codec diagnostics at app startup and surfaces the decode backend result inline next to each codec option in Settings. The existing manual test behavior is preserved, sharing the same state and results between startup and Settings.

**Shared Renderer Utilities:**
* Added `src/renderer/src/lib/codecDiagnostics.ts` module with `CodecTestResult`, `CODEC_TEST_RESULTS_STORAGE_KEY`, `loadStoredCodecResults`, `saveStoredCodecResults`, `testCodecSupport`, `getCodecDecodeBadgeState`, and platform-specific backend inference helpers

**App State & Startup:**
* Moved codec diagnostics ownership to App with state initialized from `sessionStorage`
* Implemented `runCodecTest` with promise tracking to prevent overlapping runs
* Added automatic background test trigger on first render when results are absent
* Passed `codecResults`, `codecTesting`, and `onRunCodecTest` to SettingsPage

**Settings UI:**
* Updated SettingsPage to consume shared codec state via props
* Added inline decode badge to each codec chip (GPU green, CPU yellow)
* Wired manual Test Codecs button to shared `onRunCodecTest` callback
* Preserved Diagnostics section display of detailed results

**Styles:**
* Added `.settings-inline-badge--codec-gpu`, `.settings-inline-badge--codec-cpu`, `.settings-inline-badge--codec-testing` variants
* Added `.settings-chip--codec` with flex-wrap layout for badge accommodation

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/efee366a-4bcf-442e-81a8-42dfcaf1caa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-56&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-56"><img alt="OPE-56 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-56"></picture></a>