### PR TITLE
Add setting to hide Anti-AFK stream indicator

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -57,6 +57,8 @@ export interface Settings {
   microphoneDeviceId: string;
   /** Hide stream buttons (mic/fullscreen/end-session) while streaming */
   hideStreamButtons: boolean;
+  /** Show the Anti-AFK indicator badge while streaming */
+  showAntiAfkIndicator: boolean;
   /** Show the stats overlay automatically when a stream launches */
   showStatsOnLaunch: boolean;
   /** Enable controller-first media bar layout for library browsing */
@@ -122,6 +124,7 @@ const DEFAULT_SETTINGS: Settings = {
   microphoneMode: "disabled",
   microphoneDeviceId: "",
   hideStreamButtons: false,
+  showAntiAfkIndicator: true,
   showStatsOnLaunch: false,
   controllerMode: false,
   controllerUiSounds: false,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -830,6 +830,7 @@ export function App(): JSX.Element {
     microphoneMode: "disabled",
     microphoneDeviceId: "",
     hideStreamButtons: false,
+    showAntiAfkIndicator: true,
     showStatsOnLaunch: false,
     controllerMode: false,
     controllerUiSounds: false,
@@ -3326,6 +3327,7 @@ export function App(): JSX.Element {
             hideStreamButtons={settings.hideStreamButtons}
             serverRegion={session?.serverIp}
             antiAfkEnabled={antiAfkEnabled}
+            showAntiAfkIndicator={settings.showAntiAfkIndicator}
             escHoldReleaseIndicator={escHoldReleaseIndicator}
             exitPrompt={exitPrompt}
             sessionStartedAtMs={sessionStartedAtMs}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -2382,6 +2382,21 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
 
                   <div className="settings-row">
                     <label className="settings-label">
+                      Show Anti-AFK Indicator
+                      <span className="settings-hint">Show the ANTI-AFK ON badge while Anti-AFK is enabled during streaming.</span>
+                    </label>
+                    <label className="settings-toggle">
+                      <input
+                        type="checkbox"
+                        checked={settings.showAntiAfkIndicator}
+                        onChange={(e) => handleChange("showAntiAfkIndicator", e.target.checked)}
+                      />
+                      <span className="settings-toggle-track" />
+                    </label>
+                  </div>
+
+                  <div className="settings-row">
+                    <label className="settings-label">
                       Auto Full Screen
                       <span className="settings-hint">Automatically enter fullscreen when connecting to or starting a session.</span>
                     </label>

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -30,6 +30,7 @@ interface StreamViewProps {
   hideStreamButtons?: boolean;
   serverRegion?: string;
   antiAfkEnabled: boolean;
+  showAntiAfkIndicator: boolean;
   escHoldReleaseIndicator: {
     visible: boolean;
     progress: number;
@@ -301,13 +302,13 @@ function ControllerIndicator({
 
 function MicrophoneIndicator({
   diagnosticsStore,
-  antiAfkEnabled,
+  showAntiAfkIndicator,
   hideStreamButtons,
   isConnecting,
   onToggleMicrophone,
 }: {
   diagnosticsStore: StreamDiagnosticsStore;
-  antiAfkEnabled: boolean;
+  showAntiAfkIndicator: boolean;
   hideStreamButtons: boolean;
   isConnecting: boolean;
   onToggleMicrophone?: () => void;
@@ -331,7 +332,7 @@ function MicrophoneIndicator({
   return (
     <button
       type="button"
-      className={`sv-mic${connectedGamepads > 0 || antiAfkEnabled ? " sv-mic--stacked" : ""}`}
+      className={`sv-mic${connectedGamepads > 0 || showAntiAfkIndicator ? " sv-mic--stacked" : ""}`}
       onClick={onToggleMicrophone}
       data-enabled={micEnabled}
       title={micEnabled ? "Mute microphone" : "Unmute microphone"}
@@ -346,10 +347,12 @@ function MicrophoneIndicator({
 function AntiAfkIndicator({
   diagnosticsStore,
   antiAfkEnabled,
+  showAntiAfkIndicator,
   isConnecting,
 }: {
   diagnosticsStore: StreamDiagnosticsStore;
   antiAfkEnabled: boolean;
+  showAntiAfkIndicator: boolean;
   isConnecting: boolean;
 }): JSX.Element | null {
   const hasController = useStreamDiagnosticsSelector(
@@ -357,7 +360,7 @@ function AntiAfkIndicator({
     (stats) => stats.connectedGamepads > 0,
   );
 
-  if (!antiAfkEnabled || isConnecting) {
+  if (!antiAfkEnabled || !showAntiAfkIndicator || isConnecting) {
     return null;
   }
 
@@ -371,7 +374,7 @@ function AntiAfkIndicator({
 
 function RecordingIndicator({
   diagnosticsStore,
-  antiAfkEnabled,
+  showAntiAfkIndicator,
   hideStreamButtons,
   isConnecting,
   isRecording,
@@ -379,7 +382,7 @@ function RecordingIndicator({
   recordingDurationMs,
 }: {
   diagnosticsStore: StreamDiagnosticsStore;
-  antiAfkEnabled: boolean;
+  showAntiAfkIndicator: boolean;
   hideStreamButtons: boolean;
   isConnecting: boolean;
   isRecording: boolean;
@@ -396,7 +399,7 @@ function RecordingIndicator({
   );
   const hasMicrophone = micState === "started" || micState === "stopped";
   const showMicIndicator = hasMicrophone && !isConnecting && !hideStreamButtons && Boolean(onToggleMicrophone);
-  const stackedBadges = [connectedGamepads > 0, antiAfkEnabled, showMicIndicator].filter(Boolean).length;
+  const stackedBadges = [connectedGamepads > 0, showAntiAfkIndicator, showMicIndicator].filter(Boolean).length;
 
   if (!isRecording || isConnecting) {
     return null;
@@ -643,6 +646,7 @@ export function StreamView({
   shortcuts,
   serverRegion,
   antiAfkEnabled,
+  showAntiAfkIndicator,
   escHoldReleaseIndicator,
   exitPrompt,
   sessionStartedAtMs,
@@ -1953,7 +1957,7 @@ export function StreamView({
       {/* Microphone toggle button (top-left, below controller badge when present) */}
       <MicrophoneIndicator
         diagnosticsStore={diagnosticsStore}
-        antiAfkEnabled={antiAfkEnabled}
+        showAntiAfkIndicator={antiAfkEnabled && showAntiAfkIndicator}
         hideStreamButtons={hideStreamButtons}
         isConnecting={isConnecting}
         onToggleMicrophone={onToggleMicrophone}
@@ -1963,13 +1967,14 @@ export function StreamView({
       <AntiAfkIndicator
         diagnosticsStore={diagnosticsStore}
         antiAfkEnabled={antiAfkEnabled}
+        showAntiAfkIndicator={showAntiAfkIndicator}
         isConnecting={isConnecting}
       />
 
       {/* Recording indicator (top-left, stacked below other badges) */}
       <RecordingIndicator
         diagnosticsStore={diagnosticsStore}
-        antiAfkEnabled={antiAfkEnabled}
+        showAntiAfkIndicator={antiAfkEnabled && showAntiAfkIndicator}
         hideStreamButtons={hideStreamButtons}
         isConnecting={isConnecting}
         isRecording={isRecording}

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -150,6 +150,7 @@ export interface Settings {
   microphoneMode: MicrophoneMode;
   microphoneDeviceId: string;
   hideStreamButtons: boolean;
+  showAntiAfkIndicator: boolean;
   showStatsOnLaunch: boolean;
   controllerMode: boolean;
   controllerUiSounds: boolean;


### PR DESCRIPTION
This PR adds a persisted user setting to hide the on-stream Anti-AFK indicator badge without changing Anti-AFK behavior or shortcut functionality. The setting defaults to `true` to preserve existing behavior.

**Shared & Main**:
- Add `showAntiAfkIndicator: boolean` to the `Settings` interface in `src/shared/gfn.ts`
- Add the field to `src/main/settings.ts` with default `true` and proper JSDoc comment

**Renderer**:
- Add `showAntiAfkIndicator` to initial settings state in `src/renderer/src/App.tsx`
- Pass the setting through to `StreamView` as a prop

**Settings UI**:
- Add toggle in Settings → Interface/Appearance section in `src/renderer/src/components/SettingsPage.tsx`
- Positioned alongside existing stream UI toggles (Hide Stream Overlay Buttons, Show Stats on Stream Launch)

**Stream View**:
- Update `AntiAfkIndicator` component to check both `antiAfkEnabled` and `showAntiAfkIndicator` before rendering
- Update `MicrophoneIndicator` and `RecordingIndicator` to use `showAntiAfkIndicator` for badge stacking logic
- Anti-AFK pulse behavior and shortcut toggling remain unchanged

**Validation**:
- Typecheck and build pass with no errors (`npm run typecheck && npm run build`)

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/3f2e4aba-5a01-4348-bdf0-d938251a61d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-062" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/3f2e4aba-5a01-4348-bdf0-d938251a61d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-062&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-062"><img alt="OPE-062" src="https://capy.ai/api/badge/thread.svg?label=OPE-062"></picture></a>
<!-- capy-pr-badge:end -->