### PR TITLE
Harden app shutdown so Exit fully terminates process

### DIFF
--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -87,6 +87,7 @@ export class GfnSignalingClient {
     this.heartbeatTimer = setInterval(() => {
       this.sendJson({ hb: 1 });
     }, 5000);
+    this.heartbeatTimer.unref?.();
   }
 
   private clearHeartbeat(): void {

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -229,6 +229,81 @@ let authService: AuthService;
 let settingsManager: SettingsManager;
 let appUpdater: AppUpdaterController | null = null;
 const SCREENSHOT_LIMIT = 60;
+const EXPLICIT_SHUTDOWN_FORCE_EXIT_DELAY_MS = 2000;
+let isShutdownRequested = false;
+let isShutdownCleanupComplete = false;
+let isUpdaterInstallQuitInProgress = false;
+let explicitShutdownFallbackTimer: NodeJS.Timeout | null = null;
+
+function clearExplicitShutdownFallback(): void {
+  if (explicitShutdownFallbackTimer) {
+    clearTimeout(explicitShutdownFallbackTimer);
+    explicitShutdownFallbackTimer = null;
+  }
+}
+
+function runShutdownCleanup(reason = "app-quit"): void {
+  if (isShutdownCleanupComplete) {
+    return;
+  }
+
+  isShutdownCleanupComplete = true;
+  console.log(`[Main] Running shutdown cleanup (${reason})`);
+
+  refreshScheduler.stop();
+  signalingClient?.disconnect();
+  signalingClient = null;
+  signalingClientKey = null;
+  void destroyDiscordRpc();
+  appUpdater?.dispose();
+  appUpdater = null;
+
+  const windowToClose = mainWindow;
+  if (windowToClose && !windowToClose.isDestroyed()) {
+    mainWindow = null;
+    try {
+      windowToClose.close();
+    } catch (error) {
+      console.warn("[Main] Failed to close main window during shutdown:", error);
+    }
+
+    if (!windowToClose.isDestroyed()) {
+      try {
+        windowToClose.destroy();
+      } catch (error) {
+        console.warn("[Main] Failed to destroy main window during shutdown:", error);
+      }
+    }
+  }
+}
+
+function scheduleExplicitShutdownFallback(reason: string, exitCode = 0): void {
+  if (explicitShutdownFallbackTimer || isUpdaterInstallQuitInProgress) {
+    return;
+  }
+
+  explicitShutdownFallbackTimer = setTimeout(() => {
+    explicitShutdownFallbackTimer = null;
+    console.warn(`[Main] Explicit shutdown fallback triggered (${reason}); forcing process exit.`);
+    app.exit(exitCode);
+  }, EXPLICIT_SHUTDOWN_FORCE_EXIT_DELAY_MS);
+  explicitShutdownFallbackTimer.unref?.();
+}
+
+function requestAppShutdown(options: { reason?: string; forceExitFallback?: boolean; exitCode?: number } = {}): void {
+  const { reason = "app-quit", forceExitFallback = false, exitCode = 0 } = options;
+
+  if (!isShutdownRequested) {
+    isShutdownRequested = true;
+    runShutdownCleanup(reason);
+  }
+
+  if (forceExitFallback) {
+    scheduleExplicitShutdownFallback(reason, exitCode);
+  }
+
+  app.quit();
+}
 
 function getScreenshotDirectory(): string {
   return join(app.getPath("pictures"), "OpenNOW", "Screenshots");
@@ -1268,7 +1343,10 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(IPC_CHANNELS.QUIT_APP, async () => {
-    app.quit();
+    requestAppShutdown({
+      reason: "renderer-explicit-exit",
+      forceExitFallback: true,
+    });
   });
 
   ipcMain.handle(IPC_CHANNELS.APP_UPDATER_GET_STATE, async (): Promise<AppUpdaterState> => {
@@ -1897,6 +1975,13 @@ app.whenReady().then(async () => {
   appUpdater = createAppUpdaterController({
     onStateChanged: emitUpdaterStateToRenderer,
     automaticChecksEnabled: settingsManager.get("autoCheckForUpdates"),
+    onBeforeQuitAndInstall: () => {
+      isUpdaterInstallQuitInProgress = true;
+      clearExplicitShutdownFallback();
+    },
+    onQuitAndInstallError: () => {
+      isUpdaterInstallQuitInProgress = false;
+    },
   });
 
   // Connect Discord Rich Presence if the user has opted in
@@ -1970,6 +2055,9 @@ app.whenReady().then(async () => {
   appUpdater.initialize();
 
   app.on("activate", async () => {
+    if (isShutdownRequested) {
+      return;
+    }
     if (BrowserWindow.getAllWindows().length === 0) {
       await createMainWindow();
     }
@@ -1978,18 +2066,21 @@ app.whenReady().then(async () => {
 
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
-    app.quit();
+    requestAppShutdown({ reason: "window-all-closed" });
   }
 });
 
 app.on("before-quit", () => {
-  refreshScheduler.stop();
-  signalingClient?.disconnect();
-  signalingClient = null;
-  signalingClientKey = null;
-  void destroyDiscordRpc();
-  appUpdater?.dispose();
-  appUpdater = null;
+  isShutdownRequested = true;
+  runShutdownCleanup(isUpdaterInstallQuitInProgress ? "before-quit-updater-install" : "before-quit");
+});
+
+app.on("will-quit", () => {
+  clearExplicitShutdownFallback();
+});
+
+app.on("quit", () => {
+  clearExplicitShutdownFallback();
 });
 
 // Export for use by other modules

--- a/opennow-stable/src/main/services/refreshScheduler.ts
+++ b/opennow-stable/src/main/services/refreshScheduler.ts
@@ -51,6 +51,7 @@ class RefreshScheduler {
     this.refreshTimer = setInterval(() => {
       void this.performRefresh();
     }, this.refreshIntervalMs);
+    this.refreshTimer.unref?.();
   }
 
   stop(): void {
@@ -148,6 +149,7 @@ class RefreshScheduler {
       this.refreshTimer = setInterval(() => {
         void this.performRefresh();
       }, this.refreshIntervalMs);
+      this.refreshTimer.unref?.();
     }
   }
 }

--- a/opennow-stable/src/main/updater.ts
+++ b/opennow-stable/src/main/updater.ts
@@ -23,6 +23,8 @@ export interface AppUpdaterController {
 interface AppUpdaterControllerOptions {
   onStateChanged: (state: AppUpdaterState) => void;
   automaticChecksEnabled: boolean;
+  onBeforeQuitAndInstall?: () => void;
+  onQuitAndInstallError?: () => void;
 }
 
 function isPrereleaseVersion(version: string): boolean {
@@ -185,9 +187,11 @@ export function createAppUpdaterController(options: AppUpdaterControllerOptions)
     startupTimer = setTimeout(() => {
       void controller.checkForUpdates("auto");
     }, STARTUP_CHECK_DELAY_MS);
+    startupTimer.unref?.();
     intervalTimer = setInterval(() => {
       void controller.checkForUpdates("auto");
     }, PERIODIC_CHECK_INTERVAL_MS);
+    intervalTimer.unref?.();
   };
 
   updater.on("checking-for-update", () => {
@@ -365,8 +369,10 @@ export function createAppUpdaterController(options: AppUpdaterControllerOptions)
 
       setImmediate(() => {
         try {
+          options.onBeforeQuitAndInstall?.();
           updater.quitAndInstall(false, true);
         } catch (error) {
+          options.onQuitAndInstallError?.();
           updateState({
             status: "error",
             message: normalizeErrorMessage(error),


### PR DESCRIPTION
This PR hardens the Electron app shutdown path so selecting Exit reliably terminates the process instead of leaving it running headless. Previously, calling `app.quit()` from the QUIT_APP IPC handler relied on the normal window-close path while long-lived timers, websockets, and Discord RPC could keep the process alive indefinitely.

**Shutdown orchestration** (`src/main/index.ts`):

- Add `runShutdownCleanup()` to idempotently stop `refreshScheduler`, disconnect `signalingClient`, dispose `appUpdater`, destroy `mainWindow`, and tear down Discord RPC
- Add `requestAppShutdown()` to coordinate explicit quit requests, running cleanup before `app.quit()` and optionally scheduling a 2s fallback to `app.exit(0)`
- Route `IPC_CHANNELS.QUIT_APP` through `requestAppShutdown()` with force-exit fallback enabled
- Reuse centralized cleanup in `before-quit` instead of duplicating logic
- Add `isShutdownRequested`/`isShutdownCleanupComplete` guards and `will-quit`/`quit` handlers to cancel fallback timers on normal termination
- Block `activate` recreation if shutdown is already requested

**Updater coordination** (`src/main/index.ts`, `src/main/updater.ts`):

- Add `onBeforeQuitAndInstall`/`onQuitAndInstallError` hooks to `AppUpdaterControllerOptions`
- Call hooks in `quitAndInstall()` to set/clear `isUpdaterInstallQuitInProgress` flag
- Suppress force-exit fallback during updater-driven install/restart to avoid disrupting `updater.quitAndInstall()`

**Timer hardening** (`src/main/updater.ts`, `src/main/services/refreshScheduler.ts`, `src/main/gfn/signaling.ts`):

- Call `.unref()` on `startupTimer`, `intervalTimer`, `refreshTimer`, and `heartbeatTimer` so they do not keep the process alive on their own

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/62fa199e-4578-43b7-84c7-9bd4f1994286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-067" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/62fa199e-4578-43b7-84c7-9bd4f1994286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-067&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-067"><img alt="OPE-067" src="https://capy.ai/api/badge/thread.svg?label=OPE-067"></picture></a>
<!-- capy-pr-badge:end -->