### PR TITLE
Fix iOS WebContent suspension with AVAudioSession activation

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 import WebKit
 import OSLog
+import AVFoundation
 
 struct StreamerView: View {
     let session: ActiveSession
@@ -133,6 +134,23 @@ struct StreamerView: View {
             }
         }
         .background(Color.black.ignoresSafeArea())
+        .onAppear {
+            do {
+                try AVAudioSession.sharedInstance().setCategory(
+                    .playback,
+                    mode: .moviePlayback,
+                    options: [.mixWithOthers]
+                )
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch {
+            }
+        }
+        .onDisappear {
+            try? AVAudioSession.sharedInstance().setActive(
+                false,
+                options: .notifyOthersOnDeactivation
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes WebContent process suspension during iOS streaming by activating an OS-level `AVAudioSession` when `StreamerView` appears. The native `.playback` category prevents iOS jetsam from killing WebContent during the WebRTC negotiation window, which JS-side `video.play()` cannot do without `com.apple.developer.web-browser-engine.webcontent` entitlements.

**StreamerView.swift:**

*   **Import:** Add `import AVFoundation`
*   **Lifecycle:** Add `.onAppear` to activate `AVAudioSession` with `.playback` / `.moviePlayback` + `.mixWithOthers`
*   **Cleanup:** Add `.onDisappear` to deactivate session with `.notifyOthersOnDeactivation`

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/f9ec487e-bc30-43c2-93aa-c8dc3b604570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-18&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-18"><img alt="OPEN-18 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-18"></picture></a>