### PR TITLE
Enhance Linux packaging support and updater logic

### DIFF
--- a/.github/scripts/merge-mac-update-metadata.mjs
+++ b/.github/scripts/merge-mac-update-metadata.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const artifactsDir = path.resolve(process.argv[2] ?? "release-artifacts");
+const metadataPaths = ["latest-mac-x64.yml", "latest-mac-arm64.yml"]
+  .map((file) => path.join(artifactsDir, file))
+  .filter((file) => existsSync(file));
+
+if (metadataPaths.length === 0) {
+  console.log("No macOS update metadata found to merge.");
+  process.exit(0);
+}
+
+function parseScalar(rawValue) {
+  const value = rawValue.trim();
+  if (/^\d+$/.test(value)) {
+    return Number(value);
+  }
+  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+function parseLatestMac(filePath) {
+  const metadata = { files: [] };
+  let currentFile = null;
+
+  for (const rawLine of readFileSync(filePath, "utf8").split(/\r?\n/)) {
+    const fileStart = rawLine.match(/^\s*-\s+url:\s*(.+)$/);
+    if (fileStart) {
+      currentFile = { url: parseScalar(fileStart[1]) };
+      metadata.files.push(currentFile);
+      continue;
+    }
+
+    const fileProperty = rawLine.match(/^\s{4}([A-Za-z0-9_-]+):\s*(.+)$/);
+    if (currentFile && fileProperty) {
+      currentFile[fileProperty[1]] = parseScalar(fileProperty[2]);
+      continue;
+    }
+
+    const topLevel = rawLine.match(/^([A-Za-z0-9_-]+):\s*(.+)$/);
+    if (topLevel) {
+      if (topLevel[1] !== "files") {
+        metadata[topLevel[1]] = parseScalar(topLevel[2]);
+      }
+      currentFile = null;
+    }
+  }
+
+  if (metadata.files.length === 0 && metadata.path && metadata.sha512) {
+    metadata.files.push({
+      url: metadata.path,
+      sha512: metadata.sha512,
+    });
+  }
+
+  return metadata;
+}
+
+const metadata = metadataPaths.map(parseLatestMac);
+const version = metadata.find((entry) => entry.version)?.version;
+if (!version) {
+  throw new Error("Cannot merge macOS metadata without a version.");
+}
+
+for (const entry of metadata) {
+  if (entry.version && entry.version !== version) {
+    throw new Error(`Mismatched macOS metadata versions: ${entry.version} !== ${version}`);
+  }
+}
+
+const seenUrls = new Set();
+const files = [];
+for (const entry of metadata) {
+  for (const file of entry.files) {
+    if (!file.url || seenUrls.has(file.url)) {
+      continue;
+    }
+    seenUrls.add(file.url);
+    files.push(file);
+  }
+}
+
+if (files.length === 0) {
+  throw new Error("Cannot merge macOS metadata without update files.");
+}
+
+const fallbackFile = files.find((file) => String(file.url).includes("x64")) ?? files[0];
+const releaseDate = metadata.find((entry) => entry.releaseDate)?.releaseDate ?? new Date().toISOString();
+const scalar = (value) => (typeof value === "number" ? String(value) : JSON.stringify(String(value)));
+
+let output = `version: ${scalar(version)}\nfiles:\n`;
+for (const file of files) {
+  output += `  - url: ${scalar(file.url)}\n`;
+  for (const key of ["sha512", "size", "blockMapSize"]) {
+    if (file[key] !== undefined) {
+      output += `    ${key}: ${scalar(file[key])}\n`;
+    }
+  }
+}
+output += `path: ${scalar(fallbackFile.url)}\n`;
+if (fallbackFile.sha512 !== undefined) {
+  output += `sha512: ${scalar(fallbackFile.sha512)}\n`;
+}
+output += `releaseDate: ${scalar(releaseDate)}\n`;
+
+writeFileSync(path.join(artifactsDir, "latest-mac.yml"), output);
+for (const filePath of metadataPaths) {
+  unlinkSync(filePath);
+}

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -50,16 +50,18 @@ jobs:
               opennow-stable/dist-release/*-arm64.zip
           - label: linux-x64
             os: blacksmith-4vcpu-ubuntu-2404
-            builder_args: "--linux AppImage deb --x64"
+            builder_args: "--linux AppImage deb pacman --x64"
             artifact_paths: |
               opennow-stable/dist-release/*-x86_64.AppImage
               opennow-stable/dist-release/*-amd64.deb
+              opennow-stable/dist-release/*.pacman
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
-            builder_args: "--linux AppImage deb --arm64"
+            builder_args: "--linux AppImage deb pacman --arm64"
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.AppImage
               opennow-stable/dist-release/*-arm64.deb
+              opennow-stable/dist-release/*.pacman
 
     defaults:
       run:
@@ -100,7 +102,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y fakeroot rpm
+          sudo apt-get install -y fakeroot rpm xz-utils
       - name: Install FPM for arm64 deb builds
         if: matrix.label == 'linux-arm64'
         run: sudo apt-get install -y ruby ruby-dev build-essential && sudo gem install fpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,25 +117,31 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
+              opennow-stable/dist-release/*-x64.zip.blockmap
+              opennow-stable/dist-release/latest-mac-x64.yml
           - label: macos-arm64
             os: macos-latest
             builder_args: "--mac dmg zip --arm64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-arm64.zip
+              opennow-stable/dist-release/*-arm64.zip.blockmap
+              opennow-stable/dist-release/latest-mac-arm64.yml
           - label: linux-x64
             os: blacksmith-4vcpu-ubuntu-2404
-            builder_args: "--linux AppImage deb --x64"
+            builder_args: "--linux AppImage deb pacman --x64"
             artifact_paths: |
               opennow-stable/dist-release/*-x86_64.AppImage
               opennow-stable/dist-release/*-amd64.deb
+              opennow-stable/dist-release/*.pacman
               opennow-stable/dist-release/latest-linux.yml
           - label: linux-arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
-            builder_args: "--linux AppImage deb --arm64"
+            builder_args: "--linux AppImage deb pacman --arm64"
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.AppImage
               opennow-stable/dist-release/*-arm64.deb
+              opennow-stable/dist-release/*.pacman
               opennow-stable/dist-release/latest-linux-arm64.yml
 
     defaults:
@@ -176,7 +182,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y fakeroot rpm
+          sudo apt-get install -y fakeroot rpm xz-utils
 
       - name: Install FPM for arm64 deb builds
         if: matrix.label == 'linux-arm64'
@@ -193,6 +199,15 @@ jobs:
 
       - name: Package installers
         run: npx electron-builder --publish never ${{ matrix.builder_args }}
+
+      - name: Preserve macOS update metadata by architecture
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          case "${{ matrix.label }}" in
+            macos-x64) cp dist-release/latest-mac.yml dist-release/latest-mac-x64.yml ;;
+            macos-arm64) cp dist-release/latest-mac.yml dist-release/latest-mac-arm64.yml ;;
+          esac
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -213,11 +228,17 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: release-artifacts
           merge-multiple: true
+
+      - name: Merge macOS update metadata
+        run: node .github/scripts/merge-mac-update-metadata.mjs release-artifacts
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Current packaging targets:
 | Windows x64 | NSIS installer, portable executable, auto-update metadata |
 | Windows ARM64 | NSIS installer, portable executable |
 | macOS | `dmg`, `zip` |
-| Linux x64 | `AppImage`, `deb` |
-| Linux ARM64 | `AppImage`, `deb` |
+| Linux x64 | `AppImage`, `deb`, `pacman` |
+| Linux ARM64 | `AppImage`, `deb`, `pacman` |
 
 Windows ARM64 builds are published as release downloads. The Windows auto-update feed remains `latest.yml` for x64 releases, so ARM64 packages do not participate in in-app auto-update yet.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -153,8 +153,8 @@ Current build matrix:
 | Windows ARM64 | NSIS installer, portable executable |
 | macOS x64 | `dmg`, `zip` |
 | macOS arm64 | `dmg`, `zip` |
-| Linux x64 | `AppImage`, `deb` |
-| Linux ARM64 | `AppImage`, `deb` |
+| Linux x64 | `AppImage`, `deb`, `pacman` |
+| Linux ARM64 | `AppImage`, `deb`, `pacman` |
 
 Windows ARM64 artifacts are release downloads only for now. The Windows auto-update channel remains the x64 `latest.yml` feed so ARM64 packaging cannot overwrite updater metadata.
 

--- a/opennow-stable/README.md
+++ b/opennow-stable/README.md
@@ -28,8 +28,8 @@ npm run dist
 | Windows x64 | NSIS installer, portable executable, auto-update metadata |
 | Windows ARM64 | NSIS installer, portable executable |
 | macOS | `dmg`, `zip` |
-| Linux x64 | `AppImage`, `deb` |
-| Linux ARM64 | `AppImage`, `deb` |
+| Linux x64 | `AppImage`, `deb`, `pacman` |
+| Linux ARM64 | `AppImage`, `deb`, `pacman` |
 
 Windows ARM64 packages are published as release downloads only. The current Windows updater channel stays on the x64 `latest.yml` feed.
 

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -21,7 +21,7 @@
     "dist": "npm run build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
     "dist:signed": "npm run build && electron-builder",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json",
-    "test": "tsx --test src/shared/gfn.test.ts src/renderer/src/lib/launchOwnership.test.ts src/renderer/src/components/GameCard.test.ts src/renderer/src/gfn/inputProtocol.test.ts"
+    "test": "tsx --test src/shared/gfn.test.ts src/main/updaterPlatform.test.ts src/renderer/src/lib/launchOwnership.test.ts src/renderer/src/components/GameCard.test.ts src/renderer/src/gfn/inputProtocol.test.ts"
   },
   "dependencies": {
     "discord-rpc": "^4.0.1",
@@ -93,7 +93,8 @@
     "linux": {
       "target": [
         "AppImage",
-        "deb"
+        "deb",
+        "pacman"
       ],
       "category": "Game",
       "maintainer": "zortos293 <zortos293@users.noreply.github.com>",

--- a/opennow-stable/src/main/updater.ts
+++ b/opennow-stable/src/main/updater.ts
@@ -3,8 +3,9 @@ import electronUpdater from "electron-updater";
 import type { AppUpdater, ProgressInfo, UpdateDownloadedEvent, UpdateInfo } from "electron-updater";
 
 import type { AppUpdaterState } from "@shared/gfn";
+import { chooseUpdaterKind, hasSystemCommand, readLinuxPackageType } from "./updaterPlatform";
 
-const { autoUpdater } = electronUpdater;
+const { autoUpdater, PacmanUpdater } = electronUpdater;
 
 const STARTUP_CHECK_DELAY_MS = 12_000;
 const PERIODIC_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
@@ -63,8 +64,27 @@ function normalizeErrorMessage(error: unknown): string {
   if (/net::|network|ENOTFOUND|ECONN|ETIMEDOUT|EAI_AGAIN|offline/i.test(message)) {
     return "Unable to reach GitHub Releases right now.";
   }
+  if (/Neither dpkg nor apt command found|Cannot install \.deb package/i.test(message)) {
+    return "This Linux install cannot apply Debian packages. Install the AppImage or Arch package from GitHub Releases.";
+  }
 
   return message || "Update check failed.";
+}
+
+function createRuntimeUpdater(): AppUpdater {
+  const packageType = readLinuxPackageType();
+  const updaterKind = chooseUpdaterKind({
+    platform: process.platform,
+    packageType,
+    hasCommand: hasSystemCommand,
+  });
+
+  if (updaterKind === "pacman") {
+    console.warn("[updater] Debian package marker detected on a pacman system; using PacmanUpdater.");
+    return new PacmanUpdater();
+  }
+
+  return autoUpdater;
 }
 
 function createDisabledState(currentVersion: string, message: string): AppUpdaterState {
@@ -107,7 +127,7 @@ export function createAppUpdaterController(options: AppUpdaterControllerOptions)
     };
   }
 
-  const updater: AppUpdater = autoUpdater;
+  const updater: AppUpdater = createRuntimeUpdater();
   const token = pickRuntimeToken();
   if (token) {
     updater.requestHeaders = {

--- a/opennow-stable/src/main/updaterPlatform.test.ts
+++ b/opennow-stable/src/main/updaterPlatform.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { chooseUpdaterKind, normalizeLinuxPackageType } from "./updaterPlatform";
+
+function commandSet(...commands: string[]): (command: string) => boolean {
+  const available = new Set(commands);
+  return (command) => available.has(command);
+}
+
+test("normalizes supported Linux package types", () => {
+  assert.equal(normalizeLinuxPackageType("deb"), "deb");
+  assert.equal(normalizeLinuxPackageType(" RPM\n"), "rpm");
+  assert.equal(normalizeLinuxPackageType("pacman"), "pacman");
+  assert.equal(normalizeLinuxPackageType("AppImage"), null);
+  assert.equal(normalizeLinuxPackageType(undefined), null);
+});
+
+test("uses pacman updater for converted deb installs on pacman systems", () => {
+  assert.equal(
+    chooseUpdaterKind({
+      platform: "linux",
+      packageType: "deb",
+      hasCommand: commandSet("pacman"),
+    }),
+    "pacman",
+  );
+});
+
+test("keeps default updater when Debian tools are available", () => {
+  assert.equal(
+    chooseUpdaterKind({
+      platform: "linux",
+      packageType: "deb",
+      hasCommand: commandSet("apt", "pacman"),
+    }),
+    "default",
+  );
+  assert.equal(
+    chooseUpdaterKind({
+      platform: "linux",
+      packageType: "deb",
+      hasCommand: commandSet("dpkg", "pacman"),
+    }),
+    "default",
+  );
+});
+
+test("keeps default updater outside the converted deb case", () => {
+  assert.equal(
+    chooseUpdaterKind({
+      platform: "darwin",
+      packageType: "deb",
+      hasCommand: commandSet("pacman"),
+    }),
+    "default",
+  );
+  assert.equal(
+    chooseUpdaterKind({
+      platform: "linux",
+      packageType: "pacman",
+      hasCommand: commandSet("pacman"),
+    }),
+    "default",
+  );
+});

--- a/opennow-stable/src/main/updaterPlatform.ts
+++ b/opennow-stable/src/main/updaterPlatform.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export type LinuxPackageType = "deb" | "rpm" | "pacman";
+export type UpdaterKind = "default" | "pacman";
+
+interface UpdaterKindInput {
+  platform: NodeJS.Platform;
+  packageType: LinuxPackageType | null;
+  hasCommand: (command: string) => boolean;
+}
+
+export function normalizeLinuxPackageType(value: string | null | undefined): LinuxPackageType | null {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "deb" || normalized === "rpm" || normalized === "pacman") {
+    return normalized;
+  }
+
+  return null;
+}
+
+export function readLinuxPackageType(resourcesPath = process.resourcesPath): LinuxPackageType | null {
+  if (process.platform !== "linux") {
+    return null;
+  }
+
+  try {
+    const packageTypePath = path.join(resourcesPath, "package-type");
+    if (!existsSync(packageTypePath)) {
+      return null;
+    }
+
+    return normalizeLinuxPackageType(readFileSync(packageTypePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function hasSystemCommand(command: string): boolean {
+  const result = spawnSync("command", ["-v", command], {
+    shell: true,
+    stdio: "ignore",
+  });
+
+  return !result.error && result.status === 0;
+}
+
+export function chooseUpdaterKind(input: UpdaterKindInput): UpdaterKind {
+  if (input.platform !== "linux" || input.packageType !== "deb") {
+    return "default";
+  }
+
+  const canInstallDeb = input.hasCommand("dpkg") || input.hasCommand("apt");
+  if (canInstallDeb || !input.hasCommand("pacman")) {
+    return "default";
+  }
+
+  return "pacman";
+}


### PR DESCRIPTION
This pull request adds support for building and distributing pacman packages for Linux (Arch and derivatives), and improves the app's updater logic to better handle Linux package types, especially for users who install Debian packages on pacman-based systems. It also introduces new scripts and workflow steps to merge and manage macOS update metadata by architecture, and updates documentation to reflect the expanded platform support.

**Linux packaging and updater improvements:**

* Added `pacman` as a build target for both x64 and ARM64 Linux in `electron-builder` config, GitHub Actions workflows, and artifact lists. Documentation in `README.md`, `docs/development.md`, and `opennow-stable/README.md` updated accordingly. [[1]](diffhunk://#diff-c75ece290902613d146fa97829a726b28022d805b21263008c68df094665c4d8L53-R64) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R120-R144) [[3]](diffhunk://#diff-92a0861fe2e1a2bea34ceb5de267e5e733bf4d1d5ed78bfb13f768da9c8269dcL96-R97) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R83) [[5]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL156-R157) [[6]](diffhunk://#diff-12e30c66b3de38dd6b85563e44f1c0ecfd10fc4ae5976fd4a6100bce0162885aL31-R32)
* Introduced new Linux updater logic: detects if the app was installed as a Debian package on a pacman-based system and switches to the `PacmanUpdater` for updates. This is handled by new helpers in `updaterPlatform.ts` and integrated into the main updater. [[1]](diffhunk://#diff-f150bd29d4cba6d920cd7b1a6a6abda74271e4d3233f4c4713f5f7b8368e1a75R6-R8) [[2]](diffhunk://#diff-f150bd29d4cba6d920cd7b1a6a6abda74271e4d3233f4c4713f5f7b8368e1a75R67-R89) [[3]](diffhunk://#diff-f150bd29d4cba6d920cd7b1a6a6abda74271e4d3233f4c4713f5f7b8368e1a75L110-R130) [[4]](diffhunk://#diff-ec977b31cb156ba0cb950e044f9e162e3c43dc89874b1307e7f763a14793ca46R1-R60)
* Added tests for Linux updater selection and package type normalization in `updaterPlatform.test.ts`.

**macOS update metadata management:**

* Added a script `.github/scripts/merge-mac-update-metadata.mjs` and related workflow steps to merge per-architecture macOS update metadata files into a single `latest-mac.yml` during release publishing, ensuring proper auto-update support for both x64 and ARM64. [[1]](diffhunk://#diff-b266f3d45c944a0caf0d62d3b36c12b1e832157f9ddfa1d80181f7012b1fc27cR1-R118) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R203-R211) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R231-R242)
* Updated release workflow to preserve and process separate macOS update metadata files for each architecture before merging. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R203-R211) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R231-R242)

**Build and workflow enhancements:**

* Updated Linux build job dependencies to include `xz-utils` for pacman packaging. [[1]](diffhunk://#diff-c75ece290902613d146fa97829a726b28022d805b21263008c68df094665c4d8L103-R105) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L179-R185)
* Added new test file to the npm test script for main process updater logic.