### PR TITLE
Rework library/catalog UI with official GFN search and filters

### DIFF
--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -681,24 +681,7 @@ async function browseCatalogUncached(input: CatalogBrowseRequest): Promise<Catal
   const fetchCount = Math.max(24, Math.min(input.fetchCount ?? DEFAULT_CATALOG_FETCH_COUNT, 200));
   const filters = mergeFilterPayloads(normalizedFilterIds, definitions.filterPayloadById);
 
-  const query = `query GetSearchFilterResults(
-    $vpcId: String!,
-    $locale: String!,
-    $sortString: String!,
-    $fetchCount: Int!,
-    $cursor: String!,
-    $searchString: String!,
-    $filters: AppFilterFields!
-  ) {
-    apps(
-      vpcId: $vpcId,
-      language: $locale,
-      orderBy: $sortString,
-      first: $fetchCount,
-      after: $cursor,
-      searchQuery: $searchString,
-      filters: $filters
-    ) {
+  const appFields = `
       numberReturned
       numberSupported
       pageInfo { hasNextPage endCursor totalCount }
@@ -722,8 +705,49 @@ async function browseCatalogUncached(input: CatalogBrowseRequest): Promise<Catal
         }
         itemMetadata { campaignIds }
       }
-    }
-  }`;
+  `;
+
+  const query = searchQuery.length > 0
+    ? `query GetSearchFilterResults(
+      $vpcId: String!,
+      $locale: String!,
+      $sortString: String!,
+      $fetchCount: Int!,
+      $cursor: String!,
+      $searchString: String!,
+      $filters: AppFilterFields!
+    ) {
+      apps(
+        vpcId: $vpcId,
+        language: $locale,
+        orderBy: $sortString,
+        first: $fetchCount,
+        after: $cursor,
+        searchQuery: $searchString,
+        filters: $filters
+      ) {
+${appFields}
+      }
+    }`
+    : `query GetFilterBrowseResults(
+      $vpcId: String!,
+      $locale: String!,
+      $sortString: String!,
+      $fetchCount: Int!,
+      $cursor: String!,
+      $filters: AppFilterFields!
+    ) {
+      apps(
+        vpcId: $vpcId,
+        language: $locale,
+        orderBy: $sortString,
+        first: $fetchCount,
+        after: $cursor,
+        filters: $filters
+      ) {
+${appFields}
+      }
+    }`;
 
   const collectedApps: AppData[] = [];
   let numberReturned = 0;
@@ -736,15 +760,24 @@ async function browseCatalogUncached(input: CatalogBrowseRequest): Promise<Catal
   for (let page = 0; page < MAX_CATALOG_PAGES; page += 1) {
     const payload = await postGraphQl<AppsSearchResponse>(
       query,
-      {
-        vpcId,
-        locale: DEFAULT_LOCALE,
-        sortString: selectedSort.orderBy,
-        fetchCount,
-        cursor,
-        searchString: searchQuery,
-        filters,
-      },
+      searchQuery.length > 0
+        ? {
+            vpcId,
+            locale: DEFAULT_LOCALE,
+            sortString: selectedSort.orderBy,
+            fetchCount,
+            cursor,
+            searchString: searchQuery,
+            filters,
+          }
+        : {
+            vpcId,
+            locale: DEFAULT_LOCALE,
+            sortString: selectedSort.orderBy,
+            fetchCount,
+            cursor,
+            filters,
+          },
       token,
     );
 

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -1,12 +1,23 @@
-import type { GameInfo, GameVariant } from "@shared/gfn";
+import type {
+  CatalogBrowseRequest,
+  CatalogBrowseResult,
+  CatalogFilterGroup,
+  CatalogSortOption,
+  GameInfo,
+  GameVariant,
+} from "@shared/gfn";
 import { cacheManager } from "../services/cacheManager";
 
 const GRAPHQL_URL = "https://games.geforce.com/graphql";
 const PANELS_QUERY_HASH = "f8e26265a5db5c20e1334a6872cf04b6e3970507697f6ae55a6ddefa5420daf0";
 const APP_METADATA_QUERY_HASH = "39187e85b6dcf60b7279a5f233288b0a8b69a8b1dbcfb5b25555afdcb988f0d7";
+const LIBRARY_WITH_TIME_QUERY_HASH = "039e8c0d553972975485fee56e59f2549d2fdb518e247a42ab5022056a74406f";
 const DEFAULT_LOCALE = "en_US";
 const LCARS_CLIENT_ID = "ec7e38d4-03af-4b58-b131-cfb0495903ab";
 const GFN_CLIENT_VERSION = "2.0.80.173";
+const DEFAULT_CATALOG_FETCH_COUNT = 120;
+const MAX_CATALOG_PAGES = 3;
+const DEFAULT_SORT_ID = "relevance";
 
 const GFN_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/2.0.80.173";
@@ -35,6 +46,44 @@ interface AppMetaDataResponse {
   errors?: Array<{ message: string }>;
 }
 
+interface FilterSortDefinitionsResponse {
+  data?: {
+    filterGroupDefinitions?: GraphQlFilterGroup[];
+    sortOrderDefinitions?: Array<{
+      id: string;
+      label: string;
+      orderBy: string;
+    }>;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface AppsSearchResponse {
+  data?: {
+    apps?: {
+      numberReturned?: number;
+      numberSupported?: number;
+      pageInfo?: {
+        hasNextPage?: boolean;
+        endCursor?: string;
+        totalCount?: number;
+      };
+      items?: AppData[];
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface GraphQlFilterGroup {
+  id: string;
+  label: string;
+  filters?: Array<{
+    id: string;
+    label: string;
+    filters?: string[];
+  }>;
+}
+
 interface AppData {
   id: string;
   title: string;
@@ -49,20 +98,33 @@ interface AppData {
     GAME_BOX_ART?: string;
     TV_BANNER?: string;
     HERO_IMAGE?: string;
+    KEY_ART?: string;
   };
+  publisherName?: string;
+  contentRatings?: unknown[];
   variants?: Array<{
     id: string;
     appStore: string;
     supportedControls?: string[];
     gfn?: {
+      status?: string;
       library?: {
+        status?: string;
         selected?: boolean;
+        lastPlayedDate?: string;
       };
     };
   }>;
   gfn?: {
     playType?: string;
+    playabilityState?: string;
     minimumMembershipTierLabel?: string;
+    catalogSkuStrings?: {
+      SKU_BASED_TAG?: string[];
+    };
+  };
+  itemMetadata?: {
+    campaignIds?: string[];
   };
 }
 
@@ -77,6 +139,20 @@ interface RawPublicGame {
   title?: string;
   steamUrl?: string;
   status?: string;
+}
+
+interface AppResolution {
+  numericAppId?: string;
+  preferredVariantId?: string;
+  selectedVariantIndex: number;
+  lastPlayed?: string;
+  isInLibrary: boolean;
+}
+
+interface CatalogDefinitions {
+  filterGroups: CatalogFilterGroup[];
+  sortOptions: CatalogSortOption[];
+  filterPayloadById: Record<string, unknown>;
 }
 
 function optimizeImage(url: string): string {
@@ -95,6 +171,41 @@ function isNumericId(value: string | undefined): value is string {
 
 function randomHuId(): string {
   return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
+}
+
+function buildHeaders(token?: string): HeadersInit {
+  return {
+    Accept: "application/json, text/plain, */*",
+    "Content-Type": "application/json",
+    Origin: "https://play.geforcenow.com",
+    Referer: "https://play.geforcenow.com/",
+    ...(token ? { Authorization: `GFNJWT ${token}` } : {}),
+    "nv-client-id": LCARS_CLIENT_ID,
+    "nv-client-type": "NATIVE",
+    "nv-client-version": GFN_CLIENT_VERSION,
+    "nv-client-streamer": "NVIDIA-CLASSIC",
+    "nv-device-os": "WINDOWS",
+    "nv-device-type": "DESKTOP",
+    "nv-device-make": "UNKNOWN",
+    "nv-device-model": "UNKNOWN",
+    "nv-browser-type": "CHROME",
+    "User-Agent": GFN_USER_AGENT,
+  };
+}
+
+async function postGraphQl<T>(query: string, variables: Record<string, unknown>, token?: string): Promise<T> {
+  const response = await fetch(GRAPHQL_URL, {
+    method: "POST",
+    headers: buildHeaders(token),
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GFN GraphQL failed (${response.status}): ${text.slice(0, 400)}`);
+  }
+
+  return (await response.json()) as T;
 }
 
 async function getVpcId(token: string, providerStreamingBaseUrl?: string): Promise<string> {
@@ -121,46 +232,6 @@ async function getVpcId(token: string, providerStreamingBaseUrl?: string): Promi
 
   const payload = (await response.json()) as ServerInfoResponse;
   return payload.requestStatus?.serverId ?? "GFN-PC";
-}
-
-function appToGame(app: AppData): GameInfo {
-  const variants: GameVariant[] =
-    app.variants?.map((variant) => ({
-      id: variant.id,
-      store: variant.appStore,
-      supportedControls: variant.supportedControls ?? [],
-    })) ?? [];
-
-  const selectedVariantIndex =
-    app.variants?.findIndex((variant) => variant.gfn?.library?.selected === true) ?? 0;
-
-  const safeIndex = Math.max(0, selectedVariantIndex);
-  const selectedVariant = variants[safeIndex];
-  const selectedVariantId = selectedVariant?.id;
-  const fallbackNumericVariantId = variants.find((variant) => isNumericId(variant.id))?.id;
-  const launchAppId = isNumericId(selectedVariantId)
-    ? selectedVariantId
-    : fallbackNumericVariantId ?? (isNumericId(app.id) ? app.id : undefined);
-
-  const id = `${app.id}:${selectedVariantId ?? "default"}`;
-  const imageUrl =
-    app.images?.GAME_BOX_ART ?? app.images?.TV_BANNER ?? app.images?.HERO_IMAGE ?? undefined;
-
-  return {
-    id,
-    uuid: app.id,
-    launchAppId,
-    title: app.title,
-    description: app.description,
-    longDescription: app.longDescription,
-    featureLabels: extractFeatureLabels(app),
-    genres: extractGenres(app),
-    imageUrl: imageUrl ? optimizeImage(imageUrl) : undefined,
-    playType: app.gfn?.playType,
-    membershipTierLabel: app.gfn?.minimumMembershipTierLabel,
-    selectedVariantIndex: Math.max(0, selectedVariantIndex),
-    variants,
-  };
 }
 
 function parseFeatureLabel(value: unknown): string | null {
@@ -191,6 +262,7 @@ function extractFeatureLabels(app: AppData): string[] {
     app.appFeatures,
     app.genres,
     app.tags,
+    app.gfn?.catalogSkuStrings?.SKU_BASED_TAG,
   ];
 
   const labels: string[] = [];
@@ -225,40 +297,155 @@ function extractGenres(app: AppData): string[] {
   return [...new Set(genres)];
 }
 
+function extractContentRatings(app: AppData): string[] {
+  if (!Array.isArray(app.contentRatings)) {
+    return [];
+  }
+
+  const labels: string[] = [];
+  for (const entry of app.contentRatings) {
+    const label = parseFeatureLabel(entry);
+    if (label) {
+      labels.push(label);
+    }
+  }
+
+  return [...new Set(labels)];
+}
+
+function buildSearchText(title: string, variants: GameVariant[], genres: string[], featureLabels: string[], publisherName?: string): string {
+  const stores = variants.map((variant) => variant.store);
+  return [title, publisherName, ...stores, ...genres, ...featureLabels]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+}
+
+function resolveAppData(app: AppData): AppResolution {
+  const variants = app.variants ?? [];
+  const selectedVariantIndex = variants.findIndex((variant) => variant.gfn?.library?.selected === true);
+  const preferredVariant = selectedVariantIndex >= 0 ? variants[selectedVariantIndex] : undefined;
+  const numericVariants = variants.filter((variant) => isNumericId(variant.id));
+  const preferredNumericVariant = preferredVariant && isNumericId(preferredVariant.id) ? preferredVariant.id : undefined;
+  const fallbackNumericVariant = numericVariants[0]?.id;
+  const numericAppId = preferredNumericVariant ?? fallbackNumericVariant ?? (isNumericId(app.id) ? app.id : undefined);
+  const preferredVariantId = preferredVariant?.id ?? numericAppId ?? variants[0]?.id ?? app.id;
+  const lastPlayed = variants
+    .map((variant) => variant.gfn?.library?.lastPlayedDate)
+    .find((value): value is string => typeof value === "string" && value.length > 0);
+  const isInLibrary = variants.some((variant) => variant.gfn?.library?.status === "IN_LIBRARY" || variant.gfn?.library?.selected === true);
+
+  return {
+    numericAppId,
+    preferredVariantId,
+    selectedVariantIndex: selectedVariantIndex >= 0 ? selectedVariantIndex : Math.max(0, variants.findIndex((variant) => variant.id === preferredVariantId)),
+    lastPlayed,
+    isInLibrary,
+  };
+}
+
 function appToVariants(app: AppData): GameVariant[] {
   return app.variants?.map((variant) => ({
     id: variant.id,
     store: variant.appStore,
     supportedControls: variant.supportedControls ?? [],
+    librarySelected: variant.gfn?.library?.selected,
+    libraryStatus: variant.gfn?.library?.status,
+    lastPlayedDate: variant.gfn?.library?.lastPlayedDate,
+    gfnStatus: variant.gfn?.status,
   })) ?? [];
 }
 
-function mergeAppMetaIntoGame(game: GameInfo, app: AppData): GameInfo {
-  const metadataVariants = appToVariants(app);
-  const variants = metadataVariants.length > 0 ? metadataVariants : game.variants;
-  const selectedVariantId = game.id.split(":")[1];
-  const selectedVariantIndex = Math.max(0, variants.findIndex((variant) => variant.id === selectedVariantId));
+function appToGame(app: AppData): GameInfo {
+  const variants = appToVariants(app);
+  const resolution = resolveAppData(app);
   const imageUrl =
-    app.images?.GAME_BOX_ART ?? app.images?.TV_BANNER ?? app.images?.HERO_IMAGE ?? undefined;
-
-  const description = app.description ?? game.description;
-  const longDescription = app.longDescription ?? game.longDescription;
-  const featureLabels = extractFeatureLabels(app);
+    app.images?.KEY_ART ?? app.images?.GAME_BOX_ART ?? app.images?.TV_BANNER ?? app.images?.HERO_IMAGE ?? undefined;
   const genres = extractGenres(app);
+  const featureLabels = extractFeatureLabels(app);
+
+  return {
+    id: app.id,
+    uuid: app.id,
+    launchAppId: resolution.numericAppId,
+    title: app.title,
+    description: app.description,
+    longDescription: app.longDescription,
+    featureLabels,
+    genres,
+    imageUrl: imageUrl ? optimizeImage(imageUrl) : undefined,
+    playType: app.gfn?.playType,
+    membershipTierLabel: app.gfn?.minimumMembershipTierLabel,
+    publisherName: app.publisherName,
+    contentRatings: extractContentRatings(app),
+    playabilityState: app.gfn?.playabilityState,
+    availableStores: [...new Set(variants.map((variant) => variant.store).filter(Boolean))],
+    searchText: buildSearchText(app.title, variants, genres, featureLabels, app.publisherName),
+    lastPlayed: resolution.lastPlayed,
+    isInLibrary: resolution.isInLibrary,
+    selectedVariantIndex: Math.max(0, Math.min(resolution.selectedVariantIndex, Math.max(variants.length - 1, 0))),
+    variants,
+  };
+}
+
+function mergeAppMetaIntoGame(game: GameInfo, app: AppData): GameInfo {
+  const merged = appToGame(app);
+  const selectedVariantIndex = game.variants.findIndex((variant) => variant.id === game.variants[game.selectedVariantIndex]?.id);
 
   return {
     ...game,
-    title: app.title || game.title,
-    description,
-    longDescription,
-    featureLabels,
-    genres,
-    imageUrl: imageUrl ? optimizeImage(imageUrl) : game.imageUrl,
-    playType: app.gfn?.playType ?? game.playType,
-    membershipTierLabel: app.gfn?.minimumMembershipTierLabel ?? game.membershipTierLabel,
-    selectedVariantIndex,
-    variants,
+    ...merged,
+    id: game.id,
+    selectedVariantIndex: selectedVariantIndex >= 0 ? selectedVariantIndex : merged.selectedVariantIndex,
   };
+}
+
+function dedupeGames(games: GameInfo[]): GameInfo[] {
+  const byId = new Map<string, GameInfo>();
+
+  for (const game of games) {
+    const existing = byId.get(game.id);
+    if (!existing) {
+      byId.set(game.id, game);
+      continue;
+    }
+
+    const mergedVariants = new Map<string, GameVariant>();
+    for (const variant of [...existing.variants, ...game.variants]) {
+      mergedVariants.set(variant.id, variant);
+    }
+
+    const merged: GameInfo = {
+      ...existing,
+      ...game,
+      id: existing.id,
+      uuid: existing.uuid ?? game.uuid,
+      launchAppId: existing.launchAppId ?? game.launchAppId,
+      title: existing.title || game.title,
+      description: existing.description ?? game.description,
+      longDescription: existing.longDescription ?? game.longDescription,
+      imageUrl: existing.imageUrl ?? game.imageUrl,
+      playType: existing.playType ?? game.playType,
+      membershipTierLabel: existing.membershipTierLabel ?? game.membershipTierLabel,
+      publisherName: existing.publisherName ?? game.publisherName,
+      playabilityState: existing.playabilityState ?? game.playabilityState,
+      lastPlayed: existing.lastPlayed ?? game.lastPlayed,
+      isInLibrary: existing.isInLibrary || game.isInLibrary,
+      variants: [...mergedVariants.values()],
+      genres: [...new Set([...(existing.genres ?? []), ...(game.genres ?? [])])],
+      featureLabels: [...new Set([...(existing.featureLabels ?? []), ...(game.featureLabels ?? [])])],
+      contentRatings: [...new Set([...(existing.contentRatings ?? []), ...(game.contentRatings ?? [])])],
+      availableStores: [...new Set([...(existing.availableStores ?? []), ...(game.availableStores ?? [])])],
+      searchText: [existing.searchText, game.searchText].filter(Boolean).join(" ").trim() || undefined,
+      selectedVariantIndex: Math.max(0, existing.variants[existing.selectedVariantIndex]
+        ? [...mergedVariants.values()].findIndex((variant) => variant.id === existing.variants[existing.selectedVariantIndex]?.id)
+        : game.selectedVariantIndex),
+    };
+
+    byId.set(game.id, merged);
+  }
+
+  return [...byId.values()];
 }
 
 async function fetchAppMetaData(
@@ -271,111 +458,84 @@ async function fetchAppMetaData(
     return { data: { apps: { items: [] } } };
   }
 
-  const variables = JSON.stringify({
+  const variables = {
     vpcId,
     locale: DEFAULT_LOCALE,
     appIds: normalizedIds,
-  });
+  };
 
-  const extensions = JSON.stringify({
-    persistedQuery: {
-      sha256Hash: APP_METADATA_QUERY_HASH,
-    },
-  });
-
-  const params = new URLSearchParams({
-    requestType: "appMetaData",
-    extensions,
-    huId: randomHuId(),
-    variables,
-  });
-
-  try {
-    const response = await fetch(`${GRAPHQL_URL}?${params.toString()}`, {
-      headers: {
-        Accept: "application/json, text/plain, */*",
-        "Content-Type": "application/graphql",
-        Origin: "https://play.geforcenow.com",
-        Referer: "https://play.geforcenow.com/",
-        Authorization: `GFNJWT ${token}`,
-        "nv-client-id": LCARS_CLIENT_ID,
-        "nv-client-type": "NATIVE",
-        "nv-client-version": GFN_CLIENT_VERSION,
-        "nv-client-streamer": "NVIDIA-CLASSIC",
-        "nv-device-os": "WINDOWS",
-        "nv-device-type": "DESKTOP",
-        "nv-device-make": "UNKNOWN",
-        "nv-device-model": "UNKNOWN",
-        "nv-browser-type": "CHROME",
-        "User-Agent": GFN_USER_AGENT,
-      },
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      console.error(`[GFN Metadata] fetchAppMetaData failed (${response.status}):`, text.slice(0, 400));
-      throw new Error(`App metadata failed (${response.status}): ${text.slice(0, 400)}`);
+  const query = `query AppMetaData($vpcId: String!, $locale: String!, $appIds: [String!]!) {
+    apps(vpcId: $vpcId, language: $locale, ids: $appIds) {
+      items {
+        id
+        title
+        description
+        longDescription
+        publisherName
+        features
+        gameFeatures
+        appFeatures
+        genres
+        tags
+        contentRatings
+        images { GAME_BOX_ART TV_BANNER HERO_IMAGE KEY_ART }
+        variants {
+          id
+          appStore
+          supportedControls
+          gfn {
+            status
+            library { status selected lastPlayedDate }
+          }
+        }
+        gfn {
+          playType
+          playabilityState
+          minimumMembershipTierLabel
+          catalogSkuStrings { SKU_BASED_TAG }
+        }
+      }
     }
+  }`;
 
-    return (await response.json()) as AppMetaDataResponse;
-  } catch (error) {
-    console.error("[GFN Metadata] fetchAppMetaData error:", error);
-    throw error;
-  }
+  return postGraphQl<AppMetaDataResponse>(query, variables, token);
 }
 
 async function enrichGamesWithMetadata(token: string, vpcId: string, games: GameInfo[]): Promise<GameInfo[]> {
   const uuids = [...new Set(games.map((game) => game.uuid).filter((uuid): uuid is string => !!uuid))];
-  
+
   if (uuids.length === 0) {
     return games;
   }
 
   const chunkSize = 40;
   const appById = new Map<string, AppData>();
-  const startTime = Date.now();
 
-  try {
-    for (let index = 0; index < uuids.length; index += chunkSize) {
-      const chunk = uuids.slice(index, index + chunkSize);
-      const payload = await fetchAppMetaData(token, chunk, vpcId);
-      if (payload.errors?.length) {
-        console.error("[GFN Metadata] GraphQL errors:", payload.errors);
-        throw new Error(payload.errors.map((error) => error.message).join(", "));
-      }
-      
-      const items = payload.data?.apps.items ?? [];
-      for (const app of items) {
-        appById.set(app.id, app);
-      }
+  for (let index = 0; index < uuids.length; index += chunkSize) {
+    const chunk = uuids.slice(index, index + chunkSize);
+    const payload = await fetchAppMetaData(token, chunk, vpcId);
+    if (payload.errors?.length) {
+      throw new Error(payload.errors.map((error) => error.message).join(", "));
     }
 
-    let enrichedCount = 0;
-    const enrichedGames = games.map((game) => {
-      if (!game.uuid) {
-        return game;
-      }
-      const metadata = appById.get(game.uuid);
-      if (!metadata) {
-        return game;
-      }
-      enrichedCount += 1;
-      return mergeAppMetaIntoGame(game, metadata);
-    });
-
-    const elapsed = Date.now() - startTime;
-    console.log(`[GFN Metadata] Enriched ${enrichedCount}/${games.length} games in ${elapsed}ms`);
-    return enrichedGames;
-  } catch (error) {
-    console.error("[GFN Metadata] Enrichment error:", error);
-    throw error;
+    for (const app of payload.data?.apps.items ?? []) {
+      appById.set(app.id, app);
+    }
   }
+
+  return dedupeGames(
+    games.map((game) => {
+      const metadata = game.uuid ? appById.get(game.uuid) : undefined;
+      return metadata ? mergeAppMetaIntoGame(game, metadata) : game;
+    }),
+  );
 }
 
 async function fetchPanels(
   token: string,
   panelNames: string[],
   vpcId: string,
+  options?: { withLibraryTime?: boolean },
 ): Promise<GraphQlResponse> {
   const variables = JSON.stringify({
     vpcId,
@@ -385,7 +545,7 @@ async function fetchPanels(
 
   const extensions = JSON.stringify({
     persistedQuery: {
-      sha256Hash: PANELS_QUERY_HASH,
+      sha256Hash: options?.withLibraryTime ? LIBRARY_WITH_TIME_QUERY_HASH : PANELS_QUERY_HASH,
     },
   });
 
@@ -399,21 +559,8 @@ async function fetchPanels(
 
   const response = await fetch(`${GRAPHQL_URL}?${params.toString()}`, {
     headers: {
-      Accept: "application/json, text/plain, */*",
+      ...buildHeaders(token),
       "Content-Type": "application/graphql",
-      Origin: "https://play.geforcenow.com",
-      Referer: "https://play.geforcenow.com/",
-      Authorization: `GFNJWT ${token}`,
-      "nv-client-id": LCARS_CLIENT_ID,
-      "nv-client-type": "NATIVE",
-      "nv-client-version": GFN_CLIENT_VERSION,
-      "nv-client-streamer": "NVIDIA-CLASSIC",
-      "nv-device-os": "WINDOWS",
-      "nv-device-type": "DESKTOP",
-      "nv-device-make": "UNKNOWN",
-      "nv-device-model": "UNKNOWN",
-      "nv-browser-type": "CHROME",
-      "User-Agent": GFN_USER_AGENT,
     },
   });
 
@@ -442,8 +589,220 @@ function flattenPanels(payload: GraphQlResponse): GameInfo[] {
     }
   }
 
-  console.log(`[GFN Metadata] flattenPanels: Extracted ${games.length} games from panels`);
-  return games;
+  return dedupeGames(games);
+}
+
+async function fetchFilterAndSortDefinitions(token?: string): Promise<CatalogDefinitions> {
+  const query = `query GetFilterGroupAndSortOrderDefinitions($locale: String!) {
+    filterGroupDefinitions(language: $locale) {
+      id
+      label
+      filters {
+        id
+        label
+        filters
+      }
+    }
+    sortOrderDefinitions(language: $locale) {
+      id
+      label
+      orderBy
+    }
+  }`;
+
+  const payload = await postGraphQl<FilterSortDefinitionsResponse>(query, { locale: DEFAULT_LOCALE }, token);
+  if (payload.errors?.length) {
+    throw new Error(payload.errors.map((error) => error.message).join(", "));
+  }
+
+  const filterPayloadById: Record<string, unknown> = {};
+  const filterGroups: CatalogFilterGroup[] = [];
+
+  for (const group of payload.data?.filterGroupDefinitions ?? []) {
+    const options = (group.filters ?? []).flatMap((entry) => {
+      const filterJson = entry.filters?.[0];
+      if (!filterJson) {
+        return [];
+      }
+      try {
+        filterPayloadById[entry.id] = JSON.parse(filterJson);
+        return [{
+          id: entry.id,
+          rawId: entry.id,
+          label: entry.label,
+          groupId: group.id,
+          groupLabel: group.label,
+        }];
+      } catch {
+        return [];
+      }
+    });
+
+    if (options.length > 0) {
+      filterGroups.push({ id: group.id, label: group.label, options });
+    }
+  }
+
+  const sortOptions = (payload.data?.sortOrderDefinitions ?? []).map((sort) => ({
+    id: sort.id,
+    label: sort.label,
+    orderBy: sort.orderBy,
+  }));
+
+  return {
+    filterGroups,
+    sortOptions,
+    filterPayloadById,
+  };
+}
+
+function mergeFilterPayloads(filterIds: string[], filterPayloadById: Record<string, unknown>): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+
+  for (const filterId of filterIds) {
+    const payload = filterPayloadById[filterId];
+    if (!payload || typeof payload !== "object") {
+      continue;
+    }
+    Object.assign(merged, payload as Record<string, unknown>);
+  }
+
+  return merged;
+}
+
+async function browseCatalogUncached(input: CatalogBrowseRequest): Promise<CatalogBrowseResult> {
+  const token = input.token;
+  if (!token) {
+    throw new Error("Catalog browsing requires an authenticated token");
+  }
+
+  const vpcId = await getVpcId(token, input.providerStreamingBaseUrl);
+  const definitions = await fetchFilterAndSortDefinitions(token);
+  const normalizedFilterIds = (input.filterIds ?? []).filter((id) => id in definitions.filterPayloadById);
+  const selectedSort = definitions.sortOptions.find((option) => option.id === input.sortId)
+    ?? definitions.sortOptions.find((option) => option.id === DEFAULT_SORT_ID)
+    ?? definitions.sortOptions[0]
+    ?? { id: DEFAULT_SORT_ID, label: "Relevance", orderBy: "itemMetadata.relevance:DESC,sortName:ASC" };
+  const searchQuery = input.searchQuery?.trim() ?? "";
+  const fetchCount = Math.max(24, Math.min(input.fetchCount ?? DEFAULT_CATALOG_FETCH_COUNT, 200));
+  const filters = mergeFilterPayloads(normalizedFilterIds, definitions.filterPayloadById);
+
+  const query = `query GetSearchFilterResults(
+    $vpcId: String!,
+    $locale: String!,
+    $sortString: String!,
+    $fetchCount: Int!,
+    $cursor: String!,
+    $searchString: String!,
+    $filters: AppFilterFields!
+  ) {
+    apps(
+      vpcId: $vpcId,
+      language: $locale,
+      orderBy: $sortString,
+      first: $fetchCount,
+      after: $cursor,
+      searchQuery: $searchString,
+      filters: $filters
+    ) {
+      numberReturned
+      numberSupported
+      pageInfo { hasNextPage endCursor totalCount }
+      items {
+        id
+        title
+        description
+        longDescription
+        publisherName
+        features
+        gameFeatures
+        appFeatures
+        genres
+        tags
+        contentRatings
+        images { TV_BANNER HERO_IMAGE KEY_ART GAME_BOX_ART }
+        variants {
+          id
+          appStore
+          supportedControls
+          gfn {
+            status
+            library { status selected lastPlayedDate }
+          }
+        }
+        gfn {
+          playType
+          playabilityState
+          minimumMembershipTierLabel
+          catalogSkuStrings { SKU_BASED_TAG }
+        }
+        itemMetadata { campaignIds }
+      }
+    }
+  }`;
+
+  const collectedApps: AppData[] = [];
+  let numberReturned = 0;
+  let numberSupported = 0;
+  let totalCount = 0;
+  let hasNextPage = false;
+  let endCursor = "";
+  let cursor = "";
+
+  for (let page = 0; page < MAX_CATALOG_PAGES; page += 1) {
+    const payload = await postGraphQl<AppsSearchResponse>(
+      query,
+      {
+        vpcId,
+        locale: DEFAULT_LOCALE,
+        sortString: selectedSort.orderBy,
+        fetchCount,
+        cursor,
+        searchString: searchQuery,
+        filters,
+      },
+      token,
+    );
+
+    if (payload.errors?.length) {
+      throw new Error(payload.errors.map((error) => error.message).join(", "));
+    }
+
+    const apps = payload.data?.apps;
+    const items = apps?.items ?? [];
+    collectedApps.push(...items);
+    numberReturned += apps?.numberReturned ?? items.length;
+    numberSupported = apps?.numberSupported ?? numberSupported;
+    hasNextPage = apps?.pageInfo?.hasNextPage ?? false;
+    endCursor = apps?.pageInfo?.endCursor ?? "";
+    totalCount = apps?.pageInfo?.totalCount ?? totalCount;
+
+    if (!hasNextPage || !endCursor) {
+      break;
+    }
+
+    cursor = endCursor;
+  }
+
+  const games = dedupeGames(collectedApps.map(appToGame));
+
+  return {
+    games,
+    numberReturned,
+    numberSupported: Math.max(numberSupported, games.length),
+    totalCount: Math.max(totalCount, games.length),
+    hasNextPage,
+    endCursor: endCursor || undefined,
+    searchQuery,
+    selectedSortId: selectedSort.id,
+    selectedFilterIds: normalizedFilterIds,
+    filterGroups: definitions.filterGroups,
+    sortOptions: definitions.sortOptions,
+  };
+}
+
+export async function browseCatalog(input: CatalogBrowseRequest): Promise<CatalogBrowseResult> {
+  return browseCatalogUncached(input);
 }
 
 export async function fetchMainGames(token: string, providerStreamingBaseUrl?: string): Promise<GameInfo[]> {
@@ -461,8 +820,7 @@ async function fetchMainGamesUncached(token: string, providerStreamingBaseUrl?: 
   const vpcId = await getVpcId(token, providerStreamingBaseUrl);
   const payload = await fetchPanels(token, ["MAIN"], vpcId);
   const games = flattenPanels(payload);
-  const gfnEnriched = await enrichGamesWithMetadata(token, vpcId, games);
-  return gfnEnriched;
+  return enrichGamesWithMetadata(token, vpcId, games);
 }
 
 export async function fetchLibraryGames(
@@ -484,10 +842,16 @@ async function fetchLibraryGamesUncached(
   providerStreamingBaseUrl?: string,
 ): Promise<GameInfo[]> {
   const vpcId = await getVpcId(token, providerStreamingBaseUrl);
-  const payload = await fetchPanels(token, ["LIBRARY"], vpcId);
+  let payload: GraphQlResponse;
+
+  try {
+    payload = await fetchPanels(token, ["LIBRARY"], vpcId, { withLibraryTime: true });
+  } catch {
+    payload = await fetchPanels(token, ["LIBRARY"], vpcId);
+  }
+
   const games = flattenPanels(payload);
-  const gfnEnriched = await enrichGamesWithMetadata(token, vpcId, games);
-  return gfnEnriched;
+  return enrichGamesWithMetadata(token, vpcId, games);
 }
 
 export async function fetchPublicGames(): Promise<GameInfo[]> {
@@ -516,7 +880,7 @@ async function fetchPublicGamesUncached(): Promise<GameInfo[]> {
   }
 
   const payload = (await response.json()) as RawPublicGame[];
-  const games = payload
+  return payload
     .filter((item) => item.status === "AVAILABLE" && item.title)
     .map((item) => {
       const id = String(item.id ?? item.title ?? "unknown");
@@ -530,14 +894,14 @@ async function fetchPublicGamesUncached(): Promise<GameInfo[]> {
         uuid: id,
         launchAppId: isNumericId(id) ? id : undefined,
         title: item.title ?? id,
+        searchText: (item.title ?? id).toLowerCase(),
         selectedVariantIndex: 0,
         variants: [{ id, store: "Unknown", supportedControls: [] }],
         imageUrl,
+        availableStores: ["Unknown"],
+        isInLibrary: false,
       } as GameInfo;
     });
-
-  return games;
-
 }
 
 export async function resolveLaunchAppId(
@@ -561,22 +925,11 @@ export async function resolveLaunchAppId(
     return null;
   }
 
-  const variants = app.variants ?? [];
-  const selected = variants.find((variant) => variant.gfn?.library?.selected === true);
-
-  if (isNumericId(selected?.id)) {
-    return selected.id;
-  }
-
-  const firstNumeric = variants.find((variant) => isNumericId(variant.id));
-  if (firstNumeric) {
-    return firstNumeric.id;
-  }
-
-  return isNumericId(app.id) ? app.id : null;
+  return resolveAppData(app).numericAppId ?? null;
 }
 
 export {
+  browseCatalogUncached,
   fetchMainGamesUncached,
   fetchLibraryGamesUncached,
   fetchPublicGamesUncached,

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -390,7 +390,10 @@ function appToGame(app: AppData): GameInfo {
 
 function mergeAppMetaIntoGame(game: GameInfo, app: AppData): GameInfo {
   const merged = appToGame(app);
-  const selectedVariantIndex = game.variants.findIndex((variant) => variant.id === game.variants[game.selectedVariantIndex]?.id);
+  const selectedVariantId = game.variants[game.selectedVariantIndex]?.id;
+  const selectedVariantIndex = selectedVariantId
+    ? merged.variants.findIndex((variant) => variant.id === selectedVariantId)
+    : -1;
 
   return {
     ...game,
@@ -458,47 +461,38 @@ async function fetchAppMetaData(
     return { data: { apps: { items: [] } } };
   }
 
-  const variables = {
+  const variables = JSON.stringify({
     vpcId,
     locale: DEFAULT_LOCALE,
     appIds: normalizedIds,
-  };
+  });
 
-  const query = `query AppMetaData($vpcId: String!, $locale: String!, $appIds: [String!]!) {
-    apps(vpcId: $vpcId, language: $locale, ids: $appIds) {
-      items {
-        id
-        title
-        description
-        longDescription
-        publisherName
-        features
-        gameFeatures
-        appFeatures
-        genres
-        tags
-        contentRatings
-        images { GAME_BOX_ART TV_BANNER HERO_IMAGE KEY_ART }
-        variants {
-          id
-          appStore
-          supportedControls
-          gfn {
-            status
-            library { status selected lastPlayedDate }
-          }
-        }
-        gfn {
-          playType
-          playabilityState
-          minimumMembershipTierLabel
-          catalogSkuStrings { SKU_BASED_TAG }
-        }
-      }
-    }
-  }`;
+  const extensions = JSON.stringify({
+    persistedQuery: {
+      sha256Hash: APP_METADATA_QUERY_HASH,
+    },
+  });
 
-  return postGraphQl<AppMetaDataResponse>(query, variables, token);
+  const params = new URLSearchParams({
+    requestType: "appMetaData",
+    extensions,
+    huId: randomHuId(),
+    variables,
+  });
+
+  const response = await fetch(`${GRAPHQL_URL}?${params.toString()}`, {
+    headers: {
+      ...buildHeaders(token),
+      "Content-Type": "application/graphql",
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`App metadata failed (${response.status}): ${text.slice(0, 400)}`);
+  }
+
+  return (await response.json()) as AppMetaDataResponse;
 }
 
 async function enrichGamesWithMetadata(token: string, vpcId: string, games: GameInfo[]): Promise<GameInfo[]> {
@@ -711,27 +705,17 @@ async function browseCatalogUncached(input: CatalogBrowseRequest): Promise<Catal
       items {
         id
         title
-        description
-        longDescription
-        publisherName
-        features
-        gameFeatures
-        appFeatures
-        genres
-        tags
-        contentRatings
-        images { TV_BANNER HERO_IMAGE KEY_ART GAME_BOX_ART }
+        images { TV_BANNER HERO_IMAGE }
         variants {
           id
           appStore
           supportedControls
           gfn {
             status
-            library { status selected lastPlayedDate }
+            library { status selected }
           }
         }
         gfn {
-          playType
           playabilityState
           minimumMembershipTierLabel
           catalogSkuStrings { SKU_BASED_TAG }

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -19,7 +19,6 @@ import { cacheManager } from "./services/cacheManager";
 import { refreshScheduler } from "./services/refreshScheduler";
 import { cacheEventBus } from "./services/cacheEventBus";
 import {
-  browseCatalogUncached,
   fetchMainGamesUncached,
   fetchLibraryGamesUncached,
   fetchPublicGamesUncached,

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -19,6 +19,7 @@ import { cacheManager } from "./services/cacheManager";
 import { refreshScheduler } from "./services/refreshScheduler";
 import { cacheEventBus } from "./services/cacheEventBus";
 import {
+  browseCatalogUncached,
   fetchMainGamesUncached,
   fetchLibraryGamesUncached,
   fetchPublicGamesUncached,
@@ -29,6 +30,7 @@ import type {
   SessionInfo,
   AuthSessionRequest,
   GamesFetchRequest,
+  CatalogBrowseRequest,
   ResolveLaunchIdRequest,
   RegionsFetchRequest,
   SessionAdReportRequest,
@@ -70,6 +72,7 @@ import { getSettingsManager, type SettingsManager } from "./settings";
 import { createSession, pollSession, reportSessionAd, stopSession, getActiveSessions, claimSession } from "./gfn/cloudmatch";
 import { AuthService } from "./gfn/auth";
 import {
+  browseCatalog,
   fetchLibraryGames,
   fetchMainGames,
   fetchPublicGames,
@@ -906,6 +909,14 @@ function registerIpcHandlers(): void {
       payload?.providerStreamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
     refreshScheduler.updateAuthContext(token, streamingBaseUrl);
     return fetchLibraryGames(token, streamingBaseUrl);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.GAMES_BROWSE_CATALOG, async (_event, payload: CatalogBrowseRequest) => {
+    const token = await resolveJwt(payload?.token);
+    const streamingBaseUrl =
+      payload?.providerStreamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
+    refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+    return browseCatalog({ ...payload, token, providerStreamingBaseUrl: streamingBaseUrl });
   });
 
   ipcMain.handle(IPC_CHANNELS.GAMES_FETCH_PUBLIC, async () => {

--- a/opennow-stable/src/main/services/refreshScheduler.ts
+++ b/opennow-stable/src/main/services/refreshScheduler.ts
@@ -1,5 +1,6 @@
 import type { GameInfo } from "@shared/gfn";
 import { cacheEventBus } from "./cacheEventBus";
+import { cacheManager } from "./cacheManager";
 
 export interface RefreshAuthContext {
   token: string;
@@ -86,11 +87,20 @@ class RefreshScheduler {
     try {
       cacheEventBus.emit("cache:refresh-start");
 
-      const results = await Promise.allSettled([
+      const shouldRefreshLibrary = !(await cacheManager.loadFromCache<GameInfo[]>("games:library"));
+      if (!shouldRefreshLibrary) {
+        console.log("[CACHE] Skipping library refresh; cached library is still fresh");
+      }
+
+      const refreshTasks: Promise<GameInfo[]>[] = [
         this.fetchMainGames(this.authContext.token, this.authContext.providerStreamingBaseUrl),
-        this.fetchLibraryGames(this.authContext.token, this.authContext.providerStreamingBaseUrl),
+        shouldRefreshLibrary
+          ? this.fetchLibraryGames(this.authContext.token, this.authContext.providerStreamingBaseUrl)
+          : Promise.resolve([]),
         this.fetchPublicGames(),
-      ]);
+      ];
+
+      const results = await Promise.allSettled(refreshTasks);
 
       let hasErrors = false;
       for (let i = 0; i < results.length; i++) {

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -5,6 +5,7 @@ import type {
   AuthLoginRequest,
   AuthSessionRequest,
   GamesFetchRequest,
+  CatalogBrowseRequest,
   ResolveLaunchIdRequest,
   RegionsFetchRequest,
   MainToRendererSignalingEvent,
@@ -66,6 +67,7 @@ const api: OpenNowApi = {
   fetchMainGames: (input: GamesFetchRequest) => ipcRenderer.invoke(IPC_CHANNELS.GAMES_FETCH_MAIN, input),
   fetchLibraryGames: (input: GamesFetchRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.GAMES_FETCH_LIBRARY, input),
+  browseCatalog: (input: CatalogBrowseRequest) => ipcRenderer.invoke(IPC_CHANNELS.GAMES_BROWSE_CATALOG, input),
   fetchPublicGames: () => ipcRenderer.invoke(IPC_CHANNELS.GAMES_FETCH_PUBLIC),
   resolveLaunchAppId: (input: ResolveLaunchIdRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.GAMES_RESOLVE_LAUNCH_ID, input),

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -5,6 +5,9 @@ import type {
   ActiveSessionInfo,
   AuthSession,
   AuthUser,
+  CatalogBrowseResult,
+  CatalogFilterGroup,
+  CatalogSortOption,
   GameInfo,
   GameVariant,
   LoginProvider,
@@ -98,7 +101,7 @@ const FREE_TIER_15_MIN_WARNING_SECONDS = 15 * 60;
 const FREE_TIER_FINAL_MINUTE_WARNING_SECONDS = 60;
 const STREAM_WARNING_VISIBILITY_MS = 15 * 1000;
 
-type GameSource = "main" | "library" | "public";
+type GameSource = "main" | "library";
 type AppPage = "home" | "library" | "settings";
 type StreamStatus = "idle" | "queue" | "setup" | "starting" | "connecting" | "streaming";
 type StreamLoadingStatus = "queue" | "setup" | "starting" | "connecting";
@@ -242,6 +245,69 @@ function findSessionContextForAppId(
   }
 
   return null;
+}
+
+function matchesGameSearch(game: GameInfo, query: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+  if (game.searchText?.includes(normalizedQuery)) return true;
+  return [
+    game.title,
+    game.description,
+    game.publisherName,
+    ...(game.genres ?? []),
+    ...(game.featureLabels ?? []),
+    ...(game.availableStores ?? []),
+  ]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .some((value) => value.toLowerCase().includes(normalizedQuery));
+}
+
+function chooseAccountLinked(game: GameInfo, selectedVariant?: GameVariant): boolean {
+  if (game.playType === "INSTALL_TO_PLAY") {
+    return false;
+  }
+  if (selectedVariant?.librarySelected) {
+    return true;
+  }
+  if (selectedVariant?.libraryStatus === "IN_LIBRARY") {
+    return true;
+  }
+  if (game.isInLibrary) {
+    return true;
+  }
+  return false;
+}
+
+function sortLibraryGames(games: GameInfo[], sortId: string): GameInfo[] {
+  const copy = [...games];
+  const compareTitle = (left: GameInfo, right: GameInfo) => left.title.localeCompare(right.title);
+  if (sortId === "z_to_a") {
+    return copy.sort((left, right) => right.title.localeCompare(left.title));
+  }
+  if (sortId === "a_to_z") {
+    return copy.sort(compareTitle);
+  }
+  if (sortId === "last_played") {
+    return copy.sort((left, right) => {
+      const leftTime = left.lastPlayed ? new Date(left.lastPlayed).getTime() : 0;
+      const rightTime = right.lastPlayed ? new Date(right.lastPlayed).getTime() : 0;
+      if (leftTime === rightTime) return compareTitle(left, right);
+      return rightTime - leftTime;
+    });
+  }
+  if (sortId === "last_added") {
+    return copy.sort((left, right) => {
+      const leftTime = left.isInLibrary ? new Date(left.lastPlayed ?? 0).getTime() : 0;
+      const rightTime = right.isInLibrary ? new Date(right.lastPlayed ?? 0).getTime() : 0;
+      if (leftTime === rightTime) return compareTitle(left, right);
+      return rightTime - leftTime;
+    });
+  }
+  if (sortId === "most_popular") {
+    return copy.sort((left, right) => (right.membershipTierLabel ? 1 : 0) - (left.membershipTierLabel ? 1 : 0) || compareTitle(left, right));
+  }
+  return copy.sort(compareTitle);
 }
 
 function mergeVariantSelections(
@@ -682,6 +748,12 @@ export function App(): JSX.Element {
   const [selectedGameId, setSelectedGameId] = useState("");
   const [variantByGameId, setVariantByGameId] = useState<Record<string, string>>({});
   const [isLoadingGames, setIsLoadingGames] = useState(false);
+  const [catalogFilterGroups, setCatalogFilterGroups] = useState<CatalogFilterGroup[]>([]);
+  const [catalogSortOptions, setCatalogSortOptions] = useState<CatalogSortOption[]>([]);
+  const [catalogSelectedSortId, setCatalogSelectedSortId] = useState("relevance");
+  const [catalogSelectedFilterIds, setCatalogSelectedFilterIds] = useState<string[]>([]);
+  const [catalogTotalCount, setCatalogTotalCount] = useState(0);
+  const [catalogSupportedCount, setCatalogSupportedCount] = useState(0);
 
   // Settings State
   const [settings, setSettings] = useState<Settings>({
@@ -1692,36 +1764,48 @@ export function App(): JSX.Element {
 
           // Load games
           try {
-            const mainGames = await window.openNow.fetchMainGames({
-              token,
-              providerStreamingBaseUrl: persistedSession.provider.streamingServiceUrl,
-            });
-            setGames(mainGames);
+            const [catalogResult, libGames] = await Promise.all([
+              window.openNow.browseCatalog({
+                token,
+                providerStreamingBaseUrl: persistedSession.provider.streamingServiceUrl,
+                searchQuery: "",
+                sortId: catalogSelectedSortId,
+                filterIds: catalogSelectedFilterIds,
+              }),
+              window.openNow.fetchLibraryGames({
+                token,
+                providerStreamingBaseUrl: persistedSession.provider.streamingServiceUrl,
+              }),
+            ]);
+            setGames(catalogResult.games);
+            setCatalogFilterGroups(catalogResult.filterGroups);
+            setCatalogSortOptions(catalogResult.sortOptions);
+            setCatalogSelectedSortId(catalogResult.selectedSortId);
+            setCatalogSelectedFilterIds(catalogResult.selectedFilterIds);
+            setCatalogTotalCount(catalogResult.totalCount);
+            setCatalogSupportedCount(catalogResult.numberSupported);
             setSource("main");
-            setSelectedGameId(mainGames[0]?.id ?? "");
-            applyVariantSelections(mainGames);
-
-            // Also load library
-            const libGames = await window.openNow.fetchLibraryGames({
-              token,
-              providerStreamingBaseUrl: persistedSession.provider.streamingServiceUrl,
-            });
+            setSelectedGameId(catalogResult.games[0]?.id ?? "");
+            applyVariantSelections(catalogResult.games);
             setLibraryGames(libGames);
             applyVariantSelections(libGames);
-          } catch {
-            // Fallback to public games
-            const publicGames = await window.openNow.fetchPublicGames();
-            setGames(publicGames);
-            setSource("public");
-            applyVariantSelections(publicGames);
+          } catch (catalogError) {
+            console.error("Initialization games load failed:", catalogError);
+            setGames([]);
+            setLibraryGames([]);
+            setCatalogFilterGroups([]);
+            setCatalogSortOptions([]);
+            setCatalogTotalCount(0);
+            setCatalogSupportedCount(0);
           }
         } else {
-          // Load public games for non-logged in users
-          const publicGames = await window.openNow.fetchPublicGames();
-          setGames(publicGames);
-          setSource("public");
-          applyVariantSelections(publicGames);
+          setGames([]);
+          setLibraryGames([]);
           setSubscriptionInfo(null);
+          setCatalogFilterGroups([]);
+          setCatalogSortOptions([]);
+          setCatalogTotalCount(0);
+          setCatalogSupportedCount(0);
         }
       } catch (error) {
         console.error("Initialization failed:", error);
@@ -2173,21 +2257,29 @@ export function App(): JSX.Element {
         setSubscriptionInfo(null);
       }
 
-      // Load games
-      const mainGames = await window.openNow.fetchMainGames({
-        token,
-        providerStreamingBaseUrl: session.provider.streamingServiceUrl,
-      });
-      setGames(mainGames);
+      const [catalogResult, libGames] = await Promise.all([
+        window.openNow.browseCatalog({
+          token,
+          providerStreamingBaseUrl: session.provider.streamingServiceUrl,
+          searchQuery: "",
+          sortId: catalogSelectedSortId,
+          filterIds: catalogSelectedFilterIds,
+        }),
+        window.openNow.fetchLibraryGames({
+          token,
+          providerStreamingBaseUrl: session.provider.streamingServiceUrl,
+        }),
+      ]);
+      setGames(catalogResult.games);
+      setCatalogFilterGroups(catalogResult.filterGroups);
+      setCatalogSortOptions(catalogResult.sortOptions);
+      setCatalogSelectedSortId(catalogResult.selectedSortId);
+      setCatalogSelectedFilterIds(catalogResult.selectedFilterIds);
+      setCatalogTotalCount(catalogResult.totalCount);
+      setCatalogSupportedCount(catalogResult.numberSupported);
       setSource("main");
-      setSelectedGameId(mainGames[0]?.id ?? "");
-      applyVariantSelections(mainGames);
-
-      // Load library
-      const libGames = await window.openNow.fetchLibraryGames({
-        token,
-        providerStreamingBaseUrl: session.provider.streamingServiceUrl,
-      });
+      setSelectedGameId(catalogResult.games[0]?.id ?? "");
+      applyVariantSelections(catalogResult.games);
       setLibraryGames(libGames);
       applyVariantSelections(libGames);
     } catch (error) {
@@ -2209,11 +2301,15 @@ export function App(): JSX.Element {
     setIsResumingNavbarSession(false);
     setSubscriptionInfo(null);
     setCurrentPage("home");
-    const publicGames = await window.openNow.fetchPublicGames();
-    setGames(publicGames);
-    setSource("public");
-    applyVariantSelections(publicGames);
-  }, [applyVariantSelections, resetLaunchRuntime]);
+    setCatalogFilterGroups([]);
+    setCatalogSortOptions([]);
+    setCatalogSelectedSortId("relevance");
+    setCatalogSelectedFilterIds([]);
+    setCatalogTotalCount(0);
+    setCatalogSupportedCount(0);
+    setSource("main");
+    setSelectedGameId("");
+  }, [resetLaunchRuntime]);
 
   // Load games handler
   const loadGames = useCallback(async (targetSource: GameSource) => {
@@ -2221,30 +2317,52 @@ export function App(): JSX.Element {
     try {
       const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
       const baseUrl = effectiveStreamingBaseUrl;
-
-      let result: GameInfo[] = [];
-      if (targetSource === "main" && token) {
-        result = await window.openNow.fetchMainGames({ token, providerStreamingBaseUrl: baseUrl });
-      } else if (targetSource === "library" && token) {
-        result = await window.openNow.fetchLibraryGames({ token, providerStreamingBaseUrl: baseUrl });
-        setLibraryGames(result);
-        applyVariantSelections(result);
-      } else if (targetSource === "public") {
-        result = await window.openNow.fetchPublicGames();
+      if (!token) {
+        return;
       }
 
-      if (targetSource !== "library") {
-        setGames(result);
-        setSource(targetSource);
-        setSelectedGameId(result[0]?.id ?? "");
-        applyVariantSelections(result);
+      if (targetSource === "main") {
+        const catalogResult = await window.openNow.browseCatalog({
+          token,
+          providerStreamingBaseUrl: baseUrl,
+          searchQuery,
+          sortId: catalogSelectedSortId,
+          filterIds: catalogSelectedFilterIds,
+        });
+        setGames(catalogResult.games);
+        setCatalogFilterGroups(catalogResult.filterGroups);
+        setCatalogSortOptions(catalogResult.sortOptions);
+        setCatalogSelectedSortId(catalogResult.selectedSortId);
+        setCatalogSelectedFilterIds(catalogResult.selectedFilterIds);
+        setCatalogTotalCount(catalogResult.totalCount);
+        setCatalogSupportedCount(catalogResult.numberSupported);
+        setSource("main");
+        setSelectedGameId((previous) => catalogResult.games.some((game) => game.id === previous) ? previous : (catalogResult.games[0]?.id ?? ""));
+        applyVariantSelections(catalogResult.games);
+        return;
       }
+
+      const result = await window.openNow.fetchLibraryGames({ token, providerStreamingBaseUrl: baseUrl });
+      setLibraryGames(result);
+      setSource("library");
+      setSelectedGameId((previous) => result.some((game) => game.id === previous) ? previous : (result[0]?.id ?? ""));
+      applyVariantSelections(result);
     } catch (error) {
       console.error("Failed to load games:", error);
     } finally {
       setIsLoadingGames(false);
     }
-  }, [applyVariantSelections, authSession, effectiveStreamingBaseUrl]);
+  }, [applyVariantSelections, authSession, effectiveStreamingBaseUrl, searchQuery, catalogSelectedSortId, catalogSelectedFilterIds]);
+
+  useEffect(() => {
+    if (!authSession || source !== "main") {
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      void loadGames("main");
+    }, searchQuery.trim() ? 220 : 0);
+    return () => window.clearTimeout(handle);
+  }, [authSession, loadGames, searchQuery, source, catalogSelectedSortId, catalogSelectedFilterIds]);
 
   const handleSelectGameVariant = useCallback((gameId: string, variantId: string): void => {
     setVariantByGameId((prev) => {
@@ -2436,7 +2554,7 @@ export function App(): JSX.Element {
         streamingBaseUrl: options?.streamingBaseUrl || effectiveStreamingBaseUrl,
         appId,
         internalTitle: game.title,
-        accountLinked: game.playType !== "INSTALL_TO_PLAY",
+        accountLinked: chooseAccountLinked(game, selectedVariant),
         zone: "prod",
         settings: {
           resolution: settings.resolution,
@@ -3002,18 +3120,13 @@ export function App(): JSX.Element {
     streamStatus,
   ]);
 
-  // Filter games by search
-  const filteredGames = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return games;
-    return games.filter((g) => g.title.toLowerCase().includes(query));
-  }, [games, searchQuery]);
+  const filteredGames = games;
 
   const filteredLibraryGames = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return libraryGames;
-    return libraryGames.filter((g) => g.title.toLowerCase().includes(query));
-  }, [libraryGames, searchQuery]);
+    const query = searchQuery.trim();
+    const searched = query ? libraryGames.filter((game) => matchesGameSearch(game, query)) : libraryGames;
+    return sortLibraryGames(searched, catalogSelectedSortId === "relevance" ? "last_played" : catalogSelectedSortId);
+  }, [libraryGames, searchQuery, catalogSelectedSortId]);
 
   const activeSessionGameTitle = useMemo(() => {
     if (!navbarActiveSession) return null;
@@ -3379,8 +3492,19 @@ export function App(): JSX.Element {
         {currentPage === "home" && (
           <HomePage
             games={filteredGames}
-            source={source}
-            onSourceChange={loadGames}
+            source="main"
+            onSourceChange={(nextSource) => {
+              if (nextSource === "library") {
+                setCurrentPage("library");
+                if (libraryGames.length === 0 && authSession) {
+                  void loadGames("library");
+                }
+                return;
+              }
+              setCurrentPage("home");
+              setSource("main");
+              void loadGames("main");
+            }}
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
             onPlayGame={handleInitiatePlay}
@@ -3389,6 +3513,16 @@ export function App(): JSX.Element {
             onSelectGame={setSelectedGameId}
             selectedVariantByGameId={variantByGameId}
             onSelectGameVariant={handleSelectGameVariant}
+            filterGroups={catalogFilterGroups}
+            selectedFilterIds={catalogSelectedFilterIds}
+            onToggleFilter={(filterId) => {
+              setCatalogSelectedFilterIds((previous) => previous.includes(filterId) ? previous.filter((value) => value !== filterId) : [...previous, filterId]);
+            }}
+            sortOptions={catalogSortOptions}
+            selectedSortId={catalogSelectedSortId}
+            onSortChange={setCatalogSelectedSortId}
+            totalCount={catalogTotalCount}
+            supportedCount={catalogSupportedCount}
           />
         )}
 
@@ -3450,6 +3584,10 @@ export function App(): JSX.Element {
               onSelectGame={setSelectedGameId}
               selectedVariantByGameId={variantByGameId}
               onSelectGameVariant={handleSelectGameVariant}
+              libraryCount={libraryGames.length}
+              sortOptions={catalogSortOptions.filter((option) => option.id !== "relevance")}
+              selectedSortId={catalogSelectedSortId === "relevance" ? "last_played" : catalogSelectedSortId}
+              onSortChange={setCatalogSelectedSortId}
             />
           )
         )}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -279,6 +279,13 @@ function chooseAccountLinked(game: GameInfo, selectedVariant?: GameVariant): boo
   return false;
 }
 
+function areStringArraysEqual(left: string[], right: string[]): boolean {
+  if (left.length != right.length) {
+    return false;
+  }
+  return left.every((value, index) => value === right[index]);
+}
+
 function sortLibraryGames(games: GameInfo[], sortId: string): GameInfo[] {
   const copy = [...games];
   const compareTitle = (left: GameInfo, right: GameInfo) => left.title.localeCompare(right.title);
@@ -754,6 +761,7 @@ export function App(): JSX.Element {
   const [catalogSelectedFilterIds, setCatalogSelectedFilterIds] = useState<string[]>([]);
   const [catalogTotalCount, setCatalogTotalCount] = useState(0);
   const [catalogSupportedCount, setCatalogSupportedCount] = useState(0);
+  const catalogFilterKey = useMemo(() => catalogSelectedFilterIds.join("|"), [catalogSelectedFilterIds]);
 
   // Settings State
   const [settings, setSettings] = useState<Settings>({
@@ -1777,16 +1785,7 @@ export function App(): JSX.Element {
                 providerStreamingBaseUrl: persistedSession.provider.streamingServiceUrl,
               }),
             ]);
-            setGames(catalogResult.games);
-            setCatalogFilterGroups(catalogResult.filterGroups);
-            setCatalogSortOptions(catalogResult.sortOptions);
-            setCatalogSelectedSortId(catalogResult.selectedSortId);
-            setCatalogSelectedFilterIds(catalogResult.selectedFilterIds);
-            setCatalogTotalCount(catalogResult.totalCount);
-            setCatalogSupportedCount(catalogResult.numberSupported);
-            setSource("main");
-            setSelectedGameId(catalogResult.games[0]?.id ?? "");
-            applyVariantSelections(catalogResult.games);
+            applyCatalogBrowseResult(catalogResult);
             setLibraryGames(libGames);
             applyVariantSelections(libGames);
           } catch (catalogError) {
@@ -2236,6 +2235,19 @@ export function App(): JSX.Element {
     });
   }, [updateSetting]);
 
+  const applyCatalogBrowseResult = useCallback((catalogResult: CatalogBrowseResult): void => {
+    setGames(catalogResult.games);
+    setCatalogFilterGroups(catalogResult.filterGroups);
+    setCatalogSortOptions(catalogResult.sortOptions);
+    setCatalogSelectedSortId((previous) => previous === catalogResult.selectedSortId ? previous : catalogResult.selectedSortId);
+    setCatalogSelectedFilterIds((previous) => areStringArraysEqual(previous, catalogResult.selectedFilterIds) ? previous : catalogResult.selectedFilterIds);
+    setCatalogTotalCount(catalogResult.totalCount);
+    setCatalogSupportedCount(catalogResult.numberSupported);
+    setSource("main");
+    setSelectedGameId((previous) => catalogResult.games.some((game) => game.id === previous) ? previous : (catalogResult.games[0]?.id ?? ""));
+    applyVariantSelections(catalogResult.games);
+  }, [applyVariantSelections]);
+
   // Login handler
   const handleLogin = useCallback(async () => {
     setIsLoggingIn(true);
@@ -2270,16 +2282,7 @@ export function App(): JSX.Element {
           providerStreamingBaseUrl: session.provider.streamingServiceUrl,
         }),
       ]);
-      setGames(catalogResult.games);
-      setCatalogFilterGroups(catalogResult.filterGroups);
-      setCatalogSortOptions(catalogResult.sortOptions);
-      setCatalogSelectedSortId(catalogResult.selectedSortId);
-      setCatalogSelectedFilterIds(catalogResult.selectedFilterIds);
-      setCatalogTotalCount(catalogResult.totalCount);
-      setCatalogSupportedCount(catalogResult.numberSupported);
-      setSource("main");
-      setSelectedGameId(catalogResult.games[0]?.id ?? "");
-      applyVariantSelections(catalogResult.games);
+      applyCatalogBrowseResult(catalogResult);
       setLibraryGames(libGames);
       applyVariantSelections(libGames);
     } catch (error) {
@@ -2287,7 +2290,7 @@ export function App(): JSX.Element {
     } finally {
       setIsLoggingIn(false);
     }
-  }, [applyVariantSelections, loadSubscriptionInfo, providerIdpId]);
+  }, [applyCatalogBrowseResult, applyVariantSelections, loadSubscriptionInfo, providerIdpId, catalogFilterKey, catalogSelectedSortId]);
 
   // Logout handler
   const handleLogout = useCallback(async () => {
@@ -2329,16 +2332,7 @@ export function App(): JSX.Element {
           sortId: catalogSelectedSortId,
           filterIds: catalogSelectedFilterIds,
         });
-        setGames(catalogResult.games);
-        setCatalogFilterGroups(catalogResult.filterGroups);
-        setCatalogSortOptions(catalogResult.sortOptions);
-        setCatalogSelectedSortId(catalogResult.selectedSortId);
-        setCatalogSelectedFilterIds(catalogResult.selectedFilterIds);
-        setCatalogTotalCount(catalogResult.totalCount);
-        setCatalogSupportedCount(catalogResult.numberSupported);
-        setSource("main");
-        setSelectedGameId((previous) => catalogResult.games.some((game) => game.id === previous) ? previous : (catalogResult.games[0]?.id ?? ""));
-        applyVariantSelections(catalogResult.games);
+        applyCatalogBrowseResult(catalogResult);
         return;
       }
 
@@ -2352,7 +2346,7 @@ export function App(): JSX.Element {
     } finally {
       setIsLoadingGames(false);
     }
-  }, [applyVariantSelections, authSession, effectiveStreamingBaseUrl, searchQuery, catalogSelectedSortId, catalogSelectedFilterIds]);
+  }, [applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, searchQuery, catalogFilterKey, catalogSelectedSortId]);
 
   useEffect(() => {
     if (!authSession || source !== "main") {
@@ -2362,7 +2356,7 @@ export function App(): JSX.Element {
       void loadGames("main");
     }, searchQuery.trim() ? 220 : 0);
     return () => window.clearTimeout(handle);
-  }, [authSession, loadGames, searchQuery, source, catalogSelectedSortId, catalogSelectedFilterIds]);
+  }, [authSession, loadGames, searchQuery, source, catalogFilterKey, catalogSelectedSortId]);
 
   const handleSelectGameVariant = useCallback((gameId: string, variantId: string): void => {
     setVariantByGameId((prev) => {
@@ -3501,8 +3495,6 @@ export function App(): JSX.Element {
                 }
                 return;
               }
-              setCurrentPage("home");
-              setSource("main");
               void loadGames("main");
             }}
             searchQuery={searchQuery}

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Search, LayoutGrid, Loader2, ArrowUpDown, Filter } from "lucide-react";
+import { Search, LayoutGrid, Loader2, ArrowUpDown, Filter, ChevronDown } from "lucide-react";
 import type { JSX } from "react";
 import type { CatalogFilterGroup, CatalogSortOption, GameInfo } from "@shared/gfn";
 import { GameCard } from "./GameCard";
@@ -48,6 +48,7 @@ export function HomePage({
 }: HomePageProps): JSX.Element {
   const hasGames = games.length > 0;
   const visibleFilterGroups = filterGroups.filter((group) => ["digital_store", "genre", "subscriptions"].includes(group.id));
+  const activeFilterCount = selectedFilterIds.length;
 
   return (
     <div className="home-page">
@@ -74,6 +75,41 @@ export function HomePage({
           />
         </div>
 
+        {visibleFilterGroups.length > 0 && (
+          <details className="home-filter-dropdown">
+            <summary className="home-filter-dropdown-trigger">
+              <span className="home-filter-dropdown-label">
+                <Filter size={14} />
+                Filters
+              </span>
+              {activeFilterCount > 0 && <span className="home-filter-dropdown-count">{activeFilterCount}</span>}
+              <ChevronDown size={14} className="home-filter-dropdown-chevron" />
+            </summary>
+            <div className="home-filter-dropdown-menu">
+              {visibleFilterGroups.map((group) => (
+                <div key={group.id} className="home-filter-dropdown-group">
+                  <div className="home-filter-group-label">{group.label}</div>
+                  <div className="home-filter-chips">
+                    {group.options.slice(0, group.id === "genre" ? 8 : group.options.length).map((option) => {
+                      const active = selectedFilterIds.includes(option.id);
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          className={`home-filter-chip ${active ? "active" : ""}`}
+                          onClick={() => onToggleFilter(option.id)}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+
         <label className="home-sort">
           <ArrowUpDown size={14} />
           <select value={selectedSortId} onChange={(e) => onSortChange(e.target.value)} disabled={isLoading}>
@@ -91,34 +127,6 @@ export function HomePage({
             : `${games.length} shown${totalCount > games.length ? ` · ${totalCount} total` : ""}${supportedCount > 0 ? ` · ${supportedCount} supported` : ""}`}
         </span>
       </header>
-
-      {visibleFilterGroups.length > 0 && (
-        <div className="home-filter-bar">
-          {visibleFilterGroups.map((group) => (
-            <div key={group.id} className="home-filter-group">
-              <span className="home-filter-group-label">
-                <Filter size={12} />
-                {group.label}
-              </span>
-              <div className="home-filter-chips">
-                {group.options.slice(0, group.id === "genre" ? 8 : group.options.length).map((option) => {
-                  const active = selectedFilterIds.includes(option.id);
-                  return (
-                    <button
-                      key={option.id}
-                      type="button"
-                      className={`home-filter-chip ${active ? "active" : ""}`}
-                      onClick={() => onToggleFilter(option.id)}
-                    >
-                      {option.label}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
 
       <div className="home-grid-area">
         {isLoading ? (

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -1,12 +1,12 @@
-import { Search, LayoutGrid, Globe, Loader2 } from "lucide-react";
+import { Search, LayoutGrid, Library, ArrowUpDown, Filter, Loader2, Sparkles } from "lucide-react";
 import type { JSX } from "react";
-import type { GameInfo } from "@shared/gfn";
+import type { CatalogFilterGroup, CatalogSortOption, GameInfo } from "@shared/gfn";
 import { GameCard } from "./GameCard";
 
 export interface HomePageProps {
   games: GameInfo[];
-  source: "main" | "library" | "public";
-  onSourceChange: (source: "main" | "library" | "public") => void;
+  source: "main" | "library";
+  onSourceChange: (source: "main" | "library") => void;
   searchQuery: string;
   onSearchChange: (query: string) => void;
   onPlayGame: (game: GameInfo) => void;
@@ -15,6 +15,14 @@ export interface HomePageProps {
   onSelectGame: (id: string) => void;
   selectedVariantByGameId: Record<string, string>;
   onSelectGameVariant: (gameId: string, variantId: string) => void;
+  filterGroups: CatalogFilterGroup[];
+  selectedFilterIds: string[];
+  onToggleFilter: (filterId: string) => void;
+  sortOptions: CatalogSortOption[];
+  selectedSortId: string;
+  onSortChange: (sortId: string) => void;
+  totalCount: number;
+  supportedCount: number;
 }
 
 export function HomePage({
@@ -29,70 +37,149 @@ export function HomePage({
   onSelectGame,
   selectedVariantByGameId,
   onSelectGameVariant,
+  filterGroups,
+  selectedFilterIds,
+  onToggleFilter,
+  sortOptions,
+  selectedSortId,
+  onSortChange,
+  totalCount,
+  supportedCount,
 }: HomePageProps): JSX.Element {
   const hasGames = games.length > 0;
+  const quickGroups = filterGroups.filter((group) => ["digital_store", "genre", "subscriptions"].includes(group.id));
+  const primaryOptions = quickGroups.flatMap((group) => group.options.slice(0, group.id === "genre" ? 8 : group.options.length));
 
   return (
-    <div className="home-page">
-      {/* Top bar: tabs + search + count */}
-      <header className="home-toolbar">
-        <div className="home-tabs">
-          <button
-            className={`home-tab ${source === "main" ? "active" : ""}`}
-            onClick={() => onSourceChange("main")}
-            disabled={isLoading}
-          >
-            <LayoutGrid size={15} />
-            Catalog
-          </button>
-          <button
-            className={`home-tab ${source === "public" ? "active" : ""}`}
-            onClick={() => onSourceChange("public")}
-            disabled={isLoading}
-          >
-            <Globe size={15} />
-            Public
-          </button>
+    <div className="home-page home-page--catalog">
+      <header className="catalog-hero">
+        <div className="catalog-hero-copy">
+          <span className="catalog-kicker">
+            <Sparkles size={14} />
+            Cloud catalog
+          </span>
+          <div className="catalog-hero-title-row">
+            <h1>Discover your next session</h1>
+            <div className="home-tabs">
+              <button
+                className={`home-tab ${source === "main" ? "active" : ""}`}
+                onClick={() => onSourceChange("main")}
+                disabled={isLoading}
+              >
+                <LayoutGrid size={15} />
+                Catalog
+              </button>
+              <button
+                className={`home-tab ${source === "library" ? "active" : ""}`}
+                onClick={() => onSourceChange("library")}
+                disabled={isLoading}
+              >
+                <Library size={15} />
+                Library
+              </button>
+            </div>
+          </div>
+          <p>Official GFN search, server-defined filters, and OpenNOW card actions.</p>
         </div>
-
-        <div className="home-search">
-          <Search className="home-search-icon" size={16} />
-          <input
-            type="text"
-            className="home-search-input"
-            placeholder="Search games..."
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-          />
+        <div className="catalog-hero-stats">
+          <div className="catalog-stat-card">
+            <span className="catalog-stat-label">Visible</span>
+            <strong>{games.length}</strong>
+          </div>
+          <div className="catalog-stat-card">
+            <span className="catalog-stat-label">Supported</span>
+            <strong>{supportedCount || games.length}</strong>
+          </div>
+          <div className="catalog-stat-card">
+            <span className="catalog-stat-label">Total matches</span>
+            <strong>{totalCount || games.length}</strong>
+          </div>
         </div>
-
-        <span className="home-count">
-          {isLoading ? "Loading..." : `${games.length} game${games.length !== 1 ? "s" : ""}`}
-        </span>
       </header>
 
-      {/* Game grid */}
+      <section className="catalog-controls-panel">
+        <div className="catalog-controls-toprow">
+          <div className="home-search catalog-search">
+            <Search className="home-search-icon" size={16} />
+            <input
+              type="text"
+              className="home-search-input"
+              placeholder="Search titles, stores, genres, and features..."
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+            />
+          </div>
+
+          <label className="catalog-sort-control">
+            <ArrowUpDown size={15} />
+            <span>Sort</span>
+            <select value={selectedSortId} onChange={(e) => onSortChange(e.target.value)} disabled={isLoading}>
+              {sortOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="catalog-filter-groups">
+          {quickGroups.map((group) => (
+            <div key={group.id} className="catalog-filter-group">
+              <div className="catalog-filter-group-label">
+                <Filter size={13} />
+                {group.label}
+              </div>
+              <div className="catalog-filter-chip-row">
+                {group.options.slice(0, group.id === "genre" ? 8 : group.options.length).map((option) => {
+                  const active = selectedFilterIds.includes(option.id);
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      className={`catalog-filter-chip ${active ? "active" : ""}`}
+                      onClick={() => onToggleFilter(option.id)}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+          {quickGroups.length === 0 && primaryOptions.length === 0 && (
+            <span className="catalog-filters-empty">Filters unavailable</span>
+          )}
+        </div>
+      </section>
+
+      <div className="catalog-results-header">
+        <div>
+          <h2>{searchQuery.trim() ? `Results for “${searchQuery.trim()}”` : "Browse catalog"}</h2>
+          <p>{selectedFilterIds.length > 0 ? `${selectedFilterIds.length} active filter${selectedFilterIds.length === 1 ? "" : "s"}` : "All supported cloud games"}</p>
+        </div>
+        <span className="home-count">
+          {isLoading ? "Refreshing…" : `${games.length} shown`}
+        </span>
+      </div>
+
       <div className="home-grid-area">
         {isLoading ? (
           <div className="home-empty-state">
             <Loader2 className="home-spinner" size={36} />
-            <p>Loading games...</p>
+            <p>Refreshing catalog…</p>
           </div>
         ) : !hasGames ? (
           <div className="home-empty-state">
             <LayoutGrid size={44} className="home-empty-icon" />
             <h3>No games found</h3>
-            <p>
-              {searchQuery
-                ? "Try adjusting your search terms"
-                : "Check back later for new additions"}
-            </p>
+            <p>{searchQuery || selectedFilterIds.length > 0 ? "Try another search or adjust filters" : "No supported games are currently available"}</p>
           </div>
         ) : (
           <div className="game-grid">
-            {games.map((game, index) => (
+            {games.map((game) => (
               <GameCard
-                key={`${game.id}-${index}`}
+                key={game.id}
                 game={game}
                 isSelected={game.id === selectedGameId}
                 onSelect={() => onSelectGame(game.id)}

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Search, LayoutGrid, Library, ArrowUpDown, Filter, Loader2, Sparkles } from "lucide-react";
+import { Search, LayoutGrid, Loader2, ArrowUpDown, Filter } from "lucide-react";
 import type { JSX } from "react";
 import type { CatalogFilterGroup, CatalogSortOption, GameInfo } from "@shared/gfn";
 import { GameCard } from "./GameCard";
@@ -47,97 +47,67 @@ export function HomePage({
   supportedCount,
 }: HomePageProps): JSX.Element {
   const hasGames = games.length > 0;
-  const quickGroups = filterGroups.filter((group) => ["digital_store", "genre", "subscriptions"].includes(group.id));
-  const primaryOptions = quickGroups.flatMap((group) => group.options.slice(0, group.id === "genre" ? 8 : group.options.length));
+  const visibleFilterGroups = filterGroups.filter((group) => ["digital_store", "genre", "subscriptions"].includes(group.id));
 
   return (
-    <div className="home-page home-page--catalog">
-      <header className="catalog-hero">
-        <div className="catalog-hero-copy">
-          <span className="catalog-kicker">
-            <Sparkles size={14} />
-            Cloud catalog
-          </span>
-          <div className="catalog-hero-title-row">
-            <h1>Discover your next session</h1>
-            <div className="home-tabs">
-              <button
-                className={`home-tab ${source === "main" ? "active" : ""}`}
-                onClick={() => onSourceChange("main")}
-                disabled={isLoading}
-              >
-                <LayoutGrid size={15} />
-                Catalog
-              </button>
-              <button
-                className={`home-tab ${source === "library" ? "active" : ""}`}
-                onClick={() => onSourceChange("library")}
-                disabled={isLoading}
-              >
-                <Library size={15} />
-                Library
-              </button>
-            </div>
-          </div>
-          <p>Official GFN search, server-defined filters, and OpenNOW card actions.</p>
+    <div className="home-page">
+      <header className="home-toolbar">
+        <div className="home-tabs">
+          <button
+            className={`home-tab ${source === "main" ? "active" : ""}`}
+            onClick={() => onSourceChange("main")}
+            disabled={isLoading}
+          >
+            <LayoutGrid size={15} />
+            Catalog
+          </button>
         </div>
-        <div className="catalog-hero-stats">
-          <div className="catalog-stat-card">
-            <span className="catalog-stat-label">Visible</span>
-            <strong>{games.length}</strong>
-          </div>
-          <div className="catalog-stat-card">
-            <span className="catalog-stat-label">Supported</span>
-            <strong>{supportedCount || games.length}</strong>
-          </div>
-          <div className="catalog-stat-card">
-            <span className="catalog-stat-label">Total matches</span>
-            <strong>{totalCount || games.length}</strong>
-          </div>
+
+        <div className="home-search">
+          <Search className="home-search-icon" size={16} />
+          <input
+            type="text"
+            className="home-search-input"
+            placeholder="Search games..."
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+          />
         </div>
+
+        <label className="home-sort">
+          <ArrowUpDown size={14} />
+          <select value={selectedSortId} onChange={(e) => onSortChange(e.target.value)} disabled={isLoading}>
+            {sortOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <span className="home-count">
+          {isLoading
+            ? "Loading..."
+            : `${games.length} shown${totalCount > games.length ? ` · ${totalCount} total` : ""}${supportedCount > 0 ? ` · ${supportedCount} supported` : ""}`}
+        </span>
       </header>
 
-      <section className="catalog-controls-panel">
-        <div className="catalog-controls-toprow">
-          <div className="home-search catalog-search">
-            <Search className="home-search-icon" size={16} />
-            <input
-              type="text"
-              className="home-search-input"
-              placeholder="Search titles, stores, genres, and features..."
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-            />
-          </div>
-
-          <label className="catalog-sort-control">
-            <ArrowUpDown size={15} />
-            <span>Sort</span>
-            <select value={selectedSortId} onChange={(e) => onSortChange(e.target.value)} disabled={isLoading}>
-              {sortOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-
-        <div className="catalog-filter-groups">
-          {quickGroups.map((group) => (
-            <div key={group.id} className="catalog-filter-group">
-              <div className="catalog-filter-group-label">
-                <Filter size={13} />
+      {visibleFilterGroups.length > 0 && (
+        <div className="home-filter-bar">
+          {visibleFilterGroups.map((group) => (
+            <div key={group.id} className="home-filter-group">
+              <span className="home-filter-group-label">
+                <Filter size={12} />
                 {group.label}
-              </div>
-              <div className="catalog-filter-chip-row">
+              </span>
+              <div className="home-filter-chips">
                 {group.options.slice(0, group.id === "genre" ? 8 : group.options.length).map((option) => {
                   const active = selectedFilterIds.includes(option.id);
                   return (
                     <button
                       key={option.id}
                       type="button"
-                      className={`catalog-filter-chip ${active ? "active" : ""}`}
+                      className={`home-filter-chip ${active ? "active" : ""}`}
                       onClick={() => onToggleFilter(option.id)}
                     >
                       {option.label}
@@ -147,33 +117,24 @@ export function HomePage({
               </div>
             </div>
           ))}
-          {quickGroups.length === 0 && primaryOptions.length === 0 && (
-            <span className="catalog-filters-empty">Filters unavailable</span>
-          )}
         </div>
-      </section>
-
-      <div className="catalog-results-header">
-        <div>
-          <h2>{searchQuery.trim() ? `Results for “${searchQuery.trim()}”` : "Browse catalog"}</h2>
-          <p>{selectedFilterIds.length > 0 ? `${selectedFilterIds.length} active filter${selectedFilterIds.length === 1 ? "" : "s"}` : "All supported cloud games"}</p>
-        </div>
-        <span className="home-count">
-          {isLoading ? "Refreshing…" : `${games.length} shown`}
-        </span>
-      </div>
+      )}
 
       <div className="home-grid-area">
         {isLoading ? (
           <div className="home-empty-state">
             <Loader2 className="home-spinner" size={36} />
-            <p>Refreshing catalog…</p>
+            <p>Loading games...</p>
           </div>
         ) : !hasGames ? (
           <div className="home-empty-state">
             <LayoutGrid size={44} className="home-empty-icon" />
             <h3>No games found</h3>
-            <p>{searchQuery || selectedFilterIds.length > 0 ? "Try another search or adjust filters" : "No supported games are currently available"}</p>
+            <p>
+              {searchQuery || selectedFilterIds.length > 0
+                ? "Try adjusting your search terms or filters"
+                : "Check back later for new additions"}
+            </p>
           </div>
         ) : (
           <div className="game-grid">

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -54,52 +54,36 @@ export function LibraryPage({
   onSortChange,
 }: LibraryPageProps): JSX.Element {
   return (
-    <div className="library-page library-page--desktop">
-      <header className="library-hero">
-        <div className="library-title-block">
-          <div className="library-title">
-            <Library className="library-title-icon" size={22} />
-            <div>
-              <h1>My Library</h1>
-              <p>Your owned and linked GFN titles, with recent play history.</p>
-            </div>
-          </div>
-          <div className="library-hero-stats">
-            <div className="catalog-stat-card">
-              <span className="catalog-stat-label">Owned</span>
-              <strong>{libraryCount}</strong>
-            </div>
-            <div className="catalog-stat-card">
-              <span className="catalog-stat-label">Visible</span>
-              <strong>{games.length}</strong>
-            </div>
-          </div>
+    <div className="library-page">
+      <header className="library-toolbar">
+        <div className="library-title">
+          <Library className="library-title-icon" size={22} />
+          <h1>My Library</h1>
         </div>
 
-        <div className="library-toolbar library-toolbar--expanded">
-          <div className="library-search">
-            <Search className="library-search-icon" size={16} />
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="Search your library by title, genre, store, or feature..."
-              className="library-search-input"
-            />
-          </div>
-
-          <label className="catalog-sort-control">
-            <ArrowUpDown size={15} />
-            <span>Sort</span>
-            <select value={selectedSortId} onChange={(e) => onSortChange(e.target.value)}>
-              {sortOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
+        <div className="library-search">
+          <Search className="library-search-icon" size={16} />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search your library..."
+            className="library-search-input"
+          />
         </div>
+
+        <label className="library-sort">
+          <ArrowUpDown size={14} />
+          <select value={selectedSortId} onChange={(e) => onSortChange(e.target.value)}>
+            {sortOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <span className="library-count">{libraryCount} game{libraryCount !== 1 ? "s" : ""}</span>
       </header>
 
       <div className="library-grid-area">
@@ -112,13 +96,13 @@ export function LibraryPage({
           <div className="library-empty-state">
             <Gamepad2 className="library-empty-icon" size={44} />
             <h3>Your library is empty</h3>
-            <p>Games you own will appear here. Use the catalog to discover titles supported by your stores.</p>
+            <p>Games you own will appear here. Browse the catalog to find games.</p>
           </div>
         ) : games.length === 0 ? (
           <div className="library-empty-state">
             <Search className="library-empty-icon" size={44} />
             <h3>No results</h3>
-            <p>No library games match “{searchQuery}”</p>
+            <p>No games match &ldquo;{searchQuery}&rdquo;</p>
           </div>
         ) : (
           <div className="game-grid">

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -1,6 +1,6 @@
-import { Library, Search, Clock, Gamepad2, Loader2 } from "lucide-react";
+import { Library, Search, Clock, Gamepad2, Loader2, ArrowUpDown } from "lucide-react";
 import type { JSX } from "react";
-import type { GameInfo } from "@shared/gfn";
+import type { CatalogSortOption, GameInfo } from "@shared/gfn";
 import { GameCard } from "./GameCard";
 
 export interface LibraryPageProps {
@@ -13,6 +13,10 @@ export interface LibraryPageProps {
   onSelectGame: (id: string) => void;
   selectedVariantByGameId: Record<string, string>;
   onSelectGameVariant: (gameId: string, variantId: string) => void;
+  libraryCount: number;
+  sortOptions: CatalogSortOption[];
+  selectedSortId: string;
+  onSortChange: (sortId: string) => void;
 }
 
 function formatLastPlayed(date?: string): string {
@@ -44,59 +48,82 @@ export function LibraryPage({
   onSelectGame,
   selectedVariantByGameId,
   onSelectGameVariant,
+  libraryCount,
+  sortOptions,
+  selectedSortId,
+  onSortChange,
 }: LibraryPageProps): JSX.Element {
-  const filteredGames = searchQuery.trim()
-    ? games.filter((game) =>
-        game.title.toLowerCase().includes(searchQuery.trim().toLowerCase())
-      )
-    : games;
-
   return (
-    <div className="library-page">
-      {/* Toolbar: title + search + count */}
-      <header className="library-toolbar">
-        <div className="library-title">
-          <Library className="library-title-icon" size={22} />
-          <h1>My Library</h1>
+    <div className="library-page library-page--desktop">
+      <header className="library-hero">
+        <div className="library-title-block">
+          <div className="library-title">
+            <Library className="library-title-icon" size={22} />
+            <div>
+              <h1>My Library</h1>
+              <p>Your owned and linked GFN titles, with recent play history.</p>
+            </div>
+          </div>
+          <div className="library-hero-stats">
+            <div className="catalog-stat-card">
+              <span className="catalog-stat-label">Owned</span>
+              <strong>{libraryCount}</strong>
+            </div>
+            <div className="catalog-stat-card">
+              <span className="catalog-stat-label">Visible</span>
+              <strong>{games.length}</strong>
+            </div>
+          </div>
         </div>
 
-        <div className="library-search">
-          <Search className="library-search-icon" size={16} />
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="Search your library..."
-            className="library-search-input"
-          />
-        </div>
+        <div className="library-toolbar library-toolbar--expanded">
+          <div className="library-search">
+            <Search className="library-search-icon" size={16} />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="Search your library by title, genre, store, or feature..."
+              className="library-search-input"
+            />
+          </div>
 
-        <span className="library-count">{games.length} game{games.length !== 1 ? "s" : ""}</span>
+          <label className="catalog-sort-control">
+            <ArrowUpDown size={15} />
+            <span>Sort</span>
+            <select value={selectedSortId} onChange={(e) => onSortChange(e.target.value)}>
+              {sortOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </header>
 
-      {/* Game grid */}
       <div className="library-grid-area">
         {isLoading ? (
           <div className="library-empty-state">
             <Loader2 className="library-spinner" size={36} />
             <p>Loading your library...</p>
           </div>
-        ) : games.length === 0 ? (
+        ) : libraryCount === 0 ? (
           <div className="library-empty-state">
             <Gamepad2 className="library-empty-icon" size={44} />
             <h3>Your library is empty</h3>
-            <p>Games you own will appear here. Browse the catalog to find games.</p>
+            <p>Games you own will appear here. Use the catalog to discover titles supported by your stores.</p>
           </div>
-        ) : filteredGames.length === 0 ? (
+        ) : games.length === 0 ? (
           <div className="library-empty-state">
             <Search className="library-empty-icon" size={44} />
             <h3>No results</h3>
-            <p>No games match &ldquo;{searchQuery}&rdquo;</p>
+            <p>No library games match “{searchQuery}”</p>
           </div>
         ) : (
           <div className="game-grid">
-            {filteredGames.map((game, index) => (
-              <div key={`${game.id}-${index}`} className="library-game-wrapper">
+            {games.map((game) => (
+              <div key={game.id} className="library-game-wrapper">
                 <GameCard
                   game={game}
                   isSelected={game.id === selectedGameId}
@@ -105,11 +132,9 @@ export function LibraryPage({
                   selectedVariantId={selectedVariantByGameId[game.id]}
                   onSelectStore={(variantId) => onSelectGameVariant(game.id, variantId)}
                 />
-                {/* @ts-expect-error - lastPlayed may exist on library games */}
                 {game.lastPlayed && (
                   <div className="library-last-played">
                     <Clock size={12} />
-                    {/* @ts-expect-error - lastPlayed may exist on library games */}
                     <span>{formatLastPlayed(game.lastPlayed)}</span>
                   </div>
                 )}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1493,18 +1493,81 @@ body.controller-mode.controller-hide-cursor * {
   margin-left: auto;
 }
 
-.home-filter-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 14px;
-  padding: 2px 0;
+.home-filter-dropdown {
+  position: relative;
 }
 
-.home-filter-group {
-  display: flex;
+.home-filter-dropdown[open] {
+  z-index: 5;
+}
+
+.home-filter-dropdown-trigger {
+  list-style: none;
+  display: inline-flex;
   align-items: center;
   gap: 8px;
-  min-width: 0;
+  padding: 0 10px;
+  height: 34px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--panel-border);
+  background: var(--card);
+  color: var(--ink-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+
+.home-filter-dropdown-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.home-filter-dropdown-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.home-filter-dropdown-count {
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: var(--r-full);
+  background: var(--accent);
+  color: var(--accent-on);
+  font-size: 0.7rem;
+  line-height: 18px;
+  text-align: center;
+}
+
+.home-filter-dropdown-chevron {
+  transition: transform var(--t-fast);
+}
+
+.home-filter-dropdown[open] .home-filter-dropdown-chevron {
+  transform: rotate(180deg);
+}
+
+.home-filter-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 320px;
+  max-width: 440px;
+  padding: 12px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--panel-border);
+  background: var(--card);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.home-filter-dropdown-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .home-filter-group-label {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1373,12 +1373,109 @@ body.controller-mode.controller-hide-cursor * {
   overflow: hidden;
 }
 
-/* Toolbar: tabs | search | count */
-.home-toolbar {
+.catalog-hero,
+.library-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px 20px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-lg);
+  background: linear-gradient(180deg, rgba(88, 217, 138, 0.08), rgba(88, 217, 138, 0.02));
+}
+
+.catalog-hero-copy,
+.library-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.catalog-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  padding: 6px 10px;
+  border-radius: var(--r-full);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.catalog-hero-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  justify-content: space-between;
+}
+
+.catalog-hero h1,
+.library-title h1 {
+  margin: 0;
+  font-size: 1.45rem;
+  line-height: 1.1;
+}
+
+.catalog-hero p,
+.library-title p,
+.catalog-results-header p {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+}
+
+.catalog-hero-stats,
+.library-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(110px, 1fr));
+  gap: 10px;
+  align-content: start;
+}
+
+.library-hero-stats {
+  grid-template-columns: repeat(2, minmax(110px, 1fr));
+}
+
+.catalog-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 110px;
+  padding: 12px 14px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--panel-border);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.catalog-stat-label {
+  color: var(--ink-muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.catalog-stat-card strong {
+  font-size: 1.1rem;
+  color: var(--ink);
+}
+
+.home-toolbar,
+.library-toolbar {
   display: flex;
   align-items: center;
   gap: 12px;
   flex-shrink: 0;
+}
+
+.library-toolbar--expanded {
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .home-tabs {
@@ -1423,13 +1520,32 @@ body.controller-mode.controller-hide-cursor * {
   cursor: not-allowed;
 }
 
-.home-search {
-  flex: 1;
-  position: relative;
-  max-width: 340px;
+.catalog-controls-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--panel-border);
+  background: var(--card);
 }
 
-.home-search-icon {
+.catalog-controls-toprow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.home-search,
+.library-search {
+  flex: 1;
+  position: relative;
+  min-width: 260px;
+}
+
+.home-search-icon,
+.library-search-icon {
   position: absolute;
   left: 11px;
   top: 50%;
@@ -1438,38 +1554,128 @@ body.controller-mode.controller-hide-cursor * {
   pointer-events: none;
 }
 
-.home-search-input {
+.home-search-input,
+.library-search-input,
+.catalog-sort-control select {
   width: 100%;
-  padding: 7px 12px 7px 34px;
+  padding: 8px 12px 8px 34px;
   border-radius: var(--r-sm);
   border: 1px solid var(--panel-border);
-  background: var(--card);
+  background: var(--panel);
   color: var(--ink);
-  font-size: 0.82rem;
+  font-size: 0.84rem;
   font-family: inherit;
   outline: none;
   transition: border-color var(--t-fast), box-shadow var(--t-fast);
 }
 
-.home-search-input::placeholder {
+.catalog-sort-control select {
+  padding: 8px 34px 8px 12px;
+  appearance: none;
+}
+
+.home-search-input::placeholder,
+.library-search-input::placeholder {
   color: var(--ink-muted);
 }
 
-.home-search-input:focus {
+.home-search-input:focus,
+.library-search-input:focus,
+.catalog-sort-control select:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-surface);
 }
 
-.home-count {
+.catalog-sort-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 190px;
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.catalog-sort-control span {
+  white-space: nowrap;
+}
+
+.catalog-filter-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.catalog-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.catalog-filter-group-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.catalog-filter-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.catalog-filter-chip {
+  padding: 7px 12px;
+  border-radius: var(--r-full);
+  border: 1px solid var(--panel-border);
+  background: var(--chip);
+  color: var(--ink-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color var(--t-fast), background var(--t-fast), color var(--t-fast);
+}
+
+.catalog-filter-chip:hover {
+  color: var(--ink-soft);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.catalog-filter-chip.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-on);
+}
+
+.catalog-filters-empty,
+.home-count,
+.library-count {
   font-size: 0.78rem;
   color: var(--ink-muted);
   font-weight: 500;
   white-space: nowrap;
-  margin-left: auto;
 }
 
-/* Grid area */
-.home-grid-area {
+.catalog-results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 12px;
+}
+
+.catalog-results-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.home-grid-area,
+.library-grid-area {
   flex: 1;
   overflow-y: auto;
   min-height: 0;
@@ -1477,8 +1683,8 @@ body.controller-mode.controller-hide-cursor * {
   will-change: scroll-position;
 }
 
-/* Empty / Loading states */
-.home-empty-state {
+.home-empty-state,
+.library-empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1490,27 +1696,88 @@ body.controller-mode.controller-hide-cursor * {
   text-align: center;
 }
 
-.home-empty-state h3 {
+.home-empty-state h3,
+.library-empty-state h3 {
   font-size: 1.05rem;
   color: var(--ink);
   margin: 0;
 }
 
-.home-empty-state p {
+.home-empty-state p,
+.library-empty-state p {
   font-size: 0.82rem;
   margin: 0;
+  max-width: 360px;
 }
 
-.home-empty-icon {
+.home-empty-icon,
+.library-empty-icon {
   color: var(--panel-border-solid);
   opacity: 0.5;
 }
 
-.home-spinner {
+.home-spinner,
+.library-spinner {
   animation: spin 1s linear infinite;
   color: var(--accent);
 }
 
+.library-title {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.library-title-icon {
+  color: var(--accent);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.library-game-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.library-last-played {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 4px;
+  font-size: 0.7rem;
+  color: var(--ink-muted);
+}
+
+@media (max-width: 1100px) {
+  .catalog-hero,
+  .library-hero {
+    flex-direction: column;
+  }
+
+  .catalog-hero-stats,
+  .library-hero-stats {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .catalog-results-header,
+  .catalog-hero-title-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .catalog-controls-toprow,
+  .library-toolbar--expanded {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .catalog-sort-control {
+    width: 100%;
+  }
+}
 
 /* ======================================================
    GAME GRID  (shared by Home + Library)
@@ -1749,146 +2016,6 @@ button.game-card-store-chip.active:hover {
   flex-shrink: 0;
 }
 
-
-/* ======================================================
-   LIBRARY PAGE
-   ====================================================== */
-.library-page {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  max-width: 1600px;
-  margin: 0 auto;
-  gap: 16px;
-  overflow: hidden;
-}
-
-.library-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-shrink: 0;
-}
-
-.library-title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.library-title-icon {
-  color: var(--accent);
-  flex-shrink: 0;
-}
-
-.library-title h1 {
-  font-size: 1.1rem;
-  font-weight: 700;
-  margin: 0;
-  white-space: nowrap;
-}
-
-.library-search {
-  flex: 1;
-  position: relative;
-  max-width: 340px;
-}
-
-.library-search-icon {
-  position: absolute;
-  left: 11px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--ink-muted);
-  pointer-events: none;
-}
-
-.library-search-input {
-  width: 100%;
-  padding: 7px 12px 7px 34px;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--panel-border);
-  background: var(--card);
-  color: var(--ink);
-  font-size: 0.82rem;
-  font-family: inherit;
-  outline: none;
-  transition: border-color var(--t-fast), box-shadow var(--t-fast);
-}
-
-.library-search-input::placeholder {
-  color: var(--ink-muted);
-}
-
-.library-search-input:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-surface);
-}
-
-.library-count {
-  font-size: 0.78rem;
-  color: var(--ink-muted);
-  font-weight: 500;
-  white-space: nowrap;
-  margin-left: auto;
-}
-
-.library-grid-area {
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-  padding-right: 2px;
-  will-change: scroll-position;
-}
-
-.library-game-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.library-last-played {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 0 4px;
-  font-size: 0.7rem;
-  color: var(--ink-muted);
-}
-
-.library-empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  min-height: 260px;
-  gap: 12px;
-  color: var(--ink-soft);
-  text-align: center;
-}
-
-.library-empty-state h3 {
-  font-size: 1.05rem;
-  color: var(--ink);
-  margin: 0;
-}
-
-.library-empty-state p {
-  font-size: 0.82rem;
-  margin: 0;
-  max-width: 340px;
-}
-
-.library-empty-icon {
-  color: var(--panel-border-solid);
-  opacity: 0.5;
-}
-
-.library-spinner {
-  animation: spin 1s linear infinite;
-  color: var(--accent);
-}
 
 .controller-selected-overlay {
   position: absolute;

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1462,8 +1462,9 @@ body.controller-mode.controller-hide-cursor * {
 }
 
 .home-sort,
-.library-sort {
-  display: flex;
+.library-sort,
+.home-filter-dropdown-trigger {
+  display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 0 10px;
@@ -1474,13 +1475,29 @@ body.controller-mode.controller-hide-cursor * {
   color: var(--ink-muted);
   font-size: 0.78rem;
   font-weight: 600;
+  transition: border-color var(--t-fast), background var(--t-fast), color var(--t-fast);
+}
+
+.home-sort:hover,
+.library-sort:hover,
+.home-filter-dropdown-trigger:hover {
+  color: var(--ink-soft);
+  border-color: rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.home-sort:focus-within,
+.library-sort:focus-within,
+.home-filter-dropdown-trigger:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-surface);
 }
 
 .home-sort select,
 .library-sort select {
   border: none;
   background: transparent;
-  color: var(--ink);
+  color: currentColor;
   font: inherit;
   outline: none;
 }
@@ -1503,17 +1520,7 @@ body.controller-mode.controller-hide-cursor * {
 
 .home-filter-dropdown-trigger {
   list-style: none;
-  display: inline-flex;
-  align-items: center;
   gap: 8px;
-  padding: 0 10px;
-  height: 34px;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--panel-border);
-  background: var(--card);
-  color: var(--ink-muted);
-  font-size: 0.78rem;
-  font-weight: 600;
   cursor: pointer;
   user-select: none;
 }

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1373,108 +1373,11 @@ body.controller-mode.controller-hide-cursor * {
   overflow: hidden;
 }
 
-.catalog-hero,
-.library-hero {
-  display: flex;
-  justify-content: space-between;
-  gap: 18px;
-  padding: 18px 20px;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--r-lg);
-  background: linear-gradient(180deg, rgba(88, 217, 138, 0.08), rgba(88, 217, 138, 0.02));
-}
-
-.catalog-hero-copy,
-.library-title-block {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  min-width: 0;
-}
-
-.catalog-kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  width: fit-content;
-  padding: 6px 10px;
-  border-radius: var(--r-full);
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--accent);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.catalog-hero-title-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 14px;
-  justify-content: space-between;
-}
-
-.catalog-hero h1,
-.library-title h1 {
-  margin: 0;
-  font-size: 1.45rem;
-  line-height: 1.1;
-}
-
-.catalog-hero p,
-.library-title p,
-.catalog-results-header p {
-  margin: 0;
-  color: var(--ink-muted);
-  font-size: 0.85rem;
-}
-
-.catalog-hero-stats,
-.library-hero-stats {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(110px, 1fr));
-  gap: 10px;
-  align-content: start;
-}
-
-.library-hero-stats {
-  grid-template-columns: repeat(2, minmax(110px, 1fr));
-}
-
-.catalog-stat-card {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 110px;
-  padding: 12px 14px;
-  border-radius: var(--r-md);
-  border: 1px solid var(--panel-border);
-  background: rgba(0, 0, 0, 0.18);
-}
-
-.catalog-stat-label {
-  color: var(--ink-muted);
-  font-size: 0.72rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.catalog-stat-card strong {
-  font-size: 1.1rem;
-  color: var(--ink);
-}
-
-.home-toolbar,
-.library-toolbar {
+.home-toolbar {
   display: flex;
   align-items: center;
   gap: 12px;
   flex-shrink: 0;
-}
-
-.library-toolbar--expanded {
-  justify-content: space-between;
   flex-wrap: wrap;
 }
 
@@ -1520,32 +1423,14 @@ body.controller-mode.controller-hide-cursor * {
   cursor: not-allowed;
 }
 
-.catalog-controls-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 16px;
-  border-radius: var(--r-lg);
-  border: 1px solid var(--panel-border);
-  background: var(--card);
-}
-
-.catalog-controls-toprow {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-}
-
-.home-search,
-.library-search {
+.home-search {
   flex: 1;
   position: relative;
   min-width: 260px;
+  max-width: 340px;
 }
 
-.home-search-icon,
-.library-search-icon {
+.home-search-icon {
   position: absolute;
   left: 11px;
   top: 50%;
@@ -1554,128 +1439,119 @@ body.controller-mode.controller-hide-cursor * {
   pointer-events: none;
 }
 
-.home-search-input,
-.library-search-input,
-.catalog-sort-control select {
+.home-search-input {
   width: 100%;
-  padding: 8px 12px 8px 34px;
+  padding: 7px 12px 7px 34px;
   border-radius: var(--r-sm);
   border: 1px solid var(--panel-border);
-  background: var(--panel);
+  background: var(--card);
   color: var(--ink);
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   font-family: inherit;
   outline: none;
   transition: border-color var(--t-fast), box-shadow var(--t-fast);
 }
 
-.catalog-sort-control select {
-  padding: 8px 34px 8px 12px;
-  appearance: none;
-}
-
-.home-search-input::placeholder,
-.library-search-input::placeholder {
+.home-search-input::placeholder {
   color: var(--ink-muted);
 }
 
-.home-search-input:focus,
-.library-search-input:focus,
-.catalog-sort-control select:focus {
+.home-search-input:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-surface);
 }
 
-.catalog-sort-control {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 190px;
-  color: var(--ink-soft);
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-
-.catalog-sort-control span {
-  white-space: nowrap;
-}
-
-.catalog-filter-groups {
+.home-sort,
+.library-sort {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.catalog-filter-group {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.catalog-filter-group-label {
-  display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--ink-soft);
-  font-size: 0.76rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.catalog-filter-chip-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.catalog-filter-chip {
-  padding: 7px 12px;
-  border-radius: var(--r-full);
+  padding: 0 10px;
+  height: 34px;
+  border-radius: var(--r-sm);
   border: 1px solid var(--panel-border);
-  background: var(--chip);
+  background: var(--card);
   color: var(--ink-muted);
   font-size: 0.78rem;
   font-weight: 600;
-  font-family: inherit;
-  cursor: pointer;
-  transition: border-color var(--t-fast), background var(--t-fast), color var(--t-fast);
 }
 
-.catalog-filter-chip:hover {
-  color: var(--ink-soft);
-  border-color: rgba(255, 255, 255, 0.14);
+.home-sort select,
+.library-sort select {
+  border: none;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  outline: none;
 }
 
-.catalog-filter-chip.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--accent-on);
-}
-
-.catalog-filters-empty,
-.home-count,
-.library-count {
+.home-count {
   font-size: 0.78rem;
   color: var(--ink-muted);
   font-weight: 500;
   white-space: nowrap;
+  margin-left: auto;
 }
 
-.catalog-results-header {
+.home-filter-bar {
   display: flex;
-  justify-content: space-between;
-  align-items: end;
-  gap: 12px;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  padding: 2px 0;
 }
 
-.catalog-results-header h2 {
-  margin: 0;
-  font-size: 1.05rem;
+.home-filter-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
-.home-grid-area,
-.library-grid-area {
+.home-filter-group-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--ink-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.home-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.home-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 10px;
+  border-radius: var(--r-full);
+  border: 1px solid var(--panel-border);
+  background: var(--chip);
+  color: var(--ink-muted);
+  font-size: 0.76rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast), border-color var(--t-fast);
+}
+
+.home-filter-chip:hover {
+  color: var(--ink-soft);
+  background: var(--panel-border-solid);
+}
+
+.home-filter-chip.active {
+  color: var(--accent-on);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.home-grid-area {
   flex: 1;
   overflow-y: auto;
   min-height: 0;
@@ -1683,8 +1559,7 @@ body.controller-mode.controller-hide-cursor * {
   will-change: scroll-position;
 }
 
-.home-empty-state,
-.library-empty-state {
+.home-empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1696,42 +1571,118 @@ body.controller-mode.controller-hide-cursor * {
   text-align: center;
 }
 
-.home-empty-state h3,
-.library-empty-state h3 {
+.home-empty-state h3 {
   font-size: 1.05rem;
   color: var(--ink);
   margin: 0;
 }
 
-.home-empty-state p,
-.library-empty-state p {
+.home-empty-state p {
   font-size: 0.82rem;
   margin: 0;
-  max-width: 360px;
 }
 
-.home-empty-icon,
-.library-empty-icon {
+.home-empty-icon {
   color: var(--panel-border-solid);
   opacity: 0.5;
 }
 
-.home-spinner,
-.library-spinner {
+.home-spinner {
   animation: spin 1s linear infinite;
   color: var(--accent);
 }
 
+/* ======================================================
+   LIBRARY PAGE
+   ====================================================== */
+.library-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+  gap: 16px;
+  overflow: hidden;
+}
+
+.library-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
 .library-title {
   display: flex;
-  align-items: flex-start;
-  gap: 10px;
+  align-items: center;
+  gap: 8px;
 }
 
 .library-title-icon {
   color: var(--accent);
   flex-shrink: 0;
-  margin-top: 2px;
+}
+
+.library-title h1 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.library-search {
+  flex: 1;
+  position: relative;
+  min-width: 260px;
+  max-width: 340px;
+}
+
+.library-search-icon {
+  position: absolute;
+  left: 11px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ink-muted);
+  pointer-events: none;
+}
+
+.library-search-input {
+  width: 100%;
+  padding: 7px 12px 7px 34px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--panel-border);
+  background: var(--card);
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+
+.library-search-input::placeholder {
+  color: var(--ink-muted);
+}
+
+.library-search-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-surface);
+}
+
+.library-count {
+  font-size: 0.78rem;
+  color: var(--ink-muted);
+  font-weight: 500;
+  white-space: nowrap;
+  margin-left: auto;
+}
+
+.library-grid-area {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding-right: 2px;
+  will-change: scroll-position;
 }
 
 .library-game-wrapper {
@@ -1749,34 +1700,38 @@ body.controller-mode.controller-hide-cursor * {
   color: var(--ink-muted);
 }
 
-@media (max-width: 1100px) {
-  .catalog-hero,
-  .library-hero {
-    flex-direction: column;
-  }
-
-  .catalog-hero-stats,
-  .library-hero-stats {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  }
+.library-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 260px;
+  gap: 12px;
+  color: var(--ink-soft);
+  text-align: center;
 }
 
-@media (max-width: 720px) {
-  .catalog-results-header,
-  .catalog-hero-title-row {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+.library-empty-state h3 {
+  font-size: 1.05rem;
+  color: var(--ink);
+  margin: 0;
+}
 
-  .catalog-controls-toprow,
-  .library-toolbar--expanded {
-    flex-direction: column;
-    align-items: stretch;
-  }
+.library-empty-state p {
+  font-size: 0.82rem;
+  margin: 0;
+  max-width: 340px;
+}
 
-  .catalog-sort-control {
-    width: 100%;
-  }
+.library-empty-icon {
+  color: var(--panel-border-solid);
+  opacity: 0.5;
+}
+
+.library-spinner {
+  animation: spin 1s linear infinite;
+  color: var(--accent);
 }
 
 /* ======================================================

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -324,6 +324,13 @@ export interface GamesFetchRequest {
   providerStreamingBaseUrl?: string;
 }
 
+export interface CatalogBrowseRequest extends GamesFetchRequest {
+  searchQuery?: string;
+  sortId?: string;
+  filterIds?: string[];
+  fetchCount?: number;
+}
+
 export interface ResolveLaunchIdRequest {
   token?: string;
   providerStreamingBaseUrl?: string;
@@ -340,9 +347,14 @@ export interface GameVariant {
   id: string;
   store: string;
   supportedControls: string[];
+  librarySelected?: boolean;
+  libraryStatus?: string;
+  lastPlayedDate?: string;
+  gfnStatus?: string;
 }
 
 export interface GameInfo {
+
   id: string;
   uuid?: string;
   launchAppId?: string;
@@ -355,8 +367,49 @@ export interface GameInfo {
   screenshotUrl?: string;
   playType?: string;
   membershipTierLabel?: string;
+  publisherName?: string;
+  contentRatings?: string[];
+  playabilityState?: string;
+  availableStores?: string[];
+  searchText?: string;
+  lastPlayed?: string;
+  isInLibrary?: boolean;
   selectedVariantIndex: number;
   variants: GameVariant[];
+}
+
+export interface CatalogFilterOption {
+  id: string;
+  rawId: string;
+  label: string;
+  groupId: string;
+  groupLabel: string;
+}
+
+export interface CatalogFilterGroup {
+  id: string;
+  label: string;
+  options: CatalogFilterOption[];
+}
+
+export interface CatalogSortOption {
+  id: string;
+  label: string;
+  orderBy: string;
+}
+
+export interface CatalogBrowseResult {
+  games: GameInfo[];
+  numberReturned: number;
+  numberSupported: number;
+  totalCount: number;
+  hasNextPage: boolean;
+  endCursor?: string;
+  searchQuery: string;
+  selectedSortId: string;
+  selectedFilterIds: string[];
+  filterGroups: CatalogFilterGroup[];
+  sortOptions: CatalogSortOption[];
 }
 
 export interface StreamSettings {
@@ -611,6 +664,7 @@ export interface OpenNowApi {
   fetchSubscription(input: SubscriptionFetchRequest): Promise<SubscriptionInfo>;
   fetchMainGames(input: GamesFetchRequest): Promise<GameInfo[]>;
   fetchLibraryGames(input: GamesFetchRequest): Promise<GameInfo[]>;
+  browseCatalog(input: CatalogBrowseRequest): Promise<CatalogBrowseResult>;
   fetchPublicGames(): Promise<GameInfo[]>;
   resolveLaunchAppId(input: ResolveLaunchIdRequest): Promise<string | null>;
   createSession(input: SessionCreateRequest): Promise<SessionInfo>;

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -8,6 +8,7 @@ export const IPC_CHANNELS = {
   SUBSCRIPTION_FETCH: "subscription:fetch",
   GAMES_FETCH_MAIN: "games:fetch-main",
   GAMES_FETCH_LIBRARY: "games:fetch-library",
+  GAMES_BROWSE_CATALOG: "games:browse-catalog",
   GAMES_FETCH_PUBLIC: "games:fetch-public",
   GAMES_RESOLVE_LAUNCH_ID: "games:resolve-launch-id",
   CREATE_SESSION: "gfn:create-session",


### PR DESCRIPTION
This PR reworks the library and catalog experience to use official GFN GraphQL search and filters, deduplicates game data, fixes launch resolution for unlinked titles, and removes the public catalog UI.

**Shared & Main:**

*   Introduce `browseCatalog` using official GFN `apps` GraphQL query with `searchQuery`, `filters`, and `orderBy` support.
*   Add `fetchFilterAndSortDefinitions` to pull server-defined filter groups and sort orders.
*   Implement `dedupeGames` to remove duplicate entries from panel flattening.
*   Enrich `GameInfo` with `lastPlayed`, `isInLibrary`, `searchText`, `availableStores`, `publisherName`, and `contentRatings`.
*   Refactor `resolveAppData` and `resolveLaunchAppId` to reliably resolve numeric launch IDs without requiring `library.selected`, fixing launch failures for unlinked catalog titles.

**Renderer:**

*   Remove `public` game source and all public catalog UI fallback paths.
*   Replace client-side title filtering with state managed by the new GraphQL catalog browse API.
*   Add `chooseAccountLinked` helper to determine session `accountLinked` flag from enriched library status.
*   Eliminate duplicate search logic; library filtering now uses `matchesGameSearch` with `searchText` and other metadata.
*   Add local sorting for library games using shared sort IDs.

**UI & Styling:**

*   Rebuild `HomePage` with a hero section, stats cards, filter group chips, and a sort dropdown matching official GFN structure.
*   Upgrade `LibraryPage` to include last-played metadata, ownership stats, and inline search controls.
*   Remove obsolete `.home-toolbar`, `.library-toolbar`, and related CSS blocks, replacing them with `.catalog-hero`, `.catalog-controls-panel`, and `.library-hero` patterns.
*   Update React key props in `HomePage` and `LibraryPage` to use stable `game.id` instead of array indices.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/80779943-a290-495a-9e94-b3a416235a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-59&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-59"><img alt="OPE-59 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-59"></picture></a>