### PR TITLE
Revert iOS Liquid Glass UI, preserve streaming bug fixes

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/BrowseView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/BrowseView.swift
@@ -45,8 +45,6 @@ struct BrowseView: View {
                 }
             }
             .navigationTitle("Browse")
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
             .searchable(
                 text: $store.searchText,
                 placement: .navigationBarDrawer(displayMode: .automatic),
@@ -109,30 +107,12 @@ private struct FilterChip: View {
 
     var body: some View {
         Button(action: action) {
-            if #available(iOS 26, *) {
-                Text(label)
-                    .font(.caption.weight(.semibold))
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 7)
-                    .foregroundStyle(isSelected ? brandAccent : .primary)
-                    .background {
-                        if isSelected {
-                            Capsule()
-                                .fill(.regularMaterial)
-                                .glassEffect(in: Capsule())
-                                .overlay(Capsule().stroke(brandAccent.opacity(0.5), lineWidth: 1))
-                        } else {
-                            Capsule().fill(Color(.systemFill))
-                        }
-                    }
-            } else {
-                Text(label)
-                    .font(.caption.weight(.semibold))
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 7)
-                    .foregroundStyle(isSelected ? .white : .primary)
-                    .background(Capsule().fill(isSelected ? brandAccent : Color(.systemFill)))
-            }
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .foregroundStyle(isSelected ? .white : .primary)
+                .background(isSelected ? brandAccent : Color(.systemFill), in: Capsule())
         }
         .buttonStyle(.plain)
         .animation(.easeOut(duration: 0.15), value: isSelected)

--- a/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
@@ -56,8 +56,6 @@ struct MainTabView: View {
                 .tabItem { Label("Settings", systemImage: "slider.horizontal.3") }
         }
         .tint(brandAccent)
-        .toolbarBackground(.ultraThinMaterial, for: .tabBar)
-        .toolbarBackground(.visible, for: .tabBar)
         .fullScreenCover(isPresented: $store.queueOverlayVisible.transaction({
             var t = Transaction()
             t.animation = t.animation?.delay(0.15)
@@ -202,15 +200,6 @@ let brandGradient = LinearGradient(
 var appBackground: some View {
     ZStack {
         Color(.systemBackground)
-        LinearGradient(
-            colors: [
-                Color(red: 0.46, green: 0.72, blue: 0.0).opacity(0.04),
-                Color.clear,
-                Color(red: 0.0, green: 0.72, blue: 0.55).opacity(0.03)
-            ],
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-        )
     }
     .ignoresSafeArea()
 }

--- a/ios/OpenNOWiOS/OpenNOWiOS/HomeView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/HomeView.swift
@@ -37,8 +37,6 @@ struct HomeView: View {
             }
             .refreshable { await store.refreshCatalog() }
             .navigationTitle("OpenNOW")
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     if store.isLoadingGames {

--- a/ios/OpenNOWiOS/OpenNOWiOS/LibraryView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/LibraryView.swift
@@ -16,8 +16,6 @@ struct LibraryView: View {
                 }
             }
             .navigationTitle("Library")
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
         }
         .printedWasteLaunchSheet(pendingGame: $pendingLaunchGame)
     }

--- a/ios/OpenNOWiOS/OpenNOWiOS/SessionView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/SessionView.swift
@@ -27,8 +27,6 @@ struct SessionView: View {
                 .padding(.vertical, 8)
             }
             .navigationTitle("Session")
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -204,19 +202,9 @@ struct SessionView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
                 .font(.headline)
-                .foregroundStyle(.white)
         }
-        .buttonStyle(.plain)
-        .background {
-            if #available(iOS 26, *) {
-                RoundedRectangle(cornerRadius: 14)
-                    .fill(.red.opacity(0.7))
-                    .glassEffect(in: RoundedRectangle(cornerRadius: 14))
-            } else {
-                RoundedRectangle(cornerRadius: 14)
-                    .fill(.red.opacity(0.85))
-            }
-        }
+        .buttonStyle(.bordered)
+        .tint(.red)
     }
 
     private var noSessionState: some View {

--- a/ios/OpenNOWiOS/OpenNOWiOS/SettingsView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/SettingsView.swift
@@ -50,13 +50,11 @@ struct SettingsView: View {
                         Spacer()
                         Toggle("", isOn: $store.settings.keepMicEnabled)
                     }
-                    .listRowBackground(glassListRowBackground)
                     HStack {
                         Label("Stats Overlay", systemImage: "chart.bar.fill")
                         Spacer()
                         Toggle("", isOn: $store.settings.showStatsOverlay)
                     }
-                    .listRowBackground(glassListRowBackground)
                 } header: {
                     Label("Experience", systemImage: "star.fill")
                 }
@@ -68,7 +66,6 @@ struct SettingsView: View {
                         Label("Reload Catalog", systemImage: "arrow.clockwise")
                     }
                     .disabled(store.isLoadingGames)
-                    .listRowBackground(glassListRowBackground)
                 } header: {
                     Label("Data", systemImage: "internaldrive.fill")
                 }
@@ -76,20 +73,16 @@ struct SettingsView: View {
                 if let user = store.user {
                     Section {
                         LabeledContent("Account", value: user.displayName)
-                            .listRowBackground(glassListRowBackground)
                         if let email = user.email {
                             LabeledContent("Email", value: email)
-                                .listRowBackground(glassListRowBackground)
                         }
                         LabeledContent("Tier", value: user.membershipTier)
-                            .listRowBackground(glassListRowBackground)
 
                         Button(role: .destructive) {
                             store.signOut()
                         } label: {
                             Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
                         }
-                        .listRowBackground(glassListRowBackground)
                     } header: {
                         Label("Account", systemImage: "person.crop.circle")
                     }
@@ -97,13 +90,10 @@ struct SettingsView: View {
 
                 Section {
                     LabeledContent("Version", value: "1.0")
-                        .listRowBackground(glassListRowBackground)
                     LabeledContent("Platform", value: "iOS")
-                        .listRowBackground(glassListRowBackground)
                     Link(destination: URL(string: "https://github.com/OpenCloudGaming/OpenNOW")!) {
                         Label("GitHub Repository", systemImage: "link")
                     }
-                    .listRowBackground(glassListRowBackground)
                 } header: {
                     Label("About", systemImage: "info.circle")
                 }
@@ -111,8 +101,6 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .scrollContentBackground(.hidden)
             .background(appBackground)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
             .onChange(of: store.settings) { _, _ in
                 store.persistSettings()
             }
@@ -138,18 +126,6 @@ struct SettingsView: View {
                 .pickerStyle(.menu)
                 .tint(.primary)
         }
-        .listRowBackground(glassListRowBackground)
-    }
-
-    private var glassListRowBackground: some View {
-        Group {
-            if #available(iOS 26, *) {
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(.regularMaterial)
-                    .glassEffect(in: RoundedRectangle(cornerRadius: 10))
-            } else {
-                Color(.secondarySystemGroupedBackground).opacity(0.75)
-            }
-        }
+        .listRowBackground(Color(.secondarySystemGroupedBackground).opacity(0.75))
     }
 }

--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
@@ -18,9 +18,10 @@ struct StreamerView: View {
             HStack {
                 Text(statusText)
                     .font(.caption)
-                    .lineLimit(1)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
+                    .background(.regularMaterial, in: Capsule())
+                    .lineLimit(1)
                 Spacer()
                 Button {
                     onClose()
@@ -30,19 +31,6 @@ struct StreamerView: View {
                         .symbolRenderingMode(.hierarchical)
                 }
             }
-            .foregroundStyle(.white)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background {
-                if #available(iOS 26, *) {
-                    Capsule()
-                        .fill(.regularMaterial)
-                        .glassEffect(in: Capsule())
-                } else {
-                    Capsule().fill(.regularMaterial)
-                }
-            }
-            .shadow(color: .black.opacity(0.25), radius: 10, y: 4)
             .padding()
         }
         .background(Color.black.ignoresSafeArea())


### PR DESCRIPTION
This PR reverts the Liquid Glass UI changes from PR #283 across 7 iOS view files, restoring the original plain backgrounds and removing `.ultraThinMaterial` toolbar overrides while keeping all streaming logic intact.

**StreamerView.swift:**
* Restored HUD capsule to wrap only the `statusText` with `.regularMaterial`, removed full-bar glass wrapper, `.foregroundStyle(.white)`, extra padding, and shadow.

**ContentView.swift:**
* Removed `.toolbarBackground(.ultraThinMaterial/.visible)` modifiers from `MainTabView`.
* Reverted `appBackground` to plain `Color(.systemBackground)`, removing gradient overlay.

**HomeView.swift, BrowseView.swift, SessionView.swift, LibraryView.swift:**
* Removed `.toolbarBackground(.ultraThinMaterial/.visible)` modifiers from all `NavigationStack` instances.

**BrowseView.swift:**
* Reverted `FilterChip` to simple implementation: removed iOS 26 `glassEffect`/stroke logic, restored direct `.background(isSelected ? brandAccent : Color(.systemFill), in: Capsule())`.

**SettingsView.swift:**
* Deleted `glassListRowBackground` computed property.
* Restored `settingRow` helper to use `.listRowBackground(Color(.secondarySystemGroupedBackground).opacity(0.75))`.
* Removed `.listRowBackground(glassListRowBackground)` from mic toggle, stats, reload catalog, account info, sign out, and about rows (these now have no explicit list row background).

**SessionView.swift:**
* Reverted `endSessionButton` to bordered style: removed `.foregroundStyle(.white)`, `.buttonStyle(.plain)`, and iOS 26 glass background block; restored `.buttonStyle(.bordered)` with `.tint(.red)`.

**Preserved (untouched):** Streaming fixes from PR #283 including mouse accumulation (`accDX/accDY`, `Math.trunc`), synchronous keyboard focus (`kbInput.focus()`), peer connection cleanup on close (`pc.close()`, `intentionalClose`, `reconnectTimer`), stream profile quality switching, and `dismissStreamer()` restart behavior.

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/f24f8232-797c-46ca-8431-d036285e24f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-11&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-11"><img alt="OPEN-11 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPEN-11"></picture></a>