### PR TITLE
fix(nvst): hard-disable server-side dynamic streaming in SDP

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -221,7 +221,9 @@ jobs:
         if: matrix.native_build == 'true' && runner.os == 'Windows'
         uses: actions/cache@v4
         with:
-          path: C:\gstreamer
+          path: |
+            C:\gstreamer
+            ${{ github.workspace }}\.cache\gstreamer-windows
           key: gstreamer-windows-${{ env.GSTREAMER_WINDOWS_VERSION }}
 
       - name: Install Windows GStreamer SDK
@@ -258,16 +260,52 @@ jobs:
             }
             return $null
           }
-          function Invoke-Download([string] $url, [string] $output) {
-            $process = Start-Process -FilePath "curl.exe" -ArgumentList @("--fail", "--location", "--retry", "3", "--output", $output, $url) -Wait -PassThru -NoNewWindow
-            return [bool]($process.ExitCode -eq 0)
+          function Get-GStreamerMsi([string] $fileName, [string] $downloadDir, [string[]] $urlBases) {
+            New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null
+            $output = Join-Path $downloadDir $fileName
+            $partial = "$output.part"
+            if ((Test-Path $output) -and ((Get-Item $output).Length -gt 0)) {
+              Write-Host "Using cached GStreamer MSI: $output"
+              return $output
+            }
+            foreach ($base in $urlBases) {
+              $url = "$base/$fileName"
+              Write-Host "Downloading GStreamer MSI from $url"
+              if ((Test-Path $partial) -and ((Get-Item $partial).Length -eq 0)) { Remove-Item -Force $partial }
+              $process = Start-Process -FilePath "curl.exe" -ArgumentList @(
+                "--fail",
+                "--location",
+                "--retry", "8",
+                "--retry-all-errors",
+                "--retry-delay", "5",
+                "--connect-timeout", "30",
+                "--continue-at", "-",
+                "--output", $partial,
+                $url
+              ) -Wait -PassThru -NoNewWindow
+              if ($process.ExitCode -eq 0 -and (Test-Path $partial) -and ((Get-Item $partial).Length -gt 0)) {
+                Move-Item -Force $partial $output
+                return $output
+              }
+              Write-Host "GStreamer MSI download failed from $url with curl exit code $($process.ExitCode)."
+              if ((Test-Path $partial) -and ((Get-Item $partial).Length -eq 0)) { Remove-Item -Force $partial }
+            }
+            if (Test-Path $partial) {
+              Write-Host "Removing incomplete GStreamer MSI download: $partial"
+              Remove-Item -Force $partial
+            }
+            return $null
           }
           function Install-GStreamerMsiSdk([string] $version) {
-            $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
-            $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime-$version.msi"
-            $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
-            if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.msi" $runtime)) { return $false }
-            if (-not (Invoke-Download "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $devel)) { return $false }
+            $urlBases = @(
+              "https://gstreamer.freedesktop.org/data/pkg/windows/$version/msvc",
+              "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
+            )
+            $downloadDir = Join-Path $env:GITHUB_WORKSPACE ".cache\gstreamer-windows\$version"
+            $runtime = Get-GStreamerMsi "gstreamer-1.0-msvc-x86_64-$version.msi" $downloadDir $urlBases
+            if (-not $runtime) { return $false }
+            $devel = Get-GStreamerMsi "gstreamer-1.0-devel-msvc-x86_64-$version.msi" $downloadDir $urlBases
+            if (-not $devel) { return $false }
             $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase", "ADDLOCAL=ALL") -Wait -PassThru
             $script:lastRuntimeMsiExitCode = $runtimeInstall.ExitCode
             if ($runtimeInstall.ExitCode -ne 0) { return $false }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,9 @@ jobs:
         if: matrix.native_build == 'true' && runner.os == 'Windows'
         uses: actions/cache@v4
         with:
-          path: C:\gstreamer
+          path: |
+            C:\gstreamer
+            ${{ github.workspace }}\.cache\gstreamer-windows
           key: gstreamer-windows-${{ env.GSTREAMER_WINDOWS_VERSION }}
 
       - name: Install Windows GStreamer SDK
@@ -332,16 +334,52 @@ jobs:
             }
             return $null
           }
-          function Invoke-Download([string] $url, [string] $output) {
-            $process = Start-Process -FilePath "curl.exe" -ArgumentList @("--fail", "--location", "--retry", "3", "--output", $output, $url) -Wait -PassThru -NoNewWindow
-            return [bool]($process.ExitCode -eq 0)
+          function Get-GStreamerMsi([string] $fileName, [string] $downloadDir, [string[]] $urlBases) {
+            New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null
+            $output = Join-Path $downloadDir $fileName
+            $partial = "$output.part"
+            if ((Test-Path $output) -and ((Get-Item $output).Length -gt 0)) {
+              Write-Host "Using cached GStreamer MSI: $output"
+              return $output
+            }
+            foreach ($base in $urlBases) {
+              $url = "$base/$fileName"
+              Write-Host "Downloading GStreamer MSI from $url"
+              if ((Test-Path $partial) -and ((Get-Item $partial).Length -eq 0)) { Remove-Item -Force $partial }
+              $process = Start-Process -FilePath "curl.exe" -ArgumentList @(
+                "--fail",
+                "--location",
+                "--retry", "8",
+                "--retry-all-errors",
+                "--retry-delay", "5",
+                "--connect-timeout", "30",
+                "--continue-at", "-",
+                "--output", $partial,
+                $url
+              ) -Wait -PassThru -NoNewWindow
+              if ($process.ExitCode -eq 0 -and (Test-Path $partial) -and ((Get-Item $partial).Length -gt 0)) {
+                Move-Item -Force $partial $output
+                return $output
+              }
+              Write-Host "GStreamer MSI download failed from $url with curl exit code $($process.ExitCode)."
+              if ((Test-Path $partial) -and ((Get-Item $partial).Length -eq 0)) { Remove-Item -Force $partial }
+            }
+            if (Test-Path $partial) {
+              Write-Host "Removing incomplete GStreamer MSI download: $partial"
+              Remove-Item -Force $partial
+            }
+            return $null
           }
           function Install-GStreamerMsiSdk([string] $version) {
-            $base = "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
-            $runtime = Join-Path $env:RUNNER_TEMP "gstreamer-runtime-$version.msi"
-            $devel = Join-Path $env:RUNNER_TEMP "gstreamer-devel-$version.msi"
-            if (-not (Invoke-Download "$base/gstreamer-1.0-msvc-x86_64-$version.msi" $runtime)) { return $false }
-            if (-not (Invoke-Download "$base/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $devel)) { return $false }
+            $urlBases = @(
+              "https://gstreamer.freedesktop.org/data/pkg/windows/$version/msvc",
+              "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
+            )
+            $downloadDir = Join-Path $env:GITHUB_WORKSPACE ".cache\gstreamer-windows\$version"
+            $runtime = Get-GStreamerMsi "gstreamer-1.0-msvc-x86_64-$version.msi" $downloadDir $urlBases
+            if (-not $runtime) { return $false }
+            $devel = Get-GStreamerMsi "gstreamer-1.0-devel-msvc-x86_64-$version.msi" $downloadDir $urlBases
+            if (-not $devel) { return $false }
             $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase", "ADDLOCAL=ALL") -Wait -PassThru
             $script:lastRuntimeMsiExitCode = $runtimeInstall.ExitCode
             if ($runtimeInstall.ExitCode -ne 0) { return $false }

--- a/native/opennow-streamer/src/backend.rs
+++ b/native/opennow-streamer/src/backend.rs
@@ -114,6 +114,7 @@ pub struct PreparedNativeOffer {
     pub fixed_offer_sdp: String,
     pub gstreamer_offer_sdp: String,
     pub gstreamer_ice_pwd_replacements: usize,
+    pub gstreamer_framerate_adjusted: bool,
     pub nvst_params: NvstParams,
     pub media_connection_info: Option<MediaConnectionInfo>,
 }
@@ -157,8 +158,10 @@ pub fn prepare_native_offer(
             prefer_hevc_profile_id: Some(preferred_hevc_profile_id(context.settings.color_quality)),
         },
     );
+    let (gstreamer_framerate_offer_sdp, gstreamer_framerate_adjusted) =
+        align_video_sdp_framerate_for_gstreamer(&fixed_offer_sdp, context.settings.fps);
     let (gstreamer_offer_sdp, gstreamer_ice_pwd_replacements) =
-        sanitize_ice_pwd_for_gstreamer(&fixed_offer_sdp);
+        sanitize_ice_pwd_for_gstreamer(&gstreamer_framerate_offer_sdp);
     let credentials = extract_ice_credentials(&fixed_offer_sdp);
     let nvst_params = NvstParams {
         width,
@@ -179,9 +182,66 @@ pub fn prepare_native_offer(
         fixed_offer_sdp,
         gstreamer_offer_sdp,
         gstreamer_ice_pwd_replacements,
+        gstreamer_framerate_adjusted,
         nvst_params,
         media_connection_info: context.session.media_connection_info.clone(),
     })
+}
+
+fn align_video_sdp_framerate_for_gstreamer(sdp: &str, fps: u32) -> (String, bool) {
+    if fps == 0 {
+        return (sdp.to_owned(), false);
+    }
+
+    let line_ending = if sdp.contains("\r\n") { "\r\n" } else { "\n" };
+    let has_trailing_ending = sdp.ends_with(line_ending);
+    let mut lines: Vec<String> = sdp
+        .split(line_ending)
+        .filter(|line| !line.is_empty() || !has_trailing_ending)
+        .map(ToOwned::to_owned)
+        .collect();
+    let mut output = Vec::with_capacity(lines.len() + 1);
+    let mut in_video = false;
+    let mut video_has_framerate = false;
+    let mut changed = false;
+    let target = format!("a=framerate:{fps}");
+
+    for line in lines.drain(..) {
+        if line.starts_with("m=") {
+            if in_video && !video_has_framerate {
+                output.push(target.clone());
+                changed = true;
+            }
+            in_video = line.starts_with("m=video");
+            video_has_framerate = false;
+            output.push(line);
+            continue;
+        }
+
+        if in_video && line.starts_with("a=framerate:") {
+            video_has_framerate = true;
+            if line != target {
+                output.push(target.clone());
+                changed = true;
+            } else {
+                output.push(line);
+            }
+            continue;
+        }
+
+        output.push(line);
+    }
+
+    if in_video && !video_has_framerate {
+        output.push(target);
+        changed = true;
+    }
+
+    let mut result = output.join(line_ending);
+    if has_trailing_ending {
+        result.push_str(line_ending);
+    }
+    (result, changed)
 }
 
 fn resolve_native_codec(configured: VideoCodec) -> VideoCodec {
@@ -212,6 +272,16 @@ pub fn prepared_offer_events(prepared: &PreparedNativeOffer) -> Vec<Event> {
             prepared.fixed_offer_sdp.len(),
         ),
     }];
+
+    if prepared.gstreamer_framerate_adjusted {
+        events.push(Event::Log {
+            level: "info",
+            message: format!(
+                "Aligned native WebRTC video SDP framerate to {} fps for GStreamer caps negotiation.",
+                nvst.fps
+            ),
+        });
+    }
 
     if let Some(media_connection_info) = &prepared.media_connection_info {
         events.push(Event::Log {
@@ -510,6 +580,40 @@ mod tests {
         assert!(prepared
             .gstreamer_offer_sdp
             .contains("a=rtpmap:100 flexfec-03/90000"));
+    }
+
+    #[test]
+    fn aligns_gstreamer_video_sdp_framerate() {
+        let sdp = "v=0\nm=video 9 UDP/TLS/RTP/SAVPF 96\na=framerate:60\na=rtpmap:96 H265/90000\n";
+
+        let (aligned, changed) = align_video_sdp_framerate_for_gstreamer(sdp, 240);
+
+        assert!(changed);
+        assert!(aligned.contains("a=framerate:240\n"));
+        assert!(!aligned.contains("a=framerate:60"));
+    }
+
+    #[test]
+    fn inserts_gstreamer_video_sdp_framerate_when_absent() {
+        let sdp = "v=0\nm=audio 9 UDP/TLS/RTP/SAVPF 111\na=rtpmap:111 OPUS/48000/2\nm=video 9 UDP/TLS/RTP/SAVPF 96\na=rtpmap:96 H265/90000\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\n";
+
+        let (aligned, changed) = align_video_sdp_framerate_for_gstreamer(sdp, 120);
+
+        assert!(changed);
+        assert!(aligned.contains(
+            "m=video 9 UDP/TLS/RTP/SAVPF 96\na=rtpmap:96 H265/90000\na=framerate:120\nm=application"
+        ));
+    }
+
+    #[test]
+    fn preserves_gstreamer_video_sdp_framerate_line_endings() {
+        let sdp = "v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 H265/90000\r\n";
+
+        let (aligned, changed) = align_video_sdp_framerate_for_gstreamer(sdp, 240);
+
+        assert!(changed);
+        assert!(aligned.contains("a=framerate:240\r\n"));
+        assert!(!aligned.contains('\n') || aligned.contains("\r\n"));
     }
 
     #[test]

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -157,6 +157,7 @@ struct VideoLivenessState {
     sink_total: AtomicU64,
     zero_copy_d3d11: AtomicBool,
     zero_copy_d3d12: AtomicBool,
+    rtp_video_src_pad: Mutex<Option<gst::Pad>>,
 }
 
 impl VideoLivenessState {
@@ -178,6 +179,7 @@ impl VideoLivenessState {
             sink_total: AtomicU64::new(0),
             zero_copy_d3d11: AtomicBool::new(false),
             zero_copy_d3d12: AtomicBool::new(false),
+            rtp_video_src_pad: Mutex::new(None),
         }
     }
 
@@ -277,6 +279,19 @@ impl VideoLivenessState {
     fn zero_copy(&self) -> bool {
         is_zero_copy_memory_mode(&self.memory_mode())
     }
+
+    fn set_rtp_video_src_pad(&self, pad: &gst::Pad) {
+        if let Ok(mut current) = self.rtp_video_src_pad.lock() {
+            *current = Some(pad.clone());
+        }
+    }
+
+    fn rtp_video_src_pad(&self) -> Option<gst::Pad> {
+        self.rtp_video_src_pad
+            .lock()
+            .ok()
+            .and_then(|current| current.clone())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -329,6 +344,10 @@ impl VideoLivenessMonitor {
 
     fn update_caps(&self, caps: &str) {
         self.state.update_caps(caps);
+    }
+
+    fn set_rtp_video_src_pad(&self, pad: &gst::Pad) {
+        self.state.set_rtp_video_src_pad(pad);
     }
 
     fn start(
@@ -3409,6 +3428,7 @@ fn run_video_liveness_watchdog(
         match tracker.evaluate(state.now_ms(), last_sink_ms) {
             VideoStallAction::None => {}
             VideoStallAction::RequestKeyframe { attempt, stall_ms } => {
+                request_upstream_key_unit(&state, &event_sender);
                 emit_video_stall_event(
                     &event_sender,
                     &sink,
@@ -3420,6 +3440,7 @@ fn run_video_liveness_watchdog(
                 );
             }
             VideoStallAction::Resync { attempt, stall_ms } => {
+                request_upstream_key_unit(&state, &event_sender);
                 emit_video_stall_event(
                     &event_sender,
                     &sink,
@@ -3452,6 +3473,39 @@ fn run_video_liveness_watchdog(
                 );
             }
         }
+    }
+}
+
+fn request_upstream_key_unit(state: &VideoLivenessState, event_sender: &Option<Sender<Event>>) {
+    let Some(src_pad) = state.rtp_video_src_pad() else {
+        send_log(
+            event_sender,
+            "warn",
+            "Unable to request upstream video key unit: no RTP video source pad registered."
+                .to_owned(),
+        );
+        return;
+    };
+
+    let event = gst::event::CustomUpstream::builder(
+        gst::Structure::builder("GstForceKeyUnit")
+            .field("all-headers", true)
+            .build(),
+    )
+    .build();
+
+    if src_pad.send_event(event) {
+        send_log(
+            event_sender,
+            "debug",
+            "Requested upstream video key unit via RTP source pad.".to_owned(),
+        );
+    } else {
+        send_log(
+            event_sender,
+            "warn",
+            "Upstream video key-unit request was not accepted by the RTP source pad.".to_owned(),
+        );
     }
 }
 
@@ -3549,7 +3603,7 @@ fn emit_video_stall_event(
         event_sender,
         "warn",
         format!(
-            "Native video stall detected: stall={stall_ms}ms stage={likely_stage} encoded={:.0}kbps decoded={:.1}fps sink={:.1}fps ages=encoded:{} decoded:{} sink:{} rendered={} dropped={} memoryMode={} zeroCopy={} zeroCopyD3D11={} zeroCopyD3D12={}.{}",
+            "Native video stall detected: stall={stall_ms}ms stage={likely_stage} encoded={:.0}kbps decoded={:.1}fps sink={:.1}fps ages=encoded:{} decoded:{} sink:{} rendered={} dropped={} memoryMode={} zeroCopy={} zeroCopyD3D11={} zeroCopyD3D12={}. If decoded/sink/rendered counters are still flowing but the visible frame is stale, suspect a transient D3D swapchain/present path freeze rather than RTP loss; it may recover after a keyframe/IDR or latency resync.{}",
             rates.encoded_kbps,
             rates.decoded_fps,
             rates.sink_fps,
@@ -3928,6 +3982,8 @@ fn wire_incoming_media_sink(
                 "warn",
                 format!("Failed to link WebRTC RTP pad to decodebin: {error:?}"),
             );
+        } else if rtp_video_encoding(src_pad).is_some() {
+            video_liveness.set_rtp_video_src_pad(src_pad);
         }
     });
 }
@@ -4080,9 +4136,11 @@ fn zero_copy_requested() -> bool {
 fn default_rtp_video_api_priority() -> Vec<RtpVideoApi> {
     #[cfg(target_os = "windows")]
     {
+        // D3D12 zero-copy is opt-in because it can decode-chain stall while RTP
+        // is still arriving on Windows; D3D11 is the safer default.
         vec![
-            RtpVideoApi::D3D12,
             RtpVideoApi::D3D11,
+            RtpVideoApi::D3D12,
             RtpVideoApi::Software,
         ]
     }
@@ -4328,6 +4386,7 @@ fn zero_copy_modes_for_backend(video_api: RtpVideoApi) -> Vec<String> {
 fn configure_rtp_video_chain_element(
     element: &gst::Element,
     spec: RtpVideoChainSpec,
+    video_api: RtpVideoApi,
     d3d_fullscreen_sink: bool,
 ) {
     match spec.role {
@@ -4364,7 +4423,11 @@ fn configure_rtp_video_chain_element(
         }
         RtpVideoChainRole::Sink => {
             configure_sink_for_low_latency(element);
-            set_property_if_supported(element, "direct-swapchain", true);
+            set_property_if_supported(
+                element,
+                "direct-swapchain",
+                !matches!(video_api, RtpVideoApi::D3D12),
+            );
             set_property_if_supported(element, "error-on-closed", false);
             set_property_if_supported(element, "fullscreen", d3d_fullscreen_sink);
             set_property_if_supported(element, "fullscreen-on-alt-enter", false);
@@ -4403,6 +4466,13 @@ fn link_rtp_video_pad(
             "info",
             format_video_chain_selection(encoding, video_api, &specs),
         );
+        if video_api == RtpVideoApi::D3D12 {
+            send_log(
+                event_sender,
+                "warn",
+                "Native D3D12 zero-copy video path is experimental and opt-in; if the visible frame freezes while sink/render counters keep increasing, use the default D3D11 path.".to_owned(),
+            );
+        }
         if d3d_fullscreen_sink {
             send_log(
                 event_sender,
@@ -4414,7 +4484,7 @@ fn link_rtp_video_pad(
         }
         for spec in &specs {
             let element = make_element(spec.factory)?;
-            configure_rtp_video_chain_element(&element, *spec, d3d_fullscreen_sink);
+            configure_rtp_video_chain_element(&element, *spec, video_api, d3d_fullscreen_sink);
             if spec.role == RtpVideoChainRole::StatsOverlay {
                 video_liveness.set_stats_overlay(Some(element.clone()));
             }
@@ -4448,6 +4518,7 @@ fn link_rtp_video_pad(
         src_pad
             .link(&first_sink_pad)
             .map_err(|error| format!("Failed to link RTP {encoding} video pad: {error:?}"))?;
+        video_liveness.set_rtp_video_src_pad(src_pad);
         watch_rtp_video_bitrate(src_pad, video_liveness.clone());
 
         let sink = elements
@@ -5626,6 +5697,19 @@ mod tests {
         assert_eq!(
             software.last().map(|spec| spec.factory),
             Some("autovideosink")
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_default_video_api_prefers_d3d11_before_d3d12() {
+        assert_eq!(
+            default_rtp_video_api_priority(),
+            vec![
+                RtpVideoApi::D3D11,
+                RtpVideoApi::D3D12,
+                RtpVideoApi::Software
+            ]
         );
     }
 

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -157,6 +157,7 @@ struct VideoLivenessState {
     last_decoded_ms: AtomicU64,
     last_sink_ms: AtomicU64,
     last_audio_ms: AtomicU64,
+    first_startup_audio_ms: AtomicU64,
     decoded_total: AtomicU64,
     sink_total: AtomicU64,
     zero_copy_d3d11: AtomicBool,
@@ -186,6 +187,7 @@ impl VideoLivenessState {
             last_decoded_ms: AtomicU64::new(0),
             last_sink_ms: AtomicU64::new(0),
             last_audio_ms: AtomicU64::new(0),
+            first_startup_audio_ms: AtomicU64::new(0),
             decoded_total: AtomicU64::new(0),
             sink_total: AtomicU64::new(0),
             zero_copy_d3d11: AtomicBool::new(false),
@@ -220,6 +222,7 @@ impl VideoLivenessState {
         self.framerate_mismatch_warned
             .store(false, Ordering::Relaxed);
         self.first_encoded_logged.store(false, Ordering::Relaxed);
+        self.first_startup_audio_ms.store(0, Ordering::Relaxed);
         self.startup_keyframe_requested
             .store(false, Ordering::Relaxed);
         self.startup_resync_requested
@@ -241,7 +244,16 @@ impl VideoLivenessState {
     }
 
     fn record_audio_buffer(&self) {
-        self.last_audio_ms.store(self.now_ms(), Ordering::Relaxed);
+        let now_ms = self.now_ms();
+        self.last_audio_ms.store(now_ms, Ordering::Relaxed);
+        if self.last_sink_ms.load(Ordering::Relaxed) == 0 {
+            let _ = self.first_startup_audio_ms.compare_exchange(
+                0,
+                now_ms,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+        }
     }
 
     fn log_first_encoded_once(&self) -> bool {
@@ -3553,10 +3565,15 @@ fn maybe_recover_video_startup(
 ) {
     let now_ms = state.now_ms();
     let last_audio_ms = state.last_audio_ms.load(Ordering::Relaxed);
+    let first_audio_ms = state.first_startup_audio_ms.load(Ordering::Relaxed);
     let last_encoded_ms = state.last_encoded_ms.load(Ordering::Relaxed);
-    if last_audio_ms == 0 || now_ms.saturating_sub(last_audio_ms) > VIDEO_STARTUP_KEYFRAME_MS {
+    if first_audio_ms == 0
+        || last_audio_ms == 0
+        || now_ms.saturating_sub(last_audio_ms) > VIDEO_STARTUP_KEYFRAME_MS
+    {
         return;
     }
+    let audio_active_ms = now_ms.saturating_sub(first_audio_ms);
 
     let decoded_total = state.decoded_total.load(Ordering::Relaxed);
     let sink_total = state.sink_total.load(Ordering::Relaxed);
@@ -3566,7 +3583,7 @@ fn maybe_recover_video_startup(
         format!("{}ms", now_ms.saturating_sub(last_encoded_ms))
     };
 
-    if now_ms >= VIDEO_STARTUP_KEYFRAME_MS
+    if audio_active_ms >= VIDEO_STARTUP_KEYFRAME_MS
         && !state
             .startup_keyframe_requested
             .swap(true, Ordering::Relaxed)
@@ -3575,20 +3592,20 @@ fn maybe_recover_video_startup(
             event_sender,
             "warn",
             format!(
-                "Native video startup has no rendered frame after {now_ms}ms while audio is active; encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Requesting keyframe."
+                "Native video startup has no rendered frame after {audio_active_ms}ms of active audio; startupAge={now_ms}ms encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Requesting keyframe."
             ),
         );
         request_upstream_key_unit(state, event_sender);
     }
 
-    if now_ms >= VIDEO_STARTUP_RESYNC_MS
+    if audio_active_ms >= VIDEO_STARTUP_RESYNC_MS
         && !state.startup_resync_requested.swap(true, Ordering::Relaxed)
     {
         send_log(
             event_sender,
             "warn",
             format!(
-                "Native video startup still has no rendered frame after {now_ms}ms while audio is active; encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Requesting keyframe and GStreamer latency resync."
+                "Native video startup still has no rendered frame after {audio_active_ms}ms of active audio; startupAge={now_ms}ms encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Requesting keyframe and GStreamer latency resync."
             ),
         );
         request_upstream_key_unit(state, event_sender);
@@ -3601,7 +3618,7 @@ fn maybe_recover_video_startup(
         }
     }
 
-    if now_ms >= VIDEO_STARTUP_PIPELINE_RESTART_MS
+    if audio_active_ms >= VIDEO_STARTUP_PIPELINE_RESTART_MS
         && !state
             .startup_pipeline_restart_requested
             .swap(true, Ordering::Relaxed)
@@ -3610,7 +3627,7 @@ fn maybe_recover_video_startup(
             event_sender,
             "warn",
             format!(
-                "Native video startup still has no rendered frame after {now_ms}ms while audio is active; encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Restarting the GStreamer pipeline to force video renegotiation."
+                "Native video startup still has no rendered frame after {audio_active_ms}ms of active audio; startupAge={now_ms}ms encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Restarting the GStreamer pipeline to force video renegotiation."
             ),
         );
         request_upstream_key_unit(state, event_sender);

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -42,6 +42,9 @@ const VIDEO_STALL_WARNING_MS: u64 = 2_500;
 const VIDEO_STALL_SECOND_ATTEMPT_MS: u64 = 5_000;
 const VIDEO_STALL_RESYNC_MS: u64 = 8_000;
 const VIDEO_STALL_MIN_KEYFRAME_REQUEST_MS: u64 = 2_000;
+const VIDEO_STARTUP_KEYFRAME_MS: u64 = 2_500;
+const VIDEO_STARTUP_RESYNC_MS: u64 = 5_000;
+const VIDEO_STARTUP_PIPELINE_RESTART_MS: u64 = 8_000;
 const VIDEO_LIVENESS_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 const HEARTBEAT_STOP_POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -153,11 +156,18 @@ struct VideoLivenessState {
     last_encoded_ms: AtomicU64,
     last_decoded_ms: AtomicU64,
     last_sink_ms: AtomicU64,
+    last_audio_ms: AtomicU64,
     decoded_total: AtomicU64,
     sink_total: AtomicU64,
     zero_copy_d3d11: AtomicBool,
     zero_copy_d3d12: AtomicBool,
     rtp_video_src_pad: Mutex<Option<gst::Pad>>,
+    requested_fps: AtomicU32,
+    framerate_mismatch_warned: AtomicBool,
+    first_encoded_logged: AtomicBool,
+    startup_keyframe_requested: AtomicBool,
+    startup_resync_requested: AtomicBool,
+    startup_pipeline_restart_requested: AtomicBool,
 }
 
 impl VideoLivenessState {
@@ -175,11 +185,18 @@ impl VideoLivenessState {
             last_encoded_ms: AtomicU64::new(0),
             last_decoded_ms: AtomicU64::new(0),
             last_sink_ms: AtomicU64::new(0),
+            last_audio_ms: AtomicU64::new(0),
             decoded_total: AtomicU64::new(0),
             sink_total: AtomicU64::new(0),
             zero_copy_d3d11: AtomicBool::new(false),
             zero_copy_d3d12: AtomicBool::new(false),
             rtp_video_src_pad: Mutex::new(None),
+            requested_fps: AtomicU32::new(0),
+            framerate_mismatch_warned: AtomicBool::new(false),
+            first_encoded_logged: AtomicBool::new(false),
+            startup_keyframe_requested: AtomicBool::new(false),
+            startup_resync_requested: AtomicBool::new(false),
+            startup_pipeline_restart_requested: AtomicBool::new(false),
         }
     }
 
@@ -199,6 +216,16 @@ impl VideoLivenessState {
         }
         self.target_bitrate_kbps
             .store(target_bitrate_kbps, Ordering::Relaxed);
+        self.requested_fps.store(settings.fps, Ordering::Relaxed);
+        self.framerate_mismatch_warned
+            .store(false, Ordering::Relaxed);
+        self.first_encoded_logged.store(false, Ordering::Relaxed);
+        self.startup_keyframe_requested
+            .store(false, Ordering::Relaxed);
+        self.startup_resync_requested
+            .store(false, Ordering::Relaxed);
+        self.startup_pipeline_restart_requested
+            .store(false, Ordering::Relaxed);
     }
 
     fn update_hardware_acceleration(&self, value: impl Into<String>) {
@@ -211,6 +238,14 @@ impl VideoLivenessState {
         self.last_encoded_ms.store(self.now_ms(), Ordering::Relaxed);
         self.encoded_bytes_total
             .fetch_add(size as u64, Ordering::Relaxed);
+    }
+
+    fn record_audio_buffer(&self) {
+        self.last_audio_ms.store(self.now_ms(), Ordering::Relaxed);
+    }
+
+    fn log_first_encoded_once(&self) -> bool {
+        !self.first_encoded_logged.swap(true, Ordering::Relaxed)
     }
 
     fn set_stats_overlay(&self, overlay: Option<gst::Element>) {
@@ -286,6 +321,15 @@ impl VideoLivenessState {
         }
     }
 
+    fn requested_fps(&self) -> Option<u32> {
+        let fps = self.requested_fps.load(Ordering::Relaxed);
+        (fps > 0).then_some(fps)
+    }
+
+    fn warn_framerate_mismatch_once(&self) -> bool {
+        !self.framerate_mismatch_warned.swap(true, Ordering::Relaxed)
+    }
+
     fn rtp_video_src_pad(&self) -> Option<gst::Pad> {
         self.rtp_video_src_pad
             .lock()
@@ -324,6 +368,10 @@ impl VideoLivenessMonitor {
 
     fn record_encoded_buffer(&self, size: usize) {
         self.state.record_encoded_buffer(size);
+    }
+
+    fn record_audio_buffer(&self) {
+        self.state.record_audio_buffer();
     }
 
     fn set_stats_overlay(&self, overlay: Option<gst::Element>) {
@@ -554,11 +602,11 @@ impl RtpVideoApi {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct RtpVideoChainSpec {
     factory: &'static str,
     role: RtpVideoChainRole,
-    caps: Option<&'static str>,
+    caps: Option<String>,
 }
 
 impl RtpVideoChainSpec {
@@ -570,11 +618,11 @@ impl RtpVideoChainSpec {
         }
     }
 
-    fn with_caps(factory: &'static str, role: RtpVideoChainRole, caps: &'static str) -> Self {
+    fn with_caps(factory: &'static str, role: RtpVideoChainRole, caps: impl Into<String>) -> Self {
         Self {
             factory,
             role,
-            caps: Some(caps),
+            caps: Some(caps.into()),
         }
     }
 }
@@ -2946,10 +2994,7 @@ fn wire_local_ice_events(
     };
 
     webrtc.connect("on-ice-candidate", false, move |values| {
-        let sdp_m_line_index = values
-            .get(1)
-            .and_then(|value| value.get::<u32>().ok())
-            .unwrap_or(0);
+        let sdp_m_line_index = values.get(1).and_then(glib_value_to_u32).unwrap_or(0);
         let candidate = values
             .get(2)
             .and_then(|value| value.get::<String>().ok())
@@ -2969,6 +3014,30 @@ fn wire_local_ice_events(
         None
     });
     Ok(())
+}
+
+fn glib_value_to_u32(value: &glib::Value) -> Option<u32> {
+    value
+        .get::<u32>()
+        .ok()
+        .or_else(|| {
+            value
+                .get::<i32>()
+                .ok()
+                .and_then(|value| u32::try_from(value).ok())
+        })
+        .or_else(|| {
+            value
+                .get::<u64>()
+                .ok()
+                .and_then(|value| u32::try_from(value).ok())
+        })
+        .or_else(|| {
+            value
+                .get::<i64>()
+                .ok()
+                .and_then(|value| u32::try_from(value).ok())
+        })
 }
 
 fn wire_webrtc_state_events(webrtc: &gst::Element, event_sender: Option<Sender<Event>>) {
@@ -3422,6 +3491,7 @@ fn run_video_liveness_watchdog(
 
         let last_sink_ms = state.last_sink_ms.load(Ordering::Relaxed);
         if last_sink_ms == 0 {
+            maybe_recover_video_startup(&state, &pipeline, &event_sender);
             continue;
         }
 
@@ -3472,6 +3542,100 @@ fn run_video_liveness_watchdog(
                     format!("Native video recovered after {stall_ms} ms."),
                 );
             }
+        }
+    }
+}
+
+fn maybe_recover_video_startup(
+    state: &VideoLivenessState,
+    pipeline: &gst::Pipeline,
+    event_sender: &Option<Sender<Event>>,
+) {
+    let now_ms = state.now_ms();
+    let last_audio_ms = state.last_audio_ms.load(Ordering::Relaxed);
+    let last_encoded_ms = state.last_encoded_ms.load(Ordering::Relaxed);
+    if last_audio_ms == 0 || now_ms.saturating_sub(last_audio_ms) > VIDEO_STARTUP_KEYFRAME_MS {
+        return;
+    }
+
+    let decoded_total = state.decoded_total.load(Ordering::Relaxed);
+    let sink_total = state.sink_total.load(Ordering::Relaxed);
+    let encoded_age = if last_encoded_ms == 0 {
+        "never".to_owned()
+    } else {
+        format!("{}ms", now_ms.saturating_sub(last_encoded_ms))
+    };
+
+    if now_ms >= VIDEO_STARTUP_KEYFRAME_MS
+        && !state
+            .startup_keyframe_requested
+            .swap(true, Ordering::Relaxed)
+    {
+        send_log(
+            event_sender,
+            "warn",
+            format!(
+                "Native video startup has no rendered frame after {now_ms}ms while audio is active; encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Requesting keyframe."
+            ),
+        );
+        request_upstream_key_unit(state, event_sender);
+    }
+
+    if now_ms >= VIDEO_STARTUP_RESYNC_MS
+        && !state.startup_resync_requested.swap(true, Ordering::Relaxed)
+    {
+        send_log(
+            event_sender,
+            "warn",
+            format!(
+                "Native video startup still has no rendered frame after {now_ms}ms while audio is active; encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Requesting keyframe and GStreamer latency resync."
+            ),
+        );
+        request_upstream_key_unit(state, event_sender);
+        if let Err(error) = pipeline.recalculate_latency() {
+            send_log(
+                event_sender,
+                "warn",
+                format!("Failed to resync GStreamer latency during native video startup recovery: {error}."),
+            );
+        }
+    }
+
+    if now_ms >= VIDEO_STARTUP_PIPELINE_RESTART_MS
+        && !state
+            .startup_pipeline_restart_requested
+            .swap(true, Ordering::Relaxed)
+    {
+        send_log(
+            event_sender,
+            "warn",
+            format!(
+                "Native video startup still has no rendered frame after {now_ms}ms while audio is active; encodedAge={encoded_age} decoded={decoded_total} sink={sink_total}. Restarting the GStreamer pipeline to force video renegotiation."
+            ),
+        );
+        request_upstream_key_unit(state, event_sender);
+        match pipeline.set_state(gst::State::Ready) {
+            Ok(_) => match pipeline.set_state(gst::State::Playing) {
+                Ok(_) => send_log(
+                    event_sender,
+                    "warn",
+                    "Restarted native GStreamer pipeline during video startup recovery.".to_owned(),
+                ),
+                Err(error) => send_log(
+                    event_sender,
+                    "warn",
+                    format!(
+                        "Failed to restore native GStreamer pipeline to Playing during video startup recovery: {error:?}."
+                    ),
+                ),
+            },
+            Err(error) => send_log(
+                event_sender,
+                "warn",
+                format!(
+                    "Failed to set native GStreamer pipeline to Ready during video startup recovery: {error:?}."
+                ),
+            ),
         }
     }
 }
@@ -4057,6 +4221,7 @@ fn rtp_video_parser_factory(codec: &str) -> Option<&'static str> {
 fn rtp_video_chain_definition(
     encoding: &str,
     video_api: RtpVideoApi,
+    requested_fps: Option<u32>,
 ) -> Option<Vec<RtpVideoChainSpec>> {
     let codec = encoding.to_ascii_uppercase();
     let mut specs = vec![
@@ -4079,7 +4244,7 @@ fn rtp_video_chain_definition(
         specs.push(RtpVideoChainSpec::with_caps(
             "capsfilter",
             RtpVideoChainRole::PostDecodeCapsFilter,
-            memory_caps,
+            memory_caps_with_framerate(memory_caps, requested_fps),
         ));
     }
     if let Some(converter) = video_api.post_decode_converter_factory() {
@@ -4104,6 +4269,13 @@ fn rtp_video_chain_definition(
     ));
 
     Some(specs)
+}
+
+fn memory_caps_with_framerate(memory_caps: &str, requested_fps: Option<u32>) -> String {
+    match requested_fps.filter(|fps| *fps > 0) {
+        Some(fps) => format!("{memory_caps},framerate=(fraction){fps}/1"),
+        None => memory_caps.to_owned(),
+    }
 }
 
 fn preferred_rtp_video_apis() -> Vec<RtpVideoApi> {
@@ -4172,14 +4344,17 @@ fn default_rtp_video_api_priority() -> Vec<RtpVideoApi> {
     }
 }
 
-fn rtp_video_chain_specs(encoding: &str) -> Option<(RtpVideoApi, Vec<RtpVideoChainSpec>)> {
+fn rtp_video_chain_specs(
+    encoding: &str,
+    requested_fps: Option<u32>,
+) -> Option<(RtpVideoApi, Vec<RtpVideoChainSpec>)> {
     preferred_rtp_video_apis()
         .into_iter()
         .find_map(|video_api| {
             let codec = encoding.to_ascii_uppercase();
             let decoder = select_decoder_factory(video_api, codec.as_str())?;
             let sink = select_sink_factory(video_api)?;
-            let mut specs = rtp_video_chain_definition(encoding, video_api)?;
+            let mut specs = rtp_video_chain_definition(encoding, video_api, requested_fps)?;
             for spec in &mut specs {
                 if spec.role == RtpVideoChainRole::Decoder {
                     spec.factory = decoder;
@@ -4317,7 +4492,7 @@ fn native_video_codec_capability(
     let decoder = platform_supported
         .then(|| select_decoder_factory(video_api, codec))
         .flatten();
-    let definition = rtp_video_chain_definition(codec, video_api);
+    let definition = rtp_video_chain_definition(codec, video_api, None);
     let available = platform_supported
         && sink.is_some()
         && decoder.is_some()
@@ -4408,7 +4583,11 @@ fn configure_rtp_video_chain_element(
             set_property_if_supported(element, "qos", false);
         }
         RtpVideoChainRole::PostDecodeCapsFilter => {
-            if let Some(caps) = spec.caps.and_then(|caps| caps.parse::<gst::Caps>().ok()) {
+            if let Some(caps) = spec
+                .caps
+                .as_deref()
+                .and_then(|caps| caps.parse::<gst::Caps>().ok())
+            {
                 element.set_property("caps", &caps);
             }
         }
@@ -4451,7 +4630,8 @@ fn link_rtp_video_pad(
         return Ok(());
     }
 
-    let (video_api, specs) = rtp_video_chain_specs(encoding).ok_or_else(|| {
+    let requested_fps = video_liveness.state.requested_fps();
+    let (video_api, specs) = rtp_video_chain_specs(encoding, requested_fps).ok_or_else(|| {
         format!(
             "Explicit low-latency decode chain is unavailable for RTP {encoding}; install the platform GStreamer plugin packages or set {NATIVE_VIDEO_BACKEND_ENV}=software to force software decode."
         )
@@ -4467,11 +4647,7 @@ fn link_rtp_video_pad(
             format_video_chain_selection(encoding, video_api, &specs),
         );
         if video_api == RtpVideoApi::D3D12 {
-            send_log(
-                event_sender,
-                "warn",
-                "Native D3D12 zero-copy video path is experimental and opt-in; if the visible frame freezes while sink/render counters keep increasing, use the default D3D11 path.".to_owned(),
-            );
+            send_log(event_sender, "warn", format_d3d12_selection_warning());
         }
         if d3d_fullscreen_sink {
             send_log(
@@ -4484,7 +4660,12 @@ fn link_rtp_video_pad(
         }
         for spec in &specs {
             let element = make_element(spec.factory)?;
-            configure_rtp_video_chain_element(&element, *spec, video_api, d3d_fullscreen_sink);
+            configure_rtp_video_chain_element(
+                &element,
+                spec.clone(),
+                video_api,
+                d3d_fullscreen_sink,
+            );
             if spec.role == RtpVideoChainRole::StatsOverlay {
                 video_liveness.set_stats_overlay(Some(element.clone()));
             }
@@ -4519,7 +4700,7 @@ fn link_rtp_video_pad(
             .link(&first_sink_pad)
             .map_err(|error| format!("Failed to link RTP {encoding} video pad: {error:?}"))?;
         video_liveness.set_rtp_video_src_pad(src_pad);
-        watch_rtp_video_bitrate(src_pad, video_liveness.clone());
+        watch_rtp_video_bitrate(src_pad, video_liveness.clone(), event_sender);
 
         let sink = elements
             .last()
@@ -4595,7 +4776,7 @@ fn format_video_chain_selection(
     let memory = specs
         .iter()
         .find(|spec| spec.role == RtpVideoChainRole::PostDecodeCapsFilter)
-        .and_then(|spec| spec.caps)
+        .and_then(|spec| spec.caps.as_deref())
         .unwrap_or("system-memory");
     let acceleration = if video_api.is_gpu_path() {
         "hardware"
@@ -4606,6 +4787,28 @@ fn format_video_chain_selection(
     format!(
         "Selected native {acceleration} video path for RTP {encoding}: backend={}, decoder={decoder}, converter={converter}, renderer={sink}, memory={memory}.",
         video_api.label()
+    )
+}
+
+fn format_d3d12_selection_warning() -> String {
+    let backend_env = std::env::var(NATIVE_VIDEO_BACKEND_ENV).ok();
+    let api_env = std::env::var(NATIVE_VIDEO_API_ENV).ok();
+    let reason = if backend_env
+        .as_deref()
+        .is_some_and(|value| value.eq_ignore_ascii_case("d3d12"))
+    {
+        format!("forced by {NATIVE_VIDEO_BACKEND_ENV}=d3d12")
+    } else if api_env
+        .as_deref()
+        .is_some_and(|value| value.eq_ignore_ascii_case("d3d12"))
+    {
+        format!("forced by {NATIVE_VIDEO_API_ENV}=d3d12")
+    } else {
+        "D3D11 was unavailable/probe failed after D3D11-first selection; if this build still prefers D3D12 by default, it is stale".to_owned()
+    };
+
+    format!(
+        "Native D3D12 zero-copy video path is experimental and opt-in; selection reason: {reason}. This build defaults Windows native video to D3D11; env {NATIVE_VIDEO_BACKEND_ENV}={backend_env:?}, {NATIVE_VIDEO_API_ENV}={api_env:?}. If the visible frame freezes while sink/render counters keep increasing, use the default D3D11 path."
     )
 }
 
@@ -4757,6 +4960,9 @@ fn link_media_chain(
             }
         }
         watch_first_sink_buffer(sink, media_label, event_sender, streaming_reported);
+        if media_label == "audio" {
+            watch_audio_activity(sink, video_liveness);
+        }
         if media_label == "video" {
             if let Some(video_liveness) = video_liveness {
                 watch_video_sink_rate(sink, event_sender, Some(video_liveness.clone()));
@@ -4772,6 +4978,17 @@ fn link_media_chain(
     }
 
     Ok(())
+}
+
+fn watch_audio_activity(sink: &gst::Element, video_liveness: &VideoLivenessMonitor) {
+    let Some(sink_pad) = sink.static_pad("sink") else {
+        return;
+    };
+    let monitor = video_liveness.clone();
+    sink_pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, _info| {
+        monitor.record_audio_buffer();
+        gst::PadProbeReturn::Ok
+    });
 }
 
 fn watch_first_sink_buffer(
@@ -4821,10 +5038,25 @@ fn watch_first_sink_buffer(
     });
 }
 
-fn watch_rtp_video_bitrate(pad: &gst::Pad, video_liveness: VideoLivenessMonitor) {
+fn watch_rtp_video_bitrate(
+    pad: &gst::Pad,
+    video_liveness: VideoLivenessMonitor,
+    event_sender: &Option<Sender<Event>>,
+) {
+    let sender = event_sender.clone();
     pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, info| {
         if let Some(buffer) = info.buffer() {
             video_liveness.record_encoded_buffer(buffer.size());
+            if video_liveness.state.log_first_encoded_once() {
+                send_log(
+                    &sender,
+                    "info",
+                    format!(
+                        "First encoded RTP video buffer arrived; size={} bytes.",
+                        buffer.size()
+                    ),
+                );
+            }
         }
         gst::PadProbeReturn::Ok
     });
@@ -4988,6 +5220,28 @@ fn watch_video_pad_rate(
             }
             let caps_framerate =
                 caps_framerate_summary(&caps).unwrap_or_else(|| "unknown".to_owned());
+            let requested_fps = video_liveness
+                .as_ref()
+                .and_then(|(monitor, _)| monitor.state.requested_fps());
+            let requested_fps_summary = requested_fps
+                .map(|fps| format!("; requestedFps={fps}"))
+                .unwrap_or_default();
+            if let (Some((monitor, _)), Some(requested_fps), Some(caps_framerate_value)) = (
+                video_liveness.as_ref(),
+                requested_fps,
+                caps_framerate_summary(&caps),
+            ) {
+                let expected = format!("{requested_fps}/1");
+                if caps_framerate_value != expected && monitor.state.warn_framerate_mismatch_once() {
+                    send_log(
+                        &sender,
+                        "warn",
+                        format!(
+                            "Native video caps framerate {caps_framerate_value} does not match requestedFps={requested_fps}; this can destabilize high-FPS native playback scheduling and buffer pools."
+                        ),
+                    );
+                }
+            }
             let sink_stats = sink
                 .as_ref()
                 .map(|sink| format!("; {}", sink_stats_summary(sink)))
@@ -4997,7 +5251,7 @@ fn watch_video_pad_rate(
                 &sender,
                 "debug",
                 format!(
-                    "{label}: {fps:.1} fps; capsFramerate={caps_framerate}; memoryMode={memory_mode}; zeroCopy={zero_copy}; zeroCopyD3D11={zero_copy_d3d11}; zeroCopyD3D12={zero_copy_d3d12}{sink_stats}."
+                    "{label}: {fps:.1} fps; capsFramerate={caps_framerate}{requested_fps_summary}; memoryMode={memory_mode}; zeroCopy={zero_copy}; zeroCopyD3D11={zero_copy_d3d11}; zeroCopyD3D12={zero_copy_d3d12}{sink_stats}."
                 ),
             );
 
@@ -5639,24 +5893,31 @@ mod tests {
     #[test]
     fn maps_rtp_video_codecs_to_explicit_gpu_decode_chains() {
         let h265 =
-            rtp_video_chain_definition("H265", RtpVideoApi::D3D11).expect("H265 D3D11 chain");
+            rtp_video_chain_definition("H265", RtpVideoApi::D3D11, None).expect("H265 D3D11 chain");
         assert_eq!(h265[0].factory, "rtph265depay");
         assert_eq!(h265[3].factory, "d3d11h265dec");
         assert_eq!(h265[4].factory, "capsfilter");
-        assert_eq!(h265[4].caps, Some("video/x-raw(memory:D3D11Memory)"));
+        assert_eq!(
+            h265[4].caps.as_deref(),
+            Some("video/x-raw(memory:D3D11Memory)")
+        );
         assert_eq!(h265[5].factory, "dwritetextoverlay");
         assert_eq!(h265[7].factory, "d3d11videosink");
 
         let h264 =
-            rtp_video_chain_definition("h264", RtpVideoApi::D3D12).expect("H264 D3D12 chain");
+            rtp_video_chain_definition("h264", RtpVideoApi::D3D12, None).expect("H264 D3D12 chain");
         assert_eq!(h264[0].factory, "rtph264depay");
         assert_eq!(h264[3].factory, "d3d12h264dec");
         assert_eq!(h264[4].factory, "capsfilter");
-        assert_eq!(h264[4].caps, Some("video/x-raw(memory:D3D12Memory)"));
+        assert_eq!(
+            h264[4].caps.as_deref(),
+            Some("video/x-raw(memory:D3D12Memory)")
+        );
         assert_eq!(h264[5].factory, "dwritetextoverlay");
         assert_eq!(h264[7].factory, "d3d12videosink");
 
-        let av1 = rtp_video_chain_definition("AV1", RtpVideoApi::D3D11).expect("AV1 D3D11 chain");
+        let av1 =
+            rtp_video_chain_definition("AV1", RtpVideoApi::D3D11, None).expect("AV1 D3D11 chain");
         assert_eq!(av1[0].factory, "rtpav1depay");
         assert_eq!(av1[3].factory, "d3d11av1dec");
         assert_eq!(av1[4].factory, "capsfilter");
@@ -5665,33 +5926,58 @@ mod tests {
     }
 
     #[test]
+    fn adds_requested_fps_to_d3d_memory_caps() {
+        let d3d11 = rtp_video_chain_definition("H265", RtpVideoApi::D3D11, Some(240))
+            .expect("H265 D3D11 chain");
+        assert_eq!(
+            d3d11[4].caps.as_deref(),
+            Some("video/x-raw(memory:D3D11Memory),framerate=(fraction)240/1")
+        );
+
+        let d3d12 = rtp_video_chain_definition("H264", RtpVideoApi::D3D12, Some(240))
+            .expect("H264 D3D12 chain");
+        assert_eq!(
+            d3d12[4].caps.as_deref(),
+            Some("video/x-raw(memory:D3D12Memory),framerate=(fraction)240/1")
+        );
+
+        let without_fps = rtp_video_chain_definition("H264", RtpVideoApi::D3D12, Some(0))
+            .expect("H264 D3D12 chain");
+        assert_eq!(
+            without_fps[4].caps.as_deref(),
+            Some("video/x-raw(memory:D3D12Memory)")
+        );
+    }
+
+    #[test]
     fn maps_cross_platform_video_paths_to_expected_decoders() {
-        let vt =
-            rtp_video_chain_definition("H264", RtpVideoApi::VideoToolbox).expect("VideoToolbox");
+        let vt = rtp_video_chain_definition("H264", RtpVideoApi::VideoToolbox, None)
+            .expect("VideoToolbox");
         assert_eq!(vt[3].factory, "vtdec_hw");
         assert!(vt.iter().any(|spec| spec.factory == "videoconvert"));
         assert_eq!(vt.last().map(|spec| spec.factory), Some("glimagesink"));
         assert!(!vt.iter().any(|spec| spec.factory == "capsfilter"));
 
-        let vaapi = rtp_video_chain_definition("AV1", RtpVideoApi::Vaapi).expect("VAAPI AV1");
+        let vaapi = rtp_video_chain_definition("AV1", RtpVideoApi::Vaapi, None).expect("VAAPI AV1");
         assert_eq!(vaapi[3].factory, "vaav1dec");
         assert!(vaapi.iter().any(|spec| spec.factory == "videoconvert"));
         assert_eq!(vaapi.last().map(|spec| spec.factory), Some("glimagesink"));
 
-        let v4l2 = rtp_video_chain_definition("H265", RtpVideoApi::V4L2).expect("V4L2 H265");
+        let v4l2 = rtp_video_chain_definition("H265", RtpVideoApi::V4L2, None).expect("V4L2 H265");
         assert_eq!(v4l2[3].factory, "v4l2slh265dec");
         assert!(v4l2.iter().any(|spec| spec.factory == "videoconvert"));
 
-        let vulkan = rtp_video_chain_definition("H265", RtpVideoApi::Vulkan).expect("Vulkan H265");
+        let vulkan =
+            rtp_video_chain_definition("H265", RtpVideoApi::Vulkan, None).expect("Vulkan H265");
         assert_eq!(vulkan[3].factory, "vulkanh265dec");
         assert!(vulkan
             .iter()
             .any(|spec| spec.factory == "vulkancolorconvert"));
         assert_eq!(vulkan.last().map(|spec| spec.factory), Some("vulkansink"));
-        assert!(rtp_video_chain_definition("AV1", RtpVideoApi::Vulkan).is_none());
+        assert!(rtp_video_chain_definition("AV1", RtpVideoApi::Vulkan, None).is_none());
 
         let software =
-            rtp_video_chain_definition("H264", RtpVideoApi::Software).expect("software H264");
+            rtp_video_chain_definition("H264", RtpVideoApi::Software, None).expect("software H264");
         assert_eq!(software[3].factory, "avdec_h264");
         assert!(software.iter().any(|spec| spec.factory == "videoconvert"));
         assert_eq!(
@@ -5716,7 +6002,7 @@ mod tests {
     #[test]
     fn formats_selected_video_chain_diagnostics() {
         let specs =
-            rtp_video_chain_definition("H264", RtpVideoApi::Software).expect("software H264");
+            rtp_video_chain_definition("H264", RtpVideoApi::Software, None).expect("software H264");
         let message = format_video_chain_selection("H264", RtpVideoApi::Software, &specs);
 
         assert!(message.contains("backend=software"));

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -4961,7 +4961,9 @@ fn link_media_chain(
         }
         watch_first_sink_buffer(sink, media_label, event_sender, streaming_reported);
         if media_label == "audio" {
-            watch_audio_activity(sink, video_liveness);
+            if let Some(video_liveness) = video_liveness {
+                watch_audio_activity(sink, video_liveness);
+            }
         }
         if media_label == "video" {
             if let Some(video_liveness) = video_liveness {

--- a/native/opennow-streamer/src/sdp.rs
+++ b/native/opennow-streamer/src/sdp.rs
@@ -640,8 +640,8 @@ pub fn build_nvst_sdp(params: &NvstParams) -> String {
         "a=vqos.fec.repairMinPercent:5".to_owned(),
         "a=vqos.fec.repairPercent:5".to_owned(),
         "a=vqos.fec.repairMaxPercent:35".to_owned(),
+        "a=vqos.dynamicStreamingMode:0".to_owned(),
         "a=vqos.drc.enable:0".to_owned(),
-        "a=vqos.dfc.enable:0".to_owned(),
         "a=video.dx9EnableNv12:1".to_owned(),
         "a=video.dx9EnableHdr:1".to_owned(),
         "a=vqos.qpg.enable:1".to_owned(),
@@ -656,6 +656,21 @@ pub fn build_nvst_sdp(params: &NvstParams) -> String {
 
     if is_high_fps {
         lines.extend([
+            "a=vqos.dfc.enable:1".to_owned(),
+            "a=vqos.dfc.decodeFpsAdjPercent:85".to_owned(),
+            "a=vqos.dfc.targetDownCooldownMs:250".to_owned(),
+            format!(
+                "a=vqos.dfc.dfcAlgoVersion:{}",
+                if is_120_fps || is_240_fps { 2 } else { 1 }
+            ),
+            format!(
+                "a=vqos.dfc.minTargetFps:{}",
+                if is_120_fps || is_240_fps { 100 } else { 60 }
+            ),
+            "a=vqos.resControl.dfc.useClientFpsPerf:0".to_owned(),
+            "a=vqos.dfc.adjustResAndFps:0".to_owned(),
+        ]);
+        lines.extend([
             "a=bwe.iirFilterFactor:8".to_owned(),
             "a=video.encoderFeatureSetting:47".to_owned(),
             "a=video.encoderPreset:6".to_owned(),
@@ -669,6 +684,11 @@ pub fn build_nvst_sdp(params: &NvstParams) -> String {
                 "a=vqos.resControl.cpmRtc.serverResolutionUpdateCoolDownCount:{}",
                 if is_120_fps { 6000 } else { 12000 }
             ),
+        ]);
+    } else {
+        lines.extend([
+            "a=vqos.dfc.enable:0".to_owned(),
+            "a=vqos.dfc.adjustResAndFps:0".to_owned(),
         ]);
     }
 
@@ -976,6 +996,52 @@ mod tests {
         assert!(nvst.contains("a=general.dtlsFingerprint:CC:DD"));
         assert!(!nvst.contains("remote-password"));
         assert!(!nvst.contains("video-password"));
+    }
+
+    fn nvst_params_for_fps(fps: u32) -> NvstParams {
+        NvstParams {
+            width: 1920,
+            height: 1080,
+            fps,
+            max_bitrate_kbps: 75_000,
+            partial_reliable_threshold_ms: 16,
+            codec: VideoCodec::H265,
+            color_quality: ColorQuality::EightBit420,
+            credentials: IceCredentials {
+                ufrag: "user".to_owned(),
+                pwd: "password".to_owned(),
+                fingerprint: "AA:BB".to_owned(),
+            },
+            hid_device_mask: None,
+            enable_partially_reliable_transfer_gamepad: None,
+            enable_partially_reliable_transfer_hid: None,
+        }
+    }
+
+    #[test]
+    fn builds_nvst_sdp_disables_dynamic_streaming_for_normal_fps() {
+        let nvst = build_nvst_sdp(&nvst_params_for_fps(60));
+
+        assert!(nvst.contains("a=vqos.dynamicStreamingMode:0"));
+        assert!(nvst.contains("a=vqos.dfc.adjustResAndFps:0"));
+        assert!(nvst.contains("a=vqos.dfc.enable:0"));
+        assert!(!nvst.contains("a=vqos.dfc.decodeFpsAdjPercent:85"));
+        assert!(!nvst.contains("a=vqos.resControl.dfc.useClientFpsPerf:0"));
+    }
+
+    #[test]
+    fn builds_nvst_sdp_disables_dynamic_streaming_for_high_fps() {
+        for fps in [120, 240] {
+            let nvst = build_nvst_sdp(&nvst_params_for_fps(fps));
+
+            assert!(nvst.contains("a=vqos.dynamicStreamingMode:0"));
+            assert!(nvst.contains("a=vqos.dfc.adjustResAndFps:0"));
+            assert!(nvst.contains("a=vqos.dfc.enable:1"));
+            assert!(nvst.contains("a=vqos.resControl.dfc.useClientFpsPerf:0"));
+            assert!(nvst.contains("a=vqos.dfc.dfcAlgoVersion:2"));
+            assert!(nvst.contains("a=vqos.dfc.minTargetFps:100"));
+            assert!(!nvst.contains("a=vqos.dfc.enable:0"));
+        }
     }
 
     #[test]

--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -60,10 +60,10 @@ function configureGstreamerSdk(env) {
     ].filter(Boolean);
     const sdk = candidates
       .map((root) => {
-        const pkgConfig = join(root, "bin", "pkg-config.exe");
-        const pkgconf = join(root, "bin", "pkgconf.exe");
         const pkgConfigFile = join(root, "lib", "pkgconfig", "gstreamer-1.0.pc");
-        const pkgConfigBinary = existsSync(pkgConfig) ? pkgConfig : existsSync(pkgconf) ? pkgconf : null;
+        const pkgConfigBinary = ["pkg-config.exe", "pkgconf.exe"]
+          .map((name) => join(root, "bin", name))
+          .find((path) => existsSync(path));
         return { root, pkgConfigBinary, pkgConfigFile };
       })
       .find((candidate) => candidate.pkgConfigBinary && existsSync(candidate.pkgConfigFile));
@@ -82,6 +82,7 @@ function configureGstreamerSdk(env) {
     env.PKG_CONFIG_PATH = env.PKG_CONFIG_PATH ? `${pkgConfigDir}${delimiter}${env.PKG_CONFIG_PATH}` : pkgConfigDir;
     prependEnvPath(env, join(sdk.root, "bin"));
     console.log(`Configured GStreamer SDK: ${sdk.root}`);
+    console.log(`Configured pkg-config executable: ${sdk.pkgConfigBinary}`);
     return sdk.root;
   }
 

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -492,12 +492,27 @@ export function buildNvstSdp(params: NvstParams): string {
     "a=vqos.fec.repairMinPercent:5",
     "a=vqos.fec.repairPercent:5",
     "a=vqos.fec.repairMaxPercent:35",
-    // DRC — always disabled to allow full bitrate
+    // Official dynamicStreamingMode=0 path disables server resolution/FPS switching.
+    "a=vqos.dynamicStreamingMode:0",
     "a=vqos.drc.enable:0",
   ];
 
-  // Force-disable dynamic frame control to avoid server-side FPS/resolution adaptation.
-  lines.push("a=vqos.dfc.enable:0");
+  if (isHighFps) {
+    lines.push(
+      "a=vqos.dfc.enable:1",
+      "a=vqos.dfc.decodeFpsAdjPercent:85",
+      "a=vqos.dfc.targetDownCooldownMs:250",
+      `a=vqos.dfc.dfcAlgoVersion:${is120Fps || is240Fps ? 2 : 1}`,
+      `a=vqos.dfc.minTargetFps:${is120Fps || is240Fps ? 100 : 60}`,
+      "a=vqos.resControl.dfc.useClientFpsPerf:0",
+      "a=vqos.dfc.adjustResAndFps:0",
+    );
+  } else {
+    lines.push(
+      "a=vqos.dfc.enable:0",
+      "a=vqos.dfc.adjustResAndFps:0",
+    );
+  }
 
   // Video encoder settings
   lines.push(
@@ -542,7 +557,7 @@ export function buildNvstSdp(params: NvstParams): string {
     }
   }
 
-  // Out-of-focus handling + disable ALL dynamic resolution control
+  // Out-of-focus handling + disable CPM-based resolution changes
   lines.push(
     "a=vqos.adjustStreamingFpsDuringOutOfFocus:1",
     "a=vqos.resControl.cpmRtc.ignoreOutOfFocusWindowState:1",


### PR DESCRIPTION
## Summary

This PR adds the official `a=vqos.dynamicStreamingMode:0` attribute to NVST SDP builders to hard-disable server-side resolution/FPS switching that was causing random native stream freezes. The official GeForce NOW client defaults this to mode 3 (adaptive), so we must explicitly advertise mode 0.

- Add `a=vqos.dynamicStreamingMode:0` and `a=vqos.dfc.adjustResAndFps:0` to both TS and Rust `buildNvstSdp` (web and native).
- Split DFC handling by FPS: normal FPS (60) gets `a=vqos.dfc.enable:0`; high FPS (90+) gets `a=vqos.dfc.enable:1` with official guard tuning but `adjustResAndFps:0` to preserve stability.
- Add Rust tests asserting `dynamicStreamingMode:0` presence and correct DFC state for 60/120/240 FPS.
- Update comments to reflect the official hard-off path.

## Test plan
- [x] Run `cargo test sdp` in `native/opennow-streamer`
- [x] Run `cargo fmt --check`
- [x] Run `git diff --check`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/2148a78d-26bf-45fd-9b08-f9f6d8ec3107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-085" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/2148a78d-26bf-45fd-9b08-f9f6d8ec3107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-085&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-085"><img alt="OPE-085" src="https://capy.ai/api/badge/thread.svg?label=OPE-085"></picture></a>
<!-- capy-pr-badge:end -->