### PR TITLE
Add macOS Catalina 10.15 legacy build lane

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -28,19 +28,22 @@ jobs:
         include:
           - label: windows
             os: blacksmith-4vcpu-windows-2025
-            builder_args: "--win nsis portable"
+            package_script: package:ci -- --win nsis portable
           - label: macos-x64
             os: macos-latest
-            builder_args: "--mac dmg zip --x64"
+            package_script: package:ci -- --mac dmg zip --x64
           - label: macos-arm64
             os: macos-latest
-            builder_args: "--mac dmg zip --arm64"
+            package_script: package:ci -- --mac dmg zip --arm64
+          - label: macos-catalina-x64
+            os: macos-latest
+            package_script: package:mac:catalina:ci
           - label: linux-x64
             os: blacksmith-4vcpu-ubuntu-2404
-            builder_args: "--linux AppImage deb --x64"
+            package_script: package:ci -- --linux AppImage deb --x64
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
-            builder_args: "--linux AppImage deb --arm64"
+            package_script: package:ci -- --linux AppImage deb --arm64
 
     defaults:
       run:
@@ -93,7 +96,7 @@ jobs:
         run: npm run build
 
       - name: Package installers
-        run: npx electron-builder --publish never ${{ matrix.builder_args }}
+        run: npm run ${{ matrix.package_script }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,19 +101,22 @@ jobs:
         include:
           - label: windows
             os: blacksmith-4vcpu-windows-2025
-            builder_args: "--win nsis portable"
+            package_script: package:ci -- --win nsis portable
           - label: macos-x64
             os: macos-latest
-            builder_args: "--mac dmg zip --x64"
+            package_script: package:ci -- --mac dmg zip --x64
           - label: macos-arm64
             os: macos-latest
-            builder_args: "--mac dmg zip --arm64"
+            package_script: package:ci -- --mac dmg zip --arm64
+          - label: macos-catalina-x64
+            os: macos-latest
+            package_script: package:mac:catalina:ci
           - label: linux-x64
             os: blacksmith-4vcpu-ubuntu-2404
-            builder_args: "--linux AppImage deb --x64"
+            package_script: package:ci -- --linux AppImage deb --x64
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
-            builder_args: "--linux AppImage deb --arm64"
+            package_script: package:ci -- --linux AppImage deb --arm64
 
     defaults:
       run:
@@ -169,7 +172,7 @@ jobs:
         run: npm run build
 
       - name: Package installers
-        run: npx electron-builder --publish never ${{ matrix.builder_args }}
+        run: npm run ${{ matrix.package_script }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,6 +26,7 @@ npm run dev
 npm run typecheck
 npm run build
 npm run dist
+npm run dist:mac:catalina
 ```
 
 Directly inside `opennow-stable/`:
@@ -37,6 +38,8 @@ npm run typecheck
 npm run build
 npm run dist
 npm run dist:signed
+npm run dist:mac:catalina
+npm run dist:mac:catalina:signed
 ```
 
 ## Workspace Layout
@@ -138,6 +141,20 @@ cd opennow-stable
 npm run dist:signed
 ```
 
+Catalina-compatible legacy macOS packages:
+
+```bash
+cd opennow-stable
+npm run dist:mac:catalina
+```
+
+Signed Catalina-compatible packages:
+
+```bash
+cd opennow-stable
+npm run dist:mac:catalina:signed
+```
+
 ## CI And Releases
 
 The repository includes two main GitHub Actions workflows:
@@ -147,18 +164,22 @@ The repository includes two main GitHub Actions workflows:
 
 Current build matrix:
 
-| Target | Output |
-| --- | --- |
-| Windows | NSIS installer, portable executable |
-| macOS x64 | `dmg`, `zip` |
-| macOS arm64 | `dmg`, `zip` |
-| Linux x64 | `AppImage`, `deb` |
-| Linux ARM64 | `AppImage`, `deb` |
+| Target | Packaging path | Output |
+| --- | --- | --- |
+| Windows | Main Electron line | NSIS installer, portable executable |
+| macOS x64 | Main Electron line | `OpenNOW-v${version}-mac-x64.{dmg,zip}` |
+| macOS arm64 | Main Electron line | `OpenNOW-v${version}-mac-arm64.{dmg,zip}` |
+| macOS Catalina x64 | Legacy Electron 27 packaging config with `minimumSystemVersion: 10.15.0` | `OpenNOW-v${version}-mac-catalina-x64.{dmg,zip}` |
+| Linux x64 | Main Electron line | `AppImage`, `deb` |
+| Linux ARM64 | Main Electron line | `AppImage`, `deb` |
+
+The Catalina lane reuses the same compiled application source and electron-vite build output. Only the packaging step switches to `electron-builder.catalina.json`, which pins `electronVersion` to `27.3.11` and sets the macOS minimum system version explicitly for Catalina-compatible distribution.
 
 ## Notes For Contributors
 
 - The active app is the Electron client. If you see older references to previous implementations, prefer `opennow-stable/`.
-- Root-level npm scripts are convenience wrappers around the `opennow-stable` workspace.
+- Root-level npm scripts are convenience wrappers around the `opennow-stable` workspace, including the Catalina-specific `dist:mac:catalina` packaging command.
+- `opennow-stable/electron-builder.json` is the default packaging config for current Electron builds; `opennow-stable/electron-builder.catalina.json` is the dedicated legacy macOS packaging config.
 - Before opening a PR, run `npm run typecheck` and `npm run build`.
 
 For contribution workflow details, see [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md).

--- a/opennow-stable/electron-builder.base.json
+++ b/opennow-stable/electron-builder.base.json
@@ -1,0 +1,52 @@
+{
+  "appId": "com.zortos.opennow.stable",
+  "productName": "OpenNOW",
+  "publish": [
+    {
+      "provider": "github",
+      "owner": "OpenCloudGaming",
+      "repo": "OpenNOW"
+    }
+  ],
+  "icon": "../logo.png",
+  "npmRebuild": false,
+  "nodeGypRebuild": false,
+  "buildDependenciesFromSource": false,
+  "directories": {
+    "output": "dist-release"
+  },
+  "files": [
+    "dist/**",
+    "dist-electron/**",
+    "package.json"
+  ],
+  "asar": true,
+  "win": {
+    "target": [
+      "nsis",
+      "portable"
+    ]
+  },
+  "nsis": {
+    "artifactName": "OpenNOW-v${version}-setup-${arch}.${ext}"
+  },
+  "portable": {
+    "artifactName": "OpenNOW-v${version}-portable-${arch}.${ext}"
+  },
+  "mac": {
+    "target": [
+      "dmg",
+      "zip"
+    ],
+    "category": "public.app-category.games"
+  },
+  "linux": {
+    "target": [
+      "AppImage",
+      "deb"
+    ],
+    "category": "Game",
+    "maintainer": "zortos293 <zortos293@users.noreply.github.com>",
+    "artifactName": "OpenNOW-v${version}-linux-${arch}.${ext}"
+  }
+}

--- a/opennow-stable/electron-builder.catalina.json
+++ b/opennow-stable/electron-builder.catalina.json
@@ -2,6 +2,11 @@
   "extends": "./electron-builder.base.json",
   "electronVersion": "27.3.11",
   "mac": {
+    "target": [
+      "dmg",
+      "zip"
+    ],
+    "category": "public.app-category.games",
     "minimumSystemVersion": "10.15.0",
     "artifactName": "OpenNOW-v${version}-mac-catalina-x64.${ext}"
   }

--- a/opennow-stable/electron-builder.catalina.json
+++ b/opennow-stable/electron-builder.catalina.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./electron-builder.base.json",
+  "electronVersion": "27.3.11",
+  "mac": {
+    "minimumSystemVersion": "10.15.0",
+    "artifactName": "OpenNOW-v${version}-mac-catalina-x64.${ext}"
+  }
+}

--- a/opennow-stable/electron-builder.json
+++ b/opennow-stable/electron-builder.json
@@ -1,6 +1,11 @@
 {
   "extends": "./electron-builder.base.json",
   "mac": {
+    "target": [
+      "dmg",
+      "zip"
+    ],
+    "category": "public.app-category.games",
     "artifactName": "OpenNOW-v${version}-mac-${arch}.${ext}"
   }
 }

--- a/opennow-stable/electron-builder.json
+++ b/opennow-stable/electron-builder.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./electron-builder.base.json",
+  "mac": {
+    "artifactName": "OpenNOW-v${version}-mac-${arch}.${ext}"
+  }
+}

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -18,8 +18,14 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
-    "dist": "npm run build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
-    "dist:signed": "npm run build && electron-builder",
+    "package:ci": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --publish never --config electron-builder.json",
+    "package:signed": "electron-builder --config electron-builder.json",
+    "package:mac:catalina:ci": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --publish never --config electron-builder.catalina.json --mac dmg zip --x64",
+    "package:mac:catalina:signed": "electron-builder --config electron-builder.catalina.json --mac dmg zip --x64",
+    "dist": "npm run build && npm run package:ci",
+    "dist:signed": "npm run build && npm run package:signed",
+    "dist:mac:catalina": "npm run build && npm run package:mac:catalina:ci",
+    "dist:mac:catalina:signed": "npm run build && npm run package:mac:catalina:signed",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json",
     "test": "tsx --test src/renderer/src/gfn/inputProtocol.test.ts"
   },
@@ -45,58 +51,5 @@
     "tsx": "^4.20.6",
     "typescript": "^6.0.2",
     "vite": "^7.3.1"
-  },
-  "build": {
-    "appId": "com.zortos.opennow.stable",
-    "productName": "OpenNOW",
-    "publish": [
-      {
-        "provider": "github",
-        "owner": "OpenCloudGaming",
-        "repo": "OpenNOW"
-      }
-    ],
-    "icon": "../logo.png",
-    "npmRebuild": false,
-    "nodeGypRebuild": false,
-    "buildDependenciesFromSource": false,
-    "directories": {
-      "output": "dist-release"
-    },
-    "files": [
-      "dist/**",
-      "dist-electron/**",
-      "package.json"
-    ],
-    "asar": true,
-    "win": {
-      "target": [
-        "nsis",
-        "portable"
-      ]
-    },
-    "nsis": {
-      "artifactName": "OpenNOW-v${version}-setup-${arch}.${ext}"
-    },
-    "portable": {
-      "artifactName": "OpenNOW-v${version}-portable-${arch}.${ext}"
-    },
-    "mac": {
-      "target": [
-        "dmg",
-        "zip"
-      ],
-      "category": "public.app-category.games",
-      "artifactName": "OpenNOW-v${version}-mac-${arch}.${ext}"
-    },
-    "linux": {
-      "target": [
-        "AppImage",
-        "deb"
-      ],
-      "category": "Game",
-      "maintainer": "zortos293 <zortos293@users.noreply.github.com>",
-      "artifactName": "OpenNOW-v${version}-linux-${arch}.${ext}"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "npm --prefix opennow-stable run build",
     "typecheck": "npm --prefix opennow-stable run typecheck",
     "dist": "npm --prefix opennow-stable run dist",
-    "dist:signed": "npm --prefix opennow-stable run dist:signed"
+    "dist:signed": "npm --prefix opennow-stable run dist:signed",
+    "dist:mac:catalina": "npm --prefix opennow-stable run dist:mac:catalina",
+    "dist:mac:catalina:signed": "npm --prefix opennow-stable run dist:mac:catalina:signed"
   }
 }


### PR DESCRIPTION
This PR introduces a dedicated macOS 10.15 Catalina build variant that packages the application with Electron 27.3.11 while preserving the same source codebase as the main Electron 41 builds. Catalina artifacts are clearly distinguished in naming to prevent confusion with regular macOS x64 builds.

**Packaging Configuration**:

- Split electron-builder config from `package.json` into standalone files: `electron-builder.base.json`, `electron-builder.json`, and `electron-builder.catalina.json`.
- `electron-builder.catalina.json` pins `electronVersion` to `27.3.11` and sets `mac.minimumSystemVersion` to `10.15.0`.
- Main builds continue using the Electron 41 line via `electron-builder.json`.

**CI Workflows**:

- Added `macos-catalina-x64` matrix entry to `.github/workflows/auto-build.yml` and `.github/workflows/release.yml`.
- Switched packaging execution from inline `npx electron-builder` commands to explicit npm scripts for clarity.
- Catalina lane runs the same build output (`npm run build`) but packages with the legacy config.

**Scripts and Naming**:

- Added `dist:mac:catalina`/`dist:mac:catalina:signed` scripts in `opennow-stable/package.json` and root `package.json`.
- Catalina artifacts are named `OpenNOW-v${version}-mac-catalina-x64.{dmg,zip}` for explicit versioning.

**Compatibility**:

- No source code changes required; existing `session.setPermissionRequestHandler` and media access APIs are compatible with Electron 27.

<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/task/bbc52b98-2388-4c0b-9949-dc4c64948979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-64&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-64"><img alt="OPE-64 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=OPE-64"></picture></a>