### PR TITLE
Fix iOS streaming input bugs and expand Liquid Glass UI

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/BrowseView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/BrowseView.swift
@@ -45,6 +45,8 @@ struct BrowseView: View {
                 }
             }
             .navigationTitle("Browse")
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .searchable(
                 text: $store.searchText,
                 placement: .navigationBarDrawer(displayMode: .automatic),
@@ -107,12 +109,30 @@ private struct FilterChip: View {
 
     var body: some View {
         Button(action: action) {
-            Text(label)
-                .font(.caption.weight(.semibold))
-                .padding(.horizontal, 14)
-                .padding(.vertical, 7)
-                .foregroundStyle(isSelected ? .white : .primary)
-                .background(isSelected ? brandAccent : Color(.systemFill), in: Capsule())
+            if #available(iOS 26, *) {
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .foregroundStyle(isSelected ? brandAccent : .primary)
+                    .background {
+                        if isSelected {
+                            Capsule()
+                                .fill(.regularMaterial)
+                                .glassEffect(in: Capsule())
+                                .overlay(Capsule().stroke(brandAccent.opacity(0.5), lineWidth: 1))
+                        } else {
+                            Capsule().fill(Color(.systemFill))
+                        }
+                    }
+            } else {
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .foregroundStyle(isSelected ? .white : .primary)
+                    .background(Capsule().fill(isSelected ? brandAccent : Color(.systemFill)))
+            }
         }
         .buttonStyle(.plain)
         .animation(.easeOut(duration: 0.15), value: isSelected)

--- a/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
@@ -56,6 +56,8 @@ struct MainTabView: View {
                 .tabItem { Label("Settings", systemImage: "slider.horizontal.3") }
         }
         .tint(brandAccent)
+        .toolbarBackground(.ultraThinMaterial, for: .tabBar)
+        .toolbarBackground(.visible, for: .tabBar)
         .fullScreenCover(isPresented: $store.queueOverlayVisible.transaction({
             var t = Transaction()
             t.animation = t.animation?.delay(0.15)
@@ -200,6 +202,15 @@ let brandGradient = LinearGradient(
 var appBackground: some View {
     ZStack {
         Color(.systemBackground)
+        LinearGradient(
+            colors: [
+                Color(red: 0.46, green: 0.72, blue: 0.0).opacity(0.04),
+                Color.clear,
+                Color(red: 0.0, green: 0.72, blue: 0.55).opacity(0.03)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
     }
     .ignoresSafeArea()
 }

--- a/ios/OpenNOWiOS/OpenNOWiOS/HomeView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/HomeView.swift
@@ -37,6 +37,8 @@ struct HomeView: View {
             }
             .refreshable { await store.refreshCatalog() }
             .navigationTitle("OpenNOW")
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     if store.isLoadingGames {
@@ -379,7 +381,7 @@ struct GlassCardModifier: ViewModifier {
         } else {
             content
                 .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
-                .shadow(color: .black.opacity(0.08), radius: 4, y: 2)
+                .shadow(color: .black.opacity(0.07), radius: 8, y: 2)
         }
     }
 }

--- a/ios/OpenNOWiOS/OpenNOWiOS/LibraryView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/LibraryView.swift
@@ -16,6 +16,8 @@ struct LibraryView: View {
                 }
             }
             .navigationTitle("Library")
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
         }
         .printedWasteLaunchSheet(pendingGame: $pendingLaunchGame)
     }

--- a/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
@@ -1697,6 +1697,9 @@ final class OpenNOWStore: ObservableObject {
 
     func dismissStreamer() {
         streamSession = nil
+        if activeSession != nil {
+            startSessionTasks()
+        }
     }
 
     func reopenStreamer() {
@@ -1734,7 +1737,7 @@ final class OpenNOWStore: ObservableObject {
         }
     }
 
-    private func startSessionTasks() {
+    fileprivate func startSessionTasks() {
         telemetryTask?.cancel()
         sessionPollTask?.cancel()
         endSessionPollBackgroundTask()

--- a/ios/OpenNOWiOS/OpenNOWiOS/SessionView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/SessionView.swift
@@ -27,6 +27,8 @@ struct SessionView: View {
                 .padding(.vertical, 8)
             }
             .navigationTitle("Session")
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -202,9 +204,19 @@ struct SessionView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
                 .font(.headline)
+                .foregroundStyle(.white)
         }
-        .buttonStyle(.bordered)
-        .tint(.red)
+        .buttonStyle(.plain)
+        .background {
+            if #available(iOS 26, *) {
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(.red.opacity(0.7))
+                    .glassEffect(in: RoundedRectangle(cornerRadius: 14))
+            } else {
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(.red.opacity(0.85))
+            }
+        }
     }
 
     private var noSessionState: some View {

--- a/ios/OpenNOWiOS/OpenNOWiOS/SettingsView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/SettingsView.swift
@@ -50,11 +50,13 @@ struct SettingsView: View {
                         Spacer()
                         Toggle("", isOn: $store.settings.keepMicEnabled)
                     }
+                    .listRowBackground(glassListRowBackground)
                     HStack {
                         Label("Stats Overlay", systemImage: "chart.bar.fill")
                         Spacer()
                         Toggle("", isOn: $store.settings.showStatsOverlay)
                     }
+                    .listRowBackground(glassListRowBackground)
                 } header: {
                     Label("Experience", systemImage: "star.fill")
                 }
@@ -66,6 +68,7 @@ struct SettingsView: View {
                         Label("Reload Catalog", systemImage: "arrow.clockwise")
                     }
                     .disabled(store.isLoadingGames)
+                    .listRowBackground(glassListRowBackground)
                 } header: {
                     Label("Data", systemImage: "internaldrive.fill")
                 }
@@ -73,16 +76,20 @@ struct SettingsView: View {
                 if let user = store.user {
                     Section {
                         LabeledContent("Account", value: user.displayName)
+                            .listRowBackground(glassListRowBackground)
                         if let email = user.email {
                             LabeledContent("Email", value: email)
+                                .listRowBackground(glassListRowBackground)
                         }
                         LabeledContent("Tier", value: user.membershipTier)
+                            .listRowBackground(glassListRowBackground)
 
                         Button(role: .destructive) {
                             store.signOut()
                         } label: {
                             Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
                         }
+                        .listRowBackground(glassListRowBackground)
                     } header: {
                         Label("Account", systemImage: "person.crop.circle")
                     }
@@ -90,10 +97,13 @@ struct SettingsView: View {
 
                 Section {
                     LabeledContent("Version", value: "1.0")
+                        .listRowBackground(glassListRowBackground)
                     LabeledContent("Platform", value: "iOS")
+                        .listRowBackground(glassListRowBackground)
                     Link(destination: URL(string: "https://github.com/OpenCloudGaming/OpenNOW")!) {
                         Label("GitHub Repository", systemImage: "link")
                     }
+                    .listRowBackground(glassListRowBackground)
                 } header: {
                     Label("About", systemImage: "info.circle")
                 }
@@ -101,6 +111,8 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .scrollContentBackground(.hidden)
             .background(appBackground)
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .onChange(of: store.settings) { _, _ in
                 store.persistSettings()
             }
@@ -126,6 +138,18 @@ struct SettingsView: View {
                 .pickerStyle(.menu)
                 .tint(.primary)
         }
-        .listRowBackground(Color(.secondarySystemGroupedBackground).opacity(0.75))
+        .listRowBackground(glassListRowBackground)
+    }
+
+    private var glassListRowBackground: some View {
+        Group {
+            if #available(iOS 26, *) {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(.regularMaterial)
+                    .glassEffect(in: RoundedRectangle(cornerRadius: 10))
+            } else {
+                Color(.secondarySystemGroupedBackground).opacity(0.75)
+            }
+        }
     }
 }

--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
@@ -18,10 +18,9 @@ struct StreamerView: View {
             HStack {
                 Text(statusText)
                     .font(.caption)
+                    .lineLimit(1)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
-                    .background(.regularMaterial, in: Capsule())
-                    .lineLimit(1)
                 Spacer()
                 Button {
                     onClose()
@@ -31,6 +30,19 @@ struct StreamerView: View {
                         .symbolRenderingMode(.hierarchical)
                 }
             }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background {
+                if #available(iOS 26, *) {
+                    Capsule()
+                        .fill(.regularMaterial)
+                        .glassEffect(in: Capsule())
+                } else {
+                    Capsule().fill(.regularMaterial)
+                }
+            }
+            .shadow(color: .black.opacity(0.25), radius: 10, y: 4)
             .padding()
         }
         .background(Color.black.ignoresSafeArea())
@@ -123,20 +135,28 @@ private struct StreamerWebView: UIViewRepresentable {
   <div id="touchHint" style="position:fixed;left:50%;bottom:60px;transform:translateX(-50%);
     color:rgba(255,255,255,0.45);font:11px -apple-system;pointer-events:none;user-select:none;
     text-align:center;transition:opacity 1s;">Drag to move · Tap to click · 2-finger tap to right-click</div>
-  <button id="kbBtn" onclick="toggleKeyboard()" style="position:fixed;right:16px;bottom:16px;z-index:20;
-    width:48px;height:48px;border-radius:50%;background:rgba(30,30,30,0.75);color:#fff;
-    border:1px solid rgba(255,255,255,0.25);font-size:22px;cursor:pointer;
-    backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);">⌨</button>
+  <button id="kbBtn" onclick="toggleKeyboard()" style="position:fixed;right:16px;bottom:20px;z-index:20;
+    width:52px;height:52px;border-radius:50%;
+    background:rgba(30,30,30,0.55);color:#fff;
+    border:1px solid rgba(255,255,255,0.18);font-size:22px;cursor:pointer;
+    backdrop-filter:blur(20px) saturate(180%);-webkit-backdrop-filter:blur(20px) saturate(180%);
+    box-shadow:0 4px 16px rgba(0,0,0,0.35);">⌨</button>
   <div id="kbBar" style="display:none;position:fixed;bottom:0;left:0;right:0;z-index:30;
-    background:rgba(20,20,20,0.92);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
-    padding:8px 12px;border-top:1px solid rgba(255,255,255,0.1);">
-    <div style="display:flex;gap:8px;align-items:center;">
+    background:rgba(18,18,20,0.75);
+    backdrop-filter:blur(30px) saturate(180%);-webkit-backdrop-filter:blur(30px) saturate(180%);
+    padding:10px 16px calc(10px + env(safe-area-inset-bottom));
+    border-top:0.5px solid rgba(255,255,255,0.12);">
+    <div style="display:flex;gap:10px;align-items:center;">
       <input id="kbInput" type="text" autocomplete="off" autocorrect="off" autocapitalize="none"
         spellcheck="false" placeholder="Type here…"
-        style="flex:1;background:#2a2a2a;color:#fff;border:1px solid rgba(255,255,255,0.2);
-          border-radius:8px;padding:8px 12px;font-size:16px;outline:none;">
-      <button onclick="hideKeyboard()" style="padding:8px 14px;background:#333;color:#fff;
-        border:none;border-radius:8px;font-size:14px;cursor:pointer;">Done</button>
+        style="flex:1;background:rgba(60,60,70,0.6);color:#fff;
+          border:0.5px solid rgba(255,255,255,0.15);
+          border-radius:10px;padding:9px 14px;font-size:16px;outline:none;">
+      <button onclick="hideKeyboard()" style="padding:9px 16px;
+        background:rgba(80,80,90,0.5);color:#fff;
+        border:0.5px solid rgba(255,255,255,0.12);border-radius:10px;
+        font-size:14px;cursor:pointer;
+        backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);">Done</button>
     </div>
   </div>
   <script>
@@ -728,6 +748,9 @@ private struct StreamerWebView: UIViewRepresentable {
   let lastTX = 0, lastTY = 0;
   let tStartTime = 0, tMoved = false;
   let twoFingerStart = 0;
+  var accDX = 0, accDY = 0;
+  var intentionalClose = false;
+  var reconnectTimer = null;
   const touchpad = document.getElementById('touchpad');
   const touchHint = document.getElementById('touchHint');
 
@@ -739,7 +762,7 @@ private struct StreamerWebView: UIViewRepresentable {
     kbBar.style.display = 'block';
     kbInput.value = '';
     kbPrevLen = 0;
-    setTimeout(() => kbInput.focus(), 80);
+    kbInput.focus();
   }
   function hideKeyboard() {
     kbBar.style.display = 'none';
@@ -797,18 +820,28 @@ private struct StreamerWebView: UIViewRepresentable {
     lastTY = t.clientY;
     tStartTime = Date.now();
     tMoved = false;
-    if (e.touches.length === 2) twoFingerStart = Date.now();
+    accDX = 0;
+    accDY = 0;
+    if (e.touches.length === 2) {
+      twoFingerStart = Date.now();
+      lastTX = e.touches[0].clientX;
+      lastTY = e.touches[0].clientY;
+    }
   }, { passive: false });
 
   touchpad.addEventListener('touchmove', (e) => {
     e.preventDefault();
     if (e.touches.length > 1) return;
     const t = e.touches[0];
-    const dx = Math.round((t.clientX - lastTX) * 2.5);
-    const dy = Math.round((t.clientY - lastTY) * 2.5);
+    accDX += (t.clientX - lastTX) * 2.0;
+    accDY += (t.clientY - lastTY) * 2.0;
     lastTX = t.clientX;
     lastTY = t.clientY;
-    if ((Math.abs(dx) > 0 || Math.abs(dy) > 0) && inputReady) {
+    const dx = Math.trunc(accDX);
+    const dy = Math.trunc(accDY);
+    accDX -= dx;
+    accDY -= dy;
+    if ((dx !== 0 || dy !== 0) && inputReady) {
       tMoved = true;
       sendPartialInput(encodeMouseMove(dx, dy));
     }
@@ -816,6 +849,8 @@ private struct StreamerWebView: UIViewRepresentable {
 
   touchpad.addEventListener('touchend', (e) => {
     e.preventDefault();
+    accDX = 0;
+    accDY = 0;
     if (!inputReady) return;
     const holdMs = Date.now() - tStartTime;
     if (!tMoved && holdMs < 500) {
@@ -871,11 +906,16 @@ private struct StreamerWebView: UIViewRepresentable {
       ws.onclose = (event) => {
         post('status', 'Signaling closed (' + event.code + ')');
         inputReady = false;
+        if (hb) { clearInterval(hb); hb = null; }
         if (hbInput) { clearInterval(hbInput); hbInput = null; }
-        if (reliableCh) { try { reliableCh.close(); } catch (_) {} }
-        if (partialCh) { try { partialCh.close(); } catch (_) {} }
-        reliableCh = null;
-        partialCh = null;
+        if (reliableCh) { try { reliableCh.close(); } catch (_) {} reliableCh = null; }
+        if (partialCh) { try { partialCh.close(); } catch (_) {} partialCh = null; }
+        if (pc) { try { pc.close(); } catch (_) {} pc = null; }
+        if (!intentionalClose) {
+          if (reconnectTimer) clearTimeout(reconnectTimer);
+          post('status', 'Reconnecting in 2.5 s…');
+          reconnectTimer = setTimeout(() => { reconnectTimer = null; connect(); }, 2500);
+        }
       };
     } catch (error) {
       fail('Signaling setup failed: ' + String(error));
@@ -911,10 +951,20 @@ private struct StreamerWebView: UIViewRepresentable {
         let longSide = max(nativeBounds.width, nativeBounds.height)
         let shortSide = min(nativeBounds.width, nativeBounds.height)
         let supports1440 = longSide >= 2500 || shortSide >= 1400 || UIScreen.main.nativeScale >= 3.0
-        if settings.preferredFPS >= 120 && supports1440 {
-            return StreamProfile(width: 2560, height: 1440, maxBitrateKbps: 50000)
+        switch settings.preferredQuality {
+        case "Data Saver":
+            return StreamProfile(width: 1280, height: 720, maxBitrateKbps: 15000)
+        case "Quality":
+            if supports1440 {
+                return StreamProfile(width: 2560, height: 1440, maxBitrateKbps: 50000)
+            }
+            return StreamProfile(width: 1920, height: 1080, maxBitrateKbps: 40000)
+        default:
+            if settings.preferredFPS >= 120 && supports1440 {
+                return StreamProfile(width: 2560, height: 1440, maxBitrateKbps: 50000)
+            }
+            return StreamProfile(width: 1920, height: 1080, maxBitrateKbps: 30000)
         }
-        return StreamProfile(width: 1920, height: 1080, maxBitrateKbps: 30000)
     }
 
     final class Coordinator: NSObject, WKScriptMessageHandler {


### PR DESCRIPTION
This PR fixes several streaming input issues and extends the Liquid Glass aesthetic throughout the iOS app.

**Streaming Fixes (`StreamerView.swift`, `OpenNOWStore.swift`):**

*   Fix sub-pixel mouse movement loss by accumulating fractional deltas with `accDX`/`accDY` and using `Math.trunc()`.
*   Ensure native keyboard raises by calling `kbInput.focus()` synchronously in `showKeyboard()`.
*   Fix `ws.onclose` to properly close `RTCPeerConnection` and add auto-reconnect logic with `reconnectTimer`.
*   Respect `preferredQuality` in `streamProfile` (Data Saver: 720p/15Mbps, Quality: 1440p/50Mbps).
*   Restart session tasks in `OpenNOWStore.dismissStreamer()` to enable auto-representation of the streamer.

**Liquid Glass UI Expansion:**

*   Add ultra-thin material navigation bars to `HomeView`, `BrowseView`, `SettingsView`, `SessionView`, and `LibraryView`.
*   Add ultra-thin material tab bar background in `ContentView`.
*   Apply brand-tinted gradient to `appBackground` in `ContentView`.
*   Update `FilterChip` in `BrowseView` to use glass effect on iOS 26+.
*   Apply glass list row backgrounds to all `SettingsView` rows.
*   Update `endSessionButton` in `SessionView` to use glass effect styling.
*   Update HUD overlay in `StreamerView` to use glass styling.
*   Tweak `GlassCardModifier` shadow in `HomeView`.

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/869b9135-c6f7-46a8-a00d-0ddd4e1e564c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-10&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-10"><img alt="OPEN-10 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-10"></picture></a>