### PR TITLE
Add 'Hide Server Selector' setting to bypass free-tier queue modal

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -61,6 +61,8 @@ export interface Settings {
   showAntiAfkIndicator: boolean;
   /** Show the stats overlay automatically when a stream launches */
   showStatsOnLaunch: boolean;
+  /** Skip the free-tier queue server selection modal and launch with default routing */
+  hideServerSelector: boolean;
   /** Enable controller-first media bar layout for library browsing */
   controllerMode: boolean;
   /** Play subtle sounds in controller library mode */
@@ -126,6 +128,7 @@ const DEFAULT_SETTINGS: Settings = {
   hideStreamButtons: false,
   showAntiAfkIndicator: true,
   showStatsOnLaunch: false,
+  hideServerSelector: false,
   controllerMode: false,
   controllerUiSounds: false,
   controllerBackgroundAnimations: false,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -817,6 +817,7 @@ export function App(): JSX.Element {
     hideStreamButtons: false,
     showAntiAfkIndicator: true,
     showStatsOnLaunch: false,
+    hideServerSelector: false,
     controllerMode: false,
     controllerUiSounds: false,
     controllerBackgroundAnimations: false,
@@ -2834,6 +2835,11 @@ export function App(): JSX.Element {
     const isFreeUser = effectiveTier === "FREE";
     const isAllianceServer = isAllianceStreamingBaseUrl(effectiveStreamingBaseUrl);
     if (isAllianceServer) {
+      setQueueModalData(null);
+      void handlePlayGame(game);
+      return;
+    }
+    if (settings.hideServerSelector) {
       setQueueModalData(null);
       void handlePlayGame(game);
       return;

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -2382,6 +2382,21 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
 
                   <div className="settings-row">
                     <label className="settings-label">
+                      Hide Server Selector
+                      <span className="settings-hint">Skip the free-tier server selection dialog and always launch with OpenNOW's default routing.</span>
+                    </label>
+                    <label className="settings-toggle">
+                      <input
+                        type="checkbox"
+                        checked={settings.hideServerSelector}
+                        onChange={(e) => handleChange("hideServerSelector", e.target.checked)}
+                      />
+                      <span className="settings-toggle-track" />
+                    </label>
+                  </div>
+
+                  <div className="settings-row">
+                    <label className="settings-label">
                       Show Anti-AFK Indicator
                       <span className="settings-hint">Show the ANTI-AFK ON badge while Anti-AFK is enabled during streaming.</span>
                     </label>

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -152,6 +152,8 @@ export interface Settings {
   hideStreamButtons: boolean;
   showAntiAfkIndicator: boolean;
   showStatsOnLaunch: boolean;
+  /** Skip the free-tier queue server selection modal and launch with default routing */
+  hideServerSelector: boolean;
   controllerMode: boolean;
   controllerUiSounds: boolean;
   autoLoadControllerLibrary: boolean;


### PR DESCRIPTION
This pull request introduces a new user setting to allow skipping the free-tier server selection dialog and always launching with the default routing. The main changes include adding the `hideServerSelector` setting to the relevant interfaces, updating default values, integrating the setting into the launch logic, and exposing it in the UI.

**New "Hide Server Selector" Setting**

* Added a new `hideServerSelector` boolean field to the `Settings` interface in `settings.ts` and `gfn.ts`, including documentation for its purpose. [[1]](diffhunk://#diff-9e21436da0b6d81822084b113a549037d9f7d4a36105cd77576ee46a7201586aR64-R65) [[2]](diffhunk://#diff-e21ccf956d30017091203ef0273aeabb57a63f8c24105e8439fe7cf90265bba6R155-R156)
* Set the default value for `hideServerSelector` to `false` in both the settings backend (`settings.ts`) and frontend (`App.tsx`). [[1]](diffhunk://#diff-9e21436da0b6d81822084b113a549037d9f7d4a36105cd77576ee46a7201586aR131) [[2]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR820)
* Integrated logic in `App.tsx` to skip the server selection modal and immediately launch the game if `hideServerSelector` is enabled.

**UI Updates**

* Added a toggle for the new setting in the `SettingsPage` component, with a label and hint explaining its function.## Description

<!-- Provide a brief description of the changes in this PR -->
