### PR TITLE
feat(navbar): termination control for active session resume (OPEN-40)

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -734,6 +734,7 @@ export function App(): JSX.Element {
   const [queuePosition, setQueuePosition] = useState<number | undefined>();
   const [navbarActiveSession, setNavbarActiveSession] = useState<ActiveSessionInfo | null>(null);
   const [isResumingNavbarSession, setIsResumingNavbarSession] = useState(false);
+  const [isTerminatingNavbarSession, setIsTerminatingNavbarSession] = useState(false);
   const [launchError, setLaunchError] = useState<LaunchErrorState | null>(null);
   const [queueModalGame, setQueueModalGame] = useState<GameInfo | null>(null);
   const [queueModalData, setQueueModalData] = useState<PrintedWasteQueueData | null>(null);
@@ -2716,6 +2717,40 @@ export function App(): JSX.Element {
     streamStatus,
   ]);
 
+  const handleTerminateNavbarSession = useCallback(async () => {
+    if (!navbarActiveSession || isTerminatingNavbarSession || isResumingNavbarSession) {
+      return;
+    }
+    const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
+    if (!token) {
+      return;
+    }
+
+    setIsTerminatingNavbarSession(true);
+    try {
+      await window.openNow.stopSession({
+        token,
+        streamingBaseUrl: effectiveStreamingBaseUrl,
+        serverIp: navbarActiveSession.serverIp,
+        zone: "prod",
+        sessionId: navbarActiveSession.sessionId,
+      });
+      setNavbarActiveSession(null);
+      void refreshNavbarActiveSession();
+    } catch (error) {
+      console.error("Terminate remote session failed:", error);
+    } finally {
+      setIsTerminatingNavbarSession(false);
+    }
+  }, [
+    authSession,
+    effectiveStreamingBaseUrl,
+    isResumingNavbarSession,
+    isTerminatingNavbarSession,
+    navbarActiveSession,
+    refreshNavbarActiveSession,
+  ]);
+
   // Stop stream handler
   const handleStopStream = useCallback(async () => {
     try {
@@ -3336,8 +3371,12 @@ export function App(): JSX.Element {
           activeSession={navbarActiveSession}
           activeSessionGameTitle={activeSessionGameTitle}
           isResumingSession={isResumingNavbarSession}
+          isTerminatingSession={isTerminatingNavbarSession}
           onResumeSession={() => {
             void handleResumeFromNavbar();
+          }}
+          onTerminateSession={() => {
+            void handleTerminateNavbarSession();
           }}
           onLogout={handleLogout}
         />

--- a/opennow-stable/src/renderer/src/components/Navbar.tsx
+++ b/opennow-stable/src/renderer/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import type { ActiveSessionInfo, AuthUser, SubscriptionInfo } from "@shared/gfn";
-import { House, Library, Settings, User, LogOut, Zap, Timer, HardDrive, X, Loader2, PlayCircle } from "lucide-react";
+import { House, Library, Settings, User, LogOut, Zap, Timer, HardDrive, X, Loader2, PlayCircle, Power } from "lucide-react";
 import { useEffect, useState, type JSX } from "react";
 import { createPortal } from "react-dom";
 
@@ -11,7 +11,9 @@ interface NavbarProps {
   activeSession: ActiveSessionInfo | null;
   activeSessionGameTitle: string | null;
   isResumingSession: boolean;
+  isTerminatingSession: boolean;
   onResumeSession: () => void;
+  onTerminateSession: () => void;
   onLogout: () => void;
 }
 
@@ -32,7 +34,9 @@ export function Navbar({
   activeSession,
   activeSessionGameTitle,
   isResumingSession,
+  isTerminatingSession,
   onResumeSession,
+  onTerminateSession,
   onLogout,
 }: NavbarProps): JSX.Element {
   const [modalType, setModalType] = useState<NavbarModalType>(null);
@@ -273,23 +277,43 @@ export function Navbar({
 
       <div className="navbar-right">
         {activeSession && (
-          <button
-            type="button"
-            className={`navbar-session-resume${isResumingSession ? " is-loading" : ""}`}
-            title={
-              activeSession.serverIp
-                ? activeSessionTitle
-                  ? `Resume active cloud session: ${activeSessionTitle}`
-                  : "Resume active cloud session"
-                : "Active session found (missing server address)"
-            }
-            onClick={onResumeSession}
-            disabled={isResumingSession || !activeSession.serverIp}
-          >
-            {isResumingSession ? <Loader2 size={14} className="navbar-session-resume-spin" /> : <PlayCircle size={14} />}
-            <span className="navbar-session-resume-text">Resume</span>
-            {activeSessionTitle && <span className="navbar-session-resume-game">{activeSessionTitle}</span>}
-          </button>
+          <div className="navbar-active-session">
+            <button
+              type="button"
+              className={`navbar-session-resume${isResumingSession ? " is-loading" : ""}`}
+              title={
+                activeSession.serverIp
+                  ? activeSessionTitle
+                    ? `Resume active cloud session: ${activeSessionTitle}`
+                    : "Resume active cloud session"
+                  : "Active session found (missing server address)"
+              }
+              onClick={onResumeSession}
+              disabled={isResumingSession || isTerminatingSession || !activeSession.serverIp}
+            >
+              {isResumingSession ? <Loader2 size={14} className="navbar-session-resume-spin" /> : <PlayCircle size={14} />}
+              <span className="navbar-session-resume-text">Resume</span>
+              {activeSessionTitle && <span className="navbar-session-resume-game">{activeSessionTitle}</span>}
+            </button>
+            <button
+              type="button"
+              className={`navbar-session-terminate${isTerminatingSession ? " is-loading" : ""}`}
+              title={
+                activeSessionTitle
+                  ? `End cloud session: ${activeSessionTitle}`
+                  : "End active cloud session"
+              }
+              onClick={onTerminateSession}
+              disabled={isResumingSession || isTerminatingSession}
+              aria-label="End active cloud session"
+            >
+              {isTerminatingSession ? (
+                <Loader2 size={14} className="navbar-session-terminate-spin" />
+              ) : (
+                <Power size={14} strokeWidth={2.5} />
+              )}
+            </button>
+          </div>
         )}
         {(timeLabel || storageLabel) && (
           <div className="navbar-subscription" aria-label="Subscription details">

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -471,6 +471,66 @@ body,
   z-index: 2;
 }
 
+.navbar-active-session {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.navbar-session-terminate {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, #f87171 42%, var(--panel-border));
+  border-radius: var(--r-full);
+  background:
+    linear-gradient(160deg, rgba(248, 113, 113, 0.22), rgba(248, 113, 113, 0.06)),
+    linear-gradient(180deg, rgba(28, 15, 15, 0.95), rgba(14, 10, 10, 0.92));
+  box-shadow:
+    0 4px 14px rgba(248, 113, 113, 0.12),
+    0 0 0 1px rgba(248, 113, 113, 0.12) inset;
+  color: #fecaca;
+  cursor: pointer;
+  transition:
+    transform var(--t-fast),
+    border-color var(--t-fast),
+    box-shadow var(--t-fast),
+    filter var(--t-fast);
+}
+
+.navbar-session-terminate:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, #f87171 72%, var(--panel-border));
+  box-shadow:
+    0 8px 22px rgba(248, 113, 113, 0.2),
+    0 0 0 1px rgba(248, 113, 113, 0.22) inset;
+}
+
+.navbar-session-terminate:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px rgba(248, 113, 113, 0.28),
+    0 8px 22px rgba(248, 113, 113, 0.2);
+}
+
+.navbar-session-terminate:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  filter: grayscale(0.15);
+}
+
+.navbar-session-terminate-spin {
+  animation: spin 1s linear infinite;
+}
+
+.navbar-session-terminate.is-loading {
+  animation: none;
+}
+
 .navbar-session-resume {
   display: inline-flex;
   align-items: center;
@@ -869,6 +929,11 @@ body.controller-mode {
 .controller-mode .navbar-session-resume {
   min-height: 42px;
   font-size: 0.84rem;
+}
+
+.controller-mode .navbar-session-terminate {
+  width: 42px;
+  height: 42px;
 }
 
 .controller-mode .navbar-link {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a power (end session) button beside the navbar **Resume** control when an active cloud session is detected. It calls the existing `stopSession` API with the same `zone: "prod"` convention used for `createSession`, clears local navbar state on success, and refreshes active sessions.

## Behavior
- **Resume** and **End** are mutually exclusive while either action is in progress (loading spinner on the active control).
- **End** stays enabled when `serverIp` is missing (Resume stays disabled), so users can still try to tear down a stuck remote session via the zone API.

## Testing
- `npm install` and `npx tsc --noEmit` for both `tsconfig.node.json` and `tsconfig.json` in `opennow-stable`.

Closes OPEN-40.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [OPEN-40](https://linear.app/zortos/issue/OPEN-40/resume-should-have-termination-button)

<div><a href="https://cursor.com/agents/bc-bc6bafa8-5274-4499-b591-8f1edd7d659b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc6bafa8-5274-4499-b591-8f1edd7d659b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

