### PR TITLE
feat(stable): transient Anti-AFK toggle acknowledgement

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -873,6 +873,7 @@ export function App(): JSX.Element {
   const [streamStatus, setStreamStatus] = useState<StreamStatus>("idle");
   const [showStatsOverlay, setShowStatsOverlay] = useState(false);
   const [antiAfkEnabled, setAntiAfkEnabled] = useState(false);
+  const [antiAfkAckNonce, setAntiAfkAckNonce] = useState(0);
   const [exitPrompt, setExitPrompt] = useState<ExitPromptState>({ open: false, gameTitle: "Game" });
   const [streamingGame, setStreamingGame] = useState<GameInfo | null>(null);
   const [streamingStore, setStreamingStore] = useState<string | null>(null);
@@ -1988,6 +1989,12 @@ export function App(): JSX.Element {
   }, [setSessionFullscreen, settings.autoFullScreen, streamStatus]);
 
   // Anti-AFK interval
+  useEffect(() => {
+    if (!isStreaming) {
+      setAntiAfkAckNonce(0);
+    }
+  }, [isStreaming]);
+
   useEffect(() => {
     if (!antiAfkEnabled || streamStatus !== "streaming") return;
 
@@ -3767,6 +3774,7 @@ export function App(): JSX.Element {
         e.stopImmediatePropagation();
         if (streamStatus === "streaming") {
           setAntiAfkEnabled((prev) => !prev);
+          setAntiAfkAckNonce((n) => n + 1);
         }
         return;
       }
@@ -3920,6 +3928,7 @@ export function App(): JSX.Element {
             hideStreamButtons={settings.hideStreamButtons}
             serverRegion={session?.serverIp}
             antiAfkEnabled={antiAfkEnabled}
+            antiAfkAckNonce={antiAfkAckNonce}
             showAntiAfkIndicator={settings.showAntiAfkIndicator}
             exitPrompt={exitPrompt}
             sessionStartedAtMs={sessionStartedAtMs}

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -12,6 +12,8 @@ import { RemainingPlaytimeIndicator, SessionElapsedIndicator } from "./ElapsedSe
 import type { MicrophoneMode, ScreenshotEntry, RecordingEntry, SubscriptionInfo } from "@shared/gfn";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
 
+const ANTI_AFK_TOGGLE_ACK_MS = 5000;
+
 interface StreamViewProps {
   videoRef: React.Ref<HTMLVideoElement>;
   audioRef: React.Ref<HTMLAudioElement>;
@@ -30,6 +32,7 @@ interface StreamViewProps {
   hideStreamButtons?: boolean;
   serverRegion?: string;
   antiAfkEnabled: boolean;
+  antiAfkAckNonce: number;
   showAntiAfkIndicator: boolean;
   exitPrompt: {
     open: boolean;
@@ -648,6 +651,7 @@ export function StreamView({
   shortcuts,
   serverRegion,
   antiAfkEnabled,
+  antiAfkAckNonce,
   showAntiAfkIndicator,
   exitPrompt,
   sessionStartedAtMs,
@@ -682,6 +686,7 @@ export function StreamView({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showHints, setShowHints] = useState(true);
   const [showSessionClock, setShowSessionClock] = useState(false);
+  const [antiAfkToggleAck, setAntiAfkToggleAck] = useState<"on" | "off" | null>(null);
   const [showSideBar, setShowSideBar] = useState(false);
   const [isPointerLocked, setIsPointerLocked] = useState(false);
   const [screenshots, setScreenshots] = useState<ScreenshotEntry[]>([]);
@@ -802,6 +807,29 @@ export function StreamView({
       }
     };
   }, [isConnecting, sessionClockShowDurationSeconds, sessionClockShowEveryMinutes, sessionCounterEnabled]);
+
+  useEffect(() => {
+    if (antiAfkAckNonce === 0 || isConnecting) {
+      setAntiAfkToggleAck(null);
+      return;
+    }
+
+    // Omit transient "on" message when persistent ANTI-AFK badge already shows it
+    if (antiAfkEnabled && showAntiAfkIndicator) {
+      setAntiAfkToggleAck(null);
+      return;
+    }
+
+    setAntiAfkToggleAck(antiAfkEnabled ? "on" : "off");
+
+    const hideTimer = window.setTimeout(() => {
+      setAntiAfkToggleAck(null);
+    }, ANTI_AFK_TOGGLE_ACK_MS);
+
+    return (): void => {
+      window.clearTimeout(hideTimer);
+    };
+  }, [antiAfkAckNonce, antiAfkEnabled, showAntiAfkIndicator, isConnecting]);
 
   const warningSeconds = formatWarningSeconds(streamWarning?.secondsLeft);
   const platformName = platformStore ? getStoreDisplayName(platformStore) : "";
@@ -1936,6 +1964,13 @@ export function StreamView({
             {streamWarning.message}
             {warningSeconds ? ` · ${warningSeconds} left` : ""}
           </span>
+        </div>
+      )}
+
+      {antiAfkToggleAck && !isConnecting && (
+        <div className={`sv-afk-ack sv-afk-ack--${antiAfkToggleAck}`} role="status" aria-live="polite">
+          <span className="sv-afk-ack-dot" aria-hidden />
+          <span>{antiAfkToggleAck === "on" ? "Anti-AFK on" : "Anti-AFK off"}</span>
         </div>
       )}
 

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -4550,6 +4550,54 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--error);
 }
 
+.sv-afk-ack {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1002;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  max-width: min(86vw, 540px);
+  padding: 8px 12px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--panel-border);
+  background: rgba(10, 10, 12, 0.93);
+  color: var(--ink);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  animation: fade-in 140ms var(--ease);
+  backdrop-filter: blur(5px);
+}
+
+.sv-afk-ack-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.sv-afk-ack--on {
+  border-color: color-mix(in srgb, var(--success) 45%, var(--panel-border));
+}
+
+.sv-afk-ack--on .sv-afk-ack-dot {
+  background: var(--success);
+  box-shadow: 0 0 8px rgba(88, 217, 138, 0.8);
+}
+
+.sv-afk-ack--off {
+  border-color: var(--panel-border);
+  color: var(--ink-muted);
+}
+
+.sv-afk-ack--off .sv-afk-ack-dot {
+  background: var(--ink-muted);
+  box-shadow: none;
+}
+
 /* Stats HUD (StreamView inline stats) */
 .sv-stats {
   position: fixed;


### PR DESCRIPTION
## Summary

This change addresses user feedback from [#331](https://github.com/OpenCloudGaming/OpenNOW/issues/331) so Anti-AFK toggles are visible during streaming even when **Show Anti-AFK Indicator** is off.

### Behavior

- On each shortcut toggle while streaming, show a bottom-centred acknowledgement (**Anti-AFK on** / **Anti-AFK off**) for **5 seconds**.
- Omit the redundant **on** message when the persistent ANTI-AFK badge is already shown.
- Clear acknowledgement whenever the session is not in the streaming phase (including **connecting**), and reset toggle metadata so acknowledgement does not reappear after reconnect without a new toggle.

### Implementation notes

- `App.tsx`: `antiAfkAckNonce`, bumped on toggle and cleared when `!isStreaming`, passed into `StreamView`.
- `StreamView.tsx` + `styles.css`: transient `.sv-afk-ack` UI mirroring compact stream overlays.

Fixes #331

Made with [Cursor](https://cursor.com)