### PR TITLE
Add stable device ID management in cloudmatch.ts (#361)

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -1,5 +1,8 @@
 import crypto from "node:crypto";
 import dns from "node:dns";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { app } from "electron";
 
 import type {
   ActiveSessionInfo,
@@ -33,6 +36,9 @@ const GFN_USER_AGENT =
 const GFN_CLIENT_VERSION = "2.0.80.173";
 const SESSION_MODIFY_ACTION_AD_UPDATE = 6;
 const READY_SESSION_STATUSES = new Set([2, 3]);
+const GFN_DEVICE_ID_FILENAME = "gfn-device-id.json";
+
+let cachedStableDeviceId: string | null = null;
 
 const AD_ACTION_CODES: Record<SessionAdAction, number> = {
   start: 1,
@@ -50,6 +56,34 @@ const GFN_AD_MEDIA_PROFILE_ORDER = new Map<string, number>([
 
 function isReadySessionStatus(status: number): boolean {
   return READY_SESSION_STATUSES.has(status);
+}
+
+function getStableDeviceId(): string {
+  if (cachedStableDeviceId) {
+    return cachedStableDeviceId;
+  }
+
+  try {
+    const path = join(app.getPath("userData"), GFN_DEVICE_ID_FILENAME);
+    if (existsSync(path)) {
+      const parsed = JSON.parse(readFileSync(path, "utf-8")) as { deviceId?: unknown };
+      if (typeof parsed.deviceId === "string" && parsed.deviceId.length > 0) {
+        cachedStableDeviceId = parsed.deviceId;
+        return parsed.deviceId;
+      }
+    }
+
+    const deviceId = crypto.randomUUID();
+    writeFileSync(path, JSON.stringify({ deviceId }, null, 2), "utf-8");
+    cachedStableDeviceId = deviceId;
+    return deviceId;
+  } catch (error) {
+    // Fallback to in-memory UUID if disk read/write fails.
+    const fallback = crypto.randomUUID();
+    cachedStableDeviceId = fallback;
+    console.warn("[CloudMatch] Failed to load persisted device ID, using in-memory fallback:", error);
+    return fallback;
+  }
 }
 
 async function resolveHostnameWithFallback(hostname: string): Promise<string | null> {
@@ -1196,7 +1230,7 @@ function buildClaimRequestBody(sessionId: string, appId: string, settings: Strea
   // The session is already configured on the server side. Sending different fps, resolution,
   // codec, etc. causes HTTP 400 from the server because those parameters are immutable for
   // an already-streaming session. Only send the action and minimal required fields.
-  const deviceId = crypto.randomUUID();
+  const deviceId = getStableDeviceId();
   const subSessionId = crypto.randomUUID();
   const timezoneMs = timezoneOffsetMs();
 
@@ -1262,7 +1296,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
     throw new Error("Missing token for session claim");
   }
 
-  const deviceId = crypto.randomUUID();
+  const deviceId = getStableDeviceId();
   const clientId = crypto.randomUUID();
 
   // Provide default values for optional parameters


### PR DESCRIPTION
This pull request introduces persistent and stable device ID generation for the GFN (GeForce NOW) client, replacing the previous approach of generating a new random device ID for each session. The device ID is now stored on disk and reused across sessions, improving consistency and user identification. The most important changes are:

**Device ID Persistence and Management:**

* Added a new function `getStableDeviceId` that generates a device ID once, saves it to a file in the user's data directory (`gfn-device-id.json`), and retrieves it for future use. If the file cannot be accessed, it falls back to an in-memory UUID and logs a warning.
* Updated both `buildClaimRequestBody` and `claimSession` to use the persistent device ID from `getStableDeviceId` instead of generating a new random UUID each time. [[1]](diffhunk://#diff-01df11ee193582e2e6ccb59c6ae0cbc276382511dfa988f49cdfd2c47a2adb11L1199-R1233) [[2]](diffhunk://#diff-01df11ee193582e2e6ccb59c6ae0cbc276382511dfa988f49cdfd2c47a2adb11L1265-R1299)

**Supporting Changes:**

* Imported necessary modules from `fs`, `path`, and `electron` to support file operations and access to the user data directory.
* Added constants and a cache variable for the device ID filename and in-memory caching.Implement a function to retrieve or generate a stable device ID, persisting it to a JSON file. This change enhances device identification consistency across sessions and improves error handling for file operations.

## Description

<!-- Provide a brief description of the changes in this PR -->
