### PR TITLE
Fix cross-platform GStreamer bundling and Linux guidance

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -99,6 +99,7 @@ jobs:
       npm_config_audit: "false"
       npm_config_fund: "false"
       GSTREAMER_VERSION: "1.28.2"
+      GSTREAMER_WINDOWS_VERSION: "1.26.1"
       # Use system fpm on arm64 (no prebuilt binaries available)
       USE_SYSTEM_FPM: ${{ matrix.label == 'linux-arm64' && 'true' || 'false' }}
 
@@ -191,42 +192,40 @@ jobs:
               ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
             } | Select-Object -First 1
           }
+          function Invoke-Download([string] $url, [string] $output) {
+            $process = Start-Process -FilePath "curl.exe" -ArgumentList @("--fail", "--location", "--retry", "3", "--output", $output, $url) -Wait -PassThru -NoNewWindow
+            return $process.ExitCode -eq 0
+          }
           function Install-GStreamerMsiSdk([string] $version) {
             $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
             $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime-$version.msi"
             $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
-            curl.exe --fail --location --retry 3 --output $runtime "$base/gstreamer-1.0-msvc-x86_64-$version.msi"
-            if ($LASTEXITCODE -ne 0) { return $false }
-            curl.exe --fail --location --retry 3 --output $devel "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi"
-            if ($LASTEXITCODE -ne 0) { return $false }
-            Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
-            Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
-            return $true
+            if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.msi" $runtime)) { return $false }
+            if (-not (Invoke-Download "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $devel)) { return $false }
+            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait -PassThru
+            if ($runtimeInstall.ExitCode -ne 0) { return $false }
+            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait -PassThru
+            if ($develInstall.ExitCode -ne 0) { return $false }
+            return [bool](Find-GStreamerRoot)
           }
-          $currentBase = "https://gstreamer.freedesktop.org/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-          $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk.exe"
-          $exeUrl = "$currentBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.exe"
-          $installed = $false
-          curl.exe --fail --location --retry 3 --output $exe $exeUrl
-          if ($LASTEXITCODE -eq 0 -and (Test-Path $exe)) {
+          function Install-GStreamerExeSdk([string] $version) {
+            $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
+            $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk-$version.exe"
+            if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.exe" $exe)) { return $false }
             $process = Start-Process -FilePath $exe -ArgumentList @("/S", "/D=$installDir") -PassThru
-            if ($process.WaitForExit(600000)) {
-              $installed = $process.ExitCode -eq 0
-            } else {
-              Write-Warning "GStreamer EXE installer timed out; killing process and falling back to MSI packages."
+            if (-not $process.WaitForExit(600000)) {
+              Write-Warning "GStreamer EXE installer timed out; killing process."
               Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+              return $false
             }
-            if (-not (Find-GStreamerRoot)) {
-              $installed = $false
-            }
+            if ($process.ExitCode -ne 0) { return $false }
+            return [bool](Find-GStreamerRoot)
           }
-          if (-not $installed) {
-            if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_VERSION)) {
-              Write-Warning "Current-version MSI packages unavailable; falling back to known-good GStreamer 1.26.1 Windows SDK."
-              if (-not (Install-GStreamerMsiSdk "1.26.1")) {
-                Write-Error "Failed to install GStreamer Windows SDK from EXE or MSI packages."
-                exit 1
-              }
+          if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
+            Write-Warning "GStreamer $env:GSTREAMER_WINDOWS_VERSION MSI SDK install failed; trying EXE fallback."
+            if (-not (Install-GStreamerExeSdk $env:GSTREAMER_WINDOWS_VERSION)) {
+              Write-Error "Failed to install GStreamer Windows SDK version $env:GSTREAMER_WINDOWS_VERSION from MSI or EXE packages."
+              exit 1
             }
           }
           $root = Find-GStreamerRoot

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -180,13 +180,22 @@ jobs:
         if: matrix.native_build == 'true' && runner.os == 'Windows'
         shell: pwsh
         run: |
-          $base = "https://gstreamer.freedesktop.org/data/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-          $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime.msi"
-          $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel.msi"
-          curl.exe --fail --location --retry 3 --output $runtime "$base/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-          curl.exe --fail --location --retry 3 --output $devel "$base/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-          Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart") -Wait
-          Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart") -Wait
+          $installDir = "C:\gstreamer\1.0\msvc_x86_64"
+          $currentBase = "https://gstreamer.freedesktop.org/pkg/windows/$env:GSTREAMER_VERSION/msvc"
+          $legacyBase = "https://gstreamer.freedesktop.org/data/pkg/windows/$env:GSTREAMER_VERSION/msvc"
+          $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk.exe"
+          $exeUrl = "$currentBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.exe"
+          curl.exe --fail --location --retry 3 --output $exe $exeUrl
+          if ($LASTEXITCODE -eq 0 -and (Test-Path $exe)) {
+            Start-Process -FilePath $exe -ArgumentList @("/quiet", "/norestart", "INSTALLDIR=$installDir") -Wait
+          } else {
+            $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime.msi"
+            $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel.msi"
+            curl.exe --fail --location --retry 3 --output $runtime "$legacyBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
+            curl.exe --fail --location --retry 3 --output $devel "$legacyBase/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
+            Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
+            Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
+          }
           $roots = @(
             "C:\gstreamer\1.0\msvc_x86_64",
             "C:\Program Files\gstreamer\1.0\msvc_x86_64"

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -100,6 +100,10 @@ jobs:
       npm_config_fund: "false"
       GSTREAMER_VERSION: "1.28.2"
       GSTREAMER_WINDOWS_VERSION: "1.26.1"
+      CARGO_NET_RETRY: "10"
+      CARGO_HTTP_MULTIPLEXING: "false"
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       # Use system fpm on arm64 (no prebuilt binaries available)
       USE_SYSTEM_FPM: ${{ matrix.label == 'linux-arm64' && 'true' || 'false' }}
 
@@ -306,6 +310,17 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --progress=false
+
+      - name: Verify macOS Cargo network trust
+        if: matrix.native_build == 'true' && runner.os == 'macOS'
+        run: |
+          if ! curl --fail --location --retry 5 https://index.crates.io/config.json --output /tmp/cargo-index-config.json; then
+            if command -v brew >/dev/null 2>&1; then
+              brew update --quiet
+              brew reinstall ca-certificates
+            fi
+            curl --fail --location --retry 5 https://index.crates.io/config.json --output /tmp/cargo-index-config.json
+          fi
 
       - name: Build native streamer
         if: matrix.native_build == 'true'

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -47,7 +47,7 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
-            os: blacksmith-6vcpu-macos-latest
+            os: macos-15-intel
             builder_args: "--mac dmg zip --x64"
             native_build: "true"
             bundle_gstreamer: "1"
@@ -57,7 +57,7 @@ jobs:
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
-            os: blacksmith-6vcpu-macos-latest
+            os: macos-15
             builder_args: "--mac dmg zip --arm64"
             native_build: "true"
             bundle_gstreamer: "1"
@@ -122,6 +122,18 @@ jobs:
         if: matrix.native_build == 'true' && matrix.native_target != ''
         run: rustup target add ${{ matrix.native_target }}
 
+      - name: Cache Rust native build
+        if: matrix.native_build == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            native/opennow-streamer/target
+          key: ${{ runner.os }}-${{ matrix.label }}-cargo-${{ hashFiles('native/opennow-streamer/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.label }}-cargo-
+
       - name: Cache Electron binaries
         uses: actions/cache@v4
         with:
@@ -132,17 +144,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-electron-
 
-      - name: Install Linux packaging tools
+      - name: Install Linux build/runtime packages
         if: runner.os == 'Linux'
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install -y fakeroot rpm
-
-      - name: Install Linux GStreamer build/runtime packages
-        if: matrix.native_build == 'true' && runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
+            fakeroot \
+            rpm \
             build-essential \
             pkg-config \
             libglib2.0-dev \
@@ -162,20 +172,40 @@ jobs:
             libvulkan1 \
             mesa-vulkan-drivers
 
+      - name: Cache macOS GStreamer packages
+        if: matrix.native_build == 'true' && runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cache/gstreamer-macos
+          key: gstreamer-macos-${{ env.GSTREAMER_VERSION }}
+
       - name: Install macOS GStreamer build/runtime packages
         if: matrix.native_build == 'true' && runner.os == 'macOS'
         run: |
           base="https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}"
-          runtime="$RUNNER_TEMP/gstreamer-runtime.pkg"
-          devel="$RUNNER_TEMP/gstreamer-devel.pkg"
-          curl --fail --location --retry 3 --output "$runtime" "$base/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
-          curl --fail --location --retry 3 --output "$devel" "$base/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
+          cache_dir="${GITHUB_WORKSPACE}/.cache/gstreamer-macos/${GSTREAMER_VERSION}"
+          mkdir -p "$cache_dir"
+          runtime="$cache_dir/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
+          devel="$cache_dir/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
+          if [ ! -s "$runtime" ]; then
+            curl --fail --location --retry 3 --output "$runtime" "$base/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
+          fi
+          if [ ! -s "$devel" ]; then
+            curl --fail --location --retry 3 --output "$devel" "$base/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
+          fi
           sudo installer -pkg "$runtime" -target /
           sudo installer -pkg "$devel" -target /
           root="/Library/Frameworks/GStreamer.framework/Versions/1.0"
           echo "GSTREAMER_1_0_ROOT_MACOS=$root" >> "$GITHUB_ENV"
           echo "$root/bin" >> "$GITHUB_PATH"
           echo "PKG_CONFIG_PATH=$root/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
+
+      - name: Cache Windows GStreamer SDK
+        if: matrix.native_build == 'true' && runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: C:\gstreamer
+          key: gstreamer-windows-${{ env.GSTREAMER_WINDOWS_VERSION }}
 
       - name: Install Windows GStreamer SDK
         if: matrix.native_build == 'true' && runner.os == 'Windows'
@@ -229,7 +259,10 @@ jobs:
             if ($develInstall.ExitCode -ne 0) { return $false }
             return [bool](Find-GStreamerRoot)
           }
-          if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
+          $root = Find-GStreamerRoot
+          if ($root) {
+            Write-Host "Using cached GStreamer Windows SDK: $root"
+          } elseif (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
             [void](Find-GStreamerRoot)
             Write-Host "GStreamer explicit roots searched: $($roots -join ', ')"
             Write-Host "GStreamer recursive search bases: $($searchBases -join ', ')"

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -221,10 +221,10 @@ jobs:
             $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
             if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.msi" $runtime)) { return $false }
             if (-not (Invoke-Download "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $devel)) { return $false }
-            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase") -Wait -PassThru
+            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase", "ADDLOCAL=ALL") -Wait -PassThru
             $script:lastRuntimeMsiExitCode = $runtimeInstall.ExitCode
             if ($runtimeInstall.ExitCode -ne 0) { return $false }
-            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installBase") -Wait -PassThru
+            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installBase", "ADDLOCAL=ALL") -Wait -PassThru
             $script:lastDevelMsiExitCode = $develInstall.ExitCode
             if ($develInstall.ExitCode -ne 0) { return $false }
             return [bool](Find-GStreamerRoot)
@@ -243,6 +243,26 @@ jobs:
           Write-Host "Discovered gstreamer-1.0.pc paths: $(if ($script:gstreamerPcPaths.Count) { $script:gstreamerPcPaths -join ', ' } else { 'none' })"
           if (-not $root) {
             Write-Error "GStreamer SDK root not found. Checked: $($roots -join ', '). Expected lib\pkgconfig\gstreamer-1.0.pc and bin\pkg-config.exe or bin\pkgconf.exe."
+            exit 1
+          }
+          $gstInspect = Join-Path $root "bin\gst-inspect-1.0.exe"
+          if (-not (Test-Path $gstInspect)) {
+            Write-Error "gst-inspect-1.0.exe not found in $root\bin after GStreamer install."
+            exit 1
+          }
+          $h264Decoders = @("avdec_h264", "d3d11h264dec", "d3d12h264dec")
+          $availableH264Decoders = @()
+          foreach ($decoder in $h264Decoders) {
+            $inspect = Start-Process -FilePath $gstInspect -ArgumentList @($decoder) -Wait -PassThru -NoNewWindow
+            if ($inspect.ExitCode -eq 0) {
+              $availableH264Decoders += $decoder
+              Write-Host "GStreamer decoder available: $decoder"
+            } else {
+              Write-Host "GStreamer decoder unavailable: $decoder"
+            }
+          }
+          if ($availableH264Decoders.Count -eq 0) {
+            Write-Error "GStreamer Windows SDK installed, but no H.264 decoder plugins were found among: $($h264Decoders -join ', ')"
             exit 1
           }
           "GSTREAMER_1_0_ROOT_MSVC_X86_64=$root" | Out-File -FilePath $env:GITHUB_ENV -Append

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -164,9 +164,17 @@ jobs:
       - name: Install macOS GStreamer build/runtime packages
         if: matrix.native_build == 'true' && runner.os == 'macOS'
         run: |
-          brew update
-          brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
-          echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
+          base="https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}"
+          runtime="$RUNNER_TEMP/gstreamer-runtime.pkg"
+          devel="$RUNNER_TEMP/gstreamer-devel.pkg"
+          curl --fail --location --retry 3 --output "$runtime" "$base/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
+          curl --fail --location --retry 3 --output "$devel" "$base/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
+          sudo installer -pkg "$runtime" -target /
+          sudo installer -pkg "$devel" -target /
+          root="/Library/Frameworks/GStreamer.framework/Versions/1.0"
+          echo "GSTREAMER_1_0_ROOT_MACOS=$root" >> "$GITHUB_ENV"
+          echo "$root/bin" >> "$GITHUB_PATH"
+          echo "PKG_CONFIG_PATH=$root/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
 
       - name: Install Windows GStreamer SDK
         if: matrix.native_build == 'true' && runner.os == 'Windows'

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -186,17 +186,30 @@ jobs:
       - name: Install macOS GStreamer build/runtime packages
         if: matrix.native_build == 'true' && runner.os == 'macOS'
         run: |
-          base="https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}"
+          primary_base="https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}"
+          mirror_base="https://gstreamer.freedesktop.org/pkg/macos/${GSTREAMER_VERSION}"
           cache_dir="${GITHUB_WORKSPACE}/.cache/gstreamer-macos/${GSTREAMER_VERSION}"
           mkdir -p "$cache_dir"
           runtime="$cache_dir/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
           devel="$cache_dir/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
-          if [ ! -s "$runtime" ]; then
-            curl --fail --location --retry 3 --output "$runtime" "$base/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
-          fi
-          if [ ! -s "$devel" ]; then
-            curl --fail --location --retry 3 --output "$devel" "$base/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
-          fi
+          download_pkg() {
+            local name="$1"
+            local destination="$2"
+            local partial="${destination}.part"
+            if [ -s "$destination" ]; then
+              return 0
+            fi
+            rm -f "$partial"
+            if ! curl --fail --location --retry 8 --retry-all-errors --retry-delay 5 --connect-timeout 30 --continue-at - --output "$partial" "$primary_base/$name"; then
+              curl --fail --location --retry 8 --retry-all-errors --retry-delay 5 --connect-timeout 30 --continue-at - --output "$partial" "$mirror_base/$name"
+            fi
+            test -s "$partial"
+            mv "$partial" "$destination"
+          }
+          download_pkg "gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg" "$runtime"
+          download_pkg "gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg" "$devel"
+          test -s "$runtime"
+          test -s "$devel"
           sudo installer -pkg "$runtime" -target /
           sudo installer -pkg "$devel" -target /
           root="/Library/Frameworks/GStreamer.framework/Versions/1.0"

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -314,6 +314,14 @@ jobs:
       - name: Verify macOS Cargo network trust
         if: matrix.native_build == 'true' && runner.os == 'macOS'
         run: |
+          if [ -f /etc/ssl/cert.pem ]; then
+            cargo_cacert=/etc/ssl/cert.pem
+          else
+            cargo_cacert="$RUNNER_TEMP/cargo-cacert.pem"
+            security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain /Library/Keychains/System.keychain > "$cargo_cacert"
+          fi
+          echo "CARGO_HTTP_CAINFO=$cargo_cacert" >> "$GITHUB_ENV"
+          echo "SSL_CERT_FILE=$cargo_cacert" >> "$GITHUB_ENV"
           if ! curl --fail --location --retry 5 https://index.crates.io/config.json --output /tmp/cargo-index-config.json; then
             if command -v brew >/dev/null 2>&1; then
               brew update --quiet
@@ -321,6 +329,7 @@ jobs:
             fi
             curl --fail --location --retry 5 https://index.crates.io/config.json --output /tmp/cargo-index-config.json
           fi
+          CARGO_HTTP_CAINFO="$cargo_cacert" SSL_CERT_FILE="$cargo_cacert" cargo search base64 --limit 1 >/tmp/cargo-search-check.txt
 
       - name: Build native streamer
         if: matrix.native_build == 'true'

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -181,20 +181,39 @@ jobs:
         if: matrix.native_build == 'true' && runner.os == 'Windows'
         shell: pwsh
         run: |
-          $installDir = "C:\gstreamer\1.0\msvc_x86_64"
+          $installBase = "C:\gstreamer"
           $roots = @(
             "C:\gstreamer\1.0\msvc_x86_64",
             "C:\Program Files\gstreamer\1.0\msvc_x86_64"
           )
+          $searchBases = @("C:\gstreamer", "C:\Program Files\gstreamer")
+          $script:gstreamerPcPaths = @()
+          $script:lastRuntimeMsiExitCode = $null
+          $script:lastDevelMsiExitCode = $null
+          function Test-GStreamerRoot([string] $candidate) {
+            return [bool]($candidate -and
+              (Test-Path (Join-Path $candidate "lib\pkgconfig\gstreamer-1.0.pc")) -and
+              ((Test-Path (Join-Path $candidate "bin\pkg-config.exe")) -or (Test-Path (Join-Path $candidate "bin\pkgconf.exe"))))
+          }
           function Find-GStreamerRoot {
-            $roots | Where-Object {
-              (Test-Path (Join-Path $_ "lib\pkgconfig\gstreamer-1.0.pc")) -and
-              ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
-            } | Select-Object -First 1
+            $script:gstreamerPcPaths = @()
+            foreach ($candidate in $roots) {
+              if (Test-GStreamerRoot $candidate) { return $candidate }
+            }
+            foreach ($base in $searchBases) {
+              if (-not (Test-Path $base)) { continue }
+              $pcFiles = @(Get-ChildItem -Path $base -Filter "gstreamer-1.0.pc" -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.FullName -like "*\lib\pkgconfig\gstreamer-1.0.pc" })
+              foreach ($pc in $pcFiles) {
+                $script:gstreamerPcPaths += $pc.FullName
+                $root = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $pc.FullName))
+                if (Test-GStreamerRoot $root) { return $root }
+              }
+            }
+            return $null
           }
           function Invoke-Download([string] $url, [string] $output) {
             $process = Start-Process -FilePath "curl.exe" -ArgumentList @("--fail", "--location", "--retry", "3", "--output", $output, $url) -Wait -PassThru -NoNewWindow
-            return $process.ExitCode -eq 0
+            return [bool]($process.ExitCode -eq 0)
           }
           function Install-GStreamerMsiSdk([string] $version) {
             $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
@@ -202,33 +221,26 @@ jobs:
             $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
             if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.msi" $runtime)) { return $false }
             if (-not (Invoke-Download "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $devel)) { return $false }
-            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait -PassThru
+            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase") -Wait -PassThru
+            $script:lastRuntimeMsiExitCode = $runtimeInstall.ExitCode
             if ($runtimeInstall.ExitCode -ne 0) { return $false }
-            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait -PassThru
+            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installBase") -Wait -PassThru
+            $script:lastDevelMsiExitCode = $develInstall.ExitCode
             if ($develInstall.ExitCode -ne 0) { return $false }
             return [bool](Find-GStreamerRoot)
           }
-          function Install-GStreamerExeSdk([string] $version) {
-            $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
-            $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk-$version.exe"
-            if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.exe" $exe)) { return $false }
-            $process = Start-Process -FilePath $exe -ArgumentList @("/S", "/D=$installDir") -PassThru
-            if (-not $process.WaitForExit(600000)) {
-              Write-Warning "GStreamer EXE installer timed out; killing process."
-              Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
-              return $false
-            }
-            if ($process.ExitCode -ne 0) { return $false }
-            return [bool](Find-GStreamerRoot)
-          }
           if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
-            Write-Warning "GStreamer $env:GSTREAMER_WINDOWS_VERSION MSI SDK install failed; trying EXE fallback."
-            if (-not (Install-GStreamerExeSdk $env:GSTREAMER_WINDOWS_VERSION)) {
-              Write-Error "Failed to install GStreamer Windows SDK version $env:GSTREAMER_WINDOWS_VERSION from MSI or EXE packages."
-              exit 1
-            }
+            [void](Find-GStreamerRoot)
+            Write-Host "GStreamer explicit roots searched: $($roots -join ', ')"
+            Write-Host "GStreamer recursive search bases: $($searchBases -join ', ')"
+            Write-Host "Discovered gstreamer-1.0.pc paths: $(if ($script:gstreamerPcPaths.Count) { $script:gstreamerPcPaths -join ', ' } else { 'none' })"
+            Write-Error "Failed to install/discover GStreamer Windows MSI SDK version $env:GSTREAMER_WINDOWS_VERSION. Runtime MSI exit code: $script:lastRuntimeMsiExitCode; devel MSI exit code: $script:lastDevelMsiExitCode."
+            exit 1
           }
           $root = Find-GStreamerRoot
+          Write-Host "GStreamer explicit roots searched: $($roots -join ', ')"
+          Write-Host "GStreamer recursive search bases: $($searchBases -join ', ')"
+          Write-Host "Discovered gstreamer-1.0.pc paths: $(if ($script:gstreamerPcPaths.Count) { $script:gstreamerPcPaths -join ', ' } else { 'none' })"
           if (-not $root) {
             Write-Error "GStreamer SDK root not found. Checked: $($roots -join ', '). Expected lib\pkgconfig\gstreamer-1.0.pc and bin\pkg-config.exe or bin\pkgconf.exe."
             exit 1

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -181,29 +181,55 @@ jobs:
         shell: pwsh
         run: |
           $installDir = "C:\gstreamer\1.0\msvc_x86_64"
-          $currentBase = "https://gstreamer.freedesktop.org/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-          $legacyBase = "https://gstreamer.freedesktop.org/data/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-          $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk.exe"
-          $exeUrl = "$currentBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.exe"
-          curl.exe --fail --location --retry 3 --output $exe $exeUrl
-          if ($LASTEXITCODE -eq 0 -and (Test-Path $exe)) {
-            Start-Process -FilePath $exe -ArgumentList @("/quiet", "/norestart", "INSTALLDIR=$installDir") -Wait
-          } else {
-            $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime.msi"
-            $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel.msi"
-            curl.exe --fail --location --retry 3 --output $runtime "$legacyBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-            curl.exe --fail --location --retry 3 --output $devel "$legacyBase/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-            Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
-            Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
-          }
           $roots = @(
             "C:\gstreamer\1.0\msvc_x86_64",
             "C:\Program Files\gstreamer\1.0\msvc_x86_64"
           )
-          $root = $roots | Where-Object {
-            (Test-Path (Join-Path $_ "lib\pkgconfig\gstreamer-1.0.pc")) -and
-            ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
-          } | Select-Object -First 1
+          function Find-GStreamerRoot {
+            $roots | Where-Object {
+              (Test-Path (Join-Path $_ "lib\pkgconfig\gstreamer-1.0.pc")) -and
+              ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
+            } | Select-Object -First 1
+          }
+          function Install-GStreamerMsiSdk([string] $version) {
+            $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
+            $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime-$version.msi"
+            $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
+            curl.exe --fail --location --retry 3 --output $runtime "$base/gstreamer-1.0-msvc-x86_64-$version.msi"
+            if ($LASTEXITCODE -ne 0) { return $false }
+            curl.exe --fail --location --retry 3 --output $devel "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi"
+            if ($LASTEXITCODE -ne 0) { return $false }
+            Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
+            Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
+            return $true
+          }
+          $currentBase = "https://gstreamer.freedesktop.org/pkg/windows/$env:GSTREAMER_VERSION/msvc"
+          $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk.exe"
+          $exeUrl = "$currentBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.exe"
+          $installed = $false
+          curl.exe --fail --location --retry 3 --output $exe $exeUrl
+          if ($LASTEXITCODE -eq 0 -and (Test-Path $exe)) {
+            $process = Start-Process -FilePath $exe -ArgumentList @("/S", "/D=$installDir") -PassThru
+            if ($process.WaitForExit(600000)) {
+              $installed = $process.ExitCode -eq 0
+            } else {
+              Write-Warning "GStreamer EXE installer timed out; killing process and falling back to MSI packages."
+              Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            }
+            if (-not (Find-GStreamerRoot)) {
+              $installed = $false
+            }
+          }
+          if (-not $installed) {
+            if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_VERSION)) {
+              Write-Warning "Current-version MSI packages unavailable; falling back to known-good GStreamer 1.26.1 Windows SDK."
+              if (-not (Install-GStreamerMsiSdk "1.26.1")) {
+                Write-Error "Failed to install GStreamer Windows SDK from EXE or MSI packages."
+                exit 1
+              }
+            }
+          }
+          $root = Find-GStreamerRoot
           if (-not $root) {
             Write-Error "GStreamer SDK root not found. Checked: $($roots -join ', '). Expected lib\pkgconfig\gstreamer-1.0.pc and bin\pkg-config.exe or bin\pkgconf.exe."
             exit 1

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -187,7 +187,20 @@ jobs:
           curl.exe --fail --location --retry 3 --output $devel "$base/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
           Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart") -Wait
           Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart") -Wait
-          "GSTREAMER_1_0_ROOT_MSVC_X86_64=C:\gstreamer\1.0\msvc_x86_64" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $roots = @(
+            "C:\gstreamer\1.0\msvc_x86_64",
+            "C:\Program Files\gstreamer\1.0\msvc_x86_64"
+          )
+          $root = $roots | Where-Object {
+            (Test-Path (Join-Path $_ "lib\pkgconfig\gstreamer-1.0.pc")) -and
+            ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
+          } | Select-Object -First 1
+          if (-not $root) {
+            Write-Error "GStreamer SDK root not found. Checked: $($roots -join ', '). Expected lib\pkgconfig\gstreamer-1.0.pc and bin\pkg-config.exe or bin\pkgconf.exe."
+            exit 1
+          }
+          "GSTREAMER_1_0_ROOT_MSVC_X86_64=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "$root\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Install FPM for arm64 deb builds
         if: matrix.label == 'linux-arm64'
         run: sudo apt-get install -y ruby ruby-dev build-essential && sudo gem install fpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,20 @@ jobs:
           curl.exe --fail --location --retry 3 --output $devel "$base/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
           Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart") -Wait
           Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart") -Wait
-          "GSTREAMER_1_0_ROOT_MSVC_X86_64=C:\gstreamer\1.0\msvc_x86_64" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $roots = @(
+            "C:\gstreamer\1.0\msvc_x86_64",
+            "C:\Program Files\gstreamer\1.0\msvc_x86_64"
+          )
+          $root = $roots | Where-Object {
+            (Test-Path (Join-Path $_ "lib\pkgconfig\gstreamer-1.0.pc")) -and
+            ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
+          } | Select-Object -First 1
+          if (-not $root) {
+            Write-Error "GStreamer SDK root not found. Checked: $($roots -join ', '). Expected lib\pkgconfig\gstreamer-1.0.pc and bin\pkg-config.exe or bin\pkgconf.exe."
+            exit 1
+          }
+          "GSTREAMER_1_0_ROOT_MSVC_X86_64=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "$root\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
 
       - name: Install FPM for arm64 deb builds
         if: matrix.label == 'linux-arm64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,20 +255,39 @@ jobs:
         if: matrix.native_build == 'true' && runner.os == 'Windows'
         shell: pwsh
         run: |
-          $installDir = "C:\gstreamer\1.0\msvc_x86_64"
+          $installBase = "C:\gstreamer"
           $roots = @(
             "C:\gstreamer\1.0\msvc_x86_64",
             "C:\Program Files\gstreamer\1.0\msvc_x86_64"
           )
+          $searchBases = @("C:\gstreamer", "C:\Program Files\gstreamer")
+          $script:gstreamerPcPaths = @()
+          $script:lastRuntimeMsiExitCode = $null
+          $script:lastDevelMsiExitCode = $null
+          function Test-GStreamerRoot([string] $candidate) {
+            return [bool]($candidate -and
+              (Test-Path (Join-Path $candidate "lib\pkgconfig\gstreamer-1.0.pc")) -and
+              ((Test-Path (Join-Path $candidate "bin\pkg-config.exe")) -or (Test-Path (Join-Path $candidate "bin\pkgconf.exe"))))
+          }
           function Find-GStreamerRoot {
-            $roots | Where-Object {
-              (Test-Path (Join-Path $_ "lib\pkgconfig\gstreamer-1.0.pc")) -and
-              ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
-            } | Select-Object -First 1
+            $script:gstreamerPcPaths = @()
+            foreach ($candidate in $roots) {
+              if (Test-GStreamerRoot $candidate) { return $candidate }
+            }
+            foreach ($base in $searchBases) {
+              if (-not (Test-Path $base)) { continue }
+              $pcFiles = @(Get-ChildItem -Path $base -Filter "gstreamer-1.0.pc" -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.FullName -like "*\lib\pkgconfig\gstreamer-1.0.pc" })
+              foreach ($pc in $pcFiles) {
+                $script:gstreamerPcPaths += $pc.FullName
+                $root = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $pc.FullName))
+                if (Test-GStreamerRoot $root) { return $root }
+              }
+            }
+            return $null
           }
           function Invoke-Download([string] $url, [string] $output) {
             $process = Start-Process -FilePath "curl.exe" -ArgumentList @("--fail", "--location", "--retry", "3", "--output", $output, $url) -Wait -PassThru -NoNewWindow
-            return $process.ExitCode -eq 0
+            return [bool]($process.ExitCode -eq 0)
           }
           function Install-GStreamerMsiSdk([string] $version) {
             $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
@@ -276,33 +295,26 @@ jobs:
             $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
             if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.msi" $runtime)) { return $false }
             if (-not (Invoke-Download "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $devel)) { return $false }
-            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait -PassThru
+            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase") -Wait -PassThru
+            $script:lastRuntimeMsiExitCode = $runtimeInstall.ExitCode
             if ($runtimeInstall.ExitCode -ne 0) { return $false }
-            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait -PassThru
+            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installBase") -Wait -PassThru
+            $script:lastDevelMsiExitCode = $develInstall.ExitCode
             if ($develInstall.ExitCode -ne 0) { return $false }
             return [bool](Find-GStreamerRoot)
           }
-          function Install-GStreamerExeSdk([string] $version) {
-            $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
-            $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk-$version.exe"
-            if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.exe" $exe)) { return $false }
-            $process = Start-Process -FilePath $exe -ArgumentList @("/S", "/D=$installDir") -PassThru
-            if (-not $process.WaitForExit(600000)) {
-              Write-Warning "GStreamer EXE installer timed out; killing process."
-              Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
-              return $false
-            }
-            if ($process.ExitCode -ne 0) { return $false }
-            return [bool](Find-GStreamerRoot)
-          }
           if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
-            Write-Warning "GStreamer $env:GSTREAMER_WINDOWS_VERSION MSI SDK install failed; trying EXE fallback."
-            if (-not (Install-GStreamerExeSdk $env:GSTREAMER_WINDOWS_VERSION)) {
-              Write-Error "Failed to install GStreamer Windows SDK version $env:GSTREAMER_WINDOWS_VERSION from MSI or EXE packages."
-              exit 1
-            }
+            [void](Find-GStreamerRoot)
+            Write-Host "GStreamer explicit roots searched: $($roots -join ', ')"
+            Write-Host "GStreamer recursive search bases: $($searchBases -join ', ')"
+            Write-Host "Discovered gstreamer-1.0.pc paths: $(if ($script:gstreamerPcPaths.Count) { $script:gstreamerPcPaths -join ', ' } else { 'none' })"
+            Write-Error "Failed to install/discover GStreamer Windows MSI SDK version $env:GSTREAMER_WINDOWS_VERSION. Runtime MSI exit code: $script:lastRuntimeMsiExitCode; devel MSI exit code: $script:lastDevelMsiExitCode."
+            exit 1
           }
           $root = Find-GStreamerRoot
+          Write-Host "GStreamer explicit roots searched: $($roots -join ', ')"
+          Write-Host "GStreamer recursive search bases: $($searchBases -join ', ')"
+          Write-Host "Discovered gstreamer-1.0.pc paths: $(if ($script:gstreamerPcPaths.Count) { $script:gstreamerPcPaths -join ', ' } else { 'none' })"
           if (-not $root) {
             Write-Error "GStreamer SDK root not found. Checked: $($roots -join ', '). Expected lib\pkgconfig\gstreamer-1.0.pc and bin\pkg-config.exe or bin\pkgconf.exe."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
-            os: blacksmith-6vcpu-macos-latest
+            os: macos-15-intel
             builder_args: "--mac dmg zip --x64"
             native_build: "true"
             bundle_gstreamer: "1"
@@ -130,7 +130,7 @@ jobs:
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
-            os: blacksmith-6vcpu-macos-latest
+            os: macos-15
             builder_args: "--mac dmg zip --arm64"
             native_build: "true"
             bundle_gstreamer: "1"
@@ -196,6 +196,18 @@ jobs:
         if: matrix.native_build == 'true' && matrix.native_target != ''
         run: rustup target add ${{ matrix.native_target }}
 
+      - name: Cache Rust native build
+        if: matrix.native_build == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            native/opennow-streamer/target
+          key: ${{ runner.os }}-${{ matrix.label }}-cargo-${{ hashFiles('native/opennow-streamer/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.label }}-cargo-
+
       - name: Cache Electron binaries
         uses: actions/cache@v4
         with:
@@ -206,17 +218,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-electron-
 
-      - name: Install Linux packaging tools
+      - name: Install Linux build/runtime packages
         if: runner.os == 'Linux'
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install -y fakeroot rpm
-
-      - name: Install Linux GStreamer build/runtime packages
-        if: matrix.native_build == 'true' && runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
+            fakeroot \
+            rpm \
             build-essential \
             pkg-config \
             libglib2.0-dev \
@@ -236,20 +246,40 @@ jobs:
             libvulkan1 \
             mesa-vulkan-drivers
 
+      - name: Cache macOS GStreamer packages
+        if: matrix.native_build == 'true' && runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cache/gstreamer-macos
+          key: gstreamer-macos-${{ env.GSTREAMER_VERSION }}
+
       - name: Install macOS GStreamer build/runtime packages
         if: matrix.native_build == 'true' && runner.os == 'macOS'
         run: |
           base="https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}"
-          runtime="$RUNNER_TEMP/gstreamer-runtime.pkg"
-          devel="$RUNNER_TEMP/gstreamer-devel.pkg"
-          curl --fail --location --retry 3 --output "$runtime" "$base/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
-          curl --fail --location --retry 3 --output "$devel" "$base/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
+          cache_dir="${GITHUB_WORKSPACE}/.cache/gstreamer-macos/${GSTREAMER_VERSION}"
+          mkdir -p "$cache_dir"
+          runtime="$cache_dir/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
+          devel="$cache_dir/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
+          if [ ! -s "$runtime" ]; then
+            curl --fail --location --retry 3 --output "$runtime" "$base/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
+          fi
+          if [ ! -s "$devel" ]; then
+            curl --fail --location --retry 3 --output "$devel" "$base/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
+          fi
           sudo installer -pkg "$runtime" -target /
           sudo installer -pkg "$devel" -target /
           root="/Library/Frameworks/GStreamer.framework/Versions/1.0"
           echo "GSTREAMER_1_0_ROOT_MACOS=$root" >> "$GITHUB_ENV"
           echo "$root/bin" >> "$GITHUB_PATH"
           echo "PKG_CONFIG_PATH=$root/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
+
+      - name: Cache Windows GStreamer SDK
+        if: matrix.native_build == 'true' && runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: C:\gstreamer
+          key: gstreamer-windows-${{ env.GSTREAMER_WINDOWS_VERSION }}
 
       - name: Install Windows GStreamer SDK
         if: matrix.native_build == 'true' && runner.os == 'Windows'
@@ -303,7 +333,10 @@ jobs:
             if ($develInstall.ExitCode -ne 0) { return $false }
             return [bool](Find-GStreamerRoot)
           }
-          if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
+          $root = Find-GStreamerRoot
+          if ($root) {
+            Write-Host "Using cached GStreamer Windows SDK: $root"
+          } elseif (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
             [void](Find-GStreamerRoot)
             Write-Host "GStreamer explicit roots searched: $($roots -join ', ')"
             Write-Host "GStreamer recursive search bases: $($searchBases -join ', ')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,13 +254,22 @@ jobs:
         if: matrix.native_build == 'true' && runner.os == 'Windows'
         shell: pwsh
         run: |
-          $base = "https://gstreamer.freedesktop.org/data/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-          $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime.msi"
-          $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel.msi"
-          curl.exe --fail --location --retry 3 --output $runtime "$base/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-          curl.exe --fail --location --retry 3 --output $devel "$base/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-          Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart") -Wait
-          Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart") -Wait
+          $installDir = "C:\gstreamer\1.0\msvc_x86_64"
+          $currentBase = "https://gstreamer.freedesktop.org/pkg/windows/$env:GSTREAMER_VERSION/msvc"
+          $legacyBase = "https://gstreamer.freedesktop.org/data/pkg/windows/$env:GSTREAMER_VERSION/msvc"
+          $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk.exe"
+          $exeUrl = "$currentBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.exe"
+          curl.exe --fail --location --retry 3 --output $exe $exeUrl
+          if ($LASTEXITCODE -eq 0 -and (Test-Path $exe)) {
+            Start-Process -FilePath $exe -ArgumentList @("/quiet", "/norestart", "INSTALLDIR=$installDir") -Wait
+          } else {
+            $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime.msi"
+            $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel.msi"
+            curl.exe --fail --location --retry 3 --output $runtime "$legacyBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
+            curl.exe --fail --location --retry 3 --output $devel "$legacyBase/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
+            Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
+            Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
+          }
           $roots = @(
             "C:\gstreamer\1.0\msvc_x86_64",
             "C:\Program Files\gstreamer\1.0\msvc_x86_64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,10 +295,10 @@ jobs:
             $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
             if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.msi" $runtime)) { return $false }
             if (-not (Invoke-Download "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $devel)) { return $false }
-            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase") -Wait -PassThru
+            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase", "ADDLOCAL=ALL") -Wait -PassThru
             $script:lastRuntimeMsiExitCode = $runtimeInstall.ExitCode
             if ($runtimeInstall.ExitCode -ne 0) { return $false }
-            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installBase") -Wait -PassThru
+            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installBase", "ADDLOCAL=ALL") -Wait -PassThru
             $script:lastDevelMsiExitCode = $develInstall.ExitCode
             if ($develInstall.ExitCode -ne 0) { return $false }
             return [bool](Find-GStreamerRoot)
@@ -317,6 +317,26 @@ jobs:
           Write-Host "Discovered gstreamer-1.0.pc paths: $(if ($script:gstreamerPcPaths.Count) { $script:gstreamerPcPaths -join ', ' } else { 'none' })"
           if (-not $root) {
             Write-Error "GStreamer SDK root not found. Checked: $($roots -join ', '). Expected lib\pkgconfig\gstreamer-1.0.pc and bin\pkg-config.exe or bin\pkgconf.exe."
+            exit 1
+          }
+          $gstInspect = Join-Path $root "bin\gst-inspect-1.0.exe"
+          if (-not (Test-Path $gstInspect)) {
+            Write-Error "gst-inspect-1.0.exe not found in $root\bin after GStreamer install."
+            exit 1
+          }
+          $h264Decoders = @("avdec_h264", "d3d11h264dec", "d3d12h264dec")
+          $availableH264Decoders = @()
+          foreach ($decoder in $h264Decoders) {
+            $inspect = Start-Process -FilePath $gstInspect -ArgumentList @($decoder) -Wait -PassThru -NoNewWindow
+            if ($inspect.ExitCode -eq 0) {
+              $availableH264Decoders += $decoder
+              Write-Host "GStreamer decoder available: $decoder"
+            } else {
+              Write-Host "GStreamer decoder unavailable: $decoder"
+            }
+          }
+          if ($availableH264Decoders.Count -eq 0) {
+            Write-Error "GStreamer Windows SDK installed, but no H.264 decoder plugins were found among: $($h264Decoders -join ', ')"
             exit 1
           }
           "GSTREAMER_1_0_ROOT_MSVC_X86_64=$root" | Out-File -FilePath $env:GITHUB_ENV -Append

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,29 +255,55 @@ jobs:
         shell: pwsh
         run: |
           $installDir = "C:\gstreamer\1.0\msvc_x86_64"
-          $currentBase = "https://gstreamer.freedesktop.org/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-          $legacyBase = "https://gstreamer.freedesktop.org/data/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-          $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk.exe"
-          $exeUrl = "$currentBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.exe"
-          curl.exe --fail --location --retry 3 --output $exe $exeUrl
-          if ($LASTEXITCODE -eq 0 -and (Test-Path $exe)) {
-            Start-Process -FilePath $exe -ArgumentList @("/quiet", "/norestart", "INSTALLDIR=$installDir") -Wait
-          } else {
-            $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime.msi"
-            $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel.msi"
-            curl.exe --fail --location --retry 3 --output $runtime "$legacyBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-            curl.exe --fail --location --retry 3 --output $devel "$legacyBase/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-            Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
-            Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
-          }
           $roots = @(
             "C:\gstreamer\1.0\msvc_x86_64",
             "C:\Program Files\gstreamer\1.0\msvc_x86_64"
           )
-          $root = $roots | Where-Object {
-            (Test-Path (Join-Path $_ "lib\pkgconfig\gstreamer-1.0.pc")) -and
-            ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
-          } | Select-Object -First 1
+          function Find-GStreamerRoot {
+            $roots | Where-Object {
+              (Test-Path (Join-Path $_ "lib\pkgconfig\gstreamer-1.0.pc")) -and
+              ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
+            } | Select-Object -First 1
+          }
+          function Install-GStreamerMsiSdk([string] $version) {
+            $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
+            $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime-$version.msi"
+            $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
+            curl.exe --fail --location --retry 3 --output $runtime "$base/gstreamer-1.0-msvc-x86_64-$version.msi"
+            if ($LASTEXITCODE -ne 0) { return $false }
+            curl.exe --fail --location --retry 3 --output $devel "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi"
+            if ($LASTEXITCODE -ne 0) { return $false }
+            Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
+            Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
+            return $true
+          }
+          $currentBase = "https://gstreamer.freedesktop.org/pkg/windows/$env:GSTREAMER_VERSION/msvc"
+          $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk.exe"
+          $exeUrl = "$currentBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.exe"
+          $installed = $false
+          curl.exe --fail --location --retry 3 --output $exe $exeUrl
+          if ($LASTEXITCODE -eq 0 -and (Test-Path $exe)) {
+            $process = Start-Process -FilePath $exe -ArgumentList @("/S", "/D=$installDir") -PassThru
+            if ($process.WaitForExit(600000)) {
+              $installed = $process.ExitCode -eq 0
+            } else {
+              Write-Warning "GStreamer EXE installer timed out; killing process and falling back to MSI packages."
+              Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            }
+            if (-not (Find-GStreamerRoot)) {
+              $installed = $false
+            }
+          }
+          if (-not $installed) {
+            if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_VERSION)) {
+              Write-Warning "Current-version MSI packages unavailable; falling back to known-good GStreamer 1.26.1 Windows SDK."
+              if (-not (Install-GStreamerMsiSdk "1.26.1")) {
+                Write-Error "Failed to install GStreamer Windows SDK from EXE or MSI packages."
+                exit 1
+              }
+            }
+          }
+          $root = Find-GStreamerRoot
           if (-not $root) {
             Write-Error "GStreamer SDK root not found. Checked: $($roots -join ', '). Expected lib\pkgconfig\gstreamer-1.0.pc and bin\pkg-config.exe or bin\pkgconf.exe."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,6 +392,14 @@ jobs:
       - name: Verify macOS Cargo network trust
         if: matrix.native_build == 'true' && runner.os == 'macOS'
         run: |
+          if [ -f /etc/ssl/cert.pem ]; then
+            cargo_cacert=/etc/ssl/cert.pem
+          else
+            cargo_cacert="$RUNNER_TEMP/cargo-cacert.pem"
+            security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain /Library/Keychains/System.keychain > "$cargo_cacert"
+          fi
+          echo "CARGO_HTTP_CAINFO=$cargo_cacert" >> "$GITHUB_ENV"
+          echo "SSL_CERT_FILE=$cargo_cacert" >> "$GITHUB_ENV"
           if ! curl --fail --location --retry 5 https://index.crates.io/config.json --output /tmp/cargo-index-config.json; then
             if command -v brew >/dev/null 2>&1; then
               brew update --quiet
@@ -399,6 +407,7 @@ jobs:
             fi
             curl --fail --location --retry 5 https://index.crates.io/config.json --output /tmp/cargo-index-config.json
           fi
+          CARGO_HTTP_CAINFO="$cargo_cacert" SSL_CERT_FILE="$cargo_cacert" cargo search base64 --limit 1 >/tmp/cargo-search-check.txt
 
       - name: Build native streamer
         if: matrix.native_build == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,7 @@ jobs:
       npm_config_audit: "false"
       npm_config_fund: "false"
       GSTREAMER_VERSION: "1.28.2"
+      GSTREAMER_WINDOWS_VERSION: "1.26.1"
       RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
       USE_SYSTEM_FPM: ${{ matrix.label == 'linux-arm64' && 'true' || 'false' }}
 
@@ -265,42 +266,40 @@ jobs:
               ((Test-Path (Join-Path $_ "bin\pkg-config.exe")) -or (Test-Path (Join-Path $_ "bin\pkgconf.exe")))
             } | Select-Object -First 1
           }
+          function Invoke-Download([string] $url, [string] $output) {
+            $process = Start-Process -FilePath "curl.exe" -ArgumentList @("--fail", "--location", "--retry", "3", "--output", $output, $url) -Wait -PassThru -NoNewWindow
+            return $process.ExitCode -eq 0
+          }
           function Install-GStreamerMsiSdk([string] $version) {
             $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
             $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime-$version.msi"
             $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
-            curl.exe --fail --location --retry 3 --output $runtime "$base/gstreamer-1.0-msvc-x86_64-$version.msi"
-            if ($LASTEXITCODE -ne 0) { return $false }
-            curl.exe --fail --location --retry 3 --output $devel "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi"
-            if ($LASTEXITCODE -ne 0) { return $false }
-            Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
-            Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait
-            return $true
+            if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.msi" $runtime)) { return $false }
+            if (-not (Invoke-Download "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $devel)) { return $false }
+            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait -PassThru
+            if ($runtimeInstall.ExitCode -ne 0) { return $false }
+            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installDir") -Wait -PassThru
+            if ($develInstall.ExitCode -ne 0) { return $false }
+            return [bool](Find-GStreamerRoot)
           }
-          $currentBase = "https://gstreamer.freedesktop.org/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-          $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk.exe"
-          $exeUrl = "$currentBase/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.exe"
-          $installed = $false
-          curl.exe --fail --location --retry 3 --output $exe $exeUrl
-          if ($LASTEXITCODE -eq 0 -and (Test-Path $exe)) {
+          function Install-GStreamerExeSdk([string] $version) {
+            $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
+            $exe = Join-Path $env:RUNNER_TEMP "gstreamer-sdk-$version.exe"
+            if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.exe" $exe)) { return $false }
             $process = Start-Process -FilePath $exe -ArgumentList @("/S", "/D=$installDir") -PassThru
-            if ($process.WaitForExit(600000)) {
-              $installed = $process.ExitCode -eq 0
-            } else {
-              Write-Warning "GStreamer EXE installer timed out; killing process and falling back to MSI packages."
+            if (-not $process.WaitForExit(600000)) {
+              Write-Warning "GStreamer EXE installer timed out; killing process."
               Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+              return $false
             }
-            if (-not (Find-GStreamerRoot)) {
-              $installed = $false
-            }
+            if ($process.ExitCode -ne 0) { return $false }
+            return [bool](Find-GStreamerRoot)
           }
-          if (-not $installed) {
-            if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_VERSION)) {
-              Write-Warning "Current-version MSI packages unavailable; falling back to known-good GStreamer 1.26.1 Windows SDK."
-              if (-not (Install-GStreamerMsiSdk "1.26.1")) {
-                Write-Error "Failed to install GStreamer Windows SDK from EXE or MSI packages."
-                exit 1
-              }
+          if (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
+            Write-Warning "GStreamer $env:GSTREAMER_WINDOWS_VERSION MSI SDK install failed; trying EXE fallback."
+            if (-not (Install-GStreamerExeSdk $env:GSTREAMER_WINDOWS_VERSION)) {
+              Write-Error "Failed to install GStreamer Windows SDK version $env:GSTREAMER_WINDOWS_VERSION from MSI or EXE packages."
+              exit 1
             }
           }
           $root = Find-GStreamerRoot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,10 @@ jobs:
       npm_config_fund: "false"
       GSTREAMER_VERSION: "1.28.2"
       GSTREAMER_WINDOWS_VERSION: "1.26.1"
+      CARGO_NET_RETRY: "10"
+      CARGO_HTTP_MULTIPLEXING: "false"
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
       USE_SYSTEM_FPM: ${{ matrix.label == 'linux-arm64' && 'true' || 'false' }}
 
@@ -384,6 +388,17 @@ jobs:
 
       - name: Update package version
         run: node -e "const fs=require('fs'); const path='package.json'; const pkg=JSON.parse(fs.readFileSync(path,'utf8')); pkg.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');"
+
+      - name: Verify macOS Cargo network trust
+        if: matrix.native_build == 'true' && runner.os == 'macOS'
+        run: |
+          if ! curl --fail --location --retry 5 https://index.crates.io/config.json --output /tmp/cargo-index-config.json; then
+            if command -v brew >/dev/null 2>&1; then
+              brew update --quiet
+              brew reinstall ca-certificates
+            fi
+            curl --fail --location --retry 5 https://index.crates.io/config.json --output /tmp/cargo-index-config.json
+          fi
 
       - name: Build native streamer
         if: matrix.native_build == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,9 +238,17 @@ jobs:
       - name: Install macOS GStreamer build/runtime packages
         if: matrix.native_build == 'true' && runner.os == 'macOS'
         run: |
-          brew update
-          brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
-          echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
+          base="https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}"
+          runtime="$RUNNER_TEMP/gstreamer-runtime.pkg"
+          devel="$RUNNER_TEMP/gstreamer-devel.pkg"
+          curl --fail --location --retry 3 --output "$runtime" "$base/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
+          curl --fail --location --retry 3 --output "$devel" "$base/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
+          sudo installer -pkg "$runtime" -target /
+          sudo installer -pkg "$devel" -target /
+          root="/Library/Frameworks/GStreamer.framework/Versions/1.0"
+          echo "GSTREAMER_1_0_ROOT_MACOS=$root" >> "$GITHUB_ENV"
+          echo "$root/bin" >> "$GITHUB_PATH"
+          echo "PKG_CONFIG_PATH=$root/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
 
       - name: Install Windows GStreamer SDK
         if: matrix.native_build == 'true' && runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,17 +260,30 @@ jobs:
       - name: Install macOS GStreamer build/runtime packages
         if: matrix.native_build == 'true' && runner.os == 'macOS'
         run: |
-          base="https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}"
+          primary_base="https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}"
+          mirror_base="https://gstreamer.freedesktop.org/pkg/macos/${GSTREAMER_VERSION}"
           cache_dir="${GITHUB_WORKSPACE}/.cache/gstreamer-macos/${GSTREAMER_VERSION}"
           mkdir -p "$cache_dir"
           runtime="$cache_dir/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
           devel="$cache_dir/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
-          if [ ! -s "$runtime" ]; then
-            curl --fail --location --retry 3 --output "$runtime" "$base/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg"
-          fi
-          if [ ! -s "$devel" ]; then
-            curl --fail --location --retry 3 --output "$devel" "$base/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg"
-          fi
+          download_pkg() {
+            local name="$1"
+            local destination="$2"
+            local partial="${destination}.part"
+            if [ -s "$destination" ]; then
+              return 0
+            fi
+            rm -f "$partial"
+            if ! curl --fail --location --retry 8 --retry-all-errors --retry-delay 5 --connect-timeout 30 --continue-at - --output "$partial" "$primary_base/$name"; then
+              curl --fail --location --retry 8 --retry-all-errors --retry-delay 5 --connect-timeout 30 --continue-at - --output "$partial" "$mirror_base/$name"
+            fi
+            test -s "$partial"
+            mv "$partial" "$destination"
+          }
+          download_pkg "gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg" "$runtime"
+          download_pkg "gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg" "$devel"
+          test -s "$runtime"
+          test -s "$devel"
           sudo installer -pkg "$runtime" -target /
           sudo installer -pkg "$devel" -target /
           root="/Library/Frameworks/GStreamer.framework/Versions/1.0"

--- a/docs/gstreamer-bundling.md
+++ b/docs/gstreamer-bundling.md
@@ -32,7 +32,7 @@ The Electron main process detects a sibling `gstreamer` directory next to the se
 
 ## Windows
 
-CI installs the official GStreamer MSVC runtime and development MSI packages. With `OPENNOW_BUNDLE_GSTREAMER_RUNTIME=1`, `scripts/bundle-gstreamer-runtime.mjs` copies `bin`, plugins, GIO modules, helper scanners, shared data, and metadata into the private runtime directory. Runtime detection prepends the private `bin` and sets GStreamer plugin/scanner environment variables for the child process.
+CI installs the official GStreamer MSVC runtime and development MSI packages. With `OPENNOW_BUNDLE_GSTREAMER_RUNTIME=1`, `scripts/bundle-gstreamer-runtime.mjs` copies `bin`, plugins, GIO modules, helper scanners, shared data, and metadata into the private runtime directory. It also copies the GStreamer core loader DLL subset and available Microsoft VC runtime DLLs next to `opennow-streamer.exe` so Windows process loading succeeds before the child PATH is applied. Runtime detection prepends the executable directory and private `bin`, then sets GStreamer plugin/scanner environment variables for the child process.
 
 ## macOS
 

--- a/docs/gstreamer-bundling.md
+++ b/docs/gstreamer-bundling.md
@@ -1,45 +1,54 @@
 # GStreamer Bundling
 
-OpenNOW's native streamer is dynamically linked against GStreamer. Release builds should not depend on a user having a matching global GStreamer install, so the packaged app should either ship a private runtime next to `opennow-streamer` or declare a platform package dependency.
+OpenNOW's native streamer is dynamically linked against GStreamer. Packaged builds use a private runtime where that is reliable and distro packages where host GPU/driver compatibility matters more than isolation.
 
-## Current Implementation
-
-The Windows x64 release path now supports a private runtime bundle:
-
-1. CI installs the official GStreamer MSVC runtime and development MSI packages.
-2. `npm run native:build` builds and verifies the Rust streamer with `OPENNOW_NATIVE_STREAMER_FEATURES=gstreamer`.
-3. When `OPENNOW_BUNDLE_GSTREAMER_RUNTIME=1`, `scripts/bundle-gstreamer-runtime.mjs` copies the Windows runtime layout to `native/opennow-streamer/bin/win32-x64/gstreamer`.
-4. Electron packages that directory through the existing `extraResources` rule.
-5. The Electron main process detects a sibling `gstreamer` directory next to the selected streamer binary and injects `PATH`, `GST_PLUGIN_PATH`, `GST_PLUGIN_SYSTEM_PATH`, `GST_PLUGIN_SCANNER`, and `GIO_MODULE_DIR` only into the native streamer child process.
-
-That keeps the app isolated from broken system installs and avoids leaking bundled GStreamer paths into the Electron process.
-
-## Platform Strategy
+## Platform strategy
 
 | Platform | Release strategy | Status |
 | --- | --- | --- |
-| Windows x64 | Bundle official MSVC runtime privately next to `opennow-streamer.exe`. | Implemented in CI. |
-| Windows arm64 | Needs either upstream arm64 GStreamer binaries or a Cerbero-built runtime and a Rust cross-build target. | Not enabled yet; keep web fallback. |
-| macOS x64/arm64 | Bundle `GStreamer.framework` into `Contents/Frameworks`, then codesign/notarize the framework with the app. | Planned. |
-| Linux deb | Prefer distro dependencies for GStreamer packages and GPU driver plugins. | CI builds against system packages; `.deb` declares core GStreamer dependencies. |
-| Linux AppImage | Bundle a private runtime or use linuxdeploy/AppImage tooling, but keep VAAPI/V4L2 driver plugins host-compatible. | Planned. |
+| Windows x64 | Bundle the official MSVC runtime privately next to `opennow-streamer.exe` at `native/opennow-streamer/win32-x64/gstreamer`. | Implemented in CI/release. |
+| Windows arm64 | No official upstream arm64 runtime path is enabled yet. | Native streamer packaging disabled; web fallback remains. |
+| macOS x64/arm64 | Install the official universal runtime/devel `.pkg` files, copy the framework version root into `native/opennow-streamer/darwin-*/gstreamer`, and relocate Mach-O load commands to the private runtime. | Implemented in CI/release. |
+| Linux deb | Use distro GStreamer packages. The `.deb` declares Debian/Ubuntu runtime dependencies. | Implemented. |
+| Linux AppImage | Use the host distro's GStreamer install and show Settings install commands when missing. | Implemented by runtime guidance, not private bundling. |
 
-## CI/CD Notes
+## Private runtime layout
 
-- `auto-build.yml` and `release.yml` build the native streamer before `electron-builder` on Windows x64 and Linux.
-- Windows x64 sets `OPENNOW_BUNDLE_GSTREAMER_RUNTIME=1`, so generated installers include the private runtime.
-- Linux currently validates the GStreamer backend in CI but does not copy a private runtime into the AppImage. The `.deb` path is a better fit for distro packages; AppImage bundling needs a separate dependency closure pass.
-- macOS native packaging should be enabled only after the framework copy and signing path is complete. Unsigned or partially relocated GStreamer dylibs will fail under Gatekeeper.
+`npm run native:build` copies the Rust streamer into both `native/opennow-streamer/bin/opennow-streamer` and `native/opennow-streamer/bin/<platformKey>/opennow-streamer`. Electron packages `native/opennow-streamer/bin` via `extraResources`, so runtime bundles live next to the platform-specific binary:
 
-## Manual Windows Packaging
-
-From `opennow-stable`:
-
-```powershell
-$env:OPENNOW_NATIVE_STREAMER_FEATURES = "gstreamer"
-$env:OPENNOW_BUNDLE_GSTREAMER_RUNTIME = "1"
-npm run native:build
-npm run dist
+```text
+native/opennow-streamer/bin/<platformKey>/
+  opennow-streamer(.exe)
+  gstreamer/
+    bin/
+    lib/
+    libexec/
+    share/
+    etc/
+    OPENNOW-GSTREAMER-RUNTIME.txt
 ```
 
-The runtime bundle is intentionally ignored by git under `native/opennow-streamer/bin/*/gstreamer/`.
+The Electron main process detects a sibling `gstreamer` directory next to the selected streamer executable, including custom executable overrides, and injects runtime paths only into the native streamer child process. It does not mutate the Electron process environment globally.
+
+## Windows
+
+CI installs the official GStreamer MSVC runtime and development MSI packages. With `OPENNOW_BUNDLE_GSTREAMER_RUNTIME=1`, `scripts/bundle-gstreamer-runtime.mjs` copies `bin`, plugins, GIO modules, helper scanners, shared data, and metadata into the private runtime directory. Runtime detection prepends the private `bin` and sets GStreamer plugin/scanner environment variables for the child process.
+
+## macOS
+
+CI/release installs official universal packages from:
+
+```text
+https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}/gstreamer-1.0-${GSTREAMER_VERSION}-universal.pkg
+https://gstreamer.freedesktop.org/data/pkg/macos/${GSTREAMER_VERSION}/gstreamer-1.0-devel-${GSTREAMER_VERSION}-universal.pkg
+```
+
+The build exports `GSTREAMER_1_0_ROOT_MACOS=/Library/Frameworks/GStreamer.framework/Versions/1.0`, prepends its `bin`, and adds its `lib/pkgconfig` directory to `PKG_CONFIG_PATH`. Local development can still fall back to `GSTREAMER_1_0_ROOT_MACOS`, `/Library/Frameworks/GStreamer.framework/Versions/Current`, Homebrew `brew --prefix`, `/opt/homebrew`, or `/usr/local` if the root has both `lib/pkgconfig/gstreamer-1.0.pc` and `lib/libgstreamer-1.0.dylib`.
+
+The bundler copies framework/Homebrew runtime content into the private `gstreamer` directory and, when `otool` and `install_name_tool` are available, rewrites the packaged native executable, copied dylibs, plugins, GIO modules, and helper executables away from framework/Homebrew absolute paths. The native executable resolves dependencies through `@executable_path/gstreamer/lib`; files inside the runtime resolve through `@loader_path` relative paths.
+
+## Linux
+
+Linux private GStreamer bundling is not treated as reliable by default. VAAPI, V4L2, Vulkan, `libdrm`, GLib/glibc, Mesa, and proprietary GPU driver stacks must match the host distro closely; an AppImage-private dependency closure can break hardware decode or plugin loading on otherwise supported systems.
+
+The `.deb` package declares Debian/Ubuntu GStreamer dependencies, including core libraries, base/good/bad/ugly/libav plugins, GL/X/ALSA helpers, VAAPI, libva, Vulkan, and Mesa Vulkan drivers. AppImage builds use the host distro's packages. If GStreamer is missing, Settings shows distro-specific install commands for Debian/Ubuntu-family, Fedora/RHEL-family, Arch-family, and openSUSE systems.

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -114,6 +114,7 @@
       "depends": [
         "libgstreamer1.0-0",
         "libgstreamer-plugins-base1.0-0",
+        "gstreamer1.0-tools",
         "gstreamer1.0-libav",
         "gstreamer1.0-plugins-base",
         "gstreamer1.0-plugins-good",
@@ -121,6 +122,8 @@
         "gstreamer1.0-plugins-ugly",
         "gstreamer1.0-vaapi",
         "gstreamer1.0-gl",
+        "gstreamer1.0-x",
+        "gstreamer1.0-alsa",
         "libva2",
         "libva-drm2",
         "libvulkan1",

--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -46,21 +46,31 @@ function configureGstreamerSdk(env) {
       "C:\\Program Files\\gstreamer\\1.0\\msvc_x86_64",
       "C:\\gstreamer\\1.0\\msvc_x86_64",
     ].filter(Boolean);
-    const sdkRoot = candidates.find((candidate) =>
-      existsSync(join(candidate, "bin", "pkg-config.exe"))
-      && existsSync(join(candidate, "lib", "pkgconfig", "gstreamer-1.0.pc"))
-      && existsSync(join(candidate, "bin", "gstreamer-1.0-0.dll")),
-    );
-    if (!sdkRoot) {
-      console.warn("GStreamer SDK was not found automatically; relying on the current PKG_CONFIG environment.");
+    const sdk = candidates
+      .map((root) => {
+        const pkgConfig = join(root, "bin", "pkg-config.exe");
+        const pkgconf = join(root, "bin", "pkgconf.exe");
+        const pkgConfigFile = join(root, "lib", "pkgconfig", "gstreamer-1.0.pc");
+        const pkgConfigBinary = existsSync(pkgConfig) ? pkgConfig : existsSync(pkgconf) ? pkgconf : null;
+        return { root, pkgConfigBinary, pkgConfigFile };
+      })
+      .find((candidate) => candidate.pkgConfigBinary && existsSync(candidate.pkgConfigFile));
+    if (!sdk) {
+      console.warn(
+        [
+          "GStreamer SDK was not found automatically; relying on the current PKG_CONFIG environment.",
+          `Checked roots: ${candidates.join(", ") || "none"}`,
+          "Expected files: bin/pkg-config.exe or bin/pkgconf.exe, and lib/pkgconfig/gstreamer-1.0.pc",
+        ].join(" "),
+      );
       return null;
     }
-    const pkgConfigDir = join(sdkRoot, "lib", "pkgconfig");
-    env.PKG_CONFIG = join(sdkRoot, "bin", "pkg-config.exe");
+    const pkgConfigDir = join(sdk.root, "lib", "pkgconfig");
+    env.PKG_CONFIG = sdk.pkgConfigBinary;
     env.PKG_CONFIG_PATH = env.PKG_CONFIG_PATH ? `${pkgConfigDir}${delimiter}${env.PKG_CONFIG_PATH}` : pkgConfigDir;
-    prependEnvPath(env, join(sdkRoot, "bin"));
-    console.log(`Configured GStreamer SDK: ${sdkRoot}`);
-    return sdkRoot;
+    prependEnvPath(env, join(sdk.root, "bin"));
+    console.log(`Configured GStreamer SDK: ${sdk.root}`);
+    return sdk.root;
   }
 
   if (process.platform === "darwin") {

--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, chmodSync, existsSync, mkdirSync } from "node:fs";
+import { copyFileSync, chmodSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -34,43 +34,68 @@ function prependEnvPath(env, directory) {
   env[pathKey] = env[pathKey] ? `${directory}${delimiter}${env[pathKey]}` : directory;
 }
 
-function configureWindowsGstreamerSdk(env) {
-  if (process.platform !== "win32") {
-    return null;
-  }
+function brewPrefix() {
+  const result = spawnSync("brew", ["--prefix"], { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() || null : null;
+}
 
-  const candidates = [
-    env.GSTREAMER_1_0_ROOT_MSVC_X86_64,
-    "C:\\Program Files\\gstreamer\\1.0\\msvc_x86_64",
-    "C:\\gstreamer\\1.0\\msvc_x86_64",
-  ].filter(Boolean);
-
-  const sdkRoot = candidates.find(
-    (candidate) =>
-      existsSync(join(candidate, "bin", "pkg-config.exe")) &&
-      existsSync(join(candidate, "lib", "pkgconfig", "gstreamer-1.0.pc")),
-  );
-
-  if (!sdkRoot) {
-    console.warn(
-      "GStreamer SDK was not found automatically; relying on the current PKG_CONFIG environment.",
+function configureGstreamerSdk(env) {
+  if (process.platform === "win32") {
+    const candidates = [
+      env.GSTREAMER_1_0_ROOT_MSVC_X86_64,
+      "C:\\Program Files\\gstreamer\\1.0\\msvc_x86_64",
+      "C:\\gstreamer\\1.0\\msvc_x86_64",
+    ].filter(Boolean);
+    const sdkRoot = candidates.find((candidate) =>
+      existsSync(join(candidate, "bin", "pkg-config.exe"))
+      && existsSync(join(candidate, "lib", "pkgconfig", "gstreamer-1.0.pc"))
+      && existsSync(join(candidate, "bin", "gstreamer-1.0-0.dll")),
     );
-    return null;
+    if (!sdkRoot) {
+      console.warn("GStreamer SDK was not found automatically; relying on the current PKG_CONFIG environment.");
+      return null;
+    }
+    const pkgConfigDir = join(sdkRoot, "lib", "pkgconfig");
+    env.PKG_CONFIG = join(sdkRoot, "bin", "pkg-config.exe");
+    env.PKG_CONFIG_PATH = env.PKG_CONFIG_PATH ? `${pkgConfigDir}${delimiter}${env.PKG_CONFIG_PATH}` : pkgConfigDir;
+    prependEnvPath(env, join(sdkRoot, "bin"));
+    console.log(`Configured GStreamer SDK: ${sdkRoot}`);
+    return sdkRoot;
   }
 
-  const pkgConfigDir = join(sdkRoot, "lib", "pkgconfig");
-  env.PKG_CONFIG = join(sdkRoot, "bin", "pkg-config.exe");
-  env.PKG_CONFIG_PATH = env.PKG_CONFIG_PATH
-    ? `${pkgConfigDir}${delimiter}${env.PKG_CONFIG_PATH}`
-    : pkgConfigDir;
-  prependEnvPath(env, join(sdkRoot, "bin"));
-  console.log(`Configured GStreamer SDK: ${sdkRoot}`);
-  return sdkRoot;
+  if (process.platform === "darwin") {
+    const candidates = [
+      env.GSTREAMER_1_0_ROOT_MACOS,
+      "/Library/Frameworks/GStreamer.framework/Versions/1.0",
+      "/Library/Frameworks/GStreamer.framework/Versions/Current",
+      brewPrefix(),
+      "/opt/homebrew",
+      "/usr/local",
+    ].filter(Boolean);
+    const sdkRoot = candidates.find((candidate) =>
+      existsSync(join(candidate, "lib", "pkgconfig", "gstreamer-1.0.pc"))
+      && existsSync(join(candidate, "lib", "libgstreamer-1.0.dylib")),
+    );
+    if (!sdkRoot) {
+      console.warn("GStreamer macOS SDK was not found automatically; relying on the current PKG_CONFIG environment.");
+      return null;
+    }
+    const pkgConfigDir = join(sdkRoot, "lib", "pkgconfig");
+    env.GSTREAMER_1_0_ROOT_MACOS = sdkRoot;
+    env.PKG_CONFIG_PATH = env.PKG_CONFIG_PATH ? `${pkgConfigDir}${delimiter}${env.PKG_CONFIG_PATH}` : pkgConfigDir;
+    prependEnvPath(env, join(sdkRoot, "bin"));
+    env.DYLD_LIBRARY_PATH = env.DYLD_LIBRARY_PATH ? `${join(sdkRoot, "lib")}${delimiter}${env.DYLD_LIBRARY_PATH}` : join(sdkRoot, "lib");
+    env.DYLD_FALLBACK_LIBRARY_PATH = env.DYLD_FALLBACK_LIBRARY_PATH ? `${join(sdkRoot, "lib")}${delimiter}${env.DYLD_FALLBACK_LIBRARY_PATH}` : join(sdkRoot, "lib");
+    console.log(`Configured GStreamer SDK: ${sdkRoot}`);
+    return sdkRoot;
+  }
+
+  return null;
 }
 
 function bundleGstreamerRuntime(sdkRoot) {
   if (process.env.OPENNOW_BUNDLE_GSTREAMER_RUNTIME !== "1") {
-    return;
+    return false;
   }
 
   const args = [
@@ -82,6 +107,7 @@ function bundleGstreamerRuntime(sdkRoot) {
   if (sdkRoot) {
     args.push("--sdk-root", sdkRoot);
   }
+  args.push("--binary", packagePlatformBinary);
 
   const result = spawnSync(process.execPath, args, {
     cwd: packageRoot,
@@ -92,6 +118,64 @@ function bundleGstreamerRuntime(sdkRoot) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+  return true;
+}
+
+function isExistingFile(path) {
+  try {
+    return existsSync(path) && statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isExistingDirectory(path) {
+  try {
+    return existsSync(path) && statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function buildBundledGstreamerEnv(baseEnv, binaryPath) {
+  const env = { ...baseEnv };
+  const runtimeRoot = join(dirname(binaryPath), "gstreamer");
+  const binDir = join(runtimeRoot, "bin");
+  const libDir = join(runtimeRoot, "lib");
+  const pluginDir = join(libDir, "gstreamer-1.0");
+  const scanner = join(runtimeRoot, "libexec", "gstreamer-1.0", process.platform === "win32" ? "gst-plugin-scanner.exe" : "gst-plugin-scanner");
+  const gioModulesDir = join(libDir, "gio", "modules");
+
+  if (!isExistingDirectory(runtimeRoot)) {
+    throw new Error(`Bundled GStreamer runtime was not found next to ${binaryPath}`);
+  }
+  if (isExistingDirectory(binDir)) prependEnvPath(env, binDir);
+  if (isExistingDirectory(pluginDir)) {
+    env.GST_PLUGIN_PATH = pluginDir;
+    env.GST_PLUGIN_PATH_1_0 = pluginDir;
+    env.GST_PLUGIN_SYSTEM_PATH = pluginDir;
+    env.GST_PLUGIN_SYSTEM_PATH_1_0 = pluginDir;
+  }
+  if (isExistingFile(scanner)) {
+    env.GST_PLUGIN_SCANNER = scanner;
+    env.GST_PLUGIN_SCANNER_1_0 = scanner;
+  }
+  env.GST_REGISTRY_REUSE_PLUGIN_SCANNER = "no";
+  if (isExistingDirectory(gioModulesDir)) {
+    env.GIO_MODULE_DIR = gioModulesDir;
+    env.GIO_EXTRA_MODULES = gioModulesDir;
+  }
+  if (process.platform === "linux" && isExistingDirectory(libDir)) {
+    env.LD_LIBRARY_PATH = env.LD_LIBRARY_PATH ? `${libDir}${delimiter}${env.LD_LIBRARY_PATH}` : libDir;
+  }
+  if (process.platform === "darwin" && isExistingDirectory(libDir)) {
+    env.DYLD_LIBRARY_PATH = env.DYLD_LIBRARY_PATH ? `${libDir}${delimiter}${env.DYLD_LIBRARY_PATH}` : libDir;
+    env.DYLD_FALLBACK_LIBRARY_PATH = env.DYLD_FALLBACK_LIBRARY_PATH ? `${libDir}${delimiter}${env.DYLD_FALLBACK_LIBRARY_PATH}` : libDir;
+  }
+  if (process.platform === "win32" && isExistingDirectory(libDir)) {
+    prependEnvPath(env, libDir);
+  }
+  return env;
 }
 
 function verifyGstreamerBinary(binaryPath, env) {
@@ -185,7 +269,7 @@ console.log(
 const buildEnv = { ...process.env };
 let gstreamerSdkRoot = null;
 if (hasFeature(nativeFeatures, "gstreamer")) {
-  gstreamerSdkRoot = configureWindowsGstreamerSdk(buildEnv);
+  gstreamerSdkRoot = configureGstreamerSdk(buildEnv);
 }
 
 const cargoCommand = process.platform === "win32" ? "cargo.exe" : "cargo";
@@ -216,7 +300,9 @@ if (process.platform !== "win32") {
 
 if (hasFeature(nativeFeatures, "gstreamer")) {
   verifyGstreamerBinary(packageBinary, buildEnv);
-  bundleGstreamerRuntime(gstreamerSdkRoot);
+  if (bundleGstreamerRuntime(gstreamerSdkRoot)) {
+    verifyGstreamerBinary(packagePlatformBinary, buildBundledGstreamerEnv(buildEnv, packagePlatformBinary));
+  }
 }
 
 console.log(`Copied native streamer to ${packageBinary}`);

--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -96,6 +96,10 @@ function configureGstreamerSdk(env) {
     prependEnvPath(env, join(sdkRoot, "bin"));
     env.DYLD_LIBRARY_PATH = env.DYLD_LIBRARY_PATH ? `${join(sdkRoot, "lib")}${delimiter}${env.DYLD_LIBRARY_PATH}` : join(sdkRoot, "lib");
     env.DYLD_FALLBACK_LIBRARY_PATH = env.DYLD_FALLBACK_LIBRARY_PATH ? `${join(sdkRoot, "lib")}${delimiter}${env.DYLD_FALLBACK_LIBRARY_PATH}` : join(sdkRoot, "lib");
+    if (/apple-darwin$/.test(nativeTarget)) {
+      env.PKG_CONFIG_ALLOW_CROSS = "1";
+      env.PKG_CONFIG_SYSROOT_DIR = env.PKG_CONFIG_SYSROOT_DIR || "/";
+    }
     console.log(`Configured GStreamer SDK: ${sdkRoot}`);
     return sdkRoot;
   }

--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -164,7 +164,7 @@ function isExistingDirectory(path) {
 }
 
 function buildBundledGstreamerEnv(baseEnv, binaryPath) {
-  const env = { ...baseEnv };
+  const env = { SystemRoot: baseEnv.SystemRoot, WINDIR: baseEnv.WINDIR };
   const runtimeRoot = join(dirname(binaryPath), "gstreamer");
   const binDir = join(runtimeRoot, "bin");
   const libDir = join(runtimeRoot, "lib");
@@ -175,6 +175,7 @@ function buildBundledGstreamerEnv(baseEnv, binaryPath) {
   if (!isExistingDirectory(runtimeRoot)) {
     throw new Error(`Bundled GStreamer runtime was not found next to ${binaryPath}`);
   }
+  if (process.platform === "win32") prependEnvPath(env, dirname(binaryPath));
   if (isExistingDirectory(binDir)) prependEnvPath(env, binDir);
   if (isExistingDirectory(pluginDir)) {
     env.GST_PLUGIN_PATH = pluginDir;

--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -34,6 +34,18 @@ function prependEnvPath(env, directory) {
   env[pathKey] = env[pathKey] ? `${directory}${delimiter}${env[pathKey]}` : directory;
 }
 
+function appendEnvValue(env, key, value) {
+  env[key] = env[key]?.trim() ? `${env[key]} ${value}` : value;
+}
+
+function configureDarwinLinkerPadding(env, nativeFeatures) {
+  const isDarwinBuild = process.platform === "darwin" || /apple-darwin$/.test(nativeTarget);
+  if (!isDarwinBuild || !hasFeature(nativeFeatures, "gstreamer") || process.env.OPENNOW_BUNDLE_GSTREAMER_RUNTIME !== "1") {
+    return;
+  }
+  appendEnvValue(env, "RUSTFLAGS", "-C link-arg=-Wl,-headerpad_max_install_names");
+}
+
 function brewPrefix() {
   const result = spawnSync("brew", ["--prefix"], { encoding: "utf8" });
   return result.status === 0 ? result.stdout.trim() || null : null;
@@ -285,6 +297,7 @@ let gstreamerSdkRoot = null;
 if (hasFeature(nativeFeatures, "gstreamer")) {
   gstreamerSdkRoot = configureGstreamerSdk(buildEnv);
 }
+configureDarwinLinkerPadding(buildEnv, nativeFeatures);
 
 const cargoCommand = process.platform === "win32" ? "cargo.exe" : "cargo";
 const result = spawnSync(cargoCommand, cargoArgs, {

--- a/opennow-stable/scripts/bundle-gstreamer-runtime.mjs
+++ b/opennow-stable/scripts/bundle-gstreamer-runtime.mjs
@@ -253,6 +253,13 @@ function patchMachO(file, destination, sourceRoot, libDir, bundledLibs) {
   }
 }
 
+function isExternalGstreamerDependency(dep, roots, bundledLibs) {
+  const name = dylibName(dep);
+  if (!name || !bundledLibs.has(name)) return false;
+  if (dep.startsWith("@")) return false;
+  return roots.some((root) => dep === join(root, "lib", name) || dep.startsWith(`${root}/`) || dep.includes("GStreamer.framework"));
+}
+
 function validatePackagedBinaryRelocation(binary, sourceRoot, bundledLibs) {
   if (!binary || !isMachO(binary) || !commandAvailable("otool")) return;
   const output = run("otool", ["-L", binary]);
@@ -264,7 +271,7 @@ function validatePackagedBinaryRelocation(binary, sourceRoot, bundledLibs) {
     .split(/\r?\n/)
     .slice(1)
     .map((line) => line.trim().split(/\s+/)[0])
-    .filter((dep) => dep && shouldRewriteDependency(dep, roots, bundledLibs));
+    .filter((dep) => dep && isExternalGstreamerDependency(dep, roots, bundledLibs));
   if (leakedDeps.length > 0) {
     throw new Error(
       `Packaged native streamer still references external GStreamer dependencies after relocation: ${leakedDeps.join(", ")}`,

--- a/opennow-stable/scripts/bundle-gstreamer-runtime.mjs
+++ b/opennow-stable/scripts/bundle-gstreamer-runtime.mjs
@@ -1,27 +1,28 @@
 import {
+  chmodSync,
   copyFileSync,
   cpSync,
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, extname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const packageRoot = resolve(__dirname, "..");
 
 function parseArgs(argv) {
   const parsed = new Map();
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
-    if (!value.startsWith("--")) {
-      continue;
-    }
+    if (!value.startsWith("--")) continue;
     const key = value.slice(2);
     const next = argv[index + 1];
     if (!next || next.startsWith("--")) {
@@ -34,35 +35,29 @@ function parseArgs(argv) {
   return parsed;
 }
 
-function windowsSdkCandidates(explicitSdkRoot) {
-  return [
-    explicitSdkRoot,
-    process.env.GSTREAMER_1_0_ROOT_MSVC_X86_64,
-    "C:\\Program Files\\gstreamer\\1.0\\msvc_x86_64",
-    "C:\\gstreamer\\1.0\\msvc_x86_64",
-  ].filter(Boolean);
+function isExistingFile(path) {
+  try { return existsSync(path) && statSync(path).isFile(); } catch { return false; }
 }
 
-function resolveWindowsSdkRoot(explicitSdkRoot) {
-  const sdkRoot = windowsSdkCandidates(explicitSdkRoot).find((candidate) =>
-    existsSync(join(candidate, "bin", "gstreamer-1.0-0.dll"))
-    && existsSync(join(candidate, "lib", "gstreamer-1.0")),
-  );
+function isExistingDirectory(path) {
+  try { return existsSync(path) && statSync(path).isDirectory(); } catch { return false; }
+}
 
-  if (!sdkRoot) {
-    throw new Error(
-      "GStreamer MSVC x86_64 runtime was not found. Install the runtime/development MSI or pass --sdk-root.",
-    );
-  }
+function run(command, args, options = {}) {
+  return spawnSync(command, args, { encoding: "utf8", ...options });
+}
 
-  return sdkRoot;
+function commandAvailable(command) {
+  return run("/usr/bin/env", ["which", command]).status === 0;
+}
+
+function brewPrefix() {
+  const result = run("brew", ["--prefix"]);
+  return result.status === 0 ? result.stdout.trim() || null : null;
 }
 
 function copyPathIfPresent(source, destination) {
-  if (!existsSync(source)) {
-    return false;
-  }
-
+  if (!existsSync(source)) return false;
   const stats = statSync(source);
   if (stats.isDirectory()) {
     cpSync(source, destination, {
@@ -78,174 +73,250 @@ function copyPathIfPresent(source, destination) {
     });
     return true;
   }
-
   mkdirSync(dirname(destination), { recursive: true });
   copyFileSync(source, destination);
   return true;
 }
 
 function copyMatchingFiles(sourceDir, destinationDir, pattern) {
-  if (!existsSync(sourceDir)) {
-    return;
-  }
-
+  if (!isExistingDirectory(sourceDir)) return;
   mkdirSync(destinationDir, { recursive: true });
   for (const name of readdirSync(sourceDir)) {
-    if (pattern.test(name)) {
-      copyFileSync(join(sourceDir, name), join(destinationDir, name));
-    }
+    if (pattern.test(name)) copyFileSync(join(sourceDir, name), join(destinationDir, name));
   }
 }
 
-function bundleWindowsRuntime({ sdkRoot, destination }) {
-  const resolvedSdkRoot = resolveWindowsSdkRoot(sdkRoot);
-  rmSync(destination, { recursive: true, force: true });
-  mkdirSync(destination, { recursive: true });
+function windowsSdkCandidates(explicitSdkRoot) {
+  return [
+    explicitSdkRoot,
+    process.env.GSTREAMER_1_0_ROOT_MSVC_X86_64,
+    "C:\\Program Files\\gstreamer\\1.0\\msvc_x86_64",
+    "C:\\gstreamer\\1.0\\msvc_x86_64",
+  ].filter(Boolean);
+}
 
-  const copied = [
-    copyPathIfPresent(join(resolvedSdkRoot, "bin"), join(destination, "bin")),
-    copyPathIfPresent(
-      join(resolvedSdkRoot, "lib", "gstreamer-1.0"),
-      join(destination, "lib", "gstreamer-1.0"),
-    ),
-    copyPathIfPresent(
-      join(resolvedSdkRoot, "lib", "gio", "modules"),
-      join(destination, "lib", "gio", "modules"),
-    ),
-    copyPathIfPresent(
-      join(resolvedSdkRoot, "libexec", "gstreamer-1.0"),
-      join(destination, "libexec", "gstreamer-1.0"),
-    ),
-    copyPathIfPresent(
-      join(resolvedSdkRoot, "share", "gstreamer-1.0"),
-      join(destination, "share", "gstreamer-1.0"),
-    ),
-    copyPathIfPresent(
-      join(resolvedSdkRoot, "share", "glib-2.0"),
-      join(destination, "share", "glib-2.0"),
-    ),
-    copyPathIfPresent(join(resolvedSdkRoot, "etc"), join(destination, "etc")),
-  ].filter(Boolean).length;
-
-  copyMatchingFiles(resolvedSdkRoot, destination, /^(copying|license|readme)/i);
-  writeFileSync(
-    join(destination, "OPENNOW-GSTREAMER-RUNTIME.txt"),
-    [
-      "OpenNOW private GStreamer runtime bundle",
-      `Source: ${resolvedSdkRoot}`,
-      `Generated: ${new Date().toISOString()}`,
-      "",
-      "This directory is loaded only for the native streamer child process.",
-      "Keep the GStreamer directory layout intact so plugins resolve relative to the core DLL.",
-      "",
-    ].join("\n"),
+function resolveWindowsSdkRoot(explicitSdkRoot) {
+  const sdkRoot = windowsSdkCandidates(explicitSdkRoot).find((candidate) =>
+    isExistingFile(join(candidate, "bin", "gstreamer-1.0-0.dll"))
+    && isExistingDirectory(join(candidate, "lib", "gstreamer-1.0")),
   );
-
-  console.log(`Bundled GStreamer runtime from ${resolvedSdkRoot} to ${destination} (${copied} paths).`);
+  if (!sdkRoot) throw new Error("GStreamer MSVC x86_64 runtime was not found. Install the runtime/development MSI or pass --sdk-root.");
+  return sdkRoot;
 }
 
-function brewPrefix() {
-  const result = spawnSync("brew", ["--prefix"], {
-    encoding: "utf8",
-  });
-  if (result.status !== 0) {
-    return null;
-  }
-  return result.stdout.trim() || null;
-}
-
-function macosRuntimeCandidates(explicitSdkRoot) {
+function macosCandidates(explicitSdkRoot) {
   return [
     explicitSdkRoot,
     process.env.GSTREAMER_1_0_ROOT_MACOS,
+    "/Library/Frameworks/GStreamer.framework/Versions/1.0",
+    "/Library/Frameworks/GStreamer.framework/Versions/Current",
     brewPrefix(),
     "/opt/homebrew",
     "/usr/local",
   ].filter(Boolean);
 }
 
+function validateMacosRoot(candidate) {
+  return isExistingFile(join(candidate, "lib", "pkgconfig", "gstreamer-1.0.pc"))
+    && isExistingFile(join(candidate, "lib", "libgstreamer-1.0.dylib"))
+    && isExistingDirectory(join(candidate, "lib", "gstreamer-1.0"));
+}
+
 function resolveMacosRuntimeRoot(explicitSdkRoot) {
-  const runtimeRoot = macosRuntimeCandidates(explicitSdkRoot).find((candidate) =>
-    existsSync(join(candidate, "lib", "libgstreamer-1.0.dylib"))
-    && existsSync(join(candidate, "lib", "gstreamer-1.0")),
-  );
-
+  const runtimeRoot = macosCandidates(explicitSdkRoot).find(validateMacosRoot);
   if (!runtimeRoot) {
-    throw new Error(
-      "GStreamer Homebrew runtime was not found. Install gstreamer and plugin packages with brew or pass --sdk-root.",
-    );
+    throw new Error("GStreamer macOS runtime was not found. Install the official runtime/devel .pkg packages or Homebrew packages, or pass --sdk-root.");
   }
-
   return runtimeRoot;
 }
 
-function bundleMacosRuntime({ sdkRoot, destination }) {
-  const resolvedRuntimeRoot = resolveMacosRuntimeRoot(sdkRoot);
-  rmSync(destination, { recursive: true, force: true });
-  mkdirSync(destination, { recursive: true });
-
-  const copied = [
-    copyPathIfPresent(
-      join(resolvedRuntimeRoot, "lib", "gstreamer-1.0"),
-      join(destination, "lib", "gstreamer-1.0"),
-    ),
-    copyPathIfPresent(
-      join(resolvedRuntimeRoot, "lib", "gio", "modules"),
-      join(destination, "lib", "gio", "modules"),
-    ),
-    copyPathIfPresent(
-      join(resolvedRuntimeRoot, "libexec", "gstreamer-1.0"),
-      join(destination, "libexec", "gstreamer-1.0"),
-    ),
-    copyPathIfPresent(
-      join(resolvedRuntimeRoot, "share", "gstreamer-1.0"),
-      join(destination, "share", "gstreamer-1.0"),
-    ),
-    copyPathIfPresent(
-      join(resolvedRuntimeRoot, "share", "glib-2.0"),
-      join(destination, "share", "glib-2.0"),
-    ),
-  ].filter(Boolean).length;
-
-  copyMatchingFiles(join(resolvedRuntimeRoot, "lib"), join(destination, "lib"), /\.dylib$/);
-  copyMatchingFiles(resolvedRuntimeRoot, destination, /^(copying|license|readme)/i);
+function writeMetadata(destination, source, platform) {
   writeFileSync(
     join(destination, "OPENNOW-GSTREAMER-RUNTIME.txt"),
     [
       "OpenNOW private GStreamer runtime bundle",
-      `Source: ${resolvedRuntimeRoot}`,
+      `Source: ${source}`,
       `Generated: ${new Date().toISOString()}`,
+      `Platform: ${platform}`,
+      "Scope: native streamer child process only",
       "",
-      "This directory is loaded only for the native streamer child process.",
-      "macOS uses DYLD_LIBRARY_PATH for this child process so copied plugins resolve against this bundle.",
+      "This directory is loaded only for the native streamer child process. Keep the private layout intact.",
       "",
     ].join("\n"),
   );
+}
 
+function bundleWindowsRuntime({ sdkRoot, destination }) {
+  const resolvedSdkRoot = resolveWindowsSdkRoot(sdkRoot);
+  rmSync(destination, { recursive: true, force: true });
+  mkdirSync(destination, { recursive: true });
+  const copied = [
+    copyPathIfPresent(join(resolvedSdkRoot, "bin"), join(destination, "bin")),
+    copyPathIfPresent(join(resolvedSdkRoot, "lib", "gstreamer-1.0"), join(destination, "lib", "gstreamer-1.0")),
+    copyPathIfPresent(join(resolvedSdkRoot, "lib", "gio", "modules"), join(destination, "lib", "gio", "modules")),
+    copyPathIfPresent(join(resolvedSdkRoot, "libexec", "gstreamer-1.0"), join(destination, "libexec", "gstreamer-1.0")),
+    copyPathIfPresent(join(resolvedSdkRoot, "share", "gstreamer-1.0"), join(destination, "share", "gstreamer-1.0")),
+    copyPathIfPresent(join(resolvedSdkRoot, "share", "glib-2.0"), join(destination, "share", "glib-2.0")),
+    copyPathIfPresent(join(resolvedSdkRoot, "etc"), join(destination, "etc")),
+  ].filter(Boolean).length;
+  copyMatchingFiles(resolvedSdkRoot, destination, /^(copying|license|readme)/i);
+  writeMetadata(destination, resolvedSdkRoot, "win32");
+  console.log(`Bundled GStreamer runtime from ${resolvedSdkRoot} to ${destination} (${copied} paths).`);
+}
+
+function walkFiles(root) {
+  if (!isExistingDirectory(root)) return [];
+  const out = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const name of readdirSync(dir)) {
+      const path = join(dir, name);
+      const stats = statSync(path);
+      if (stats.isDirectory()) stack.push(path);
+      else if (stats.isFile()) out.push(path);
+    }
+  }
+  return out;
+}
+
+function isMachO(path) {
+  try {
+    const buffer = readFileSync(path, { flag: "r" });
+    if (buffer.length < 4) return false;
+    const magic = buffer.readUInt32BE(0);
+    return [0xfeedface, 0xfeedfacf, 0xcafebabe, 0xcafebabf, 0xbebafeca, 0xcffaedfe, 0xcefaedfe].includes(magic);
+  } catch {
+    return false;
+  }
+}
+
+function dylibName(ref) {
+  return ref.split("/").pop();
+}
+
+function isPathInside(path, parent) {
+  const relativePath = relative(parent, path);
+  return relativePath === "" || (!relativePath.startsWith("..") && !relativePath.startsWith("/"));
+}
+
+function posixPath(path) {
+  return path.split(/[\\/]+/).filter(Boolean).join("/");
+}
+
+function relocationTarget(file, destination, libDir, dep) {
+  const name = dylibName(dep);
+  if (!name) return null;
+  if (!isPathInside(file, destination)) return `@executable_path/gstreamer/lib/${name}`;
+  const relativeLibDir = posixPath(relative(dirname(file), libDir));
+  return relativeLibDir ? `@loader_path/${relativeLibDir}/${name}` : `@loader_path/${name}`;
+}
+
+function shouldRewriteDependency(dep, roots, bundledLibs) {
+  const name = dylibName(dep);
+  if (!name || !bundledLibs.has(name)) return false;
+  if (dep.startsWith("@rpath/") || dep.startsWith("@loader_path/") || dep.startsWith("@executable_path/")) return bundledLibs.has(name);
+  return roots.some((root) => dep === join(root, "lib", name) || dep.startsWith(`${root}/`) || dep.includes("GStreamer.framework"));
+}
+
+function macosExternalRoots(sourceRoot) {
+  return [
+    sourceRoot,
+    "/Library/Frameworks/GStreamer.framework/Versions/1.0",
+    "/Library/Frameworks/GStreamer.framework/Versions/Current",
+    "/Library/Frameworks/GStreamer.framework",
+    "/opt/homebrew",
+    "/usr/local",
+  ];
+}
+
+function runInstallNameTool(args, file) {
+  const result = run("install_name_tool", args, { stdio: "inherit" });
+  if (result.status !== 0) {
+    throw new Error(`install_name_tool failed for ${file}: install_name_tool ${args.join(" ")}`);
+  }
+}
+
+function patchMachO(file, destination, sourceRoot, libDir, bundledLibs) {
+  if (!isMachO(file) || !commandAvailable("otool") || !commandAvailable("install_name_tool")) return;
+  const output = run("otool", ["-L", file]);
+  if (output.status !== 0) return;
+  const roots = macosExternalRoots(sourceRoot);
+  for (const line of output.stdout.split(/\r?\n/).slice(1)) {
+    const dep = line.trim().split(/\s+/)[0];
+    if (!dep || !shouldRewriteDependency(dep, roots, bundledLibs)) continue;
+    const target = relocationTarget(file, destination, libDir, dep);
+    if (target && target !== dep) runInstallNameTool(["-change", dep, target, file], file);
+  }
+  if (isPathInside(file, libDir) && extname(file) === ".dylib") {
+    runInstallNameTool(["-id", `@rpath/${dylibName(file)}`, file], file);
+  }
+}
+
+function validatePackagedBinaryRelocation(binary, sourceRoot, bundledLibs) {
+  if (!binary || !isMachO(binary) || !commandAvailable("otool")) return;
+  const output = run("otool", ["-L", binary]);
+  if (output.status !== 0) {
+    throw new Error(`otool -L failed for packaged native streamer: ${binary}`);
+  }
+  const roots = macosExternalRoots(sourceRoot);
+  const leakedDeps = output.stdout
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim().split(/\s+/)[0])
+    .filter((dep) => dep && shouldRewriteDependency(dep, roots, bundledLibs));
+  if (leakedDeps.length > 0) {
+    throw new Error(
+      `Packaged native streamer still references external GStreamer dependencies after relocation: ${leakedDeps.join(", ")}`,
+    );
+  }
+}
+
+function bundleMacosRuntime({ sdkRoot, destination, binary }) {
+  const resolvedRuntimeRoot = resolveMacosRuntimeRoot(sdkRoot);
+  rmSync(destination, { recursive: true, force: true });
+  mkdirSync(destination, { recursive: true });
+  const copied = [
+    copyPathIfPresent(join(resolvedRuntimeRoot, "bin"), join(destination, "bin")),
+    copyPathIfPresent(join(resolvedRuntimeRoot, "lib", "gstreamer-1.0"), join(destination, "lib", "gstreamer-1.0")),
+    copyPathIfPresent(join(resolvedRuntimeRoot, "lib", "gio", "modules"), join(destination, "lib", "gio", "modules")),
+    copyPathIfPresent(join(resolvedRuntimeRoot, "libexec", "gstreamer-1.0"), join(destination, "libexec", "gstreamer-1.0")),
+    copyPathIfPresent(join(resolvedRuntimeRoot, "share"), join(destination, "share")),
+    copyPathIfPresent(join(resolvedRuntimeRoot, "etc"), join(destination, "etc")),
+  ].filter(Boolean).length;
+  copyMatchingFiles(join(resolvedRuntimeRoot, "lib"), join(destination, "lib"), /\.(dylib|so)$/);
+  copyMatchingFiles(resolvedRuntimeRoot, destination, /^(copying|license|readme)/i);
+  const libDir = join(destination, "lib");
+  const bundledLibs = new Set(readdirSync(libDir).filter((name) => name.endsWith(".dylib") || name.endsWith(".so")));
+  for (const file of [...walkFiles(destination), binary].filter(Boolean)) {
+    try { chmodSync(file, statSync(file).mode | 0o200); } catch {}
+    patchMachO(file, destination, resolvedRuntimeRoot, libDir, bundledLibs);
+  }
+  validatePackagedBinaryRelocation(binary, resolvedRuntimeRoot, bundledLibs);
+  writeMetadata(destination, resolvedRuntimeRoot, "darwin");
   console.log(`Bundled GStreamer runtime from ${resolvedRuntimeRoot} to ${destination} (${copied} paths plus dylibs).`);
 }
 
 const args = parseArgs(process.argv.slice(2));
 const destination = args.get("dest");
 if (!destination) {
-  console.error("Usage: node scripts/bundle-gstreamer-runtime.mjs --dest <runtime-dir> [--sdk-root <path>]");
+  console.error("Usage: node scripts/bundle-gstreamer-runtime.mjs --dest <runtime-dir> [--sdk-root <path>] [--binary <path>]");
   process.exit(1);
 }
 
 try {
+  const resolvedDestination = resolve(packageRoot, destination);
   if (process.platform === "win32") {
-    bundleWindowsRuntime({
-      sdkRoot: args.get("sdk-root"),
-      destination: resolve(__dirname, "..", destination),
-    });
+    bundleWindowsRuntime({ sdkRoot: args.get("sdk-root"), destination: resolvedDestination });
   } else if (process.platform === "darwin") {
     bundleMacosRuntime({
       sdkRoot: args.get("sdk-root"),
-      destination: resolve(__dirname, "..", destination),
+      destination: resolvedDestination,
+      binary: args.get("binary") ? resolve(packageRoot, args.get("binary")) : null,
     });
   } else {
     throw new Error(
-      `Bundled GStreamer runtime collection is implemented for Windows and macOS only (got ${process.platform}).`,
+      `Private GStreamer runtime collection is intentionally unsupported on Linux (${process.platform}). Linux builds use distro GStreamer packages because AppImage/private bundling is unreliable across glibc, libdrm/VAAPI/Vulkan, and GPU driver stacks.`,
     );
   }
 } catch (error) {

--- a/opennow-stable/scripts/bundle-gstreamer-runtime.mjs
+++ b/opennow-stable/scripts/bundle-gstreamer-runtime.mjs
@@ -10,7 +10,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, extname, join, relative, resolve } from "node:path";
+import { delimiter, dirname, extname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
@@ -146,7 +146,69 @@ function writeMetadata(destination, source, platform) {
   );
 }
 
-function bundleWindowsRuntime({ sdkRoot, destination }) {
+const WINDOWS_LOADER_DLLS = [
+  "gstreamer-1.0-0.dll",
+  "glib-2.0-0.dll",
+  "gobject-2.0-0.dll",
+  "gio-2.0-0.dll",
+  "gmodule-2.0-0.dll",
+  "gthread-2.0-0.dll",
+  "intl-8.dll",
+  "ffi-8.dll",
+  "pcre2-8-0.dll",
+  "orc-0.4-0.dll",
+  "winpthread-1.dll",
+  "zlib1.dll",
+];
+
+const WINDOWS_VC_RUNTIME_DLLS = [
+  "vcruntime140.dll",
+  "vcruntime140_1.dll",
+  "msvcp140.dll",
+  "msvcp140_1.dll",
+  "msvcp140_2.dll",
+  "msvcp140_atomic_wait.dll",
+  "msvcp140_codecvt_ids.dll",
+  "concrt140.dll",
+];
+
+function windowsVcRuntimeSearchDirs() {
+  return [
+    process.env.VCToolsRedistDir ? join(process.env.VCToolsRedistDir, "x64", "Microsoft.VC143.CRT") : null,
+    process.env.VCToolsRedistDir ? join(process.env.VCToolsRedistDir, "x64", "Microsoft.VC142.CRT") : null,
+    process.env.VCToolsRedistDir ? join(process.env.VCToolsRedistDir, "x64", "Microsoft.VC141.CRT") : null,
+    process.env.SystemRoot ? join(process.env.SystemRoot, "System32") : null,
+    ...String(process.env.PATH ?? "").split(delimiter),
+  ].filter(Boolean);
+}
+
+function copyWindowsLoaderDlls({ sdkRoot, destination, binary }) {
+  const executableDir = binary ? dirname(binary) : dirname(destination);
+  const sdkBin = join(sdkRoot, "bin");
+  const copiedLoader = [];
+  const copiedVc = [];
+
+  for (const name of WINDOWS_LOADER_DLLS) {
+    const source = join(sdkBin, name);
+    if (!isExistingFile(source)) continue;
+    copyFileSync(source, join(executableDir, name));
+    copiedLoader.push(name);
+  }
+
+  const vcSearchDirs = windowsVcRuntimeSearchDirs();
+  for (const name of WINDOWS_VC_RUNTIME_DLLS) {
+    const source = vcSearchDirs.map((dir) => join(dir, name)).find(isExistingFile);
+    if (!source) continue;
+    copyFileSync(source, join(executableDir, name));
+    copyFileSync(source, join(destination, "bin", name));
+    copiedVc.push(name);
+  }
+
+  console.log(`Copied Windows loader DLLs next to native streamer: ${copiedLoader.length ? copiedLoader.join(", ") : "none"}.`);
+  console.log(`Copied Windows VC runtime DLLs: ${copiedVc.length ? copiedVc.join(", ") : "none found"}.`);
+}
+
+function bundleWindowsRuntime({ sdkRoot, destination, binary }) {
   const resolvedSdkRoot = resolveWindowsSdkRoot(sdkRoot);
   rmSync(destination, { recursive: true, force: true });
   mkdirSync(destination, { recursive: true });
@@ -160,6 +222,7 @@ function bundleWindowsRuntime({ sdkRoot, destination }) {
     copyPathIfPresent(join(resolvedSdkRoot, "etc"), join(destination, "etc")),
   ].filter(Boolean).length;
   copyMatchingFiles(resolvedSdkRoot, destination, /^(copying|license|readme)/i);
+  copyWindowsLoaderDlls({ sdkRoot: resolvedSdkRoot, destination, binary });
   writeMetadata(destination, resolvedSdkRoot, "win32");
   console.log(`Bundled GStreamer runtime from ${resolvedSdkRoot} to ${destination} (${copied} paths).`);
 }
@@ -314,7 +377,11 @@ if (!destination) {
 try {
   const resolvedDestination = resolve(packageRoot, destination);
   if (process.platform === "win32") {
-    bundleWindowsRuntime({ sdkRoot: args.get("sdk-root"), destination: resolvedDestination });
+    bundleWindowsRuntime({
+      sdkRoot: args.get("sdk-root"),
+      destination: resolvedDestination,
+      binary: args.get("binary") ? resolve(packageRoot, args.get("binary")) : null,
+    });
   } else if (process.platform === "darwin") {
     bundleMacosRuntime({
       sdkRoot: args.get("sdk-root"),

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -152,6 +152,7 @@ function configureBundledGstreamerRuntime(
   );
   const gioModulesDir = join(runtimeRoot, "lib", "gio", "modules");
 
+  if (process.platform === "win32") prependProcessPath(env, dirname(executablePath));
   if (isExistingDirectory(binDir)) prependProcessPath(env, binDir);
   if (isExistingDirectory(pluginDir)) {
     env.GST_PLUGIN_PATH = pluginDir;
@@ -189,6 +190,20 @@ function configureBundledGstreamerRuntime(
     path: runtimeRoot,
     message: "Using bundled GStreamer runtime next to the native streamer executable.",
   };
+}
+
+function isWindowsDllLoadFailure(error: unknown): boolean {
+  const message = formatError(error);
+  return process.platform === "win32" && (message.includes("3221225781") || message.toLowerCase().includes("0xc0000135"));
+}
+
+function formatNativeStreamerDetectionFailure(error: unknown, runtime: NativeGstreamerRuntimeStatus | null): string {
+  if (isWindowsDllLoadFailure(error)) {
+    return runtime?.bundled
+      ? `Native streamer could not load a required DLL even though bundled GStreamer was detected at ${runtime.path}. The packaged runtime may be incomplete or blocked. ${formatError(error)}`
+      : `Native streamer could not load a required DLL and no bundled GStreamer runtime was detected. ${formatError(error)}`;
+  }
+  return `Native streamer was not detected: ${formatError(error)}`;
 }
 
 function formatError(error: unknown): string {
@@ -409,19 +424,20 @@ export class NativeStreamerManager {
           : this.capabilities?.fallbackReason ?? effectiveRuntime.message,
       };
     } catch (error) {
+      const runtime = this.gstreamerRuntime ?? {
+        source: process.platform === "linux" ? "missing" : "unknown",
+        bundled: false,
+        message: process.platform === "linux"
+          ? "GStreamer is not ready. Linux uses distro packages because private AppImage GStreamer bundling is unreliable across glibc, libdrm/VAAPI/Vulkan, and GPU driver stacks."
+          : "GStreamer runtime could not be checked because the native streamer did not start.",
+        installInstructions: linuxInstallInstructions(),
+      } satisfies NativeGstreamerRuntimeStatus;
       return {
         detected: false,
         gstreamerAvailable: false,
         supportsOfferAnswer: false,
-        gstreamerRuntime: {
-          source: process.platform === "linux" ? "missing" : "unknown",
-          bundled: false,
-          message: process.platform === "linux"
-            ? "GStreamer is not ready. Linux uses distro packages because private AppImage GStreamer bundling is unreliable across glibc, libdrm/VAAPI/Vulkan, and GPU driver stacks."
-            : "GStreamer runtime could not be checked because the native streamer did not start.",
-          installInstructions: linuxInstallInstructions(),
-        },
-        message: `Native streamer was not detected: ${formatError(error)}`,
+        gstreamerRuntime: runtime,
+        message: formatNativeStreamerDetectionFailure(error, runtime),
       };
     }
   }

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -12,6 +12,8 @@ import {
   type NativeStreamerBackendPreference,
   type NativeStreamerFeatureMode,
   type NativeStreamerStatus,
+  type NativeGstreamerRuntimeStatus,
+  type NativeGstreamerInstallInstruction,
   type NativeRenderSurface,
   type NativeStreamerSessionContext,
   type NativeVideoBackendCapability,
@@ -98,13 +100,45 @@ function prependProcessPath(env: NodeJS.ProcessEnv, directory: string): void {
   prependEnvPath(env, pathKey, directory);
 }
 
+const LINUX_GSTREAMER_INSTALL_INSTRUCTIONS: NativeGstreamerInstallInstruction[] = [
+  {
+    distro: "Debian / Ubuntu / Mint / Pop!_OS / KDE neon",
+    command: "sudo apt update && sudo apt install libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-gl gstreamer1.0-vaapi gstreamer1.0-x gstreamer1.0-alsa libva2 libva-drm2 libvulkan1 mesa-vulkan-drivers",
+  },
+  {
+    distro: "Fedora / RHEL / Nobara / Bazzite",
+    command: "sudo dnf install gstreamer1 gstreamer1-plugins-base gstreamer1-plugins-good gstreamer1-plugins-bad-free gstreamer1-plugins-bad-freeworld gstreamer1-plugins-ugly gstreamer1-libav gstreamer1-vaapi gstreamer1-plugin-openh264 mesa-vulkan-drivers libva",
+    note: "RPM Fusion may be required for libav, ugly, or bad-freeworld packages.",
+  },
+  {
+    distro: "Arch / Manjaro / EndeavourOS / SteamOS",
+    command: "sudo pacman -S --needed gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav gst-plugin-va libva mesa vulkan-radeon",
+    note: "NVIDIA users should use their distro NVIDIA/Vulkan driver packages instead of vulkan-radeon.",
+  },
+  {
+    distro: "openSUSE Tumbleweed / Leap",
+    command: "sudo zypper install gstreamer gstreamer-plugins-base gstreamer-plugins-good gstreamer-plugins-bad gstreamer-plugins-ugly gstreamer-plugins-libav gstreamer-plugins-vaapi libva2 Mesa-vulkan-device-select",
+  },
+];
+
+function linuxInstallInstructions(): NativeGstreamerInstallInstruction[] | undefined {
+  return process.platform === "linux" ? LINUX_GSTREAMER_INSTALL_INSTRUCTIONS : undefined;
+}
+
 function configureBundledGstreamerRuntime(
   env: NodeJS.ProcessEnv,
   executablePath: string,
-): boolean {
+): NativeGstreamerRuntimeStatus {
   const runtimeRoot = join(dirname(executablePath), "gstreamer");
   if (!isExistingDirectory(runtimeRoot)) {
-    return false;
+    return {
+      source: "system",
+      bundled: false,
+      message: process.platform === "linux"
+        ? "No bundled GStreamer runtime was found. Linux uses distro GStreamer packages so VAAPI/V4L2/Vulkan plugins match the host driver stack."
+        : "No bundled GStreamer runtime was found; using the system runtime if available.",
+      installInstructions: linuxInstallInstructions(),
+    };
   }
 
   const binDir = join(runtimeRoot, "bin");
@@ -118,9 +152,7 @@ function configureBundledGstreamerRuntime(
   );
   const gioModulesDir = join(runtimeRoot, "lib", "gio", "modules");
 
-  if (isExistingDirectory(binDir)) {
-    prependProcessPath(env, binDir);
-  }
+  if (isExistingDirectory(binDir)) prependProcessPath(env, binDir);
   if (isExistingDirectory(pluginDir)) {
     env.GST_PLUGIN_PATH = pluginDir;
     env.GST_PLUGIN_PATH_1_0 = pluginDir;
@@ -129,28 +161,34 @@ function configureBundledGstreamerRuntime(
   }
   if (isExistingFile(scanner)) {
     env.GST_PLUGIN_SCANNER = scanner;
+    env.GST_PLUGIN_SCANNER_1_0 = scanner;
   }
+  env.GST_REGISTRY_REUSE_PLUGIN_SCANNER = "no";
   if (isExistingDirectory(gioModulesDir)) {
     env.GIO_MODULE_DIR = gioModulesDir;
+    env.GIO_EXTRA_MODULES = gioModulesDir;
   }
   if (process.platform === "linux") {
-    if (isExistingDirectory(libDir)) {
-      prependEnvPath(env, "LD_LIBRARY_PATH", libDir);
-    }
-    if (isExistingDirectory(binDir)) {
-      prependEnvPath(env, "LD_LIBRARY_PATH", binDir);
-    }
+    if (isExistingDirectory(libDir)) prependEnvPath(env, "LD_LIBRARY_PATH", libDir);
+    if (isExistingDirectory(binDir)) prependEnvPath(env, "LD_LIBRARY_PATH", binDir);
   }
   if (process.platform === "darwin") {
     if (isExistingDirectory(libDir)) {
       prependEnvPath(env, "DYLD_LIBRARY_PATH", libDir);
+      prependEnvPath(env, "DYLD_FALLBACK_LIBRARY_PATH", libDir);
     }
     if (isExistingDirectory(binDir)) {
       prependEnvPath(env, "DYLD_LIBRARY_PATH", binDir);
+      prependEnvPath(env, "DYLD_FALLBACK_LIBRARY_PATH", binDir);
     }
   }
 
-  return true;
+  return {
+    source: "bundled",
+    bundled: true,
+    path: runtimeRoot,
+    message: "Using bundled GStreamer runtime next to the native streamer executable.",
+  };
 }
 
 function formatError(error: unknown): string {
@@ -249,6 +287,8 @@ function isEvent(message: NativeStreamerMessage): message is NativeStreamerEvent
 export class NativeStreamerManager {
   private child: ChildProcessWithoutNullStreams | null = null;
   private stdoutBuffer = "";
+  private stderrTail: string[] = [];
+  private gstreamerRuntime: NativeGstreamerRuntimeStatus | null = null;
   private pending = new Map<string, PendingRequest>();
   private capabilities: NativeStreamerCapabilities | null = null;
   private activeSessionId: string | null = null;
@@ -329,6 +369,30 @@ export class NativeStreamerManager {
       const activeVideoBackend = resolveActiveVideoBackend(videoBackends);
       const codecSummary = summarizeCodecs(activeVideoBackend);
       const zeroCopySummary = summarizeZeroCopy(activeVideoBackend);
+      const runtime = this.gstreamerRuntime ?? {
+        source: "unknown",
+        bundled: false,
+        message: "GStreamer runtime has not been checked yet.",
+        installInstructions: linuxInstallInstructions(),
+      } satisfies NativeGstreamerRuntimeStatus;
+      const effectiveRuntime: NativeGstreamerRuntimeStatus = gstreamerAvailable
+        ? runtime.bundled
+          ? runtime
+          : {
+            ...runtime,
+            source: "system",
+            message: "Using system GStreamer runtime; packaged Windows/macOS builds should use the bundled runtime.",
+          }
+        : {
+          ...runtime,
+          source: runtime.bundled ? "bundled" : process.platform === "linux" ? "missing" : runtime.source,
+          message: runtime.bundled
+            ? "Bundled GStreamer runtime was found, but the GStreamer backend is not ready."
+            : process.platform === "linux"
+              ? "GStreamer is not ready. Install distro GStreamer packages so plugins match the host GPU/driver stack."
+              : runtime.message,
+          installInstructions: runtime.installInstructions ?? linuxInstallInstructions(),
+        };
       return {
         detected: true,
         gstreamerAvailable,
@@ -339,15 +403,24 @@ export class NativeStreamerManager {
         activeVideoBackend,
         codecSummary,
         zeroCopySummary,
+        gstreamerRuntime: effectiveRuntime,
         message: gstreamerAvailable
-          ? `GStreamer native streamer is ready. Video path: ${formatVideoBackendName(activeVideoBackend?.backend)}.`
-          : this.capabilities?.fallbackReason ?? "Native streamer is present, but GStreamer is not available.",
+          ? `${effectiveRuntime.message} Video path: ${formatVideoBackendName(activeVideoBackend?.backend)}.`
+          : this.capabilities?.fallbackReason ?? effectiveRuntime.message,
       };
     } catch (error) {
       return {
         detected: false,
         gstreamerAvailable: false,
         supportsOfferAnswer: false,
+        gstreamerRuntime: {
+          source: process.platform === "linux" ? "missing" : "unknown",
+          bundled: false,
+          message: process.platform === "linux"
+            ? "GStreamer is not ready. Linux uses distro packages because private AppImage GStreamer bundling is unreliable across glibc, libdrm/VAAPI/Vulkan, and GPU driver stacks."
+            : "GStreamer runtime could not be checked because the native streamer did not start.",
+          installInstructions: linuxInstallInstructions(),
+        },
         message: `Native streamer was not detected: ${formatError(error)}`,
       };
     }
@@ -473,8 +546,12 @@ export class NativeStreamerManager {
     if (backendPreference !== "auto") {
       childEnv.OPENNOW_NATIVE_STREAMER_BACKEND = backendPreference;
     }
-    if (configureBundledGstreamerRuntime(childEnv, executablePath)) {
-      console.log("[NativeStreamer] Using bundled GStreamer runtime:", join(dirname(executablePath), "gstreamer"));
+    const runtimeStatus = configureBundledGstreamerRuntime(childEnv, executablePath);
+    this.gstreamerRuntime = runtimeStatus;
+    if (runtimeStatus.bundled) {
+      console.log("[NativeStreamer] Using bundled GStreamer runtime:", runtimeStatus.path);
+    } else {
+      console.log("[NativeStreamer]", runtimeStatus.message);
     }
 
     const child = spawn(executablePath, [], {
@@ -488,6 +565,7 @@ export class NativeStreamerManager {
 
     this.child = child;
     this.stdoutBuffer = "";
+    this.stderrTail = [];
 
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => this.handleStdout(chunk));
@@ -495,6 +573,7 @@ export class NativeStreamerManager {
     child.stderr.on("data", (chunk: string) => {
       for (const line of chunk.split(/\r?\n/)) {
         if (line.trim()) {
+          this.appendStderr(line);
           console.warn(`[NativeStreamer] ${line}`);
         }
       }
@@ -592,7 +671,7 @@ export class NativeStreamerManager {
     return new Promise<NativeStreamerResponse>((resolveRequest, rejectRequest) => {
       const timeout = setTimeout(() => {
         this.pending.delete(id);
-        rejectRequest(new Error(`Native streamer request "${input.type}" timed out.`));
+        rejectRequest(new Error(`Native streamer request "${input.type}" timed out.${this.formatStderrTail()}`));
       }, timeoutMs);
       timeout.unref?.();
 
@@ -781,12 +860,23 @@ export class NativeStreamerManager {
       return;
     }
 
-    console.warn(`[NativeStreamer] Process ended (${reason})`);
+    const tail = this.formatStderrTail();
+    console.warn(`[NativeStreamer] Process ended (${reason})${tail}`);
     this.child = null;
     this.stdoutBuffer = "";
+    this.stderrTail = [];
     this.activeSessionId = null;
     this.capabilities = null;
-    this.rejectPending(new Error(`Native streamer process ended (${reason}).`));
+    this.rejectPending(new Error(`Native streamer process ended (${reason}).${tail}`));
+  }
+
+  private appendStderr(line: string): void {
+    this.stderrTail.push(line);
+    if (this.stderrTail.length > 12) this.stderrTail.shift();
+  }
+
+  private formatStderrTail(): string {
+    return this.stderrTail.length > 0 ? ` Recent stderr: ${this.stderrTail.join(" | ")}` : "";
   }
 
   private rejectPending(error: Error): void {

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -103,6 +103,25 @@ function getAvailableNativeCodecLabels(backend: NativeVideoBackendCapability | u
     .map((codec) => formatNativeVideoCodec(codec.codec)) ?? [];
 }
 
+function formatGstreamerRuntimeLabel(status: NativeStreamerStatus | null): string {
+  switch (status?.gstreamerRuntime.source) {
+    case "bundled":
+      return status.gstreamerAvailable ? "Bundled Runtime Used" : "Bundled Runtime Found";
+    case "system":
+      return "System Runtime";
+    case "missing":
+      return "Runtime Missing";
+    default:
+      return "Runtime Unknown";
+  }
+}
+
+function getGstreamerRuntimeBadgeClass(status: NativeStreamerStatus | null): string {
+  if (status?.gstreamerRuntime.source === "bundled" && status.gstreamerAvailable) return "settings-inline-badge--codec-gpu";
+  if (status?.gstreamerRuntime.source === "system" && status.gstreamerAvailable) return "settings-inline-badge--codec-testing";
+  return "settings-inline-badge--updater-error";
+}
+
 /* ── Static fallbacks (used when MES API is unavailable) ─────────── */
 
 interface ResolutionPreset {
@@ -638,6 +657,11 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
         detected: false,
         gstreamerAvailable: false,
         supportsOfferAnswer: false,
+        gstreamerRuntime: {
+          source: "unknown",
+          bundled: false,
+          message: "GStreamer runtime could not be checked.",
+        },
         message: "Native streamer status could not be checked.",
       });
     } finally {
@@ -1968,6 +1992,37 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                 <span className="settings-subtle-hint">
                   {nativeStreamerStatus?.message ?? "OpenNOW will check the bundled GStreamer streamer when this tab opens."}
                 </span>
+              </div>
+
+              <div className="settings-row settings-row--column">
+                <label className="settings-label">GStreamer Runtime</label>
+                <div className="settings-chip-row">
+                  <span className={`settings-inline-badge ${getGstreamerRuntimeBadgeClass(nativeStreamerStatus)}`}>
+                    {formatGstreamerRuntimeLabel(nativeStreamerStatus)}
+                  </span>
+                  {nativeStreamerStatus?.gstreamerRuntime.path ? (
+                    <span className="settings-inline-badge settings-inline-badge--codec">
+                      Bundled path detected
+                    </span>
+                  ) : null}
+                </div>
+                <span className="settings-subtle-hint">
+                  {nativeStreamerStatus?.gstreamerRuntime.message ?? "Packaged Windows/macOS builds auto-detect a bundled runtime next to the native streamer. Linux uses distro packages."}
+                </span>
+                {!nativeStreamerStatus?.gstreamerAvailable && nativeStreamerStatus?.gstreamerRuntime.installInstructions?.length ? (
+                  <div className="settings-install-steps">
+                    <span className="settings-subtle-hint">
+                      Linux AppImage/private GStreamer bundling is intentionally not used by default because VAAPI/V4L2/Vulkan plugins must match the host distro and GPU driver stack. .deb packages declare Debian/Ubuntu dependencies automatically.
+                    </span>
+                    {nativeStreamerStatus.gstreamerRuntime.installInstructions.map((instruction) => (
+                      <div key={instruction.distro} className="settings-install-step">
+                        <span className="settings-install-step-title">{instruction.distro}</span>
+                        <code>{instruction.command}</code>
+                        {instruction.note ? <span className="settings-subtle-hint">{instruction.note}</span> : null}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
               </div>
 
               <div className="settings-row settings-row--column">

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3067,6 +3067,36 @@ button.game-card-store-chip.owned.active:hover {
   font-weight: 500;
 }
 
+.settings-install-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.settings-install-step {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 9px;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: var(--bg-e);
+}
+
+.settings-install-step-title {
+  font-size: 0.78rem;
+  color: var(--ink-soft);
+  font-weight: 700;
+}
+
+.settings-install-step code {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.74rem;
+  color: var(--ink);
+}
+
 .settings-shortcut-hint {
   font-size: 0.72rem;
   color: var(--ink-muted);

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -142,6 +142,22 @@ export interface MicrophonePermissionResult {
   shouldUseBrowserApi: boolean;
 }
 
+export type NativeGstreamerRuntimeSource = "bundled" | "system" | "missing" | "unknown";
+
+export interface NativeGstreamerInstallInstruction {
+  distro: string;
+  command: string;
+  note?: string;
+}
+
+export interface NativeGstreamerRuntimeStatus {
+  source: NativeGstreamerRuntimeSource;
+  bundled: boolean;
+  path?: string;
+  message: string;
+  installInstructions?: NativeGstreamerInstallInstruction[];
+}
+
 export interface NativeStreamerStatus {
   detected: boolean;
   gstreamerAvailable: boolean;
@@ -152,6 +168,7 @@ export interface NativeStreamerStatus {
   activeVideoBackend?: NativeVideoBackendCapability;
   codecSummary?: string;
   zeroCopySummary?: string;
+  gstreamerRuntime: NativeGstreamerRuntimeStatus;
   message: string;
 }
 


### PR DESCRIPTION
This PR implements robust private GStreamer runtime bundling for Windows and macOS, updates Linux to rely on distro packages, and adds Settings UI guidance for missing runtimes.

**Build and Bundling**
- Update `build-native-streamer.mjs` to auto-detect official macOS framework roots or Homebrew, validate via `pkg-config`, and set build env vars.
- Rewrite `bundle-gstreamer-runtime.mjs` to copy macOS framework/Homebrew content into a private runtime, relocate Mach-O load commands via `otool`/`install_name_tool`, and validate the packaged binary leaks no external GStreamer paths.
- Add verification of the platform-specific binary against the bundled runtime environment instead of the build SDK.

**CI and Packaging**
- Switch macOS jobs in `auto-build.yml` and `release.yml` to install official universal `.pkg` packages; export `GSTREAMER_1_0_ROOT_MACOS` and `PKG_CONFIG_PATH`.
- Update `.deb` dependencies in `package.json` to include `gstreamer1.0-tools`, `gstreamer1.0-x`, and `gstreamer1.0-alsa`.
- Update `gstreamer-bundling.md` to document platform-specific strategies and private layout.

**Runtime and UI**
- Refactor manager runtime detection into `NativeGstreamerRuntimeStatus` with `bundled`/`system`/`missing` source and Linux distro install instructions.
- Inject bundled GStreamer env (`PATH`, `GST_PLUGIN_*`, `GIO_*`, library paths) only into the native streamer child process.
- Improve diagnostics by keeping a stderr tail for timeout and exit errors.
- Add a GStreamer Runtime row in Settings showing status and rendering Linux install commands only when unavailable.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/8a4fde5c-11b5-41ca-93fb-283bebe38d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-084" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/8a4fde5c-11b5-41ca-93fb-283bebe38d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-084&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-084"><img alt="OPE-084" src="https://capy.ai/api/badge/thread.svg?label=OPE-084"></picture></a>
<!-- capy-pr-badge:end -->