### PR TITLE
Fix keyboard scancode mapping for GFN input translation

### DIFF
--- a/opennow-stable/package-lock.json
+++ b/opennow-stable/package-lock.json
@@ -26,6 +26,7 @@
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
         "react-scan": "^0.5.3",
+        "tsx": "^4.20.6",
         "typescript": "^6.0.2",
         "vite": "^7.3.1"
       }
@@ -4360,6 +4361,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6051,6 +6065,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
@@ -6693,6 +6717,510 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/type-fest": {

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -20,7 +20,8 @@
     "preview": "electron-vite preview",
     "dist": "npm run build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
     "dist:signed": "npm run build && electron-builder",
-    "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json",
+    "test": "tsx --test src/renderer/src/gfn/inputProtocol.test.ts"
   },
   "dependencies": {
     "discord-rpc": "^4.0.1",
@@ -41,6 +42,7 @@
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "react-scan": "^0.5.3",
+    "tsx": "^4.20.6",
     "typescript": "^6.0.2",
     "vite": "^7.3.1"
   },

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -87,9 +87,13 @@ const getResolutionsByAspectRatio = (aspectRatio: string): string[] => {
 };
 const resolutionOptions = getResolutionsByAspectRatio("16:9");
 
-function getAppStyle(posterSizeScale: number): CSSProperties {
+type AppStyle = CSSProperties & {
+  "--game-poster-scale"?: string;
+};
+
+function getAppStyle(posterSizeScale: number): AppStyle {
   return {
-    ["--game-poster-scale" as "--game-poster-scale"]: String(posterSizeScale),
+    "--game-poster-scale": String(posterSizeScale),
   };
 }
 const SESSION_READY_POLL_INTERVAL_MS = 2000;
@@ -803,6 +807,7 @@ export function App(): JSX.Element {
   const [settings, setSettings] = useState<Settings>({
     resolution: "1920x1080",
     aspectRatio: "16:9",
+    posterSizeScale: 1,
     fps: 60,
     maxBitrateMbps: 75,
     codec: DEFAULT_STREAM_PREFERENCES.codec,
@@ -1132,9 +1137,9 @@ export function App(): JSX.Element {
   const queueAdPlaybackRef = useRef<{ adId: string; phase: "playing" | "finishing" } | null>(null);
   const queueAdPreviewRef = useRef<QueueAdPreviewHandle | null>(null);
   const activeQueueAdIdRef = useRef<string | null>(null);
-  const adForcePlayTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const adStartTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const adProgressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const adForcePlayTimeoutRef = useRef<number | null>(null);
+  const adStartTimeoutRef = useRef<number | null>(null);
+  const adProgressIntervalRef = useRef<number | null>(null);
   const adLastProgressTsRef = useRef<number | null>(null);
   // Stable ref so timer callbacks can call the latest reportQueueAdAction without
   // capturing a stale closure (auth state can change between scheduling and firing).

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -7,6 +9,7 @@ function keyboardEvent(init: Partial<KeyboardEvent> & Pick<KeyboardEvent, "code"
   return {
     code: init.code,
     key: init.key,
+    location: init.location ?? 0,
     shiftKey: init.shiftKey ?? false,
     ctrlKey: init.ctrlKey ?? false,
     altKey: init.altKey ?? false,
@@ -26,9 +29,9 @@ test("maps representative physical keys to Windows set-1 scancodes", () => {
 });
 
 test("maps escape and left/right modifiers with correct scancodes", () => {
-  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "Escape", key: "Escape" })), codeMap.Escape);
-  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "ShiftLeft", key: "Shift" })), codeMap.ShiftLeft);
-  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "ShiftRight", key: "Shift" })), codeMap.ShiftRight);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "Escape", key: "Escape", keyCode: 27 })), codeMap.Escape);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "ShiftLeft", key: "Shift", keyCode: 16 })), codeMap.ShiftLeft);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "ShiftRight", key: "Shift", keyCode: 16 })), codeMap.ShiftRight);
 });
 
 test("maps non-US and numpad physical keys", () => {
@@ -36,19 +39,30 @@ test("maps non-US and numpad physical keys", () => {
     mapKeyboardEvent(keyboardEvent({ code: "IntlBackslash", key: "<" })),
     codeMap.IntlBackslash,
   );
-  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "NumLock", key: "NumLock" })), codeMap.NumLock);
-  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "Numpad0", key: "0" })), codeMap.Numpad0);
-  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "NumpadEnter", key: "Enter" })), codeMap.NumpadEnter);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "NumLock", key: "NumLock", keyCode: 144 })), codeMap.NumLock);
+  assert.deepEqual(
+    mapKeyboardEvent(keyboardEvent({ code: "Numpad0", key: "0", keyCode: 96, location: 3 })),
+    codeMap.Numpad0,
+  );
+  assert.deepEqual(
+    mapKeyboardEvent(keyboardEvent({ code: "NumpadEnter", key: "Enter", keyCode: 13, location: 3 })),
+    codeMap.NumpadEnter,
+  );
 });
 
 test("prefers physical code over layout-dependent key value", () => {
-  const event = keyboardEvent({ code: "KeyZ", key: "y" });
+  const event = keyboardEvent({ code: "KeyZ", key: "y", keyCode: 89 });
   assert.deepEqual(mapKeyboardEvent(event), codeMap.KeyZ);
 });
 
 test("falls back to key-based escape detection when code is unavailable", () => {
   const event = keyboardEvent({ code: "", key: "Escape", keyCode: 27 });
   assert.deepEqual(mapKeyboardEvent(event), codeMap.Escape);
+});
+
+test("prefers platform keyCode for virtual-key derivation when available", () => {
+  const event = keyboardEvent({ code: "Slash", key: "ö", keyCode: 191 });
+  assert.deepEqual(mapKeyboardEvent(event), codeMap.Slash);
 });
 
 test("uses corrected scancodes for synthetic text injection", () => {

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { codeMap, mapKeyboardEvent, mapTextCharToKeySpec } from "./inputProtocol";
+
+function keyboardEvent(init: Partial<KeyboardEvent> & Pick<KeyboardEvent, "code" | "key">): KeyboardEvent {
+  return {
+    code: init.code,
+    key: init.key,
+    shiftKey: init.shiftKey ?? false,
+    ctrlKey: init.ctrlKey ?? false,
+    altKey: init.altKey ?? false,
+    metaKey: init.metaKey ?? false,
+    keyCode: init.keyCode ?? 0,
+    getModifierState: init.getModifierState ?? (() => false),
+  } as KeyboardEvent;
+}
+
+test("maps representative physical keys to Windows set-1 scancodes", () => {
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "KeyA", key: "a" })), codeMap.KeyA);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "KeyN", key: "n" })), codeMap.KeyN);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "KeyT", key: "t" })), codeMap.KeyT);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "KeyZ", key: "z" })), codeMap.KeyZ);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "Comma", key: "," })), codeMap.Comma);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "Slash", key: "/" })), codeMap.Slash);
+});
+
+test("maps escape and left/right modifiers with correct scancodes", () => {
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "Escape", key: "Escape" })), codeMap.Escape);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "ShiftLeft", key: "Shift" })), codeMap.ShiftLeft);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "ShiftRight", key: "Shift" })), codeMap.ShiftRight);
+});
+
+test("maps non-US and numpad physical keys", () => {
+  assert.deepEqual(
+    mapKeyboardEvent(keyboardEvent({ code: "IntlBackslash", key: "<" })),
+    codeMap.IntlBackslash,
+  );
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "NumLock", key: "NumLock" })), codeMap.NumLock);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "Numpad0", key: "0" })), codeMap.Numpad0);
+  assert.deepEqual(mapKeyboardEvent(keyboardEvent({ code: "NumpadEnter", key: "Enter" })), codeMap.NumpadEnter);
+});
+
+test("prefers physical code over layout-dependent key value", () => {
+  const event = keyboardEvent({ code: "KeyZ", key: "y" });
+  assert.deepEqual(mapKeyboardEvent(event), codeMap.KeyZ);
+});
+
+test("falls back to key-based escape detection when code is unavailable", () => {
+  const event = keyboardEvent({ code: "", key: "Escape", keyCode: 27 });
+  assert.deepEqual(mapKeyboardEvent(event), codeMap.Escape);
+});
+
+test("uses corrected scancodes for synthetic text injection", () => {
+  assert.deepEqual(mapTextCharToKeySpec("a"), { ...codeMap.KeyA });
+  assert.deepEqual(mapTextCharToKeySpec("N"), { ...codeMap.KeyN, shift: true });
+  assert.deepEqual(mapTextCharToKeySpec("<"), { ...codeMap.Comma, shift: true });
+  assert.deepEqual(mapTextCharToKeySpec("/"), { ...codeMap.Slash });
+  assert.deepEqual(mapTextCharToKeySpec("?"), { ...codeMap.Slash, shift: true });
+});

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -94,130 +94,206 @@ export function isPartiallyReliableHidTransferEligible(inputType: number): boole
   return inputType === INPUT_MOUSE_REL;
 }
 
-const codeMap: Record<string, { vk: number; scancode: number }> = {
-  // Letters
-  KeyA: { vk: 0x41, scancode: 0x04 },
-  KeyB: { vk: 0x42, scancode: 0x05 },
-  KeyC: { vk: 0x43, scancode: 0x06 },
-  KeyD: { vk: 0x44, scancode: 0x07 },
-  KeyE: { vk: 0x45, scancode: 0x08 },
-  KeyF: { vk: 0x46, scancode: 0x09 },
-  KeyG: { vk: 0x47, scancode: 0x0a },
-  KeyH: { vk: 0x48, scancode: 0x0b },
-  KeyI: { vk: 0x49, scancode: 0x0c },
-  KeyJ: { vk: 0x4a, scancode: 0x0d },
-  KeyK: { vk: 0x4b, scancode: 0x0e },
-  KeyL: { vk: 0x4c, scancode: 0x0f },
-  KeyM: { vk: 0x4d, scancode: 0x10 },
-  KeyN: { vk: 0x4e, scancode: 0x11 },
-  KeyO: { vk: 0x4f, scancode: 0x12 },
-  KeyP: { vk: 0x50, scancode: 0x13 },
-  KeyQ: { vk: 0x51, scancode: 0x14 },
-  KeyR: { vk: 0x52, scancode: 0x15 },
-  KeyS: { vk: 0x53, scancode: 0x16 },
-  KeyT: { vk: 0x54, scancode: 0x17 },
-  KeyU: { vk: 0x55, scancode: 0x18 },
-  KeyV: { vk: 0x56, scancode: 0x19 },
-  KeyW: { vk: 0x57, scancode: 0x1a },
-  KeyX: { vk: 0x58, scancode: 0x1b },
-  KeyY: { vk: 0x59, scancode: 0x1c },
-  KeyZ: { vk: 0x5a, scancode: 0x1d },
-  // Numbers
-  Digit1: { vk: 0x31, scancode: 0x1e },
-  Digit2: { vk: 0x32, scancode: 0x1f },
-  Digit3: { vk: 0x33, scancode: 0x20 },
-  Digit4: { vk: 0x34, scancode: 0x21 },
-  Digit5: { vk: 0x35, scancode: 0x22 },
-  Digit6: { vk: 0x36, scancode: 0x23 },
-  Digit7: { vk: 0x37, scancode: 0x24 },
-  Digit8: { vk: 0x38, scancode: 0x25 },
-  Digit9: { vk: 0x39, scancode: 0x26 },
-  Digit0: { vk: 0x30, scancode: 0x27 },
-  // Special keys
-  Enter: { vk: 0x0d, scancode: 0x28 },
-  Escape: { vk: 0x1b, scancode: 0x29 },
-  Backspace: { vk: 0x08, scancode: 0x2a },
-  Tab: { vk: 0x09, scancode: 0x2b },
-  Space: { vk: 0x20, scancode: 0x2c },
-  // Punctuation
-  Minus: { vk: 0xbd, scancode: 0x2d },
-  Equal: { vk: 0xbb, scancode: 0x2e },
-  BracketLeft: { vk: 0xdb, scancode: 0x2f },
-  BracketRight: { vk: 0xdd, scancode: 0x30 },
-  Backslash: { vk: 0xdc, scancode: 0x31 },
-  Semicolon: { vk: 0xba, scancode: 0x33 },
-  Quote: { vk: 0xde, scancode: 0x34 },
-  Backquote: { vk: 0xc0, scancode: 0x35 },
-  Comma: { vk: 0xbc, scancode: 0x36 },
-  Period: { vk: 0xbe, scancode: 0x37 },
-  Slash: { vk: 0xbf, scancode: 0x38 },
-  // Function keys
-  F1: { vk: 0x70, scancode: 0x3a },
-  F2: { vk: 0x71, scancode: 0x3b },
-  F3: { vk: 0x72, scancode: 0x3c },
-  F4: { vk: 0x73, scancode: 0x3d },
-  F5: { vk: 0x74, scancode: 0x3e },
-  F6: { vk: 0x75, scancode: 0x3f },
-  F7: { vk: 0x76, scancode: 0x40 },
-  F8: { vk: 0x77, scancode: 0x41 },
-  F9: { vk: 0x78, scancode: 0x42 },
-  F10: { vk: 0x79, scancode: 0x43 },
-  F11: { vk: 0x7a, scancode: 0x44 },
-  F12: { vk: 0x7b, scancode: 0x45 },
-  F13: { vk: 0x7c, scancode: 0x64 },
-  // Navigation keys
-  ArrowRight: { vk: 0x27, scancode: 0x4f },
-  ArrowLeft: { vk: 0x25, scancode: 0x50 },
-  ArrowDown: { vk: 0x28, scancode: 0x51 },
-  ArrowUp: { vk: 0x26, scancode: 0x52 },
-  // Modifier keys
-  ControlLeft: { vk: 0xa2, scancode: 0xe0 },
-  ShiftLeft: { vk: 0xa0, scancode: 0xe1 },
-  AltLeft: { vk: 0xa4, scancode: 0xe2 },
-  MetaLeft: { vk: 0x5b, scancode: 0xe3 },
-  ControlRight: { vk: 0xa3, scancode: 0xe4 },
-  ShiftRight: { vk: 0xa1, scancode: 0xe5 },
-  AltRight: { vk: 0xa5, scancode: 0xe6 },
-  MetaRight: { vk: 0x5c, scancode: 0xe7 },
-  // Caps Lock and Num Lock
-  CapsLock: { vk: 0x14, scancode: 0x39 },
-  NumLock: { vk: 0x90, scancode: 0x53 },
-  // Navigation cluster
-  Insert: { vk: 0x2d, scancode: 0x49 },
-  Delete: { vk: 0x2e, scancode: 0x4c },
-  Home: { vk: 0x24, scancode: 0x4a },
-  End: { vk: 0x23, scancode: 0x4d },
-  PageUp: { vk: 0x21, scancode: 0x4b },
-  PageDown: { vk: 0x22, scancode: 0x4e },
-  // System keys
-  PrintScreen: { vk: 0x2c, scancode: 0x46 },
-  ScrollLock: { vk: 0x91, scancode: 0x47 },
-  Pause: { vk: 0x13, scancode: 0x48 },
-  // Context Menu key
-  ContextMenu: { vk: 0x5d, scancode: 0x65 },
-  // Numpad keys
-  Numpad0: { vk: 0x60, scancode: 0x62 },
-  Numpad1: { vk: 0x61, scancode: 0x59 },
-  Numpad2: { vk: 0x62, scancode: 0x5a },
-  Numpad3: { vk: 0x63, scancode: 0x5b },
-  Numpad4: { vk: 0x64, scancode: 0x5c },
-  Numpad5: { vk: 0x65, scancode: 0x5d },
-  Numpad6: { vk: 0x66, scancode: 0x5e },
-  Numpad7: { vk: 0x67, scancode: 0x5f },
-  Numpad8: { vk: 0x68, scancode: 0x60 },
-  Numpad9: { vk: 0x69, scancode: 0x61 },
-  NumpadAdd: { vk: 0x6b, scancode: 0x57 },
-  NumpadSubtract: { vk: 0x6d, scancode: 0x56 },
-  NumpadMultiply: { vk: 0x6a, scancode: 0x55 },
-  NumpadDivide: { vk: 0x6f, scancode: 0x54 },
-  NumpadDecimal: { vk: 0x6e, scancode: 0x63 },
-  NumpadEnter: { vk: 0x0d, scancode: 0x58 },
+export interface KeyMapping {
+  vk: number;
+  scancode: number;
+}
+
+export interface TextKeySpec extends KeyMapping {
+  shift?: boolean;
+}
+
+export const codeMap: Record<string, KeyMapping> = {
+  KeyA: { vk: 0x41, scancode: 0x001e },
+  KeyB: { vk: 0x42, scancode: 0x0030 },
+  KeyC: { vk: 0x43, scancode: 0x002e },
+  KeyD: { vk: 0x44, scancode: 0x0020 },
+  KeyE: { vk: 0x45, scancode: 0x0012 },
+  KeyF: { vk: 0x46, scancode: 0x0021 },
+  KeyG: { vk: 0x47, scancode: 0x0022 },
+  KeyH: { vk: 0x48, scancode: 0x0023 },
+  KeyI: { vk: 0x49, scancode: 0x0017 },
+  KeyJ: { vk: 0x4a, scancode: 0x0024 },
+  KeyK: { vk: 0x4b, scancode: 0x0025 },
+  KeyL: { vk: 0x4c, scancode: 0x0026 },
+  KeyM: { vk: 0x4d, scancode: 0x0032 },
+  KeyN: { vk: 0x4e, scancode: 0x0031 },
+  KeyO: { vk: 0x4f, scancode: 0x0018 },
+  KeyP: { vk: 0x50, scancode: 0x0019 },
+  KeyQ: { vk: 0x51, scancode: 0x0010 },
+  KeyR: { vk: 0x52, scancode: 0x0013 },
+  KeyS: { vk: 0x53, scancode: 0x001f },
+  KeyT: { vk: 0x54, scancode: 0x0014 },
+  KeyU: { vk: 0x55, scancode: 0x0016 },
+  KeyV: { vk: 0x56, scancode: 0x002f },
+  KeyW: { vk: 0x57, scancode: 0x0011 },
+  KeyX: { vk: 0x58, scancode: 0x002d },
+  KeyY: { vk: 0x59, scancode: 0x0015 },
+  KeyZ: { vk: 0x5a, scancode: 0x002c },
+  Digit1: { vk: 0x31, scancode: 0x0002 },
+  Digit2: { vk: 0x32, scancode: 0x0003 },
+  Digit3: { vk: 0x33, scancode: 0x0004 },
+  Digit4: { vk: 0x34, scancode: 0x0005 },
+  Digit5: { vk: 0x35, scancode: 0x0006 },
+  Digit6: { vk: 0x36, scancode: 0x0007 },
+  Digit7: { vk: 0x37, scancode: 0x0008 },
+  Digit8: { vk: 0x38, scancode: 0x0009 },
+  Digit9: { vk: 0x39, scancode: 0x000a },
+  Digit0: { vk: 0x30, scancode: 0x000b },
+  Enter: { vk: 0x0d, scancode: 0x001c },
+  Escape: { vk: 0x1b, scancode: 0x0001 },
+  Backspace: { vk: 0x08, scancode: 0x000e },
+  Tab: { vk: 0x09, scancode: 0x000f },
+  Space: { vk: 0x20, scancode: 0x0039 },
+  Minus: { vk: 0xbd, scancode: 0x000c },
+  Equal: { vk: 0xbb, scancode: 0x000d },
+  BracketLeft: { vk: 0xdb, scancode: 0x001a },
+  BracketRight: { vk: 0xdd, scancode: 0x001b },
+  Backslash: { vk: 0xdc, scancode: 0x002b },
+  IntlBackslash: { vk: 0xe2, scancode: 0x0056 },
+  IntlRo: { vk: 0xc1, scancode: 0x0073 },
+  IntlYen: { vk: 0xdc, scancode: 0x007d },
+  Semicolon: { vk: 0xba, scancode: 0x0027 },
+  Quote: { vk: 0xde, scancode: 0x0028 },
+  Backquote: { vk: 0xc0, scancode: 0x0029 },
+  Comma: { vk: 0xbc, scancode: 0x0033 },
+  Period: { vk: 0xbe, scancode: 0x0034 },
+  Slash: { vk: 0xbf, scancode: 0x0035 },
+  F1: { vk: 0x70, scancode: 0x003b },
+  F2: { vk: 0x71, scancode: 0x003c },
+  F3: { vk: 0x72, scancode: 0x003d },
+  F4: { vk: 0x73, scancode: 0x003e },
+  F5: { vk: 0x74, scancode: 0x003f },
+  F6: { vk: 0x75, scancode: 0x0040 },
+  F7: { vk: 0x76, scancode: 0x0041 },
+  F8: { vk: 0x77, scancode: 0x0042 },
+  F9: { vk: 0x78, scancode: 0x0043 },
+  F10: { vk: 0x79, scancode: 0x0044 },
+  F11: { vk: 0x7a, scancode: 0x0057 },
+  F12: { vk: 0x7b, scancode: 0x0058 },
+  F13: { vk: 0x7c, scancode: 0x0064 },
+  ArrowRight: { vk: 0x27, scancode: 0xe04d },
+  ArrowLeft: { vk: 0x25, scancode: 0xe04b },
+  ArrowDown: { vk: 0x28, scancode: 0xe050 },
+  ArrowUp: { vk: 0x26, scancode: 0xe048 },
+  ControlLeft: { vk: 0xa2, scancode: 0x001d },
+  ShiftLeft: { vk: 0xa0, scancode: 0x002a },
+  AltLeft: { vk: 0xa4, scancode: 0x0038 },
+  MetaLeft: { vk: 0x5b, scancode: 0xe05b },
+  ControlRight: { vk: 0xa3, scancode: 0xe01d },
+  ShiftRight: { vk: 0xa1, scancode: 0x0036 },
+  AltRight: { vk: 0xa5, scancode: 0xe038 },
+  MetaRight: { vk: 0x5c, scancode: 0xe05c },
+  CapsLock: { vk: 0x14, scancode: 0x003a },
+  NumLock: { vk: 0x90, scancode: 0xe045 },
+  Insert: { vk: 0x2d, scancode: 0xe052 },
+  Delete: { vk: 0x2e, scancode: 0xe053 },
+  Home: { vk: 0x24, scancode: 0xe047 },
+  End: { vk: 0x23, scancode: 0xe04f },
+  PageUp: { vk: 0x21, scancode: 0xe049 },
+  PageDown: { vk: 0x22, scancode: 0xe051 },
+  PrintScreen: { vk: 0x2c, scancode: 0xe037 },
+  ScrollLock: { vk: 0x91, scancode: 0x0046 },
+  Pause: { vk: 0x13, scancode: 0x0045 },
+  ContextMenu: { vk: 0x5d, scancode: 0xe05d },
+  Numpad0: { vk: 0x60, scancode: 0x0052 },
+  Numpad1: { vk: 0x61, scancode: 0x004f },
+  Numpad2: { vk: 0x62, scancode: 0x0050 },
+  Numpad3: { vk: 0x63, scancode: 0x0051 },
+  Numpad4: { vk: 0x64, scancode: 0x004b },
+  Numpad5: { vk: 0x65, scancode: 0x004c },
+  Numpad6: { vk: 0x66, scancode: 0x004d },
+  Numpad7: { vk: 0x67, scancode: 0x0047 },
+  Numpad8: { vk: 0x68, scancode: 0x0048 },
+  Numpad9: { vk: 0x69, scancode: 0x0049 },
+  NumpadAdd: { vk: 0x6b, scancode: 0x004e },
+  NumpadSubtract: { vk: 0x6d, scancode: 0x004a },
+  NumpadMultiply: { vk: 0x6a, scancode: 0x0037 },
+  NumpadDivide: { vk: 0x6f, scancode: 0xe035 },
+  NumpadDecimal: { vk: 0x6e, scancode: 0x0053 },
+  NumpadEnter: { vk: 0x0d, scancode: 0xe01c },
+  NumpadEqual: { vk: 0xbb, scancode: 0x0059 },
+  NumpadComma: { vk: 0xbc, scancode: 0x007e },
 };
 
-const keyFallbackMap: Record<string, { vk: number; scancode: number }> = {
-  Escape: { vk: 0x1b, scancode: 0x29 },
-  Esc: { vk: 0x1b, scancode: 0x29 },
+const keyFallbackMap: Record<string, KeyMapping> = {
+  Escape: { vk: 0x1b, scancode: 0x0001 },
+  Esc: { vk: 0x1b, scancode: 0x0001 },
 };
+
+const baseCharKeyMap: Record<string, TextKeySpec> = {
+  " ": codeMap.Space,
+  "\n": codeMap.Enter,
+  "\r": codeMap.Enter,
+  "\t": codeMap.Tab,
+  "0": codeMap.Digit0,
+  "1": codeMap.Digit1,
+  "2": codeMap.Digit2,
+  "3": codeMap.Digit3,
+  "4": codeMap.Digit4,
+  "5": codeMap.Digit5,
+  "6": codeMap.Digit6,
+  "7": codeMap.Digit7,
+  "8": codeMap.Digit8,
+  "9": codeMap.Digit9,
+  "-": codeMap.Minus,
+  "=": codeMap.Equal,
+  "[": codeMap.BracketLeft,
+  "]": codeMap.BracketRight,
+  "\\": codeMap.Backslash,
+  ";": codeMap.Semicolon,
+  "'": codeMap.Quote,
+  "`": codeMap.Backquote,
+  ",": codeMap.Comma,
+  ".": codeMap.Period,
+  "/": codeMap.Slash,
+};
+
+const shiftedCharKeyMap: Record<string, TextKeySpec> = {
+  "!": { ...codeMap.Digit1, shift: true },
+  "@": { ...codeMap.Digit2, shift: true },
+  "#": { ...codeMap.Digit3, shift: true },
+  "$": { ...codeMap.Digit4, shift: true },
+  "%": { ...codeMap.Digit5, shift: true },
+  "^": { ...codeMap.Digit6, shift: true },
+  "&": { ...codeMap.Digit7, shift: true },
+  "*": { ...codeMap.Digit8, shift: true },
+  "(": { ...codeMap.Digit9, shift: true },
+  ")": { ...codeMap.Digit0, shift: true },
+  "_": { ...codeMap.Minus, shift: true },
+  "+": { ...codeMap.Equal, shift: true },
+  "{": { ...codeMap.BracketLeft, shift: true },
+  "}": { ...codeMap.BracketRight, shift: true },
+  "|": { ...codeMap.Backslash, shift: true },
+  ":": { ...codeMap.Semicolon, shift: true },
+  '"': { ...codeMap.Quote, shift: true },
+  "~": { ...codeMap.Backquote, shift: true },
+  "<": { ...codeMap.Comma, shift: true },
+  ">": { ...codeMap.Period, shift: true },
+  "?": { ...codeMap.Slash, shift: true },
+};
+
+export function mapTextCharToKeySpec(char: string): TextKeySpec | null {
+  if (baseCharKeyMap[char]) {
+    return baseCharKeyMap[char];
+  }
+
+  if (shiftedCharKeyMap[char]) {
+    return shiftedCharKeyMap[char];
+  }
+
+  if (char >= "a" && char <= "z") {
+    const mapped = codeMap[`Key${char.toUpperCase()}`];
+    return mapped ? { ...mapped } : null;
+  }
+
+  if (char >= "A" && char <= "Z") {
+    const mapped = codeMap[`Key${char}`];
+    return mapped ? { ...mapped, shift: true } : null;
+  }
+
+  return null;
+}
 
 /**
  * Write an 8-byte big-endian timestamp (performance.now() * 1000 = microseconds)
@@ -517,7 +593,7 @@ export function modifierFlags(event: KeyboardEvent): number {
   return flags;
 }
 
-export function mapKeyboardEvent(event: KeyboardEvent): { vk: number; scancode: number } | null {
+export function mapKeyboardEvent(event: KeyboardEvent): KeyMapping | null {
   const mapped = codeMap[event.code];
   if (mapped) {
     return mapped;
@@ -530,12 +606,9 @@ export function mapKeyboardEvent(event: KeyboardEvent): { vk: number; scancode: 
 
   const key = event.key;
   if (key.length === 1) {
-    const upper = key.toUpperCase();
-    if (upper >= "A" && upper <= "Z") {
-      return { vk: upper.charCodeAt(0), scancode: 0 };
-    }
-    if (key >= "0" && key <= "9") {
-      return { vk: key.charCodeAt(0), scancode: 0 };
+    const textMapped = mapTextCharToKeySpec(key);
+    if (textMapped) {
+      return { vk: textMapped.vk, scancode: textMapped.scancode };
     }
   }
 

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -103,117 +103,178 @@ export interface TextKeySpec extends KeyMapping {
   shift?: boolean;
 }
 
-export const codeMap: Record<string, KeyMapping> = {
-  KeyA: { vk: 0x41, scancode: 0x001e },
-  KeyB: { vk: 0x42, scancode: 0x0030 },
-  KeyC: { vk: 0x43, scancode: 0x002e },
-  KeyD: { vk: 0x44, scancode: 0x0020 },
-  KeyE: { vk: 0x45, scancode: 0x0012 },
-  KeyF: { vk: 0x46, scancode: 0x0021 },
-  KeyG: { vk: 0x47, scancode: 0x0022 },
-  KeyH: { vk: 0x48, scancode: 0x0023 },
-  KeyI: { vk: 0x49, scancode: 0x0017 },
-  KeyJ: { vk: 0x4a, scancode: 0x0024 },
-  KeyK: { vk: 0x4b, scancode: 0x0025 },
-  KeyL: { vk: 0x4c, scancode: 0x0026 },
-  KeyM: { vk: 0x4d, scancode: 0x0032 },
-  KeyN: { vk: 0x4e, scancode: 0x0031 },
-  KeyO: { vk: 0x4f, scancode: 0x0018 },
-  KeyP: { vk: 0x50, scancode: 0x0019 },
-  KeyQ: { vk: 0x51, scancode: 0x0010 },
-  KeyR: { vk: 0x52, scancode: 0x0013 },
-  KeyS: { vk: 0x53, scancode: 0x001f },
-  KeyT: { vk: 0x54, scancode: 0x0014 },
-  KeyU: { vk: 0x55, scancode: 0x0016 },
-  KeyV: { vk: 0x56, scancode: 0x002f },
-  KeyW: { vk: 0x57, scancode: 0x0011 },
-  KeyX: { vk: 0x58, scancode: 0x002d },
-  KeyY: { vk: 0x59, scancode: 0x0015 },
-  KeyZ: { vk: 0x5a, scancode: 0x002c },
-  Digit1: { vk: 0x31, scancode: 0x0002 },
-  Digit2: { vk: 0x32, scancode: 0x0003 },
-  Digit3: { vk: 0x33, scancode: 0x0004 },
-  Digit4: { vk: 0x34, scancode: 0x0005 },
-  Digit5: { vk: 0x35, scancode: 0x0006 },
-  Digit6: { vk: 0x36, scancode: 0x0007 },
-  Digit7: { vk: 0x37, scancode: 0x0008 },
-  Digit8: { vk: 0x38, scancode: 0x0009 },
-  Digit9: { vk: 0x39, scancode: 0x000a },
-  Digit0: { vk: 0x30, scancode: 0x000b },
-  Enter: { vk: 0x0d, scancode: 0x001c },
-  Escape: { vk: 0x1b, scancode: 0x0001 },
-  Backspace: { vk: 0x08, scancode: 0x000e },
-  Tab: { vk: 0x09, scancode: 0x000f },
-  Space: { vk: 0x20, scancode: 0x0039 },
-  Minus: { vk: 0xbd, scancode: 0x000c },
-  Equal: { vk: 0xbb, scancode: 0x000d },
-  BracketLeft: { vk: 0xdb, scancode: 0x001a },
-  BracketRight: { vk: 0xdd, scancode: 0x001b },
-  Backslash: { vk: 0xdc, scancode: 0x002b },
-  IntlBackslash: { vk: 0xe2, scancode: 0x0056 },
-  IntlRo: { vk: 0xc1, scancode: 0x0073 },
-  IntlYen: { vk: 0xdc, scancode: 0x007d },
-  Semicolon: { vk: 0xba, scancode: 0x0027 },
-  Quote: { vk: 0xde, scancode: 0x0028 },
-  Backquote: { vk: 0xc0, scancode: 0x0029 },
-  Comma: { vk: 0xbc, scancode: 0x0033 },
-  Period: { vk: 0xbe, scancode: 0x0034 },
-  Slash: { vk: 0xbf, scancode: 0x0035 },
-  F1: { vk: 0x70, scancode: 0x003b },
-  F2: { vk: 0x71, scancode: 0x003c },
-  F3: { vk: 0x72, scancode: 0x003d },
-  F4: { vk: 0x73, scancode: 0x003e },
-  F5: { vk: 0x74, scancode: 0x003f },
-  F6: { vk: 0x75, scancode: 0x0040 },
-  F7: { vk: 0x76, scancode: 0x0041 },
-  F8: { vk: 0x77, scancode: 0x0042 },
-  F9: { vk: 0x78, scancode: 0x0043 },
-  F10: { vk: 0x79, scancode: 0x0044 },
-  F11: { vk: 0x7a, scancode: 0x0057 },
-  F12: { vk: 0x7b, scancode: 0x0058 },
-  F13: { vk: 0x7c, scancode: 0x0064 },
-  ArrowRight: { vk: 0x27, scancode: 0xe04d },
-  ArrowLeft: { vk: 0x25, scancode: 0xe04b },
-  ArrowDown: { vk: 0x28, scancode: 0xe050 },
-  ArrowUp: { vk: 0x26, scancode: 0xe048 },
-  ControlLeft: { vk: 0xa2, scancode: 0x001d },
-  ShiftLeft: { vk: 0xa0, scancode: 0x002a },
-  AltLeft: { vk: 0xa4, scancode: 0x0038 },
-  MetaLeft: { vk: 0x5b, scancode: 0xe05b },
-  ControlRight: { vk: 0xa3, scancode: 0xe01d },
-  ShiftRight: { vk: 0xa1, scancode: 0x0036 },
-  AltRight: { vk: 0xa5, scancode: 0xe038 },
-  MetaRight: { vk: 0x5c, scancode: 0xe05c },
-  CapsLock: { vk: 0x14, scancode: 0x003a },
-  NumLock: { vk: 0x90, scancode: 0xe045 },
-  Insert: { vk: 0x2d, scancode: 0xe052 },
-  Delete: { vk: 0x2e, scancode: 0xe053 },
-  Home: { vk: 0x24, scancode: 0xe047 },
-  End: { vk: 0x23, scancode: 0xe04f },
-  PageUp: { vk: 0x21, scancode: 0xe049 },
-  PageDown: { vk: 0x22, scancode: 0xe051 },
-  PrintScreen: { vk: 0x2c, scancode: 0xe037 },
-  ScrollLock: { vk: 0x91, scancode: 0x0046 },
-  Pause: { vk: 0x13, scancode: 0x0045 },
-  ContextMenu: { vk: 0x5d, scancode: 0xe05d },
-  Numpad0: { vk: 0x60, scancode: 0x0052 },
-  Numpad1: { vk: 0x61, scancode: 0x004f },
-  Numpad2: { vk: 0x62, scancode: 0x0050 },
-  Numpad3: { vk: 0x63, scancode: 0x0051 },
-  Numpad4: { vk: 0x64, scancode: 0x004b },
-  Numpad5: { vk: 0x65, scancode: 0x004c },
-  Numpad6: { vk: 0x66, scancode: 0x004d },
-  Numpad7: { vk: 0x67, scancode: 0x0047 },
-  Numpad8: { vk: 0x68, scancode: 0x0048 },
-  Numpad9: { vk: 0x69, scancode: 0x0049 },
-  NumpadAdd: { vk: 0x6b, scancode: 0x004e },
-  NumpadSubtract: { vk: 0x6d, scancode: 0x004a },
-  NumpadMultiply: { vk: 0x6a, scancode: 0x0037 },
-  NumpadDivide: { vk: 0x6f, scancode: 0xe035 },
-  NumpadDecimal: { vk: 0x6e, scancode: 0x0053 },
-  NumpadEnter: { vk: 0x0d, scancode: 0xe01c },
-  NumpadEqual: { vk: 0xbb, scancode: 0x0059 },
-  NumpadComma: { vk: 0xbc, scancode: 0x007e },
+type KeyLike = Pick<KeyboardEvent, "code" | "key" | "keyCode" | "location">;
+
+const DOM_KEY_LOCATION_STANDARD = 0;
+const DOM_KEY_LOCATION_LEFT = 1;
+const DOM_KEY_LOCATION_RIGHT = 2;
+const DOM_KEY_LOCATION_NUMPAD = 3;
+
+const scancodeByCode: Record<string, number> = {
+  KeyA: 0x001e,
+  KeyB: 0x0030,
+  KeyC: 0x002e,
+  KeyD: 0x0020,
+  KeyE: 0x0012,
+  KeyF: 0x0021,
+  KeyG: 0x0022,
+  KeyH: 0x0023,
+  KeyI: 0x0017,
+  KeyJ: 0x0024,
+  KeyK: 0x0025,
+  KeyL: 0x0026,
+  KeyM: 0x0032,
+  KeyN: 0x0031,
+  KeyO: 0x0018,
+  KeyP: 0x0019,
+  KeyQ: 0x0010,
+  KeyR: 0x0013,
+  KeyS: 0x001f,
+  KeyT: 0x0014,
+  KeyU: 0x0016,
+  KeyV: 0x002f,
+  KeyW: 0x0011,
+  KeyX: 0x002d,
+  KeyY: 0x0015,
+  KeyZ: 0x002c,
+  Digit1: 0x0002,
+  Digit2: 0x0003,
+  Digit3: 0x0004,
+  Digit4: 0x0005,
+  Digit5: 0x0006,
+  Digit6: 0x0007,
+  Digit7: 0x0008,
+  Digit8: 0x0009,
+  Digit9: 0x000a,
+  Digit0: 0x000b,
+  Enter: 0x001c,
+  Escape: 0x0001,
+  Backspace: 0x000e,
+  Tab: 0x000f,
+  Space: 0x0039,
+  Minus: 0x000c,
+  Equal: 0x000d,
+  BracketLeft: 0x001a,
+  BracketRight: 0x001b,
+  Backslash: 0x002b,
+  IntlBackslash: 0x0056,
+  IntlRo: 0x0073,
+  IntlYen: 0x007d,
+  Semicolon: 0x0027,
+  Quote: 0x0028,
+  Backquote: 0x0029,
+  Comma: 0x0033,
+  Period: 0x0034,
+  Slash: 0x0035,
+  F1: 0x003b,
+  F2: 0x003c,
+  F3: 0x003d,
+  F4: 0x003e,
+  F5: 0x003f,
+  F6: 0x0040,
+  F7: 0x0041,
+  F8: 0x0042,
+  F9: 0x0043,
+  F10: 0x0044,
+  F11: 0x0057,
+  F12: 0x0058,
+  F13: 0x0064,
+  ArrowRight: 0xe04d,
+  ArrowLeft: 0xe04b,
+  ArrowDown: 0xe050,
+  ArrowUp: 0xe048,
+  ControlLeft: 0x001d,
+  ShiftLeft: 0x002a,
+  AltLeft: 0x0038,
+  MetaLeft: 0xe05b,
+  ControlRight: 0xe01d,
+  ShiftRight: 0x0036,
+  AltRight: 0xe038,
+  MetaRight: 0xe05c,
+  CapsLock: 0x003a,
+  NumLock: 0xe045,
+  Insert: 0xe052,
+  Delete: 0xe053,
+  Home: 0xe047,
+  End: 0xe04f,
+  PageUp: 0xe049,
+  PageDown: 0xe051,
+  PrintScreen: 0xe037,
+  ScrollLock: 0x0046,
+  Pause: 0x0045,
+  ContextMenu: 0xe05d,
+  Numpad0: 0x0052,
+  Numpad1: 0x004f,
+  Numpad2: 0x0050,
+  Numpad3: 0x0051,
+  Numpad4: 0x004b,
+  Numpad5: 0x004c,
+  Numpad6: 0x004d,
+  Numpad7: 0x0047,
+  Numpad8: 0x0048,
+  Numpad9: 0x0049,
+  NumpadAdd: 0x004e,
+  NumpadSubtract: 0x004a,
+  NumpadMultiply: 0x0037,
+  NumpadDivide: 0xe035,
+  NumpadDecimal: 0x0053,
+  NumpadEnter: 0xe01c,
+  NumpadEqual: 0x0059,
+  NumpadComma: 0x007e,
+};
+
+const specialVirtualKeyByCode: Record<string, number> = {
+  Enter: 0x0d,
+  Escape: 0x1b,
+  Backspace: 0x08,
+  Tab: 0x09,
+  Space: 0x20,
+  Minus: 0xbd,
+  Equal: 0xbb,
+  BracketLeft: 0xdb,
+  BracketRight: 0xdd,
+  Backslash: 0xdc,
+  IntlBackslash: 0xe2,
+  IntlRo: 0xc1,
+  IntlYen: 0xdc,
+  Semicolon: 0xba,
+  Quote: 0xde,
+  Backquote: 0xc0,
+  Comma: 0xbc,
+  Period: 0xbe,
+  Slash: 0xbf,
+  ArrowRight: 0x27,
+  ArrowLeft: 0x25,
+  ArrowDown: 0x28,
+  ArrowUp: 0x26,
+  ControlLeft: 0xa2,
+  ShiftLeft: 0xa0,
+  AltLeft: 0xa4,
+  MetaLeft: 0x5b,
+  ControlRight: 0xa3,
+  ShiftRight: 0xa1,
+  AltRight: 0xa5,
+  MetaRight: 0x5c,
+  CapsLock: 0x14,
+  NumLock: 0x90,
+  Insert: 0x2d,
+  Delete: 0x2e,
+  Home: 0x24,
+  End: 0x23,
+  PageUp: 0x21,
+  PageDown: 0x22,
+  PrintScreen: 0x2c,
+  ScrollLock: 0x91,
+  Pause: 0x13,
+  ContextMenu: 0x5d,
+  NumpadAdd: 0x6b,
+  NumpadSubtract: 0x6d,
+  NumpadMultiply: 0x6a,
+  NumpadDivide: 0x6f,
+  NumpadDecimal: 0x6e,
+  NumpadEnter: 0x0d,
+  NumpadEqual: 0xbb,
+  NumpadComma: 0xbc,
 };
 
 const keyFallbackMap: Record<string, KeyMapping> = {
@@ -221,75 +282,218 @@ const keyFallbackMap: Record<string, KeyMapping> = {
   Esc: { vk: 0x1b, scancode: 0x0001 },
 };
 
-const baseCharKeyMap: Record<string, TextKeySpec> = {
-  " ": codeMap.Space,
-  "\n": codeMap.Enter,
-  "\r": codeMap.Enter,
-  "\t": codeMap.Tab,
-  "0": codeMap.Digit0,
-  "1": codeMap.Digit1,
-  "2": codeMap.Digit2,
-  "3": codeMap.Digit3,
-  "4": codeMap.Digit4,
-  "5": codeMap.Digit5,
-  "6": codeMap.Digit6,
-  "7": codeMap.Digit7,
-  "8": codeMap.Digit8,
-  "9": codeMap.Digit9,
-  "-": codeMap.Minus,
-  "=": codeMap.Equal,
-  "[": codeMap.BracketLeft,
-  "]": codeMap.BracketRight,
-  "\\": codeMap.Backslash,
-  ";": codeMap.Semicolon,
-  "'": codeMap.Quote,
-  "`": codeMap.Backquote,
-  ",": codeMap.Comma,
-  ".": codeMap.Period,
-  "/": codeMap.Slash,
+const baseCharCodeMap: Record<string, string> = {
+  " ": "Space",
+  "\n": "Enter",
+  "\r": "Enter",
+  "\t": "Tab",
+  "0": "Digit0",
+  "1": "Digit1",
+  "2": "Digit2",
+  "3": "Digit3",
+  "4": "Digit4",
+  "5": "Digit5",
+  "6": "Digit6",
+  "7": "Digit7",
+  "8": "Digit8",
+  "9": "Digit9",
+  "-": "Minus",
+  "=": "Equal",
+  "[": "BracketLeft",
+  "]": "BracketRight",
+  "\\": "Backslash",
+  ";": "Semicolon",
+  "'": "Quote",
+  "`": "Backquote",
+  ",": "Comma",
+  ".": "Period",
+  "/": "Slash",
 };
 
-const shiftedCharKeyMap: Record<string, TextKeySpec> = {
-  "!": { ...codeMap.Digit1, shift: true },
-  "@": { ...codeMap.Digit2, shift: true },
-  "#": { ...codeMap.Digit3, shift: true },
-  "$": { ...codeMap.Digit4, shift: true },
-  "%": { ...codeMap.Digit5, shift: true },
-  "^": { ...codeMap.Digit6, shift: true },
-  "&": { ...codeMap.Digit7, shift: true },
-  "*": { ...codeMap.Digit8, shift: true },
-  "(": { ...codeMap.Digit9, shift: true },
-  ")": { ...codeMap.Digit0, shift: true },
-  "_": { ...codeMap.Minus, shift: true },
-  "+": { ...codeMap.Equal, shift: true },
-  "{": { ...codeMap.BracketLeft, shift: true },
-  "}": { ...codeMap.BracketRight, shift: true },
-  "|": { ...codeMap.Backslash, shift: true },
-  ":": { ...codeMap.Semicolon, shift: true },
-  '"': { ...codeMap.Quote, shift: true },
-  "~": { ...codeMap.Backquote, shift: true },
-  "<": { ...codeMap.Comma, shift: true },
-  ">": { ...codeMap.Period, shift: true },
-  "?": { ...codeMap.Slash, shift: true },
+const shiftedCharCodeMap: Record<string, string> = {
+  "!": "Digit1",
+  "@": "Digit2",
+  "#": "Digit3",
+  "$": "Digit4",
+  "%": "Digit5",
+  "^": "Digit6",
+  "&": "Digit7",
+  "*": "Digit8",
+  "(": "Digit9",
+  ")": "Digit0",
+  "_": "Minus",
+  "+": "Equal",
+  "{": "BracketLeft",
+  "}": "BracketRight",
+  "|": "Backslash",
+  ":": "Semicolon",
+  '"': "Quote",
+  "~": "Backquote",
+  "<": "Comma",
+  ">": "Period",
+  "?": "Slash",
 };
 
-export function mapTextCharToKeySpec(char: string): TextKeySpec | null {
-  if (baseCharKeyMap[char]) {
-    return baseCharKeyMap[char];
+function defaultVirtualKeyFromCode(code: string): number | null {
+  if (code.startsWith("Key") && code.length === 4) {
+    return code.charCodeAt(3);
   }
 
-  if (shiftedCharKeyMap[char]) {
-    return shiftedCharKeyMap[char];
+  if (code.startsWith("Digit") && code.length === 6) {
+    return code.charCodeAt(5);
+  }
+
+  if (code.startsWith("F")) {
+    const index = Number.parseInt(code.slice(1), 10);
+    if (index >= 1 && index <= 24) {
+      return 0x70 + index - 1;
+    }
+  }
+
+  if (code.startsWith("Numpad") && code.length === 7) {
+    const digit = Number.parseInt(code.slice(6), 10);
+    if (digit >= 0 && digit <= 9) {
+      return 0x60 + digit;
+    }
+  }
+
+  return specialVirtualKeyByCode[code] ?? null;
+}
+
+function keyMappingFromCode(code: string): KeyMapping | null {
+  const scancode = scancodeByCode[code];
+  if (scancode === undefined) {
+    return null;
+  }
+
+  const vk = defaultVirtualKeyFromCode(code);
+  if (vk === null) {
+    return null;
+  }
+
+  return { vk, scancode };
+}
+
+export const codeMap: Record<string, KeyMapping> = Object.freeze(
+  Object.fromEntries(Object.keys(scancodeByCode).map((code) => [code, keyMappingFromCode(code)!])),
+) as Record<string, KeyMapping>;
+
+function virtualKeyFromKeyCode(event: KeyLike): number | null {
+  const keyCode = event.keyCode;
+  if (!Number.isInteger(keyCode) || keyCode <= 0 || keyCode === 229) {
+    return null;
+  }
+
+  switch (event.code) {
+    case "ShiftLeft":
+      return 0xa0;
+    case "ShiftRight":
+      return 0xa1;
+    case "ControlLeft":
+      return 0xa2;
+    case "ControlRight":
+      return 0xa3;
+    case "AltLeft":
+      return 0xa4;
+    case "AltRight":
+      return 0xa5;
+    case "MetaLeft":
+      return 0x5b;
+    case "MetaRight":
+      return 0x5c;
+  }
+
+  if (event.location === DOM_KEY_LOCATION_NUMPAD) {
+    if (keyCode >= 0x60 && keyCode <= 0x69) {
+      return keyCode;
+    }
+    if (keyCode === 0x0d && event.code === "NumpadEnter") {
+      return keyCode;
+    }
+  }
+
+  return keyCode;
+}
+
+function virtualKeyFromKeyValue(key: string): number | null {
+  if (key.length === 1) {
+    const codePoint = key.toUpperCase().charCodeAt(0);
+    if ((codePoint >= 0x30 && codePoint <= 0x39) || (codePoint >= 0x41 && codePoint <= 0x5a)) {
+      return codePoint;
+    }
+  }
+
+  switch (key) {
+    case "Escape":
+    case "Esc":
+      return 0x1b;
+    case "Enter":
+      return 0x0d;
+    case "Tab":
+      return 0x09;
+    case "Backspace":
+      return 0x08;
+    case " ":
+    case "Spacebar":
+      return 0x20;
+    case "ArrowLeft":
+      return 0x25;
+    case "ArrowUp":
+      return 0x26;
+    case "ArrowRight":
+      return 0x27;
+    case "ArrowDown":
+      return 0x28;
+    case "Delete":
+      return 0x2e;
+    case "Insert":
+      return 0x2d;
+    case "Home":
+      return 0x24;
+    case "End":
+      return 0x23;
+    case "PageUp":
+      return 0x21;
+    case "PageDown":
+      return 0x22;
+  }
+
+  return null;
+}
+
+function virtualKeyFromEvent(event: KeyLike): number | null {
+  if (event.code.startsWith("Key") || event.code.startsWith("Digit")) {
+    return defaultVirtualKeyFromCode(event.code);
+  }
+
+  return virtualKeyFromKeyCode(event) ?? virtualKeyFromKeyValue(event.key) ?? defaultVirtualKeyFromCode(event.code);
+}
+
+function textKeySpecFromCode(code: string, shift: boolean = false): TextKeySpec | null {
+  const mapped = keyMappingFromCode(code);
+  if (!mapped) {
+    return null;
+  }
+  return shift ? { ...mapped, shift: true } : mapped;
+}
+
+export function mapTextCharToKeySpec(char: string): TextKeySpec | null {
+  const baseCode = baseCharCodeMap[char];
+  if (baseCode) {
+    return textKeySpecFromCode(baseCode);
+  }
+
+  const shiftedCode = shiftedCharCodeMap[char];
+  if (shiftedCode) {
+    return textKeySpecFromCode(shiftedCode, true);
   }
 
   if (char >= "a" && char <= "z") {
-    const mapped = codeMap[`Key${char.toUpperCase()}`];
-    return mapped ? { ...mapped } : null;
+    return textKeySpecFromCode(`Key${char.toUpperCase()}`);
   }
 
   if (char >= "A" && char <= "Z") {
-    const mapped = codeMap[`Key${char}`];
-    return mapped ? { ...mapped, shift: true } : null;
+    return textKeySpecFromCode(`Key${char}`, true);
   }
 
   return null;
@@ -594,25 +798,28 @@ export function modifierFlags(event: KeyboardEvent): number {
 }
 
 export function mapKeyboardEvent(event: KeyboardEvent): KeyMapping | null {
-  const mapped = codeMap[event.code];
-  if (mapped) {
-    return mapped;
+  // The official GFN web client appears to forward the raw DOM key event into a lower-level
+  // virtual input controller instead of keeping a large JS `{ code -> { vk, scancode } }` table.
+  // Electron does not expose that downstream native translation layer to this renderer, so the
+  // closest behavior we can reproduce here is:
+  // 1. derive the Windows virtual-key from the DOM event itself (`keyCode`, `key`, `location`)
+  // 2. keep only a DOM `code -> scancode` lookup for the protocol field that Chromium does not expose
+  // This preserves physical-key behavior across layouts while minimizing JS-side policy.
+  const scancode =
+    (event.code ? scancodeByCode[event.code] : undefined)
+    ?? keyFallbackMap[event.key]?.scancode
+    ?? (event.key.length === 1 ? mapTextCharToKeySpec(event.key)?.scancode : undefined);
+
+  if (scancode === undefined) {
+    return null;
   }
 
-  const fallbackMapped = keyFallbackMap[event.key];
-  if (fallbackMapped) {
-    return fallbackMapped;
+  const vk = virtualKeyFromEvent(event);
+  if (vk === null) {
+    return null;
   }
 
-  const key = event.key;
-  if (key.length === 1) {
-    const textMapped = mapTextCharToKeySpec(key);
-    if (textMapped) {
-      return { vk: textMapped.vk, scancode: textMapped.scancode };
-    }
-  }
-
-  return null;
+  return { vk, scancode };
 }
 
 /**

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -23,6 +23,8 @@ import {
   normalizeToUint8,
   GAMEPAD_MAX_CONTROLLERS,
   type GamepadInput,
+  codeMap,
+  mapTextCharToKeySpec,
 } from "./inputProtocol";
 import {
   buildNvstSdp,
@@ -50,86 +52,6 @@ interface RiInputCapabilities {
   hidDeviceMask: number;
   enablePartiallyReliableTransferGamepad: number;
   enablePartiallyReliableTransferHid: number;
-}
-
-interface KeyStrokeSpec {
-  vk: number;
-  scancode: number;
-  shift?: boolean;
-}
-
-const baseCharKeyMap: Record<string, KeyStrokeSpec> = {
-  " ": { vk: 0x20, scancode: 0x2c },
-  "\n": { vk: 0x0d, scancode: 0x28 },
-  "\r": { vk: 0x0d, scancode: 0x28 },
-  "\t": { vk: 0x09, scancode: 0x2b },
-  "0": { vk: 0x30, scancode: 0x27 },
-  "1": { vk: 0x31, scancode: 0x1e },
-  "2": { vk: 0x32, scancode: 0x1f },
-  "3": { vk: 0x33, scancode: 0x20 },
-  "4": { vk: 0x34, scancode: 0x21 },
-  "5": { vk: 0x35, scancode: 0x22 },
-  "6": { vk: 0x36, scancode: 0x23 },
-  "7": { vk: 0x37, scancode: 0x24 },
-  "8": { vk: 0x38, scancode: 0x25 },
-  "9": { vk: 0x39, scancode: 0x26 },
-  "-": { vk: 0xbd, scancode: 0x2d },
-  "=": { vk: 0xbb, scancode: 0x2e },
-  "[": { vk: 0xdb, scancode: 0x2f },
-  "]": { vk: 0xdd, scancode: 0x30 },
-  "\\": { vk: 0xdc, scancode: 0x31 },
-  ";": { vk: 0xba, scancode: 0x33 },
-  "'": { vk: 0xde, scancode: 0x34 },
-  "`": { vk: 0xc0, scancode: 0x35 },
-  ",": { vk: 0xbc, scancode: 0x36 },
-  ".": { vk: 0xbe, scancode: 0x37 },
-  "/": { vk: 0xbf, scancode: 0x38 },
-};
-
-const shiftedCharKeyMap: Record<string, KeyStrokeSpec> = {
-  "!": { vk: 0x31, scancode: 0x1e, shift: true },
-  "@": { vk: 0x32, scancode: 0x1f, shift: true },
-  "#": { vk: 0x33, scancode: 0x20, shift: true },
-  "$": { vk: 0x34, scancode: 0x21, shift: true },
-  "%": { vk: 0x35, scancode: 0x22, shift: true },
-  "^": { vk: 0x36, scancode: 0x23, shift: true },
-  "&": { vk: 0x37, scancode: 0x24, shift: true },
-  "*": { vk: 0x38, scancode: 0x25, shift: true },
-  "(": { vk: 0x39, scancode: 0x26, shift: true },
-  ")": { vk: 0x30, scancode: 0x27, shift: true },
-  "_": { vk: 0xbd, scancode: 0x2d, shift: true },
-  "+": { vk: 0xbb, scancode: 0x2e, shift: true },
-  "{": { vk: 0xdb, scancode: 0x2f, shift: true },
-  "}": { vk: 0xdd, scancode: 0x30, shift: true },
-  "|": { vk: 0xdc, scancode: 0x31, shift: true },
-  ":": { vk: 0xba, scancode: 0x33, shift: true },
-  "\"": { vk: 0xde, scancode: 0x34, shift: true },
-  "~": { vk: 0xc0, scancode: 0x35, shift: true },
-  "<": { vk: 0xbc, scancode: 0x36, shift: true },
-  ">": { vk: 0xbe, scancode: 0x37, shift: true },
-  "?": { vk: 0xbf, scancode: 0x38, shift: true },
-};
-
-function mapTextCharToKeySpec(char: string): KeyStrokeSpec | null {
-  if (baseCharKeyMap[char]) {
-    return baseCharKeyMap[char];
-  }
-
-  if (shiftedCharKeyMap[char]) {
-    return shiftedCharKeyMap[char];
-  }
-
-  if (char >= "a" && char <= "z") {
-    const code = char.charCodeAt(0);
-    return { vk: code - 32, scancode: 0x04 + (code - 97) };
-  }
-
-  if (char >= "A" && char <= "Z") {
-    const code = char.charCodeAt(0);
-    return { vk: code, scancode: 0x04 + (code - 65), shift: true };
-  }
-
-  return null;
 }
 
 function hevcPreferredProfileId(colorQuality: ColorQuality): 1 | 2 {
@@ -2365,8 +2287,8 @@ export class GfnWebRtcClient {
       return false;
     }
 
-    this.sendKeyPacket(0x7c, 0x64, 0, true); // F13 down
-    window.setTimeout(() => this.sendKeyPacket(0x7c, 0x64, 0, false), 50); // F13 up
+    this.sendKeyPacket(codeMap.F13.vk, codeMap.F13.scancode, 0, true);
+    window.setTimeout(() => this.sendKeyPacket(codeMap.F13.vk, codeMap.F13.scancode, 0, false), 50);
     return true;
   }
 
@@ -2376,12 +2298,12 @@ export class GfnWebRtcClient {
     }
 
     const modifier = useMeta
-      ? { vk: 0x5b, scancode: 0xe3, flag: 0x08 } // Meta/Command
-      : { vk: 0xa2, scancode: 0xe0, flag: 0x02 }; // Ctrl
+      ? { ...codeMap.MetaLeft, flag: 0x08 }
+      : { ...codeMap.ControlLeft, flag: 0x02 };
 
     this.sendKeyPacket(modifier.vk, modifier.scancode, modifier.flag, true);
-    this.sendKeyPacket(0x56, 0x19, modifier.flag, true); // V down
-    this.sendKeyPacket(0x56, 0x19, modifier.flag, false); // V up
+    this.sendKeyPacket(codeMap.KeyV.vk, codeMap.KeyV.scancode, modifier.flag, true);
+    this.sendKeyPacket(codeMap.KeyV.vk, codeMap.KeyV.scancode, modifier.flag, false);
     this.sendKeyPacket(modifier.vk, modifier.scancode, 0, false);
     return true;
   }
@@ -2400,7 +2322,7 @@ export class GfnWebRtcClient {
       }
 
       if (key.shift) {
-        this.sendKeyPacket(0xa0, 0xe1, 0x01, true); // Shift down
+        this.sendKeyPacket(codeMap.ShiftLeft.vk, codeMap.ShiftLeft.scancode, 0x01, true);
       }
 
       const mods = key.shift ? 0x01 : 0;
@@ -2408,7 +2330,7 @@ export class GfnWebRtcClient {
       this.sendKeyPacket(key.vk, key.scancode, mods, false);
 
       if (key.shift) {
-        this.sendKeyPacket(0xa0, 0xe1, 0, false); // Shift up
+        this.sendKeyPacket(codeMap.ShiftLeft.vk, codeMap.ShiftLeft.scancode, 0, false);
       }
 
       sent++;
@@ -2735,7 +2657,7 @@ export class GfnWebRtcClient {
         || event.key === "Esc"
         || event.code === "Escape"
         || event.keyCode === 27;
-      const mapped = mapKeyboardEvent(event) ?? (isEscapeEvent ? { vk: 0x1B, scancode: 0x29 } : null);
+      const mapped = mapKeyboardEvent(event) ?? (isEscapeEvent ? codeMap.Escape : null);
 
       // Keep browser from handling held keys (for example Tab focus traversal)
       // while streaming input is active.
@@ -2791,7 +2713,7 @@ export class GfnWebRtcClient {
         || event.key === "Esc"
         || event.code === "Escape"
         || event.keyCode === 27;
-      const mapped = mapKeyboardEvent(event) ?? (isEscapeEvent ? { vk: 0x1B, scancode: 0x29 } : null);
+      const mapped = mapKeyboardEvent(event) ?? (isEscapeEvent ? codeMap.Escape : null);
       if (!mapped) {
         return;
       }
@@ -2806,8 +2728,8 @@ export class GfnWebRtcClient {
         if (wasTap && this.pressedKeys.has(0x1B)) {
           // This was a quick tap - send Escape to the stream now
           this.log("Escape tap detected - sending to stream");
-          this.sendKeyPacket(0x1B, mapped.scancode || 0x29, 0, true);
-          this.sendKeyPacket(0x1B, mapped.scancode || 0x29, 0, false);
+          this.sendKeyPacket(codeMap.Escape.vk, mapped.scancode || codeMap.Escape.scancode, 0, true);
+          this.sendKeyPacket(codeMap.Escape.vk, mapped.scancode || codeMap.Escape.scancode, 0, false);
         }
         // If hold timer was already cleared, hold completed and pointer lock was released.
         // In that case we don't send Escape to stream.
@@ -2955,7 +2877,7 @@ export class GfnWebRtcClient {
         this.log("Sending synthetic Escape (pointer lock lost by browser)");
         const escDown = this.inputEncoder.encodeKeyDown({
           keycode: 0x1B,
-          scancode: 0x29, // Escape scancode
+          scancode: codeMap.Escape.scancode,
           modifiers: 0,
           timestampUs: timestampUs(),
         });
@@ -2963,7 +2885,7 @@ export class GfnWebRtcClient {
 
         const escUp = this.inputEncoder.encodeKeyUp({
           keycode: 0x1B,
-          scancode: 0x29,
+          scancode: codeMap.Escape.scancode,
           modifiers: 0,
           timestampUs: timestampUs(),
         });

--- a/opennow-stable/tsconfig.json
+++ b/opennow-stable/tsconfig.json
@@ -20,8 +20,7 @@
       "DOM.Iterable"
     ],
     "types": [
-      "vite/client",
-      "node"
+      "vite/client"
     ],
     "skipLibCheck": true,
     "noEmit": true

--- a/opennow-stable/tsconfig.json
+++ b/opennow-stable/tsconfig.json
@@ -20,7 +20,8 @@
       "DOM.Iterable"
     ],
     "types": [
-      "vite/client"
+      "vite/client",
+      "node"
     ],
     "skipLibCheck": true,
     "noEmit": true


### PR DESCRIPTION
This PR fixes broken keyboard behavior across layouts by replacing the incorrect USB HID usage ID mappings with Windows Set-1 scancodes required by the GFN input protocol.

**`src/renderer/src/gfn/inputProtocol.ts`**:

*   Replaced `codeMap` with correct Windows Set-1/extended scancodes for letters (A–Z), digits, punctuation, navigation, and function keys.
*   Added mappings for international physical keys (`IntlBackslash`, `IntlRo`, `IntlYen`) to support non-US layouts.
*   Consolidated synthetic text injection (`mapTextCharToKeySpec`) and keyboard event mapping (`mapKeyboardEvent`) to use the shared `codeMap`, ensuring consistent scancodes for pasted text and physical presses.
*   Fixed numpad (e.g., `NumLock`, `Numpad0`) and modifier (e.g., `ShiftLeft/Right`) scancodes to match Windows scan code set 1.

**`src/renderer/src/gfn/webrtcClient.ts`**:

*   Updated AFK pulse (`sendAntiAfkPulse`), paste shortcuts (`sendPasteShortcut`), and shift handling in `sendText` to reference the shared `codeMap` instead of hardcoded values.

**Tests & Tooling**:

*   Added `src/renderer/src/gfn/inputProtocol.test.ts` with coverage for representative keys (`KeyN`, `KeyT`, `KeyZ`, `Escape`, `IntlBackslash`, numpad) and verifying code-over-key precedence.
*   Added `tsx` dependency to `devDependencies` and created `npm run test` script.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/233ab6e3-e0d8-48c2-99b8-dfbc5be605c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-61&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-61"><img alt="OPE-61 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-61"></picture></a>