### PR TITLE
Fix library search empty-state message to use consistent wording

### DIFF
--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -101,7 +101,7 @@ export function LibraryPage({
         ) : games.length === 0 ? (
           <div className="library-empty-state">
             <Search className="library-empty-icon" size={44} />
-            <h3>No results</h3>
+            <h3>No games found</h3>
             <p>No games match &ldquo;{searchQuery}&rdquo;</p>
           </div>
         ) : (


### PR DESCRIPTION
## Description

This PR aligns the Library search empty-state message with the Catalog/Store page terminology.

**Change**:
- Updated `opennow-stable/src/renderer/src/components/LibraryPage.tsx`: Changed search result empty heading from "No results" to "No games found"

When users search their library with no matches, the message now reads "No games found" instead of "No results", matching the wording used in the Catalog tab and resolving the inconsistency reported in issue #313.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/982fe26f-98ed-4247-a946-4455c78d59dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-064" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/982fe26f-98ed-4247-a946-4455c78d59dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-064&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-064"><img alt="OPE-064" src="https://capy.ai/api/badge/thread.svg?label=OPE-064"></picture></a>
<!-- capy-pr-badge:end -->