### PR TITLE
Add navbar terminate action for active cloud sessions

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -1177,6 +1177,7 @@ export async function getActiveSessions(
         appId,
         gpuType: s.gpuType,
         status: s.status,
+        streamingBaseUrl: base,
         serverIp,
         signalingUrl,
         resolution,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -16,6 +16,7 @@ import type {
   SessionAdInfo,
   SessionAdState,
   SessionInfo,
+  SessionStopRequest,
   Settings,
   SubscriptionInfo,
   StreamRegion,
@@ -873,6 +874,7 @@ export function App(): JSX.Element {
   const [queuePosition, setQueuePosition] = useState<number | undefined>();
   const [navbarActiveSession, setNavbarActiveSession] = useState<ActiveSessionInfo | null>(null);
   const [isResumingNavbarSession, setIsResumingNavbarSession] = useState(false);
+  const [isTerminatingNavbarSession, setIsTerminatingNavbarSession] = useState(false);
   const [launchError, setLaunchError] = useState<LaunchErrorState | null>(null);
   const [queueModalGame, setQueueModalGame] = useState<GameInfo | null>(null);
   const [queueModalData, setQueueModalData] = useState<PrintedWasteQueueData | null>(null);
@@ -907,6 +909,7 @@ export function App(): JSX.Element {
   const controllerOverlayOpenRef = useRef(false);
   const codecTestPromiseRef = useRef<Promise<CodecTestResult[] | null> | null>(null);
   const codecStartupTestAttemptedRef = useRef(false);
+  const navbarSessionActionInFlightRef = useRef<"resume" | "terminate" | null>(null);
 
   const resetStatsOverlayToPreference = useCallback((): void => {
     setShowStatsOverlay(settings.showStatsOnLaunch);
@@ -1722,6 +1725,29 @@ export function App(): JSX.Element {
     return findSessionContextForAppId(allKnownGames, variantByGameId, activeSession.appId);
   }, [allKnownGames, variantByGameId]);
 
+  const stopSessionByTarget = useCallback(async (
+    target: Pick<SessionStopRequest, "sessionId" | "zone" | "streamingBaseUrl" | "serverIp" | "clientId" | "deviceId"> | null | undefined,
+  ): Promise<boolean> => {
+    if (!target) {
+      return false;
+    }
+    const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
+    if (!token) {
+      console.warn("Skipping session stop: missing auth token");
+      return false;
+    }
+    await window.openNow.stopSession({
+      token,
+      streamingBaseUrl: target.streamingBaseUrl,
+      serverIp: target.serverIp,
+      zone: target.zone,
+      sessionId: target.sessionId,
+      clientId: target.clientId,
+      deviceId: target.deviceId,
+    });
+    return true;
+  }, [authSession]);
+
   useEffect(() => {
     if (!startupRefreshNotice) return;
     const timer = window.setTimeout(() => setStartupRefreshNotice(null), 7000);
@@ -2517,10 +2543,11 @@ export function App(): JSX.Element {
       bypass: options?.bypassGuards ?? false,
     });
 
-    if (!options?.bypassGuards && (launchInFlightRef.current || streamStatus !== "idle")) {
+    if (!options?.bypassGuards && (launchInFlightRef.current || streamStatus !== "idle" || navbarSessionActionInFlightRef.current)) {
       console.warn("Ignoring play request: launch already in progress or stream not idle", {
         inFlight: launchInFlightRef.current,
         streamStatus,
+        navbarSessionAction: navbarSessionActionInFlightRef.current,
       });
       return;
     }
@@ -2879,13 +2906,20 @@ export function App(): JSX.Element {
   }, []);
 
   const handleResumeFromNavbar = useCallback(async () => {
-    if (!selectedProvider || !navbarActiveSession || isResumingNavbarSession) {
+    if (
+      !selectedProvider
+      || !navbarActiveSession
+      || isResumingNavbarSession
+      || isTerminatingNavbarSession
+      || navbarSessionActionInFlightRef.current
+    ) {
       return;
     }
     if (launchInFlightRef.current || streamStatus !== "idle") {
       return;
     }
 
+    navbarSessionActionInFlightRef.current = "resume";
     launchInFlightRef.current = true;
     setIsResumingNavbarSession(true);
     let loadingStep: StreamLoadingStatus = "setup";
@@ -2921,11 +2955,13 @@ export function App(): JSX.Element {
       resetLaunchRuntime({ keepLaunchError: true });
       void refreshNavbarActiveSession();
     } finally {
+      navbarSessionActionInFlightRef.current = null;
       launchInFlightRef.current = false;
       setIsResumingNavbarSession(false);
     }
   }, [
     claimAndConnectSession,
+    isTerminatingNavbarSession,
     isResumingNavbarSession,
     navbarActiveSession,
     findGameContextForSession,
@@ -2933,6 +2969,52 @@ export function App(): JSX.Element {
     resetLaunchRuntime,
     resetStatsOverlayToPreference,
     selectedProvider,
+    streamStatus,
+  ]);
+
+  const handleTerminateNavbarSession = useCallback(async () => {
+    if (
+      !navbarActiveSession
+      || isResumingNavbarSession
+      || isTerminatingNavbarSession
+      || navbarSessionActionInFlightRef.current
+    ) {
+      return;
+    }
+    if (launchInFlightRef.current || streamStatus !== "idle") {
+      return;
+    }
+
+    const activeSessionTitle = gameTitleByAppId.get(navbarActiveSession.appId)?.trim() || "this session";
+    if (!window.confirm(`Terminate ${activeSessionTitle}? This will end the active cloud session immediately.`)) {
+      return;
+    }
+
+    navbarSessionActionInFlightRef.current = "terminate";
+    setIsTerminatingNavbarSession(true);
+    try {
+      await stopSessionByTarget({
+        sessionId: navbarActiveSession.sessionId,
+        zone: "",
+        streamingBaseUrl: navbarActiveSession.streamingBaseUrl ?? (effectiveStreamingBaseUrl || undefined),
+        serverIp: navbarActiveSession.serverIp,
+      });
+      setNavbarActiveSession(null);
+    } catch (error) {
+      console.error("Navbar terminate failed:", error);
+    } finally {
+      navbarSessionActionInFlightRef.current = null;
+      setIsTerminatingNavbarSession(false);
+      void refreshNavbarActiveSession();
+    }
+  }, [
+    effectiveStreamingBaseUrl,
+    gameTitleByAppId,
+    isResumingNavbarSession,
+    isTerminatingNavbarSession,
+    navbarActiveSession,
+    refreshNavbarActiveSession,
+    stopSessionByTarget,
     streamStatus,
   ]);
 
@@ -2948,9 +3030,7 @@ export function App(): JSX.Element {
 
       const current = sessionRef.current;
       if (current) {
-        const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
-        await window.openNow.stopSession({
-          token: token || undefined,
+        await stopSessionByTarget({
           streamingBaseUrl: current.streamingBaseUrl,
           serverIp: current.serverIp,
           zone: current.zone,
@@ -2969,7 +3049,7 @@ export function App(): JSX.Element {
     } catch (error) {
       console.error("Stop failed:", error);
     }
-  }, [authSession, endPlaytimeSession, refreshNavbarActiveSession, resetLaunchRuntime, resolveExitPrompt, streamingGame]);
+  }, [endPlaytimeSession, refreshNavbarActiveSession, resetLaunchRuntime, resolveExitPrompt, stopSessionByTarget, streamingGame]);
 
   const handleSwitchGame = useCallback(async (game: GameInfo) => {
     setControllerOverlayOpen(false);
@@ -3562,8 +3642,12 @@ export function App(): JSX.Element {
           activeSession={navbarActiveSession}
           activeSessionGameTitle={activeSessionGameTitle}
           isResumingSession={isResumingNavbarSession}
+          isTerminatingSession={isTerminatingNavbarSession}
           onResumeSession={() => {
             void handleResumeFromNavbar();
+          }}
+          onTerminateSession={() => {
+            void handleTerminateNavbarSession();
           }}
           onLogout={handleLogout}
         />

--- a/opennow-stable/src/renderer/src/components/Navbar.tsx
+++ b/opennow-stable/src/renderer/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import type { ActiveSessionInfo, AuthUser, SubscriptionInfo } from "@shared/gfn";
-import { House, Library, Settings, User, LogOut, Zap, Timer, HardDrive, X, Loader2, PlayCircle } from "lucide-react";
+import { House, Library, Settings, User, LogOut, Zap, Timer, HardDrive, X, Loader2, PlayCircle, Square } from "lucide-react";
 import { useEffect, useState, type JSX } from "react";
 import { createPortal } from "react-dom";
 
@@ -11,7 +11,9 @@ interface NavbarProps {
   activeSession: ActiveSessionInfo | null;
   activeSessionGameTitle: string | null;
   isResumingSession: boolean;
+  isTerminatingSession: boolean;
   onResumeSession: () => void;
+  onTerminateSession: () => void;
   onLogout: () => void;
 }
 
@@ -32,7 +34,9 @@ export function Navbar({
   activeSession,
   activeSessionGameTitle,
   isResumingSession,
+  isTerminatingSession,
   onResumeSession,
+  onTerminateSession,
   onLogout,
 }: NavbarProps): JSX.Element {
   const [modalType, setModalType] = useState<NavbarModalType>(null);
@@ -273,23 +277,39 @@ export function Navbar({
 
       <div className="navbar-right">
         {activeSession && (
-          <button
-            type="button"
-            className={`navbar-session-resume${isResumingSession ? " is-loading" : ""}`}
-            title={
-              activeSession.serverIp
-                ? activeSessionTitle
-                  ? `Resume active cloud session: ${activeSessionTitle}`
-                  : "Resume active cloud session"
-                : "Active session found (missing server address)"
-            }
-            onClick={onResumeSession}
-            disabled={isResumingSession || !activeSession.serverIp}
-          >
-            {isResumingSession ? <Loader2 size={14} className="navbar-session-resume-spin" /> : <PlayCircle size={14} />}
-            <span className="navbar-session-resume-text">Resume</span>
-            {activeSessionTitle && <span className="navbar-session-resume-game">{activeSessionTitle}</span>}
-          </button>
+          <div className="navbar-session-actions">
+            <button
+              type="button"
+              className={`navbar-session-resume${isResumingSession ? " is-loading" : ""}`}
+              title={
+                activeSession.serverIp
+                  ? activeSessionTitle
+                    ? `Resume active cloud session: ${activeSessionTitle}`
+                    : "Resume active cloud session"
+                  : "Active session found (missing server address)"
+              }
+              onClick={onResumeSession}
+              disabled={isResumingSession || isTerminatingSession || !activeSession.serverIp}
+            >
+              {isResumingSession ? <Loader2 size={14} className="navbar-session-resume-spin" /> : <PlayCircle size={14} />}
+              <span className="navbar-session-resume-text">Resume</span>
+              {activeSessionTitle && <span className="navbar-session-resume-game">{activeSessionTitle}</span>}
+            </button>
+            <button
+              type="button"
+              className={`navbar-session-terminate${isTerminatingSession ? " is-loading" : ""}`}
+              title={
+                activeSessionTitle
+                  ? `Terminate active cloud session: ${activeSessionTitle}`
+                  : "Terminate active cloud session"
+              }
+              onClick={onTerminateSession}
+              disabled={isResumingSession || isTerminatingSession}
+            >
+              {isTerminatingSession ? <Loader2 size={14} className="navbar-session-resume-spin" /> : <Square size={12} />}
+              <span className="navbar-session-terminate-text">Terminate</span>
+            </button>
+          </div>
         )}
         {(timeLabel || storageLabel) && (
           <div className="navbar-subscription" aria-label="Subscription details">

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -472,23 +472,20 @@ body,
   z-index: 2;
 }
 
-.navbar-session-resume {
+.navbar-session-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.navbar-session-resume,
+.navbar-session-terminate {
   display: inline-flex;
   align-items: center;
   justify-content: flex-start;
   gap: 7px;
-  width: 210px;
-  min-width: 210px;
   padding: 6px 10px;
-  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--panel-border));
   border-radius: var(--r-full);
-  background:
-    linear-gradient(160deg, rgba(88, 217, 138, 0.26), rgba(88, 217, 138, 0.08)),
-    linear-gradient(180deg, rgba(15, 24, 19, 0.95), rgba(10, 12, 11, 0.92));
-  box-shadow:
-    0 6px 20px rgba(88, 217, 138, 0.16),
-    0 0 0 1px rgba(88, 217, 138, 0.14) inset;
-  color: #d7ffe8;
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.01em;
@@ -499,26 +496,50 @@ body,
     transform var(--t-fast),
     border-color var(--t-fast),
     box-shadow var(--t-fast),
-    filter var(--t-fast);
+    filter var(--t-fast),
+    background var(--t-fast),
+    color var(--t-fast);
   overflow: hidden;
 }
 
-.navbar-session-resume:hover:not(:disabled) {
+.navbar-session-resume {
+  width: 210px;
+  min-width: 210px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--panel-border));
+  background:
+    linear-gradient(160deg, rgba(88, 217, 138, 0.26), rgba(88, 217, 138, 0.08)),
+    linear-gradient(180deg, rgba(15, 24, 19, 0.95), rgba(10, 12, 11, 0.92));
+  box-shadow:
+    0 6px 20px rgba(88, 217, 138, 0.16),
+    0 0 0 1px rgba(88, 217, 138, 0.14) inset;
+  color: #d7ffe8;
+}
+
+.navbar-session-resume:hover:not(:disabled),
+.navbar-session-terminate:hover:not(:disabled) {
   transform: translateY(-1px);
+}
+
+.navbar-session-resume:hover:not(:disabled) {
   border-color: color-mix(in srgb, var(--accent) 75%, var(--panel-border));
   box-shadow:
     0 10px 28px rgba(88, 217, 138, 0.24),
     0 0 0 1px rgba(88, 217, 138, 0.24) inset;
 }
 
-.navbar-session-resume:focus-visible {
+.navbar-session-resume:focus-visible,
+.navbar-session-terminate:focus-visible {
   outline: none;
+}
+
+.navbar-session-resume:focus-visible {
   box-shadow:
     0 0 0 2px rgba(88, 217, 138, 0.24),
     0 10px 28px rgba(88, 217, 138, 0.24);
 }
 
-.navbar-session-resume:disabled {
+.navbar-session-resume:disabled,
+.navbar-session-terminate:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   filter: grayscale(0.1);
@@ -542,11 +563,41 @@ body,
   white-space: nowrap;
 }
 
+.navbar-session-terminate {
+  min-width: 104px;
+  border: 1px solid color-mix(in srgb, var(--error) 42%, var(--panel-border));
+  background:
+    linear-gradient(160deg, rgba(248, 113, 113, 0.2), rgba(248, 113, 113, 0.06)),
+    linear-gradient(180deg, rgba(28, 16, 16, 0.95), rgba(12, 10, 10, 0.92));
+  box-shadow:
+    0 6px 20px rgba(248, 113, 113, 0.12),
+    0 0 0 1px rgba(248, 113, 113, 0.12) inset;
+  color: #ffdada;
+}
+
+.navbar-session-terminate:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--error) 72%, var(--panel-border));
+  box-shadow:
+    0 10px 24px rgba(248, 113, 113, 0.18),
+    0 0 0 1px rgba(248, 113, 113, 0.18) inset;
+}
+
+.navbar-session-terminate:focus-visible {
+  box-shadow:
+    0 0 0 2px rgba(248, 113, 113, 0.22),
+    0 10px 24px rgba(248, 113, 113, 0.18);
+}
+
+.navbar-session-terminate-text {
+  color: #ffe7e7;
+}
+
 .navbar-session-resume-spin {
   animation: spin 1s linear infinite;
 }
 
-.navbar-session-resume.is-loading {
+.navbar-session-resume.is-loading,
+.navbar-session-terminate.is-loading {
   animation: none;
 }
 
@@ -819,6 +870,15 @@ body,
     width: 170px;
     min-width: 170px;
   }
+
+  .navbar-session-terminate-text {
+    display: none;
+  }
+
+  .navbar-session-terminate {
+    min-width: 38px;
+    padding-inline: 10px;
+  }
 }
 
 
@@ -867,7 +927,8 @@ body.controller-mode {
 .controller-mode .region-selected,
 .controller-mode .region-dropdown-item,
 .controller-mode .navbar-subscription-chip,
-.controller-mode .navbar-session-resume {
+.controller-mode .navbar-session-resume,
+.controller-mode .navbar-session-terminate {
   min-height: 42px;
   font-size: 0.84rem;
 }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -608,6 +608,7 @@ export interface ActiveSessionInfo {
   appId: number;
   gpuType?: string;
   status: number;
+  streamingBaseUrl?: string;
   serverIp?: string;
   signalingUrl?: string;
   resolution?: string;


### PR DESCRIPTION
## Description

This PR implements issue #316, allowing users to forcibly terminate an active cloud session from the navbar while the app is idle. Previously, users could only resume sessions but had no way to close a stuck session without connecting to it.

**Main changes:**

- **Shared stop helper** (`src/renderer/src/App.tsx`): Extracted `stopSessionByTarget` to centralize session stop request assembly and auth token handling; reused by both the existing in-stream stop flow and the new navbar terminate flow.

- **Navbar terminate handler** (`src/renderer/src/App.tsx`): Added `handleTerminateNavbarSession` with user confirmation via `window.confirm`, guarded against concurrent resume/terminate/play actions, loading state (`isTerminatingNavbarSession`), error handling, and automatic refresh of the active session list after completion.

- **Race prevention** (`src/renderer/src/App.tsx`): Introduced `navbarSessionActionInFlightRef` to track "resume" or "terminate" operations in-flight; guards in `handleResumeFromNavbar`, `handleTerminateNavbarSession`, and `handlePlayGame` prevent overlapping actions.

- **ActiveSessionInfo extension** (`src/shared/gfn.ts`, `src/main/gfn/cloudmatch.ts`): Added `streamingBaseUrl` field to the active session payload so terminate requests can include the correct base URL without requiring new backend plumbing.

- **Navbar UI** (`src/renderer/src/components/Navbar.tsx`): Replaced the standalone resume button with a flex `navbar-session-actions` container containing paired Resume (green) and Terminate (red) buttons; both show loading spinners during their respective operations and are disabled during conflicting actions.

- **Styling** (`src/renderer/src/styles.css`): Added `.navbar-session-terminate` and `.navbar-session-actions` variants with error-tone gradients on hover/focus; responsive rules hide the Terminate label on narrower screens; controller-mode size adjustments applied.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/1b8899a4-79ea-4d10-b162-13cb46e64f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-066" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/1b8899a4-79ea-4d10-b162-13cb46e64f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-066&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-066"><img alt="OPE-066" src="https://capy.ai/api/badge/thread.svg?label=OPE-066"></picture></a>
<!-- capy-pr-badge:end -->