### PR TITLE
feat(controller-ui): add account switching and themed controller visuals

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -4058,6 +4058,9 @@ export function App(): JSX.Element {
               pendingSwitchGameCover={pendingSwitchGameCover}
               userName={authSession?.user.displayName}
               userAvatarUrl={authSession?.user.avatarUrl}
+              savedAccounts={savedAccounts}
+              activeUserId={authSession?.user.userId}
+              onSwitchAccount={handleSwitchAccount}
               subscriptionInfo={subscriptionInfo}
               playtimeData={playtime}
               sessionStartedAtMs={sessionStartedAtMs}
@@ -4236,6 +4239,9 @@ export function App(): JSX.Element {
               pendingSwitchGameCover={pendingSwitchGameCover}
               userName={authSession?.user.displayName}
               userAvatarUrl={authSession?.user.avatarUrl}
+              savedAccounts={savedAccounts}
+              activeUserId={authSession?.user.userId}
+              onSwitchAccount={handleSwitchAccount}
               subscriptionInfo={subscriptionInfo}
               playtimeData={playtime}
               sessionStartedAtMs={sessionStartedAtMs}

--- a/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerLibraryPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
-import type { GameInfo, MediaListingEntry, Settings } from "@shared/gfn";
+import type { GameInfo, MediaListingEntry, SavedAccount, Settings } from "@shared/gfn";
 import { Star, Clock, Calendar, Repeat2 } from "lucide-react";
 import { ButtonA, ButtonB, ButtonX, ButtonY, ButtonPSCross, ButtonPSCircle, ButtonPSSquare, ButtonPSTriangle } from "./ControllerButtons";
 import { getStoreDisplayName } from "./GameCard";
@@ -14,6 +14,8 @@ interface ControllerLibraryPageProps {
   uiSoundsEnabled: boolean;
   selectedVariantByGameId: Record<string, string>;
   favoriteGameIds: string[];
+  savedAccounts?: SavedAccount[];
+  activeUserId?: string;
   userName?: string;
   userAvatarUrl?: string;
   subscriptionInfo: import("@shared/gfn").SubscriptionInfo | null;
@@ -22,6 +24,7 @@ interface ControllerLibraryPageProps {
   onSelectGameVariant: (gameId: string, variantId: string) => void;
   onToggleFavoriteGame: (gameId: string) => void;
   onPlayGame: (game: GameInfo) => void;
+  onSwitchAccount?: (userId: string) => Promise<void> | void;
   onOpenSettings?: () => void;
   currentStreamingGame?: GameInfo | null;
   onResumeGame?: (game: GameInfo) => void;
@@ -59,7 +62,7 @@ interface ControllerLibraryPageProps {
 type Direction = "up" | "down" | "left" | "right";
 type TopCategory = "current" | "all" | "settings" | "media" | "favorites" | `genre:${string}`;
 type SoundKind = "move" | "confirm";
-type SettingsSubcategory = "root" | "Network" | "Audio" | "Video" | "System";
+type SettingsSubcategory = "root" | "Network" | "Audio" | "Video" | "System" | "Accounts";
 type MediaSubcategory = "root" | "Videos" | "Screenshots";
 const CATEGORY_STEP_PX = 160;
 const CATEGORY_ACTIVE_HALF_WIDTH_PX = 60;
@@ -108,10 +111,13 @@ export function ControllerLibraryPage({
   selectedVariantByGameId,
   uiSoundsEnabled,
   favoriteGameIds,
+  savedAccounts = [],
+  activeUserId,
   onSelectGame,
   onSelectGameVariant,
   onToggleFavoriteGame,
   onPlayGame,
+  onSwitchAccount,
   onOpenSettings,
   currentStreamingGame,
   onResumeGame,
@@ -183,6 +189,7 @@ export function ControllerLibraryPage({
   const [mediaThumbById, setMediaThumbById] = useState<Record<string, string>>({});
   const [controllerType, setControllerType] = useState<"ps" | "xbox" | "nintendo" | "generic">("generic");
   const [editingBandwidth, setEditingBandwidth] = useState(false);
+  const [isSwitchingAccount, setIsSwitchingAccount] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -240,6 +247,13 @@ export function ControllerLibraryPage({
       window.removeEventListener("gamepaddisconnected", updateFromConnected);
     };
   }, []);
+
+  const getTierDisplayLabel = (tier: string): string => {
+    const normalized = tier.toUpperCase();
+    if (normalized === "ULTIMATE") return "Ultimate";
+    if (normalized === "PRIORITY" || normalized === "PERFORMANCE") return "Priority";
+    return "Free";
+  };
 
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -327,6 +341,7 @@ export function ControllerLibraryPage({
         { id: "audio", label: "Audio", value: "" },
         { id: "video", label: "Video", value: "" },
         { id: "system", label: "System", value: "" },
+        { id: "accounts", label: "Accounts", value: `${savedAccounts.length || 0} saved` },
         { id: "exitApp", label: "Exit", value: "" },
       ],
       Network: [
@@ -364,8 +379,19 @@ export function ControllerLibraryPage({
         },
         { id: "exitControllerMode", label: "Exit Controller Mode", value: "" },
       ],
+      Accounts: savedAccounts.map((account) => {
+        const isActive = account.userId === activeUserId;
+        const tierLabel = getTierDisplayLabel(account.membershipTier);
+        const email = account.email?.trim();
+        const details = [tierLabel, email].filter(Boolean).join(" • ");
+        return {
+          id: `account:${account.userId}`,
+          label: `${account.displayName}${isActive ? " (Active)" : ""}`,
+          value: details,
+        };
+      }),
     } as Record<string, Array<{ id: string; label: string; value: string }>>;
-  }, [settings, microphoneDevices]);
+  }, [settings, microphoneDevices, savedAccounts, activeUserId]);
  
   const currentGameItems = useMemo(() => [
     { id: "resume", label: "Resume Game", value: "" },
@@ -657,12 +683,13 @@ export function ControllerLibraryPage({
       if (topCategory === "settings") {
         const setting = displayItems[selectedSettingIndex];
         // Enter subcategory if at root and selecting network/audio/system
-        if (settingsSubcategory === "root" && setting && (setting.id === "network" || setting.id === "audio" || setting.id === "video" || setting.id === "system")) {
+        if (settingsSubcategory === "root" && setting && (setting.id === "network" || setting.id === "audio" || setting.id === "video" || setting.id === "system" || setting.id === "accounts")) {
           setLastRootSettingIndex(selectedSettingIndex);
           if (setting.id === "network") setSettingsSubcategory("Network");
           if (setting.id === "audio") setSettingsSubcategory("Audio");
           if (setting.id === "video") setSettingsSubcategory("Video");
           if (setting.id === "system") setSettingsSubcategory("System");
+          if (setting.id === "accounts") setSettingsSubcategory("Accounts");
           setSelectedSettingIndex(0);
           playUiSound("confirm");
           return;
@@ -678,6 +705,18 @@ export function ControllerLibraryPage({
         }
         // In subcategory, A toggles values like X does
         if (settingsSubcategory !== "root") {
+          if (settingsSubcategory === "Accounts" && setting?.id.startsWith("account:")) {
+            const selectedUserId = setting.id.slice("account:".length);
+            if (!selectedUserId || selectedUserId === activeUserId || !onSwitchAccount || isSwitchingAccount) {
+              return;
+            }
+            setIsSwitchingAccount(true);
+            playUiSound("confirm");
+            void Promise.resolve(onSwitchAccount(selectedUserId)).finally(() => {
+              setIsSwitchingAccount(false);
+            });
+            return;
+          }
           if (setting?.id === "exitControllerMode") {
             if (onExitControllerMode) {
               onExitControllerMode();
@@ -729,9 +768,10 @@ export function ControllerLibraryPage({
           // X button cycles through setting values (no-op for exit actions or subcategory items at root)
           const setting = displayItems[selectedSettingIndex];
           if (!setting || !onSettingChange) return;
+          if (settingsSubcategory === "Accounts") return;
           if (setting.id === "exitApp" || setting.id === "exitControllerMode") return;
           // Skip X cycling for subcategory items at root
-          if (settingsSubcategory === "root" && (setting.id === "network" || setting.id === "audio" || setting.id === "video" || setting.id === "system")) return;
+          if (settingsSubcategory === "root" && (setting.id === "network" || setting.id === "audio" || setting.id === "video" || setting.id === "system" || setting.id === "accounts")) return;
 
           // Microphone device cycling
           if (setting.id === "microphone") {
@@ -1082,12 +1122,13 @@ export function ControllerLibraryPage({
       >
         {displayItems.map((item, idx) => {
           const isActive = idx === (topCategory === "media" ? selectedMediaIndex : selectedSettingIndex);
-          const isSubcategoryItem = settingsSubcategory === "root" && (item.id === "network" || item.id === "audio" || item.id === "video" || item.id === "system");
+          const isSubcategoryItem = settingsSubcategory === "root" && (item.id === "network" || item.id === "audio" || item.id === "video" || item.id === "system" || item.id === "accounts");
           const isMediaSubcategoryItem = topCategory === "media" && mediaSubcategory === "root" && (item.id === "videos" || item.id === "screenshots");
+          const isActiveAccountItem = settingsSubcategory === "Accounts" && item.id === `account:${activeUserId ?? ""}`;
           return (
             <div 
               key={item.id} 
-              className={`xmb-game-item ${isActive ? 'active' : ''}`}
+              className={`xmb-game-item ${isActive ? 'active' : ''}${isActiveAccountItem ? ' xmb-account-item-active' : ''}`}
               role="option"
               aria-selected={isActive}
               data-subcategory-id={isSubcategoryItem || isMediaSubcategoryItem ? item.id : undefined}
@@ -1113,6 +1154,11 @@ export function ControllerLibraryPage({
                     ) : (
                       <span className="xmb-game-meta-chip">{item.value}</span>
                     )}
+                  </div>
+                )}
+                {settingsSubcategory === "Accounts" && isActiveAccountItem && (
+                  <div className="xmb-game-meta">
+                    <span className="xmb-game-meta-chip">Current account</span>
                   </div>
                 )}
               </div>
@@ -1287,7 +1333,7 @@ export function ControllerLibraryPage({
                   ) : (
                     <ButtonA className="xmb-btn-icon" size={24} />
                   )}
-                  <span>Toggle</span>
+                  <span>{settingsSubcategory === "Accounts" ? "Select" : "Toggle"}</span>
                 </div>
               </>
             )}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -2593,18 +2593,6 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                 {settings.controllerMode && (
                   <div className="settings-controller-subsettings">
                     <div className="settings-row">
-                      <label className="settings-label">Exit Controller Mode</label>
-                      <div>
-                        <button
-                          className="settings-exit-btn"
-                          onClick={() => handleChange("controllerMode", false)}
-                        >
-                          Exit
-                        </button>
-                      </div>
-                    </div>
-
-                    <div className="settings-row">
                       <label className="settings-label">
                         Controller UI Sounds
                         <span className="settings-hint">Play subtle move, open, and back sounds inside controller mode only.</span>

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -6956,7 +6956,7 @@ button.game-card-store-chip.owned.active:hover {
   25%  { transform: translate3d(5%, -7%, 0) scale(1.06); filter: blur(24px) brightness(1.04); }
   50%  { transform: translate3d(7%, 5%, 0) scale(1.08);  filter: blur(30px) brightness(1.0);  }
   75%  { transform: translate3d(-4%, 7%, 0) scale(1.04); filter: blur(26px) brightness(0.96); }
-  100% { transform: translate3d(-6%, -5%, 0) scale(1.02); filter: blur(28px) brightness(1.02); }
+  100% { transform: translate3d(-6%, -5%, 0) scale(1.0);  filter: blur(28px) brightness(0.92); }
 }
 
 @keyframes xmb-mesh-orb-b {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -6633,15 +6633,22 @@ button.game-card-store-chip.owned.active:hover {
   animation: none;
 }
 
-/* Enable ribbon animations when wrapper has xmb-animate */
-.xmb-wrapper.xmb-animate .xmb-bg-gradient {
+/* Ribbon animations — scoped to ribbon style only */
+.xmb-wrapper.xmb-bg-style-ribbon.xmb-animate .xmb-bg-gradient {
   animation: xmb-ribbon-pan 30s linear infinite;
 }
-.xmb-wrapper.xmb-animate .xmb-bg-gradient::before {
+.xmb-wrapper.xmb-bg-style-ribbon.xmb-animate .xmb-bg-gradient::before {
   animation: xmb-ribbon-float 26s ease-in-out infinite;
 }
-.xmb-wrapper.xmb-animate .xmb-bg-gradient::after {
+.xmb-wrapper.xmb-bg-style-ribbon.xmb-animate .xmb-bg-gradient::after {
   animation: xmb-ribbon-swell 22s ease-in-out infinite;
+}
+
+/* Promote GPU compositing for all animated backgrounds */
+.xmb-wrapper.xmb-animate .xmb-bg-gradient,
+.xmb-wrapper.xmb-animate .xmb-bg-gradient::before,
+.xmb-wrapper.xmb-animate .xmb-bg-gradient::after {
+  will-change: transform, opacity, background-position;
 }
 
 @keyframes xmb-enter-bg {
@@ -6699,6 +6706,8 @@ button.game-card-store-chip.owned.active:hover {
     linear-gradient(118deg, transparent 21%, rgba(231, 225, 255, 0.08) 28%, rgba(219, 206, 255, 0.21) 31%, rgba(165, 139, 255, 0.2) 35%, rgba(231, 225, 255, 0.07) 39%, transparent 44%),
     linear-gradient(128deg, transparent 30%, rgba(186, 172, 255, 0.08) 37%, rgba(237, 231, 255, 0.2) 41%, rgba(153, 122, 255, 0.2) 44%, rgba(237, 231, 255, 0.06) 48%, transparent 54%),
     radial-gradient(circle at 52% 48%, rgba(210, 194, 255, 0.08), transparent 34%);
+  background-size: 140% 140%, 155% 155%, 100% 100%;
+  background-repeat: no-repeat;
 }
 
 .xmb-wrapper.xmb-theme-nebula .xmb-bg-gradient::before {
@@ -6726,6 +6735,8 @@ button.game-card-store-chip.owned.active:hover {
     linear-gradient(118deg, transparent 21%, rgba(255, 227, 198, 0.08) 28%, rgba(255, 206, 157, 0.22) 31%, rgba(255, 144, 114, 0.2) 34%, rgba(255, 224, 202, 0.07) 38%, transparent 44%),
     linear-gradient(128deg, transparent 30%, rgba(255, 183, 138, 0.08) 37%, rgba(255, 217, 191, 0.2) 40%, rgba(255, 128, 128, 0.2) 44%, rgba(255, 225, 206, 0.06) 48%, transparent 54%),
     radial-gradient(circle at 52% 48%, rgba(255, 214, 172, 0.08), transparent 34%);
+  background-size: 140% 140%, 155% 155%, 100% 100%;
+  background-repeat: no-repeat;
 }
 
 .xmb-wrapper.xmb-theme-sunset .xmb-bg-gradient::before {
@@ -6753,6 +6764,8 @@ button.game-card-store-chip.owned.active:hover {
     linear-gradient(118deg, transparent 21%, rgba(215, 236, 255, 0.07) 28%, rgba(188, 222, 255, 0.17) 31%, rgba(119, 176, 255, 0.16) 34%, rgba(215, 236, 255, 0.05) 38%, transparent 44%),
     linear-gradient(128deg, transparent 30%, rgba(162, 201, 255, 0.06) 37%, rgba(214, 235, 255, 0.17) 40%, rgba(114, 161, 255, 0.14) 44%, rgba(214, 235, 255, 0.05) 48%, transparent 54%),
     radial-gradient(circle at 52% 48%, rgba(186, 221, 255, 0.06), transparent 34%);
+  background-size: 140% 140%, 155% 155%, 100% 100%;
+  background-repeat: no-repeat;
 }
 
 .xmb-wrapper.xmb-theme-midnight .xmb-bg-gradient::before {
@@ -6801,102 +6814,182 @@ button.game-card-store-chip.owned.active:hover {
   --xmb-base-bottom: #020409;
 }
 
+/* ── MESH background style ─────────────────────────────────────────────────
+   Three large radial orbs sit on .xmb-bg-layer. The animated gradient layers
+   (gradient, ::before, ::after) each carry one or two orbs that drift on
+   independent paths so the aurora-like blobs appear to float past each other.
+   ────────────────────────────────────────────────────────────────────────── */
 .xmb-wrapper.xmb-bg-style-mesh .xmb-bg-layer {
   background:
-    radial-gradient(88% 66% at 18% 22%, rgba(var(--xmb-accent-rgb), 0.28) 0%, rgba(var(--xmb-accent-rgb), 0.08) 40%, rgba(0, 0, 0, 0) 72%),
-    radial-gradient(80% 72% at 84% 24%, rgba(var(--xmb-highlight-rgb), 0.2) 0%, rgba(var(--xmb-highlight-rgb), 0.05) 42%, rgba(0, 0, 0, 0) 76%),
-    radial-gradient(78% 72% at 54% 80%, rgba(var(--xmb-accent-strong-rgb), 0.24) 0%, rgba(var(--xmb-accent-strong-rgb), 0.08) 42%, rgba(0, 0, 0, 0) 78%),
+    radial-gradient(88% 66% at 18% 22%, rgba(var(--xmb-accent-rgb), 0.3) 0%, rgba(var(--xmb-accent-rgb), 0.08) 40%, transparent 72%),
+    radial-gradient(80% 72% at 84% 24%, rgba(var(--xmb-highlight-rgb), 0.22) 0%, rgba(var(--xmb-highlight-rgb), 0.05) 42%, transparent 76%),
+    radial-gradient(78% 72% at 54% 82%, rgba(var(--xmb-accent-strong-rgb), 0.26) 0%, rgba(var(--xmb-accent-strong-rgb), 0.07) 42%, transparent 78%),
     linear-gradient(180deg, var(--xmb-base-top) 0%, color-mix(in srgb, var(--xmb-base-top) 55%, var(--xmb-base-bottom)) 54%, var(--xmb-base-bottom) 100%);
 }
 
+/* Primary orb layer — drifts in a slow figure-of-eight */
 .xmb-wrapper.xmb-bg-style-mesh .xmb-bg-gradient {
-  inset: -8%;
+  inset: -16%;
   background:
-    radial-gradient(52% 52% at 30% 30%, rgba(var(--xmb-highlight-rgb), 0.14) 0%, rgba(var(--xmb-highlight-rgb), 0) 68%),
-    radial-gradient(48% 58% at 74% 34%, rgba(var(--xmb-accent-rgb), 0.2) 0%, rgba(var(--xmb-accent-rgb), 0) 70%),
-    radial-gradient(60% 56% at 54% 76%, rgba(var(--xmb-accent-strong-rgb), 0.18) 0%, rgba(var(--xmb-accent-strong-rgb), 0) 70%);
+    radial-gradient(55% 55% at 38% 34%, rgba(var(--xmb-highlight-rgb), 0.22) 0%, rgba(var(--xmb-highlight-rgb), 0) 65%),
+    radial-gradient(50% 60% at 70% 62%, rgba(var(--xmb-accent-rgb), 0.26) 0%, rgba(var(--xmb-accent-rgb), 0) 66%),
+    radial-gradient(44% 48% at 22% 74%, rgba(var(--xmb-accent-strong-rgb), 0.2) 0%, rgba(var(--xmb-accent-strong-rgb), 0) 68%);
   background-size: 100% 100%;
   mix-blend-mode: screen;
-  opacity: 0.95;
-  filter: blur(2px);
+  opacity: 1;
+  filter: blur(28px);
+  transform-origin: center center;
 }
 
 .xmb-wrapper.xmb-bg-style-mesh .xmb-bg-gradient::before,
 .xmb-wrapper.xmb-bg-style-mesh .xmb-bg-gradient::after {
-  display: none;
+  display: block;
 }
 
+/* Secondary orb layer — counter-rotates for cross-dissolve depth */
+.xmb-wrapper.xmb-bg-style-mesh .xmb-bg-gradient::before {
+  inset: -12%;
+  background:
+    radial-gradient(48% 46% at 68% 26%, rgba(var(--xmb-accent-strong-rgb), 0.28) 0%, rgba(var(--xmb-accent-strong-rgb), 0) 64%),
+    radial-gradient(42% 50% at 28% 66%, rgba(var(--xmb-highlight-rgb), 0.2) 0%, rgba(var(--xmb-highlight-rgb), 0) 66%);
+  mix-blend-mode: screen;
+  filter: blur(20px);
+  opacity: 0.9;
+  transform-origin: center center;
+}
+
+/* Shimmer bloom — a subtle large bright centre that breathes */
+.xmb-wrapper.xmb-bg-style-mesh .xmb-bg-gradient::after {
+  inset: 0;
+  background:
+    radial-gradient(ellipse 80% 50% at 50% 40%, rgba(var(--xmb-highlight-rgb), 0.1) 0%, transparent 68%),
+    radial-gradient(rgba(255, 255, 255, 0.04) 0.6px, transparent 0.6px);
+  background-size: 100% 100%, 4px 4px;
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+/* ── GRID background style ──────────────────────────────────────────────────
+   Grid lines scroll diagonally. A bright scan-line accent sweeps across once
+   every ~14 s. Two accent glows breathe and slowly orbit the grid.
+   ────────────────────────────────────────────────────────────────────────── */
 .xmb-wrapper.xmb-bg-style-grid .xmb-bg-layer {
   background:
-    radial-gradient(120% 78% at 50% -8%, rgba(var(--xmb-accent-rgb), 0.18) 0%, rgba(var(--xmb-accent-rgb), 0.04) 42%, rgba(0, 0, 0, 0) 70%),
+    radial-gradient(130% 80% at 50% -10%, rgba(var(--xmb-accent-rgb), 0.22) 0%, rgba(var(--xmb-accent-rgb), 0.04) 44%, transparent 70%),
     linear-gradient(180deg, var(--xmb-base-top) 0%, color-mix(in srgb, var(--xmb-base-top) 48%, var(--xmb-base-bottom)) 56%, var(--xmb-base-bottom) 100%);
 }
 
+/* Grid lines + centre glow */
 .xmb-wrapper.xmb-bg-style-grid .xmb-bg-gradient {
   inset: 0;
   background:
-    linear-gradient(rgba(var(--xmb-highlight-rgb), 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(var(--xmb-highlight-rgb), 0.05) 1px, transparent 1px),
-    radial-gradient(circle at 52% 46%, rgba(var(--xmb-accent-strong-rgb), 0.16), rgba(var(--xmb-accent-strong-rgb), 0) 62%);
+    linear-gradient(rgba(var(--xmb-highlight-rgb), 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(var(--xmb-highlight-rgb), 0.06) 1px, transparent 1px),
+    radial-gradient(ellipse 70% 60% at 52% 46%, rgba(var(--xmb-accent-strong-rgb), 0.18), transparent 64%);
   background-size: 56px 56px, 56px 56px, 100% 100%;
   mix-blend-mode: screen;
-  opacity: 0.72;
+  opacity: 0.8;
 }
 
+/* Two orbiting accent glows */
 .xmb-wrapper.xmb-bg-style-grid .xmb-bg-gradient::before {
-  inset: 0;
+  inset: -4%;
   background:
-    radial-gradient(circle at 20% 30%, rgba(var(--xmb-highlight-rgb), 0.14) 0%, rgba(var(--xmb-highlight-rgb), 0) 32%),
-    radial-gradient(circle at 72% 68%, rgba(var(--xmb-accent-strong-rgb), 0.12) 0%, rgba(var(--xmb-accent-strong-rgb), 0) 32%);
-  opacity: 0.42;
+    radial-gradient(circle at 22% 28%, rgba(var(--xmb-highlight-rgb), 0.22) 0%, transparent 30%),
+    radial-gradient(circle at 76% 66%, rgba(var(--xmb-accent-strong-rgb), 0.2) 0%, transparent 28%);
+  filter: blur(6px);
+  opacity: 0.5;
 }
 
+/* Diagonal scan-line accent */
 .xmb-wrapper.xmb-bg-style-grid .xmb-bg-gradient::after {
   inset: 0;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.06) 0.6px, transparent 0.6px);
-  background-size: 3px 3px;
-  mix-blend-mode: soft-light;
-  opacity: 0.24;
+  background: linear-gradient(
+    118deg,
+    transparent 30%,
+    rgba(var(--xmb-highlight-rgb), 0.18) 48%,
+    rgba(var(--xmb-accent-rgb), 0.22) 50%,
+    rgba(var(--xmb-highlight-rgb), 0.18) 52%,
+    transparent 70%
+  );
+  background-size: 200% 200%;
+  mix-blend-mode: screen;
+  opacity: 0.34;
 }
 
+/* ── Animation rules ──────────────────────────────────────────────────────── */
+
+/* Mesh: primary orb layer drifts in a slow figure-of-eight */
 .xmb-wrapper.xmb-bg-style-mesh.xmb-animate .xmb-bg-gradient {
-  animation: xmb-mesh-drift 24s ease-in-out infinite alternate;
+  animation: xmb-mesh-orb-a 28s linear infinite;
 }
 
+/* Mesh: secondary orb layer drifts on a counter path */
+.xmb-wrapper.xmb-bg-style-mesh.xmb-animate .xmb-bg-gradient::before {
+  animation: xmb-mesh-orb-b 22s linear infinite;
+}
+
+/* Mesh: shimmer bloom breathes */
+.xmb-wrapper.xmb-bg-style-mesh.xmb-animate .xmb-bg-gradient::after {
+  animation: xmb-mesh-bloom 9s linear infinite;
+}
+
+/* Grid: grid lines scroll diagonally */
 .xmb-wrapper.xmb-bg-style-grid.xmb-animate .xmb-bg-gradient {
-  animation: xmb-grid-pan 18s linear infinite;
+  animation: xmb-grid-scroll 14s linear infinite;
 }
 
+/* Grid: accent glows orbit */
 .xmb-wrapper.xmb-bg-style-grid.xmb-animate .xmb-bg-gradient::before {
-  animation: xmb-grid-pulse 10s ease-in-out infinite;
+  animation: xmb-grid-orbit 18s linear infinite;
 }
 
-@keyframes xmb-mesh-drift {
-  0% {
-    transform: translate3d(-1.2%, -0.8%, 0) scale(1.01);
-  }
-  100% {
-    transform: translate3d(1.2%, 0.8%, 0) scale(1.03);
-  }
+/* Grid: scan-line sweeps */
+.xmb-wrapper.xmb-bg-style-grid.xmb-animate .xmb-bg-gradient::after {
+  animation: xmb-grid-scan 14s linear infinite;
 }
 
-@keyframes xmb-grid-pan {
-  0% {
-    background-position: 0 0, 0 0, 0 0;
-  }
-  100% {
-    background-position: 56px 0, 0 56px, 0 0;
-  }
+/* ── Keyframes ────────────────────────────────────────────────────────────── */
+
+@keyframes xmb-mesh-orb-a {
+  0%   { transform: translate3d(-6%, -5%, 0) scale(1.0);  filter: blur(28px) brightness(0.92); }
+  25%  { transform: translate3d(5%, -7%, 0) scale(1.06); filter: blur(24px) brightness(1.04); }
+  50%  { transform: translate3d(7%, 5%, 0) scale(1.08);  filter: blur(30px) brightness(1.0);  }
+  75%  { transform: translate3d(-4%, 7%, 0) scale(1.04); filter: blur(26px) brightness(0.96); }
+  100% { transform: translate3d(-6%, -5%, 0) scale(1.02); filter: blur(28px) brightness(1.02); }
 }
 
-@keyframes xmb-grid-pulse {
+@keyframes xmb-mesh-orb-b {
+  0%   { transform: translate3d(5%, 4%, 0) scale(1.0);   filter: blur(20px) brightness(0.94); opacity: 0.9; }
+  30%  { transform: translate3d(-6%, 5%, 0) scale(1.05); filter: blur(18px) brightness(1.06); opacity: 1.0; }
+  60%  { transform: translate3d(-7%, -4%, 0) scale(1.07); filter: blur(22px) brightness(1.0); opacity: 0.85; }
+  100% { transform: translate3d(5%, 4%, 0) scale(1.02);  filter: blur(20px) brightness(0.98); opacity: 0.9; }
+}
+
+@keyframes xmb-mesh-bloom {
   0%,
-  100% {
-    opacity: 0.35;
-  }
-  50% {
-    opacity: 0.56;
-  }
+  100% { opacity: 0.4; transform: scale(1);    }
+  40%  { opacity: 0.72; transform: scale(1.06); }
+  70%  { opacity: 0.5;  transform: scale(1.02); }
+}
+
+@keyframes xmb-grid-scroll {
+  0%   { background-position: 0 0,   0 0,   0 0; }
+  100% { background-position: 56px 56px, 56px 56px, 0 0; }
+}
+
+@keyframes xmb-grid-orbit {
+  0%   { transform: translate3d(0, 0, 0);      opacity: 0.44; }
+  25%  { transform: translate3d(6%, -5%, 0);  opacity: 0.62; }
+  50%  { transform: translate3d(10%, 4%, 0);  opacity: 0.56; }
+  75%  { transform: translate3d(-4%, 8%, 0);  opacity: 0.68; }
+  100% { transform: translate3d(0, 0, 0);      opacity: 0.44; }
+}
+
+@keyframes xmb-grid-scan {
+  0%   { background-position: 200% 200%; opacity: 0.28; }
+  50%  { background-position: 90% 90%; opacity: 0.48; }
+  100% { background-position: -10% -10%; opacity: 0.28; }
 }
 
 .xmb-categories-container {
@@ -6973,8 +7066,14 @@ button.game-card-store-chip.owned.active:hover {
   opacity: 0.34;
   /* smaller by default so inactive rows are significantly reduced in size; active rows will scale up separately */
   transform: translateX(0) scale(0.75);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(233, 255, 242, 0.08);
+  background:
+    linear-gradient(
+      120deg,
+      rgba(var(--xmb-highlight-rgb), 0.09) 0%,
+      rgba(var(--xmb-accent-rgb), 0.05) 52%,
+      rgba(var(--xmb-accent-strong-rgb), 0.04) 100%
+    );
+  border: 1px solid rgba(var(--xmb-highlight-rgb), 0.16);
   backdrop-filter: blur(18px);
   transition: all 450ms cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -6983,10 +7082,32 @@ button.game-card-store-chip.owned.active:hover {
   opacity: 1;
   /* counter the default scale so the active row appears larger than its neighbours */
   transform: translateX(50px) scale(1.12);
-  background: linear-gradient(90deg, rgba(103, 236, 159, 0.34), rgba(245, 255, 249, 0.12));
-  border-color: rgba(231, 255, 240, 0.36);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.52), 0 0 28px rgba(116, 255, 177, 0.22);
+  background:
+    linear-gradient(
+      92deg,
+      rgba(var(--xmb-accent-rgb), 0.3) 0%,
+      rgba(var(--xmb-accent-strong-rgb), 0.2) 56%,
+      rgba(var(--xmb-highlight-rgb), 0.14) 100%
+    );
+  border-color: rgba(var(--xmb-highlight-rgb), 0.42);
+  box-shadow:
+    0 24px 48px rgba(0, 0, 0, 0.52),
+    0 0 32px rgba(var(--xmb-accent-rgb), 0.28),
+    inset 0 0 0 1px rgba(var(--xmb-highlight-rgb), 0.12);
   z-index: 10;
+}
+
+.xmb-account-item-active {
+  border-color: rgba(246, 208, 103, 0.42);
+  background: linear-gradient(90deg, rgba(246, 208, 103, 0.16), rgba(255, 255, 255, 0.09));
+}
+
+.xmb-account-item-active .xmb-game-title {
+  color: rgba(255, 246, 214, 0.98);
+}
+
+.xmb-account-item-active .xmb-game-meta-chip {
+  border-color: rgba(255, 228, 164, 0.38);
 }
 
 .xmb-game-poster-container {


### PR DESCRIPTION
## Summary
- add account switching inside controller mode settings, including active-account state and controller navigation/actions
- remove the main settings "Exit Controller Mode" action while keeping the controller mode toggle
- overhaul mesh/grid controller backgrounds with continuous animations and retheme vertical selector rows to match active style/theme

## Test plan
- [ ] enable Controller Mode Library, open controller UI settings, and verify Accounts appears at top-level Settings
- [ ] switch between saved accounts from controller UI and confirm active user badge/session data updates
- [ ] verify ribbon/mesh/grid animations run continuously across aurora/nebula/sunset/midnight themes
- [ ] verify the main vertical selector rows pick up each selected theme palette

Made with [Cursor](https://cursor.com)