### PR TITLE
Remove redundant Catalog tab from store page

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -143,7 +143,6 @@ function saveCatalogPreferences(prefs: CatalogPreferences): void {
   }
 }
 
-type GameSource = "main" | "library";
 type AppPage = "home" | "library" | "settings";
 type StreamStatus = "idle" | "queue" | "setup" | "starting" | "connecting" | "streaming";
 type StreamLoadingStatus = "queue" | "setup" | "starting" | "connecting";
@@ -793,7 +792,6 @@ export function App(): JSX.Element {
   // Games State
   const [games, setGames] = useState<GameInfo[]>([]);
   const [libraryGames, setLibraryGames] = useState<GameInfo[]>([]);
-  const [source, setSource] = useState<GameSource>("main");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedGameId, setSelectedGameId] = useState("");
   const [variantByGameId, setVariantByGameId] = useState<Record<string, string>>({});
@@ -2349,7 +2347,6 @@ export function App(): JSX.Element {
     setCatalogSelectedFilterIds((previous) => areStringArraysEqual(previous, catalogResult.selectedFilterIds) ? previous : catalogResult.selectedFilterIds);
     setCatalogTotalCount(catalogResult.totalCount);
     setCatalogSupportedCount(catalogResult.numberSupported);
-    setSource("main");
     setSelectedGameId((previous) => catalogResult.games.some((game) => game.id === previous) ? previous : (catalogResult.games[0]?.id ?? ""));
     applyVariantSelections(catalogResult.games);
   }, [applyVariantSelections]);
@@ -2416,7 +2413,6 @@ export function App(): JSX.Element {
     setCatalogSelectedFilterIds([]);
     setCatalogTotalCount(0);
     setCatalogSupportedCount(0);
-    setSource("main");
     setSelectedGameId("");
   }, [resetLaunchRuntime]);
 
@@ -2426,7 +2422,7 @@ export function App(): JSX.Element {
   }, []);
 
   // Load games handler
-  const loadGames = useCallback(async (targetSource: GameSource) => {
+  const loadGames = useCallback(async (targetSource: "main" | "library") => {
     setIsLoadingGames(true);
     try {
       const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
@@ -2449,7 +2445,6 @@ export function App(): JSX.Element {
 
       const result = await window.openNow.fetchLibraryGames({ token, providerStreamingBaseUrl: baseUrl });
       setLibraryGames(result);
-      setSource("library");
       setSelectedGameId((previous) => result.some((game) => game.id === previous) ? previous : (result[0]?.id ?? ""));
       applyVariantSelections(result);
     } catch (error) {
@@ -2460,14 +2455,14 @@ export function App(): JSX.Element {
   }, [applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, searchQuery, catalogFilterKey, catalogSelectedSortId]);
 
   useEffect(() => {
-    if (!authSession || source !== "main") {
+    if (!authSession || currentPage !== "home") {
       return;
     }
     const handle = window.setTimeout(() => {
       void loadGames("main");
     }, searchQuery.trim() ? 220 : 0);
     return () => window.clearTimeout(handle);
-  }, [authSession, loadGames, searchQuery, source, catalogFilterKey, catalogSelectedSortId]);
+  }, [authSession, currentPage, loadGames, searchQuery, catalogFilterKey, catalogSelectedSortId]);
 
   const handleSelectGameVariant = useCallback((gameId: string, variantId: string): void => {
     setVariantByGameId((prev) => {
@@ -3729,17 +3724,6 @@ export function App(): JSX.Element {
         {currentPage === "home" && (
           <HomePage
             games={filteredGames}
-            source="main"
-            onSourceChange={(nextSource) => {
-              if (nextSource === "library") {
-                setCurrentPage("library");
-                if (libraryGames.length === 0 && authSession) {
-                  void loadGames("library");
-                }
-                return;
-              }
-              void loadGames("main");
-            }}
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
             onPlayGame={handleInitiatePlay}

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -5,8 +5,6 @@ import { GameCard } from "./GameCard";
 
 export interface HomePageProps {
   games: GameInfo[];
-  source: "main" | "library";
-  onSourceChange: (source: "main" | "library") => void;
   searchQuery: string;
   onSearchChange: (query: string) => void;
   onPlayGame: (game: GameInfo) => void;
@@ -27,8 +25,6 @@ export interface HomePageProps {
 
 export function HomePage({
   games,
-  source,
-  onSourceChange,
   searchQuery,
   onSearchChange,
   onPlayGame,
@@ -53,17 +49,6 @@ export function HomePage({
   return (
     <div className="home-page">
       <header className="home-toolbar">
-        <div className="home-tabs">
-          <button
-            className={`home-tab ${source === "main" ? "active" : ""}`}
-            onClick={() => onSourceChange("main")}
-            disabled={isLoading}
-          >
-            <LayoutGrid size={15} />
-            Catalog
-          </button>
-        </div>
-
         <div className="home-search">
           <Search className="home-search-icon" size={16} />
           <input

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1602,48 +1602,6 @@ body.controller-mode.controller-hide-cursor * {
   flex-wrap: wrap;
 }
 
-.home-tabs {
-  display: flex;
-  gap: 2px;
-  background: var(--card);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--r-sm);
-  padding: 3px;
-}
-
-.home-tab {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 6px 12px;
-  border-radius: 6px;
-  border: none;
-  background: transparent;
-  color: var(--ink-muted);
-  font-size: 0.8rem;
-  font-weight: 600;
-  font-family: inherit;
-  cursor: pointer;
-  transition: color var(--t-fast), background var(--t-fast);
-  outline: none;
-  white-space: nowrap;
-}
-
-.home-tab:hover:not(:disabled) {
-  color: var(--ink-soft);
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.home-tab.active {
-  color: var(--accent-on);
-  background: var(--accent);
-}
-
-.home-tab:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .home-search {
   flex: 1;
   position: relative;


### PR DESCRIPTION
This PR removes the redundant Catalog toggle from the store page and cleans up unused props/state plumbing, since HomePage is always rendered in catalog mode on the home route.

**Main changes:**

- **HomePage** (`opennow-stable/src/renderer/src/components/HomePage.tsx`):
  - Removed `source` and `onSourceChange` props from `HomePageProps`
  - Removed the toolbar's `home-tabs` div containing the dead Catalog button

- **App** (`opennow-stable/src/renderer/src/App.tsx`):
  - Removed `GameSource` type and `source` state variable
  - Simplified `loadGames` handler to use inline literal union type
  - Updated home-page refresh effect to key off `currentPage !== "home"` instead of `source !== "main"`
  - Removed stale `setSource` calls from catalog browse and reset handlers
  - Removed `source` and `onSourceChange` props from `HomePage` call site

- **Styles** (`opennow-stable/src/renderer/src/styles.css`):
  - Removed unused `.home-tabs` and `.home-tab` selectors including hover/active/disabled variants

The rest of the toolbar (search, filters, sort, counts, and game grid) remains unchanged.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/15379e75-5d3d-40b2-b5fd-6cce354946c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-072" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/15379e75-5d3d-40b2-b5fd-6cce354946c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-072&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-072"><img alt="OPE-072" src="https://capy.ai/api/badge/thread.svg?label=OPE-072"></picture></a>
<!-- capy-pr-badge:end -->