### PR TITLE
Remove 180s session ready timeout

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -105,7 +105,6 @@ const SESSION_AD_PROGRESS_CHECK_INTERVAL_MS = 1000;
 const SESSION_AD_START_TIMEOUT_MS = 30000;
 const SESSION_AD_FORCE_PLAY_TIMEOUT_MS = 10000;
 const SESSION_AD_STUCK_TIMEOUT_MS = 30000;
-const SESSION_READY_TIMEOUT_MS = 180000;
 const VARIANT_SELECTION_LOCALSTORAGE_KEY = "opennow.variantByGameId";
 const CATALOG_PREFERENCES_LOCALSTORAGE_KEY = "opennow.catalogPreferences.v1";
 const PLAYTIME_RESYNC_INTERVAL_MS = 5 * 60 * 1000;
@@ -2686,12 +2685,11 @@ export function App(): JSX.Element {
       setQueuePosition(newSession.queuePosition);
 
       // Poll for readiness.
-      // Queue mode: no timeout - users wait indefinitely and see position updates.
-      // Setup/Starting mode: 180s timeout applies while machine is being allocated.
+      // Queue and setup/starting modes wait indefinitely until the session becomes ready
+      // or the launch is explicitly aborted. Some rigs take much longer than 180s.
       let finalSession: SessionInfo | null = null;
       let latestSession = newSession;
       let isInQueueMode = isSessionInQueue(newSession);
-      let setupTimeoutStartAt: number | null = isInQueueMode ? null : Date.now();
       let attempt = 0;
 
       while (true) {
@@ -2765,13 +2763,8 @@ export function App(): JSX.Element {
         setSession(mergedSession);
         setQueuePosition(mergedSession.queuePosition);
 
-        // Check if queue just cleared - transition from queue mode to setup mode
-        const wasInQueueMode = isInQueueMode;
+        // Check if queue just cleared so the loading UI can transition to setup mode.
         isInQueueMode = isSessionInQueue(mergedSession);
-        if (wasInQueueMode && !isInQueueMode) {
-          // Queue just cleared, start timeout counting from now.
-          setupTimeoutStartAt = Date.now();
-        }
 
         console.log(
           `Poll attempt ${attempt}: status=${mergedSession.status}, seatSetupStep=${mergedSession.seatSetupStep ?? "n/a"}, queuePosition=${mergedSession.queuePosition ?? "n/a"}, serverIp=${mergedSession.serverIp}, queueMode=${isInQueueMode}, adsRequired=${isSessionAdsRequired(mergedSession.adState)}`,
@@ -2789,14 +2782,9 @@ export function App(): JSX.Element {
           updateLoadingStep("setup");
         }
 
-        // Only check timeout when NOT in queue mode (i.e., during setup/starting)
-        if (!isInQueueMode && setupTimeoutStartAt !== null && Date.now() - setupTimeoutStartAt >= SESSION_READY_TIMEOUT_MS) {
-          throw new Error(`Session did not become ready in time (${Math.round(SESSION_READY_TIMEOUT_MS / 1000)}s)`);
-        }
       }
 
       // finalSession is guaranteed to be set here (we only exit the loop via break when session is ready)
-      // Timeout only applies during setup/starting phase, not during queue wait
 
       setQueuePosition(undefined);
       updateLoadingStep("connecting");


### PR DESCRIPTION
This PR removes the hardcoded 180-second timeout for session readiness (`SESSION_READY_TIMEOUT_MS`). The timeout was previously enforced during the setup/starting phase after clearing the queue, causing launch failures when rig allocation exceeded 3 minutes.

**Changes:**

- **Session polling loop** (`opennow-stable/src/renderer/src/App.tsx`):
  - Removed `SESSION_READY_TIMEOUT_MS` constant (line 108).
  - Removed `setupTimeoutStartAt` tracking and timeout check logic (lines 2693-2694, 2771-2793).
  - Updated comments to clarify that queue and setup/starting modes now wait indefinitely.

The polling loop will now continue indefinitely in both queue and setup/starting states until the session status reaches ready (`status === 2 || status === 3`) or the launch is explicitly aborted via the UI.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/0f62b4e9-93c7-41b7-a94d-dc93e983cf6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-071" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/0f62b4e9-93c7-41b7-a94d-dc93e983cf6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-071&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-071"><img alt="OPE-071" src="https://capy.ai/api/badge/thread.svg?label=OPE-071"></picture></a>
<!-- capy-pr-badge:end -->