### PR TITLE
Add controller rumble from GFN input channel

### DIFF
--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -6,6 +6,7 @@ export const INPUT_MOUSE_BUTTON_DOWN = 8;
 export const INPUT_MOUSE_BUTTON_UP = 9;
 export const INPUT_MOUSE_WHEEL = 10;
 export const INPUT_GAMEPAD = 12;
+export const INPUT_HAPTICS_ENABLED = 13;
 
 // Mouse button constants (1-based for GFN protocol)
 // GFN uses: 1=Left, 2=Middle, 3=Right, 4=Back, 5=Forward
@@ -687,6 +688,14 @@ export class InputEncoder {
     view.setUint16(8, 0, false);                         // reserved: BE
     view.setUint32(10, 0, false);                        // reserved: BE
     view.setBigUint64(14, payload.timestampUs, false);   // timestamp: BE
+    return wrapSingleEvent(bytes, this.protocolVersion);
+  }
+
+  encodeHapticsEnabled(enabled: boolean): Uint8Array {
+    const bytes = new Uint8Array(6);
+    const view = new DataView(bytes.buffer);
+    view.setUint32(0, INPUT_HAPTICS_ENABLED, true);
+    view.setUint16(4, enabled ? 1 : 0, false);
     return wrapSingleEvent(bytes, this.protocolVersion);
   }
 

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -708,9 +708,9 @@ export class InputEncoder {
     // Offset 0x06: Gamepad index (u16 LE)
     view.setUint16(6, payload.controllerId & 0x03, true);
     
-    // Offset 0x08: Bitmap (u16 LE) — NOT a simple connected flag!
-    // Official client uses a bitmask: bit i = gamepad i connected, bit (i+8) = additional state.
-    // Passed as the `ae` parameter in gl() from the gamepad manager's this.nu field.
+    // Offset 0x08: Bitmap (u16 LE) — official this.nu bitmask.
+    // Bit i = gamepad i connected; bit (i+8) = Xbox/xinput style device.
+    // The high bit likely advertises the XInput/haptics-capable variant.
     view.setUint16(8, bitmap, true);
     
     // Offset 0x0A: Inner payload size (u16 LE) = 20

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -243,6 +243,10 @@ function clampRumbleMagnitude(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
 
+function isXboxLikeGamepad(gamepad: Gamepad): boolean {
+  return /xbox|xinput/i.test(gamepad.id);
+}
+
 function getGamepadRumbleApi(gamepad: Gamepad): GamepadRumbleApi | null {
   const hapticGamepad = gamepad as GamepadWithOptionalHaptics;
   const playEffectActuator = hapticGamepad.vibrationActuator;
@@ -576,8 +580,8 @@ export class GfnWebRtcClient {
   private static readonly RUMBLE_THROTTLE_MS = 500;
   private static readonly HAPTICS_LOG_INTERVAL_MS = 5000;
 
-  // Gamepad bitmap: tracks which gamepads are connected, matching official client's this.nu field.
-  // Bit i (0-3) = gamepad i is connected. Sent in every gamepad packet at offset 8.
+  // Gamepad bitmap sent at packet offset 8, matching official client's this.nu field:
+  // bit i (0-3) = connected, bit i+8 = Xbox/xinput style device.
   private gamepadBitmap = 0;
 
   // Stats tracking
@@ -1877,6 +1881,22 @@ export class GfnWebRtcClient {
 
   private gamepadSendCount = 0;
 
+  private updateGamepadBitmap(controllerId: number, gamepad: Gamepad): void {
+    const connectedBit = 1 << controllerId;
+    const xboxBit = 1 << (controllerId + 8);
+    this.gamepadBitmap |= connectedBit;
+    if (isXboxLikeGamepad(gamepad)) {
+      this.gamepadBitmap |= xboxBit;
+    } else {
+      this.gamepadBitmap &= ~xboxBit;
+    }
+  }
+
+  private clearGamepadBitmap(controllerId: number): void {
+    this.gamepadBitmap &= ~(1 << controllerId);
+    this.gamepadBitmap &= ~(1 << (controllerId + 8));
+  }
+
   private pollGamepads(): void {
     if (this.inputPaused) return;
     const gamepads = navigator.getGamepads();
@@ -1892,12 +1912,11 @@ export class GfnWebRtcClient {
 
       if (gamepad && gamepad.connected) {
         connectedCount++;
+        this.updateGamepadBitmap(i, gamepad);
 
         // Track connected gamepads and update bitmap
         if (!this.connectedGamepads.has(i)) {
           this.connectedGamepads.add(i);
-          // Set bit i in bitmap (matching official client's AA(i) = 1 << i)
-          this.gamepadBitmap |= (1 << i);
           this.log(`Gamepad ${i} connected: ${gamepad.id}`);
           this.log(`  Buttons: ${gamepad.buttons.length}, Axes: ${gamepad.axes.length}, Mapping: ${gamepad.mapping}`);
           this.log(`  Bitmap now: 0x${this.gamepadBitmap.toString(16)}`);
@@ -1942,7 +1961,7 @@ export class GfnWebRtcClient {
         this.stopGamepadRumble(i, gamepad ?? undefined);
         this.connectedGamepads.delete(i);
         this.previousGamepadStates.delete(i);
-        this.gamepadBitmap &= ~(1 << i);
+        this.clearGamepadBitmap(i);
         this.log(`Gamepad ${i} disconnected, bitmap now: 0x${this.gamepadBitmap.toString(16)}`);
         this.diagnostics.connectedGamepads = this.connectedGamepads.size;
         this.emitStats();

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -54,6 +54,22 @@ interface RiInputCapabilities {
   enablePartiallyReliableTransferHid: number;
 }
 
+interface DualRumbleEffectOptions {
+  startDelay: 0;
+  duration: number;
+  weakMagnitude: number;
+  strongMagnitude: number;
+}
+
+interface GamepadHapticActuatorLike {
+  readonly type?: string;
+  playEffect(effectType: "dual-rumble", options: DualRumbleEffectOptions): Promise<unknown>;
+}
+
+type GamepadWithOptionalVibration = Gamepad & {
+  readonly vibrationActuator?: GamepadHapticActuatorLike | null;
+};
+
 function hevcPreferredProfileId(colorQuality: ColorQuality): 1 | 2 {
   // 10-bit modes should prefer HEVC Main10 profile-id=2.
   return colorQuality.startsWith("10bit") ? 2 : 1;
@@ -202,6 +218,21 @@ function parseRiInputCapabilities(sdp: string): RiInputCapabilities {
       PARTIALLY_RELIABLE_HID_DEVICE_MASK_ALL,
     ),
   };
+}
+
+function getDualRumbleActuator(gamepad: Gamepad): GamepadHapticActuatorLike | null {
+  const actuator = (gamepad as GamepadWithOptionalVibration).vibrationActuator;
+  if (actuator?.type === "dual-rumble" && typeof actuator.playEffect === "function") {
+    return actuator;
+  }
+  return null;
+}
+
+function clampRumbleMagnitude(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
 }
 
 export interface AdaptiveMouseFlushDecisionParams {
@@ -518,6 +549,9 @@ export class GfnWebRtcClient {
   private static readonly DECODER_KEYFRAME_COOLDOWN_MS = 1200;
   private static readonly DECODER_BITRATE_STEP_FACTOR = 0.85;
   private static readonly DECODER_MIN_RECOVERY_BITRATE_KBPS = 4000;
+  private static readonly RUMBLE_EFFECT_MS = 500;
+  private static readonly RUMBLE_THROTTLE_MS = 500;
+  private static readonly HAPTICS_LOG_INTERVAL_MS = 5000;
 
   // Gamepad bitmap: tracks which gamepads are connected, matching official client's this.nu field.
   // Bit i (0-3) = gamepad i is connected. Sent in every gamepad packet at offset 8.
@@ -536,6 +570,11 @@ export class GfnWebRtcClient {
   private renderFpsCounter = { frames: 0, lastUpdate: 0, fps: 0 };
   private connectedGamepads: Set<number> = new Set();
   private previousGamepadStates: Map<number, GamepadInput> = new Map();
+  private lastRumbleWeak: number[] = [0, 0, 0, 0];
+  private lastRumbleStrong: number[] = [0, 0, 0, 0];
+  private lastRumbleEffectAtMs: number[] = [0, 0, 0, 0];
+  private hapticsSupportLogged: boolean[] = [false, false, false, false];
+  private lastHapticsWarningAtMs = 0;
 
   // Track currently pressed keys (VK codes) for synthetic Escape detection
   private pressedKeys: Set<number> = new Set();
@@ -1539,6 +1578,7 @@ export class GfnWebRtcClient {
     for (const cleanup of this.inputCleanup.splice(0)) {
       cleanup();
     }
+    this.stopAllGamepadRumble();
   }
 
   private replaceTrackInStream(stream: MediaStream, track: MediaStreamTrack): void {
@@ -1875,6 +1915,7 @@ export class GfnWebRtcClient {
         }
       } else if (this.connectedGamepads.has(i)) {
         // Gamepad disconnected — clear bit from bitmap
+        this.stopGamepadRumble(i, gamepad ?? undefined);
         this.connectedGamepads.delete(i);
         this.previousGamepadStates.delete(i);
         this.gamepadBitmap &= ~(1 << i);
@@ -1950,8 +1991,201 @@ export class GfnWebRtcClient {
 
   private onGamepadDisconnected = (event: GamepadEvent): void => {
     this.log(`Gamepad disconnected event: ${event.gamepad.id}`);
+    this.stopGamepadRumble(event.gamepad.index, event.gamepad);
     // The polling loop will detect and handle the disconnection
   };
+
+  private logHapticsWarning(message: string): void {
+    const nowMs = performance.now();
+    if (nowMs - this.lastHapticsWarningAtMs < GfnWebRtcClient.HAPTICS_LOG_INTERVAL_MS) {
+      return;
+    }
+    this.lastHapticsWarningAtMs = nowMs;
+    this.log(message);
+  }
+
+  private findConnectedGamepad(controllerId: number): { index: number; gamepad: Gamepad } | null {
+    const gamepads = navigator.getGamepads();
+    if (!gamepads) {
+      return null;
+    }
+
+    if (controllerId >= 0 && controllerId < GAMEPAD_MAX_CONTROLLERS) {
+      const exact = gamepads[controllerId];
+      if (exact?.connected && this.connectedGamepads.has(controllerId)) {
+        return { index: controllerId, gamepad: exact };
+      }
+    }
+
+    return null;
+  }
+
+  private applyGamepadRumble(controllerId: number, weakMagnitude16: number, strongMagnitude16: number): void {
+    const target = this.findConnectedGamepad(controllerId);
+    if (!target) {
+      return;
+    }
+
+    const actuator = getDualRumbleActuator(target.gamepad);
+    if (!actuator) {
+      return;
+    }
+
+    const index = target.index;
+    if (!this.hapticsSupportLogged[index]) {
+      this.hapticsSupportLogged[index] = true;
+      this.log(`Gamepad ${index} dual-rumble haptics available`);
+    }
+
+    const weakMagnitude = clampRumbleMagnitude(weakMagnitude16 / 65535);
+    const strongMagnitude = clampRumbleMagnitude(strongMagnitude16 / 65535);
+    const isStop = weakMagnitude === 0 && strongMagnitude === 0;
+    const nowMs = performance.now();
+    this.lastRumbleWeak[index] = weakMagnitude;
+    this.lastRumbleStrong[index] = strongMagnitude;
+
+    if (
+      !isStop
+      && this.lastRumbleEffectAtMs[index] !== 0
+      && nowMs - this.lastRumbleEffectAtMs[index] <= GfnWebRtcClient.RUMBLE_THROTTLE_MS
+    ) {
+      return;
+    }
+
+    this.lastRumbleEffectAtMs[index] = isStop ? 0 : nowMs;
+    void actuator.playEffect("dual-rumble", {
+      startDelay: 0,
+      duration: isStop ? 0 : GfnWebRtcClient.RUMBLE_EFFECT_MS,
+      weakMagnitude: isStop ? 0 : weakMagnitude,
+      strongMagnitude: isStop ? 0 : strongMagnitude,
+    }).catch(() => {});
+  }
+
+  private stopGamepadRumble(controllerId: number, gamepad?: Gamepad): void {
+    if (controllerId < 0 || controllerId >= GAMEPAD_MAX_CONTROLLERS) {
+      return;
+    }
+    if (gamepad) {
+      const actuator = getDualRumbleActuator(gamepad);
+      void actuator?.playEffect("dual-rumble", {
+        startDelay: 0,
+        duration: 0,
+        weakMagnitude: 0,
+        strongMagnitude: 0,
+      }).catch(() => {});
+    } else {
+      this.applyGamepadRumble(controllerId, 0, 0);
+    }
+    this.lastRumbleWeak[controllerId] = 0;
+    this.lastRumbleStrong[controllerId] = 0;
+    this.lastRumbleEffectAtMs[controllerId] = 0;
+    this.hapticsSupportLogged[controllerId] = false;
+  }
+
+  private stopAllGamepadRumble(): void {
+    for (let i = 0; i < GAMEPAD_MAX_CONTROLLERS; i++) {
+      this.stopGamepadRumble(i);
+    }
+    this.lastHapticsWarningAtMs = 0;
+  }
+
+  private parseLegacyHapticPacket(view: DataView, offset: number): boolean {
+    if (offset < 0 || offset + 10 > view.byteLength) {
+      this.logHapticsWarning(`Input haptics: malformed legacy packet (${view.byteLength - offset} bytes)`);
+      return false;
+    }
+
+    const kind = view.getUint16(offset, true);
+    if (kind !== 1) {
+      if (kind !== 0) {
+        this.logHapticsWarning(`Input haptics: unknown legacy kind ${kind}`);
+      }
+      return false;
+    }
+
+    const length = view.getUint16(offset + 2, true);
+    if (length < 6) {
+      return false;
+    }
+
+    const controllerId = view.getUint16(offset + 4, true);
+    const weakMagnitude = view.getUint16(offset + 6, true);
+    const strongMagnitude = view.getUint16(offset + 8, true);
+    this.applyGamepadRumble(controllerId, weakMagnitude, strongMagnitude);
+    return true;
+  }
+
+  private parseOcHapticPacket(view: DataView, offset: number): boolean {
+    if (offset < 0 || offset + 9 > view.byteLength) {
+      this.logHapticsWarning(`Input haptics: malformed Oc packet (${view.byteLength - offset} bytes)`);
+      return false;
+    }
+
+    const controllerByte = view.getUint8(offset);
+    if (controllerByte < 6 || controllerByte >= 10) {
+      this.logHapticsWarning(`Input haptics: unknown Oc controller byte ${controllerByte}`);
+      return false;
+    }
+
+    const reportKind = view.getUint8(offset + 3);
+    const flags = view.getUint8(offset + 4);
+    if (reportKind !== 5 || (flags & ~1) !== 0) {
+      this.logHapticsWarning(`Input haptics: unsupported Oc report kind=${reportKind} flags=0x${flags.toString(16)}`);
+      return false;
+    }
+
+    const controllerId = controllerByte - 6;
+    const weakMagnitude = view.getUint8(offset + 7) << 8;
+    const strongMagnitude = view.getUint8(offset + 8) << 8;
+    this.applyGamepadRumble(controllerId, weakMagnitude, strongMagnitude);
+    return true;
+  }
+
+  private parseInputSubMessage(view: DataView, offset: number): boolean {
+    if (offset < 0 || offset + 4 > view.byteLength) {
+      this.logHapticsWarning(`Input haptics: malformed sub-message (${view.byteLength - offset} bytes)`);
+      return false;
+    }
+
+    const type = view.getUint32(offset, true);
+    if (type === 267) {
+      return this.parseLegacyHapticPacket(view, offset + 4);
+    }
+    if (type === 17) {
+      return this.parseOcHapticPacket(view, offset + 4);
+    }
+
+    this.logHapticsWarning(`Input haptics: unknown sub-message type ${type}`);
+    return false;
+  }
+
+  private parseInputHapticsMessage(bytes: Uint8Array): void {
+    if (bytes.length < 2) {
+      return;
+    }
+
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const firstWord = view.getUint16(0, true);
+    if (firstWord === 267) {
+      this.parseLegacyHapticPacket(view, 2);
+      return;
+    }
+
+    const wrapperType = firstWord & 0xff;
+    switch (wrapperType) {
+      case 34:
+        this.parseInputSubMessage(view, 1);
+        return;
+      case 32:
+      case 33:
+      case 35:
+      case 36:
+      case 255:
+        return;
+      default:
+        this.parseLegacyHapticPacket(view, 0);
+    }
+  }
 
   private isPartiallyReliableChannelOpen(): boolean {
     return this.partiallyReliableInputChannel?.readyState === "open";
@@ -2000,7 +2234,18 @@ export class GfnWebRtcClient {
 
   private onInputHandshakeMessage(bytes: Uint8Array): void {
     if (bytes.length < 2) {
-      this.log(`Input handshake: ignoring short message (${bytes.length} bytes)`);
+      if (!this.inputReady) {
+        this.log(`Input handshake: ignoring short message (${bytes.length} bytes)`);
+      }
+      return;
+    }
+
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const firstWord = view.getUint16(0, true);
+    let version = 2;
+
+    if (this.inputReady) {
+      this.parseInputHapticsMessage(bytes);
       return;
     }
 
@@ -2008,10 +2253,6 @@ export class GfnWebRtcClient {
       .map((b) => b.toString(16).padStart(2, "0"))
       .join(" ");
     this.log(`Input channel message: ${bytes.length} bytes [${hex}]`);
-
-    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-    const firstWord = view.getUint16(0, true);
-    let version = 2;
 
     if (firstWord === 526) {
       version = bytes.length >= 4 ? view.getUint16(2, true) : 2;

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -66,9 +66,25 @@ interface GamepadHapticActuatorLike {
   playEffect(effectType: "dual-rumble", options: DualRumbleEffectOptions): Promise<unknown>;
 }
 
-type GamepadWithOptionalVibration = Gamepad & {
+interface LegacyGamepadHapticActuatorLike {
+  pulse(value: number, duration: number): Promise<unknown>;
+}
+
+type GamepadWithOptionalHaptics = Gamepad & {
   readonly vibrationActuator?: GamepadHapticActuatorLike | null;
+  readonly hapticActuators?: readonly (LegacyGamepadHapticActuatorLike | null | undefined)[] | null;
 };
+
+interface GamepadRumbleApi {
+  playEffectActuator: GamepadHapticActuatorLike | null;
+  pulseActuator: LegacyGamepadHapticActuatorLike | null;
+}
+
+interface ConnectedRumbleGamepad {
+  index: number;
+  gamepad: Gamepad;
+  api: GamepadRumbleApi | null;
+}
 
 function hevcPreferredProfileId(colorQuality: ColorQuality): 1 | 2 {
   // 10-bit modes should prefer HEVC Main10 profile-id=2.
@@ -220,19 +236,26 @@ function parseRiInputCapabilities(sdp: string): RiInputCapabilities {
   };
 }
 
-function getDualRumbleActuator(gamepad: Gamepad): GamepadHapticActuatorLike | null {
-  const actuator = (gamepad as GamepadWithOptionalVibration).vibrationActuator;
-  if (actuator?.type === "dual-rumble" && typeof actuator.playEffect === "function") {
-    return actuator;
-  }
-  return null;
-}
-
 function clampRumbleMagnitude(value: number): number {
   if (!Number.isFinite(value)) {
     return 0;
   }
   return Math.max(0, Math.min(1, value));
+}
+
+function getGamepadRumbleApi(gamepad: Gamepad): GamepadRumbleApi | null {
+  const hapticGamepad = gamepad as GamepadWithOptionalHaptics;
+  const playEffectActuator = hapticGamepad.vibrationActuator;
+  const pulseActuator = hapticGamepad.hapticActuators?.[0];
+  const api: GamepadRumbleApi = {
+    playEffectActuator: playEffectActuator && typeof playEffectActuator.playEffect === "function"
+      ? playEffectActuator
+      : null,
+    pulseActuator: pulseActuator && typeof pulseActuator.pulse === "function"
+      ? pulseActuator
+      : null,
+  };
+  return api.playEffectActuator || api.pulseActuator ? api : null;
 }
 
 export interface AdaptiveMouseFlushDecisionParams {
@@ -574,6 +597,7 @@ export class GfnWebRtcClient {
   private lastRumbleStrong: number[] = [0, 0, 0, 0];
   private lastRumbleEffectAtMs: number[] = [0, 0, 0, 0];
   private hapticsSupportLogged: boolean[] = [false, false, false, false];
+  private fallbackHapticsSupportLogged: boolean[] = [false, false, false, false];
   private lastHapticsWarningAtMs = 0;
 
   // Track currently pressed keys (VK codes) for synthetic Escape detection
@@ -2004,20 +2028,74 @@ export class GfnWebRtcClient {
     this.log(message);
   }
 
-  private findConnectedGamepad(controllerId: number): { index: number; gamepad: Gamepad } | null {
+  private getConnectedRumbleGamepads(): ConnectedRumbleGamepad[] {
     const gamepads = navigator.getGamepads();
     if (!gamepads) {
+      return [];
+    }
+
+    const connected: ConnectedRumbleGamepad[] = [];
+    for (let i = 0; i < Math.min(gamepads.length, GAMEPAD_MAX_CONTROLLERS); i++) {
+      const gamepad = gamepads[i];
+      if (gamepad?.connected) {
+        connected.push({ index: i, gamepad, api: getGamepadRumbleApi(gamepad) });
+      }
+    }
+    return connected;
+  }
+
+  private findConnectedGamepad(controllerId: number): ConnectedRumbleGamepad | null {
+    const connected = this.getConnectedRumbleGamepads();
+    if (connected.length === 0) {
+      this.logHapticsWarning(`Input haptics: no haptic-capable gamepad for controller ${controllerId} (connected=0)`);
       return null;
     }
 
-    if (controllerId >= 0 && controllerId < GAMEPAD_MAX_CONTROLLERS) {
-      const exact = gamepads[controllerId];
-      if (exact?.connected && this.connectedGamepads.has(controllerId)) {
-        return { index: controllerId, gamepad: exact };
-      }
+    const exact = controllerId >= 0 && controllerId < GAMEPAD_MAX_CONTROLLERS
+      ? connected.find((candidate) => candidate.index === controllerId)
+      : undefined;
+    if (exact?.api) {
+      return exact;
     }
 
+    const hapticConnected = connected.filter((candidate) => candidate.api);
+    const indexedFallback = controllerId >= 0 && controllerId < GAMEPAD_MAX_CONTROLLERS
+      ? hapticConnected[controllerId]
+      : undefined;
+    if (indexedFallback) {
+      return indexedFallback;
+    }
+
+    if (hapticConnected.length === 1) {
+      return hapticConnected[0];
+    }
+
+    this.logHapticsWarning(
+      `Input haptics: no haptic-capable gamepad for controller ${controllerId} (connected=${connected.length})`,
+    );
     return null;
+  }
+
+  private applyRumbleApi(api: GamepadRumbleApi, index: number, weakMagnitude: number, strongMagnitude: number, isStop: boolean): void {
+    const duration = isStop ? 0 : GfnWebRtcClient.RUMBLE_EFFECT_MS;
+    let usedPlayEffect = false;
+    if (api.playEffectActuator) {
+      usedPlayEffect = true;
+      void api.playEffectActuator.playEffect("dual-rumble", {
+        startDelay: 0,
+        duration,
+        weakMagnitude: isStop ? 0 : weakMagnitude,
+        strongMagnitude: isStop ? 0 : strongMagnitude,
+      }).catch(() => {});
+    }
+
+    if (api.pulseActuator && (isStop || !usedPlayEffect)) {
+      if (!isStop && !this.fallbackHapticsSupportLogged[index]) {
+        this.fallbackHapticsSupportLogged[index] = true;
+        this.log(`Gamepad ${index} fallback pulse haptics available`);
+      }
+      void api.pulseActuator.pulse(isStop ? 0 : Math.max(weakMagnitude, strongMagnitude), duration).catch(() => {});
+    }
   }
 
   private applyGamepadRumble(controllerId: number, weakMagnitude16: number, strongMagnitude16: number): void {
@@ -2025,14 +2103,12 @@ export class GfnWebRtcClient {
     if (!target) {
       return;
     }
-
-    const actuator = getDualRumbleActuator(target.gamepad);
-    if (!actuator) {
+    if (!target.api) {
       return;
     }
 
     const index = target.index;
-    if (!this.hapticsSupportLogged[index]) {
+    if (target.api.playEffectActuator && !this.hapticsSupportLogged[index]) {
       this.hapticsSupportLogged[index] = true;
       this.log(`Gamepad ${index} dual-rumble haptics available`);
     }
@@ -2053,12 +2129,7 @@ export class GfnWebRtcClient {
     }
 
     this.lastRumbleEffectAtMs[index] = isStop ? 0 : nowMs;
-    void actuator.playEffect("dual-rumble", {
-      startDelay: 0,
-      duration: isStop ? 0 : GfnWebRtcClient.RUMBLE_EFFECT_MS,
-      weakMagnitude: isStop ? 0 : weakMagnitude,
-      strongMagnitude: isStop ? 0 : strongMagnitude,
-    }).catch(() => {});
+    this.applyRumbleApi(target.api, index, weakMagnitude, strongMagnitude, isStop);
   }
 
   private stopGamepadRumble(controllerId: number, gamepad?: Gamepad): void {
@@ -2066,13 +2137,10 @@ export class GfnWebRtcClient {
       return;
     }
     if (gamepad) {
-      const actuator = getDualRumbleActuator(gamepad);
-      void actuator?.playEffect("dual-rumble", {
-        startDelay: 0,
-        duration: 0,
-        weakMagnitude: 0,
-        strongMagnitude: 0,
-      }).catch(() => {});
+      const api = getGamepadRumbleApi(gamepad);
+      if (api) {
+        this.applyRumbleApi(api, controllerId, 0, 0, true);
+      }
     } else {
       this.applyGamepadRumble(controllerId, 0, 0);
     }
@@ -2080,11 +2148,21 @@ export class GfnWebRtcClient {
     this.lastRumbleStrong[controllerId] = 0;
     this.lastRumbleEffectAtMs[controllerId] = 0;
     this.hapticsSupportLogged[controllerId] = false;
+    this.fallbackHapticsSupportLogged[controllerId] = false;
   }
 
   private stopAllGamepadRumble(): void {
-    for (let i = 0; i < GAMEPAD_MAX_CONTROLLERS; i++) {
-      this.stopGamepadRumble(i);
+    for (const target of this.getConnectedRumbleGamepads()) {
+      if (target.api) {
+        this.applyRumbleApi(target.api, target.index, 0, 0, true);
+      }
+    }
+    for (let i = 0; i < this.lastRumbleWeak.length; i++) {
+      this.lastRumbleWeak[i] = 0;
+      this.lastRumbleStrong[i] = 0;
+      this.lastRumbleEffectAtMs[i] = 0;
+      this.hapticsSupportLogged[i] = false;
+      this.fallbackHapticsSupportLogged[i] = false;
     }
     this.lastHapticsWarningAtMs = 0;
   }

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -582,6 +582,7 @@ export class GfnWebRtcClient {
 
   // Gamepad bitmap sent at packet offset 8, matching official client's this.nu field:
   // bit i (0-3) = connected, bit i+8 = Xbox/xinput style device.
+  // Haptics availability is advertised separately with input event type 13.
   private gamepadBitmap = 0;
 
   // Stats tracking
@@ -603,6 +604,7 @@ export class GfnWebRtcClient {
   private hapticsSupportLogged: boolean[] = [false, false, false, false];
   private fallbackHapticsSupportLogged: boolean[] = [false, false, false, false];
   private lastHapticsWarningAtMs = 0;
+  private hapticsAdvertised = false;
 
   // Track currently pressed keys (VK codes) for synthetic Escape detection
   private pressedKeys: Set<number> = new Set();
@@ -997,6 +999,7 @@ export class GfnWebRtcClient {
   private resetInputState(): void {
     this.inputReady = false;
     this.inputProtocolVersion = 2;
+    this.hapticsAdvertised = false;
     this.inputEncoder.setProtocolVersion(2);
     this.diagnostics.inputReady = false;
     this.diagnostics.partiallyReliableInputOpen = false;
@@ -1607,6 +1610,7 @@ export class GfnWebRtcClient {
       cleanup();
     }
     this.stopAllGamepadRumble();
+    this.updateHapticsAdvertisement(false);
   }
 
   private replaceTrackInStream(stream: MediaStream, track: MediaStreamTrack): void {
@@ -1990,6 +1994,7 @@ export class GfnWebRtcClient {
     }
 
     this.diagnostics.connectedGamepads = connectedCount;
+    this.updateHapticsAdvertisement(this.hasConnectedHapticGamepad());
   }
 
   private readGamepadState(gamepad: Gamepad, controllerId: number): GamepadInput {
@@ -2061,6 +2066,31 @@ export class GfnWebRtcClient {
       }
     }
     return connected;
+  }
+
+  private hasConnectedHapticGamepad(): boolean {
+    const gamepads = navigator.getGamepads();
+    if (!gamepads) {
+      return false;
+    }
+
+    for (let i = 0; i < Math.min(gamepads.length, GAMEPAD_MAX_CONTROLLERS); i++) {
+      const gamepad = gamepads[i];
+      if (gamepad?.connected && getGamepadRumbleApi(gamepad)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private updateHapticsAdvertisement(enabled: boolean): void {
+    if (!this.inputReady || this.reliableInputChannel?.readyState !== "open" || this.hapticsAdvertised === enabled) {
+      return;
+    }
+
+    this.sendReliable(this.inputEncoder.encodeHapticsEnabled(enabled));
+    this.hapticsAdvertised = enabled;
+    this.log(`Gamepad haptics advertised: ${enabled ? "enabled" : "disabled"}`);
   }
 
   private findConnectedGamepad(controllerId: number): ConnectedRumbleGamepad | null {
@@ -2372,6 +2402,7 @@ export class GfnWebRtcClient {
       this.diagnostics.inputReady = true;
       this.emitStats();
       this.log(`Input handshake complete (protocol v${version}) — starting heartbeat + gamepad polling`);
+      this.updateHapticsAdvertisement(this.hasConnectedHapticGamepad());
       this.setupInputHeartbeat();
       this.setupGamepadPolling();
       // After input becomes ready, attempt to auto-enable pointer lock.


### PR DESCRIPTION
## Summary
- Extend reliable input channel message handling to dispatch post-handshake messages through new haptics parsers instead of ignoring them
- Add official GFN-compatible parsing for legacy haptic packets and v3+ sub-message wrappers that rumble commands
- Apply rumble through browser Gamepad API using dual-rumble actuators with official 0-65535 magnitude scaling
- Track per-controller rumble state/timestamps and throttle nonzero effects to 500ms while allowing stop commands immediately
- Stop active rumble and clear state on gamepad disconnect, input capture detach, and peer cleanup
- Add rate-limited diagnostics for haptics support and malformed/unknown haptic messages

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/bb7847c5-8667-4184-b670-be845f10b025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-080" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/bb7847c5-8667-4184-b670-be845f10b025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-080&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-080"><img alt="OPE-080" src="https://capy.ai/api/badge/thread.svg?label=OPE-080"></picture></a>
<!-- capy-pr-badge:end -->