### PR TITLE
Add poster size scaling feature to game settings and UI

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -9,6 +9,8 @@ export interface Settings {
   resolution: string;
   /** Aspect ratio (16:9, 16:10, 21:9, 32:9) */
   aspectRatio: AspectRatio;
+  /** Game poster size multiplier used by the renderer */
+  posterSizeScale: number;
   /** Target FPS (30, 60, 120, etc.) */
   fps: number;
   /** Maximum bitrate in Mbps (cap at 150) */
@@ -94,6 +96,7 @@ const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
 const DEFAULT_SETTINGS: Settings = {
   resolution: "1920x1080",
   aspectRatio: "16:9",
+  posterSizeScale: 1,
   fps: 60,
   maxBitrateMbps: 75,
   codec: DEFAULT_STREAM_PREFERENCES.codec,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { JSX } from "react";
+import type { CSSProperties, JSX } from "react";
 
 import type {
   ActiveSessionInfo,
@@ -83,6 +83,12 @@ const getResolutionsByAspectRatio = (aspectRatio: string): string[] => {
   return allResolutionOptions.filter(res => RESOLUTION_TO_ASPECT_RATIO[res] === aspectRatio);
 };
 const resolutionOptions = getResolutionsByAspectRatio("16:9");
+
+function getAppStyle(posterSizeScale: number): CSSProperties {
+  return {
+    ["--game-poster-scale" as "--game-poster-scale"]: String(posterSizeScale),
+  };
+}
 const SESSION_READY_POLL_INTERVAL_MS = 2000;
 const SESSION_AD_POLL_INTERVAL_MS = 30000;
 const SESSION_AD_PROGRESS_CHECK_INTERVAL_MS = 1000;
@@ -3274,6 +3280,7 @@ export function App(): JSX.Element {
                 autoLoadControllerLibrary: settings.autoLoadControllerLibrary,
                 autoFullScreen: settings.autoFullScreen,
                 aspectRatio: settings.aspectRatio,
+                posterSizeScale: settings.posterSizeScale,
                 maxBitrateMbps: settings.maxBitrateMbps,
               }}
               resolutionOptions={getResolutionsByAspectRatio(settings.aspectRatio)}
@@ -3353,7 +3360,7 @@ export function App(): JSX.Element {
 
   // Main app layout
   return (
-    <div className="app-container">
+    <div className="app-container" style={getAppStyle(settings.posterSizeScale)}>
       {startupRefreshNotice && (
         <div className={`auth-refresh-notice auth-refresh-notice--${startupRefreshNotice.tone}`}>
           {startupRefreshNotice.text}
@@ -3429,6 +3436,7 @@ export function App(): JSX.Element {
                 autoLoadControllerLibrary: settings.autoLoadControllerLibrary,
                 autoFullScreen: settings.autoFullScreen,
                 aspectRatio: settings.aspectRatio,
+                posterSizeScale: settings.posterSizeScale,
                 maxBitrateMbps: settings.maxBitrateMbps,
               }}
               resolutionOptions={getResolutionsByAspectRatio(settings.aspectRatio)}

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -40,6 +40,7 @@ interface ControllerLibraryPageProps {
     autoLoadControllerLibrary?: boolean;
     autoFullScreen?: boolean;
     aspectRatio?: string;
+    posterSizeScale?: number;
     maxBitrateMbps?: number;
   };
   resolutionOptions?: string[];

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -39,6 +39,10 @@ type ThanksLoadState = "idle" | "loading" | "loaded" | "error";
 
 type SettingsSectionId = "stream" | "game" | "audio" | "input" | "interface" | "thanks";
 
+const POSTER_SIZE_MIN = 75;
+const POSTER_SIZE_MAX = 150;
+const POSTER_SIZE_STEP = 5;
+
 const codecOptions: VideoCodec[] = [...USER_FACING_VIDEO_CODEC_OPTIONS];
 
 const accelerationOptions: { value: VideoAccelerationPreference; label: string }[] = [
@@ -519,6 +523,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
     () => (hasDynamic ? getFpsForResolution(entitledResolutions, settings.resolution) : []),
     [entitledResolutions, settings.resolution, hasDynamic]
   );
+  const posterSizePercent = Math.round(settings.posterSizeScale * 100);
 
   const selectedResolutionLabel = useMemo(() => {
     if (hasDynamic) {
@@ -2141,6 +2146,23 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                     </div>
                   </div>
                 )}
+
+                <div className="settings-row settings-row--column">
+                  <div className="settings-row-top">
+                    <label className="settings-label">Poster Size</label>
+                    <span className="settings-value-badge">{posterSizePercent}%</span>
+                  </div>
+                  <input
+                    type="range"
+                    className="settings-slider"
+                    min={POSTER_SIZE_MIN}
+                    max={POSTER_SIZE_MAX}
+                    step={POSTER_SIZE_STEP}
+                    value={posterSizePercent}
+                    onChange={(e) => handleChange("posterSizeScale", Number(e.target.value) / 100)}
+                  />
+                  <span className="settings-subtle-hint">Adjusts game posters in real time across the library and controller views.</span>
+                </div>
 
                 {/* Session Counter */}
                 <div className="settings-row">

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1,6 +1,7 @@
 /* ---------- Design Tokens ---------- */
 :root {
   color-scheme: dark;
+  --game-poster-scale: 1;
 
   /* Backgrounds — layered obsidian-charcoal */
   --bg-a: #0a0a0c;
@@ -1517,39 +1518,9 @@ body.controller-mode.controller-hide-cursor * {
    ====================================================== */
 .game-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(calc(200px * var(--game-poster-scale, 1)), 1fr));
   gap: 12px;
   padding-bottom: 16px;
-}
-
-@media (min-width: 1600px) {
-  .game-grid {
-    grid-template-columns: repeat(6, 1fr);
-  }
-}
-
-@media (min-width: 1280px) and (max-width: 1599px) {
-  .game-grid {
-    grid-template-columns: repeat(5, 1fr);
-  }
-}
-
-@media (min-width: 1024px) and (max-width: 1279px) {
-  .game-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1023px) {
-  .game-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (max-width: 767px) {
-  .game-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
 }
 
 
@@ -1596,10 +1567,10 @@ body.controller-mode.controller-hide-cursor * {
   box-shadow: 0 0 0 1px var(--accent-glow);
 }
 
-/* Image wrapper — 16:9 landscape for GFN cover art */
+/* Image wrapper — portrait poster art */
 .game-card-image-wrapper {
   position: relative;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: 2 / 3;
   overflow: hidden;
   background: var(--bg-c);
   backface-visibility: hidden;
@@ -6262,8 +6233,9 @@ button.game-card-store-chip.active:hover {
 }
 
 .xmb-game-poster-container {
-  width: 56px;
-  height: 80px;
+  width: calc(56px * var(--game-poster-scale, 1));
+  aspect-ratio: 2 / 3;
+  height: auto;
   border-radius: 8px;
   overflow: hidden;
   margin-right: 24px;
@@ -6445,7 +6417,7 @@ button.game-card-store-chip.active:hover {
 }
 
 .xmb-current-poster {
-  width: min(100%, 250px);
+  width: min(100%, calc(250px * var(--game-poster-scale, 1)));
   border-radius: 20px;
   overflow: hidden;
   border: 1px solid rgba(234, 255, 241, 0.16);

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -128,6 +128,7 @@ export interface MicrophonePermissionResult {
 export interface Settings {
   resolution: string;
   aspectRatio: AspectRatio;
+  posterSizeScale: number;
   fps: number;
   maxBitrateMbps: number;
   codec: VideoCodec;


### PR DESCRIPTION
## Description

Introduce a feature that allows users to adjust the size of game posters through a new setting in the UI. This change enhances the visual presentation of game posters across the library and controller views. The implementation includes a slider for real-time adjustments and updates to the relevant styles and settings.

