### PR TITLE
Fix iOS GPU idle-exit killing WKWebView streamer before video

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
@@ -1649,6 +1649,24 @@ private struct StreamerWebView: UIViewRepresentable {
     tap.style.display = 'none';
     try { await video.play(); } catch (_) {}
   };
+  // GPU keep-alive: prevents WKWebView GPUProcess idle-exit during WebRTC negotiation.
+  // Without active GPU work, iOS terminates the GPU process before video frames arrive,
+  // crashing the stream. A minimal WebGL rAF loop keeps the process alive until playing.
+  (function() {
+    var c = document.createElement('canvas');
+    c.width = c.height = 1;
+    c.style.cssText = 'position:fixed;width:1px;height:1px;opacity:0;pointer-events:none;z-index:-1;';
+    document.body.appendChild(c);
+    var gl = c.getContext('webgl') || c.getContext('experimental-webgl');
+    if (!gl) { c.remove(); return; }
+    var rafId = null;
+    function loop() { gl.clear(gl.COLOR_BUFFER_BIT); rafId = requestAnimationFrame(loop); }
+    loop();
+    video.addEventListener('playing', function() {
+      if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
+      c.remove();
+    }, { once: true });
+  })();
   connect();
   </script>
 </body>


### PR DESCRIPTION
This PR adds a WebGL keep-alive loop in `buildHTML` that runs until video starts playing, preventing iOS from killing the idle GPU process during the WebRTC negotiation window. The GPU process launches when the streamer is presented but has no work to do until frames arrive; without active GPU work, iOS terminates the process (IdleExit), crashing the WKWebView before streaming can begin. The IIFE creates a minimal 1x1 WebGL canvas, runs a `gl.clear()` loop via `requestAnimationFrame`, and tears down on the first `playing` event.

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/82057ef0-4148-405e-943e-8ebdf3ffedd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-14&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-14"><img alt="OPEN-14 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-14"></picture></a>