### PR TITLE
Fix iOS WebRTC SDP processing, dual-path token refresh, and polish queue UI

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
@@ -56,12 +56,14 @@ struct MainTabView: View {
                 .tabItem { Label("Settings", systemImage: "slider.horizontal.3") }
         }
         .tint(brandAccent)
-        .fullScreenCover(isPresented: $store.queueOverlayVisible) {
+        .fullScreenCover(isPresented: $store.queueOverlayVisible.transaction { transaction in
+            transaction.animation = transaction.animation?.delay(0.15)
+        }) {
             StreamLoadingView()
                 .environmentObject(store)
         }
         .fullScreenCover(item: $store.streamSession) { session in
-            StreamerView(session: session) {
+            StreamerView(session: session, settings: store.settings) {
                 store.dismissStreamer()
             }
         }
@@ -151,6 +153,7 @@ private struct QueueStatusPill: View {
         }
         .padding(.horizontal, 10)
         .queuePillBackground()
+        .shadow(color: brandAccent.opacity(0.12), radius: 8, y: 2)
         .shadow(color: .black.opacity(0.2), radius: 12, y: 4)
         .padding(.horizontal, 16)
         .onAppear {

--- a/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
@@ -67,6 +67,8 @@ struct ActiveSession: Identifiable, Codable, Equatable {
     var status: Int
     var queuePosition: Int?
     var serverIp: String?
+    var mediaIp: String?
+    var mediaPort: Int
     var signalingServer: String?
     var signalingUrl: String?
     var iceServers: [IceServerConfig]
@@ -138,239 +140,6 @@ private enum GFNConstants {
     static let oauthRedirectPort: UInt16 = 2259
 }
 
-private final class GFNSignalingClient: NSObject, URLSessionWebSocketDelegate {
-    enum Event {
-        case connected
-        case disconnected(reason: String)
-        case offer(sdp: String)
-        case remoteIce(candidate: String)
-        case log(String)
-        case failure(String)
-    }
-
-    private let signalingServer: String
-    private let sessionId: String
-    private let signalingUrl: String?
-    private let userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/131.0.0.0 Safari/537.36"
-    private let peerName = "peer-\(Int.random(in: 1_000_000...9_999_999_999))"
-    private var peerId = 2
-    private var ackCounter = 0
-    private var webSocketTask: URLSessionWebSocketTask?
-    private var urlSession: URLSession?
-    private var heartbeatTimer: Timer?
-    private var openContinuation: CheckedContinuation<Void, Error>?
-    private var eventHandler: ((Event) -> Void)?
-
-    init(signalingServer: String, sessionId: String, signalingUrl: String?) {
-        self.signalingServer = signalingServer
-        self.sessionId = sessionId
-        self.signalingUrl = signalingUrl
-    }
-
-    func onEvent(_ handler: @escaping (Event) -> Void) {
-        eventHandler = handler
-    }
-
-    func connect() async throws {
-        if webSocketTask != nil {
-            return
-        }
-        let signInURL = try buildSignInURL()
-        var request = URLRequest(url: signInURL)
-        request.setValue("https://play.geforcenow.com", forHTTPHeaderField: "Origin")
-        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-        request.timeoutInterval = 20
-        let config = URLSessionConfiguration.default
-        config.waitsForConnectivity = true
-        let session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
-        urlSession = session
-        let subprotocol = "x-nv-sessionid.\(sessionId)"
-        request.setValue(subprotocol, forHTTPHeaderField: "Sec-WebSocket-Protocol")
-        let task = session.webSocketTask(with: request)
-        webSocketTask = task
-        task.resume()
-
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { [weak self] in
-                guard let self else { return }
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    self.openContinuation = continuation
-                }
-            }
-            group.addTask {
-                try await Task.sleep(for: .seconds(12))
-                throw NSError(
-                    domain: "OpenNOW.Signaling",
-                    code: 91,
-                    userInfo: [NSLocalizedDescriptionKey: "Signaling connect timeout"]
-                )
-            }
-            let _ = try await group.next()
-            group.cancelAll()
-        }
-
-        receiveNextMessage()
-    }
-
-    func disconnect() {
-        heartbeatTimer?.invalidate()
-        heartbeatTimer = nil
-        webSocketTask?.cancel(with: .goingAway, reason: nil)
-        webSocketTask = nil
-        urlSession?.invalidateAndCancel()
-        urlSession = nil
-        if let openContinuation {
-            openContinuation.resume(throwing: NSError(
-                domain: "OpenNOW.Signaling",
-                code: 92,
-                userInfo: [NSLocalizedDescriptionKey: "Signaling disconnected before open"]
-            ))
-            self.openContinuation = nil
-        }
-    }
-
-    private func buildSignInURL() throws -> URL {
-        let fallbackHost = signalingServer.contains(":") ? signalingServer : "\(signalingServer):443"
-        let base = (signalingUrl?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
-            ? signalingUrl!
-            : "wss://\(fallbackHost)/nvst/"
-        guard var components = URLComponents(string: base) else {
-            throw NSError(domain: "OpenNOW.Signaling", code: 90, userInfo: [NSLocalizedDescriptionKey: "Invalid signaling URL"])
-        }
-        components.scheme = "wss"
-        let normalizedPath = components.path.hasSuffix("/") ? components.path : "\(components.path)/"
-        components.path = "\(normalizedPath)sign_in"
-        components.queryItems = [
-            URLQueryItem(name: "peer_id", value: peerName),
-            URLQueryItem(name: "version", value: "2")
-        ]
-        guard let url = components.url else {
-            throw NSError(domain: "OpenNOW.Signaling", code: 90, userInfo: [NSLocalizedDescriptionKey: "Invalid signaling URL"])
-        }
-        return url
-    }
-
-    private func nextAckId() -> Int {
-        ackCounter += 1
-        return ackCounter
-    }
-
-    private func sendJson(_ payload: [String: Any]) {
-        guard let task = webSocketTask else { return }
-        guard let data = try? JSONSerialization.data(withJSONObject: payload),
-              let text = String(data: data, encoding: .utf8) else { return }
-        task.send(.string(text)) { [weak self] error in
-            if let error {
-                self?.eventHandler?(.failure("send failed: \(error.localizedDescription)"))
-            }
-        }
-    }
-
-    private func setupHeartbeat() {
-        heartbeatTimer?.invalidate()
-        heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
-            self?.sendJson(["hb": 1])
-        }
-    }
-
-    private func sendPeerInfo() {
-        sendJson([
-            "ackid": nextAckId(),
-            "peer_info": [
-                "browser": "Chrome",
-                "browserVersion": "131",
-                "connected": true,
-                "id": peerId,
-                "name": peerName,
-                "peerRole": 0,
-                "resolution": "1920x1080",
-                "version": 2
-            ]
-        ])
-    }
-
-    private func receiveNextMessage() {
-        guard let task = webSocketTask else { return }
-        task.receive { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .failure(let error):
-                self.eventHandler?(.failure("receive failed: \(error.localizedDescription)"))
-                self.disconnect()
-            case .success(let message):
-                switch message {
-                case .string(let text):
-                    self.handleIncomingText(text)
-                case .data(let data):
-                    if let text = String(data: data, encoding: .utf8) {
-                        self.handleIncomingText(text)
-                    }
-                @unknown default:
-                    break
-                }
-                self.receiveNextMessage()
-            }
-        }
-    }
-
-    private func handleIncomingText(_ text: String) {
-        guard let data = text.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            eventHandler?(.log("Ignoring non-JSON signaling packet"))
-            return
-        }
-
-        if parsed["hb"] != nil {
-            sendJson(["hb": 1])
-            return
-        }
-
-        if let ackId = parsed["ackid"] as? Int {
-            let peerInfo = parsed["peer_info"] as? [String: Any]
-            let sourcePeerId = peerInfo?["id"] as? Int
-            if sourcePeerId != peerId {
-                sendJson(["ack": ackId])
-            }
-        }
-
-        guard let peerMsg = parsed["peer_msg"] as? [String: Any],
-              let msg = peerMsg["msg"] as? String,
-              let msgData = msg.data(using: .utf8),
-              let peerPayload = try? JSONSerialization.jsonObject(with: msgData) as? [String: Any] else {
-            return
-        }
-
-        if let type = peerPayload["type"] as? String,
-           type == "offer",
-           let sdp = peerPayload["sdp"] as? String {
-            eventHandler?(.offer(sdp: sdp))
-            return
-        }
-
-        if let candidate = peerPayload["candidate"] as? String {
-            eventHandler?(.remoteIce(candidate: candidate))
-            return
-        }
-
-        eventHandler?(.log("Unhandled signaling message keys: \(peerPayload.keys.joined(separator: ","))"))
-    }
-
-    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
-        sendPeerInfo()
-        setupHeartbeat()
-        openContinuation?.resume()
-        openContinuation = nil
-        eventHandler?(.connected)
-    }
-
-    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
-        let reasonText = reason.flatMap { String(data: $0, encoding: .utf8) } ?? "socket closed (\(closeCode.rawValue))"
-        eventHandler?(.disconnected(reason: reasonText))
-        disconnect()
-    }
-}
-
-@MainActor
 private final class OAuthWebAuthenticator: NSObject, ASWebAuthenticationPresentationContextProviding {
     private var session: ASWebAuthenticationSession?
 
@@ -707,12 +476,70 @@ private actor GFNAPIClient {
     }
 
     func refreshSession(_ session: AuthSession) async throws -> AuthSession {
-        guard Date().timeIntervalSince1970 >= session.tokens.expiresAt - (10 * 60) else {
+        let nowEpoch = Date().timeIntervalSince1970
+        guard nowEpoch >= session.tokens.expiresAt - (10 * 60) else {
             return session
         }
-        guard let refreshToken = session.tokens.refreshToken else {
-            return session
+
+        if let clientToken = session.tokens.clientToken,
+           let expiry = session.tokens.clientTokenExpiresAt,
+           nowEpoch < expiry - (5 * 60) {
+            if let refreshed = try? await refreshWithClientToken(clientToken, userId: session.user.userId, existing: session) {
+                return refreshed
+            }
         }
+
+        if let refreshToken = session.tokens.refreshToken {
+            return try await refreshWithOAuthToken(refreshToken, existing: session)
+        }
+
+        return session
+    }
+
+    private func refreshWithClientToken(_ clientToken: String, userId: String, existing: AuthSession) async throws -> AuthSession {
+        let body = URLQueryItemEncoder.encode([
+            "grant_type": "urn:ietf:params:oauth:grant-type:client_token",
+            "client_token": clientToken,
+            "client_id": GFNConstants.clientId,
+            "sub": userId
+        ])
+        var headers = headersForOAuth()
+        headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+        let (data, response) = try await request(
+            url: GFNConstants.tokenEndpoint,
+            method: "POST",
+            headers: headers,
+            body: body.data(using: .utf8)
+        )
+        guard response.statusCode == 200 else {
+            throw NSError(domain: "OpenNOW.Auth", code: response.statusCode, userInfo: [NSLocalizedDescriptionKey: "client_token refresh failed"])
+        }
+        let json = try parseJSON(data)
+        guard let accessToken = json["access_token"] as? String else {
+            throw NSError(domain: "OpenNOW.Auth", code: 4, userInfo: [NSLocalizedDescriptionKey: "client_token response missing access_token"])
+        }
+        let newRefresh = (json["refresh_token"] as? String) ?? existing.tokens.refreshToken
+        let newIdToken = (json["id_token"] as? String) ?? existing.tokens.idToken
+        let expiresIn = (json["expires_in"] as? Double) ?? 86400
+        var newClientToken = existing.tokens.clientToken
+        var newClientTokenExpiry = existing.tokens.clientTokenExpiresAt
+        if let fresh = try? await requestClientToken(accessToken: accessToken) {
+            newClientToken = fresh.token
+            newClientTokenExpiry = fresh.expiresAt
+        }
+        let newTokens = AuthTokens(
+            accessToken: accessToken,
+            refreshToken: newRefresh,
+            idToken: newIdToken,
+            expiresAt: Date().addingTimeInterval(expiresIn).timeIntervalSince1970,
+            clientToken: newClientToken,
+            clientTokenExpiresAt: newClientTokenExpiry
+        )
+        let user = (try? await fetchUser(tokens: newTokens)) ?? existing.user
+        return AuthSession(provider: existing.provider, tokens: newTokens, user: user)
+    }
+
+    private func refreshWithOAuthToken(_ refreshToken: String, existing: AuthSession) async throws -> AuthSession {
         let body = URLQueryItemEncoder.encode([
             "grant_type": "refresh_token",
             "refresh_token": refreshToken,
@@ -724,40 +551,34 @@ private actor GFNAPIClient {
             url: GFNConstants.tokenEndpoint,
             method: "POST",
             headers: headers,
-            body: body.data(using: String.Encoding.utf8)
+            body: body.data(using: .utf8)
         )
         guard response.statusCode == 200 else {
-            return session
+            throw NSError(domain: "OpenNOW.Auth", code: response.statusCode, userInfo: [NSLocalizedDescriptionKey: "refresh_token exchange failed"])
         }
         let json = try parseJSON(data)
         guard let accessToken = json["access_token"] as? String else {
-            return session
+            throw NSError(domain: "OpenNOW.Auth", code: 4, userInfo: [NSLocalizedDescriptionKey: "refresh_token response missing access_token"])
         }
         let newRefresh = (json["refresh_token"] as? String) ?? refreshToken
-        let newIdToken = json["id_token"] as? String ?? session.tokens.idToken
-        let expiresIn = json["expires_in"] as? Double ?? 86400
-        let user = (try? await fetchUser(tokens: AuthTokens(
+        let newIdToken = (json["id_token"] as? String) ?? existing.tokens.idToken
+        let expiresIn = (json["expires_in"] as? Double) ?? 86400
+        var newClientToken = existing.tokens.clientToken
+        var newClientTokenExpiry = existing.tokens.clientTokenExpiresAt
+        if let fresh = try? await requestClientToken(accessToken: accessToken) {
+            newClientToken = fresh.token
+            newClientTokenExpiry = fresh.expiresAt
+        }
+        let newTokens = AuthTokens(
             accessToken: accessToken,
             refreshToken: newRefresh,
             idToken: newIdToken,
             expiresAt: Date().addingTimeInterval(expiresIn).timeIntervalSince1970,
-            clientToken: session.tokens.clientToken,
-            clientTokenExpiresAt: session.tokens.clientTokenExpiresAt
-        ))) ?? session.user
-
-        let refreshed = AuthSession(
-            provider: session.provider,
-            tokens: AuthTokens(
-                accessToken: accessToken,
-                refreshToken: newRefresh,
-                idToken: newIdToken,
-                expiresAt: Date().addingTimeInterval(expiresIn).timeIntervalSince1970,
-                clientToken: session.tokens.clientToken,
-                clientTokenExpiresAt: session.tokens.clientTokenExpiresAt
-            ),
-            user: user
+            clientToken: newClientToken,
+            clientTokenExpiresAt: newClientTokenExpiry
         )
-        return refreshed
+        let user = (try? await fetchUser(tokens: newTokens)) ?? existing.user
+        return AuthSession(provider: existing.provider, tokens: newTokens, user: user)
     }
 
     func fetchMainGames(session: AuthSession) async throws -> ([CloudGame], String) {
@@ -856,6 +677,7 @@ private actor GFNAPIClient {
         let queue = sessionObj["queuePosition"] as? Int
         let control = sessionObj["sessionControlInfo"] as? [String: Any]
         let serverIp = Self.extractServerIp(sessionObj: sessionObj) ?? (control?["ip"] as? String)
+        let mediaConnectionInfo = Self.extractMediaConnectionInfo(sessionObj: sessionObj)
         let signaling = Self.resolveSignaling(sessionObj: sessionObj, fallbackServerIp: serverIp)
         let iceServers = Self.extractIceServers(sessionObj: sessionObj)
         return ActiveSession(
@@ -865,6 +687,8 @@ private actor GFNAPIClient {
             status: status,
             queuePosition: queue,
             serverIp: serverIp,
+            mediaIp: mediaConnectionInfo.ip,
+            mediaPort: mediaConnectionInfo.port,
             signalingServer: signaling.server,
             signalingUrl: signaling.url,
             iceServers: iceServers,
@@ -920,6 +744,7 @@ private actor GFNAPIClient {
         let queue = (sessionObj["queuePosition"] as? Int) ??
             ((sessionObj["seatSetupInfo"] as? [String: Any])?["queuePosition"] as? Int)
         let serverIp = Self.extractServerIp(sessionObj: sessionObj) ?? activeSession.serverIp
+        let mediaConnectionInfo = Self.extractMediaConnectionInfo(sessionObj: sessionObj)
         let signaling = Self.resolveSignaling(sessionObj: sessionObj, fallbackServerIp: serverIp ?? activeSession.signalingServer)
         let iceServers = Self.extractIceServers(sessionObj: sessionObj)
 
@@ -927,6 +752,8 @@ private actor GFNAPIClient {
         updated.status = status
         updated.queuePosition = queue
         updated.serverIp = serverIp
+        updated.mediaIp = mediaConnectionInfo.ip ?? updated.mediaIp
+        updated.mediaPort = mediaConnectionInfo.port > 0 ? mediaConnectionInfo.port : updated.mediaPort
         updated.signalingServer = signaling.server ?? updated.signalingServer
         updated.signalingUrl = signaling.url ?? updated.signalingUrl
         if !iceServers.isEmpty {
@@ -1009,16 +836,25 @@ private actor GFNAPIClient {
             throw NSError(domain: "OpenNOW.Session", code: claimResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: text])
         }
 
+        let claimJSON = (try? parseJSON(claimData)) ?? [:]
+        let claimSessionObj = claimJSON["session"] as? [String: Any] ?? [:]
+        let claimServerIp = Self.extractServerIp(sessionObj: claimSessionObj) ?? candidate.serverIp
+        let mediaConnectionInfo = Self.extractMediaConnectionInfo(sessionObj: claimSessionObj)
+        let signaling = Self.resolveSignaling(sessionObj: claimSessionObj, fallbackServerIp: claimServerIp)
+        let iceServers = Self.extractIceServers(sessionObj: claimSessionObj)
+
         var active = ActiveSession(
             id: candidate.id,
             game: game,
             startedAt: .now,
-            status: candidate.status,
+            status: (claimSessionObj["status"] as? Int) ?? candidate.status,
             queuePosition: nil,
-            serverIp: candidate.serverIp,
-            signalingServer: candidate.serverIp,
-            signalingUrl: candidate.serverIp.flatMap { "wss://\($0):443/nvst/" },
-            iceServers: [],
+            serverIp: claimServerIp,
+            mediaIp: mediaConnectionInfo.ip,
+            mediaPort: mediaConnectionInfo.port,
+            signalingServer: signaling.server ?? claimServerIp,
+            signalingUrl: signaling.url ?? claimServerIp.flatMap { "wss://\($0):443/nvst/" },
+            iceServers: iceServers,
             zone: vpcId,
             streamingBaseUrl: zoneBase,
             clientId: clientId,
@@ -1078,6 +914,21 @@ private actor GFNAPIClient {
             }
         }
         return nil
+    }
+
+    private static func extractMediaConnectionInfo(sessionObj: [String: Any]) -> (ip: String?, port: Int) {
+        let connectionInfo = sessionObj["connectionInfo"] as? [[String: Any]] ?? []
+        let mediaConn = connectionInfo.first(where: { ($0["usage"] as? Int) == 1 })
+        let mediaIp: String?
+        if let ip = mediaConn?["ip"] as? String, !ip.isEmpty {
+            mediaIp = ip
+        } else if let ips = mediaConn?["ip"] as? [String], let first = ips.first, !first.isEmpty {
+            mediaIp = first
+        } else {
+            mediaIp = nil
+        }
+        let mediaPort = mediaConn?["port"] as? Int ?? 0
+        return (mediaIp, mediaPort)
     }
 
     private static func resolveSignaling(sessionObj: [String: Any], fallbackServerIp: String?) -> (server: String?, url: String?) {
@@ -1564,8 +1415,6 @@ final class OpenNOWStore: ObservableObject {
     private var telemetryTask: Task<Void, Never>?
     private var sessionPollTask: Task<Void, Never>?
     private var launchTask: Task<Void, Never>?
-    private var signalingClient: GFNSignalingClient?
-    private var signalingClientKey: String?
     private var sessionPollBackgroundTaskId: UIBackgroundTaskIdentifier = .invalid
     private var cachedVpcId: String = "GFN-PC"
 
@@ -1575,7 +1424,11 @@ final class OpenNOWStore: ObservableObject {
     private let setupPhaseTimeoutSeconds: TimeInterval = 90
 
     init() {
-        settings = Self.loadSettings(from: defaults) ?? .default
+        var loadedSettings = Self.loadSettings(from: defaults) ?? .default
+        if loadedSettings.preferredCodec == "HEVC" {
+            loadedSettings.preferredCodec = "H265"
+        }
+        settings = loadedSettings
         authSession = Self.loadAuthSession(from: defaults)
         user = authSession?.user
     }
@@ -1584,7 +1437,6 @@ final class OpenNOWStore: ObservableObject {
         launchTask?.cancel()
         telemetryTask?.cancel()
         sessionPollTask?.cancel()
-        signalingClient?.disconnect()
     }
 
     func bootstrap() async {
@@ -1640,7 +1492,6 @@ final class OpenNOWStore: ObservableObject {
         sessionElapsedSeconds = 0
         showStreamLoading = false
         queueOverlayVisible = false
-        disconnectSignaling()
         defaults.removeObject(forKey: authSessionKey)
     }
 
@@ -1781,7 +1632,6 @@ final class OpenNOWStore: ObservableObject {
         showStreamLoading = false
         queueOverlayVisible = false
         await NotificationManager.shared.cancelSessionNotifications()
-        disconnectSignaling()
         guard let session = authSession, let active = activeSession else {
             activeSession = nil
             streamSession = nil
@@ -1825,6 +1675,10 @@ final class OpenNOWStore: ObservableObject {
         if let encoded = try? JSONEncoder().encode(settings) {
             defaults.set(encoded, forKey: settingsKey)
         }
+    }
+
+    var authProviderCode: String? {
+        authSession?.provider.code
     }
 
     func formattedSessionElapsed() -> String {
@@ -1962,68 +1816,6 @@ final class OpenNOWStore: ObservableObject {
 
     private func isReadyForStreamer(_ session: ActiveSession) -> Bool {
         session.status == 2 || session.status == 3
-    }
-
-    private func connectSignalingIfNeeded(for session: ActiveSession) async {
-        guard let signalingServer = signalingServerHost(for: session) else {
-            logger.error("Cannot connect signaling: missing signaling server for session id=\(session.id, privacy: .public)")
-            return
-        }
-        let signalingUrl = "wss://\(signalingServer):443/nvst/"
-        let nextKey = "\(session.id)|\(signalingServer)|\(signalingUrl)"
-        if signalingClientKey == nextKey {
-            return
-        }
-        disconnectSignaling()
-        logger.info(
-            "Connecting signaling sessionId=\(session.id, privacy: .public) server=\(signalingServer, privacy: .public) url=\(signalingUrl, privacy: .public)"
-        )
-        let client = GFNSignalingClient(signalingServer: signalingServer, sessionId: session.id, signalingUrl: signalingUrl)
-        client.onEvent { [weak self] event in
-            guard let self else { return }
-            Task { @MainActor in
-                switch event {
-                case .connected:
-                    self.logger.info("Signaling connected for session id=\(session.id, privacy: .public)")
-                case .disconnected(let reason):
-                    self.logger.info("Signaling disconnected reason=\(reason, privacy: .public)")
-                case .offer(let sdp):
-                    self.logger.notice("Signaling offer received (len=\(sdp.count)). WebRTC client not wired in iOS target yet.")
-                case .remoteIce(let candidate):
-                    self.logger.debug("Remote ICE candidate received: \(candidate, privacy: .public)")
-                case .log(let message):
-                    self.logger.debug("Signaling log: \(message, privacy: .public)")
-                case .failure(let message):
-                    self.logger.error("Signaling failure: \(message, privacy: .public)")
-                }
-            }
-        }
-
-        do {
-            try await client.connect()
-            signalingClient = client
-            signalingClientKey = nextKey
-        } catch {
-            logger.error("Signaling connect failed: \(error.localizedDescription, privacy: .public)")
-            signalingClient = nil
-            signalingClientKey = nil
-        }
-    }
-
-    private func disconnectSignaling() {
-        signalingClient?.disconnect()
-        signalingClient = nil
-        signalingClientKey = nil
-    }
-
-    private func signalingServerHost(for session: ActiveSession) -> String? {
-        if let ip = session.serverIp?.trimmingCharacters(in: .whitespacesAndNewlines), !ip.isEmpty {
-            return ip
-        }
-        guard let host = URL(string: session.streamingBaseUrl)?.host else {
-            return nil
-        }
-        return host
     }
 
     private func refreshSessionPollBackgroundTask() {

--- a/ios/OpenNOWiOS/OpenNOWiOS/PrintedWasteQueueView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/PrintedWasteQueueView.swift
@@ -90,20 +90,29 @@ struct PrintedWasteQueueView: View {
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if zones.isEmpty {
-                    ContentUnavailableView(
-                        "No Servers Available",
-                        systemImage: "network.slash",
-                        description: Text("Try again in a moment.")
-                    )
+                    VStack(spacing: 18) {
+                        ContentUnavailableView(
+                            "No Servers Available",
+                            systemImage: "network.slash",
+                            description: Text("No servers are available right now.")
+                        )
+                        Button("Launch Anyway") {
+                            onConfirm(nil)
+                            dismiss()
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     List {
                         Section {
                             header
+                                .listRowBackground(Color(.secondarySystemGroupedBackground).opacity(0.7))
                         }
 
                         Section("Routing") {
                             routingRow
+                                .listRowBackground(Color(.secondarySystemGroupedBackground).opacity(0.7))
                         }
 
                         ForEach(groupedZones, id: \.region) { group in
@@ -121,13 +130,15 @@ struct PrintedWasteQueueView: View {
                                         )
                                     }
                                     .buttonStyle(.plain)
+                                    .listRowBackground(Color(.secondarySystemGroupedBackground).opacity(0.7))
                                 }
                             }
                         }
                     }
-                    .listStyle(.insetGrouped)
+                    .listStyle(.plain)
                 }
             }
+            .animation(.spring(response: 0.35), value: isLoading)
             .navigationTitle("Choose Server")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -146,7 +157,9 @@ struct PrintedWasteQueueView: View {
                 }
             }
         }
+        .interactiveDismissDisabled(isLoading)
         .presentationDragIndicator(.visible)
+        .presentationCornerRadius(32)
         .presentationBackground(.regularMaterial)
         .task {
             await loadZones()
@@ -518,7 +531,20 @@ private struct PrintedWasteLaunchSheetModifier: ViewModifier {
     @Binding var pendingGame: CloudGame?
 
     func body(content: Content) -> some View {
-        content.sheet(item: $pendingGame) { game in
+        let sheetBinding = Binding<CloudGame?>(
+            get: {
+                store.authProviderCode == "BPC" ? nil : pendingGame
+            },
+            set: { pendingGame = $0 }
+        )
+
+        content
+            .onChange(of: pendingGame?.id) { _, _ in
+                guard store.authProviderCode == "BPC", let game = pendingGame else { return }
+                store.scheduleLaunch(game: game, zoneUrl: nil)
+                pendingGame = nil
+            }
+            .sheet(item: sheetBinding) { game in
             PrintedWasteQueueView(game: game) { selectedZoneUrl in
                 store.scheduleLaunch(game: game, zoneUrl: selectedZoneUrl)
             }

--- a/ios/OpenNOWiOS/OpenNOWiOS/SettingsView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/SettingsView.swift
@@ -5,7 +5,7 @@ struct SettingsView: View {
 
     private let fpsValues = [60, 120]
     private let qualityValues = ["Balanced", "Data Saver", "Quality"]
-    private let codecValues = ["Auto", "H264", "HEVC", "AV1"]
+    private let codecValues = ["Auto", "H264", "H265", "AV1"]
     private let regionValues = ["Auto", "US East", "US West", "Europe", "Asia"]
 
     var body: some View {
@@ -99,6 +99,8 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
+            .scrollContentBackground(.hidden)
+            .background(appBackground)
             .onChange(of: store.settings) { _, _ in
                 store.persistSettings()
             }
@@ -124,5 +126,6 @@ struct SettingsView: View {
                 .pickerStyle(.menu)
                 .tint(.primary)
         }
+        .listRowBackground(Color(.secondarySystemGroupedBackground).opacity(0.75))
     }
 }

--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamLoadingView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamLoadingView.swift
@@ -51,16 +51,8 @@ struct StreamLoadingView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(
-                colors: [
-                    Color.black.opacity(0.98),
-                    Color(red: 0.06, green: 0.06, blue: 0.08),
-                    Color.black.opacity(0.96)
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-            .ignoresSafeArea()
+            Color(.systemBackground)
+                .ignoresSafeArea()
 
             VStack(spacing: 24) {
                 Spacer()
@@ -84,7 +76,7 @@ struct StreamLoadingView: View {
 
                 Text(statusMessage)
                     .font(.subheadline)
-                    .foregroundStyle(.white.opacity(0.82))
+                    .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
 
                 ProgressView()
@@ -125,9 +117,16 @@ struct StreamLoadingView: View {
     private var gameHeader: some View {
         VStack(spacing: 14) {
             ZStack {
-                Circle()
-                    .fill(Color.white.opacity(0.06))
-                    .frame(width: 92, height: 92)
+                if #available(iOS 26, *) {
+                    Circle()
+                        .fill(.regularMaterial)
+                        .glassEffect(in: Circle())
+                        .frame(width: 92, height: 92)
+                } else {
+                    Circle()
+                        .fill(Color.secondary.opacity(0.12))
+                        .frame(width: 92, height: 92)
+                }
 
                 if let session = store.activeSession {
                     Image(systemName: session.game.icon)
@@ -143,7 +142,7 @@ struct StreamLoadingView: View {
             VStack(spacing: 4) {
                 Text(store.activeSession?.game.title ?? "Preparing your game")
                     .font(.title2.bold())
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
                     .multilineTextAlignment(.center)
 
                 Text(store.activeSession?.game.platform ?? "Cloud Gaming")
@@ -182,7 +181,7 @@ struct StreamLoadingView: View {
 
                 if index < steps.count - 1 {
                     Rectangle()
-                        .fill(connectorColor(after: index))
+                        .fill(connectorGradient(after: index))
                         .frame(width: 24, height: 2)
                         .padding(.bottom, 26)
                 }
@@ -208,17 +207,29 @@ struct StreamLoadingView: View {
         switch state {
         case .pending:
             Circle()
-                .fill(Color.white.opacity(0.12))
+                .fill(Color.secondary.opacity(0.12))
                 .overlay(
                     Circle()
-                        .stroke(Color.white.opacity(0.2), lineWidth: 2)
+                        .stroke(Color.secondary.opacity(0.2), lineWidth: 2)
                 )
         case .active:
-            Circle()
-                .fill(brandAccent)
-                .scaleEffect(pulsing ? 1.15 : 1.0)
-                .opacity(pulsing ? 0.92 : 1.0)
-                .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: pulsing)
+            Group {
+                if #available(iOS 26, *) {
+                    Circle()
+                        .fill(.regularMaterial)
+                        .glassEffect(in: Circle())
+                        .overlay(
+                            Circle()
+                                .stroke(brandAccent.opacity(0.55), lineWidth: 1.5)
+                        )
+                } else {
+                    Circle()
+                        .fill(brandAccent)
+                }
+            }
+            .scaleEffect(pulsing ? 1.15 : 1.0)
+            .opacity(pulsing ? 0.92 : 1.0)
+            .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: pulsing)
         case .completed:
             Circle()
                 .fill(brandAccent.opacity(0.35))
@@ -232,8 +243,10 @@ struct StreamLoadingView: View {
     private func iconColor(for state: StepState) -> Color {
         switch state {
         case .pending:
-            return Color.white.opacity(0.4)
-        case .active, .completed:
+            return .secondary.opacity(0.7)
+        case .active:
+            return brandAccent
+        case .completed:
             return .white
         }
     }
@@ -241,21 +254,24 @@ struct StreamLoadingView: View {
     private func labelColor(for state: StepState) -> Color {
         switch state {
         case .pending:
-            return Color.white.opacity(0.4)
+            return .secondary
         case .active:
-            return .white
+            return .primary
         case .completed:
             return brandAccent
         }
     }
 
-    private func connectorColor(after index: Int) -> Color {
+    private func connectorGradient(after index: Int) -> LinearGradient {
+        let startColor: Color = stepState(index: index) == .completed ? brandAccent : .secondary.opacity(0.2)
+        let endColor: Color
         switch stepState(index: index + 1) {
         case .pending:
-            return Color.white.opacity(0.15)
+            endColor = .secondary.opacity(0.2)
         case .active, .completed:
-            return brandAccent
+            endColor = brandAccent
         }
+        return LinearGradient(colors: [startColor, endColor], startPoint: .leading, endPoint: .trailing)
     }
 }
 

--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
@@ -1,14 +1,16 @@
 import SwiftUI
+import UIKit
 import WebKit
 
 struct StreamerView: View {
     let session: ActiveSession
+    let settings: AppSettings
     let onClose: () -> Void
     @State private var statusText = "Connecting streamer..."
 
     var body: some View {
         ZStack(alignment: .top) {
-            StreamerWebView(session: session) { event in
+            StreamerWebView(session: session, settings: settings) { event in
                 statusText = event
             }
             .ignoresSafeArea()
@@ -37,7 +39,14 @@ struct StreamerView: View {
 
 private struct StreamerWebView: UIViewRepresentable {
     let session: ActiveSession
+    let settings: AppSettings
     let onEvent: (String) -> Void
+
+    private struct StreamProfile {
+        let width: Int
+        let height: Int
+        let maxBitrateKbps: Int
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(onEvent: onEvent)
@@ -53,30 +62,49 @@ private struct StreamerWebView: UIViewRepresentable {
         webView.isOpaque = false
         webView.backgroundColor = .black
         webView.scrollView.isScrollEnabled = false
-        webView.loadHTMLString(buildHTML(for: session), baseURL: nil)
+        webView.loadHTMLString(buildHTML(for: session, settings: settings), baseURL: nil)
         return webView
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {}
 
-    private func buildHTML(for session: ActiveSession) -> String {
+    private func buildHTML(for session: ActiveSession, settings: AppSettings) -> String {
         struct Bridge: Encodable {
             let sessionId: String
             let signalingServer: String
             let signalingUrl: String
             let iceServers: [IceServerConfig]
+            let serverIp: String
+            let mediaIp: String?
+            let mediaPort: Int
+            let preferredCodec: String
+            let fps: Int
+            let maxBitrateKbps: Int
+            let width: Int
+            let height: Int
         }
+
         let signalingServer = session.signalingServer ?? session.serverIp ?? URL(string: session.streamingBaseUrl)?.host ?? ""
         let signalingUrl = session.signalingUrl ?? "wss://\(signalingServer):443/nvst/"
+        let serverIp = session.serverIp ?? signalingServer
+        let profile = Self.streamProfile(for: settings)
         let bridge = Bridge(
             sessionId: session.id,
             signalingServer: signalingServer,
             signalingUrl: signalingUrl,
-            iceServers: session.iceServers
+            iceServers: session.iceServers,
+            serverIp: serverIp,
+            mediaIp: session.mediaIp,
+            mediaPort: session.mediaPort,
+            preferredCodec: Self.normalizePreferredCodec(settings.preferredCodec),
+            fps: settings.preferredFPS,
+            maxBitrateKbps: profile.maxBitrateKbps,
+            width: profile.width,
+            height: profile.height
         )
         let data = (try? JSONEncoder().encode(bridge)) ?? Data("{}".utf8)
         let payload = String(data: data, encoding: .utf8) ?? "{}"
-        return """
+        return #"""
 <!doctype html>
 <html>
 <head>
@@ -92,7 +120,7 @@ private struct StreamerWebView: UIViewRepresentable {
   <video id="video" playsinline autoplay muted></video>
   <div id="tap">Tap to unmute</div>
   <script>
-  const cfg = \(payload);
+  const cfg = \#(payload);
   const video = document.getElementById("video");
   const tap = document.getElementById("tap");
   let ws = null;
@@ -105,12 +133,23 @@ private struct StreamerWebView: UIViewRepresentable {
   function post(type, message) {
     try { window.webkit.messageHandlers.opennow.postMessage({ type, message }); } catch (_) {}
   }
-  function log(m) { post("log", m); }
-  function fail(m) { post("error", m); }
+  function log(message) { post("log", message); }
+  function fail(message) { post("error", message); }
   function nextAck() { ack += 1; return ack; }
   function send(obj) {
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
     ws.send(JSON.stringify(obj));
+  }
+  function buildSignInUrl() {
+    const base = (cfg.signalingUrl || "").trim() || ("wss://" + cfg.signalingServer + "/nvst/");
+    const url = new URL(base);
+    url.protocol = "wss:";
+    if (!url.pathname.endsWith("/")) url.pathname += "/";
+    url.pathname += "sign_in";
+    url.search = "";
+    url.searchParams.set("peer_id", peerName);
+    url.searchParams.set("version", "2");
+    return url.toString();
   }
   function sendPeerInfo() {
     send({
@@ -122,78 +161,445 @@ private struct StreamerWebView: UIViewRepresentable {
         id: peerId,
         name: peerName,
         peerRole: 0,
-        resolution: "1920x1080",
+        resolution: `${cfg.width}x${cfg.height}`,
         version: 2
       }
     });
   }
-  function buildSignInUrl() {
-    const base = (cfg.signalingUrl || "").trim() || ("wss://" + cfg.signalingServer + "/nvst/");
-    const u = new URL(base);
-    u.protocol = "wss:";
-    if (!u.pathname.endsWith("/")) u.pathname += "/";
-    u.pathname += "sign_in";
-    u.search = "";
-    u.searchParams.set("peer_id", peerName);
-    u.searchParams.set("version", "2");
-    return u.toString();
+  function extractPublicIp(hostOrIp) {
+    if (!hostOrIp) return null;
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostOrIp)) return hostOrIp;
+    const first = hostOrIp.split('.')[0] ?? '';
+    const parts = first.split('-');
+    if (parts.length === 4 && parts.every(p => /^\d{1,3}$/.test(p))) return parts.join('.');
+    return null;
+  }
+  function fixServerIp(sdp, serverIp) {
+    const ip = extractPublicIp(serverIp);
+    if (!ip) return sdp;
+    let fixed = sdp.replace(/c=IN IP4 0\.0\.0\.0/g, `c=IN IP4 ${ip}`);
+    fixed = fixed.replace(/(a=candidate:\S+\s+\d+\s+\w+\s+\d+\s+)0\.0\.0\.0(\s+)/g, `$1${ip}$2`);
+    return fixed;
+  }
+  function extractIceUfragFromOffer(sdp) {
+    const match = sdp.match(/a=ice-ufrag:([^\r\n]+)/);
+    return match?.[1]?.trim() ?? "";
+  }
+  function extractIceCredentials(sdp) {
+    const lines = sdp.split(/\r?\n/);
+    const ufrag = lines.find((line) => line.startsWith('a=ice-ufrag:'))?.slice('a=ice-ufrag:'.length).trim() ?? '';
+    const pwd = lines.find((line) => line.startsWith('a=ice-pwd:'))?.slice('a=ice-pwd:'.length).trim() ?? '';
+    const fingerprint = lines.find((line) => line.startsWith('a=fingerprint:sha-256 '))?.slice('a=fingerprint:sha-256 '.length).trim() ?? '';
+    return { ufrag, pwd, fingerprint };
+  }
+  function normalizeCodec(name) {
+    const upper = String(name || '').toUpperCase();
+    return upper === 'HEVC' ? 'H265' : upper;
+  }
+  function offerHasCodec(sdp, codec) {
+    const target = normalizeCodec(codec);
+    let inVideo = false;
+    for (const line of sdp.split(/\r?\n/)) {
+      if (line.startsWith('m=video')) {
+        inVideo = true;
+        continue;
+      }
+      if (line.startsWith('m=') && inVideo) {
+        break;
+      }
+      if (!inVideo || !line.startsWith('a=rtpmap:')) continue;
+      const rest = line.slice('a=rtpmap:'.length);
+      const [pt, codecPart] = rest.split(/\s+/, 2);
+      const codecName = normalizeCodec((codecPart || '').split('/')[0] || '');
+      if (pt && codecName === target) return true;
+    }
+    return false;
+  }
+  function resolvePreferredCodec(offerSdp) {
+    const preferred = normalizeCodec(cfg.preferredCodec || 'Auto');
+    if (preferred === 'AUTO') {
+      return offerHasCodec(offerSdp, 'H265') ? 'H265' : 'H264';
+    }
+    return preferred;
+  }
+  function preferCodec(sdp, codec) {
+    const target = normalizeCodec(codec);
+    const lineEnding = sdp.includes('\r\n') ? '\r\n' : '\n';
+    const lines = sdp.split(/\r?\n/);
+    let inVideoSection = false;
+    const payloadTypesByCodec = new Map();
+    const codecByPayloadType = new Map();
+    const rtxAptByPayloadType = new Map();
+
+    for (const line of lines) {
+      if (line.startsWith('m=video')) {
+        inVideoSection = true;
+        continue;
+      }
+      if (line.startsWith('m=') && inVideoSection) {
+        inVideoSection = false;
+      }
+      if (!inVideoSection || !line.startsWith('a=rtpmap:')) continue;
+      const rest = line.slice('a=rtpmap:'.length);
+      const [pt, codecPart] = rest.split(/\s+/, 2);
+      const codecName = normalizeCodec((codecPart || '').split('/')[0] || '');
+      if (!pt || !codecName) continue;
+      const list = payloadTypesByCodec.get(codecName) ?? [];
+      list.push(pt);
+      payloadTypesByCodec.set(codecName, list);
+      codecByPayloadType.set(pt, codecName);
+    }
+
+    inVideoSection = false;
+    for (const line of lines) {
+      if (line.startsWith('m=video')) {
+        inVideoSection = true;
+        continue;
+      }
+      if (line.startsWith('m=') && inVideoSection) {
+        inVideoSection = false;
+      }
+      if (!inVideoSection || !line.startsWith('a=fmtp:')) continue;
+      const rest = line.split(':', 2)[1] ?? '';
+      const [pt = '', params = ''] = rest.split(/\s+/, 2);
+      if (!pt || !params) continue;
+      const aptMatch = params.match(/(?:^|;)\s*apt=(\d+)/i);
+      if (aptMatch?.[1]) {
+        rtxAptByPayloadType.set(pt, aptMatch[1]);
+      }
+    }
+
+    const preferredPayloads = payloadTypesByCodec.get(target) ?? [];
+    if (preferredPayloads.length === 0) {
+      return sdp;
+    }
+
+    const preferred = new Set(preferredPayloads);
+    const allowed = new Set(preferredPayloads);
+    for (const [rtxPt, apt] of rtxAptByPayloadType.entries()) {
+      if (preferred.has(apt) && codecByPayloadType.get(rtxPt) === 'RTX') {
+        allowed.add(rtxPt);
+      }
+    }
+
+    const filtered = [];
+    inVideoSection = false;
+    for (const line of lines) {
+      if (line.startsWith('m=video')) {
+        inVideoSection = true;
+        const parts = line.split(/\s+/);
+        const header = parts.slice(0, 3);
+        const available = parts.slice(3).filter((pt) => allowed.has(pt));
+        const ordered = [];
+        for (const pt of preferredPayloads) {
+          if (available.includes(pt)) ordered.push(pt);
+        }
+        for (const pt of available) {
+          if (!preferred.has(pt)) ordered.push(pt);
+        }
+        filtered.push(ordered.length > 0 ? [...header, ...ordered].join(' ') : line);
+        continue;
+      }
+      if (line.startsWith('m=') && inVideoSection) {
+        inVideoSection = false;
+      }
+      if (inVideoSection && (line.startsWith('a=rtpmap:') || line.startsWith('a=fmtp:') || line.startsWith('a=rtcp-fb:'))) {
+        const rest = line.split(':', 2)[1] ?? '';
+        const [pt = ''] = rest.split(/\s+/, 1);
+        if (pt && !allowed.has(pt)) continue;
+      }
+      filtered.push(line);
+    }
+
+    return filtered.join(lineEnding);
+  }
+  function mungeAnswerSdp(sdp, maxBitrateKbps) {
+    const lines = sdp.split(/\r?\n/);
+    const out = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      out.push(line);
+      if (line.startsWith('m=video') || line.startsWith('m=audio')) {
+        const bw = line.startsWith('m=video') ? maxBitrateKbps : 128;
+        if (!(lines[i + 1] ?? '').startsWith('b=')) out.push(`b=AS:${bw}`);
+      }
+      if (line.startsWith('a=fmtp:') && line.includes('minptime=') && !line.includes('stereo=1')) {
+        out[out.length - 1] = line + ';stereo=1';
+      }
+    }
+    return out.join(sdp.includes('\r\n') ? '\r\n' : '\n');
+  }
+  function detectNegotiatedCodec(sdp) {
+    const lines = sdp.split(/\r?\n/);
+    let inVideo = false;
+    let orderedPayloads = [];
+    const codecByPayload = new Map();
+    for (const line of lines) {
+      if (line.startsWith('m=video')) {
+        inVideo = true;
+        orderedPayloads = line.split(/\s+/).slice(3);
+        continue;
+      }
+      if (line.startsWith('m=') && inVideo) {
+        break;
+      }
+      if (!inVideo || !line.startsWith('a=rtpmap:')) continue;
+      const rest = line.slice('a=rtpmap:'.length);
+      const [pt, codecPart] = rest.split(/\s+/, 2);
+      if (!pt) continue;
+      codecByPayload.set(pt, normalizeCodec((codecPart || '').split('/')[0] || ''));
+    }
+    for (const pt of orderedPayloads) {
+      const codec = codecByPayload.get(pt);
+      if (codec && codec !== 'RTX') return codec;
+    }
+    return '';
+  }
+  function buildNvstSdp(params) {
+    const minBitrate = Math.max(5000, Math.floor(params.maxBitrateKbps * 0.35));
+    const initialBitrate = Math.max(minBitrate, Math.floor(params.maxBitrateKbps * 0.7));
+    const isHighFps = params.fps >= 90;
+    const is120Fps = params.fps === 120;
+    const is240Fps = params.fps >= 240;
+    const isAv1 = params.codec === 'AV1';
+    const bitDepth = params.colorQuality.startsWith('10bit') ? 10 : 8;
+    const hidDeviceMask = params.hidDeviceMask ?? 0xFFFFFFFF;
+    const enablePartiallyReliableTransferGamepad = params.enablePartiallyReliableTransferGamepad ?? 0xF;
+    const enablePartiallyReliableTransferHid = params.enablePartiallyReliableTransferHid ?? hidDeviceMask;
+    const lines = [
+      'v=0',
+      'o=SdpTest test_id_13 14 IN IPv4 127.0.0.1',
+      's=-',
+      't=0 0',
+      `a=general.icePassword:${params.credentials.pwd}`,
+      `a=general.iceUserNameFragment:${params.credentials.ufrag}`,
+      `a=general.dtlsFingerprint:${params.credentials.fingerprint}`,
+      'm=video 0 RTP/AVP',
+      'a=msid:fbc-video-0',
+      'a=vqos.fec.rateDropWindow:10',
+      'a=vqos.fec.minRequiredFecPackets:2',
+      'a=vqos.fec.repairMinPercent:5',
+      'a=vqos.fec.repairPercent:5',
+      'a=vqos.fec.repairMaxPercent:35',
+      'a=vqos.drc.enable:0',
+      'a=vqos.dfc.enable:0',
+      'a=video.dx9EnableNv12:1',
+      'a=video.dx9EnableHdr:1',
+      'a=vqos.qpg.enable:1',
+      'a=vqos.resControl.qp.qpg.featureSetting:7',
+      'a=bwe.useOwdCongestionControl:1',
+      'a=video.enableRtpNack:1',
+      'a=vqos.bw.txRxLag.minFeedbackTxDeltaMs:200',
+      'a=vqos.drc.bitrateIirFilterFactor:18',
+      'a=video.packetSize:1140',
+      'a=packetPacing.minNumPacketsPerGroup:15'
+    ];
+    if (isHighFps) {
+      lines.push(
+        'a=bwe.iirFilterFactor:8',
+        'a=video.encoderFeatureSetting:47',
+        'a=video.encoderPreset:6',
+        'a=vqos.resControl.cpmRtc.badNwSkipFramesCount:600',
+        'a=vqos.resControl.cpmRtc.decodeTimeThresholdMs:9',
+        `a=video.fbcDynamicFpsGrabTimeoutMs:${is120Fps ? 6 : 18}`,
+        `a=vqos.resControl.cpmRtc.serverResolutionUpdateCoolDownCount:${is120Fps ? 6000 : 12000}`
+      );
+    }
+    if (is240Fps) {
+      lines.push(
+        'a=video.enableNextCaptureMode:1',
+        'a=vqos.maxStreamFpsEstimate:240',
+        'a=video.videoSplitEncodeStripsPerFrame:3',
+        'a=video.updateSplitEncodeStateDynamically:1'
+      );
+    }
+    lines.push(
+      'a=vqos.adjustStreamingFpsDuringOutOfFocus:1',
+      'a=vqos.resControl.cpmRtc.ignoreOutOfFocusWindowState:1',
+      'a=vqos.resControl.perfHistory.rtcIgnoreOutOfFocusWindowState:1',
+      'a=vqos.resControl.cpmRtc.featureMask:0',
+      'a=vqos.resControl.cpmRtc.enable:0',
+      'a=vqos.resControl.cpmRtc.minResolutionPercent:100',
+      'a=vqos.resControl.cpmRtc.resolutionChangeHoldonMs:999999',
+      `a=packetPacing.numGroups:${is120Fps ? 3 : 5}`,
+      'a=packetPacing.maxDelayUs:1000',
+      'a=packetPacing.minNumPacketsFrame:10',
+      'a=video.rtpNackQueueLength:1024',
+      'a=video.rtpNackQueueMaxPackets:512',
+      'a=video.rtpNackMaxPacketCount:25',
+      'a=vqos.drc.qpMaxResThresholdAdj:4',
+      'a=vqos.grc.qpMaxResThresholdAdj:4',
+      'a=vqos.drc.iirFilterFactor:100'
+    );
+    if (isAv1) {
+      lines.push(
+        'a=vqos.drc.minQpHeadroom:20',
+        'a=vqos.drc.lowerQpThreshold:100',
+        'a=vqos.drc.upperQpThreshold:200',
+        'a=vqos.drc.minAdaptiveQpThreshold:180',
+        'a=vqos.drc.qpCodecThresholdAdj:0',
+        'a=vqos.drc.qpMaxResThresholdAdj:20',
+        'a=vqos.dfc.minQpHeadroom:20',
+        'a=vqos.dfc.qpLowerLimit:100',
+        'a=vqos.dfc.qpMaxUpperLimit:200',
+        'a=vqos.dfc.qpMinUpperLimit:180',
+        'a=vqos.dfc.qpMaxResThresholdAdj:20',
+        'a=vqos.dfc.qpCodecThresholdAdj:0',
+        'a=vqos.grc.minQpHeadroom:20',
+        'a=vqos.grc.lowerQpThreshold:100',
+        'a=vqos.grc.upperQpThreshold:200',
+        'a=vqos.grc.minAdaptiveQpThreshold:180',
+        'a=vqos.grc.qpMaxResThresholdAdj:20',
+        'a=vqos.grc.qpCodecThresholdAdj:0',
+        'a=video.minQp:25',
+        'a=video.enableAv1RcPrecisionFactor:1'
+      );
+    }
+    lines.push(
+      `a=video.clientViewportWd:${params.width}`,
+      `a=video.clientViewportHt:${params.height}`,
+      `a=video.maxFPS:${params.fps}`,
+      `a=video.initialBitrateKbps:${initialBitrate}`,
+      `a=video.initialPeakBitrateKbps:${params.maxBitrateKbps}`,
+      `a=vqos.bw.maximumBitrateKbps:${params.maxBitrateKbps}`,
+      `a=vqos.bw.minimumBitrateKbps:${minBitrate}`,
+      `a=vqos.bw.peakBitrateKbps:${params.maxBitrateKbps}`,
+      `a=vqos.bw.serverPeakBitrateKbps:${params.maxBitrateKbps}`,
+      'a=vqos.bw.enableBandwidthEstimation:1',
+      'a=vqos.bw.disableBitrateLimit:0',
+      `a=vqos.grc.maximumBitrateKbps:${params.maxBitrateKbps}`,
+      'a=vqos.grc.enable:0',
+      'a=video.maxNumReferenceFrames:4',
+      'a=video.mapRtpTimestampsToFrames:1',
+      'a=video.encoderCscMode:3',
+      'a=video.dynamicRangeMode:0',
+      `a=video.bitDepth:${bitDepth}`,
+      `a=video.scalingFeature1:${isAv1 ? 1 : 0}`,
+      'a=video.prefilterParams.prefilterModel:0',
+      'm=audio 0 RTP/AVP',
+      'a=msid:audio',
+      'm=mic 0 RTP/AVP',
+      'a=msid:mic',
+      'a=rtpmap:0 PCMU/8000',
+      'm=application 0 RTP/AVP',
+      'a=msid:input_1',
+      `a=ri.partialReliableThresholdMs:${params.partialReliableThresholdMs}`,
+      `a=ri.hidDeviceMask:${hidDeviceMask}`,
+      `a=ri.enablePartiallyReliableTransferGamepad:${enablePartiallyReliableTransferGamepad}`,
+      `a=ri.enablePartiallyReliableTransferHid:${enablePartiallyReliableTransferHid}`,
+      ''
+    );
+    return lines.join('\n');
+  }
+  async function waitForIceGathering(rtc, timeoutMs) {
+    if (!rtc.localDescription) return '';
+    if (rtc.iceGatheringState === 'complete') {
+      return rtc.localDescription?.sdp || '';
+    }
+    return await new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        rtc.removeEventListener('icegatheringstatechange', onChange);
+        resolve(rtc.localDescription?.sdp || '');
+      }, timeoutMs);
+      function onChange() {
+        if (rtc.iceGatheringState === 'complete') {
+          clearTimeout(timeout);
+          rtc.removeEventListener('icegatheringstatechange', onChange);
+          resolve(rtc.localDescription?.sdp || '');
+        }
+      }
+      rtc.addEventListener('icegatheringstatechange', onChange);
+    });
+  }
+  async function injectManualIce(rtc, ip, port, ufrag) {
+    const rawIp = extractPublicIp(ip);
+    if (!rawIp || !port) return;
+    const candidateStr = `candidate:1 1 udp 2130706431 ${rawIp} ${port} typ host`;
+    for (const mid of ['0', '1', '2', '3']) {
+      try {
+        await rtc.addIceCandidate({ candidate: candidateStr, sdpMid: mid, sdpMLineIndex: parseInt(mid, 10), usernameFragment: ufrag || undefined });
+        break;
+      } catch (_) {}
+    }
   }
   function ensurePeerConnection() {
     if (pc) return pc;
-    const ice = (cfg.iceServers || []).map((s) => ({
-      urls: Array.isArray(s.urls) ? s.urls : [s.urls],
-      username: s.username || undefined,
-      credential: s.credential || undefined
+    const ice = (cfg.iceServers || []).map((server) => ({
+      urls: Array.isArray(server.urls) ? server.urls : [server.urls],
+      username: server.username || undefined,
+      credential: server.credential || undefined
     }));
     pc = new RTCPeerConnection({ iceServers: ice });
-    pc.ontrack = (ev) => {
-      if (ev.streams && ev.streams[0]) {
-        video.srcObject = ev.streams[0];
+    pc.ontrack = (event) => {
+      if (event.streams && event.streams[0]) {
+        video.srcObject = event.streams[0];
       } else {
-        const ms = new MediaStream();
-        ms.addTrack(ev.track);
-        video.srcObject = ms;
+        const stream = new MediaStream();
+        stream.addTrack(event.track);
+        video.srcObject = stream;
       }
       video.play().catch(() => {});
-      post("status", "Streamer connected");
+      post('status', 'Streamer connected');
     };
-    pc.onicecandidate = (ev) => {
-      if (!ev.candidate) return;
+    pc.onicecandidate = (event) => {
+      if (!event.candidate) return;
       send({
         peer_msg: {
           from: peerId,
           to: 1,
           msg: JSON.stringify({
-            candidate: ev.candidate.candidate,
-            sdpMid: ev.candidate.sdpMid,
-            sdpMLineIndex: ev.candidate.sdpMLineIndex
+            candidate: event.candidate.candidate,
+            sdpMid: event.candidate.sdpMid,
+            sdpMLineIndex: event.candidate.sdpMLineIndex
           })
         },
         ackid: nextAck()
       });
     };
     pc.onconnectionstatechange = () => {
-      post("status", "Peer: " + pc.connectionState);
+      post('status', 'Peer: ' + pc.connectionState);
     };
     return pc;
   }
   async function onOffer(sdp) {
     try {
       const rtc = ensurePeerConnection();
-      await rtc.setRemoteDescription({ type: "offer", sdp });
+      const fixedOffer = fixServerIp(sdp, cfg.serverIp || cfg.signalingServer || '');
+      const serverIceUfrag = extractIceUfragFromOffer(fixedOffer);
+      const selectedCodec = resolvePreferredCodec(fixedOffer);
+      const filteredOffer = preferCodec(fixedOffer, selectedCodec);
+      await rtc.setRemoteDescription({ type: 'offer', sdp: filteredOffer });
       const answer = await rtc.createAnswer();
+      answer.sdp = mungeAnswerSdp(answer.sdp || '', cfg.maxBitrateKbps);
       await rtc.setLocalDescription(answer);
+      const finalSdp = (await waitForIceGathering(rtc, 5000)) || rtc.localDescription?.sdp || answer.sdp || '';
+      const effectiveCodec = detectNegotiatedCodec(finalSdp) || selectedCodec;
+      const credentials = extractIceCredentials(finalSdp);
+      const nvstSdp = buildNvstSdp({
+        width: cfg.width,
+        height: cfg.height,
+        fps: cfg.fps,
+        maxBitrateKbps: cfg.maxBitrateKbps,
+        codec: effectiveCodec,
+        colorQuality: '8bit',
+        partialReliableThresholdMs: 100,
+        hidDeviceMask: 0xFFFFFFFF,
+        enablePartiallyReliableTransferGamepad: 0xF,
+        enablePartiallyReliableTransferHid: 0xFFFFFFFF,
+        credentials
+      });
       send({
         peer_msg: {
           from: peerId,
           to: 1,
-          msg: JSON.stringify({ type: "answer", sdp: answer.sdp || "" })
+          msg: JSON.stringify({ type: 'answer', sdp: finalSdp, nvstSdp })
         },
         ackid: nextAck()
       });
-      post("status", "Offer accepted");
-    } catch (e) {
-      fail("Offer handling failed: " + String(e));
+      await injectManualIce(rtc, cfg.mediaIp, cfg.mediaPort, serverIceUfrag);
+      post('status', 'Offer accepted');
+    } catch (error) {
+      fail('Offer handling failed: ' + String(error));
     }
   }
   async function onRemoteIce(payload) {
@@ -204,57 +610,81 @@ private struct StreamerWebView: UIViewRepresentable {
         sdpMid: payload.sdpMid ?? null,
         sdpMLineIndex: payload.sdpMLineIndex ?? null
       });
-    } catch (e) {
-      log("Remote ICE add failed: " + String(e));
+    } catch (error) {
+      log('Remote ICE add failed: ' + String(error));
     }
   }
   function handle(text) {
     let parsed;
     try { parsed = JSON.parse(text); } catch (_) { return; }
     if (parsed.hb) { send({ hb: 1 }); return; }
-    if (typeof parsed.ackid === "number") {
+    if (typeof parsed.ackid === 'number') {
       const src = parsed.peer_info && parsed.peer_info.id;
       if (src !== peerId) send({ ack: parsed.ackid });
     }
     if (!parsed.peer_msg || !parsed.peer_msg.msg) return;
     let msg;
     try { msg = JSON.parse(parsed.peer_msg.msg); } catch (_) { return; }
-    if (msg.type === "offer" && typeof msg.sdp === "string") {
+    if (msg.type === 'offer' && typeof msg.sdp === 'string') {
       onOffer(msg.sdp);
       return;
     }
-    if (typeof msg.candidate === "string") {
+    if (typeof msg.candidate === 'string') {
       onRemoteIce(msg);
     }
   }
   function connect() {
     try {
       const signIn = buildSignInUrl();
-      post("status", "Connecting signaling");
-      ws = new WebSocket(signIn, "x-nv-sessionid." + cfg.sessionId);
+      post('status', 'Connecting signaling');
+      ws = new WebSocket(signIn, 'x-nv-sessionid.' + cfg.sessionId);
       ws.onopen = () => {
         sendPeerInfo();
         if (hb) clearInterval(hb);
         hb = setInterval(() => send({ hb: 1 }), 5000);
-        post("status", "Signaling connected");
+        post('status', 'Signaling connected');
       };
-      ws.onmessage = (ev) => handle(ev.data);
-      ws.onerror = () => fail("Signaling error");
-      ws.onclose = (ev) => post("status", "Signaling closed (" + ev.code + ")");
-    } catch (e) {
-      fail("Signaling setup failed: " + String(e));
+      ws.onmessage = (event) => handle(event.data);
+      ws.onerror = () => fail('Signaling error');
+      ws.onclose = (event) => post('status', 'Signaling closed (' + event.code + ')');
+    } catch (error) {
+      fail('Signaling setup failed: ' + String(error));
     }
   }
   tap.onclick = async () => {
     video.muted = false;
-    tap.style.display = "none";
+    tap.style.display = 'none';
     try { await video.play(); } catch (_) {}
   };
   connect();
   </script>
 </body>
 </html>
-"""
+"""#
+    }
+
+    private static func normalizePreferredCodec(_ codec: String) -> String {
+        switch codec.uppercased() {
+        case "HEVC", "H265":
+            return "H265"
+        case "AV1":
+            return "AV1"
+        case "H264":
+            return "H264"
+        default:
+            return "Auto"
+        }
+    }
+
+    private static func streamProfile(for settings: AppSettings) -> StreamProfile {
+        let nativeBounds = UIScreen.main.nativeBounds
+        let longSide = max(nativeBounds.width, nativeBounds.height)
+        let shortSide = min(nativeBounds.width, nativeBounds.height)
+        let supports1440 = longSide >= 2500 || shortSide >= 1400 || UIScreen.main.nativeScale >= 3.0
+        if settings.preferredFPS >= 120 && supports1440 {
+            return StreamProfile(width: 2560, height: 1440, maxBitrateKbps: 50000)
+        }
+        return StreamProfile(width: 1920, height: 1080, maxBitrateKbps: 30000)
     }
 
     final class Coordinator: NSObject, WKScriptMessageHandler {


### PR DESCRIPTION
This PR ports full desktop WebRTC SDP manipulation (`fixServerIp`, `preferCodec`, `mungeAnswerSdp`, `buildNvstSdp`) into the iOS streaming WebView to fix "internal error" handshakes, implements dual-path token refresh (client_token preferred, OAuth fallback) to keep sessions alive, skips the PrintedWaste zone picker for Alliance/BPC providers, and polishes the queue/streaming UI with Liquid Glass aesthetics.

**OpenNOWStore.swift:**

* Added `mediaIp` and `mediaPort` to `ActiveSession` and extracted them from `usage == 1` in `connectionInfo`
* Rewrote `refreshSession` to try `client_token` grant first (preferred), then `refresh_token` OAuth, renewing client tokens after each refresh
* Removed dead `GFNSignalingClient` class, `connectSignalingIfNeeded`, `disconnectSignaling`, and all signaling client state properties
* Exposed `authProviderCode` for BPC bypass checks

**StreamerView.swift:**

* Added `settings: AppSettings` parameter and resolved stream profile (width/height/bitrate) from native screen bounds and FPS
* Expanded bridge JSON to include `serverIp`, `mediaIp`, `mediaPort`, `preferredCodec`, `fps`, `maxBitrateKbps`, `width`, `height`
* Implemented `fixServerIp` to replace `0.0.0.0` in offer SDP with actual server IP (extracts dash-encoded hostnames)
* Implemented `preferCodec` to filter/reorder `m=video` payload types for H265/H264/AV1 preference with "Auto" logic
* Implemented `mungeAnswerSdp` to inject `b=AS` for video/audio and `stereo=1` on Opus fmtp
* Implemented `buildNvstSdp` to construct the proprietary `nvstSdp` payload from answer credentials and stream params
* Implemented `injectManualIce` to add the media endpoint as a host candidate using `mediaIp`/`mediaPort` after answer send
* Integrated `waitForIceGathering` and extracted ICE credentials for nvstSdp construction

**PrintedWasteQueueView.swift:**

* Bypassed zone picker for `provider.code == "BPC"` by calling `scheduleLaunch(game, zoneUrl: nil)` directly and dismissing the sheet
* Wrapped zone list appearance in `.animation(.spring(response: 0.35), value: isLoading)` for smooth spinner-to-content transition
* Added `.interactiveDismissDisabled(isLoading)` to prevent accidental dismissal during fetch
* Added `"Launch Anyway"` button in empty zones view to allow forcing launch
* Changed List style to `.plain` with `Color(.secondarySystemGroupedBackground).opacity(0.7)` row backgrounds
* Added `.presentationCornerRadius(32)` and `.presentationBackground(.regularMaterial)` for premium modal feel

**ContentView.swift:**

* Passed `store.settings` to `StreamerView(session:settings:)` for appSettings access
* Added `.transaction { $0.animation = $0.animation?.delay(0.15) }` to `queueOverlayVisible` full screen cover to wait for launch sheet dismiss
* Added `.shadow(color: brandAccent.opacity(0.12), radius: 8, y: 2)` to `QueueStatusPill` for subtle glass glow

**StreamLoadingView.swift:**

* Replaced dark gradient with `Color(.systemBackground).ignoresSafeArea()` for system-adaptive appearance
* Wrapped `.active` step circles in `glassEffect(in: Circle())` on iOS 26+ with `brandAccent` stroke
* Wrapped game header icon circle in `glassEffect(in: Circle())` on iOS 26+
* Implemented `connectorGradient` using `LinearGradient` from completed/pending colors
* Updated text foregrounds to `.primary`/`.secondary` for adaptive coloring

**SettingsView.swift:**

* Changed codec options from `["Auto", "H264", "HEVC", "AV1"]` to `["Auto", "H264", "H265", "AV1"]`
* Added `.scrollContentBackground(.hidden)` and `.background(appBackground)` to NavigationStack
* Added `.listRowBackground(Color(.secondarySystemGroupedBackground).opacity(0.75))` to settings picker rows

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/2a1a7285-823a-4bc2-a0e4-281991b20f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-7&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-7"><img alt="OPEN-7 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-7"></picture></a>