### PR TITLE
Add iOS full-screen stream loading overlay with 3-step progress

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS.xcodeproj/project.pbxproj
+++ b/ios/OpenNOWiOS/OpenNOWiOS.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0A1B2C3D4E5F6A7B8C9D1002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1B2C3D4E5F6A7B8C9D2002 /* ContentView.swift */; };
 		0A1B2C3D4E5F6A7B8C9D1004 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A1B2C3D4E5F6A7B8C9D2004 /* Assets.xcassets */; };
 		0A1B2C3D4E5F6A7B8C9D1005 /* OpenNOWStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1B2C3D4E5F6A7B8C9D2006 /* OpenNOWStore.swift */; };
+		BB0000000000000000000007 /* StreamLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000017 /* StreamLoadingView.swift */; };
 		BB0000000000000000000001 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000011 /* LoginView.swift */; };
 		BB0000000000000000000002 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000012 /* HomeView.swift */; };
 		BB0000000000000000000003 /* BrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000013 /* BrowseView.swift */; };
@@ -31,6 +32,7 @@
 		BB0000000000000000000014 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		BB0000000000000000000015 /* SessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionView.swift; sourceTree = "<group>"; };
 		BB0000000000000000000016 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		BB0000000000000000000017 /* StreamLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamLoadingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +66,7 @@
 				BB0000000000000000000014 /* LibraryView.swift */,
 				BB0000000000000000000015 /* SessionView.swift */,
 				BB0000000000000000000016 /* SettingsView.swift */,
+				BB0000000000000000000017 /* StreamLoadingView.swift */,
 				0A1B2C3D4E5F6A7B8C9D2004 /* Assets.xcassets */
 			);
 			path = OpenNOWiOS;
@@ -154,6 +157,7 @@
 				BB0000000000000000000004 /* LibraryView.swift in Sources */,
 				BB0000000000000000000005 /* SessionView.swift in Sources */,
 				BB0000000000000000000006 /* SettingsView.swift in Sources */,
+				BB0000000000000000000007 /* StreamLoadingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
@@ -60,6 +60,13 @@ struct MainTabView: View {
                 .tabItem { Label("Settings", systemImage: "slider.horizontal.3") }
         }
         .tint(brandAccent)
+        .fullScreenCover(isPresented: Binding(
+            get: { store.showStreamLoading },
+            set: { if !$0 { Task { await store.endSession() } } }
+        )) {
+            StreamLoadingView()
+                .environmentObject(store)
+        }
     }
 }
 

--- a/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
@@ -1206,6 +1206,7 @@ final class OpenNOWStore: ObservableObject {
     @Published var isAuthenticating = false
     @Published var isLoadingGames = false
     @Published var isLaunchingSession = false
+    @Published var showStreamLoading: Bool = false
     @Published var lastError: String?
     @Published var isBootstrapping: Bool = true
 
@@ -1323,6 +1324,7 @@ final class OpenNOWStore: ObservableObject {
             return
         }
         isLaunchingSession = true
+        showStreamLoading = true
         defer { isLaunchingSession = false }
         do {
             let started = try await api.startSession(
@@ -1336,6 +1338,7 @@ final class OpenNOWStore: ObservableObject {
             startSessionTasks()
             lastError = nil
         } catch {
+            showStreamLoading = false
             lastError = "Session launch failed: \(error.localizedDescription)"
         }
     }
@@ -1362,6 +1365,7 @@ final class OpenNOWStore: ObservableObject {
             return
         }
         isLaunchingSession = true
+        showStreamLoading = true
         defer { isLaunchingSession = false }
         do {
             let refreshed = try await api.refreshSession(session)
@@ -1379,11 +1383,13 @@ final class OpenNOWStore: ObservableObject {
             startSessionTasks()
             lastError = nil
         } catch {
+            showStreamLoading = false
             lastError = "Failed to resume session: \(error.localizedDescription)"
         }
     }
 
     func endSession() async {
+        showStreamLoading = false
         guard let session = authSession, let active = activeSession else {
             activeSession = nil
             telemetryTask?.cancel()
@@ -1464,6 +1470,14 @@ final class OpenNOWStore: ObservableObject {
                     self.persistAuthSession(refreshed)
                     let polled = try await self.api.pollSession(session: refreshed, activeSession: active)
                     self.activeSession = polled
+                    if polled.status == 0 && self.showStreamLoading {
+                        try? await Task.sleep(for: .milliseconds(600))
+                        guard !Task.isCancelled,
+                              self.showStreamLoading,
+                              self.activeSession?.id == polled.id,
+                              self.activeSession?.status == 0 else { continue }
+                        self.showStreamLoading = false
+                    }
                 } catch {
                     self.lastError = "Session poll failed: \(error.localizedDescription)"
                 }

--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamLoadingView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamLoadingView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+
+struct StreamLoadingView: View {
+    @EnvironmentObject private var store: OpenNOWStore
+    @State private var pulsing = false
+
+    private enum StreamPhase: Equatable {
+        case queue
+        case setup
+        case launching
+    }
+
+    private enum StepState: Equatable {
+        case pending
+        case active
+        case completed
+    }
+
+    private let steps: [(title: String, icon: String)] = [
+        ("Queue", "person.3.fill"),
+        ("Setup", "cpu"),
+        ("Launching", "wifi")
+    ]
+
+    private var currentPhase: StreamPhase {
+        guard let session = store.activeSession else { return .queue }
+        switch session.status {
+        case 0: return .launching
+        case 2: return .setup
+        default: return .queue
+        }
+    }
+
+    private var statusMessage: String {
+        switch currentPhase {
+        case .queue:
+            if let pos = store.activeSession?.queuePosition {
+                return "Position #\(pos) in queue"
+            }
+            return store.isLaunchingSession ? "Starting session..." : "Waiting in queue..."
+        case .setup:
+            return "Setting up your gaming rig..."
+        case .launching:
+            return "Connecting to server..."
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.95)
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Spacer()
+
+                gameHeader
+
+                if currentPhase == .queue, let pos = store.activeSession?.queuePosition {
+                    HStack {
+                        Image(systemName: "person.3.fill")
+                            .foregroundStyle(.orange)
+                        Text("Queue position: \(pos)")
+                            .font(.subheadline.bold())
+                            .foregroundStyle(.orange)
+                    }
+                    .padding(12)
+                    .background(.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+                    .frame(maxWidth: 320)
+                }
+
+                stepsView
+
+                Text(statusMessage)
+                    .font(.subheadline)
+                    .foregroundStyle(.white.opacity(0.8))
+                    .multilineTextAlignment(.center)
+
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .tint(brandAccent)
+                    .scaleEffect(1.3)
+
+                Button(role: .cancel) {
+                    Task { await store.endSession() }
+                } label: {
+                    Label("Cancel", systemImage: "xmark")
+                        .font(.subheadline.bold())
+                        .foregroundStyle(.white.opacity(0.6))
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 10)
+                        .background(Color.white.opacity(0.08), in: Capsule())
+                }
+                .padding(.top, 8)
+
+                Spacer()
+            }
+            .padding(.horizontal, 24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .onAppear {
+            pulsing = true
+        }
+    }
+
+    private var gameHeader: some View {
+        VStack(spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(Color.white.opacity(0.06))
+                    .frame(width: 92, height: 92)
+
+                if let session = store.activeSession {
+                    Image(systemName: session.game.icon)
+                        .font(.system(size: 34, weight: .semibold))
+                        .foregroundStyle(gameColor(for: session.game.title))
+                } else {
+                    Image(systemName: "bolt.fill")
+                        .font(.system(size: 34, weight: .semibold))
+                        .foregroundStyle(brandGradient)
+                }
+            }
+
+            VStack(spacing: 4) {
+                Text(store.activeSession?.game.title ?? "Preparing your game")
+                    .font(.title2.bold())
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+
+                Text(store.activeSession?.game.platform ?? "Cloud Gaming")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var stepsView: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                VStack(spacing: 10) {
+                    ZStack {
+                        stepCircle(for: stepState(index: index))
+
+                        if stepState(index: index) == .completed {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 16, weight: .bold))
+                                .foregroundStyle(.white)
+                        } else {
+                            Image(systemName: step.icon)
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(iconColor(for: stepState(index: index)))
+                        }
+                    }
+                    .frame(width: 44, height: 44)
+
+                    Text(step.title)
+                        .font(.caption.bold())
+                        .foregroundStyle(labelColor(for: stepState(index: index)))
+                }
+
+                if index < steps.count - 1 {
+                    Rectangle()
+                        .fill(connectorColor(after: index))
+                        .frame(width: 36, height: 2)
+                        .padding(.bottom, 26)
+                }
+            }
+        }
+        .frame(maxWidth: 320)
+    }
+
+    private func stepState(index: Int) -> StepState {
+        let activeIndex: Int
+        switch currentPhase {
+        case .queue: activeIndex = 0
+        case .setup: activeIndex = 1
+        case .launching: activeIndex = 2
+        }
+        if index < activeIndex { return .completed }
+        if index == activeIndex { return .active }
+        return .pending
+    }
+
+    @ViewBuilder
+    private func stepCircle(for state: StepState) -> some View {
+        switch state {
+        case .pending:
+            Circle()
+                .fill(Color.white.opacity(0.12))
+                .overlay(
+                    Circle()
+                        .stroke(Color.white.opacity(0.2), lineWidth: 2)
+                )
+        case .active:
+            Circle()
+                .fill(brandAccent)
+                .scaleEffect(pulsing ? 1.15 : 1.0)
+                .opacity(pulsing ? 0.92 : 1.0)
+                .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: pulsing)
+        case .completed:
+            Circle()
+                .fill(brandAccent.opacity(0.35))
+                .overlay(
+                    Circle()
+                        .stroke(brandAccent, lineWidth: 2)
+                )
+        }
+    }
+
+    private func iconColor(for state: StepState) -> Color {
+        switch state {
+        case .pending:
+            return Color.white.opacity(0.4)
+        case .active:
+            return .white
+        case .completed:
+            return .white
+        }
+    }
+
+    private func labelColor(for state: StepState) -> Color {
+        switch state {
+        case .pending:
+            return Color.white.opacity(0.4)
+        case .active:
+            return .white
+        case .completed:
+            return brandAccent
+        }
+    }
+
+    private func connectorColor(after index: Int) -> Color {
+        switch stepState(index: index + 1) {
+        case .pending:
+            return Color.white.opacity(0.15)
+        case .active, .completed:
+            return brandAccent
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a full-screen loading overlay that displays session launch progress through three animated steps: Queue, Setup, and Launching.

**State Management (`OpenNOWStore.swift`):**

*   Added `showStreamLoading` published flag to control overlay visibility.
*   Set `showStreamLoading = true` in `launch()` and `resumeSession()`, and `false` on error or in `endSession()`.
*   Auto-dismiss overlay in `sessionPollTask` when session status reaches connected (0) after a 600ms delay.

**View Integration (`ContentView.swift`):**

*   Wired `.fullScreenCover` on `MainTabView` to `store.showStreamLoading` with dismiss logic calling `endSession()`.

**UI Implementation (`StreamLoadingView.swift`):**

*   Implemented phase-driven UI for Queue, Setup, and Launching states based on session status.
*   Added animated progress dots, queue position banner, game header, and cancel button using design tokens.

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/ae4468ea-e09c-44f8-b609-9cc4dcc201ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-3&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-3"><img alt="OPEN-3 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-3"></picture></a>