### PR TITLE
Fix iOS TLS hostname mismatch for BPC/Alliance servers

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/Info.plist
+++ b/ios/OpenNOWiOS/OpenNOWiOS/Info.plist
@@ -35,6 +35,21 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>nvidiagrid.net</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSExceptionMinimumTLSVersion</key>
+				<string>TLSv1.2</string>
+			</dict>
+		</dict>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
@@ -301,7 +301,30 @@ private final class OAuthLoopbackServer {
     }
 }
 
+private final class GFNTLSDelegate: NSObject, URLSessionDelegate {
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust,
+              challenge.protectionSpace.host.hasSuffix("nvidiagrid.net") else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: serverTrust))
+    }
+}
+
 private actor GFNAPIClient {
+    private let session: URLSession = {
+        let delegate = GFNTLSDelegate()
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        return URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
+    }()
+
     private func request(
         url: URL,
         method: String = "GET",
@@ -314,7 +337,7 @@ private actor GFNAPIClient {
         for (k, v) in headers {
             req.setValue(v, forHTTPHeaderField: k)
         }
-        let (data, response) = try await URLSession.shared.data(for: req)
+        let (data, response) = try await self.session.data(for: req)
         guard let http = response as? HTTPURLResponse else {
             throw NSError(domain: "OpenNOW.Network", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid response"])
         }


### PR DESCRIPTION
This PR fixes session launch failures on BPC/Alliance servers by allowing TLS connections despite certificate hostname mismatches on `*.nvidiagrid.net` domains.

**Info.plist:**

* Added `NSAppTransportSecurity` domain exception for `nvidiagrid.net` with subdomain support to allow WKWebView signaling WebSocket connections.

**OpenNOWStore.swift:**

* Added `GFNTLSDelegate` class to handle server trust challenges, bypassing TLS validation only for hosts ending in `nvidiagrid.net`.
* Replaced `URLSession.shared` with a custom `URLSession` instance using the `GFNTLSDelegate` for all HTTP API calls.

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/6e5838e1-35eb-432f-890b-6fab03e65511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-8&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-8"><img alt="OPEN-8 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-8"></picture></a>