### PR TITLE
Add support for Cloud G-Sync (Variable Refresh Rate) in session settings

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -1239,7 +1239,8 @@ function buildClaimRequestBody(sessionId: string, appId: string, settings: Strea
       requestedStreamingFeatures: {
         reflex: false,
         bitDepth: 0,
-        cloudGsync: settings.enableCloudGsync ?? false,
+        // RESUME claims must not renegotiate session creation-only streaming features.
+        cloudGsync: false,
         profile: 0,
         fallbackToLogicalResolution: false,
         chromaFormat: 0,

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -526,7 +526,7 @@ function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest
       requestedStreamingFeatures: {
         reflex: input.settings.fps >= 120,
         bitDepth,
-        cloudGsync: false,
+        cloudGsync: input.settings.enableCloudGsync,
         enabledL4S: input.settings.enableL4S,
         mouseMovementFlags: 0,
         trueHdr: hdrEnabled,
@@ -1239,8 +1239,7 @@ function buildClaimRequestBody(sessionId: string, appId: string, settings: Strea
       requestedStreamingFeatures: {
         reflex: false,
         bitDepth: 0,
-        cloudGsync: false,
-        enabledL4S: false,
+        cloudGsync: settings.enableCloudGsync ?? false,
         profile: 0,
         fallbackToLogicalResolution: false,
         chromaFormat: 0,
@@ -1275,6 +1274,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
     keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
     gameLanguage: "en_US",
     enableL4S: false,
+    enableCloudGsync: false,
   };
   const keyboardLayout = resolveGfnKeyboardLayout(settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = settings.gameLanguage ?? "en_US";

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -78,6 +78,8 @@ export interface Settings {
   gameLanguage: GameLanguage;
   /** Experimental request for Low Latency, Low Loss, Scalable throughput on new sessions */
   enableL4S: boolean;
+  /** Request Cloud G-Sync / Variable Refresh Rate on new sessions */
+  enableCloudGsync: boolean;
   /** Show the currently streaming game as Discord Rich Presence activity */
   discordRichPresence: boolean;
 }
@@ -127,6 +129,7 @@ const DEFAULT_SETTINGS: Settings = {
   keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
   gameLanguage: "en_US",
   enableL4S: false,
+  enableCloudGsync: false,
   discordRichPresence: false,
 };
 

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -712,6 +712,7 @@ export function App(): JSX.Element {
     keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
     gameLanguage: "en_US",
     enableL4S: false,
+    enableCloudGsync: false,
     discordRichPresence: false,
   });
   const [settingsLoaded, setSettingsLoaded] = useState(false);
@@ -2282,6 +2283,7 @@ export function App(): JSX.Element {
         keyboardLayout: settings.keyboardLayout,
         gameLanguage: settings.gameLanguage,
         enableL4S: settings.enableL4S,
+        enableCloudGsync: settings.enableCloudGsync,
       },
     });
 
@@ -2435,6 +2437,7 @@ export function App(): JSX.Element {
           keyboardLayout: settings.keyboardLayout,
           gameLanguage: settings.gameLanguage,
           enableL4S: settings.enableL4S,
+          enableCloudGsync: settings.enableCloudGsync,
         },
       });
 
@@ -3248,6 +3251,7 @@ export function App(): JSX.Element {
                 fps: settings.fps,
                 codec: settings.codec,
                 enableL4S: settings.enableL4S,
+                enableCloudGsync: settings.enableCloudGsync,
                 microphoneDeviceId: settings.microphoneDeviceId,
                 controllerUiSounds: settings.controllerUiSounds,
                 controllerBackgroundAnimations: settings.controllerBackgroundAnimations,
@@ -3402,6 +3406,7 @@ export function App(): JSX.Element {
                 fps: settings.fps,
                 codec: settings.codec,
                 enableL4S: settings.enableL4S,
+                enableCloudGsync: settings.enableCloudGsync,
                 microphoneDeviceId: settings.microphoneDeviceId,
                 controllerUiSounds: settings.controllerUiSounds,
                 controllerBackgroundAnimations: settings.controllerBackgroundAnimations,

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -33,6 +33,7 @@ interface ControllerLibraryPageProps {
     fps?: number;
     codec?: string;
     enableL4S?: boolean;
+    enableCloudGsync?: boolean;
     microphoneDeviceId?: string;
     controllerUiSounds?: boolean;
     controllerBackgroundAnimations?: boolean;
@@ -332,6 +333,7 @@ export function ControllerLibraryPage({
       Network: [
         { id: "bandwidth", label: "Max Bitrate", value: `${(settings.maxBitrateMbps ?? 75)} Mbps` },
         { id: "l4s", label: "Experimental L4S", value: settings.enableL4S ? "On" : "Off" },
+        { id: "cloudGsync", label: "Cloud G-Sync (VRR)", value: settings.enableCloudGsync ? "On" : "Off" },
       ],
       Video: [
         { id: "resolution", label: "Resolution", value: settings.resolution || "1920x1080" },
@@ -826,6 +828,9 @@ export function ControllerLibraryPage({
             playUiSound("move");
           } else if (setting.id === "l4s") {
             onSettingChange("enableL4S" as any, !((settings as any).enableL4S || false));
+            playUiSound("move");
+          } else if (setting.id === "cloudGsync") {
+            onSettingChange("enableCloudGsync" as any, !((settings as any).enableCloudGsync || false));
             playUiSound("move");
           }
           else if (setting.id === "bandwidth") {

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1460,6 +1460,28 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
               </span>
             </div>
 
+            <div className="settings-row settings-row--column">
+              <div className="settings-row-top settings-row-top--compact">
+                <label className="settings-label settings-label--wrap">
+                  <span className="settings-label-title">
+                    Cloud G-Sync / Variable Refresh Rate
+                    <span className="settings-inline-badge settings-inline-badge--beta">Beta</span>
+                  </span>
+                </label>
+                <label className="settings-toggle">
+                  <input
+                    type="checkbox"
+                    checked={settings.enableCloudGsync}
+                    onChange={(e) => handleChange("enableCloudGsync", e.target.checked)}
+                  />
+                  <span className="settings-toggle-track" />
+                </label>
+              </div>
+              <span className="settings-subtle-hint">
+                Request Cloud G-Sync (VRR) on newly created sessions. Smooths frame pacing on variable frame rate streams. Requires a VRR-capable display. The service may ignore this request depending on your subscription tier.
+              </span>
+            </div>
+
           </div>
         </section>
 

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -168,6 +168,8 @@ export interface Settings {
   gameLanguage: GameLanguage;
   /** Experimental request for Low Latency, Low Loss, Scalable throughput on new sessions */
   enableL4S: boolean;
+  /** Request Cloud G-Sync / Variable Refresh Rate on new sessions */
+  enableCloudGsync: boolean;
   /** Show the currently streaming game as Discord Rich Presence activity */
   discordRichPresence: boolean;
 }
@@ -369,6 +371,8 @@ export interface StreamSettings {
   gameLanguage: GameLanguage;
   /** Experimental request for Low Latency, Low Loss, Scalable throughput on new sessions */
   enableL4S: boolean;
+  /** Request Cloud G-Sync / Variable Refresh Rate on new sessions */
+  enableCloudGsync: boolean;
 }
 
 export interface SessionCreateRequest {


### PR DESCRIPTION
## Description

Enable Cloud G-Sync (Variable Refresh Rate) in session settings, allowing users to request smoother frame pacing on variable frame rate streams. This feature includes a toggle in the settings page and updates to session request bodies to accommodate the new option.

