### PR TITLE
Switch macOS builds to GitHub-hosted runners

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -37,13 +37,13 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
-            os: blacksmith-6vcpu-macos-latest
+            os: macos-latest
             builder_args: "--mac dmg zip --x64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
-            os: blacksmith-6vcpu-macos-latest
+            os: macos-latest
             builder_args: "--mac dmg zip --arm64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,13 +112,13 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
-            os: blacksmith-6vcpu-macos-latest
+            os: macos-latest
             builder_args: "--mac dmg zip --x64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
-            os: blacksmith-6vcpu-macos-latest
+            os: macos-latest
             builder_args: "--mac dmg zip --arm64"
             artifact_paths: |
               opennow-stable/dist-release/*.dmg


### PR DESCRIPTION
## Summary

This PR replaces the self-hosted Blacksmith macOS runners with GitHub-hosted runners for all macOS builds (x64 and arm64) in the CI workflows to standardize infrastructure and reduce maintenance overhead.

- Change `macos-x64` and `macos-arm64` matrix `os` labels from `blacksmith-6vcpu-macos-latest` to `macos-latest` in `.github/workflows/auto-build.yml`
- Change `macos-x64` and `macos-arm64` matrix `os` labels from `blacksmith-6vcpu-macos-latest` to `macos-latest` in `.github/workflows/release.yml`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c416ec98-a9a3-4bbd-ba98-a7e2735c3039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-083" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c416ec98-a9a3-4bbd-ba98-a7e2735c3039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-083&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-083"><img alt="OPE-083" src="https://capy.ai/api/badge/thread.svg?label=OPE-083"></picture></a>
<!-- capy-pr-badge:end -->