### PR TITLE
Add Windows ARM64 release builds to pipeline

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -52,8 +52,8 @@ jobs:
             os: blacksmith-4vcpu-ubuntu-2404
             builder_args: "--linux AppImage deb --x64"
             artifact_paths: |
-              opennow-stable/dist-release/*-x64.AppImage
-              opennow-stable/dist-release/*-x64.deb
+              opennow-stable/dist-release/*-x86_64.AppImage
+              opennow-stable/dist-release/*-amd64.deb
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
             builder_args: "--linux AppImage deb --arm64"

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -26,21 +26,40 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: windows
+          - label: windows-x64
             os: blacksmith-4vcpu-windows-2025
-            builder_args: "--win nsis portable"
+            builder_args: "--win nsis portable --x64"
+            artifact_paths: |
+              opennow-stable/dist-release/*-x64.exe
+          - label: windows-arm64
+            os: blacksmith-4vcpu-windows-2025
+            builder_args: "--win nsis portable --arm64"
+            artifact_paths: |
+              opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
             os: macos-latest
             builder_args: "--mac dmg zip --x64"
+            artifact_paths: |
+              opennow-stable/dist-release/*.dmg
+              opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
             os: macos-latest
             builder_args: "--mac dmg zip --arm64"
+            artifact_paths: |
+              opennow-stable/dist-release/*.dmg
+              opennow-stable/dist-release/*-arm64.zip
           - label: linux-x64
             os: blacksmith-4vcpu-ubuntu-2404
             builder_args: "--linux AppImage deb --x64"
+            artifact_paths: |
+              opennow-stable/dist-release/*-x64.AppImage
+              opennow-stable/dist-release/*-x64.deb
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
             builder_args: "--linux AppImage deb --arm64"
+            artifact_paths: |
+              opennow-stable/dist-release/*-arm64.AppImage
+              opennow-stable/dist-release/*-arm64.deb
 
     defaults:
       run:
@@ -99,10 +118,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opennow-stable-${{ matrix.label }}
-          path: |
-            opennow-stable/dist-release/*.exe
-            opennow-stable/dist-release/*.dmg
-            opennow-stable/dist-release/*.zip
-            opennow-stable/dist-release/*.AppImage
-            opennow-stable/dist-release/*.deb
+          path: ${{ matrix.artifact_paths }}
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,21 +99,44 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: windows
+          - label: windows-x64
             os: blacksmith-4vcpu-windows-2025
-            builder_args: "--win nsis portable"
+            builder_args: "--win nsis portable --x64"
+            artifact_paths: |
+              opennow-stable/dist-release/*-x64.exe
+              opennow-stable/dist-release/latest*.yml
+              opennow-stable/dist-release/*.blockmap
+          - label: windows-arm64
+            os: blacksmith-4vcpu-windows-2025
+            builder_args: "--win nsis portable --arm64"
+            artifact_paths: |
+              opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
             os: macos-latest
             builder_args: "--mac dmg zip --x64"
+            artifact_paths: |
+              opennow-stable/dist-release/*.dmg
+              opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
             os: macos-latest
             builder_args: "--mac dmg zip --arm64"
+            artifact_paths: |
+              opennow-stable/dist-release/*.dmg
+              opennow-stable/dist-release/*-arm64.zip
           - label: linux-x64
             os: blacksmith-4vcpu-ubuntu-2404
             builder_args: "--linux AppImage deb --x64"
+            artifact_paths: |
+              opennow-stable/dist-release/*-x64.AppImage
+              opennow-stable/dist-release/*-x64.deb
+              opennow-stable/dist-release/latest-linux.yml
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
             builder_args: "--linux AppImage deb --arm64"
+            artifact_paths: |
+              opennow-stable/dist-release/*-arm64.AppImage
+              opennow-stable/dist-release/*-arm64.deb
+              opennow-stable/dist-release/latest-linux-arm64.yml
 
     defaults:
       run:
@@ -175,14 +198,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opennow-stable-${{ matrix.label }}
-          path: |
-            opennow-stable/dist-release/*.exe
-            opennow-stable/dist-release/*.dmg
-            opennow-stable/dist-release/*.zip
-            opennow-stable/dist-release/*.AppImage
-            opennow-stable/dist-release/*.deb
-            opennow-stable/dist-release/latest*.yml
-            opennow-stable/dist-release/*.blockmap
+          # electron-updater still consumes a single Windows latest.yml feed.
+          # Keep that metadata x64-only so ARM64 release assets cannot overwrite it.
+          path: ${{ matrix.artifact_paths }}
           if-no-files-found: error
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,8 +127,8 @@ jobs:
             os: blacksmith-4vcpu-ubuntu-2404
             builder_args: "--linux AppImage deb --x64"
             artifact_paths: |
-              opennow-stable/dist-release/*-x64.AppImage
-              opennow-stable/dist-release/*-x64.deb
+              opennow-stable/dist-release/*-x86_64.AppImage
+              opennow-stable/dist-release/*-amd64.deb
               opennow-stable/dist-release/latest-linux.yml
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm

--- a/README.md
+++ b/README.md
@@ -76,10 +76,13 @@ Current packaging targets:
 
 | Platform | Formats |
 | --- | --- |
-| Windows | NSIS installer, portable executable |
+| Windows x64 | NSIS installer, portable executable, auto-update metadata |
+| Windows ARM64 | NSIS installer, portable executable |
 | macOS | `dmg`, `zip` |
 | Linux x64 | `AppImage`, `deb` |
 | Linux ARM64 | `AppImage`, `deb` |
+
+Windows ARM64 builds are published as release downloads. The Windows auto-update feed remains `latest.yml` for x64 releases, so ARM64 packages do not participate in in-app auto-update yet.
 
 ### Develop Locally
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -149,11 +149,14 @@ Current build matrix:
 
 | Target | Output |
 | --- | --- |
-| Windows | NSIS installer, portable executable |
+| Windows x64 | NSIS installer, portable executable, `latest.yml`, `.blockmap` |
+| Windows ARM64 | NSIS installer, portable executable |
 | macOS x64 | `dmg`, `zip` |
 | macOS arm64 | `dmg`, `zip` |
 | Linux x64 | `AppImage`, `deb` |
 | Linux ARM64 | `AppImage`, `deb` |
+
+Windows ARM64 artifacts are release downloads only for now. The Windows auto-update channel remains the x64 `latest.yml` feed so ARM64 packaging cannot overwrite updater metadata.
 
 ## Notes For Contributors
 

--- a/opennow-stable/README.md
+++ b/opennow-stable/README.md
@@ -25,10 +25,13 @@ npm run dist
 
 | Platform | Formats |
 | --- | --- |
-| Windows | NSIS installer, portable executable |
+| Windows x64 | NSIS installer, portable executable, auto-update metadata |
+| Windows ARM64 | NSIS installer, portable executable |
 | macOS | `dmg`, `zip` |
 | Linux x64 | `AppImage`, `deb` |
 | Linux ARM64 | `AppImage`, `deb` |
+
+Windows ARM64 packages are published as release downloads only. The current Windows updater channel stays on the x64 `latest.yml` feed.
 
 ## Technical Notes
 


### PR DESCRIPTION
This PR restores Windows ARM64 release builds that were missing since v0.3.6, preserving Windows x64 auto-update metadata by restricting `latest.yml` and `.blockmap` uploads to the x64 job.

**Workflows** (`.github/workflows/auto-build.yml`, `.github/workflows/release.yml`):
- Split Windows build matrix into `windows-x64` and `windows-arm64` entries with explicit `--x64` / `--arm64` flags
- Added per-matrix `artifact_paths` so each job uploads only its architecture-specific artifacts
- Restricted Windows updater metadata (`latest*.yml`, `*.blockmap`) to `windows-x64` release job to prevent ARM64 overwriting the canonical feed
- Kept Linux per-arch metadata uploads (`latest-linux.yml`, `latest-linux-arm64.yml`) intact

**Documentation** (`README.md`, `opennow-stable/README.md`, `docs/development.md`):
- Updated packaging targets tables to list Windows x64 and ARM64 separately
- Added notes clarifying that ARM64 packages are release-download-only and do not participate in auto-update yet

**Resulting artifacts**:
- Windows x64: `OpenNOW-v{version}-setup-x64.exe`, `OpenNOW-v{version}-portable-x64.exe`, `latest.yml`, `.blockmap`
- Windows ARM64: `OpenNOW-v{version}-setup-arm64.exe`, `OpenNOW-v{version}-portable-arm64.exe` (metadata excluded)

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/a112b7c9-2b5d-483e-ab90-6f6d9e54d4cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-073" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/a112b7c9-2b5d-483e-ab90-6f6d9e54d4cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-073&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-073"><img alt="OPE-073" src="https://capy.ai/api/badge/thread.svg?label=OPE-073"></picture></a>
<!-- capy-pr-badge:end -->