### PR TITLE
Switch macOS workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -37,13 +37,13 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
-            os: macos-latest
+            os: blacksmith-6vcpu-macos-latest
             builder_args: "--mac dmg zip --x64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
-            os: macos-latest
+            os: blacksmith-6vcpu-macos-latest
             builder_args: "--mac dmg zip --arm64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,13 +112,13 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
-            os: macos-latest
+            os: blacksmith-6vcpu-macos-latest
             builder_args: "--mac dmg zip --x64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
-            os: macos-latest
+            os: blacksmith-6vcpu-macos-latest
             builder_args: "--mac dmg zip --arm64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg


### PR DESCRIPTION
## Description

This PR switches macOS build jobs in auto-build and release workflows to Blacksmith runners. Both `macos-x64` and `macos-arm64` matrix entries now use `blacksmith-6vcpu-macos-latest` instead of GitHub-hosted `macos-latest` runners.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/925419ec-04b1-462e-91df-65382a697d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-077" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/925419ec-04b1-462e-91df-65382a697d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-077&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-077"><img alt="OPE-077" src="https://capy.ai/api/badge/thread.svg?label=OPE-077"></picture></a>
<!-- capy-pr-badge:end -->