### PR TITLE
Fix Ping testing and remove inactive servers

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -1670,6 +1670,72 @@ function registerIpcHandlers(): void {
     return normalizedData;
   });
 
+  ipcMain.handle(IPC_CHANNELS.PRINTEDWASTE_SERVER_MAPPING_FETCH, async () => {
+    const PRINTEDWASTE_MAPPING_TIMEOUT_MS = 7000;
+    const version = app.getVersion();
+    const response = await fetchWithTimeout(
+      "https://remote.printedwaste.com/config/GFN_SERVERID_TO_REGION_MAPPING",
+      {
+        headers: {
+          "User-Agent": `opennow/${version}`,
+          Accept: "application/json",
+        },
+      },
+      PRINTEDWASTE_MAPPING_TIMEOUT_MS,
+      "PrintedWaste server mapping request",
+    );
+    if (!response.ok) {
+      throw new Error(`PrintedWaste server mapping returned HTTP ${response.status}`);
+    }
+
+    const body = await withTimeout(
+      response.json() as Promise<unknown>,
+      PRINTEDWASTE_MAPPING_TIMEOUT_MS,
+      "PrintedWaste server mapping response parse",
+    );
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      throw new Error("PrintedWaste server mapping response was not an object");
+    }
+
+    const apiBody = body as { status?: unknown; data?: unknown };
+    if (typeof apiBody.status !== "boolean") {
+      throw new Error("PrintedWaste server mapping response missing boolean status");
+    }
+    if (!apiBody.status) {
+      throw new Error("PrintedWaste server mapping returned status:false");
+    }
+    if (!apiBody.data || typeof apiBody.data !== "object" || Array.isArray(apiBody.data)) {
+      throw new Error("PrintedWaste server mapping response missing data object");
+    }
+
+    const normalizedData: Record<
+      string,
+      { title?: string; region?: string; is4080Server?: boolean; is5080Server?: boolean; nuked?: boolean }
+    > = {};
+
+    for (const [zoneId, rawZone] of Object.entries(apiBody.data as Record<string, unknown>)) {
+      if (!rawZone || typeof rawZone !== "object" || Array.isArray(rawZone)) {
+        continue;
+      }
+      const zone = rawZone as Record<string, unknown>;
+      const title = zone.title;
+      const region = zone.region;
+      const is4080Server = zone.is4080Server;
+      const is5080Server = zone.is5080Server;
+      const nuked = zone.nuked;
+
+      normalizedData[zoneId] = {
+        ...(typeof title === "string" ? { title } : {}),
+        ...(typeof region === "string" ? { region } : {}),
+        ...(typeof is4080Server === "boolean" ? { is4080Server } : {}),
+        ...(typeof is5080Server === "boolean" ? { is5080Server } : {}),
+        ...(typeof nuked === "boolean" ? { nuked } : {}),
+      };
+    }
+
+    return normalizedData;
+  });
+
   // Save window size when it changes
   mainWindow?.on("resize", () => {
     if (mainWindow && !mainWindow.isDestroyed()) {

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -33,6 +33,7 @@ import type {
   RecordingDeleteRequest,
   MediaListingResult,
   PrintedWasteQueueData,
+  PrintedWasteServerMapping,
   ThankYouDataResult,
 } from "@shared/gfn";
 import { parseSerializedSessionErrorTransport } from "@shared/sessionError";
@@ -146,6 +147,8 @@ const api: OpenNowApi = {
     ipcRenderer.invoke(IPC_CHANNELS.CACHE_DELETE_ALL),
   fetchPrintedWasteQueue: (): Promise<PrintedWasteQueueData> =>
     ipcRenderer.invoke(IPC_CHANNELS.PRINTEDWASTE_QUEUE_FETCH),
+  fetchPrintedWasteServerMapping: (): Promise<PrintedWasteServerMapping> =>
+    ipcRenderer.invoke(IPC_CHANNELS.PRINTEDWASTE_SERVER_MAPPING_FETCH),
   getThanksData: (): Promise<ThankYouDataResult> => ipcRenderer.invoke(IPC_CHANNELS.COMMUNITY_GET_THANKS),
 };
 

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -2592,7 +2592,10 @@ export function App(): JSX.Element {
 
   // Gate handler: shows queue server modal for FREE-tier users before launching
   const handleInitiatePlay = useCallback(async (game: GameInfo) => {
-    const isFreeUser = subscriptionInfo?.membershipTier === "FREE";
+    const effectiveTier = normalizeMembershipTier(
+      subscriptionInfo?.membershipTier ?? authSession?.user.membershipTier,
+    );
+    const isFreeUser = effectiveTier === "FREE";
     if (isFreeUser && streamStatus === "idle" && !launchInFlightRef.current) {
       try {
         const [queueResult, mappingResult] = await Promise.allSettled([
@@ -2639,7 +2642,7 @@ export function App(): JSX.Element {
       return;
     }
     void handlePlayGame(game);
-  }, [subscriptionInfo, streamStatus, handlePlayGame]);
+  }, [subscriptionInfo, authSession, streamStatus, handlePlayGame]);
 
   const handleQueueModalConfirm = useCallback((zoneUrl: string | null) => {
     const game = queueModalGame;

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import type {
   StreamRegion,
   VideoCodec,
   PrintedWasteQueueData,
+  PrintedWasteServerMapping,
 } from "@shared/gfn";
 import {
   DEFAULT_KEYBOARD_LAYOUT,
@@ -132,6 +133,19 @@ type QueueAdReportOptions = {
 const APP_PAGE_ORDER: AppPage[] = ["home", "library", "settings"];
 
 const isMac = navigator.platform.toLowerCase().includes("mac");
+
+function isStandardPrintedWasteZone(zoneId: string): boolean {
+  return zoneId.startsWith("NP-") && !zoneId.startsWith("NPA-");
+}
+
+function hasAnyEligiblePrintedWasteZone(
+  queueData: PrintedWasteQueueData,
+  mapping: PrintedWasteServerMapping,
+): boolean {
+  return Object.keys(queueData).some((zoneId) => (
+    isStandardPrintedWasteZone(zoneId) && mapping[zoneId]?.nuked !== true
+  ));
+}
 
 const DEFAULT_SHORTCUTS = {
   shortcutToggleStats: "F3",
@@ -2581,15 +2595,44 @@ export function App(): JSX.Element {
     const isFreeUser = subscriptionInfo?.membershipTier === "FREE";
     if (isFreeUser && streamStatus === "idle" && !launchInFlightRef.current) {
       try {
-        const queueData = await window.openNow.fetchPrintedWasteQueue();
-        if (!queueData || Object.keys(queueData).length === 0) {
+        const [queueResult, mappingResult] = await Promise.allSettled([
+          window.openNow.fetchPrintedWasteQueue(),
+          window.openNow.fetchPrintedWasteServerMapping(),
+        ]);
+
+        if (queueResult.status !== "fulfilled" || mappingResult.status !== "fulfilled") {
+          console.warn(
+            "[QueueServerSelect] PrintedWaste unavailable, skipping queue checks and launching with default routing.",
+            {
+              queueStatus: queueResult.status,
+              mappingStatus: mappingResult.status,
+            },
+          );
+          setQueueModalData(null);
           void handlePlayGame(game);
           return;
         }
+
+        const queueData = queueResult.value;
+        if (!queueData || Object.keys(queueData).length === 0) {
+          setQueueModalData(null);
+          void handlePlayGame(game);
+          return;
+        }
+
+        if (!hasAnyEligiblePrintedWasteZone(queueData, mappingResult.value)) {
+          console.warn(
+            "[QueueServerSelect] No eligible non-nuked PrintedWaste zones available, skipping queue checks.",
+          );
+          setQueueModalData(null);
+          void handlePlayGame(game);
+          return;
+        }
+
         setQueueModalData(queueData);
         setQueueModalGame(game);
       } catch (error) {
-        console.warn("[QueueServerSelect] Queue API unavailable, launching without modal.", error);
+        console.warn("[QueueServerSelect] PrintedWaste queue checks failed, launching without modal.", error);
         setQueueModalData(null);
         void handlePlayGame(game);
       }

--- a/opennow-stable/src/renderer/src/components/QueueServerSelectModal.tsx
+++ b/opennow-stable/src/renderer/src/components/QueueServerSelectModal.tsx
@@ -57,7 +57,6 @@ const REGION_META: Record<string, { label: string; flag: string }> = {
 };
 const REGION_ORDER = ["US", "CA", "EU", "JP", "KR", "THAI", "MY"];
 const PRINTEDWASTE_PING_CACHE_KEY = "opennow.printedwaste-pings.v1";
-const MAX_PING_ZONES_PER_OPEN = 12;
 const QUEUE_REFRESH_INTERVAL_MS = 2 * 60 * 1000;
 
 interface PingCacheEntry {
@@ -117,6 +116,7 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
   const [queueData,  setQueueData]  = useState<PrintedWasteQueueData | null>(initialQueueData);
   const [queueLoading, setQueueLoading] = useState(initialQueueData === null);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const [nukedZoneIds, setNukedZoneIds] = useState<Set<string> | null>(null);
 
   // Ping state — populated after queue data loads
   const [zonePings,  setZonePings]  = useState<Map<string, number | null> | null>(null);
@@ -176,18 +176,53 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
     dialogRef.current?.focus();
   }, []);
 
+  // Fetch PrintedWaste server metadata and hide zones flagged as nuked.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const mapping = await window.openNow.fetchPrintedWasteServerMapping();
+        if (cancelled) return;
+        const nextNuked = new Set<string>();
+        for (const [zoneId, meta] of Object.entries(mapping)) {
+          if (isStandardZone(zoneId) && meta.nuked === true) {
+            nextNuked.add(zoneId);
+          }
+        }
+        setNukedZoneIds(nextNuked);
+      } catch (error) {
+        // PrintedWaste metadata is required for queue checks. If unavailable,
+        // bypass this modal and continue launch with default routing.
+        if (!cancelled) {
+          console.warn("[QueueServerSelect] PrintedWaste mapping unavailable, skipping queue checks.", error);
+          onConfirm(null);
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [onConfirm]);
+
   // ── Ping all standard zones once queue data arrives ───────────────────────
   useEffect(() => {
-    if (!queueData) return;
+    if (nukedZoneIds === null) return;
+    if (!queueData) {
+      setZonePings(null);
+      setIsPinging(false);
+      return;
+    }
     const allStandardZones = Object.entries(queueData)
-      .filter(([zoneId]) => isStandardZone(zoneId))
+      .filter(([zoneId]) => isStandardZone(zoneId) && !nukedZoneIds.has(zoneId))
       .map(([zoneId, zone]) => ({
         zoneId,
         pwRegion: zone.Region,
         queuePosition: zone.QueuePosition,
         routingUrl: constructZoneUrl(zoneId),
       }));
-    if (allStandardZones.length === 0) return;
+    if (allStandardZones.length === 0) {
+      setZonePings(new Map());
+      setIsPinging(false);
+      return;
+    }
 
     let cancelled = false;
     const cachedPings = loadStoredPingResults();
@@ -217,11 +252,14 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
         .sort((a, b) => a.queuePosition - b.queuePosition),
     ];
 
-    const zonesToPing = prioritized
-      .filter((zone) => !seedMap.has(zone.routingUrl))
-      .slice(0, MAX_PING_ZONES_PER_OPEN);
+    // Ping every uncached standard zone in this pass so recommendations are based on
+    // complete latency data instead of a partial subset.
+    const zonesToPing = prioritized.filter((zone) => !seedMap.has(zone.routingUrl));
 
-    if (zonesToPing.length === 0) return;
+    if (zonesToPing.length === 0) {
+      setIsPinging(false);
+      return;
+    }
     const regionsToTest = zonesToPing.map((zone) => ({ name: zone.zoneId, url: zone.routingUrl }));
 
     setIsPinging(true);
@@ -240,13 +278,13 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
       }
     })();
     return () => { cancelled = true; };
-  }, [queueData]);
+  }, [queueData, nukedZoneIds]);
 
   // ── Build enriched zone list (standard zones only) ────────────────────────
   const zones = useMemo<ZoneInfo[]>(() => {
     if (!queueData) return [];
     return Object.entries(queueData)
-      .filter(([zoneId]) => isStandardZone(zoneId))
+      .filter(([zoneId]) => isStandardZone(zoneId) && !nukedZoneIds?.has(zoneId))
       .map(([zoneId, zone]: [string, PrintedWasteZone]) => {
         const routingUrl = constructZoneUrl(zoneId);
         const pingMs = zonePings?.get(routingUrl) ?? null;
@@ -259,7 +297,16 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
           pingMs,
         };
       });
-  }, [queueData, zonePings]);
+  }, [queueData, zonePings, nukedZoneIds]);
+
+  // If queue refresh removes a previously selected manual zone, fall back to auto.
+  useEffect(() => {
+    if (selected === "auto" || selected === "closest") return;
+    const stillExists = zones.some((zone) => zone.zoneId === selected);
+    if (!stillExists) {
+      setSelected("auto");
+    }
+  }, [selected, zones]);
 
   // ── Recommendations ───────────────────────────────────────────────────────
 
@@ -311,10 +358,10 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
     if (selected === "auto") {
       onConfirm(autoZone?.routingUrl ?? null);
     } else if (selected === "closest") {
-      onConfirm(closestZone?.routingUrl ?? null);
+      onConfirm(closestZone?.routingUrl ?? autoZone?.routingUrl ?? null);
     } else {
       const zone = zones.find((z) => z.zoneId === selected);
-      onConfirm(zone?.routingUrl ?? null);
+      onConfirm(zone?.routingUrl ?? autoZone?.routingUrl ?? null);
     }
   }, [selected, autoZone, closestZone, zones, onConfirm]);
 
@@ -323,7 +370,7 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
     if (e.key === "Enter")  handleConfirm();
   }, [onCancel, handleConfirm]);
 
-  const isLoading = queueLoading;
+  const isLoading = queueLoading || nukedZoneIds === null;
 
   // ── Render ────────────────────────────────────────────────────────────────
   return (

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -689,6 +689,8 @@ export interface OpenNowApi {
 
   /** Fetch current GFN queue wait times from the PrintedWaste API */
   fetchPrintedWasteQueue(): Promise<PrintedWasteQueueData>;
+  /** Fetch PrintedWaste server mapping metadata (includes nuked status) */
+  fetchPrintedWasteServerMapping(): Promise<PrintedWasteServerMapping>;
   getThanksData(): Promise<ThankYouDataResult>;
 }
 
@@ -788,3 +790,15 @@ export interface PrintedWasteZone {
 
 /** Full data payload from https://api.printedwaste.com/gfn/queue/ */
 export type PrintedWasteQueueData = Record<string, PrintedWasteZone>;
+
+/** PrintedWaste server metadata entry from remote mapping config */
+export interface PrintedWasteServerMappingEntry {
+  title?: string;
+  region?: string;
+  is4080Server?: boolean;
+  is5080Server?: boolean;
+  nuked?: boolean;
+}
+
+/** Full data payload from PrintedWaste server-to-region mapping config */
+export type PrintedWasteServerMapping = Record<string, PrintedWasteServerMappingEntry>;

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -54,6 +54,7 @@ export const IPC_CHANNELS = {
   MEDIA_SHOW_IN_FOLDER: "media:show-in-folder",
   // PrintedWaste queue integration
   PRINTEDWASTE_QUEUE_FETCH: "printedwaste:queue-fetch",
+  PRINTEDWASTE_SERVER_MAPPING_FETCH: "printedwaste:server-mapping-fetch",
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];


### PR DESCRIPTION
This PR adds automatic sizing 
This pull request introduces Discord Rich Presence support to the project by adding the `discord-rpc` integration. It includes the necessary dependencies and a new module to manage Discord RPC connections and activity updates. The changes are primarily focused on enabling the application to show the current game being played as a Discord activity, with robust error handling to ensure the feature does not interfere with the rest of the app.

**Discord Rich Presence Integration:**

* Added the `discord-rpc` package and its type definitions (`@types/discord-rpc`) to both `dependencies` and `devDependencies` in `package.json` and `package-lock.json`. This allows the app to communicate with Discord for Rich Presence features. [[1]](diffhunk://#diff-92a0861fe2e1a2bea34ceb5de267e5e733bf4d1d5ed78bfb13f768da9c8269dcR26-R33) [[2]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR11-R18) [[3]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR2061-R2084) [[4]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f8304
This pull request enhances how the PrintedWaste queue and server selection logic work by integrating server metadata (including "nuked" status) from a new remote mapping API. This ensures that users are only shown eligible, non-nuked servers and that recommendations are based on complete, up-to-date data. The changes span the main process, preload, renderer, shared types, and IPC definitions.

**PrintedWaste server metadata integration:**

* Added a new IPC handler in `index.ts` to fetch PrintedWaste server-to-region mapping metadata from a remote API, with validation and error handling. This metadata includes the "nuked" status for each server.
* Defined new types in `gfn.ts` for `PrintedWasteServerMapping` and `PrintedWasteServerMappingEntry`, and added a corresponding API method to the `OpenNowApi` interface. [[1]](diffhunk://#diff-e21ccf956d30017091203ef0273aeabb57a63f8c24105e8439fe7cf90265bba6R793-R804) [[2]](diffhunk://#diff-e21ccf956d30017091203ef0273aeabb57a63f8c24105e8439fe7cf90265bba6R692-R693)
* Added a new IPC channel constant for fetching PrintedWaste server mapping metadata.

**Queue and server selection improvements:**

* Updated the preload script and renderer to use the new server mapping metadata, filtering out "nuked" zones from all server selection logic and queue modals. This includes new utility functions and changes to the modal's React state and effects. [[1]](diffhunk://#diff-485219907090ce2b7dff7098e5527ace94cc883ed6f3468470459f590c600081R36) [[2]](diffhunk://#diff-485219907090ce2b7dff7098e5527ace94cc883ed6f3468470459f590c600081R150-R151) [[3]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR21) [[4]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR137-R149) [[5]](diffhunk://#diff-d54a29e9ee619183cc7a210615ca451fda05f50998d5a2425ddd99cd38cb3ba9R119) [[6]](diffhunk://#diff-d54a29e9ee619183cc7a210615ca451fda05f50998d5a2425ddd99cd38cb3ba9R179-R225) [[7]](diffhunk://#diff-d54a29e9ee619183cc7a210615ca451fda05f50998d5a2425ddd99cd38cb3ba9L243-R287)
* Changed the logic so that if no eligible non-nuked zones are available, the queue modal is skipped and the game launches with default routing.
* Adjusted ping logic to always test all uncached, eligible zones, and updated modal behavior to handle zone removal and fallback scenarios more robustly. [[1]](diffhunk://#diff-d54a29e9ee619183cc7a210615ca451fda05f50998d5a2425ddd99cd38cb3ba9L220-R262) [[2]](diffhunk://#diff-d54a29e9ee619183cc7a210615ca451fda05f50998d5a2425ddd99cd38cb3ba9L262-R309) [[3]](diffhunk://#diff-d54a29e9ee619183cc7a210615ca451fda05f50998d5a2425ddd99cd38cb3ba9L314-R364) [[4]](diffhunk://#diff-d54a29e9ee619183cc7a210615ca451fda05f50998d5a2425ddd99cd38cb3ba9L326-R373)

These changes collectively improve the reliability and user experience of server selection by ensuring only valid, available servers are presented and chosen.87687f5dd456510ededR3462-L3424)
* Introduced a new module, `discordRpc.ts`, which handles connecting to Discord, updating the user's activity with the current game, clearing the activity, and gracefully destroying the connection on app quit. The implementation includes robust error handling to avoid crashes if Discord is not running.

**Dependency and Lockfile Updates:**

* Added several new dependencies required by `discord-rpc` (such as `node-fetch`, `register-scheme`, `bindings`, `file-uri-to-path`, `whatwg-url`, `tr46`, `webidl-conversions`) to `package-lock.json`. [[1]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR4146-R4152) [[2]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR5417-R5436) [[3]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR6020-R6030) [[4]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR6695-R6700) [[5]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR7437-R7442) [[6]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR7451-R7460) [[7]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededR2650-R2659)
* Updated some existing dependency metadata, including removing `peer: true` flags and updating how dev/optional dependencies are marked, to reflect the new dependency tree and ensure compatibility. [[1]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL62) [[2]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL2129) [[3]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL2261) [[4]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL2679) [[5]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL3822) [[6]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL4612-R4695) [[7]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL5321) [[8]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL5825) [[9]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL5835) [[10]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL6045) [[11]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL6110-R6207) [[12]](diffhunk://#diff-6cdfaa05461a427dcefec77c4d464bc710041924f830487687f5dd456510ededL6771)

These changes collectively enable the application to display real-time game activity on Discord, enhancing the user experience for those who use Discord while streaming or playing games with OpenNOW.