### PR TITLE
Fix iOS cancel-during-launch race with cancellable launch task wrappers

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/BrowseView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/BrowseView.swift
@@ -57,7 +57,7 @@ struct BrowseView: View {
             LazyVGrid(columns: gridColumns, spacing: 14) {
                 ForEach(filtered) { game in
                     GameCardView(game: game) {
-                        Task { await store.launch(game: game) }
+                        store.scheduleLaunch(game: game)
                     }
                 }
             }

--- a/ios/OpenNOWiOS/OpenNOWiOS/HomeView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/HomeView.swift
@@ -104,7 +104,7 @@ struct HomeView: View {
                 } else {
                     ForEach(store.featuredGames.prefix(8)) { game in
                         FeaturedGameCard(game: game) {
-                            Task { await store.launch(game: game) }
+                            store.scheduleLaunch(game: game)
                         }
                     }
                 }
@@ -125,7 +125,7 @@ struct HomeView: View {
             } else {
                 ForEach(games) { game in
                     GameCardView(game: game) {
-                        Task { await store.launch(game: game) }
+                        store.scheduleLaunch(game: game)
                     }
                 }
             }

--- a/ios/OpenNOWiOS/OpenNOWiOS/LibraryView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/LibraryView.swift
@@ -29,7 +29,7 @@ struct LibraryView: View {
                 } else {
                     ForEach(store.libraryGames) { game in
                         GameCardView(game: game) {
-                            Task { await store.launch(game: game) }
+                            store.scheduleLaunch(game: game)
                         }
                     }
                 }

--- a/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
@@ -1215,6 +1215,7 @@ final class OpenNOWStore: ObservableObject {
     private var authSession: AuthSession?
     private var telemetryTask: Task<Void, Never>?
     private var sessionPollTask: Task<Void, Never>?
+    private var launchTask: Task<Void, Never>?
     private var cachedVpcId: String = "GFN-PC"
 
     private let settingsKey = "OpenNOW.iOS.settings"
@@ -1228,6 +1229,7 @@ final class OpenNOWStore: ObservableObject {
     }
 
     deinit {
+        launchTask?.cancel()
         telemetryTask?.cancel()
         sessionPollTask?.cancel()
     }
@@ -1337,10 +1339,18 @@ final class OpenNOWStore: ObservableObject {
             sessionElapsedSeconds = 0
             startSessionTasks()
             lastError = nil
+        } catch is CancellationError {
+            showStreamLoading = false
+            return
         } catch {
             showStreamLoading = false
             lastError = "Session launch failed: \(error.localizedDescription)"
         }
+    }
+
+    func scheduleLaunch(game: CloudGame) {
+        launchTask?.cancel()
+        launchTask = Task { await self.launch(game: game) }
     }
 
     func refreshRemoteSessions() async {
@@ -1382,13 +1392,23 @@ final class OpenNOWStore: ObservableObject {
             sessionElapsedSeconds = 0
             startSessionTasks()
             lastError = nil
+        } catch is CancellationError {
+            showStreamLoading = false
+            return
         } catch {
             showStreamLoading = false
             lastError = "Failed to resume session: \(error.localizedDescription)"
         }
     }
 
+    func scheduleResume(candidate: RemoteSessionCandidate) {
+        launchTask?.cancel()
+        launchTask = Task { await self.resumeSession(candidate: candidate) }
+    }
+
     func endSession() async {
+        launchTask?.cancel()
+        launchTask = nil
         showStreamLoading = false
         guard let session = authSession, let active = activeSession else {
             activeSession = nil

--- a/ios/OpenNOWiOS/OpenNOWiOS/SessionView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/SessionView.swift
@@ -257,7 +257,7 @@ struct SessionView: View {
                         }
                         Spacer()
                         Button("Resume") {
-                            Task { await store.resumeSession(candidate: candidate) }
+                            store.scheduleResume(candidate: candidate)
                         }
                         .buttonStyle(.bordered)
                         .tint(brandAccent)


### PR DESCRIPTION
This PR fixes a race condition in OpenNOWiOS where tapping Cancel on `StreamLoadingView` during `isLaunchingSession` would leave the in-flight `api.startSession()` running because `endSession()` early-returned when `activeSession == nil`. The pending launch would then complete and start the session, ignoring the user's cancel request.

**OpenNOWStore.swift:**

* Added `launchTask` private property to track the in-flight launch or resume operation.
* `deinit` now cancels `launchTask` in addition to `telemetryTask` and `sessionPollTask`.
* Added explicit `CancellationError` handling in `launch()` and `resumeSession()` to dismiss the loading overlay without setting an error when cancelled.
* Added `scheduleLaunch(game:)` and `scheduleResume(candidate:)` synchronous wrappers that cancel any existing `launchTask` and start the new operation.
* Updated `endSession()` to cancel and nil out `launchTask` immediately before checking `activeSession`, ensuring the pending API call is aborted even when `activeSession` is not yet set.

**View Call Sites:**

* `HomeView.swift`: Replaced `Task { await store.launch(game:) }` with `store.scheduleLaunch(game:)` in both the featured section and the game grid.
* `BrowseView.swift`: Replaced `Task { await store.launch(game:) }` with `store.scheduleLaunch(game:)`.
* `LibraryView.swift`: Replaced `Task { await store.launch(game:) }` with `store.scheduleLaunch(game:)`.
* `SessionView.swift`: Replaced `Task { await store.resumeSession(candidate:) }` with `store.scheduleResume(candidate:)`.

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/87c44776-84d7-4173-8a28-2d10aadd8afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-4&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-4"><img alt="OPEN-4 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-4"></picture></a>