### PR TITLE
Fix iOS stale cancellation race against stream loading state

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
@@ -1340,7 +1340,6 @@ final class OpenNOWStore: ObservableObject {
             startSessionTasks()
             lastError = nil
         } catch is CancellationError {
-            showStreamLoading = false
             return
         } catch {
             showStreamLoading = false
@@ -1393,7 +1392,6 @@ final class OpenNOWStore: ObservableObject {
             startSessionTasks()
             lastError = nil
         } catch is CancellationError {
-            showStreamLoading = false
             return
         } catch {
             showStreamLoading = false


### PR DESCRIPTION
This PR prevents stale `CancellationError` handlers from clearing the stream loading overlay when a new `scheduleLaunch` or `scheduleResume` fires concurrently while a previous launch is still being cancelled. `endSession()` already handles clearing `showStreamLoading`, so these catch blocks should just silently return.

**OpenNOWiOS/OpenNOWStore.swift:**

* Removed `showStreamLoading = false` from `CancellationError` catch in `launch()`
* Removed `showStreamLoading = false` from `CancellationError` catch in `resumeSession()`

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/e159c60c-e833-41a2-b815-986c267259de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-5&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-5"><img alt="OPEN-5 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-5"></picture></a>