### PR TITLE
Fix Settings search to show relevant sections only (scope-aware filtering + sidebar UX polish)

### DIFF
--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1162,7 +1162,28 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   }, []);
 
   useEffect(() => {
-    if (activeSection !== "thanks") {
+    const normalizedSearch = settingsSearch.trim().toLowerCase();
+    const showAll = normalizedSearch.length > 0;
+    const shouldShowThanks = activeSection === "thanks" || (showAll && (() => {
+      const terms = SETTINGS_SCOPE_SEARCH_TERMS["thanks"];
+      const searchTokens = normalizedSearch.split(/[^a-z0-9]+/).filter((token) => token.length > 0);
+      if (searchTokens.length === 0) {
+        return true;
+      }
+      const searchableWords = Array.from(
+        new Set(
+          terms
+            .join(" ")
+            .toLowerCase()
+            .split(/[^a-z0-9]+/)
+            .filter((word) => word.length > 0),
+        ),
+      );
+      const tokenMatchesWord = (token: string, word: string): boolean => token === word || word.startsWith(token);
+      return searchTokens.every((token) => searchableWords.some((word) => tokenMatchesWord(token, word)));
+    })());
+
+    if (!shouldShowThanks) {
       thanksRequestIdRef.current += 1;
       setThanksLoadState((current) => (current === "loading" || current === "error" ? "idle" : current));
       setThanksFetchError(null);
@@ -1210,7 +1231,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
         setThanksLoadState("error");
       },
     );
-  }, [activeSection, thanksData, thanksLoadState]);
+  }, [activeSection, thanksData, thanksLoadState, settingsSearch]);
 
   const renderPersonLink = useCallback((person: ThankYouContributor | ThankYouSupporter, content: JSX.Element) => {
     if (!person.profileUrl) {

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1374,7 +1374,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
       return true;
     }
     const terms = SETTINGS_SCOPE_SEARCH_TERMS[scopeId];
-    const searchTokens = normalizedSettingsSearch.split(/\s+/).filter((token) => token.length > 0);
+    const searchTokens = normalizedSettingsSearch.split(/[^a-z0-9]+/).filter((token) => token.length > 0);
     if (searchTokens.length === 0) {
       return true;
     }

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -39,6 +39,75 @@ interface SettingsPageProps {
 type ThanksLoadState = "idle" | "loading" | "loaded" | "error";
 
 type SettingsSectionId = "stream" | "game" | "audio" | "input" | "interface" | "about" | "thanks";
+type SettingsSearchScopeId =
+  | "stream-region"
+  | "stream-video"
+  | "stream-codec-diagnostics"
+  | "game"
+  | "audio"
+  | "input"
+  | "interface"
+  | "about"
+  | "thanks";
+
+const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string[]> = {
+  "stream-region": ["stream", "region", "latency", "ping", "server", "route", "auto best"],
+  "stream-video": [
+    "stream",
+    "video",
+    "quality",
+    "codec",
+    "fps",
+    "resolution",
+    "bitrate",
+    "aspect ratio",
+    "l4s",
+    "cloud gsync",
+    "video acceleration",
+  ],
+  "stream-codec-diagnostics": [
+    "stream",
+    "codec diagnostics",
+    "diagnostics",
+    "decode",
+    "encode",
+    "gpu",
+    "cpu",
+    "test codecs",
+  ],
+  game: ["game", "language", "keyboard layout", "store", "launch"],
+  audio: ["audio", "microphone", "mic", "push to talk", "voice activity"],
+  input: [
+    "input",
+    "mouse",
+    "keyboard layout",
+    "shortcut",
+    "hotkey",
+    "keybind",
+    "controls",
+    "anti afk",
+    "pointer lock",
+    "recording",
+    "screenshot",
+  ],
+  interface: [
+    "interface",
+    "ui",
+    "overlay",
+    "controller mode",
+    "controller mode library",
+    "auto-load controller library",
+    "library",
+    "fullscreen",
+    "discord",
+    "rich presence",
+    "poster",
+    "session timer",
+    "counter",
+  ],
+  about: ["about", "update", "version", "logs", "cache", "download"],
+  thanks: ["thanks", "contributors", "supporters", "sponsors", "community"],
+};
 
 const POSTER_SIZE_MIN = 75;
 const POSTER_SIZE_MAX = 135;
@@ -1297,13 +1366,42 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
     </div>
   );
 
-  const showAll = settingsSearch.length > 0;
-  const showStream = activeSection === "stream" || showAll;
-  const showGame = activeSection === "game" || showAll;
-  const showAudio = activeSection === "audio" || showAll;
-  const showInput = activeSection === "input" || showAll;
-  const showInterface = activeSection === "interface" || showAll;
-  const showAbout = activeSection === "about" || showAll;
+  const normalizedSettingsSearch = settingsSearch.trim().toLowerCase();
+  const showAll = normalizedSettingsSearch.length > 0;
+  const tokenMatchesWord = (token: string, word: string): boolean => token === word || word.startsWith(token);
+  const scopeMatchesSearch = (scopeId: SettingsSearchScopeId): boolean => {
+    if (!showAll) {
+      return true;
+    }
+    const terms = SETTINGS_SCOPE_SEARCH_TERMS[scopeId];
+    const searchTokens = normalizedSettingsSearch.split(/\s+/).filter((token) => token.length > 0);
+    if (searchTokens.length === 0) {
+      return true;
+    }
+    const searchableWords = Array.from(
+      new Set(
+        terms
+          .join(" ")
+          .toLowerCase()
+          .split(/[^a-z0-9]+/)
+          .filter((word) => word.length > 0),
+      ),
+    );
+    return searchTokens.every((token) => searchableWords.some((word) => tokenMatchesWord(token, word)));
+  };
+
+  const showStreamRegion = showAll ? scopeMatchesSearch("stream-region") : activeSection === "stream";
+  const showStreamVideo = showAll ? scopeMatchesSearch("stream-video") : activeSection === "stream";
+  const showStreamCodecDiagnostics = showAll ? scopeMatchesSearch("stream-codec-diagnostics") : activeSection === "stream";
+  const showStream = showStreamRegion || showStreamVideo || showStreamCodecDiagnostics;
+  const showGame = showAll ? scopeMatchesSearch("game") : activeSection === "game";
+  const showAudio = showAll ? scopeMatchesSearch("audio") : activeSection === "audio";
+  const showInput = showAll ? scopeMatchesSearch("input") : activeSection === "input";
+  const showInterface = showAll ? scopeMatchesSearch("interface") : activeSection === "interface";
+  const showAbout = showAll ? scopeMatchesSearch("about") : activeSection === "about";
+  const showThanks = showAll ? scopeMatchesSearch("thanks") : activeSection === "thanks";
+  const hasAnySearchMatches = showStream || showGame || showAudio || showInput || showInterface || showAbout || showThanks;
+  const shouldRenderSettingsSections = showAll || activeSection !== "thanks";
 
   return (
     <div className="settings-page">
@@ -1347,7 +1445,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
             <button
               key={item.id}
               type="button"
-              className={`settings-nav-item ${activeSection === item.id ? "active" : ""}`}
+              className={`settings-nav-item ${!showAll && activeSection === item.id ? "active" : ""}`}
               onClick={() => { setActiveSection(item.id); setSettingsSearch(""); }}
             >
               {item.icon}
@@ -1359,14 +1457,22 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
 
       {/* ── Content ───────────────────────────────────────── */}
       <div className="settings-content">
-        {activeSection === "thanks" ? (
-          thanksTabContent
+        {showAll && !hasAnySearchMatches ? (
+          <section className="settings-section">
+            <div className="settings-thanks-state settings-thanks-state--muted">
+              <span>No settings matched "{settingsSearch.trim()}".</span>
+            </div>
+          </section>
         ) : (
           <>
+            {showThanks && thanksTabContent}
+            {shouldRenderSettingsSections && (
+              <>
             {/* ═══ STREAM ════════════════════════════════════ */}
             {showStream && (
               <>
                 {/* ── Region ── */}
+                {showStreamRegion && (
                 <section className="settings-section">
                   {showAll && <div className="settings-section-context">Stream</div>}
                   <div className="settings-section-header">
@@ -1531,7 +1637,8 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
               </div>
             </section>
 
-            {/* ── Video ── */}
+                )}
+            {showStreamVideo && (
             <section className="settings-section">
               {showAll && <div className="settings-section-context">Stream</div>}
               <div className="settings-section-header">
@@ -1752,7 +1859,8 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
               </div>
             </section>
 
-            {/* ── Codec Diagnostics (advanced disclosure) ── */}
+            )}
+            {showStreamCodecDiagnostics && (
             <div className="settings-advanced-wrap">
               <button
                 type="button"
@@ -1839,6 +1947,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                 </section>
               )}
             </div>
+            )}
           </>
         )}
 
@@ -2784,8 +2893,10 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
               </div>
             </div>
           </section>
-        )}
-      </>
+                )}
+              </>
+            )}
+          </>
         )}
       </div>
       </div>


### PR DESCRIPTION
 ## Summary
This PR overhauls Settings search behavior so results are relevant and predictable instead of showing broad tab content.

Previously:
- Any non-empty search could effectively show too much content.
- Search could match misleading terms (for example, `controller` showing Input due to loose matching).
- Stream search always surfaced broad Stream content instead of only the relevant subsection.
- Sidebar could still look like a tab was selected during search, which was confusing.
- Some valid queries like `keyboard layout` didn’t surface all expected places.

Now:
- Search is **scope-aware** and filters by specific settings scopes/subsections.
- Stream is split into searchable scopes:
  - `stream-region`
  - `stream-video`
  - `stream-codec-diagnostics`
- Query matching is token/prefix-based against normalized scope terms.
- `keyboard layout` now matches both Game and Input contexts.
- Sidebar active tab highlight is disabled while search is active.
- A clear empty state appears when nothing matches:  
  `No settings matched "<query>"`.
- Thanks can appear in search results without requiring explicit tab selection.

## Key Changes
- Added `SettingsSearchScopeId` and `SETTINGS_SCOPE_SEARCH_TERMS`.
- Replaced coarse section-wide search checks with scope-specific matching.
- Added per-scope visibility booleans:
  - `showStreamRegion`
  - `showStreamVideo`
  - `showStreamCodecDiagnostics`
- Rendered Stream subsections conditionally, so queries only show relevant subsection(s).
- Updated content branch to support:
  - normal tab mode
  - search mode (multi-scope results)
  - no-results state
- Updated sidebar active style logic to avoid misleading highlight during search.

## Why this is better
- Search results are much closer to user intent.
- Reduces noise in results (especially inside Stream).
- Avoids false UI signals during search.
- More maintainable: scope terms can be extended safely as Settings evolves.

## Validation
- Typecheck passed:
  - `npm --prefix opennow-stable run typecheck`

## Manual QA suggestions
- `cloud gsync` → shows Stream Video subsection only (not Region).
- `region` / `ping` → shows Stream Region subsection only.
- `codec diagnostics` / `test codecs` → shows Stream diagnostics subsection.
- `keyboard layout` → shows both Game and Input.
- `controller mode library` → shows Interface.
- Random string (`zzzz`) → shows no-results message.
- While searching, sidebar should not show an active tab highlight.

## Notes
- Search behavior is driven by `SETTINGS_SCOPE_SEARCH_TERMS`; future tuning can be done by adjusting this map without changing render architecture.


Description generated by Codex free. :)))