### PR TITLE
Fix audio context and microphone listener cleanup leaks

### DIFF
--- a/opennow-stable/src/renderer/src/gfn/microphoneManager.ts
+++ b/opennow-stable/src/renderer/src/gfn/microphoneManager.ts
@@ -30,6 +30,12 @@ export class MicrophoneManager {
 
   // Track if we should auto-retry with different devices on failure
   private attemptedDevices: Set<string> = new Set();
+  private readonly handleMicStreamInactive = (): void => {
+    console.log("[Microphone] Stream inactive");
+    this.detachMicStreamListeners(this.micStream);
+    this.attemptedDevices.clear();
+    this.micStream = null;
+  };
 
   /**
    * Check if microphone is supported in this browser
@@ -161,6 +167,8 @@ export class MicrophoneManager {
    * Start microphone capture
    */
   private async startCapture(): Promise<void> {
+    this.clearMicStream();
+
     const constraints: MediaStreamConstraints = {
       audio: {
         sampleRate: { ideal: this.sampleRate },
@@ -177,8 +185,9 @@ export class MicrophoneManager {
     }
 
     try {
-      this.micStream = await navigator.mediaDevices.getUserMedia(constraints);
-      const track = this.micStream.getAudioTracks()[0];
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      this.attachMicStream(stream);
+      const track = stream.getAudioTracks()[0];
 
       if (!track) {
         throw new Error("No audio track available");
@@ -189,13 +198,6 @@ export class MicrophoneManager {
         console.log("[Microphone] Track ended");
         this.stop();
       };
-
-      // Handle stream inactive
-      this.micStream.addEventListener("inactive", () => {
-        console.log("[Microphone] Stream inactive");
-        this.attemptedDevices.clear();
-        this.micStream = null;
-      });
 
       // Add track to peer connection if available
       if (this.pc) {
@@ -255,8 +257,16 @@ export class MicrophoneManager {
           // Try without sample rate constraint
           console.warn("[Microphone] Constraints not supported, trying with basic constraints");
           try {
-            this.micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            const track = this.micStream.getAudioTracks()[0];
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            this.attachMicStream(stream);
+            const track = stream.getAudioTracks()[0];
+            if (!track) {
+              throw new Error("No audio track available");
+            }
+            track.onended = () => {
+              console.log("[Microphone] Track ended");
+              this.stop();
+            };
             if (this.pc && track) {
               await this.addTrackToPeerConnection(track);
             }
@@ -375,6 +385,32 @@ export class MicrophoneManager {
     }
   }
 
+  private attachMicStream(stream: MediaStream): void {
+    this.detachMicStreamListeners(this.micStream);
+    this.micStream = stream;
+    stream.addEventListener("inactive", this.handleMicStreamInactive);
+  }
+
+  private detachMicStreamListeners(stream: MediaStream | null): void {
+    if (!stream) {
+      return;
+    }
+    stream.removeEventListener("inactive", this.handleMicStreamInactive);
+    for (const track of stream.getTracks()) {
+      track.onended = null;
+    }
+  }
+
+  private clearMicStream(): void {
+    if (!this.micStream) {
+      return;
+    }
+    const stream = this.micStream;
+    this.detachMicStreamListeners(stream);
+    stream.getTracks().forEach((track) => track.stop());
+    this.micStream = null;
+  }
+
   /**
    * Enable/disable microphone track (mute/unmute)
    */
@@ -428,13 +464,7 @@ export class MicrophoneManager {
       }
     }
 
-    if (this.micStream) {
-      this.micStream.getTracks().forEach(track => {
-        track.onended = null;
-        track.stop();
-      });
-      this.micStream = null;
-    }
+    this.clearMicStream();
 
     this.attemptedDevices.clear();
     this.setState("stopped");

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -422,6 +422,7 @@ export class GfnWebRtcClient {
   private partiallyReliableInputChannel: RTCDataChannel | null = null;
   private controlChannel: RTCDataChannel | null = null;
   private audioContext: AudioContext | null = null;
+  private audioSourceNode: MediaStreamAudioSourceNode | null = null;
 
   private inputReady = false;
   public inputPaused = false;
@@ -1485,16 +1486,43 @@ export class GfnWebRtcClient {
     stream.addTrack(track);
   }
 
+  private cleanupAudioRouting(): void {
+    if (this.audioSourceNode) {
+      try {
+        this.audioSourceNode.disconnect();
+      } catch {
+        // Ignore cleanup errors from an already-disconnected node.
+      }
+      this.audioSourceNode = null;
+    }
+
+    if (this.audioContext) {
+      void this.audioContext.close().catch(() => {});
+      this.audioContext = null;
+    }
+
+    this.options.audioElement.pause();
+    this.options.audioElement.muted = true;
+  }
+
+  private startDirectAudioPlayback(reason: string): void {
+    this.log(reason);
+    this.options.audioElement.muted = false;
+    this.options.audioElement
+      .play()
+      .then(() => {
+        this.log("Audio track attached (fallback)");
+      })
+      .catch((playError) => {
+        this.log(`Audio autoplay blocked: ${String(playError)}`);
+      });
+  }
+
   private cleanupPeerConnection(): void {
     this.clearTimers();
     this.detachInputCapture();
     this.closeDataChannels();
-    if (this.audioContext) {
-      void this.audioContext.close();
-      this.audioContext = null;
-    }
-    this.options.audioElement.pause();
-    this.options.audioElement.muted = true;
+    this.cleanupAudioRouting();
     if (this.pc) {
       this.pc.onicecandidate = null;
       this.pc.ontrack = null;
@@ -1584,45 +1612,44 @@ export class GfnWebRtcClient {
 
     if (track.kind === "audio") {
       this.replaceTrackInStream(this.audioStream, track);
-
-      if (this.audioContext) {
-        void this.audioContext.close();
-        this.audioContext = null;
-      }
-
-      this.options.audioElement.pause();
-      this.options.audioElement.muted = true;
+      this.cleanupAudioRouting();
 
       // Route audio through an AudioContext with interactive latency hint.
       // This tells the OS audio subsystem to use the smallest possible buffer,
       // matching what the official GFN browser client does for low-latency playback.
+      let audioContext: AudioContext | null = null;
+      let audioSourceNode: MediaStreamAudioSourceNode | null = null;
+
       try {
-        const ctx = new AudioContext({
+        audioContext = new AudioContext({
           latencyHint: "interactive",
           sampleRate: 48000,
         });
-        this.audioContext = ctx;
-        const source = ctx.createMediaStreamSource(this.audioStream);
-        source.connect(ctx.destination);
+        audioSourceNode = audioContext.createMediaStreamSource(this.audioStream);
+        audioSourceNode.connect(audioContext.destination);
 
         // Resume the context (browsers require user gesture, but Electron is more lenient)
-        if (ctx.state === "suspended") {
-          void ctx.resume();
+        if (audioContext.state === "suspended") {
+          void audioContext.resume();
         }
 
-        this.log(`Audio routed through AudioContext (latency: ${(ctx.baseLatency * 1000).toFixed(1)}ms, sampleRate: ${ctx.sampleRate}Hz)`);
+        this.audioContext = audioContext;
+        this.audioSourceNode = audioSourceNode;
+        this.log(
+          `Audio routed through AudioContext (latency: ${(audioContext.baseLatency * 1000).toFixed(1)}ms, sampleRate: ${audioContext.sampleRate}Hz)`,
+        );
       } catch (error) {
-        // Fallback: play directly through the audio element
-        this.log(`AudioContext creation failed, falling back to audio element: ${String(error)}`);
-        this.options.audioElement.muted = false;
-        this.options.audioElement
-          .play()
-          .then(() => {
-            this.log("Audio track attached (fallback)");
-          })
-          .catch((playError) => {
-            this.log(`Audio autoplay blocked: ${String(playError)}`);
-          });
+        if (audioSourceNode) {
+          try {
+            audioSourceNode.disconnect();
+          } catch {
+            // Ignore cleanup errors from a partially-created node.
+          }
+        }
+        if (audioContext) {
+          void audioContext.close().catch(() => {});
+        }
+        this.startDirectAudioPlayback(`AudioContext creation failed, falling back to audio element: ${String(error)}`);
       }
     }
   }


### PR DESCRIPTION
This PR fixes memory/resource leaks in the WebRTC audio and microphone management paths by ensuring explicit cleanup of native audio objects and stream listeners.

**Main changes:**

- **GfnWebRtcClient** (`opennow-stable/src/renderer/src/gfn/webrtcClient.ts`):
  - Added `audioSourceNode` field to track the `MediaStreamAudioSourceNode` used for remote audio routing.
  - Introduced `cleanupAudioRouting()` helper to idempotently disconnect the source node, close the `AudioContext`, and reset the audio element state.
  - Modified `cleanupPeerConnection()` to call `cleanupAudioRouting()` instead of inline logic.
  - Updated audio track attachment to build the routing graph using local variables first; instance fields are only assigned after successful setup.
  - On setup failure or fallback, partially created objects are now cleaned up before `startDirectAudioPlayback()` is invoked.

- **MicrophoneManager** (`opennow-stable/src/renderer/src/gfn/microphoneManager.ts`):
  - Replaced the anonymous `inactive` stream listener with a stable, stored handler (`handleMicStreamInactive`).
  - Added `attachMicStream()`, `detachMicStreamListeners()`, and `clearMicStream()` helpers to manage listener lifecycle.
  - Modified `startCapture()` to clear previous streams and attach listeners via `attachMicStream()`.
  - Updated `stop()` to use `clearMicStream()` instead of inline cleanup.
  - Ensured the `OverconstrainedError` fallback path also attaches listeners correctly.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/ec0cb5f9-a199-495c-a7a5-8fa839440cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-068" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/ec0cb5f9-a199-495c-a7a5-8fa839440cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-068&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-068"><img alt="OPE-068" src="https://capy.ai/api/badge/thread.svg?label=OPE-068"></picture></a>
<!-- capy-pr-badge:end -->