### PR TITLE
Add selectable controller background styles

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -1,7 +1,7 @@
 import { app } from "electron";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode, GameLanguage, AspectRatio, KeyboardLayout, ControllerBackgroundTheme } from "@shared/gfn";
+import type { VideoCodec, ColorQuality, VideoAccelerationPreference, MicrophoneMode, GameLanguage, AspectRatio, KeyboardLayout, ControllerBackgroundTheme, ControllerBackgroundStyle } from "@shared/gfn";
 import { DEFAULT_KEYBOARD_LAYOUT, getDefaultStreamPreferences, normalizeStreamPreferences } from "@shared/gfn";
 
 export interface Settings {
@@ -69,6 +69,8 @@ export interface Settings {
   controllerUiSounds: boolean;
   /** Enable animated background visuals for controller-mode loading screens */
   controllerBackgroundAnimations: boolean;
+  /** Visual composition style for controller-mode UI background */
+  controllerBackgroundStyle: ControllerBackgroundStyle;
   /** Visual background theme for controller-mode UI */
   controllerBackgroundTheme: ControllerBackgroundTheme;
   /** Auto-load controller library at startup when controller mode is enabled */
@@ -134,6 +136,7 @@ const DEFAULT_SETTINGS: Settings = {
   controllerMode: false,
   controllerUiSounds: false,
   controllerBackgroundAnimations: false,
+  controllerBackgroundStyle: "ribbon",
   controllerBackgroundTheme: "aurora",
   autoLoadControllerLibrary: false,
   autoFullScreen: false,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -844,6 +844,7 @@ export function App(): JSX.Element {
     controllerMode: false,
     controllerUiSounds: false,
     controllerBackgroundAnimations: false,
+    controllerBackgroundStyle: "ribbon",
     controllerBackgroundTheme: "aurora",
     autoLoadControllerLibrary: false,
     autoFullScreen: false,
@@ -3992,6 +3993,8 @@ export function App(): JSX.Element {
             playtimeData={playtime}
             gameId={pendingSwitchGameId ?? streamingGame?.id}
             enableBackgroundAnimations={settings.controllerBackgroundAnimations}
+            backgroundStyle={settings.controllerBackgroundStyle}
+            backgroundTheme={settings.controllerBackgroundTheme}
           />
         )}
         {isSwitchingGame && !settings.controllerMode && (
@@ -4064,6 +4067,7 @@ export function App(): JSX.Element {
                 microphoneDeviceId: settings.microphoneDeviceId,
                 controllerUiSounds: settings.controllerUiSounds,
                 controllerBackgroundAnimations: settings.controllerBackgroundAnimations,
+                controllerBackgroundStyle: settings.controllerBackgroundStyle,
                 controllerBackgroundTheme: settings.controllerBackgroundTheme,
                 autoLoadControllerLibrary: settings.autoLoadControllerLibrary,
                 autoFullScreen: settings.autoFullScreen,
@@ -4103,6 +4107,8 @@ export function App(): JSX.Element {
             playtimeData={playtime}
             gameId={streamingGame?.id}
             enableBackgroundAnimations={settings.controllerBackgroundAnimations}
+            backgroundStyle={settings.controllerBackgroundStyle}
+            backgroundTheme={settings.controllerBackgroundTheme}
           />
         )}
         {showDesktopLaunchLoading && (
@@ -4239,6 +4245,7 @@ export function App(): JSX.Element {
                 microphoneDeviceId: settings.microphoneDeviceId,
                 controllerUiSounds: settings.controllerUiSounds,
                 controllerBackgroundAnimations: settings.controllerBackgroundAnimations,
+                controllerBackgroundStyle: settings.controllerBackgroundStyle,
                 controllerBackgroundTheme: settings.controllerBackgroundTheme,
                 autoLoadControllerLibrary: settings.autoLoadControllerLibrary,
                 autoFullScreen: settings.autoFullScreen,

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -37,6 +37,7 @@ interface ControllerLibraryPageProps {
     microphoneDeviceId?: string;
     controllerUiSounds?: boolean;
     controllerBackgroundAnimations?: boolean;
+    controllerBackgroundStyle?: "ribbon" | "mesh" | "grid";
     controllerBackgroundTheme?: "aurora" | "nebula" | "sunset" | "midnight";
     autoLoadControllerLibrary?: boolean;
     autoFullScreen?: boolean;
@@ -347,6 +348,13 @@ export function ControllerLibraryPage({
         { id: "autoFullScreen", label: "Auto Full Screen", value: (settings as any).autoFullScreen ? "On" : "Off" },
         { id: "autoLoad", label: "Auto-Load Library", value: (settings as any).autoLoadControllerLibrary ? "On" : "Off" },
         { id: "backgroundAnimations", label: "Background Animations", value: ((settings as any).controllerBackgroundAnimations ? "On" : "Off") },
+        {
+          id: "backgroundStyle",
+          label: "Background Style",
+          value: settings.controllerBackgroundStyle
+            ? settings.controllerBackgroundStyle.charAt(0).toUpperCase() + settings.controllerBackgroundStyle.slice(1)
+            : "Ribbon",
+        },
         {
           id: "backgroundTheme",
           label: "Background Theme",
@@ -769,6 +777,13 @@ export function ControllerLibraryPage({
           } else if (setting.id === "backgroundAnimations") {
             onSettingChange("controllerBackgroundAnimations" as any, !((settings as any).controllerBackgroundAnimations || false));
             playUiSound("move");
+          } else if (setting.id === "backgroundStyle") {
+            const styles = ["ribbon", "mesh", "grid"] as const;
+            const currentStyle = settings.controllerBackgroundStyle ?? "ribbon";
+            const currentIdx = styles.indexOf(currentStyle);
+            const nextStyle = styles[(currentIdx + 1) % styles.length];
+            onSettingChange("controllerBackgroundStyle" as any, nextStyle as any);
+            playUiSound("move");
           } else if (setting.id === "backgroundTheme") {
             const themes = ["aurora", "nebula", "sunset", "midnight"] as const;
             const currentTheme = settings.controllerBackgroundTheme ?? "aurora";
@@ -921,8 +936,9 @@ export function ControllerLibraryPage({
       : <ButtonY className={className} size={size} />;
   };
 
+  const controllerBackgroundStyle = settings.controllerBackgroundStyle ?? "ribbon";
   const controllerBackgroundTheme = settings.controllerBackgroundTheme ?? "aurora";
-  const wrapperClassName = `xmb-wrapper xmb-theme-${controllerBackgroundTheme} ${settings.controllerBackgroundAnimations ? "xmb-animate" : "xmb-static"} ${isEntering ? "xmb-entering" : "xmb-ready"}`;
+  const wrapperClassName = `xmb-wrapper xmb-bg-style-${controllerBackgroundStyle} xmb-theme-${controllerBackgroundTheme} ${settings.controllerBackgroundAnimations ? "xmb-animate" : "xmb-static"} ${isEntering ? "xmb-entering" : "xmb-ready"}`;
 
   if (isLoading && topCategory !== "settings" && topCategory !== "current" && topCategory !== "media") return <div className={wrapperClassName}><div className="xmb-bg-layer"><div className="xmb-bg-gradient" /></div><div style={{display:'flex',justifyContent:'center',alignItems:'center',height:'100vh'}}>Loading...</div></div>;
 

--- a/opennow-stable/src/renderer/src/components/ControllerStreamLoading.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerStreamLoading.tsx
@@ -7,7 +7,7 @@ import {
   getSessionAdMessage,
   isSessionQueuePaused,
 } from "@shared/gfn";
-import type { SessionAdInfo, SessionAdState } from "@shared/gfn";
+import type { ControllerBackgroundStyle, ControllerBackgroundTheme, SessionAdInfo, SessionAdState } from "@shared/gfn";
 import { formatPlaytime } from "../utils/usePlaytime";
 import type { PlaytimeStore } from "../utils/usePlaytime";
 import { QueueAdPreview, type QueueAdPlaybackEvent, type QueueAdPreviewHandle } from "./QueueAdPreview";
@@ -31,6 +31,8 @@ export interface ControllerStreamLoadingProps {
   playtimeData?: PlaytimeStore;
   gameId?: string;
   enableBackgroundAnimations?: boolean;
+  backgroundStyle?: ControllerBackgroundStyle;
+  backgroundTheme?: ControllerBackgroundTheme;
 }
 
 function getStatusMessage(
@@ -86,6 +88,8 @@ export function ControllerStreamLoading({
   playtimeData = {},
   gameId,
   enableBackgroundAnimations = false,
+  backgroundStyle = "ribbon",
+  backgroundTheme = "aurora",
 }: ControllerStreamLoadingProps): JSX.Element {
   const statusMessage = getStatusMessage(status, queuePosition, adState);
   const statusPhase = getStatusPhase(status);
@@ -101,14 +105,15 @@ export function ControllerStreamLoading({
 
   return (
     <div className="controller-stream-loading">
-      {enableBackgroundAnimations && (
-        <div className={`xmb-wrapper ${enableBackgroundAnimations ? "xmb-animate" : ""}`} aria-hidden>
-          <div className="xmb-bg-layer">
-            <div className="xmb-bg-gradient" />
-            <div className="xmb-bg-overlay" />
-          </div>
+      <div
+        className={`xmb-wrapper xmb-bg-style-${backgroundStyle} xmb-theme-${backgroundTheme} ${enableBackgroundAnimations ? "xmb-animate" : "xmb-static"}`}
+        aria-hidden
+      >
+        <div className="xmb-bg-layer">
+          <div className="xmb-bg-gradient" />
+          <div className="xmb-bg-overlay" />
         </div>
-      )}
+      </div>
       {/* Fade-to-black backdrop */}
       <div className="csl-backdrop" />
 

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -2636,8 +2636,24 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
 
                     <div className="settings-row">
                       <label className="settings-label">
+                        Controller Background Style
+                        <span className="settings-hint">Choose the visual layout (ribbon, mesh, or grid/noise) for controller-mode backgrounds.</span>
+                      </label>
+                      <select
+                        className="settings-select"
+                        value={settings.controllerBackgroundStyle}
+                        onChange={(e) => handleChange("controllerBackgroundStyle", e.target.value as any)}
+                      >
+                        <option value="ribbon">Ribbon (Default)</option>
+                        <option value="mesh">Soft Mesh</option>
+                        <option value="grid">Grid + Noise</option>
+                      </select>
+                    </div>
+
+                    <div className="settings-row">
+                      <label className="settings-label">
                         Controller Background Theme
-                        <span className="settings-hint">Choose the controller-mode background style.</span>
+                        <span className="settings-hint">Choose the color palette used by the selected background style.</span>
                       </label>
                       <select
                         className="settings-select"

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -6769,6 +6769,136 @@ button.game-card-store-chip.owned.active:hover {
   opacity: 0.5;
 }
 
+.xmb-wrapper {
+  --xmb-accent-rgb: 124, 241, 177;
+  --xmb-accent-strong-rgb: 133, 247, 187;
+  --xmb-highlight-rgb: 241, 255, 248;
+  --xmb-base-top: #081711;
+  --xmb-base-bottom: #010302;
+}
+
+.xmb-wrapper.xmb-theme-nebula {
+  --xmb-accent-rgb: 153, 122, 255;
+  --xmb-accent-strong-rgb: 170, 143, 255;
+  --xmb-highlight-rgb: 236, 228, 255;
+  --xmb-base-top: #10072c;
+  --xmb-base-bottom: #03030a;
+}
+
+.xmb-wrapper.xmb-theme-sunset {
+  --xmb-accent-rgb: 255, 144, 114;
+  --xmb-accent-strong-rgb: 255, 154, 117;
+  --xmb-highlight-rgb: 255, 232, 203;
+  --xmb-base-top: #3a0d20;
+  --xmb-base-bottom: #08050f;
+}
+
+.xmb-wrapper.xmb-theme-midnight {
+  --xmb-accent-rgb: 119, 176, 255;
+  --xmb-accent-strong-rgb: 126, 176, 255;
+  --xmb-highlight-rgb: 224, 238, 255;
+  --xmb-base-top: #071121;
+  --xmb-base-bottom: #020409;
+}
+
+.xmb-wrapper.xmb-bg-style-mesh .xmb-bg-layer {
+  background:
+    radial-gradient(88% 66% at 18% 22%, rgba(var(--xmb-accent-rgb), 0.28) 0%, rgba(var(--xmb-accent-rgb), 0.08) 40%, rgba(0, 0, 0, 0) 72%),
+    radial-gradient(80% 72% at 84% 24%, rgba(var(--xmb-highlight-rgb), 0.2) 0%, rgba(var(--xmb-highlight-rgb), 0.05) 42%, rgba(0, 0, 0, 0) 76%),
+    radial-gradient(78% 72% at 54% 80%, rgba(var(--xmb-accent-strong-rgb), 0.24) 0%, rgba(var(--xmb-accent-strong-rgb), 0.08) 42%, rgba(0, 0, 0, 0) 78%),
+    linear-gradient(180deg, var(--xmb-base-top) 0%, color-mix(in srgb, var(--xmb-base-top) 55%, var(--xmb-base-bottom)) 54%, var(--xmb-base-bottom) 100%);
+}
+
+.xmb-wrapper.xmb-bg-style-mesh .xmb-bg-gradient {
+  inset: -8%;
+  background:
+    radial-gradient(52% 52% at 30% 30%, rgba(var(--xmb-highlight-rgb), 0.14) 0%, rgba(var(--xmb-highlight-rgb), 0) 68%),
+    radial-gradient(48% 58% at 74% 34%, rgba(var(--xmb-accent-rgb), 0.2) 0%, rgba(var(--xmb-accent-rgb), 0) 70%),
+    radial-gradient(60% 56% at 54% 76%, rgba(var(--xmb-accent-strong-rgb), 0.18) 0%, rgba(var(--xmb-accent-strong-rgb), 0) 70%);
+  background-size: 100% 100%;
+  mix-blend-mode: screen;
+  opacity: 0.95;
+  filter: blur(2px);
+}
+
+.xmb-wrapper.xmb-bg-style-mesh .xmb-bg-gradient::before,
+.xmb-wrapper.xmb-bg-style-mesh .xmb-bg-gradient::after {
+  display: none;
+}
+
+.xmb-wrapper.xmb-bg-style-grid .xmb-bg-layer {
+  background:
+    radial-gradient(120% 78% at 50% -8%, rgba(var(--xmb-accent-rgb), 0.18) 0%, rgba(var(--xmb-accent-rgb), 0.04) 42%, rgba(0, 0, 0, 0) 70%),
+    linear-gradient(180deg, var(--xmb-base-top) 0%, color-mix(in srgb, var(--xmb-base-top) 48%, var(--xmb-base-bottom)) 56%, var(--xmb-base-bottom) 100%);
+}
+
+.xmb-wrapper.xmb-bg-style-grid .xmb-bg-gradient {
+  inset: 0;
+  background:
+    linear-gradient(rgba(var(--xmb-highlight-rgb), 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(var(--xmb-highlight-rgb), 0.05) 1px, transparent 1px),
+    radial-gradient(circle at 52% 46%, rgba(var(--xmb-accent-strong-rgb), 0.16), rgba(var(--xmb-accent-strong-rgb), 0) 62%);
+  background-size: 56px 56px, 56px 56px, 100% 100%;
+  mix-blend-mode: screen;
+  opacity: 0.72;
+}
+
+.xmb-wrapper.xmb-bg-style-grid .xmb-bg-gradient::before {
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(var(--xmb-highlight-rgb), 0.14) 0%, rgba(var(--xmb-highlight-rgb), 0) 32%),
+    radial-gradient(circle at 72% 68%, rgba(var(--xmb-accent-strong-rgb), 0.12) 0%, rgba(var(--xmb-accent-strong-rgb), 0) 32%);
+  opacity: 0.42;
+}
+
+.xmb-wrapper.xmb-bg-style-grid .xmb-bg-gradient::after {
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.06) 0.6px, transparent 0.6px);
+  background-size: 3px 3px;
+  mix-blend-mode: soft-light;
+  opacity: 0.24;
+}
+
+.xmb-wrapper.xmb-bg-style-mesh.xmb-animate .xmb-bg-gradient {
+  animation: xmb-mesh-drift 24s ease-in-out infinite alternate;
+}
+
+.xmb-wrapper.xmb-bg-style-grid.xmb-animate .xmb-bg-gradient {
+  animation: xmb-grid-pan 18s linear infinite;
+}
+
+.xmb-wrapper.xmb-bg-style-grid.xmb-animate .xmb-bg-gradient::before {
+  animation: xmb-grid-pulse 10s ease-in-out infinite;
+}
+
+@keyframes xmb-mesh-drift {
+  0% {
+    transform: translate3d(-1.2%, -0.8%, 0) scale(1.01);
+  }
+  100% {
+    transform: translate3d(1.2%, 0.8%, 0) scale(1.03);
+  }
+}
+
+@keyframes xmb-grid-pan {
+  0% {
+    background-position: 0 0, 0 0, 0 0;
+  }
+  100% {
+    background-position: 56px 0, 0 56px, 0 0;
+  }
+}
+
+@keyframes xmb-grid-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.56;
+  }
+}
+
 .xmb-categories-container {
   position: absolute;
   top: 25%;

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -101,6 +101,7 @@ export function colorQualityIs10Bit(cq: ColorQuality): boolean {
 export type MicrophoneMode = "disabled" | "push-to-talk" | "voice-activity";
 export type AspectRatio = "16:9" | "16:10" | "21:9" | "32:9";
 export type ControllerBackgroundTheme = "aurora" | "nebula" | "sunset" | "midnight";
+export type ControllerBackgroundStyle = "ribbon" | "mesh" | "grid";
 export type RuntimePlatform =
   | "aix"
   | "android"
@@ -160,6 +161,8 @@ export interface Settings {
   autoLoadControllerLibrary: boolean;
   /** When true, controller-mode overlays will show animated background orbs */
   controllerBackgroundAnimations: boolean;
+  /** Visual composition style for controller-mode background surfaces */
+  controllerBackgroundStyle: ControllerBackgroundStyle;
   /** Visual background theme for controller-mode UI surfaces */
   controllerBackgroundTheme: ControllerBackgroundTheme;
   /** When true, the app will automatically enter fullscreen when controller mode triggers it */


### PR DESCRIPTION
## Summary
- add a dedicated controller background style setting (`ribbon`, `mesh`, `grid`) separate from existing color themes
- apply style + theme consistently across controller library and controller loading overlays
- add new settings controls and style-specific CSS treatments while preserving existing animation toggle behavior

## Test plan
- [x] `npm run typecheck --prefix opennow-stable`
- [x] verify edited files have no lints
- [ ] in app settings, switch style/theme combinations and confirm controller library visuals update
- [ ] launch/switch in controller mode and confirm loading overlay matches selected style/theme

Made with [Cursor](https://cursor.com)