### PR TITLE
Fix hard-exit resume parity and recovery loops

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -485,7 +485,7 @@ function timezoneOffsetMs(): number {
   return -new Date().getTimezoneOffset() * 60 * 1000;
 }
 
-function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest {
+function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: string): CloudMatchRequest {
   const { width, height } = parseResolution(input.settings.resolution);
   const cq = input.settings.colorQuality;
   // IMPORTANT: hdrEnabled is a SEPARATE toggle from color quality.
@@ -506,7 +506,9 @@ function buildSessionRequestBody(input: SessionCreateRequest): CloudMatchRequest
       networkTestSessionId: null,
       parentSessionId: null,
       clientIdentification: "GFN-PC",
-      deviceHashId: crypto.randomUUID(),
+      // Keep device identity stable across create -> reconnect/resume flows.
+      // The official client preserves this identity, and resume reliability depends on it.
+      deviceHashId,
       clientVersion: "30.0",
       sdkVersion: "1.0",
       streamerVersion: 1,
@@ -946,9 +948,9 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
 
   // Generate client/device IDs once for the entire session lifecycle
   const clientId = crypto.randomUUID();
-  const deviceId = crypto.randomUUID();
+  const deviceId = getStableDeviceId();
 
-  const body = buildSessionRequestBody(input);
+  const body = buildSessionRequestBody(input, deviceId);
 
   const base = resolveStreamingBaseUrl(input.zone, input.streamingBaseUrl);
   const keyboardLayout = resolveGfnKeyboardLayout(input.settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
@@ -1296,8 +1298,8 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
     throw new Error("Missing token for session claim");
   }
 
-  const deviceId = getStableDeviceId();
-  const clientId = crypto.randomUUID();
+  const deviceId = input.deviceId ?? getStableDeviceId();
+  const clientId = input.clientId ?? crypto.randomUUID();
 
   // Provide default values for optional parameters
   const appId = input.appId ?? "0";
@@ -1356,6 +1358,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
   // with SESSION_NOT_PAUSED. For these sessions we skip the claim PUT and poll directly.
   // Status 2/3 (ready/streaming) sessions are paused and can be RESUME'd normally.
   let preClaimStatus: number | null = null;
+  let shouldSendResumeClaim = true;
   try {
     const validationUrl = `https://${effectiveServerIp}/v2/session/${input.sessionId}`;
     const validationHeaders = requestHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
@@ -1369,6 +1372,17 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
       console.log(`[CloudMatch] claimSession: validation response (first 1000 chars): ${validationText.slice(0, 1000)}`);
       if (preClaimStatus === 1) {
         console.log(`[CloudMatch] claimSession: session is still launching (status=1), skipping RESUME claim — polling directly to ready state`);
+      } else if (
+        input.recoveryMode === true &&
+        (preClaimStatus === 2 || preClaimStatus === 3)
+      ) {
+        // Recovery parity: if the session is already ready/streaming, avoid sending
+        // another RESUME mutation. Repeated RESUME PUTs can rotate signaling hosts
+        // and push the session back into transient setup/cleanup states.
+        shouldSendResumeClaim = false;
+        console.log(
+          `[CloudMatch] claimSession: recoveryMode and session already ready (status=${preClaimStatus}); skipping redundant RESUME claim`,
+        );
       } else if (preClaimStatus !== 2 && preClaimStatus !== 3) {
         console.warn(`[CloudMatch] claimSession: session not in ready state (status=${preClaimStatus}), claim may fail`);
       }
@@ -1381,7 +1395,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
 
   // Only send the RESUME claim PUT if the session is in a paused state (status 2 or 3).
   // For status=1 (still launching) we bypass the claim and fall through to the polling loop.
-  if (preClaimStatus !== 1) {
+  if (preClaimStatus !== 1 && shouldSendResumeClaim) {
     const payload = buildClaimRequestBody(input.sessionId, appId, settings);
 
     const headers: Record<string, string> = {
@@ -1472,6 +1486,8 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
         iceServers: await normalizeIceServers(pollApiResponse),
         mediaConnectionInfo: signaling.mediaConnectionInfo,
         negotiatedStreamProfile: extractNegotiatedStreamProfile(pollApiResponse),
+        clientId,
+        deviceId,
       };
     }
 

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -256,7 +256,17 @@ function runShutdownCleanup(reason = "app-quit"): void {
   console.log(`[Main] Running shutdown cleanup (${reason})`);
 
   refreshScheduler.stop();
-  signalingClient?.disconnect();
+  // Parity with soft-reset behavior: on full app quit, let process teardown close
+  // signaling sockets naturally instead of emitting an explicit disconnect event
+  // into the renderer during shutdown.
+  const shouldSkipExplicitSignalingDisconnect =
+    reason === "renderer-explicit-exit" ||
+    reason === "app-quit" ||
+    reason === "before-quit" ||
+    reason === "window-all-closed";
+  if (!shouldSkipExplicitSignalingDisconnect) {
+    signalingClient?.disconnect();
+  }
   signalingClient = null;
   signalingClientKey = null;
   void destroyDiscordRpc();

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -111,6 +111,7 @@ const SESSION_AD_FORCE_PLAY_TIMEOUT_MS = 10000;
 const SESSION_AD_STUCK_TIMEOUT_MS = 30000;
 const VARIANT_SELECTION_LOCALSTORAGE_KEY = "opennow.variantByGameId";
 const CATALOG_PREFERENCES_LOCALSTORAGE_KEY = "opennow.catalogPreferences.v1";
+const RUNTIME_SNAPSHOT_LOCALSTORAGE_KEY = "opennow.runtimeSnapshot.v1";
 const PLAYTIME_RESYNC_INTERVAL_MS = 5 * 60 * 1000;
 const FREE_TIER_SESSION_LIMIT_SECONDS = 60 * 60;
 const FREE_TIER_30_MIN_WARNING_SECONDS = 30 * 60;
@@ -121,6 +122,27 @@ const STREAM_WARNING_VISIBILITY_MS = 15 * 1000;
 interface CatalogPreferences {
   sortId: string;
   filterIds: string[];
+}
+
+interface RuntimeSnapshot {
+  version: 1;
+  updatedAt: number;
+  streamStatus: StreamStatus;
+  sessionId: string | null;
+  sessionAppId: number | null;
+  streamingGameId: string | null;
+  streamingStore: string | null;
+  recoveryAppId: number | null;
+  resumeContext: {
+    sessionId: string;
+    serverIp: string;
+    streamingBaseUrl?: string;
+    signalingServer?: string;
+    signalingUrl?: string;
+    appId?: number;
+    clientId?: string;
+    deviceId?: string;
+  } | null;
 }
 
 function loadCatalogPreferences(): CatalogPreferences {
@@ -142,6 +164,77 @@ function loadCatalogPreferences(): CatalogPreferences {
 function saveCatalogPreferences(prefs: CatalogPreferences): void {
   try {
     localStorage.setItem(CATALOG_PREFERENCES_LOCALSTORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // ignore
+  }
+}
+
+function loadRuntimeSnapshot(): RuntimeSnapshot | null {
+  try {
+    const raw = localStorage.getItem(RUNTIME_SNAPSHOT_LOCALSTORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<RuntimeSnapshot>;
+    if (parsed.version !== 1) return null;
+    return {
+      version: 1,
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : Date.now(),
+      streamStatus: (typeof parsed.streamStatus === "string" ? parsed.streamStatus : "idle") as StreamStatus,
+      sessionId: typeof parsed.sessionId === "string" ? parsed.sessionId : null,
+      sessionAppId: typeof parsed.sessionAppId === "number" ? parsed.sessionAppId : null,
+      streamingGameId: typeof parsed.streamingGameId === "string" ? parsed.streamingGameId : null,
+      streamingStore: typeof parsed.streamingStore === "string" ? parsed.streamingStore : null,
+      recoveryAppId: typeof parsed.recoveryAppId === "number" ? parsed.recoveryAppId : null,
+      resumeContext:
+        parsed.resumeContext &&
+        typeof parsed.resumeContext === "object" &&
+        typeof parsed.resumeContext.sessionId === "string" &&
+        typeof parsed.resumeContext.serverIp === "string"
+          ? {
+            sessionId: parsed.resumeContext.sessionId,
+            serverIp: parsed.resumeContext.serverIp,
+            streamingBaseUrl:
+              typeof parsed.resumeContext.streamingBaseUrl === "string"
+                ? parsed.resumeContext.streamingBaseUrl
+                : undefined,
+            signalingServer:
+              typeof parsed.resumeContext.signalingServer === "string"
+                ? parsed.resumeContext.signalingServer
+                : undefined,
+            signalingUrl:
+              typeof parsed.resumeContext.signalingUrl === "string"
+                ? parsed.resumeContext.signalingUrl
+                : undefined,
+            appId:
+              typeof parsed.resumeContext.appId === "number" && Number.isFinite(parsed.resumeContext.appId)
+                ? parsed.resumeContext.appId
+                : undefined,
+            clientId:
+              typeof parsed.resumeContext.clientId === "string"
+                ? parsed.resumeContext.clientId
+                : undefined,
+            deviceId:
+              typeof parsed.resumeContext.deviceId === "string"
+                ? parsed.resumeContext.deviceId
+                : undefined,
+          }
+          : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function saveRuntimeSnapshot(snapshot: RuntimeSnapshot): void {
+  try {
+    localStorage.setItem(RUNTIME_SNAPSHOT_LOCALSTORAGE_KEY, JSON.stringify(snapshot));
+  } catch {
+    // ignore
+  }
+}
+
+function clearRuntimeSnapshot(): void {
+  try {
+    localStorage.removeItem(RUNTIME_SNAPSHOT_LOCALSTORAGE_KEY);
   } catch {
     // ignore
   }
@@ -187,8 +280,11 @@ type SignalingRecoveryState = {
 };
 
 const APP_PAGE_ORDER: AppPage[] = ["home", "library", "settings"];
-const RECOVERABLE_STREAM_STATUSES: readonly StreamStatus[] = ["queue", "setup", "starting", "connecting", "streaming"];
+const RECOVERABLE_STREAM_STATUSES: readonly StreamStatus[] = ["streaming"];
 const SIGNALING_RECOVERY_ATTEMPT_DELAYS_MS = [0, 3000] as const;
+const SIGNALING_RECOVERY_STABLE_RESET_DELAY_MS = 15000;
+const SIGNALING_REMOTE_ICE_GRACE_MS = 5000;
+const ICE_DISCONNECTED_RECOVERY_GRACE_MS = 7000;
 
 const isMac = navigator.platform.toLowerCase().includes("mac");
 
@@ -1120,10 +1216,21 @@ export function App(): JSX.Element {
   const hasInitializedRef = useRef(false);
   const regionsRequestRef = useRef(0);
   const launchInFlightRef = useRef(false);
+  const runtimeSnapshotRef = useRef<RuntimeSnapshot | null>(loadRuntimeSnapshot());
   /** Joins concurrent claim/resume calls for the same Cloud session id (single CloudMatch RESUME + signaling). */
   const claimResumePromisesRef = useRef<Map<string, Promise<void>>>(new Map());
   const launchAbortRef = useRef(false);
   const streamStatusRef = useRef<StreamStatus>(streamStatus);
+  const stableRecoveryResetTimerRef = useRef<number | null>(null);
+  const remoteIceGraceTimerRef = useRef<number | null>(null);
+  const remoteIceSeenForSessionRef = useRef<string | null>(null);
+  const remoteIceRecoveryGenerationRef = useRef<number | null>(null);
+  const awaitingRecoveryRemoteIceRef = useRef(false);
+  const appUnloadingRef = useRef(false);
+  const hasConfirmedRemoteIceRef = useRef(false);
+  const latestIceConnectionStateRef = useRef<RTCIceConnectionState>("new");
+  const iceDisconnectedRecoveryTimerRef = useRef<number | null>(null);
+  const pendingControlledDisconnectsRef = useRef(0);
   const signalingRecoveryRef = useRef<SignalingRecoveryState>({
     attemptCount: 0,
     inFlight: null,
@@ -1350,6 +1457,24 @@ export function App(): JSX.Element {
     keepLaunchError?: boolean;
     keepStreamingContext?: boolean;
   }): void => {
+    if (stableRecoveryResetTimerRef.current !== null) {
+      window.clearTimeout(stableRecoveryResetTimerRef.current);
+      stableRecoveryResetTimerRef.current = null;
+    }
+    if (remoteIceGraceTimerRef.current !== null) {
+      window.clearTimeout(remoteIceGraceTimerRef.current);
+      remoteIceGraceTimerRef.current = null;
+    }
+    if (iceDisconnectedRecoveryTimerRef.current !== null) {
+      window.clearTimeout(iceDisconnectedRecoveryTimerRef.current);
+      iceDisconnectedRecoveryTimerRef.current = null;
+    }
+    remoteIceSeenForSessionRef.current = null;
+    remoteIceRecoveryGenerationRef.current = null;
+    awaitingRecoveryRemoteIceRef.current = false;
+    hasConfirmedRemoteIceRef.current = false;
+    latestIceConnectionStateRef.current = "new";
+    pendingControlledDisconnectsRef.current = 0;
     signalingRecoveryRef.current.attemptCount = 0;
     signalingRecoveryRef.current.inFlight = null;
     signalingRecoveryRef.current.appId = null;
@@ -1375,11 +1500,31 @@ export function App(): JSX.Element {
     if (settings.discordRichPresence) {
       void window.openNow.clearDiscordActivity();
     }
+    runtimeSnapshotRef.current = null;
+    clearRuntimeSnapshot();
   }, [diagnosticsStore, resetStatsOverlayToPreference, settings.discordRichPresence]);
 
   const resetSignalingRecoveryState = useCallback((options?: {
     keepExplicitShutdown?: boolean;
   }): void => {
+    if (stableRecoveryResetTimerRef.current !== null) {
+      window.clearTimeout(stableRecoveryResetTimerRef.current);
+      stableRecoveryResetTimerRef.current = null;
+    }
+    if (remoteIceGraceTimerRef.current !== null) {
+      window.clearTimeout(remoteIceGraceTimerRef.current);
+      remoteIceGraceTimerRef.current = null;
+    }
+    if (iceDisconnectedRecoveryTimerRef.current !== null) {
+      window.clearTimeout(iceDisconnectedRecoveryTimerRef.current);
+      iceDisconnectedRecoveryTimerRef.current = null;
+    }
+    remoteIceSeenForSessionRef.current = null;
+    remoteIceRecoveryGenerationRef.current = null;
+    awaitingRecoveryRemoteIceRef.current = false;
+    hasConfirmedRemoteIceRef.current = false;
+    latestIceConnectionStateRef.current = "new";
+    pendingControlledDisconnectsRef.current = 0;
     signalingRecoveryRef.current.generation += 1;
     signalingRecoveryRef.current.attemptCount = 0;
     signalingRecoveryRef.current.inFlight = null;
@@ -1390,6 +1535,24 @@ export function App(): JSX.Element {
   }, []);
 
   const markExplicitSignalingShutdown = useCallback((): void => {
+    if (stableRecoveryResetTimerRef.current !== null) {
+      window.clearTimeout(stableRecoveryResetTimerRef.current);
+      stableRecoveryResetTimerRef.current = null;
+    }
+    if (remoteIceGraceTimerRef.current !== null) {
+      window.clearTimeout(remoteIceGraceTimerRef.current);
+      remoteIceGraceTimerRef.current = null;
+    }
+    if (iceDisconnectedRecoveryTimerRef.current !== null) {
+      window.clearTimeout(iceDisconnectedRecoveryTimerRef.current);
+      iceDisconnectedRecoveryTimerRef.current = null;
+    }
+    remoteIceSeenForSessionRef.current = null;
+    remoteIceRecoveryGenerationRef.current = null;
+    awaitingRecoveryRemoteIceRef.current = false;
+    hasConfirmedRemoteIceRef.current = false;
+    latestIceConnectionStateRef.current = "new";
+    pendingControlledDisconnectsRef.current = 0;
     signalingRecoveryRef.current.generation += 1;
     signalingRecoveryRef.current.explicitShutdown = true;
     signalingRecoveryRef.current.inFlight = null;
@@ -1400,10 +1563,140 @@ export function App(): JSX.Element {
     return state.generation === generation && !state.explicitShutdown;
   }, []);
 
+  const scheduleStableRecoveryReset = useCallback((sessionId: string): void => {
+    if (stableRecoveryResetTimerRef.current !== null) {
+      window.clearTimeout(stableRecoveryResetTimerRef.current);
+      stableRecoveryResetTimerRef.current = null;
+    }
+
+    stableRecoveryResetTimerRef.current = window.setTimeout(() => {
+      stableRecoveryResetTimerRef.current = null;
+      const activeSessionId = sessionRef.current?.sessionId;
+      if (
+        streamStatusRef.current !== "streaming"
+        || !activeSessionId
+        || activeSessionId !== sessionId
+      ) {
+        return;
+      }
+      console.log(
+        `[Recovery] Stream remained stable for ${SIGNALING_RECOVERY_STABLE_RESET_DELAY_MS}ms; resetting recovery budget`,
+      );
+      resetSignalingRecoveryState({ keepExplicitShutdown: true });
+    }, SIGNALING_RECOVERY_STABLE_RESET_DELAY_MS);
+  }, [resetSignalingRecoveryState]);
+
+  const disconnectSignalingControlled = useCallback(async (): Promise<void> => {
+    pendingControlledDisconnectsRef.current += 1;
+    await window.openNow.disconnectSignaling().catch(() => {});
+  }, []);
+
   // Session ref sync
   useEffect(() => {
     sessionRef.current = session;
   }, [session]);
+
+  useEffect(() => {
+    const streamIsActive = streamStatus !== "idle" || session !== null || navbarActiveSession !== null;
+    if (!streamIsActive) {
+      runtimeSnapshotRef.current = null;
+      clearRuntimeSnapshot();
+      return;
+    }
+
+    const snapshot: RuntimeSnapshot = {
+      version: 1,
+      updatedAt: Date.now(),
+      streamStatus,
+      sessionId: session?.sessionId ?? navbarActiveSession?.sessionId ?? null,
+      sessionAppId:
+        (Number.isFinite(signalingRecoveryRef.current.appId ?? NaN) ? signalingRecoveryRef.current.appId : null) ??
+        (navbarActiveSession ? navbarActiveSession.appId : null),
+      streamingGameId: streamingGame?.id ?? null,
+      streamingStore: streamingStore ?? null,
+      recoveryAppId: signalingRecoveryRef.current.appId,
+      resumeContext: session
+        ? {
+          sessionId: session.sessionId,
+          serverIp: session.serverIp,
+          streamingBaseUrl: session.streamingBaseUrl,
+          signalingServer: session.signalingServer,
+          signalingUrl: session.signalingUrl,
+          appId: Number.isFinite(signalingRecoveryRef.current.appId ?? NaN) ? signalingRecoveryRef.current.appId ?? undefined : undefined,
+          clientId: session.clientId,
+          deviceId: session.deviceId,
+        }
+        : (navbarActiveSession?.sessionId && navbarActiveSession.serverIp)
+          ? {
+            sessionId: navbarActiveSession.sessionId,
+            serverIp: navbarActiveSession.serverIp,
+            streamingBaseUrl: navbarActiveSession.streamingBaseUrl,
+            signalingUrl: navbarActiveSession.signalingUrl,
+            appId: Number.isFinite(navbarActiveSession.appId) ? navbarActiveSession.appId : undefined,
+          }
+          : null,
+    };
+
+    runtimeSnapshotRef.current = snapshot;
+    saveRuntimeSnapshot(snapshot);
+  }, [navbarActiveSession, session, streamStatus, streamingGame?.id, streamingStore]);
+
+  const persistRuntimeSnapshotNow = useCallback((): void => {
+    const latestSession = sessionRef.current;
+    const latestNavbarSession = navbarActiveSession;
+    const hasActiveContext =
+      streamStatusRef.current !== "idle" || latestSession !== null || latestNavbarSession !== null;
+    if (!hasActiveContext) {
+      runtimeSnapshotRef.current = null;
+      clearRuntimeSnapshot();
+      return;
+    }
+
+    const snapshot: RuntimeSnapshot = {
+      version: 1,
+      updatedAt: Date.now(),
+      streamStatus: streamStatusRef.current,
+      sessionId: latestSession?.sessionId ?? latestNavbarSession?.sessionId ?? null,
+      sessionAppId:
+        (Number.isFinite(signalingRecoveryRef.current.appId ?? NaN) ? signalingRecoveryRef.current.appId : null) ??
+        (latestNavbarSession ? latestNavbarSession.appId : null),
+      streamingGameId: streamingGame?.id ?? null,
+      streamingStore: streamingStore ?? null,
+      recoveryAppId: signalingRecoveryRef.current.appId,
+      resumeContext: latestSession
+        ? {
+          sessionId: latestSession.sessionId,
+          serverIp: latestSession.serverIp,
+          streamingBaseUrl: latestSession.streamingBaseUrl,
+          signalingServer: latestSession.signalingServer,
+          signalingUrl: latestSession.signalingUrl,
+          appId: Number.isFinite(signalingRecoveryRef.current.appId ?? NaN) ? signalingRecoveryRef.current.appId ?? undefined : undefined,
+          clientId: latestSession.clientId,
+          deviceId: latestSession.deviceId,
+        }
+        : (latestNavbarSession?.sessionId && latestNavbarSession.serverIp)
+          ? {
+            sessionId: latestNavbarSession.sessionId,
+            serverIp: latestNavbarSession.serverIp,
+            streamingBaseUrl: latestNavbarSession.streamingBaseUrl,
+            signalingUrl: latestNavbarSession.signalingUrl,
+            appId: Number.isFinite(latestNavbarSession.appId) ? latestNavbarSession.appId : undefined,
+          }
+          : null,
+    };
+
+    runtimeSnapshotRef.current = snapshot;
+    saveRuntimeSnapshot(snapshot);
+  }, [navbarActiveSession, streamingGame?.id, streamingStore]);
+
+  useEffect(() => {
+    const onBeforeUnload = (): void => {
+      appUnloadingRef.current = true;
+      persistRuntimeSnapshotNow();
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [persistRuntimeSnapshotNow]);
 
   useEffect(() => {
     adReportStateRef.current = {};
@@ -1734,7 +2027,17 @@ export function App(): JSX.Element {
     }
     try {
       const activeSessions = await window.openNow.getActiveSessions(token, streamingBaseUrl);
-      const candidate = activeSessions.find((entry) => entry.status === 3 || entry.status === 2) ?? null;
+      const snapshot = runtimeSnapshotRef.current;
+      const resumableSessions = activeSessions.filter((entry) => entry.status === 3 || entry.status === 2);
+      const candidate =
+        (snapshot?.sessionId
+          ? resumableSessions.find((entry) => entry.sessionId === snapshot.sessionId)
+          : undefined) ??
+        (snapshot?.sessionAppId !== null && snapshot?.sessionAppId !== undefined
+          ? resumableSessions.find((entry) => entry.appId === snapshot.sessionAppId)
+          : undefined) ??
+        resumableSessions[0] ??
+        null;
       setNavbarActiveSession(candidate);
     } catch (error) {
       console.warn("Failed to refresh active sessions:", error);
@@ -2210,10 +2513,12 @@ export function App(): JSX.Element {
   }, [settingsLoaded]);
 
   const handleExitApp = useCallback(() => {
+    appUnloadingRef.current = true;
+    persistRuntimeSnapshotNow();
     void window.openNow.quitApp().catch((error) => {
       console.warn("Failed to quit application:", error);
     });
-  }, []);
+  }, [persistRuntimeSnapshotNow]);
 
   const handleMicrophoneModeChange = useCallback((value: import("@shared/gfn").MicrophoneMode) => {
     // Keep UI responsive while still surfacing persistence failures.
@@ -2333,6 +2638,12 @@ export function App(): JSX.Element {
           }
         } catch (e) {
           // ignore parse/storage errors
+        }
+
+        const persistedRuntimeSnapshot = loadRuntimeSnapshot();
+        runtimeSnapshotRef.current = persistedRuntimeSnapshot;
+        if (persistedRuntimeSnapshot?.recoveryAppId !== null && persistedRuntimeSnapshot?.recoveryAppId !== undefined) {
+          signalingRecoveryRef.current.appId = persistedRuntimeSnapshot.recoveryAppId;
         }
 
         setProviders(providerList);
@@ -2547,13 +2858,35 @@ export function App(): JSX.Element {
 
   const resolveSessionClaimAppId = useCallback((existingSession: ActiveSessionInfo): string => {
     const trackedAppId = signalingRecoveryRef.current.appId;
+    const persistedAppId = runtimeSnapshotRef.current?.sessionAppId ?? runtimeSnapshotRef.current?.recoveryAppId;
     if (Number.isFinite(existingSession.appId) && existingSession.appId > 0) {
       return String(existingSession.appId);
     }
     if (trackedAppId && Number.isFinite(trackedAppId)) {
       return String(trackedAppId);
     }
+    if (persistedAppId && Number.isFinite(persistedAppId)) {
+      return String(persistedAppId);
+    }
     throw new Error("Active session is missing app metadata required for resume.");
+  }, []);
+
+  const resolveResumeIdentity = useCallback((sessionId: string): { clientId?: string; deviceId?: string } => {
+    const liveSession = sessionRef.current;
+    if (liveSession?.sessionId === sessionId) {
+      return {
+        clientId: liveSession.clientId,
+        deviceId: liveSession.deviceId,
+      };
+    }
+    const persisted = runtimeSnapshotRef.current?.resumeContext;
+    if (persisted?.sessionId === sessionId) {
+      return {
+        clientId: persisted.clientId,
+        deviceId: persisted.deviceId,
+      };
+    }
+    return {};
   }, []);
 
   const applyClaimedSessionAndConnect = useCallback(async (
@@ -2612,7 +2945,8 @@ export function App(): JSX.Element {
     });
     clientRef.current?.dispose();
     clientRef.current = null;
-    await window.openNow.disconnectSignaling().catch(() => {});
+    await disconnectSignalingControlled();
+    awaitingRecoveryRemoteIceRef.current = expectedRecoveryGeneration !== undefined;
 
     setSession(claimed);
     sessionRef.current = claimed;
@@ -2624,7 +2958,7 @@ export function App(): JSX.Element {
       signalingServer: claimed.signalingServer,
       signalingUrl: claimed.signalingUrl,
     });
-  }, [isRecoveryGenerationCurrent]);
+  }, [disconnectSignalingControlled, isRecoveryGenerationCurrent]);
 
   const claimAndConnectSession = useCallback(async (existingSession: ActiveSessionInfo): Promise<void> => {
     const sid = existingSession.sessionId;
@@ -2666,6 +3000,7 @@ export function App(): JSX.Element {
           streamingBaseUrl: effectiveStreamingBaseUrl,
           serverIp: existingSession.serverIp,
           sessionId: existingSession.sessionId,
+          ...resolveResumeIdentity(existingSession.sessionId),
           appId: resolveSessionClaimAppId(existingSession),
           settings: {
             resolution: settings.resolution,
@@ -2692,7 +3027,7 @@ export function App(): JSX.Element {
 
     claimResumePromisesRef.current.set(sid, resumePromiseHolder.promise);
     await resumePromiseHolder.promise;
-  }, [applyClaimedSessionAndConnect, authSession, effectiveStreamingBaseUrl, findGameContextForSession, resolveSessionClaimAppId, settings]);
+  }, [applyClaimedSessionAndConnect, authSession, effectiveStreamingBaseUrl, findGameContextForSession, resolveResumeIdentity, resolveSessionClaimAppId, settings]);
 
   const attemptSessionRecovery = useCallback(async (reason: string): Promise<boolean> => {
     const recoveryState = signalingRecoveryRef.current;
@@ -2731,7 +3066,7 @@ export function App(): JSX.Element {
       clientRef.current?.dispose();
       clientRef.current = null;
       setStreamStatus("connecting");
-      await window.openNow.disconnectSignaling().catch(() => {});
+      await disconnectSignalingControlled();
 
       let lastError: Error | null = null;
       while (recoveryState.attemptCount < SIGNALING_RECOVERY_ATTEMPT_DELAYS_MS.length) {
@@ -2782,6 +3117,32 @@ export function App(): JSX.Element {
           }
 
           if (!candidate) {
+            const persisted = runtimeSnapshotRef.current?.resumeContext;
+            if (
+              persisted &&
+              persisted.sessionId === currentSessionId &&
+              persisted.serverIp
+            ) {
+              candidate = {
+                sessionId: persisted.sessionId,
+                appId:
+                  Number.isFinite(persisted.appId ?? NaN)
+                    ? (persisted.appId as number)
+                    : (previousAppId ?? 0),
+                status: 2,
+                serverIp: persisted.serverIp,
+                streamingBaseUrl: persisted.streamingBaseUrl,
+                signalingUrl: persisted.signalingUrl,
+              };
+              console.log("[Recovery] Falling back to persisted resume context", {
+                sessionId: persisted.sessionId,
+                serverIp: persisted.serverIp,
+                appId: persisted.appId ?? previousAppId ?? null,
+              });
+            }
+          }
+
+          if (!candidate) {
             const hasQueueOnlyMatch = activeSessions.some((entry) => entry.sessionId === currentSessionId && entry.status === 1);
             if (hasQueueOnlyMatch) {
               throw new Error("The session is still queued and cannot be reclaimed until the server marks it ready again.");
@@ -2798,6 +3159,8 @@ export function App(): JSX.Element {
             streamingBaseUrl: effectiveStreamingBaseUrl,
             serverIp: candidate.serverIp,
             sessionId: candidate.sessionId,
+            ...resolveResumeIdentity(candidate.sessionId),
+            recoveryMode: true,
             appId: resolveSessionClaimAppId(candidate),
             settings: {
               resolution: settings.resolution,
@@ -2829,7 +3192,6 @@ export function App(): JSX.Element {
             console.log("[Recovery] Recovery generation changed before connect completed");
             return false;
           }
-          recoveryState.attemptCount = 0;
           return true;
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
@@ -2854,9 +3216,11 @@ export function App(): JSX.Element {
   }, [
     applyClaimedSessionAndConnect,
     authSession,
+    disconnectSignalingControlled,
     effectiveStreamingBaseUrl,
     findGameContextForSession,
     isRecoveryGenerationCurrent,
+    resolveResumeIdentity,
     resolveSessionClaimAppId,
     settings,
   ]);
@@ -2867,10 +3231,45 @@ export function App(): JSX.Element {
       console.log(`[App] Signaling event: ${event.type}`, event.type === "offer" ? `(SDP ${event.sdp.length} chars)` : "", event.type === "remote-ice" ? event.candidate : "");
       try {
         if (event.type === "offer") {
+          pendingControlledDisconnectsRef.current = 0;
           const activeSession = sessionRef.current;
           if (!activeSession) {
             console.warn("[App] Received offer but no active session in sessionRef!");
             return;
+          }
+          const shouldEnforceRemoteIceGrace = awaitingRecoveryRemoteIceRef.current;
+          remoteIceSeenForSessionRef.current = null;
+          hasConfirmedRemoteIceRef.current = false;
+          if (remoteIceGraceTimerRef.current !== null) {
+            window.clearTimeout(remoteIceGraceTimerRef.current);
+            remoteIceGraceTimerRef.current = null;
+          }
+          const expectedSessionId = activeSession.sessionId;
+          const recoveryGenerationAtOffer = signalingRecoveryRef.current.generation;
+          if (shouldEnforceRemoteIceGrace) {
+            remoteIceGraceTimerRef.current = window.setTimeout(() => {
+              remoteIceGraceTimerRef.current = null;
+              if (sessionRef.current?.sessionId !== expectedSessionId) {
+                return;
+              }
+              if (remoteIceSeenForSessionRef.current === expectedSessionId) {
+                return;
+              }
+              if (remoteIceRecoveryGenerationRef.current === recoveryGenerationAtOffer) {
+                return;
+              }
+              if (!RECOVERABLE_STREAM_STATUSES.includes(streamStatusRef.current)) {
+                return;
+              }
+              awaitingRecoveryRemoteIceRef.current = false;
+              remoteIceRecoveryGenerationRef.current = recoveryGenerationAtOffer;
+              console.warn(
+                `[Recovery] No remote ICE received within ${SIGNALING_REMOTE_ICE_GRACE_MS}ms after offer; forcing targeted recovery`,
+              );
+              void attemptSessionRecovery("No remote ICE received after offer").catch((error) => {
+                console.error("[Recovery] ICE-timeout recovery failed:", error);
+              });
+            }, SIGNALING_REMOTE_ICE_GRACE_MS);
           }
           console.log("[App] Active session for offer:", JSON.stringify({
             sessionId: activeSession.sessionId,
@@ -2902,6 +3301,41 @@ export function App(): JSX.Element {
               onMicStateChange: (state) => {
                 console.log(`[App] Mic state: ${state.state}${state.deviceLabel ? ` (${state.deviceLabel})` : ""}`);
               },
+              onIceConnectionStateChange: (iceState) => {
+                latestIceConnectionStateRef.current = iceState;
+                if (iceDisconnectedRecoveryTimerRef.current !== null) {
+                  window.clearTimeout(iceDisconnectedRecoveryTimerRef.current);
+                  iceDisconnectedRecoveryTimerRef.current = null;
+                }
+                if (appUnloadingRef.current) {
+                  return;
+                }
+                if (streamStatusRef.current !== "streaming") {
+                  return;
+                }
+                if (iceState === "failed") {
+                  console.warn("[Recovery] ICE failed; attempting targeted recovery");
+                  void attemptSessionRecovery("ICE failed").catch((error) => {
+                    console.error("[Recovery] ICE-failed recovery failed:", error);
+                  });
+                  return;
+                }
+                if (iceState === "disconnected") {
+                  iceDisconnectedRecoveryTimerRef.current = window.setTimeout(() => {
+                    iceDisconnectedRecoveryTimerRef.current = null;
+                    if (appUnloadingRef.current || streamStatusRef.current !== "streaming") {
+                      return;
+                    }
+                    if (latestIceConnectionStateRef.current !== "disconnected") {
+                      return;
+                    }
+                    console.warn("[Recovery] ICE remained disconnected; attempting targeted recovery");
+                    void attemptSessionRecovery("ICE disconnected timeout").catch((error) => {
+                      console.error("[Recovery] ICE-disconnected recovery failed:", error);
+                    });
+                  }, ICE_DISCONNECTED_RECOVERY_GRACE_MS);
+                }
+              },
               onControllerMetaPress: () => {
                 handleControllerMetaToggle();
               },
@@ -2922,7 +3356,7 @@ export function App(): JSX.Element {
             });
             setLaunchError(null);
             setStreamStatus("streaming");
-            resetSignalingRecoveryState({ keepExplicitShutdown: true });
+            scheduleStableRecoveryReset(activeSession.sessionId);
             console.log(
               "[Stream] Offer applied; use [WebRTC] logs for ICE/video dimensions. signalingServer=%s media=%s",
               activeSession.signalingServer,
@@ -2932,8 +3366,55 @@ export function App(): JSX.Element {
             );
           }
         } else if (event.type === "remote-ice") {
+          remoteIceSeenForSessionRef.current = sessionRef.current?.sessionId ?? null;
+          hasConfirmedRemoteIceRef.current = true;
+          awaitingRecoveryRemoteIceRef.current = false;
+          if (remoteIceGraceTimerRef.current !== null) {
+            window.clearTimeout(remoteIceGraceTimerRef.current);
+            remoteIceGraceTimerRef.current = null;
+          }
           await clientRef.current?.addRemoteCandidate(event.candidate);
         } else if (event.type === "disconnected") {
+          if (appUnloadingRef.current) {
+            console.log("[Recovery] Ignoring signaling disconnect during app shutdown");
+            return;
+          }
+          const iceState = latestIceConnectionStateRef.current;
+          if (
+            iceState === "connected" ||
+            iceState === "completed" ||
+            iceState === "checking"
+          ) {
+            console.log(`[Recovery] Ignoring signaling disconnect while ICE state is ${iceState}`);
+            return;
+          }
+          // Official-style behavior: if the attach never reached a confirmed remote ICE
+          // handshake, do not auto-recover. Fail this attempt and require explicit resume.
+          if (!hasConfirmedRemoteIceRef.current) {
+            console.warn("[Recovery] Skipping auto-recovery: disconnected before remote ICE handshake");
+            clientRef.current?.dispose();
+            clientRef.current = null;
+            setLaunchError({
+              stage: streamStatusToLoadingStage(streamStatusRef.current),
+              title: "Session Connection Lost",
+              description: "Resume attach failed before media handshake. Try resuming once again.",
+            });
+            resetLaunchRuntime({ keepLaunchError: true, keepStreamingContext: true });
+            void refreshNavbarActiveSession();
+            launchInFlightRef.current = false;
+            return;
+          }
+          if (remoteIceGraceTimerRef.current !== null) {
+            window.clearTimeout(remoteIceGraceTimerRef.current);
+            remoteIceGraceTimerRef.current = null;
+          }
+          remoteIceSeenForSessionRef.current = null;
+          awaitingRecoveryRemoteIceRef.current = false;
+          if (pendingControlledDisconnectsRef.current > 0) {
+            pendingControlledDisconnectsRef.current -= 1;
+            console.log("[Recovery] Ignoring controlled signaling disconnect");
+            return;
+          }
           console.warn("Signaling disconnected:", event.reason);
           const recovered = await attemptSessionRecovery(event.reason).catch((error) => {
             console.error("[Recovery] Signaling recovery failed:", error);
@@ -2962,6 +3443,10 @@ export function App(): JSX.Element {
           console.error("Signaling error:", event.message);
         }
       } catch (error) {
+        if (appUnloadingRef.current) {
+          console.log("[Recovery] Suppressing signaling handler errors during app shutdown");
+          return;
+        }
         if (
           signalingRecoveryRef.current.explicitShutdown
           || !RECOVERABLE_STREAM_STATUSES.includes(streamStatusRef.current)
@@ -2985,7 +3470,7 @@ export function App(): JSX.Element {
     });
 
     return () => unsubscribe();
-  }, [attemptSessionRecovery, diagnosticsStore, refreshNavbarActiveSession, resetLaunchRuntime, resetSignalingRecoveryState, settings]);
+  }, [attemptSessionRecovery, diagnosticsStore, refreshNavbarActiveSession, resetLaunchRuntime, scheduleStableRecoveryReset, settings]);
 
   // Play game handler
   const handlePlayGame = useCallback(async (game: GameInfo, options?: { bypassGuards?: boolean; streamingBaseUrl?: string }) => {
@@ -3273,7 +3758,7 @@ export function App(): JSX.Element {
       }
       console.error("Launch failed:", error);
       setLaunchError(toLaunchErrorState(error, loadingStep));
-      await window.openNow.disconnectSignaling().catch(() => {});
+      await disconnectSignalingControlled();
       clientRef.current?.dispose();
       clientRef.current = null;
       resetLaunchRuntime({ keepLaunchError: true, keepStreamingContext: true });
@@ -3553,7 +4038,7 @@ export function App(): JSX.Element {
     } catch (error) {
       console.error("Navbar resume failed:", error);
       setLaunchError(toLaunchErrorState(error, loadingStep));
-      await window.openNow.disconnectSignaling().catch(() => {});
+      await disconnectSignalingControlled();
       clientRef.current?.dispose();
       clientRef.current = null;
       resetLaunchRuntime({ keepLaunchError: true });
@@ -3632,7 +4117,7 @@ export function App(): JSX.Element {
         launchAbortRef.current = true;
       }
       markExplicitSignalingShutdown();
-      await window.openNow.disconnectSignaling();
+      await disconnectSignalingControlled();
 
       const current = sessionRef.current;
       if (current) {
@@ -3707,7 +4192,7 @@ export function App(): JSX.Element {
 
   const handleDismissLaunchError = useCallback(async () => {
     markExplicitSignalingShutdown();
-    await window.openNow.disconnectSignaling().catch(() => {});
+    await disconnectSignalingControlled();
     clientRef.current?.dispose();
     clientRef.current = null;
     resetLaunchRuntime();

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -183,6 +183,8 @@ interface ClientOptions {
   onStats?: (stats: StreamDiagnostics) => void;
   onTimeWarning?: (warning: StreamTimeWarning) => void;
   onMicStateChange?: (state: MicStateChange) => void;
+  onIceConnectionStateChange?: (state: RTCIceConnectionState) => void;
+  onPeerConnectionStateChange?: (state: RTCPeerConnectionState) => void;
   /** Optional host callback for Meta/Home button edge presses (button 16). */
   onControllerMetaPress?: (event: { controllerId: number; gamepad: Gamepad }) => void;
 }
@@ -3938,6 +3940,7 @@ export class GfnWebRtcClient {
       this.diagnostics.connectionState = pc.connectionState;
       this.emitStats();
       this.log(`Peer connection state: ${pc.connectionState}`);
+      this.options.onPeerConnectionStateChange?.(pc.connectionState);
     };
 
     pc.ondatachannel = (event) => {
@@ -3973,6 +3976,7 @@ export class GfnWebRtcClient {
 
     pc.oniceconnectionstatechange = () => {
       this.log(`ICE connection state: ${pc.iceConnectionState}`);
+      this.options.onIceConnectionStateChange?.(pc.iceConnectionState);
     };
 
     pc.onicegatheringstatechange = () => {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -673,8 +673,12 @@ export interface SessionClaimRequest {
   streamingBaseUrl?: string;
   sessionId: string;
   serverIp: string;
+  clientId?: string;
+  deviceId?: string;
   appId?: string;
   settings?: StreamSettings;
+  /** True when claim is triggered by automatic reconnect recovery logic */
+  recoveryMode?: boolean;
 }
 
 export interface SignalingConnectRequest {


### PR DESCRIPTION
## Summary
- preserve session claim identity across resume/recovery (client/device continuity)
- harden quit/reopen resume path by persisting runtime snapshot on unload and avoiding shutdown disconnect churn
- switch recovery policy to official-style gating: avoid setup-phase loops and trigger targeted recovery from ICE failure signals

## Test plan
- [ ] Start stream, use File > Exit, relaunch, then resume
- [ ] Start stream, close window only, relaunch window, then resume
- [ ] Simulate network change while streaming and verify one targeted recovery path
- [ ] Confirm no repeated setup/black-screen reconnect loop