### PR TITLE
Fix iOS streaming initial handoff cold server migration

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
@@ -2424,49 +2424,27 @@ final class OpenNOWStore: ObservableObject {
     }
 
     private func prepareSessionForStreamer(_ session: ActiveSession) async -> ActiveSession {
-        // Mirrors the successful "resume" behavior: when status=2, claim once before
-        // handoff so backend can return stabilized signaling/media coordinates.
         guard session.status == 2 else { return session }
+        // Refresh auth token so it's valid for the upcoming signaling connection.
+        // Do NOT claim/migrate the session — the polled server has already handled
+        // this session throughout queue/setup and is ready to serve WebRTC offers.
+        // Migrating to a different server (via claimSession PUT) moves to a cold
+        // server that hasn't set up its WebRTC endpoint and won't offer in time.
+        // This matches desktop behavior: connect signaling directly to the polled server.
         guard let currentAuth = authSession else { return session }
         do {
             let refreshed = try await api.refreshSession(currentAuth)
             authSession = refreshed
             persistAuthSession(refreshed)
-            let activeCandidates = try await api.fetchActiveSessions(session: refreshed, vpcId: cachedVpcId)
-            let candidate =
-                activeCandidates.first(where: { $0.id == session.id }) ??
-                activeCandidates.first(where: { $0.appId == session.game.launchAppId && ($0.status == 2 || $0.status == 3) }) ??
-                RemoteSessionCandidate(
-                    id: session.id,
-                    appId: session.game.launchAppId,
-                    status: session.status,
-                    serverIp: session.serverIp
-                )
-            let claimed = try await api.claimSession(
-                session: refreshed,
-                candidate: candidate,
-                game: session.game,
-                vpcId: cachedVpcId,
-                settings: settings
-            )
-            logger.info(
-                "Pre-handoff claim refreshed session id=\(claimed.id, privacy: .public) status=\(claimed.status) candidateServerIp=\(candidate.serverIp ?? "nil", privacy: .public) signalingServer=\(claimed.signalingServer ?? "nil", privacy: .public) signalingUrl=\(claimed.signalingUrl ?? "nil", privacy: .public) mediaIp=\(claimed.mediaIp ?? "nil", privacy: .public) mediaPort=\(claimed.mediaPort)"
-            )
-            let serverMigrated = (claimed.signalingServer ?? "") != (session.signalingServer ?? "")
-                && !(claimed.signalingServer ?? "").isEmpty
-            if serverMigrated {
-                logger.info(
-                    "Pre-handoff claim: server migrated from \(session.signalingServer ?? "nil", privacy: .public) to \(claimed.signalingServer ?? "nil", privacy: .public), waiting 3s for WebRTC init"
-                )
-                try? await Task.sleep(for: .seconds(3))
-            }
-            return claimed
         } catch {
             logger.error(
-                "Pre-handoff claim failed id=\(session.id, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                "Pre-handoff auth refresh failed id=\(session.id, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
             )
-            return session
         }
+        logger.info(
+            "Pre-handoff ready id=\(session.id, privacy: .public) signalingServer=\(session.signalingServer ?? "nil", privacy: .public) signalingUrl=\(session.signalingUrl ?? "nil", privacy: .public) mediaIp=\(session.mediaIp ?? "nil", privacy: .public)"
+        )
+        return session
     }
 
     private var isFreeTierUser: Bool {


### PR DESCRIPTION
## Description

This PR fixes initial stream failures caused by connecting to a cold server after unnecessary session migration. The pre-handoff `claimSession` PUT migrated the session to a different server (e.g., `.132` → `.133`) that hadn't set up its WebRTC endpoint yet for fresh sessions, causing the 15-second offer timeout to exhaust and the streamer to dismiss. The fix removes the migration entirely—refreshing only the auth token and connecting signaling directly to the polled server that is already warm and ready to offer. This matches desktop behavior and saves ~3-5 seconds per stream start.

**ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift:**

*   **Logic:** Remove `fetchActiveSessions`, `claimSession` PUT, server migration detection, and 3s sleep
*   **Logic:** Keep only `refreshSession` for token freshness (non-fatal on error)
*   **Logging:** Log warm-server coordinates at handoff (`signalingServer`, `signalingUrl`, `mediaIp`)
*   **Flow:** Return original `session` so streamer connects to the same server that handled polling

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/9f4711fb-a7e6-4ee0-9230-e164632bf496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-17&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-17"><img alt="OPEN-17 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-17"></picture></a>