### PR TITLE
Add Discord activity clearing functionality to rich presence

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -1248,6 +1248,10 @@ function registerIpcHandlers(): void {
     return getActiveSessions(jwt, baseUrl);
   });
 
+  ipcMain.handle(IPC_CHANNELS.DISCORD_CLEAR_ACTIVITY, async () => {
+    void clearActivity();
+  });
+
   ipcMain.handle(IPC_CHANNELS.CLAIM_SESSION, async (_event, payload: SessionClaimRequest) => {
     try {
       const token = await resolveJwt(payload.token);

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -167,6 +167,7 @@ const api: OpenNowApi = {
   fetchPrintedWasteServerMapping: (): Promise<PrintedWasteServerMapping> =>
     ipcRenderer.invoke(IPC_CHANNELS.PRINTEDWASTE_SERVER_MAPPING_FETCH),
   getThanksData: (): Promise<ThankYouDataResult> => ipcRenderer.invoke(IPC_CHANNELS.COMMUNITY_GET_THANKS),
+  clearDiscordActivity: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.DISCORD_CLEAR_ACTIVITY),
 };
 
 contextBridge.exposeInMainWorld("openNow", api);

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1358,7 +1358,12 @@ export function App(): JSX.Element {
     if (!options?.keepLaunchError) {
       setLaunchError(null);
     }
-  }, [diagnosticsStore, resetStatsOverlayToPreference]);
+
+    // Clear Discord activity when returning to idle state
+    if (settings.discordRichPresence) {
+      void window.openNow.clearDiscordActivity();
+    }
+  }, [diagnosticsStore, resetStatsOverlayToPreference, settings.discordRichPresence]);
 
   // Session ref sync
   useEffect(() => {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -822,6 +822,8 @@ export interface OpenNowApi {
   /** Fetch PrintedWaste server mapping metadata (includes nuked status) */
   fetchPrintedWasteServerMapping(): Promise<PrintedWasteServerMapping>;
   getThanksData(): Promise<ThankYouDataResult>;
+  /** Clear Discord rich presence activity */
+  clearDiscordActivity(): Promise<void>;
 }
 
 export interface ScreenshotSaveRequest {

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -61,6 +61,8 @@ export const IPC_CHANNELS = {
   // PrintedWaste queue integration
   PRINTEDWASTE_QUEUE_FETCH: "printedwaste:queue-fetch",
   PRINTEDWASTE_SERVER_MAPPING_FETCH: "printedwaste:server-mapping-fetch",
+  // Discord Rich Presence
+  DISCORD_CLEAR_ACTIVITY: "discord:clear-activity",
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];


### PR DESCRIPTION
## Description

Clear Discord activity when returning to idle state by adding functionality to the rich presence feature. This includes IPC channel handling and updates to the API for clearing activity.

