### PR TITLE
Extract fullscreen keyboard lock codes

### DIFF
--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -21,7 +21,7 @@
     "dist": "npm run build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
     "dist:signed": "npm run build && electron-builder",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json",
-    "test": "tsx --test src/renderer/src/gfn/inputProtocol.test.ts"
+    "test": "tsx --test src/renderer/src/gfn/*.test.ts"
   },
   "dependencies": {
     "discord-rpc": "^4.0.1",

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -43,6 +43,7 @@ import {
   type StreamDiagnostics,
   type StreamTimeWarning,
 } from "./gfn/webrtcClient";
+import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "./gfn/keyboardLock";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
 import { useControllerNavigation } from "./controllerNavigation";
 import { useElapsedSeconds } from "./utils/useElapsedSeconds";
@@ -1976,9 +1977,7 @@ export function App(): JSX.Element {
 
     const nav = navigator as any;
     if (document.fullscreenElement && nav.keyboard?.lock) {
-      await nav.keyboard.lock([
-        "Escape", "F11", "BrowserBack", "BrowserForward", "BrowserRefresh",
-      ]).catch(() => {});
+      await nav.keyboard.lock(FULLSCREEN_KEYBOARD_LOCK_CODES).catch(() => {});
     }
 
     await requestPointerLockCompat({ unadjustedMovement: true })

--- a/opennow-stable/src/renderer/src/gfn/keyboardLock.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/keyboardLock.test.ts
@@ -1,0 +1,22 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "./keyboardLock";
+
+test("matches the official fullscreen keyboard lock coverage for affected regional keys", () => {
+  assert.equal(FULLSCREEN_KEYBOARD_LOCK_CODES[0], "Escape");
+  assert.equal(FULLSCREEN_KEYBOARD_LOCK_CODES[1], "F11");
+  assert.ok(FULLSCREEN_KEYBOARD_LOCK_CODES.includes("KeyT"));
+  assert.ok(FULLSCREEN_KEYBOARD_LOCK_CODES.includes("KeyN"));
+  assert.ok(FULLSCREEN_KEYBOARD_LOCK_CODES.includes("KeyZ"));
+  assert.ok(FULLSCREEN_KEYBOARD_LOCK_CODES.includes("Slash"));
+  assert.ok(FULLSCREEN_KEYBOARD_LOCK_CODES.includes("Digit1"));
+  assert.ok(FULLSCREEN_KEYBOARD_LOCK_CODES.includes("PrintScreen"));
+  assert.ok(FULLSCREEN_KEYBOARD_LOCK_CODES.includes("LaunchMail"));
+  assert.equal(
+    FULLSCREEN_KEYBOARD_LOCK_CODES[FULLSCREEN_KEYBOARD_LOCK_CODES.length - 1],
+    "KeyG",
+  );
+});

--- a/opennow-stable/src/renderer/src/gfn/keyboardLock.ts
+++ b/opennow-stable/src/renderer/src/gfn/keyboardLock.ts
@@ -1,0 +1,12 @@
+export const FULLSCREEN_KEYBOARD_LOCK_CODES: readonly string[] = [
+  "Escape", "F11", "BrowserBack", "BrowserForward", "BrowserRefresh",
+  "BrowserHome", "BrowserFavorites", "BrowserSearch", "BrowserStop",
+  "Sleep", "Power", "WakeUp", "KeyT", "KeyZ", "Slash",
+  "Digit1", "Digit2", "Digit3", "Digit4", "Digit5",
+  "Digit6", "Digit7", "Digit8", "Digit9", "KeyM",
+  "KeyD", "KeyN", "KeyS", "KeyK", "KeyL",
+  "Space", "PrintScreen", "LaunchApp1", "LaunchApp2", "LaunchMail",
+  "Comma", "Semicolon", "ArrowLeft", "ArrowRight",
+  "BracketLeft", "BracketRight", "KeyW", "KeyQ", "KeyR",
+  "KeyY", "KeyO", "KeyP", "KeyF", "KeyG",
+] as const;

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -37,6 +37,7 @@ import {
   rewriteH265LevelIdByProfile,
   rewriteH265TierFlag,
 } from "./sdp";
+import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "./keyboardLock";
 import { MicrophoneManager, type MicState, type MicStateChange } from "./microphoneManager";
 
 interface OfferSettings {
@@ -2100,9 +2101,7 @@ export class GfnWebRtcClient {
     }
 
     try {
-      await nav.keyboard.lock([
-        "Escape", "F11", "BrowserBack", "BrowserForward", "BrowserRefresh",
-      ]);
+      await nav.keyboard.lock(FULLSCREEN_KEYBOARD_LOCK_CODES);
       this.log("Keyboard lock acquired (Escape captured in fullscreen)");
     } catch (error) {
       this.log(`Keyboard lock failed: ${String(error)}`);


### PR DESCRIPTION
## Summary
- Centralize the fullscreen keyboard lock key list in a shared module
- Reuse the shared list in the renderer app and WebRTC client
- Expand test coverage to include the keyboard lock module

## Testing
- Not run (not requested)