### PR TITLE
Fix iOS WebRTC suspension with CSS animation and MediaStream

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
@@ -224,10 +224,12 @@ private struct StreamerWebView: UIViewRepresentable {
     #video{position:fixed;inset:0;width:100%;height:100%;object-fit:contain;background:#000}
     #tap{position:fixed;left:50%;bottom:20px;transform:translateX(-50%);padding:8px 12px;
       color:#fff;background:rgba(0,0,0,.5);border-radius:999px;font:12px -apple-system;}
+    @keyframes _gpuKA{from{transform:scale(1)}to{transform:scale(1.0001)}}
   </style>
 </head>
 <body>
   <video id="video" playsinline autoplay muted></video>
+  <div id="_gpuKA" style="position:fixed;width:1px;height:1px;opacity:0;pointer-events:none;will-change:transform;animation:_gpuKA 1s linear infinite alternate"></div>
   <div id="tap">Tap to unmute</div>
   <div id="stats" style="position:fixed;left:12px;top:12px;z-index:30;padding:6px 10px;
     color:#d5ffd5;background:rgba(0,0,0,0.58);border:1px solid rgba(255,255,255,0.15);
@@ -1649,24 +1651,11 @@ private struct StreamerWebView: UIViewRepresentable {
     tap.style.display = 'none';
     try { await video.play(); } catch (_) {}
   };
-  // GPU keep-alive: prevents WKWebView GPUProcess idle-exit during WebRTC negotiation.
-  // Without active GPU work, iOS terminates the GPU process before video frames arrive,
-  // crashing the stream. A minimal WebGL rAF loop keeps the process alive until playing.
-  (function() {
-    var c = document.createElement('canvas');
-    c.width = c.height = 1;
-    c.style.cssText = 'position:fixed;width:1px;height:1px;opacity:0;pointer-events:none;z-index:-1;';
-    document.body.appendChild(c);
-    var gl = c.getContext('webgl') || c.getContext('experimental-webgl');
-    if (!gl) { c.remove(); return; }
-    var rafId = null;
-    function loop() { gl.clear(gl.COLOR_BUFFER_BIT); rafId = requestAnimationFrame(loop); }
-    loop();
-    video.addEventListener('playing', function() {
-      if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
-      c.remove();
-    }, { once: true });
-  })();
+  // WebContent keep-alive: iOS suspends WKWebView WebContent processes that
+  // lack browser-engine entitlements unless they have active media playback.
+  // An empty MediaStream on the video element activates the "playing media"
+  // state, preventing suspension during the WebRTC negotiation window.
+  try { video.srcObject = new MediaStream(); video.play().catch(function(){}); } catch(e) {}
   connect();
   </script>
 </body>


### PR DESCRIPTION
This PR fixes streaming failures caused by iOS suspending the WebContent process during WebRTC negotiation. The previous WebGL-based GPU keep-alive triggered `WebProcess NearSuspended Assertion` failures due to missing entitlements. The fix uses CSS animation for GPU process liveness and an empty MediaStream to keep WebContent active.

**StreamerView.swift:**

*   **CSS:** Add `@keyframes _gpuKA` animation rule for GPU compositor layer keep-alive
*   **CSS:** Add `<div id="_gpuKA">` with `will-change:transform` and animation in `<body>` after `<video>`
*   **JavaScript:** Remove WebGL IIFE keep-alive block; replace with `video.srcObject = new MediaStream(); video.play()` before `connect()` to prevent WebContent suspension

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/76a08797-a2d9-4319-a4a4-fa783599c697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-15&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-15"><img alt="OPEN-15 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-15"></picture></a>