### PR TITLE
Fix release workflow source version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       prerelease: ${{ steps.release.outputs.prerelease }}
       make_latest: ${{ steps.release.outputs.make_latest }}
       release_tag: ${{ steps.release.outputs.release_tag }}
+      source_ref: ${{ steps.release.outputs.source_ref }}
 
     steps:
       - name: Checkout
@@ -80,8 +81,10 @@ jobs:
 
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             release_tag="v${version}"
+            source_ref="$REF_NAME"
           else
             release_tag="$raw"
+            source_ref="$REF_NAME"
           fi
 
           {
@@ -89,12 +92,64 @@ jobs:
             echo "prerelease=$prerelease"
             echo "make_latest=$make_latest"
             echo "release_tag=$release_tag"
+            echo "source_ref=$source_ref"
           } >> "$GITHUB_OUTPUT"
+
+  prepare-source:
+    name: prepare-source
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: preflight
+    permissions:
+      contents: write
+    outputs:
+      release_sha: ${{ steps.source.outputs.release_sha }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.source_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Sync or validate release version
+        id: source
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+          SOURCE_REF: ${{ needs.preflight.outputs.source_ref }}
+        run: |
+          if [[ "$EVENT_NAME" != "workflow_dispatch" ]]; then
+            node opennow-stable/scripts/sync-release-version.mjs --check "$RELEASE_VERSION"
+            echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$REF_TYPE" != "branch" ]]; then
+            echo "workflow_dispatch releases must run from a branch so the version bump can be committed before tagging." >&2
+            exit 1
+          fi
+
+          node opennow-stable/scripts/sync-release-version.mjs "$RELEASE_VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add opennow-stable/package.json opennow-stable/package-lock.json
+          if git diff --cached --quiet; then
+            echo "No version bump changes to commit."
+          else
+            git commit -m "chore(release): prepare v${RELEASE_VERSION}"
+            git push origin HEAD:"$SOURCE_REF"
+          fi
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   build:
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
-    needs: preflight
+    needs:
+      - preflight
+      - prepare-source
     strategy:
       fail-fast: false
       matrix:
@@ -154,6 +209,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-source.outputs.release_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -185,8 +242,8 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --progress=false
 
-      - name: Update package version
-        run: node -e "const fs=require('fs'); const path='package.json'; const pkg=JSON.parse(fs.readFileSync(path,'utf8')); pkg.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');"
+      - name: Sync package version
+        run: node scripts/sync-release-version.mjs "$RELEASE_VERSION"
 
       - name: Build app bundles
         run: npm run build
@@ -208,6 +265,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs:
       - preflight
+      - prepare-source
       - build
     permissions:
       contents: write
@@ -223,58 +281,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.preflight.outputs.release_tag }}
+          target_commitish: ${{ needs.prepare-source.outputs.release_sha }}
           name: OpenNOW v${{ needs.preflight.outputs.version }}
           prerelease: ${{ needs.preflight.outputs.prerelease }}
           make_latest: ${{ needs.preflight.outputs.make_latest }}
           generate_release_notes: true
           files: release-artifacts/**/*
-
-  finalize:
-    name: finalize-version-bump
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    needs:
-      - preflight
-      - release
-    permissions:
-      contents: write
-
-    steps:
-      - name: Resolve release branch
-        id: branch
-        shell: bash
-        env:
-          REF_TYPE: ${{ github.ref_type }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [[ "$REF_TYPE" == "branch" ]]; then
-            branch="$REF_NAME"
-          else
-            branch="dev"
-          fi
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout release branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.branch.outputs.branch }}
-          fetch-depth: 0
-          token: ${{ secrets.RELEASE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
-
-      - name: Update package version
-        working-directory: opennow-stable
-        env:
-          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
-        run: node -e "const fs=require('fs'); const path='package.json'; const pkg=JSON.parse(fs.readFileSync(path,'utf8')); pkg.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');"
-
-      - name: Commit and push
-        shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add opennow-stable/package.json
-          if git diff --cached --quiet; then
-            echo "No version bump changes to commit."
-            exit 0
-          fi
-          git commit -m "chore(release): prepare v${{ needs.preflight.outputs.version }}"
-          git push origin HEAD:${{ steps.branch.outputs.branch }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -158,6 +158,8 @@ Current build matrix:
 
 Windows ARM64 artifacts are release downloads only for now. The Windows auto-update channel remains the x64 `latest.yml` feed so ARM64 packaging cannot overwrite updater metadata.
 
+Manual release runs sync `opennow-stable/package.json` and `opennow-stable/package-lock.json` to the requested version, commit that change to the selected branch when needed, and create the release tag from that commit so GitHub source archives match the app's internal version. Direct tag-push releases do not rewrite tags; the tagged source must already have matching package and lockfile versions or the release workflow fails before publishing.
+
 ## Notes For Contributors
 
 - The active app is the Electron client. If you see older references to previous implementations, prefer `opennow-stable/`.

--- a/opennow-stable/scripts/sync-release-version.mjs
+++ b/opennow-stable/scripts/sync-release-version.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const semverPattern = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+function normalizeVersion(rawVersion) {
+  if (!rawVersion) {
+    throw new Error('Release version is required as an argument or RELEASE_VERSION environment variable.');
+  }
+
+  let version = rawVersion.trim();
+  if (version.startsWith('opennow-stable-v')) {
+    version = version.slice('opennow-stable-v'.length);
+  } else if (version.startsWith('v')) {
+    version = version.slice(1);
+  }
+
+  if (!semverPattern.test(version)) {
+    throw new Error(`Invalid semver version: ${rawVersion}`);
+  }
+
+  return version;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+async function writeJson(path, value) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const check = args.includes('--check');
+  const versionArg = args.find((arg) => arg !== '--check');
+  return { check, versionArg };
+}
+
+function validateCurrentVersions(packageJson, packageLock, version) {
+  const mismatches = [];
+
+  if (packageJson.version !== version) {
+    mismatches.push(`package.json version is ${packageJson.version}`);
+  }
+
+  if (packageLock.version !== version) {
+    mismatches.push(`package-lock.json version is ${packageLock.version}`);
+  }
+
+  if (packageLock.packages?.['']?.version !== version) {
+    mismatches.push(`package-lock.json packages[""].version is ${packageLock.packages?.['']?.version}`);
+  }
+
+  if (mismatches.length > 0) {
+    throw new Error(`Committed package versions do not match release version ${version}: ${mismatches.join('; ')}.`);
+  }
+}
+
+try {
+  const { check, versionArg } = parseArgs(process.argv);
+  const version = normalizeVersion(versionArg ?? process.env.RELEASE_VERSION);
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const appDir = join(scriptDir, '..');
+  const packageJsonPath = join(appDir, 'package.json');
+  const packageLockPath = join(appDir, 'package-lock.json');
+
+  const packageJson = await readJson(packageJsonPath);
+  const packageLock = await readJson(packageLockPath);
+
+  if (check) {
+    validateCurrentVersions(packageJson, packageLock, version);
+    console.log(`Package versions already match ${version}.`);
+    process.exit(0);
+  }
+
+  packageJson.version = version;
+  packageLock.version = version;
+  packageLock.packages ??= {};
+  packageLock.packages[''] ??= {};
+  packageLock.packages[''].version = version;
+
+  await writeJson(packageJsonPath, packageJson);
+  await writeJson(packageLockPath, packageLock);
+  console.log(`Synced package versions to ${version}.`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}


### PR DESCRIPTION
This PR fixes the release workflow so that tag/source tarballs contain a bumped app version, resolving an inconsistency where GitHub release assets and notes announced a new version but the archived source code showed a stale version.

**Workflow and Script Changes**
- Add shared `opennow-stable/scripts/sync-release-version.mjs` to normalize versions, sync `opennow-stable/package.json` and `opennow-stable/package-lock.json` root versions, and validate via `--check` for tag-push releases.
- Add `prepare-source` job in `release.yml` that commits version bumps before release for `workflow_dispatch` (only from branches) and validates committed versions for tag-push triggers.
- Update `build` jobs to depend on `prepare-source`, check out the resulting commit SHA, and run the sync script idempotently before packaging.
- Pass `target_commitish: ${{ needs.prepare-source.outputs.release_sha }}` to `softprops/action-gh-release@v2` so GitHub creates the tag from the bumped commit.
- Remove the post-release `finalize-version-bump` job to avoid duplicate or out-of-order version writes.

**Documentation**
- Update `docs/development.md` to clarify that manual releases auto-commit the version bump before tagging, while tag-push releases require the package files to already match.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/68d058dd-c046-4a1f-95a0-c9506d13fef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-087" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/68d058dd-c046-4a1f-95a0-c9506d13fef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-087&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-087"><img alt="OPE-087" src="https://capy.ai/api/badge/thread.svg?label=OPE-087"></picture></a>
<!-- capy-pr-badge:end -->