### PR TITLE
Fix ESC handling to preserve fullscreen and pointer lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
+---
+description: 
+alwaysApply: true
+---
+
 # AGENTS.md
 
+## Graphify-first policy
+For any codebase question, architecture question, or "where/how/why" query:
+1. Call Graphify MCP first (`graph_stats`, `query_graph`, `get_node`, `get_neighbors`, `shortest_path`) to gather graph context.
+2. Base the answer on Graphify results plus file verification when needed.
+3. If Graphify is unavailable, state that explicitly and continue with normal code search.
 
 ## Core Priorities
 

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -888,6 +888,7 @@ export function App(): JSX.Element {
   const [queueModalData, setQueueModalData] = useState<PrintedWasteQueueData | null>(null);
   const [sessionStartedAtMs, setSessionStartedAtMs] = useState<number | null>(null);
   const [remoteStreamWarning, setRemoteStreamWarning] = useState<StreamWarningState | null>(null);
+  const [pointerLockDisengagingNotice, setPointerLockDisengagingNotice] = useState<string | null>(null);
   const [localSessionTimerWarning, setLocalSessionTimerWarning] = useState<LocalSessionTimerWarningState | null>(null);
   const [activeQueueAdId, setActiveQueueAdId] = useState<string | null>(null);
   const previousFreeTierRemainingSecondsRef = useRef<number | null>(null);
@@ -2819,6 +2820,9 @@ export function App(): JSX.Element {
                   secondsLeft: warning.secondsLeft,
                 });
               },
+              onPointerLockDisengagingNoticeChange: (message) => {
+                setPointerLockDisengagingNotice(message);
+              },
               onMicStateChange: (state) => {
                 console.log(`[App] Mic state: ${state.state}${state.deviceLabel ? ` (${state.deviceLabel})` : ""}`);
               },
@@ -3927,6 +3931,7 @@ export function App(): JSX.Element {
             sessionClockShowEveryMinutes={settings.sessionClockShowEveryMinutes}
             sessionClockShowDurationSeconds={settings.sessionClockShowDurationSeconds}
             streamWarning={streamWarning}
+            pointerLockDisengagingNotice={pointerLockDisengagingNotice}
             isConnecting={streamStatus === "connecting"}
             isStreaming={isStreaming}
             gameTitle={streamingGame?.title ?? "Game"}

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -46,6 +46,7 @@ interface StreamViewProps {
     tone: "warn" | "critical";
     secondsLeft?: number;
   } | null;
+  pointerLockDisengagingNotice?: string | null;
   isConnecting: boolean;
   gameTitle: string;
   platformStore?: string;
@@ -656,6 +657,7 @@ export function StreamView({
   sessionClockShowEveryMinutes,
   sessionClockShowDurationSeconds,
   streamWarning,
+  pointerLockDisengagingNotice,
   isConnecting,
   gameTitle,
   platformStore,
@@ -1936,6 +1938,16 @@ export function StreamView({
             {streamWarning.message}
             {warningSeconds ? ` · ${warningSeconds} left` : ""}
           </span>
+        </div>
+      )}
+
+      {pointerLockDisengagingNotice && !isConnecting && !exitPrompt.open && (
+        <div
+          className="sv-time-warning sv-time-warning--warn"
+          title="Pointer lock hold warning"
+        >
+          <AlertTriangle size={14} />
+          <span>{pointerLockDisengagingNotice}</span>
         </div>
       )}
 

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -150,6 +150,7 @@ interface ClientOptions {
   onLog: (line: string) => void;
   onStats?: (stats: StreamDiagnostics) => void;
   onTimeWarning?: (warning: StreamTimeWarning) => void;
+  onPointerLockDisengagingNoticeChange?: (message: string | null) => void;
   onMicStateChange?: (state: MicStateChange) => void;
 }
 
@@ -547,6 +548,14 @@ export class GfnWebRtcClient {
   private pointerLockEscapeTimer: number | null = null;
   // Skip one synthetic Escape on pointer loss when lock was released intentionally (e.g. F8).
   private suppressNextSyntheticEscape = false;
+  // Timer for the 3-second ESC hold-to-release pointer lock feature
+  private escHoldTimer: number | null = null;
+  // Delay timer before showing "pointer lock disengaging" notice
+  private escHoldNoticeTimer: number | null = null;
+  private pointerLockDisengagingNotice: string | null = null;
+  private interceptedEscapeHoldStartedAtMs: number | null = null;
+  private interceptedEscapeSyntheticSent = false;
+  private escapeKeyLockActive = false;
   private mouseBackpressureLoggedAtMs = 0;
   private mouseFlushBaseIntervalMs = GfnWebRtcClient.MOUSE_FLUSH_NORMAL_MS;
   private mouseAdaptiveFlushActive = false;
@@ -849,6 +858,14 @@ export class GfnWebRtcClient {
 
   private log(message: string): void {
     this.options.onLog(message);
+  }
+
+  private setPointerLockDisengagingNotice(message: string | null): void {
+    if (this.pointerLockDisengagingNotice === message) {
+      return;
+    }
+    this.pointerLockDisengagingNotice = message;
+    this.options.onPointerLockDisengagingNoticeChange?.(message);
   }
 
   private emitStats(): void {
@@ -2233,6 +2250,43 @@ export class GfnWebRtcClient {
     }
   }
 
+  private syncEscapeKeyLockState(): void {
+    const nav = navigator as any;
+    const keyboardApi = nav.keyboard;
+    const canLock = typeof keyboardApi?.lock === "function";
+    const canUnlock = typeof keyboardApi?.unlock === "function";
+    if (!canLock && !canUnlock) {
+      this.escapeKeyLockActive = false;
+      return;
+    }
+
+    const shouldLock = Boolean(document.fullscreenElement && document.pointerLockElement);
+    if (shouldLock) {
+      if (!canLock || this.escapeKeyLockActive) {
+        return;
+      }
+      void keyboardApi
+        .lock(["Escape"])
+        .then(() => {
+          this.escapeKeyLockActive = true;
+        })
+        .catch((error: unknown) => {
+          this.escapeKeyLockActive = false;
+          this.log(`Keyboard lock(Escape) request failed: ${String(error)}`);
+        });
+      return;
+    }
+
+    if (canUnlock) {
+      try {
+        keyboardApi.unlock();
+      } catch {
+        // Ignore unlock failures (browser may already have released lock).
+      }
+    }
+    this.escapeKeyLockActive = false;
+  }
+
   private shouldSendSyntheticEscapeOnPointerLockLoss(): boolean {
     if (document.visibilityState !== "visible") {
       return false;
@@ -2741,6 +2795,34 @@ export class GfnWebRtcClient {
       event.preventDefault();
       this.pressedKeys.add(mapped.vk);
 
+      if (isEscapeEvent && isPointerLockActive()) {
+        if (this.escHoldTimer !== null) {
+          window.clearTimeout(this.escHoldTimer);
+        }
+        if (this.escHoldNoticeTimer !== null) {
+          window.clearTimeout(this.escHoldNoticeTimer);
+        }
+        this.setPointerLockDisengagingNotice(null);
+        this.escHoldNoticeTimer = window.setTimeout(() => {
+          this.escHoldNoticeTimer = null;
+          if (this.escHoldTimer === null || !isPointerLockActive()) {
+            return;
+          }
+          this.setPointerLockDisengagingNotice("Pointer lock disengaging - keep holding ESC...");
+        }, 1000);
+        this.escHoldTimer = window.setTimeout(() => {
+          this.escHoldTimer = null;
+          if (this.escHoldNoticeTimer !== null) {
+            window.clearTimeout(this.escHoldNoticeTimer);
+            this.escHoldNoticeTimer = null;
+          }
+          this.setPointerLockDisengagingNotice(null);
+          if (!isPointerLockActive()) return;
+          this.suppressNextSyntheticEscape = true;
+          document.exitPointerLock();
+        }, 3000);
+      }
+
       const payload = this.inputEncoder.encodeKeyDown({
         keycode: mapped.vk,
         scancode: mapped.scancode,
@@ -2770,6 +2852,19 @@ export class GfnWebRtcClient {
 
       event.preventDefault();
       this.pressedKeys.delete(mapped.vk);
+
+      if (isEscapeEvent && this.escHoldTimer !== null) {
+        window.clearTimeout(this.escHoldTimer);
+        this.escHoldTimer = null;
+      }
+      if (isEscapeEvent && this.escHoldNoticeTimer !== null) {
+        window.clearTimeout(this.escHoldNoticeTimer);
+        this.escHoldNoticeTimer = null;
+      }
+      if (isEscapeEvent) {
+        this.setPointerLockDisengagingNotice(null);
+      }
+
       const payload = this.inputEncoder.encodeKeyUp({
         keycode: mapped.vk,
         scancode: mapped.scancode,
@@ -2847,6 +2942,7 @@ export class GfnWebRtcClient {
     // Handle pointer lock changes — send synthetic Escape when lock is lost by browser
     // (matches official GFN client's "pointerLockEscape" feature)
     const onPointerLockChange = () => {
+      this.syncEscapeKeyLockState();
       if (isPointerLockActive()) {
         // Pointer lock gained — cancel any pending synthetic Escape.
         // Reset absolute position tracking since we switch to relative movement.
@@ -2856,6 +2952,13 @@ export class GfnWebRtcClient {
           window.clearTimeout(this.pointerLockEscapeTimer);
           this.pointerLockEscapeTimer = null;
         }
+        if (this.escHoldNoticeTimer !== null) {
+          window.clearTimeout(this.escHoldNoticeTimer);
+          this.escHoldNoticeTimer = null;
+        }
+        this.setPointerLockDisengagingNotice(null);
+        this.interceptedEscapeHoldStartedAtMs = null;
+        this.interceptedEscapeSyntheticSent = false;
         this.suppressNextSyntheticEscape = false;
         return;
       }
@@ -2869,12 +2972,26 @@ export class GfnWebRtcClient {
       if (!this.inputReady) return;
 
       if (this.suppressNextSyntheticEscape) {
+        if (this.escHoldNoticeTimer !== null) {
+          window.clearTimeout(this.escHoldNoticeTimer);
+          this.escHoldNoticeTimer = null;
+        }
+        this.setPointerLockDisengagingNotice(null);
+        this.interceptedEscapeHoldStartedAtMs = null;
+        this.interceptedEscapeSyntheticSent = false;
         this.suppressNextSyntheticEscape = false;
         this.releasePressedKeys("pointer lock intentionally released");
         return;
       }
 
       if (!this.shouldSendSyntheticEscapeOnPointerLockLoss()) {
+        if (this.escHoldNoticeTimer !== null) {
+          window.clearTimeout(this.escHoldNoticeTimer);
+          this.escHoldNoticeTimer = null;
+        }
+        this.setPointerLockDisengagingNotice(null);
+        this.interceptedEscapeHoldStartedAtMs = null;
+        this.interceptedEscapeSyntheticSent = false;
         this.releasePressedKeys("pointer lock lost while unfocused");
         return;
       }
@@ -2885,26 +3002,28 @@ export class GfnWebRtcClient {
       if (escapeWasPressed) {
         // Escape was already tracked as pressed — the normal keyup handler will fire
         // and send Escape keyup to the server. No synthetic needed.
+        // Re-acquire lock immediately so a short ESC press does not permanently end
+        // pointer lock. This must not depend on escHoldTimer because keyup can clear
+        // the timer before pointerlockchange is delivered on some platforms.
+        if (this.pointerLockTarget) {
+          void this.requestPointerLockWithOptionalFullscreen(this.pointerLockTarget, false).catch(() => {});
+        }
         return;
       }
 
-      // Escape was NOT tracked as pressed — browser intercepted it before our keydown fired.
-      // Send synthetic Escape keydown+keyup after 50ms (matches official GFN client).
-      // Also re-acquire pointer lock so the user stays in the game.
-      this.pointerLockEscapeTimer = window.setTimeout(() => {
-        this.pointerLockEscapeTimer = null;
+      // Escape was NOT tracked as pressed — browser intercepted it before our keydown fired
+      // (common on macOS). Drive hold behavior from repeated lock-loss duration instead
+      // of relying on keydown/keyup delivery.
+      const nowMs = performance.now();
+      if (this.interceptedEscapeHoldStartedAtMs === null) {
+        this.interceptedEscapeHoldStartedAtMs = nowMs;
+        this.interceptedEscapeSyntheticSent = false;
+      }
+      const heldMs = nowMs - this.interceptedEscapeHoldStartedAtMs;
 
-        if (!this.inputReady) return;
-
-        if (!this.shouldSendSyntheticEscapeOnPointerLockLoss()) {
-          this.releasePressedKeys("focus changed before synthetic Escape");
-          return;
-        }
-
-        // Release all currently held keys first (matching official client's MS() function)
+      if (!this.interceptedEscapeSyntheticSent) {
         this.releasePressedKeys("pointer lock lost before synthetic Escape");
 
-        // Send synthetic Escape keydown + keyup
         this.log("Sending synthetic Escape (pointer lock lost by browser)");
         const escDown = this.inputEncoder.encodeKeyDown({
           keycode: 0x1B,
@@ -2921,13 +3040,27 @@ export class GfnWebRtcClient {
           timestampUs: timestampUs(),
         });
         this.sendReliable(escUp);
+        this.interceptedEscapeSyntheticSent = true;
+      }
 
-        // Re-acquire pointer lock so the user stays in the game
-        if (this.pointerLockTarget) {
-          void this.requestPointerLockWithOptionalFullscreen(this.pointerLockTarget, false)
-            .catch(() => {});
-        }
-      }, 50);
+      if (heldMs >= 1000) {
+        this.setPointerLockDisengagingNotice("Pointer lock disengaging - keep holding ESC...");
+      } else {
+        this.setPointerLockDisengagingNotice(null);
+      }
+
+      // Held for >=3s: treat as intentional disengage and remain unlocked.
+      if (heldMs >= 3000) {
+        this.setPointerLockDisengagingNotice(null);
+        this.interceptedEscapeHoldStartedAtMs = null;
+        this.interceptedEscapeSyntheticSent = false;
+        return;
+      }
+
+      // Short press path: re-acquire pointer lock quickly.
+      if (this.pointerLockTarget) {
+        void this.requestPointerLockWithOptionalFullscreen(this.pointerLockTarget, false).catch(() => {});
+      }
     };
 
     const onWindowBlur = () => {
@@ -2969,6 +3102,7 @@ export class GfnWebRtcClient {
 
     // Release any prior Keyboard API lock when leaving fullscreen (e.g. other UI may have locked keys).
     const onFullscreenChange = () => {
+      this.syncEscapeKeyLockState();
       if (document.fullscreenElement) {
         return;
       }
@@ -3116,6 +3250,17 @@ export class GfnWebRtcClient {
           window.clearTimeout(this.pointerLockEscapeTimer);
           this.pointerLockEscapeTimer = null;
         }
+        if (this.escHoldTimer !== null) {
+          window.clearTimeout(this.escHoldTimer);
+          this.escHoldTimer = null;
+        }
+        if (this.escHoldNoticeTimer !== null) {
+          window.clearTimeout(this.escHoldNoticeTimer);
+          this.escHoldNoticeTimer = null;
+        }
+        this.setPointerLockDisengagingNotice(null);
+        this.interceptedEscapeHoldStartedAtMs = null;
+        this.interceptedEscapeSyntheticSent = false;
       this.releasePressedKeys("input cleanup");
       this.pendingMouseDxFloat = 0;
       this.pendingMouseDyFloat = 0;
@@ -3127,6 +3272,7 @@ export class GfnWebRtcClient {
       if (nav.keyboard?.unlock) {
         nav.keyboard.unlock();
       }
+      this.escapeKeyLockActive = false;
     });
   }
 

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -2952,6 +2952,10 @@ export class GfnWebRtcClient {
           window.clearTimeout(this.pointerLockEscapeTimer);
           this.pointerLockEscapeTimer = null;
         }
+        if (this.escHoldTimer !== null) {
+          window.clearTimeout(this.escHoldTimer);
+          this.escHoldTimer = null;
+        }
         if (this.escHoldNoticeTimer !== null) {
           window.clearTimeout(this.escHoldNoticeTimer);
           this.escHoldNoticeTimer = null;


### PR DESCRIPTION
## Summary
- Improve stream ESC handling so short ESC presses no longer drop pointer lock unexpectedly while streaming.
- Add keyboard lock coordination for `Escape` during active fullscreen + pointer-lock sessions.
- Preserve intentional long-hold ESC behavior to release lock, with explicit disengaging notice wiring to UI.

## What Changed
- `opennow-stable/src/renderer/src/gfn/webrtcClient.ts`
  - Added pointer-lock disengaging notice plumbing and hold timers.
  - Added robust synthetic ESC handling for browser-intercepted ESC paths.
  - Added `syncEscapeKeyLockState()` to call `navigator.keyboard.lock([\"Escape\"])` while fullscreen + pointer lock are active, and unlock when not active.
  - Tightened pointer-lock-loss recovery: re-acquire lock for non-intentional short ESC paths without depending on a timer race.
  - Kept intentional release flow (`suppressNextSyntheticEscape`) intact.
- `opennow-stable/src/renderer/src/App.tsx`
  - Added local state for `pointerLockDisengagingNotice`.
  - Passed notice callback into client options and forwarded notice state into stream view.
- `opennow-stable/src/renderer/src/components/StreamView.tsx`
  - Added optional notice prop and warning banner rendering while streaming.
- `AGENTS.md`
  - Added/retained Graphify-first policy guidance for repo-level agent behavior.

## Why
- ESC handling had race-prone behavior where fullscreen was retained but pointer lock could still be lost after short ESC taps.
- Browser-level ESC interception differs by platform; keyboard lock + lock-loss recovery is needed for consistent stream control semantics.

## Test Plan
- [x] Build/lint sanity check for edited file (`webrtcClient.ts`) via project diagnostics.
- [x] Start stream, enable fullscreen + pointer lock, tap `Esc` briefly -> pointer lock should re-acquire and stream input remains active.
- [x] Hold `Esc` for ~3s -> pointer lock intentionally disengages.
- [x] Use explicit pointer lock toggle shortcut -> no synthetic ESC side effects.
- [x] Verify warning banner appears after ~1s hold and clears after release/disengage.
- [ ] Verify behavior on macOS and Windows if available (keyboard lock support can vary by environment).

## Notes / Risks
- `navigator.keyboard.lock` availability is runtime-dependent; logic safely falls back when unsupported.
- Existing pointer lock recovery paths are preserved, but this area is timing-sensitive and should be regression-tested with real stream sessions.

Made with [Cursor](https://cursor.com)