### PR TITLE
Mitigate Fedora/Bazzite blank screen on Linux X11

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -124,6 +124,10 @@ function loadBootstrapVideoPreferences(): BootstrapVideoPreferences {
   }
 }
 
+function hasLinuxNvidiaProprietaryDriver(): boolean {
+  return existsSync("/proc/driver/nvidia/version") || existsSync("/sys/module/nvidia/version");
+}
+
 const bootstrapVideoPrefs = loadBootstrapVideoPreferences();
 console.log(
   `[Main] Video acceleration preference: decode=${bootstrapVideoPrefs.decoderPreference}, encode=${bootstrapVideoPrefs.encoderPreference}`,
@@ -132,6 +136,8 @@ console.log(
 // --- Platform-specific HW video decode features ---
 const platformFeatures: string[] = [];
 const isLinuxArm = process.platform === "linux" && (process.arch === "arm64" || process.arch === "arm");
+const isLinuxDesktopX64 = process.platform === "linux" && !isLinuxArm;
+const shouldEnableLinuxDesktopVaapi = isLinuxDesktopX64 && !hasLinuxNvidiaProprietaryDriver();
 
 if (process.platform === "win32") {
   // Windows: D3D11 + Media Foundation path for HW decode/encode acceleration
@@ -150,7 +156,7 @@ if (process.platform === "win32") {
     if (bootstrapVideoPrefs.decoderPreference !== "software") {
       platformFeatures.push("UseChromeOSDirectVideoDecoder");
     }
-  } else {
+  } else if (shouldEnableLinuxDesktopVaapi) {
     // Linux x64 desktop GPUs: VA-API path (Intel/AMD).
     if (bootstrapVideoPrefs.decoderPreference !== "software") {
       platformFeatures.push("VaapiVideoDecoder");
@@ -185,7 +191,18 @@ const disableFeatures: string[] = [
   // Prevents mDNS candidate generation — faster ICE connectivity
   "WebRtcHideLocalIpsWithMdns",
 ];
-if (process.platform === "linux" && !isLinuxArm) {
+if (process.platform === "linux") {
+  // Fedora/Bazzite Electron builds have hit renderer crashes in newer Linux font
+  // service backends. Keep Linux on the older path; Chromium changed the feature
+  // names over time, so include both known spellings.
+  disableFeatures.push(
+    "SkiaFontService",
+    "FontationBackend",
+    "FontationsFontBackend",
+    "FontationsLinuxSystemFonts",
+  );
+}
+if (isLinuxDesktopX64) {
   // ChromeOS-only direct video decoder path interferes on regular Linux
   disableFeatures.push("UseChromeOSDirectVideoDecoder");
 }

--- a/opennow-stable/src/renderer/index.html
+++ b/opennow-stable/src/renderer/index.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenNOW</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/opennow-stable/src/renderer/src/components/ControllerButtons.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerButtons.tsx
@@ -5,6 +5,9 @@ interface ButtonProps {
   size?: number;
 }
 
+const buttonLabelFontFamily =
+  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, "Noto Sans", "DejaVu Sans", sans-serif';
+
 export function ButtonA({ className, size = 18 }: ButtonProps): JSX.Element {
   return (
     <svg 
@@ -17,7 +20,7 @@ export function ButtonA({ className, size = 18 }: ButtonProps): JSX.Element {
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle cx="12" cy="12" r="10" stroke="#58d98a" strokeWidth="2.5" fill="rgba(88, 217, 138, 0.1)" />
-      <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize="12" fontWeight="900" fill="#58d98a" fontFamily="Inter, system-ui">A</text>
+      <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize="12" fontWeight="900" fill="#58d98a" fontFamily={buttonLabelFontFamily}>A</text>
     </svg>
   );
 }
@@ -34,7 +37,7 @@ export function ButtonB({ className, size = 18 }: ButtonProps): JSX.Element {
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle cx="12" cy="12" r="10" stroke="#ef4444" strokeWidth="2.5" fill="rgba(239, 68, 68, 0.1)" />
-      <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize="12" fontWeight="900" fill="#ef4444" fontFamily="Inter, system-ui">B</text>
+      <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize="12" fontWeight="900" fill="#ef4444" fontFamily={buttonLabelFontFamily}>B</text>
     </svg>
   );
 }
@@ -51,7 +54,7 @@ export function ButtonX({ className, size = 18 }: ButtonProps): JSX.Element {
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle cx="12" cy="12" r="10" stroke="#3b82f6" strokeWidth="2.5" fill="rgba(59, 130, 246, 0.1)" />
-      <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize="12" fontWeight="900" fill="#3b82f6" fontFamily="Inter, system-ui">X</text>
+      <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize="12" fontWeight="900" fill="#3b82f6" fontFamily={buttonLabelFontFamily}>X</text>
     </svg>
   );
 }
@@ -68,7 +71,7 @@ export function ButtonY({ className, size = 18 }: ButtonProps): JSX.Element {
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle cx="12" cy="12" r="10" stroke="#eab308" strokeWidth="2.5" fill="rgba(234, 179, 8, 0.1)" />
-      <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize="12" fontWeight="900" fill="#eab308" fontFamily="Inter, system-ui">Y</text>
+      <text x="50%" y="50%" dominantBaseline="central" textAnchor="middle" fontSize="12" fontWeight="900" fill="#eab308" fontFamily={buttonLabelFontFamily}>Y</text>
     </svg>
   );
 }

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -77,7 +77,7 @@ body,
 #root {
   width: 100%;
   height: 100%;
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, "Noto Sans", "DejaVu Sans", sans-serif;
   font-size: 14px;
   line-height: 1.5;
   color: var(--ink);


### PR DESCRIPTION
This PR mitigates the renderer crash reported on Fedora/Bazzite with NVIDIA proprietary drivers on X11 by disabling unstable Linux font backend features and removing external font dependencies.

**Linux Electron Flags** (`src/main/index.ts`):

* Disable `SkiaFontService` and Fontations-related features (`FontationBackend`, `FontationsFontBackend`, `FontationsLinuxSystemFonts`) on Linux to avoid `SkFontMgr_FontConfigInterface` crashes.
* Scope Linux x64 VA-API enablement to exclude systems with NVIDIA proprietary drivers detected via `/proc` or `/sys`, preventing potential instability on affected hardware.

**Renderer Font Stack** (`src/renderer/index.html`, `src/renderer/src/styles.css`, `src/renderer/src/components/ControllerButtons.tsx`):

* Remove Google Fonts `Inter` dependency from startup to avoid remote font loading issues.
* Replace global `font-family` and SVG button labels with a robust system-local stack (`system-ui`, `Noto Sans`, etc.) to ensure rendering reliability without remote assets.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c40d2a91-fff0-4cf7-aa72-07f0aaebcc8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-075" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c40d2a91-fff0-4cf7-aa72-07f0aaebcc8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-075&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-075"><img alt="OPE-075" src="https://capy.ai/api/badge/thread.svg?label=OPE-075"></picture></a>
<!-- capy-pr-badge:end -->