### PR TITLE
feat(stable): experimental Sony controller gyro support via WebHID

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -497,6 +497,7 @@ function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: stri
   const bitDepth = colorQualityBitDepth(cq);
   const chromaFormat = colorQualityChromaFormat(cq);
   const accountLinked = input.accountLinked ?? true;
+  const sonyHidEnabled = input.settings.experimentalGamepadGyro === true;
 
   return {
     sessionRequestData: {
@@ -550,7 +551,7 @@ function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: stri
           }
         : null,
       surroundAudioInfo: 0,
-      remoteControllersBitmap: 0,
+      remoteControllersBitmap: sonyHidEnabled ? 1 : 0,
       clientTimezoneOffset: timezoneOffsetMs(),
       enhancedStreamMode: 1,
       appLaunchMode: 1,
@@ -566,7 +567,7 @@ function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: stri
         enabledL4S: input.settings.enableL4S,
         mouseMovementFlags: 0,
         trueHdr: hdrEnabled,
-        supportedHidDevices: 0,
+        supportedHidDevices: sonyHidEnabled ? 3 : 0,
         profile: 0,
         fallbackToLogicalResolution: false,
         hidDevices: null,

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -2272,19 +2272,24 @@ app.whenReady().then(async () => {
   }
 
   // Set up permission handlers for getUserMedia, fullscreen, pointer lock
-  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
-    const allowedPermissions = new Set([
-      "media",
-      "microphone",
-      "fullscreen",
-      "automatic-fullscreen",
-      "pointerLock",
-      "keyboardLock",
-      "speaker-selection",
-      "hid",
-    ]);
+  const isExperimentalGamepadGyroEnabled = (): boolean => settingsManager.get("experimentalGamepadGyro") === true;
+  const allowedNonHidPermissions = new Set([
+    "media",
+    "microphone",
+    "fullscreen",
+    "automatic-fullscreen",
+    "pointerLock",
+    "keyboardLock",
+    "speaker-selection",
+  ]);
 
-    if (allowedPermissions.has(permission)) {
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+    if ((permission as string) === "hid") {
+      callback(isExperimentalGamepadGyroEnabled());
+      return;
+    }
+
+    if (allowedNonHidPermissions.has(permission)) {
       callback(true);
       return;
     }
@@ -2293,25 +2298,21 @@ app.whenReady().then(async () => {
   });
 
   session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
-    const allowedPermissions = new Set([
-      "media",
-      "microphone",
-      "fullscreen",
-      "automatic-fullscreen",
-      "pointerLock",
-      "keyboardLock",
-      "speaker-selection",
-      "hid",
-    ]);
+    if ((permission as string) === "hid") {
+      return isExperimentalGamepadGyroEnabled();
+    }
 
-    return allowedPermissions.has(permission);
+    return allowedNonHidPermissions.has(permission);
   });
 
   session.defaultSession.setDevicePermissionHandler((details) => {
-    return details.deviceType === "hid" && details.device.vendorId === 0x054c;
+    return isExperimentalGamepadGyroEnabled() && details.deviceType === "hid" && details.device.vendorId === 0x054c;
   });
 
   session.defaultSession.on("select-hid-device", (event, details, callback) => {
+    if (!isExperimentalGamepadGyroEnabled()) {
+      return;
+    }
     const sonyDevice = details.deviceList.find((device) => device.vendorId === 0x054c);
     if (sonyDevice) {
       event.preventDefault();

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -1622,7 +1622,7 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(IPC_CHANNELS.SETTINGS_SET, async <K extends keyof Settings>(_event: Electron.IpcMainInvokeEvent, key: K, value: Settings[K]) => {
-    settingsManager.set(key, value);
+    settingsManager.set(key as keyof import("./settings").Settings, value as import("./settings").Settings[keyof import("./settings").Settings]);
     // React to certain setting changes immediately in main process
     try {
       if (key === "autoCheckForUpdates") {
@@ -2281,6 +2281,7 @@ app.whenReady().then(async () => {
       "pointerLock",
       "keyboardLock",
       "speaker-selection",
+      "hid",
     ]);
 
     if (allowedPermissions.has(permission)) {
@@ -2300,9 +2301,22 @@ app.whenReady().then(async () => {
       "pointerLock",
       "keyboardLock",
       "speaker-selection",
+      "hid",
     ]);
 
     return allowedPermissions.has(permission);
+  });
+
+  session.defaultSession.setDevicePermissionHandler((details) => {
+    return details.deviceType === "hid" && details.device.vendorId === 0x054c;
+  });
+
+  session.defaultSession.on("select-hid-device", (event, details, callback) => {
+    const sonyDevice = details.deviceList.find((device) => device.vendorId === 0x054c);
+    if (sonyDevice) {
+      event.preventDefault();
+      callback(sonyDevice.deviceId);
+    }
   });
 
   registerOpenNowMediaProtocol();

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -104,6 +104,8 @@ export interface Settings {
   enableL4S: boolean;
   /** Request Cloud G-Sync / Variable Refresh Rate on new sessions */
   enableCloudGsync: boolean;
+  /** Experimental Sony controller gyro support over WebHID */
+  experimentalGamepadGyro: boolean;
   /** Show the currently streaming game as Discord Rich Presence activity */
   discordRichPresence: boolean;
   /** Automatically check GitHub Releases for app updates in the background */
@@ -187,6 +189,7 @@ const DEFAULT_SETTINGS: Settings = {
   gameLanguage: "en_US",
   enableL4S: false,
   enableCloudGsync: false,
+  experimentalGamepadGyro: false,
   discordRichPresence: false,
   autoCheckForUpdates: true,
   allowEscapeToExitFullscreen: false,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -44,6 +44,7 @@ import {
   type StreamDiagnostics,
   type StreamTimeWarning,
 } from "./gfn/webrtcClient";
+import { requestSonyGamepadHidAccess } from "./gfn/gamepadMotion";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
 import { useControllerNavigation } from "./controllerNavigation";
 import { useElapsedSeconds } from "./utils/useElapsedSeconds";
@@ -935,6 +936,7 @@ export function App(): JSX.Element {
     gameLanguage: "en_US",
     enableL4S: false,
     enableCloudGsync: false,
+    experimentalGamepadGyro: false,
     discordRichPresence: false,
     autoCheckForUpdates: true,
   });
@@ -2444,6 +2446,13 @@ export function App(): JSX.Element {
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {
     setSettings((prev) => ({ ...prev, [key]: value }));
+    if (key === "experimentalGamepadGyro" && value) {
+      try {
+        void requestSonyGamepadHidAccess((line) => console.log(`[WebHID] ${line}`));
+      } catch {
+        // ignore
+      }
+    }
     if (settingsLoaded) {
       await window.openNow.setSetting(key, value);
     }
@@ -2472,6 +2481,13 @@ export function App(): JSX.Element {
     if (key === "maxBitrateMbps") {
       try {
         void (clientRef.current as any)?.setMaxBitrateKbps?.((value as number) * 1000);
+      } catch {
+        // ignore
+      }
+    }
+    if (key === "experimentalGamepadGyro") {
+      try {
+        clientRef.current?.setExperimentalGamepadGyroEnabled(Boolean(value));
       } catch {
         // ignore
       }
@@ -3025,6 +3041,7 @@ export function App(): JSX.Element {
             gameLanguage: settings.gameLanguage,
             enableL4S: settings.enableL4S,
             enableCloudGsync: settings.enableCloudGsync,
+                experimentalGamepadGyro: settings.experimentalGamepadGyro,
           },
         });
 
@@ -3185,6 +3202,7 @@ export function App(): JSX.Element {
               gameLanguage: settings.gameLanguage,
               enableL4S: settings.enableL4S,
               enableCloudGsync: settings.enableCloudGsync,
+                experimentalGamepadGyro: settings.experimentalGamepadGyro,
             },
           });
           if (!isRecoveryGenerationCurrent(recoveryGeneration)) {
@@ -3301,6 +3319,7 @@ export function App(): JSX.Element {
               microphoneDeviceId: settings.microphoneDeviceId || undefined,
               mouseSensitivity: settings.mouseSensitivity,
               mouseAcceleration: settings.mouseAcceleration,
+                experimentalGamepadGyro: settings.experimentalGamepadGyro,
               onLog: (line: string) => console.log(`[WebRTC] ${line}`),
               onStats: (stats) => diagnosticsStore.set(stats),
               onTimeWarning: (warning) => {
@@ -3639,6 +3658,7 @@ export function App(): JSX.Element {
           gameLanguage: settings.gameLanguage,
           enableL4S: settings.enableL4S,
           enableCloudGsync: settings.enableCloudGsync,
+                experimentalGamepadGyro: settings.experimentalGamepadGyro,
         },
       });
 

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -2159,6 +2159,24 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
 
                 <div className="settings-row settings-row--top-aligned">
                   <label className="settings-label settings-label--wrap">
+                    <span>
+                      Experimental Gamepad Gyro
+                      <span className="settings-inline-badge settings-inline-badge--beta">Beta</span>
+                    </span>
+                    <span className="settings-hint">Requires a Sony DualShock 4 or DualSense exposed through WebHID. Sends DS4-style HID motion packets to GFN when motion data is available.</span>
+                  </label>
+                  <label className="settings-toggle">
+                    <input
+                      type="checkbox"
+                      checked={settings.experimentalGamepadGyro ?? false}
+                      onChange={(e) => handleChange("experimentalGamepadGyro", e.target.checked)}
+                    />
+                    <span className="settings-toggle-track" />
+                  </label>
+                </div>
+
+                <div className="settings-row settings-row--top-aligned">
+                  <label className="settings-label settings-label--wrap">
                     Keyboard Layout
                     <span className="settings-hint">Controls how your physical keyboard is mapped inside the remote session. Separate from the in-game language setting.</span>
                   </label>

--- a/opennow-stable/src/renderer/src/gfn/gamepadMotion.ts
+++ b/opennow-stable/src/renderer/src/gfn/gamepadMotion.ts
@@ -1,0 +1,200 @@
+export interface GamepadMotionSample {
+  receivedAtMs: number;
+  gyroX: number;
+  gyroY: number;
+  gyroZ: number;
+  accelX: number;
+  accelY: number;
+  accelZ: number;
+  sensorTimestamp: number;
+}
+
+type HidDeviceFilter = { vendorId?: number; productId?: number };
+type HidRequestOptions = { filters: HidDeviceFilter[] };
+type HidInputReportEvent = Event & { device: HidDevice; reportId: number; data: DataView };
+type HidDevice = EventTarget & {
+  vendorId: number;
+  productId: number;
+  productName?: string;
+  opened: boolean;
+  open(): Promise<void>;
+  close(): Promise<void>;
+  addEventListener(type: "inputreport", listener: (event: HidInputReportEvent) => void): void;
+  removeEventListener(type: "inputreport", listener: (event: HidInputReportEvent) => void): void;
+};
+type HidNavigator = Navigator & {
+  hid?: {
+    getDevices(): Promise<HidDevice[]>;
+    requestDevice(options: HidRequestOptions): Promise<HidDevice[]>;
+  };
+};
+
+const SONY_VENDOR_ID = 0x054c;
+const DEFAULT_FRESHNESS_MS = 150;
+const DS4_PRODUCT_IDS = new Set([0x05c4, 0x09cc]);
+const DUALSENSE_PRODUCT_IDS = new Set([0x0ce6, 0x0df2]);
+
+export function isSonyGamepad(gamepad: Gamepad): boolean {
+  return /054c|sony|wireless controller|dualsense|dualshock/i.test(gamepad.id);
+}
+
+export async function requestSonyGamepadHidAccess(log: (line: string) => void = () => {}): Promise<boolean> {
+  const hid = (navigator as HidNavigator).hid;
+  if (!hid?.requestDevice) {
+    log("Experimental gamepad gyro permission skipped: WebHID is not exposed");
+    return false;
+  }
+
+  try {
+    const devices = await hid.requestDevice({ filters: [{ vendorId: SONY_VENDOR_ID }] });
+    return devices.some(isSonyHidDevice);
+  } catch (error) {
+    log(`Experimental gamepad gyro permission request failed: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
+}
+
+export class GamepadMotionManager {
+  private enabled = false;
+  private devices: HidDevice[] = [];
+  private latestSample: GamepadMotionSample | null = null;
+  private requested = false;
+  private readonly onReport = (event: HidInputReportEvent): void => this.handleInputReport(event);
+
+  constructor(private readonly log: (line: string) => void = () => {}) {}
+
+  get supported(): boolean {
+    return Boolean((navigator as HidNavigator).hid);
+  }
+
+  async setEnabled(enabled: boolean, requestPermission = false): Promise<void> {
+    if (enabled === this.enabled && (!enabled || !requestPermission || this.requested)) {
+      return;
+    }
+    this.enabled = enabled;
+    if (!enabled) {
+      this.stop();
+      return;
+    }
+    await this.start(requestPermission);
+  }
+
+  async start(requestPermission = false): Promise<void> {
+    const hid = (navigator as HidNavigator).hid;
+    if (!hid) {
+      this.log("Experimental gamepad gyro unavailable: WebHID is not exposed");
+      return;
+    }
+
+    try {
+      const devices = hid.getDevices ? await hid.getDevices() : [];
+      await this.openDevices(devices.filter(isSonyHidDevice));
+      if (requestPermission && !this.requested) {
+        this.requested = true;
+        await requestSonyGamepadHidAccess(this.log);
+        const requestedDevices = hid.getDevices ? await hid.getDevices() : [];
+        await this.openDevices(requestedDevices.filter(isSonyHidDevice));
+      }
+    } catch (error) {
+      this.log(`Experimental gamepad gyro WebHID start failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  stop(): void {
+    for (const device of this.devices) {
+      try {
+        device.removeEventListener("inputreport", this.onReport);
+      } catch {}
+      try {
+        if (device.opened) {
+          void device.close().catch(() => {});
+        }
+      } catch {}
+    }
+    this.devices = [];
+    this.latestSample = null;
+  }
+
+  getFreshSample(gamepad: Gamepad, controllerId: number, maxAgeMs = DEFAULT_FRESHNESS_MS): GamepadMotionSample | null {
+    if (!this.enabled || controllerId !== 0 || !isSonyGamepad(gamepad)) {
+      return null;
+    }
+    const sample = this.latestSample;
+    if (!sample || performance.now() - sample.receivedAtMs > maxAgeMs) {
+      return null;
+    }
+    return sample;
+  }
+
+  private async openDevices(devices: HidDevice[]): Promise<void> {
+    for (const device of devices) {
+      if (this.devices.includes(device)) {
+        continue;
+      }
+      try {
+        if (!device.opened) {
+          await device.open();
+        }
+        device.addEventListener("inputreport", this.onReport);
+        this.devices.push(device);
+        this.log(`Experimental gamepad gyro opened Sony HID device: ${device.productName || `0x${device.productId.toString(16)}`}`);
+      } catch (error) {
+        this.log(`Experimental gamepad gyro could not open Sony HID device: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+
+  private handleInputReport(event: HidInputReportEvent): void {
+    if (!isSonyHidDevice(event.device)) {
+      return;
+    }
+    const sample = parseSonyMotionReport(event.device, event.reportId, event.data);
+    if (sample) {
+      this.latestSample = sample;
+    }
+  }
+}
+
+function isSonyHidDevice(device: HidDevice): boolean {
+  return device.vendorId === SONY_VENDOR_ID;
+}
+
+function parseSonyMotionReport(device: HidDevice, reportId: number, data: DataView): GamepadMotionSample | null {
+  if (reportId !== 1) {
+    return null;
+  }
+
+  if (isDualSenseHidDevice(device)) {
+    return data.byteLength >= 27 ? sampleFromOffsets(data, 15, 17, 19, 21, 23, 25) : null;
+  }
+
+  if (isDs4HidDevice(device) || !isDualSenseHidDevice(device)) {
+    return data.byteLength >= 24 ? sampleFromOffsets(data, 12, 14, 16, 18, 20, 22) : null;
+  }
+
+  return null;
+}
+
+function isDs4HidDevice(device: HidDevice): boolean {
+  const name = device.productName ?? "";
+  return DS4_PRODUCT_IDS.has(device.productId) || /dualshock|wireless controller/i.test(name);
+}
+
+function isDualSenseHidDevice(device: HidDevice): boolean {
+  const name = device.productName ?? "";
+  return DUALSENSE_PRODUCT_IDS.has(device.productId) || /dualsense/i.test(name);
+}
+
+function sampleFromOffsets(data: DataView, gx: number, gy: number, gz: number, ax: number, ay: number, az: number): GamepadMotionSample {
+  const now = performance.now();
+  return {
+    receivedAtMs: now,
+    gyroX: data.getInt16(gx, true),
+    gyroY: data.getInt16(gy, true),
+    gyroZ: data.getInt16(gz, true),
+    accelX: data.getInt16(ax, true),
+    accelY: data.getInt16(ay, true),
+    accelZ: data.getInt16(az, true),
+    sensorTimestamp: Math.floor(now) & 0xffff,
+  };
+}

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
@@ -3,7 +3,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { codeMap, mapKeyboardEvent, mapTextCharToKeySpec } from "./inputProtocol";
+import {
+  GAMEPAD_A,
+  GAMEPAD_DPAD_UP,
+  GAMEPAD_HID_PACKET_SIZE,
+  GAMEPAD_LB,
+  GAMEPAD_RB,
+  GAMEPAD_X,
+  INPUT_GAMEPAD_HID,
+  InputEncoder,
+  codeMap,
+  mapKeyboardEvent,
+  mapTextCharToKeySpec,
+} from "./inputProtocol";
 
 function keyboardEvent(init: Partial<KeyboardEvent> & Pick<KeyboardEvent, "code" | "key">): KeyboardEvent {
   return {
@@ -71,4 +83,47 @@ test("uses corrected scancodes for synthetic text injection", () => {
   assert.deepEqual(mapTextCharToKeySpec("<"), { ...codeMap.Comma, shift: true });
   assert.deepEqual(mapTextCharToKeySpec("/"), { ...codeMap.Slash });
   assert.deepEqual(mapTextCharToKeySpec("?"), { ...codeMap.Slash, shift: true });
+});
+
+test("encodes DS4-compatible Sony HID gamepad packet payload", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(2);
+  const bytes = encoder.encodeSonyGamepadHidState({
+    controllerId: 0,
+    buttons: GAMEPAD_DPAD_UP | GAMEPAD_A | GAMEPAD_X | GAMEPAD_LB | GAMEPAD_RB,
+    leftTrigger: 7,
+    rightTrigger: 255,
+    leftStickX: 0,
+    leftStickY: 0,
+    rightStickX: 32767,
+    rightStickY: -32768,
+    connected: true,
+    timestampUs: 123456n,
+    sensorTimestamp: 0x3456,
+    gyroX: 111,
+    gyroY: -222,
+    gyroZ: 333,
+    accelX: -444,
+    accelY: 555,
+    accelZ: -666,
+  });
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const k = 7;
+
+  assert.equal(bytes.length, GAMEPAD_HID_PACKET_SIZE);
+  assert.equal(view.getUint32(0, true), INPUT_GAMEPAD_HID);
+  assert.equal(view.getUint8(4), 6);
+  assert.equal(view.getUint8(k), 1);
+  assert.equal(view.getUint8(k + 5), 0x30);
+  assert.equal(view.getUint8(k + 6), 0x0f);
+  assert.equal(view.getUint8(k + 8), 7);
+  assert.equal(view.getUint8(k + 9), 255);
+  assert.equal(view.getUint16(k + 10, true), 0x3456);
+  assert.equal(view.getInt16(k + 13, true), 111);
+  assert.equal(view.getInt16(k + 15, true), -222);
+  assert.equal(view.getInt16(k + 17, true), 333);
+  assert.equal(view.getInt16(k + 19, true), -444);
+  assert.equal(view.getInt16(k + 21, true), 555);
+  assert.equal(view.getInt16(k + 23, true), -666);
+  assert.equal(view.getUint8(k + 30), 11);
 });

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -7,6 +7,7 @@ export const INPUT_MOUSE_BUTTON_UP = 9;
 export const INPUT_MOUSE_WHEEL = 10;
 export const INPUT_GAMEPAD = 12;
 export const INPUT_HAPTICS_ENABLED = 13;
+export const INPUT_GAMEPAD_HID = 17;
 
 // Mouse button constants (1-based for GFN protocol)
 // GFN uses: 1=Left, 2=Middle, 3=Right, 4=Back, 5=Forward
@@ -44,6 +45,7 @@ export const GAMEPAD_AXIS_RT = 5; // Right trigger
 // Gamepad constants
 export const GAMEPAD_MAX_CONTROLLERS = 4;
 export const GAMEPAD_PACKET_SIZE = 38;
+export const GAMEPAD_HID_PACKET_SIZE = 72;
 export const GAMEPAD_DEADZONE = 0.15; // 15% radial deadzone
 export const PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL = (1 << GAMEPAD_MAX_CONTROLLERS) - 1;
 export const PARTIALLY_RELIABLE_HID_DEVICE_MASK_ALL = 0xFFFFFFFF;
@@ -82,6 +84,62 @@ export interface GamepadInput {
   rightStickY: number; // -32768 to 32767 (inverted in XInput)
   connected: boolean; // true = connected, false = disconnected
   timestampUs: bigint;
+}
+
+export interface SonyGamepadHidInput extends GamepadInput {
+  gyroX: number;
+  gyroY: number;
+  gyroZ: number;
+  accelX: number;
+  accelY: number;
+  accelZ: number;
+  sensorTimestamp?: number;
+}
+
+function clampUint8(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(255, Math.round(value))) : 0;
+}
+
+function clampInt16(value: number): number {
+  return Number.isFinite(value) ? Math.max(-32768, Math.min(32767, Math.round(value))) : 0;
+}
+
+function stickInt16ToDs4Byte(value: number): number {
+  return clampUint8(Math.round(((clampInt16(value) + 32768) * 255) / 65535));
+}
+
+function ds4Hat(buttons: number): number {
+  const up = (buttons & GAMEPAD_DPAD_UP) !== 0;
+  const down = (buttons & GAMEPAD_DPAD_DOWN) !== 0;
+  const left = (buttons & GAMEPAD_DPAD_LEFT) !== 0;
+  const right = (buttons & GAMEPAD_DPAD_RIGHT) !== 0;
+  if (up && right) return 1;
+  if (down && right) return 3;
+  if (down && left) return 5;
+  if (up && left) return 7;
+  if (up) return 0;
+  if (right) return 2;
+  if (down) return 4;
+  if (left) return 6;
+  return 8;
+}
+
+function ds4FaceButtons(buttons: number): number {
+  return ((buttons & GAMEPAD_X) ? 0x10 : 0)
+    | ((buttons & GAMEPAD_A) ? 0x20 : 0)
+    | ((buttons & GAMEPAD_B) ? 0x40 : 0)
+    | ((buttons & GAMEPAD_Y) ? 0x80 : 0);
+}
+
+function ds4ShoulderButtons(buttons: number, leftTrigger: number, rightTrigger: number): number {
+  return ((buttons & GAMEPAD_LB) ? 0x01 : 0)
+    | ((buttons & GAMEPAD_RB) ? 0x02 : 0)
+    | (leftTrigger > 0 ? 0x04 : 0)
+    | (rightTrigger > 0 ? 0x08 : 0)
+    | ((buttons & GAMEPAD_BACK) ? 0x10 : 0)
+    | ((buttons & GAMEPAD_START) ? 0x20 : 0)
+    | ((buttons & GAMEPAD_LS) ? 0x40 : 0)
+    | ((buttons & GAMEPAD_RS) ? 0x80 : 0);
 }
 
 export function partiallyReliableHidMaskForInputType(inputType: number): number {
@@ -765,6 +823,47 @@ export class InputEncoder {
       return wrapGamepadPartiallyReliable(bytes, this.protocolVersion, payload.controllerId, seq);
     }
     // Reliable channel: [0x23][8B ts][0x21][2B size][38B payload]
+    return wrapGamepadReliable(bytes, this.protocolVersion);
+  }
+
+  encodeSonyGamepadHidState(payload: SonyGamepadHidInput, usePartiallyReliable: boolean = false): Uint8Array {
+    const bytes = new Uint8Array(GAMEPAD_HID_PACKET_SIZE);
+    const view = new DataView(bytes.buffer);
+    const k = 7;
+
+    view.setUint32(0, INPUT_GAMEPAD_HID, true);
+    view.setUint8(4, 6 + (payload.controllerId & 0x03));
+    view.setUint8(5, 4);
+    view.setUint8(6, 0);
+    view.setUint8(k, 1);
+    view.setUint8(k + 1, stickInt16ToDs4Byte(payload.leftStickX));
+    view.setUint8(k + 2, stickInt16ToDs4Byte(payload.leftStickY));
+    view.setUint8(k + 3, stickInt16ToDs4Byte(payload.rightStickX));
+    view.setUint8(k + 4, stickInt16ToDs4Byte(payload.rightStickY));
+    view.setUint8(k + 5, ds4Hat(payload.buttons) | ds4FaceButtons(payload.buttons));
+    view.setUint8(k + 6, ds4ShoulderButtons(payload.buttons, payload.leftTrigger, payload.rightTrigger));
+    view.setUint8(k + 7, (payload.buttons & GAMEPAD_GUIDE) ? 0x01 : 0);
+    view.setUint8(k + 8, clampUint8(payload.leftTrigger));
+    view.setUint8(k + 9, clampUint8(payload.rightTrigger));
+    view.setUint16(k + 10, payload.sensorTimestamp ?? Number(payload.timestampUs & 0xffffn), true);
+    view.setUint8(k + 12, 0);
+    view.setInt16(k + 13, clampInt16(payload.gyroX), true);
+    view.setInt16(k + 15, clampInt16(payload.gyroY), true);
+    view.setInt16(k + 17, clampInt16(payload.gyroZ), true);
+    view.setInt16(k + 19, clampInt16(payload.accelX), true);
+    view.setInt16(k + 21, clampInt16(payload.accelY), true);
+    view.setInt16(k + 23, clampInt16(payload.accelZ), true);
+    view.setUint32(k + 25, 0, true);
+    view.setUint8(k + 29, 0);
+    view.setUint8(k + 30, 11);
+    view.setUint8(k + 31, 0);
+    view.setUint8(k + 32, 0);
+    view.setUint8(k + 33, 0);
+
+    if (usePartiallyReliable) {
+      const seq = this.getNextGamepadSequence(payload.controllerId);
+      return wrapGamepadPartiallyReliable(bytes, this.protocolVersion, payload.controllerId, seq);
+    }
     return wrapGamepadReliable(bytes, this.protocolVersion);
   }
 

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -23,6 +23,7 @@ import {
   normalizeToUint8,
   GAMEPAD_MAX_CONTROLLERS,
   type GamepadInput,
+  type SonyGamepadHidInput,
   codeMap,
   mapTextCharToKeySpec,
 } from "./inputProtocol";
@@ -38,6 +39,7 @@ import {
   rewriteH265TierFlag,
 } from "./sdp";
 import { MicrophoneManager, type MicState, type MicStateChange } from "./microphoneManager";
+import { GamepadMotionManager, isSonyGamepad } from "./gamepadMotion";
 
 interface OfferSettings {
   codec: VideoCodec;
@@ -187,6 +189,7 @@ interface ClientOptions {
   onPeerConnectionStateChange?: (state: RTCPeerConnectionState) => void;
   /** Optional host callback for Meta/Home button edge presses (button 16). */
   onControllerMetaPress?: (event: { controllerId: number; gamepad: Gamepad }) => void;
+  experimentalGamepadGyro?: boolean;
 }
 
 function timestampUs(sourceTimestampMs?: number): bigint {
@@ -736,6 +739,10 @@ export class GfnWebRtcClient {
     this.mouseSensitivity = options.mouseSensitivity ?? 1;
     this.mouseAccelerationPercent = Math.max(1, Math.min(150, Math.round(options.mouseAcceleration ?? 1)));
     this.autoFullScreenEnabled = options.autoFullScreen !== false;
+    if (options.experimentalGamepadGyro) {
+      this.gamepadMotion = new GamepadMotionManager((line) => this.log(line));
+      void this.gamepadMotion.setEnabled(true, false);
+    }
 
     // Configure video element for lowest latency playback
     this.configureVideoElementForLowLatency(options.videoElement);
@@ -1044,6 +1051,7 @@ export class GfnWebRtcClient {
       this.controlChannel.onclose = null;
       this.controlChannel.onerror = null;
     }
+    this.gamepadMotion?.stop();
     this.reliableInputChannel?.close();
     this.partiallyReliableInputChannel?.close();
     this.controlChannel?.close();
@@ -1941,6 +1949,7 @@ export class GfnWebRtcClient {
   }
 
   private gamepadSendCount = 0;
+  private gamepadMotion: GamepadMotionManager | null = null;
 
   private updateGamepadBitmap(controllerId: number, gamepad: Gamepad): void {
     const connectedBit = 1 << controllerId;
@@ -1956,6 +1965,18 @@ export class GfnWebRtcClient {
   private clearGamepadBitmap(controllerId: number): void {
     this.gamepadBitmap &= ~(1 << controllerId);
     this.gamepadBitmap &= ~(1 << (controllerId + 8));
+  }
+
+  public setExperimentalGamepadGyroEnabled(enabled: boolean): void {
+    this.options.experimentalGamepadGyro = enabled;
+    if (enabled) {
+      if (!this.gamepadMotion) {
+        this.gamepadMotion = new GamepadMotionManager((line) => this.log(line));
+      }
+      void this.gamepadMotion.setEnabled(true, true);
+    } else {
+      this.gamepadMotion?.setEnabled(false).catch(() => {});
+    }
   }
 
   private pollGamepads(): void {
@@ -1999,6 +2020,10 @@ export class GfnWebRtcClient {
         if (streamInputBlocked) {
           continue;
         }
+        if (this.options.experimentalGamepadGyro && !this.gamepadMotion) {
+          this.gamepadMotion = new GamepadMotionManager((line) => this.log(line));
+          void this.gamepadMotion.setEnabled(true, false);
+        }
         const gamepadInput = this.readGamepadState(gamepad, i);
         const stateChanged = this.hasGamepadStateChanged(i, gamepadInput);
 
@@ -2009,12 +2034,33 @@ export class GfnWebRtcClient {
           && (nowMs - this.lastGamepadSendMs) >= GfnWebRtcClient.GAMEPAD_KEEPALIVE_MS;
 
         if (stateChanged || needsKeepalive) {
-          const usePR = this.canSendGamepadPartiallyReliable(i);
-          const bytes = this.inputEncoder.encodeGamepadState(gamepadInput, this.gamepadBitmap, usePR);
-          if (usePR) {
-            this.sendGamepad(bytes);
-          } else {
+          const motionSample = this.options.experimentalGamepadGyro && isSonyGamepad(gamepad)
+            ? this.gamepadMotion?.getFreshSample(gamepad, i) ?? null
+            : null;
+          let sentBytesLength = 0;
+          if (motionSample) {
+            const hidInput: SonyGamepadHidInput = {
+              ...gamepadInput,
+              gyroX: motionSample.gyroX,
+              gyroY: motionSample.gyroY,
+              gyroZ: motionSample.gyroZ,
+              accelX: motionSample.accelX,
+              accelY: motionSample.accelY,
+              accelZ: motionSample.accelZ,
+              sensorTimestamp: motionSample.sensorTimestamp,
+            };
+            const bytes = this.inputEncoder.encodeSonyGamepadHidState(hidInput, false);
             this.sendReliable(bytes);
+            sentBytesLength = bytes.length;
+          } else {
+            const usePR = this.canSendGamepadPartiallyReliable(i);
+            const bytes = this.inputEncoder.encodeGamepadState(gamepadInput, this.gamepadBitmap, usePR);
+            if (usePR) {
+              this.sendGamepad(bytes);
+            } else {
+              this.sendReliable(bytes);
+            }
+            sentBytesLength = bytes.length;
           }
           this.lastGamepadSendMs = nowMs;
 
@@ -2026,7 +2072,7 @@ export class GfnWebRtcClient {
           if (stateChanged) {
             this.gamepadSendCount++;
             if (this.gamepadSendCount <= 20) {
-              this.log(`Gamepad send #${this.gamepadSendCount}: pad=${i} btns=0x${gamepadInput.buttons.toString(16)} lt=${gamepadInput.leftTrigger} rt=${gamepadInput.rightTrigger} lx=${gamepadInput.leftStickX} ly=${gamepadInput.leftStickY} rx=${gamepadInput.rightStickX} ry=${gamepadInput.rightStickY} bytes=${bytes.length}`);
+              this.log(`Gamepad send #${this.gamepadSendCount}: pad=${i} btns=0x${gamepadInput.buttons.toString(16)} lt=${gamepadInput.leftTrigger} rt=${gamepadInput.rightTrigger} lx=${gamepadInput.leftStickX} ly=${gamepadInput.leftStickY} rx=${gamepadInput.rightStickX} ry=${gamepadInput.rightStickY} bytes=${sentBytesLength}`);
             }
           }
         }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -194,6 +194,7 @@ export interface Settings {
   enableL4S: boolean;
   /** Request Cloud G-Sync / Variable Refresh Rate on new sessions */
   enableCloudGsync: boolean;
+  experimentalGamepadGyro?: boolean;
   /** Show the currently streaming game as Discord Rich Presence activity */
   discordRichPresence: boolean;
   /** Automatically check GitHub Releases for app updates in the background */
@@ -486,6 +487,7 @@ export interface StreamSettings {
   enableL4S: boolean;
   /** Request Cloud G-Sync / Variable Refresh Rate on new sessions */
   enableCloudGsync: boolean;
+  experimentalGamepadGyro?: boolean;
 }
 
 export interface SessionCreateRequest {


### PR DESCRIPTION
## Summary

This PR adds experimental Sony DualShock 4/DualSense gyro support for the Electron desktop client only. When enabled via a new "Experimental Gamepad Gyro" setting (off by default), the client negotiates HID support with GFN, requests WebHID access to Sony controllers (vendor ID 0x054c), reads motion samples, and sends DS4-compatible synthetic HID packets (input type 17) containing gyro/accelerometer data. Normal XInput gamepad behavior remains unchanged unless the setting is enabled, a Sony controller is detected, and fresh motion data is available.

- Add `INPUT_GAMEPAD_HID = 17` constant and 72-byte HID packet layout in `inputProtocol.ts`
- Add `encodeSonyGamepadHidState` method matching DS4 report ID 1 structure and official GFN vendor packet offsets
- Add WebHID motion helper (`gamepadMotion.ts`) with `GamepadMotionManager` and `requestSonyGamepadHidAccess` helper
- Parse DS4 (offsets 12/14/16 gyro, 18/20/22 accel) and DualSense (best-effort offsets 15/17/19 gyro, 21/23/25 accel) motion samples based on device product ID/name
- Add Electron device permission/check handlers restricted to Sony vendor ID 0x054c; add `select-hid-device` auto-selection
- Add `experimentalGamepadGyro` setting to shared/main/renderer settings/defaults/CloudMatch negotiation
- Expose setting toggle with Beta badge in Input settings section
- Wire client gamepad polling to send HID packets when enabled; fallback to existing XInput path otherwise
- Add focused unit coverage for DS4 HID packet encoder

## Test plan

- [x] Run `npm run typecheck`
- [x] Run `npx tsx --test src/renderer/src/gfn/inputProtocol.test.ts`
- Verified HID permission request occurs synchronously within user activation when toggle is enabled in Settings
- Verified device cleanup in `GamepadMotionManager.stop()` closes HID handles and removes listeners
- Verified CloudMatch sends `supportedHidDevices: 3` and minimal `remoteControllersBitmap` when enabled
- Verified non-Sony controllers and cases without fresh motion fall back to existing XInput path unchanged

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/fc858dac-db25-4723-a650-e686595afffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-086" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/fc858dac-db25-4723-a650-e686595afffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-086&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-086"><img alt="OPE-086" src="https://capy.ai/api/badge/thread.svg?label=OPE-086"></picture></a>
<!-- capy-pr-badge:end -->