### PR TITLE
fix(settings): improve keybind binding UX (OPEN-54)

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -3091,6 +3091,7 @@ export function App(): JSX.Element {
               toggleStats: formatShortcutForDisplay(settings.shortcutToggleStats, isMac),
               togglePointerLock: formatShortcutForDisplay(settings.shortcutTogglePointerLock, isMac),
               stopStream: formatShortcutForDisplay(settings.shortcutStopStream, isMac),
+              toggleAntiAfk: shortcuts.toggleAntiAfk.canonical,
               toggleMicrophone: formatShortcutForDisplay(settings.shortcutToggleMicrophone, isMac),
               screenshot: shortcuts.screenshot.canonical,
               recording: shortcuts.recording.canonical,

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -23,7 +23,7 @@ import {
   USER_FACING_COLOR_QUALITY_OPTIONS,
   USER_FACING_VIDEO_CODEC_OPTIONS,
 } from "@shared/gfn";
-import { formatShortcutForDisplay, normalizeShortcut } from "../shortcuts";
+import { formatShortcutForDisplay, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
 import { getCodecDecodeBadgeState, type CodecTestResult } from "../lib/codecDiagnostics";
 
 interface SettingsPageProps {
@@ -113,7 +113,34 @@ const shortcutDefaults = {
   shortcutToggleAntiAfk: "Ctrl+Shift+K",
   shortcutToggleMicrophone: "Ctrl+Shift+M",
   shortcutScreenshot: "F11",
+  shortcutToggleRecording: "F12",
 } as const;
+
+/** Canonical shortcut for toggling the stream sidebar (must match StreamView key handler). */
+const SIDEBAR_TOGGLE_SHORTCUT_RAW = isMac ? "Meta+G" : "Ctrl+Shift+G";
+
+type ShortcutSettingKey = keyof typeof shortcutDefaults;
+
+const SHORTCUT_SETTING_KEYS = Object.keys(shortcutDefaults) as ShortcutSettingKey[];
+
+function getShortcutConflictMessage(
+  editingKey: ShortcutSettingKey,
+  candidateCanonical: string,
+  currentSettings: Settings,
+): string | null {
+  const sidebarParsed = normalizeShortcut(SIDEBAR_TOGGLE_SHORTCUT_RAW);
+  if (sidebarParsed.valid && candidateCanonical === sidebarParsed.canonical) {
+    return "Shortcut conflicts with the settings sidebar toggle.";
+  }
+  for (const key of SHORTCUT_SETTING_KEYS) {
+    if (key === editingKey) continue;
+    const parsed = normalizeShortcut(currentSettings[key]);
+    if (parsed.valid && parsed.canonical === candidateCanonical) {
+      return "Shortcut conflicts with another binding.";
+    }
+  }
+  return null;
+}
 
 const microphoneModeOptions: Array<{ value: MicrophoneMode; label: string }> = [
   { value: "disabled", label: "Disabled" },
@@ -413,12 +440,14 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   const [toggleAntiAfkInput, setToggleAntiAfkInput] = useState(settings.shortcutToggleAntiAfk);
   const [toggleMicrophoneInput, setToggleMicrophoneInput] = useState(settings.shortcutToggleMicrophone);
   const [screenshotInput, setScreenshotInput] = useState(settings.shortcutScreenshot);
-  const [toggleStatsError, setToggleStatsError] = useState(false);
-  const [togglePointerLockError, setTogglePointerLockError] = useState(false);
-  const [stopStreamError, setStopStreamError] = useState(false);
-  const [toggleAntiAfkError, setToggleAntiAfkError] = useState(false);
-  const [toggleMicrophoneError, setToggleMicrophoneError] = useState(false);
-  const [screenshotError, setScreenshotError] = useState(false);
+  const [recordingInput, setRecordingInput] = useState(settings.shortcutToggleRecording);
+  const [toggleStatsError, setToggleStatsError] = useState<string | null>(null);
+  const [togglePointerLockError, setTogglePointerLockError] = useState<string | null>(null);
+  const [stopStreamError, setStopStreamError] = useState<string | null>(null);
+  const [toggleAntiAfkError, setToggleAntiAfkError] = useState<string | null>(null);
+  const [toggleMicrophoneError, setToggleMicrophoneError] = useState<string | null>(null);
+  const [screenshotError, setScreenshotError] = useState<string | null>(null);
+  const [recordingError, setRecordingError] = useState<string | null>(null);
 
   const [keyboardLayoutDropdownOpen, setKeyboardLayoutDropdownOpen] = useState(false);
   const keyboardLayoutDropdownRef = useRef<HTMLDivElement | null>(null);
@@ -454,6 +483,10 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   useEffect(() => {
     setScreenshotInput(settings.shortcutScreenshot);
   }, [settings.shortcutScreenshot]);
+
+  useEffect(() => {
+    setRecordingInput(settings.shortcutToggleRecording);
+  }, [settings.shortcutToggleRecording]);
 
   // Fetch subscription data (cached per account; reload only when account changes)
   useEffect(() => {
@@ -720,28 +753,157 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
     return () => document.removeEventListener("mousedown", handlePointerDown);
   }, []);
 
-  const handleShortcutBlur = <K extends keyof Settings>(
-    key: K,
-    rawValue: string,
-    setInput: (value: string) => void,
-    setError: (value: boolean) => void
-  ): void => {
-    const normalized = normalizeShortcut(rawValue.trim());
-    if (!normalized.valid) {
-      setError(true);
+  const handleShortcutBlur = (key: ShortcutSettingKey, rawValue: string): void => {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      const msg = "Shortcut cannot be empty.";
+      switch (key) {
+        case "shortcutToggleStats": setToggleStatsError(msg); break;
+        case "shortcutTogglePointerLock": setTogglePointerLockError(msg); break;
+        case "shortcutStopStream": setStopStreamError(msg); break;
+        case "shortcutToggleAntiAfk": setToggleAntiAfkError(msg); break;
+        case "shortcutToggleMicrophone": setToggleMicrophoneError(msg); break;
+        case "shortcutScreenshot": setScreenshotError(msg); break;
+        case "shortcutToggleRecording": setRecordingError(msg); break;
+      }
       return;
     }
-    setError(false);
-    setInput(normalized.canonical);
+
+    const normalized = normalizeShortcut(trimmed);
+    if (!normalized.valid) {
+      const msg = "Invalid shortcut format.";
+      switch (key) {
+        case "shortcutToggleStats": setToggleStatsError(msg); break;
+        case "shortcutTogglePointerLock": setTogglePointerLockError(msg); break;
+        case "shortcutStopStream": setStopStreamError(msg); break;
+        case "shortcutToggleAntiAfk": setToggleAntiAfkError(msg); break;
+        case "shortcutToggleMicrophone": setToggleMicrophoneError(msg); break;
+        case "shortcutScreenshot": setScreenshotError(msg); break;
+        case "shortcutToggleRecording": setRecordingError(msg); break;
+      }
+      return;
+    }
+
+    const conflict = getShortcutConflictMessage(key, normalized.canonical, settings);
+    if (conflict) {
+      switch (key) {
+        case "shortcutToggleStats": setToggleStatsError(conflict); break;
+        case "shortcutTogglePointerLock": setTogglePointerLockError(conflict); break;
+        case "shortcutStopStream": setStopStreamError(conflict); break;
+        case "shortcutToggleAntiAfk": setToggleAntiAfkError(conflict); break;
+        case "shortcutToggleMicrophone": setToggleMicrophoneError(conflict); break;
+        case "shortcutScreenshot": setScreenshotError(conflict); break;
+        case "shortcutToggleRecording": setRecordingError(conflict); break;
+      }
+      return;
+    }
+
+    switch (key) {
+      case "shortcutToggleStats": setToggleStatsError(null); break;
+      case "shortcutTogglePointerLock": setTogglePointerLockError(null); break;
+      case "shortcutStopStream": setStopStreamError(null); break;
+      case "shortcutToggleAntiAfk": setToggleAntiAfkError(null); break;
+      case "shortcutToggleMicrophone": setToggleMicrophoneError(null); break;
+      case "shortcutScreenshot": setScreenshotError(null); break;
+      case "shortcutToggleRecording": setRecordingError(null); break;
+    }
+
+    switch (key) {
+      case "shortcutToggleStats": setToggleStatsInput(normalized.canonical); break;
+      case "shortcutTogglePointerLock": setTogglePointerLockInput(normalized.canonical); break;
+      case "shortcutStopStream": setStopStreamInput(normalized.canonical); break;
+      case "shortcutToggleAntiAfk": setToggleAntiAfkInput(normalized.canonical); break;
+      case "shortcutToggleMicrophone": setToggleMicrophoneInput(normalized.canonical); break;
+      case "shortcutScreenshot": setScreenshotInput(normalized.canonical); break;
+      case "shortcutToggleRecording": setRecordingInput(normalized.canonical); break;
+    }
+
     if (settings[key] !== normalized.canonical) {
-      handleChange(key, normalized.canonical as Settings[K]);
+      handleChange(key, normalized.canonical);
     }
   };
 
-  const handleShortcutKeyDown = (e: React.KeyboardEvent): void => {
-    if (e.key === "Enter") {
-      (e.target as HTMLInputElement).blur();
+  const applyShortcutCapture = (key: ShortcutSettingKey, canonical: string): void => {
+    const conflict = getShortcutConflictMessage(key, canonical, settings);
+    if (conflict) {
+      switch (key) {
+        case "shortcutToggleStats": setToggleStatsError(conflict); break;
+        case "shortcutTogglePointerLock": setTogglePointerLockError(conflict); break;
+        case "shortcutStopStream": setStopStreamError(conflict); break;
+        case "shortcutToggleAntiAfk": setToggleAntiAfkError(conflict); break;
+        case "shortcutToggleMicrophone": setToggleMicrophoneError(conflict); break;
+        case "shortcutScreenshot": setScreenshotError(conflict); break;
+        case "shortcutToggleRecording": setRecordingError(conflict); break;
+      }
+      return;
     }
+
+    switch (key) {
+      case "shortcutToggleStats": setToggleStatsError(null); break;
+      case "shortcutTogglePointerLock": setTogglePointerLockError(null); break;
+      case "shortcutStopStream": setStopStreamError(null); break;
+      case "shortcutToggleAntiAfk": setToggleAntiAfkError(null); break;
+      case "shortcutToggleMicrophone": setToggleMicrophoneError(null); break;
+      case "shortcutScreenshot": setScreenshotError(null); break;
+      case "shortcutToggleRecording": setRecordingError(null); break;
+    }
+
+    switch (key) {
+      case "shortcutToggleStats": setToggleStatsInput(canonical); break;
+      case "shortcutTogglePointerLock": setTogglePointerLockInput(canonical); break;
+      case "shortcutStopStream": setStopStreamInput(canonical); break;
+      case "shortcutToggleAntiAfk": setToggleAntiAfkInput(canonical); break;
+      case "shortcutToggleMicrophone": setToggleMicrophoneInput(canonical); break;
+      case "shortcutScreenshot": setScreenshotInput(canonical); break;
+      case "shortcutToggleRecording": setRecordingInput(canonical); break;
+    }
+
+    if (settings[key] !== canonical) {
+      handleChange(key, canonical);
+    }
+  };
+
+  const handleShortcutCaptureKeyDown = (key: ShortcutSettingKey, e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.currentTarget.blur();
+      return;
+    }
+    if (e.key === "Enter" || e.key === "Tab") {
+      return;
+    }
+
+    const captured = shortcutFromKeyboardEvent(e.nativeEvent);
+    if (!captured) {
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+    applyShortcutCapture(key, captured);
+  };
+
+  const handleShortcutPaste = (key: ShortcutSettingKey, e: React.ClipboardEvent<HTMLInputElement>): void => {
+    const text = e.clipboardData.getData("text/plain").trim();
+    if (!text) {
+      return;
+    }
+    e.preventDefault();
+    const normalized = normalizeShortcut(text);
+    if (!normalized.valid) {
+      const msg = "Invalid shortcut format.";
+      switch (key) {
+        case "shortcutToggleStats": setToggleStatsError(msg); break;
+        case "shortcutTogglePointerLock": setTogglePointerLockError(msg); break;
+        case "shortcutStopStream": setStopStreamError(msg); break;
+        case "shortcutToggleAntiAfk": setToggleAntiAfkError(msg); break;
+        case "shortcutToggleMicrophone": setToggleMicrophoneError(msg); break;
+        case "shortcutScreenshot": setScreenshotError(msg); break;
+        case "shortcutToggleRecording": setRecordingError(msg); break;
+      }
+      return;
+    }
+    applyShortcutCapture(key, normalized.canonical);
   };
 
   const areShortcutsDefault = useMemo(
@@ -751,7 +913,8 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
       && settings.shortcutStopStream === shortcutDefaults.shortcutStopStream
       && settings.shortcutToggleAntiAfk === shortcutDefaults.shortcutToggleAntiAfk
       && settings.shortcutToggleMicrophone === shortcutDefaults.shortcutToggleMicrophone
-      && settings.shortcutScreenshot === shortcutDefaults.shortcutScreenshot,
+      && settings.shortcutScreenshot === shortcutDefaults.shortcutScreenshot
+      && settings.shortcutToggleRecording === shortcutDefaults.shortcutToggleRecording,
     [
       settings.shortcutToggleStats,
       settings.shortcutTogglePointerLock,
@@ -759,6 +922,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
       settings.shortcutToggleAntiAfk,
       settings.shortcutToggleMicrophone,
       settings.shortcutScreenshot,
+      settings.shortcutToggleRecording,
     ]
   );
 
@@ -769,23 +933,16 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
     setToggleAntiAfkInput(shortcutDefaults.shortcutToggleAntiAfk);
     setToggleMicrophoneInput(shortcutDefaults.shortcutToggleMicrophone);
     setScreenshotInput(shortcutDefaults.shortcutScreenshot);
-    setToggleStatsError(false);
-    setTogglePointerLockError(false);
-    setStopStreamError(false);
-    setToggleAntiAfkError(false);
-    setToggleMicrophoneError(false);
-    setScreenshotError(false);
+    setRecordingInput(shortcutDefaults.shortcutToggleRecording);
+    setToggleStatsError(null);
+    setTogglePointerLockError(null);
+    setStopStreamError(null);
+    setToggleAntiAfkError(null);
+    setToggleMicrophoneError(null);
+    setScreenshotError(null);
+    setRecordingError(null);
 
-    const shortcutKeys = [
-      "shortcutToggleStats",
-      "shortcutTogglePointerLock",
-      "shortcutStopStream",
-      "shortcutToggleAntiAfk",
-      "shortcutToggleMicrophone",
-      "shortcutScreenshot",
-    ] as const;
-
-    for (const key of shortcutKeys) {
+    for (const key of SHORTCUT_SETTING_KEYS) {
       const value = shortcutDefaults[key];
       if (settings[key] !== value) {
         handleChange(key, value);
@@ -1807,109 +1964,168 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
               </div>
 
               <div className="settings-shortcut-grid">
-                <label className="settings-shortcut-row">
-                  <span className="settings-shortcut-label">Toggle Stats</span>
+                <div className="settings-shortcut-row">
+                  <span className="settings-shortcut-label" id="shortcut-toggle-stats-label">Toggle Stats</span>
                   <input
                     type="text"
+                    id="shortcut-toggle-stats"
+                    aria-labelledby="shortcut-toggle-stats-label"
+                    readOnly
                     className={`settings-text-input settings-shortcut-input ${toggleStatsError ? "error" : ""}`}
                     value={toggleStatsInput}
-                    onChange={(e) => setToggleStatsInput(e.target.value)}
-                    onBlur={() => handleShortcutBlur("shortcutToggleStats", toggleStatsInput, setToggleStatsInput, setToggleStatsError)}
-                    onKeyDown={handleShortcutKeyDown}
-                    placeholder="F3"
+                    onFocus={(e) => e.target.select()}
+                    onBlur={() => handleShortcutBlur("shortcutToggleStats", toggleStatsInput)}
+                    onPaste={(e) => handleShortcutPaste("shortcutToggleStats", e)}
+                    onKeyDown={(e) => handleShortcutCaptureKeyDown("shortcutToggleStats", e)}
+                    placeholder="Click here, then press a key"
+                    title="Focus and press the key combination to bind"
                     spellCheck={false}
                   />
-                </label>
+                </div>
 
-                <label className="settings-shortcut-row">
-                  <span className="settings-shortcut-label">Mouse Lock</span>
+                <div className="settings-shortcut-row">
+                  <span className="settings-shortcut-label" id="shortcut-pointer-lock-label">Mouse Lock</span>
                   <input
                     type="text"
+                    id="shortcut-pointer-lock"
+                    aria-labelledby="shortcut-pointer-lock-label"
+                    readOnly
                     className={`settings-text-input settings-shortcut-input ${togglePointerLockError ? "error" : ""}`}
                     value={togglePointerLockInput}
-                    onChange={(e) => setTogglePointerLockInput(e.target.value)}
-                    onBlur={() => handleShortcutBlur("shortcutTogglePointerLock", togglePointerLockInput, setTogglePointerLockInput, setTogglePointerLockError)}
-                    onKeyDown={handleShortcutKeyDown}
-                    placeholder="F8"
+                    onFocus={(e) => e.target.select()}
+                    onBlur={() => handleShortcutBlur("shortcutTogglePointerLock", togglePointerLockInput)}
+                    onPaste={(e) => handleShortcutPaste("shortcutTogglePointerLock", e)}
+                    onKeyDown={(e) => handleShortcutCaptureKeyDown("shortcutTogglePointerLock", e)}
+                    placeholder="Click here, then press a key"
+                    title="Focus and press the key combination to bind"
                     spellCheck={false}
                   />
-                </label>
+                </div>
 
-                <label className="settings-shortcut-row">
-                  <span className="settings-shortcut-label">Stop Stream</span>
+                <div className="settings-shortcut-row">
+                  <span className="settings-shortcut-label" id="shortcut-stop-stream-label">Stop Stream</span>
                   <input
                     type="text"
+                    id="shortcut-stop-stream"
+                    aria-labelledby="shortcut-stop-stream-label"
+                    readOnly
                     className={`settings-text-input settings-shortcut-input ${stopStreamError ? "error" : ""}`}
                     value={stopStreamInput}
-                    onChange={(e) => setStopStreamInput(e.target.value)}
-                    onBlur={() => handleShortcutBlur("shortcutStopStream", stopStreamInput, setStopStreamInput, setStopStreamError)}
-                    onKeyDown={handleShortcutKeyDown}
-                    placeholder="Ctrl+Shift+Q"
+                    onFocus={(e) => e.target.select()}
+                    onBlur={() => handleShortcutBlur("shortcutStopStream", stopStreamInput)}
+                    onPaste={(e) => handleShortcutPaste("shortcutStopStream", e)}
+                    onKeyDown={(e) => handleShortcutCaptureKeyDown("shortcutStopStream", e)}
+                    placeholder="Click here, then press a key"
+                    title="Focus and press the key combination to bind"
                     spellCheck={false}
                   />
-                </label>
+                </div>
 
-                <label className="settings-shortcut-row">
-                  <span className="settings-shortcut-label">Toggle Anti-AFK</span>
+                <div className="settings-shortcut-row">
+                  <span className="settings-shortcut-label" id="shortcut-anti-afk-label">Toggle Anti-AFK</span>
                   <input
                     type="text"
+                    id="shortcut-anti-afk"
+                    aria-labelledby="shortcut-anti-afk-label"
+                    readOnly
                     className={`settings-text-input settings-shortcut-input ${toggleAntiAfkError ? "error" : ""}`}
                     value={toggleAntiAfkInput}
-                    onChange={(e) => setToggleAntiAfkInput(e.target.value)}
-                    onBlur={() => handleShortcutBlur("shortcutToggleAntiAfk", toggleAntiAfkInput, setToggleAntiAfkInput, setToggleAntiAfkError)}
-                    onKeyDown={handleShortcutKeyDown}
-                    placeholder="Ctrl+Shift+K"
+                    onFocus={(e) => e.target.select()}
+                    onBlur={() => handleShortcutBlur("shortcutToggleAntiAfk", toggleAntiAfkInput)}
+                    onPaste={(e) => handleShortcutPaste("shortcutToggleAntiAfk", e)}
+                    onKeyDown={(e) => handleShortcutCaptureKeyDown("shortcutToggleAntiAfk", e)}
+                    placeholder="Click here, then press a key"
+                    title="Focus and press the key combination to bind"
                     spellCheck={false}
                   />
-                </label>
+                </div>
 
-                <label className="settings-shortcut-row">
-                  <span className="settings-shortcut-label">Toggle Microphone</span>
+                <div className="settings-shortcut-row">
+                  <span className="settings-shortcut-label" id="shortcut-mic-label">Toggle Microphone</span>
                   <input
                     type="text"
+                    id="shortcut-mic"
+                    aria-labelledby="shortcut-mic-label"
+                    readOnly
                     className={`settings-text-input settings-shortcut-input ${toggleMicrophoneError ? "error" : ""}`}
                     value={toggleMicrophoneInput}
-                    onChange={(e) => setToggleMicrophoneInput(e.target.value)}
-                    onBlur={() => handleShortcutBlur("shortcutToggleMicrophone", toggleMicrophoneInput, setToggleMicrophoneInput, setToggleMicrophoneError)}
-                    onKeyDown={handleShortcutKeyDown}
-                    placeholder="Ctrl+Shift+M"
+                    onFocus={(e) => e.target.select()}
+                    onBlur={() => handleShortcutBlur("shortcutToggleMicrophone", toggleMicrophoneInput)}
+                    onPaste={(e) => handleShortcutPaste("shortcutToggleMicrophone", e)}
+                    onKeyDown={(e) => handleShortcutCaptureKeyDown("shortcutToggleMicrophone", e)}
+                    placeholder="Click here, then press a key"
+                    title="Focus and press the key combination to bind"
                     spellCheck={false}
                   />
-                </label>
+                </div>
 
-                <label className="settings-shortcut-row">
-                  <span className="settings-shortcut-label">ScreensShot</span>
+                <div className="settings-shortcut-row">
+                  <span className="settings-shortcut-label" id="shortcut-screenshot-label">Screenshot</span>
                   <input
                     type="text"
+                    id="shortcut-screenshot"
+                    aria-labelledby="shortcut-screenshot-label"
+                    readOnly
                     className={`settings-text-input settings-shortcut-input ${screenshotError ? "error" : ""}`}
                     value={screenshotInput}
-                    onChange={(e) => setScreenshotInput(e.target.value)}
-                    onBlur={() => handleShortcutBlur("shortcutScreenshot", screenshotInput, setScreenshotInput, setScreenshotError)}
-                    onKeyDown={handleShortcutKeyDown}
-                    placeholder="F11"
+                    onFocus={(e) => e.target.select()}
+                    onBlur={() => handleShortcutBlur("shortcutScreenshot", screenshotInput)}
+                    onPaste={(e) => handleShortcutPaste("shortcutScreenshot", e)}
+                    onKeyDown={(e) => handleShortcutCaptureKeyDown("shortcutScreenshot", e)}
+                    placeholder="Click here, then press a key"
+                    title="Focus and press the key combination to bind"
                     spellCheck={false}
                   />
-                </label>
-                <label className="settings-shortcut-row">
-                  <span className="settings-shortcut-label">Toggle Settings Menu</span>
+                </div>
+
+                <div className="settings-shortcut-row">
+                  <span className="settings-shortcut-label" id="shortcut-recording-label">Recording</span>
                   <input
                     type="text"
-                    value="Cmd+G / Ctrl+Shift+G"
-                    className="settings-text-input settings-shortcut-input settings-shortcut-input--static"
-                    disabled
+                    id="shortcut-recording"
+                    aria-labelledby="shortcut-recording-label"
+                    readOnly
+                    className={`settings-text-input settings-shortcut-input ${recordingError ? "error" : ""}`}
+                    value={recordingInput}
+                    onFocus={(e) => e.target.select()}
+                    onBlur={() => handleShortcutBlur("shortcutToggleRecording", recordingInput)}
+                    onPaste={(e) => handleShortcutPaste("shortcutToggleRecording", e)}
+                    onKeyDown={(e) => handleShortcutCaptureKeyDown("shortcutToggleRecording", e)}
+                    placeholder="Click here, then press a key"
+                    title="Focus and press the key combination to bind"
+                    spellCheck={false}
                   />
-                </label>
+                </div>
+
+                <div className="settings-shortcut-row">
+                  <span className="settings-shortcut-label" id="shortcut-sidebar-label">Toggle stream sidebar</span>
+                  <input
+                    type="text"
+                    id="shortcut-sidebar"
+                    aria-labelledby="shortcut-sidebar-label"
+                    value={formatShortcutForDisplay(SIDEBAR_TOGGLE_SHORTCUT_RAW, isMac)}
+                    className="settings-text-input settings-shortcut-input settings-shortcut-input--static"
+                    readOnly
+                    tabIndex={-1}
+                  />
+                </div>
               </div>
 
-              {(toggleStatsError || togglePointerLockError || stopStreamError || toggleAntiAfkError || toggleMicrophoneError || screenshotError) && (
+              {(toggleStatsError || togglePointerLockError || stopStreamError || toggleAntiAfkError || toggleMicrophoneError || screenshotError || recordingError) && (
                 <span className="settings-input-hint">
-                  Invalid shortcut. Use {shortcutExamples}
+                  {toggleStatsError
+                    || togglePointerLockError
+                    || stopStreamError
+                    || toggleAntiAfkError
+                    || toggleMicrophoneError
+                    || screenshotError
+                    || recordingError}
                 </span>
               )}
 
-              {!toggleStatsError && !togglePointerLockError && !stopStreamError && !toggleAntiAfkError && !toggleMicrophoneError && !screenshotError && (
+              {!toggleStatsError && !togglePointerLockError && !stopStreamError && !toggleAntiAfkError && !toggleMicrophoneError && !screenshotError && !recordingError && (
                 <span className="settings-shortcut-hint">
-                  {shortcutExamples}. Stop: {formatShortcutForDisplay(settings.shortcutStopStream, isMac)}. Mic: {formatShortcutForDisplay(settings.shortcutToggleMicrophone, isMac)}. ScreensShot: {formatShortcutForDisplay(settings.shortcutScreenshot, isMac)}.
+                  Click a field and press the keys to bind, or paste a shortcut ({shortcutExamples}). Escape cancels focus. Stop: {formatShortcutForDisplay(settings.shortcutStopStream, isMac)}. Mic: {formatShortcutForDisplay(settings.shortcutToggleMicrophone, isMac)}. Screenshot: {formatShortcutForDisplay(settings.shortcutScreenshot, isMac)}. Recording: {formatShortcutForDisplay(settings.shortcutToggleRecording, isMac)}.
                 </span>
               )}
             </div>

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -10,7 +10,7 @@ import type { MicState } from "../gfn/microphoneManager";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { RemainingPlaytimeIndicator, SessionElapsedIndicator } from "./ElapsedSessionIndicators";
 import type { MicrophoneMode, ScreenshotEntry, RecordingEntry, SubscriptionInfo } from "@shared/gfn";
-import { isShortcutMatch, normalizeShortcut } from "../shortcuts";
+import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
 
 interface StreamViewProps {
   videoRef: React.Ref<HTMLVideoElement>;
@@ -21,6 +21,7 @@ interface StreamViewProps {
     toggleStats: string;
     togglePointerLock: string;
     stopStream: string;
+    toggleAntiAfk: string;
     toggleMicrophone?: string;
     screenshot: string;
     recording: string;
@@ -845,9 +846,10 @@ export function StreamView({
       shortcuts.toggleStats,
       shortcuts.togglePointerLock,
       shortcuts.stopStream,
+      shortcuts.toggleAntiAfk,
       shortcuts.toggleMicrophone,
       shortcuts.recording,
-      isMacClient ? "Cmd+G" : "Ctrl+Shift+G",
+      isMacClient ? "Meta+G" : "Ctrl+Shift+G",
     ]
       .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
       .map((value) => normalizeShortcut(value))
@@ -859,7 +861,7 @@ export function StreamView({
     }
 
     return null;
-  }, [isMacClient, shortcuts.recording, shortcuts.stopStream, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
+  }, [isMacClient, shortcuts.recording, shortcuts.stopStream, shortcuts.toggleAntiAfk, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
 
   const getRecordingShortcutError = useCallback((rawValue: string): string | null => {
     const trimmed = rawValue.trim();
@@ -876,9 +878,10 @@ export function StreamView({
       shortcuts.toggleStats,
       shortcuts.togglePointerLock,
       shortcuts.stopStream,
+      shortcuts.toggleAntiAfk,
       shortcuts.toggleMicrophone,
       shortcuts.screenshot,
-      isMacClient ? "Cmd+G" : "Ctrl+Shift+G",
+      isMacClient ? "Meta+G" : "Ctrl+Shift+G",
     ]
       .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
       .map((value) => normalizeShortcut(value))
@@ -890,7 +893,106 @@ export function StreamView({
     }
 
     return null;
-  }, [isMacClient, shortcuts.screenshot, shortcuts.stopStream, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
+  }, [isMacClient, shortcuts.screenshot, shortcuts.stopStream, shortcuts.toggleAntiAfk, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
+
+  const SIDEBAR_TOGGLE_RAW = isMacClient ? "Meta+G" : "Ctrl+Shift+G";
+  const sidebarToggleShortcutDisplay = formatShortcutForDisplay(SIDEBAR_TOGGLE_RAW, isMacClient);
+
+  const applyScreenshotShortcutFromCapture = useCallback(
+    (canonical: string) => {
+      const error = getScreenshotShortcutError(canonical);
+      if (error) {
+        setScreenshotShortcutError(error);
+        return;
+      }
+      const normalized = normalizeShortcut(canonical.trim());
+      if (!normalized.valid) {
+        setScreenshotShortcutError("Invalid shortcut format.");
+        return;
+      }
+      setScreenshotShortcutError(null);
+      setScreenshotShortcutInput(normalized.canonical);
+      if (normalized.canonical !== shortcuts.screenshot) {
+        onScreenshotShortcutChange(normalized.canonical);
+      }
+    },
+    [getScreenshotShortcutError, onScreenshotShortcutChange, shortcuts.screenshot],
+  );
+
+  const applyRecordingShortcutFromCapture = useCallback(
+    (canonical: string) => {
+      const error = getRecordingShortcutError(canonical);
+      if (error) {
+        setRecordingShortcutError(error);
+        return;
+      }
+      const normalized = normalizeShortcut(canonical.trim());
+      if (!normalized.valid) {
+        setRecordingShortcutError("Invalid shortcut format.");
+        return;
+      }
+      setRecordingShortcutError(null);
+      setRecordingShortcutInput(normalized.canonical);
+      if (normalized.canonical !== shortcuts.recording) {
+        onRecordingShortcutChange(normalized.canonical);
+      }
+    },
+    [getRecordingShortcutError, onRecordingShortcutChange, shortcuts.recording],
+  );
+
+  const handleStreamScreenshotShortcutKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.currentTarget.blur();
+      return;
+    }
+    if (e.key === "Enter" || e.key === "Tab") {
+      return;
+    }
+    const captured = shortcutFromKeyboardEvent(e.nativeEvent);
+    if (!captured) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    applyScreenshotShortcutFromCapture(captured);
+  };
+
+  const handleStreamRecordingShortcutKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.currentTarget.blur();
+      return;
+    }
+    if (e.key === "Enter" || e.key === "Tab") {
+      return;
+    }
+    const captured = shortcutFromKeyboardEvent(e.nativeEvent);
+    if (!captured) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    applyRecordingShortcutFromCapture(captured);
+  };
+
+  const handleStreamScreenshotShortcutPaste = (e: React.ClipboardEvent<HTMLInputElement>): void => {
+    const text = e.clipboardData.getData("text/plain").trim();
+    if (!text) {
+      return;
+    }
+    e.preventDefault();
+    applyScreenshotShortcutFromCapture(text);
+  };
+
+  const handleStreamRecordingShortcutPaste = (e: React.ClipboardEvent<HTMLInputElement>): void => {
+    const text = e.clipboardData.getData("text/plain").trim();
+    if (!text) {
+      return;
+    }
+    e.preventDefault();
+    applyRecordingShortcutFromCapture(text);
+  };
 
   const refreshScreenshots = useCallback(async () => {
     setGalleryError(null);
@@ -1646,11 +1748,9 @@ export function StreamView({
                       type="text"
                       className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${screenshotShortcutError ? "error" : ""}`}
                       value={screenshotShortcutInput}
-                      onChange={(event) => {
-                        const nextValue = event.target.value;
-                        setScreenshotShortcutInput(nextValue);
-                        setScreenshotShortcutError(getScreenshotShortcutError(nextValue));
-                      }}
+                      readOnly
+                      onFocus={(event) => event.target.select()}
+                      onPaste={handleStreamScreenshotShortcutPaste}
                       onBlur={() => {
                         const error = getScreenshotShortcutError(screenshotShortcutInput);
                         if (error) {
@@ -1668,12 +1768,9 @@ export function StreamView({
                           onScreenshotShortcutChange(normalized.canonical);
                         }
                       }}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter") {
-                          (event.target as HTMLInputElement).blur();
-                        }
-                      }}
-                      placeholder="F11"
+                      onKeyDown={handleStreamScreenshotShortcutKeyDown}
+                      placeholder="Click, then press a key"
+                      title="Focus and press the key combination to bind"
                       spellCheck={false}
                     />
                   </div>
@@ -1686,11 +1783,9 @@ export function StreamView({
                       type="text"
                       className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${recordingShortcutError ? "error" : ""}`}
                       value={recordingShortcutInput}
-                      onChange={(event) => {
-                        const nextValue = event.target.value;
-                        setRecordingShortcutInput(nextValue);
-                        setRecordingShortcutError(getRecordingShortcutError(nextValue));
-                      }}
+                      readOnly
+                      onFocus={(event) => event.target.select()}
+                      onPaste={handleStreamRecordingShortcutPaste}
                       onBlur={() => {
                         const error = getRecordingShortcutError(recordingShortcutInput);
                         if (error) {
@@ -1708,12 +1803,9 @@ export function StreamView({
                           onRecordingShortcutChange(normalized.canonical);
                         }
                       }}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter") {
-                          (event.target as HTMLInputElement).blur();
-                        }
-                      }}
-                      placeholder="F12"
+                      onKeyDown={handleStreamRecordingShortcutKeyDown}
+                      placeholder="Click, then press a key"
+                      title="Focus and press the key combination to bind"
                       spellCheck={false}
                     />
                   </div>
@@ -1738,7 +1830,7 @@ export function StreamView({
                   )}
                   <div className="sidebar-row sidebar-row--aligned">
                     <span className="sidebar-label">Toggle Sidebar</span>
-                    <span className="settings-value-badge">{isMacClient ? "Cmd+G" : "Ctrl+Shift+G"}</span>
+                    <span className="settings-value-badge">{sidebarToggleShortcutDisplay}</span>
                   </div>
                 </section>
               </>

--- a/opennow-stable/src/renderer/src/shortcuts.ts
+++ b/opennow-stable/src/renderer/src/shortcuts.ts
@@ -210,3 +210,46 @@ export function formatShortcutForDisplay(raw: string, isMac: boolean): string {
   parts.push(parsed.key);
   return parts.join("+");
 }
+
+const MODIFIER_ONLY_CODES = new Set([
+  "ControlLeft",
+  "ControlRight",
+  "AltLeft",
+  "AltRight",
+  "ShiftLeft",
+  "ShiftRight",
+  "MetaLeft",
+  "MetaRight",
+  "OSLeft",
+  "OSRight",
+]);
+
+/**
+ * Builds a canonical shortcut string from a keydown event (for press-to-bind UIs).
+ * Returns null for modifier-only keys, unknown keys, or invalid combinations.
+ */
+export function shortcutFromKeyboardEvent(event: KeyboardEvent): string | null {
+  if (event.repeat) {
+    return null;
+  }
+  if (MODIFIER_ONLY_CODES.has(event.code)) {
+    return null;
+  }
+
+  const fromCode = normalizeEventCode(event.code);
+  const fromKey = normalizeKeyToken(normalizeEventKey(event.key));
+  const keyToken = fromCode ?? fromKey;
+  if (!keyToken) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  if (event.ctrlKey) parts.push("Ctrl");
+  if (event.altKey) parts.push("Alt");
+  if (event.shiftKey) parts.push("Shift");
+  if (event.metaKey) parts.push("Meta");
+  parts.push(keyToken);
+
+  const parsed = normalizeShortcut(parts.join("+"));
+  return parsed.valid ? parsed.canonical : null;
+}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -2435,6 +2435,10 @@ button.game-card-store-chip.active:hover {
   text-align: right;
 }
 
+.settings-shortcut-input[readonly]:not(.settings-shortcut-input--static) {
+  cursor: pointer;
+}
+
 .settings-shortcut-input--static {
   background: var(--bg-e);
   color: var(--ink);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Addresses **OPEN-54** by making shortcut configuration in Settings and the stream sidebar easier and safer.

## Changes
- **Press-to-bind**: Shortcut fields are read-only; focus the field and press the desired key combination to bind (Escape blurs without saving invalid state from partial typing).
- **Paste**: Clipboard paste still works via explicit `onPaste` handlers (needed because read-only inputs often block default paste).
- **Duplicate detection**: Saving or capturing a shortcut now rejects conflicts with any other editable binding and with the fixed **stream sidebar** toggle (`Meta+G` on macOS, `Ctrl+Shift+G` elsewhere), matching the actual handler in `StreamView`.
- **Recording shortcut in Settings**: `shortcutToggleRecording` was already persisted but had no Settings UI; it is now editable alongside the others and included in reset-to-defaults.
- **Stream sidebar shortcuts tab**: Screenshot/recording fields use the same capture flow; conflict checks now include **Anti-AFK**; sidebar toggle display uses `formatShortcutForDisplay` with canonical `Meta+G` on Mac.
- **UX**: Replaced `<label>` wrappers around inputs with separate labels so clicking the label text no longer steals focus from the adjacent field. Read-only bind fields use a pointer cursor in CSS.

## Testing
- `npm install` and `npx tsc --noEmit` for both `tsconfig.node.json` and `tsconfig.json` (pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [OPEN-54](https://linear.app/zortos/issue/OPEN-54/fix-binding-issue-in-settings-key-binds)

<div><a href="https://cursor.com/agents/bc-1eafa6e5-09c7-401e-abbe-52e5bcb245a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1eafa6e5-09c7-401e-abbe-52e5bcb245a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

