### PR TITLE
Fix iOS streaming stale onRetry reopening old session during queue

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/ContentView.swift
@@ -100,9 +100,7 @@ struct MainTabView: View {
                 onRetry: streamerAutoRetryCount < Self.maxStreamerAutoRetries ? {
                     streamerAutoRetryCount += 1
                     store.dismissStreamer()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                        store.reopenStreamer()
-                    }
+                    store.scheduleStreamerReopen()
                 } : nil
             )
         }
@@ -115,6 +113,9 @@ struct MainTabView: View {
             }
         }
         .animation(.spring(response: 0.36, dampingFraction: 0.88), value: store.showStreamLoading && !store.queueOverlayVisible)
+        .onChange(of: store.activeSession?.id) { _ in
+            streamerAutoRetryCount = 0
+        }
     }
 }
 

--- a/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/OpenNOWStore.swift
@@ -1825,6 +1825,7 @@ final class OpenNOWStore: ObservableObject {
     private var cachedVpcId: String = "GFN-PC"
     private var adReportStateById: [String: SessionAdAction] = [:]
     private var adStartedAtById: [String: Date] = [:]
+    private var reopenToken: UUID = UUID()
 
     private let settingsKey = "OpenNOW.iOS.settings"
     private let authSessionKey = "OpenNOW.iOS.authSession"
@@ -2205,6 +2206,17 @@ final class OpenNOWStore: ObservableObject {
         streamSession = active
     }
 
+    /// Schedule a streamer reopen with a 0.8s delay.
+    /// Automatically aborts if a new session starts before the delay completes.
+    func scheduleStreamerReopen() {
+        let token = UUID()
+        reopenToken = token
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+            guard let self, self.reopenToken == token else { return }
+            self.reopenStreamer()
+        }
+    }
+
     func persistSettings() {
         if let encoded = try? JSONEncoder().encode(settings) {
             defaults.set(encoded, forKey: settingsKey)
@@ -2236,6 +2248,8 @@ final class OpenNOWStore: ObservableObject {
     }
 
     private func startSessionTasks() {
+        streamSession = nil
+        reopenToken = UUID()
         telemetryTask?.cancel()
         sessionPollTask?.cancel()
         endSessionPollBackgroundTask()


### PR DESCRIPTION
Fix iOS streaming stale onRetry reopening old session during queue

<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/pull/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/task/e92eaebd-d79d-4be2-a0bc-954089d759ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-19&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-19"><img alt="OPEN-19 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=OPEN-19"></picture></a>