### PR TITLE
Replace PR/push packaging with cheap CI validation

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: validate

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit --progress=false
 
       - name: Lint
-        run: npm run lint --if-present
+        run: npm run lint
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -1,4 +1,4 @@
-name: auto-build
+name: ci
 
 on:
   workflow_dispatch:
@@ -15,65 +15,21 @@ on:
       - ".github/workflows/auto-build.yml"
 
 concurrency:
-  group: auto-build-${{ github.ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: ${{ matrix.label }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - label: windows-x64
-            os: blacksmith-4vcpu-windows-2025
-            builder_args: "--win nsis portable --x64"
-            artifact_paths: |
-              opennow-stable/dist-release/*-x64.exe
-          - label: windows-arm64
-            os: blacksmith-4vcpu-windows-2025
-            builder_args: "--win nsis portable --arm64"
-            artifact_paths: |
-              opennow-stable/dist-release/*-arm64.exe
-          - label: macos-x64
-            os: macos-latest
-            builder_args: "--mac dmg zip --x64"
-            artifact_paths: |
-              opennow-stable/dist-release/*.dmg
-              opennow-stable/dist-release/*-x64.zip
-          - label: macos-arm64
-            os: macos-latest
-            builder_args: "--mac dmg zip --arm64"
-            artifact_paths: |
-              opennow-stable/dist-release/*.dmg
-              opennow-stable/dist-release/*-arm64.zip
-          - label: linux-x64
-            os: blacksmith-4vcpu-ubuntu-2404
-            builder_args: "--linux AppImage deb --x64"
-            artifact_paths: |
-              opennow-stable/dist-release/*-x86_64.AppImage
-              opennow-stable/dist-release/*-amd64.deb
-          - label: linux-arm64
-            os: blacksmith-4vcpu-ubuntu-2404-arm
-            builder_args: "--linux AppImage deb --arm64"
-            artifact_paths: |
-              opennow-stable/dist-release/*-arm64.AppImage
-              opennow-stable/dist-release/*-arm64.deb
+  validate:
+    name: validate
+    runs-on: ubuntu-24.04
 
     defaults:
       run:
         working-directory: opennow-stable
 
     env:
-      CSC_IDENTITY_AUTO_DISCOVERY: "false"
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
-      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
       npm_config_audit: "false"
       npm_config_fund: "false"
-      # Use system fpm on arm64 (no prebuilt binaries available)
-      USE_SYSTEM_FPM: ${{ matrix.label == 'linux-arm64' && 'true' || 'false' }}
 
     steps:
       - name: Checkout
@@ -84,39 +40,16 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: "**/package-lock.json"
-
-      - name: Cache Electron binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ github.workspace }}/.cache/electron
-            ${{ github.workspace }}/.cache/electron-builder
-          key: ${{ runner.os }}-electron-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-electron-
-
-      - name: Install Linux packaging tools
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y fakeroot rpm
-      - name: Install FPM for arm64 deb builds
-        if: matrix.label == 'linux-arm64'
-        run: sudo apt-get install -y ruby ruby-dev build-essential && sudo gem install fpm
+          cache-dependency-path: opennow-stable/package-lock.json
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --progress=false
 
-      - name: Build app bundles
-        run: npm run build
+      - name: Lint
+        run: npm run lint --if-present
 
-      - name: Package installers
-        run: npx electron-builder --publish never ${{ matrix.builder_args }}
+      - name: Typecheck
+        run: npm run typecheck
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: opennow-stable-${{ matrix.label }}
-          path: ${{ matrix.artifact_paths }}
-          if-no-files-found: error
+      - name: Test
+        run: npm test

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -49,10 +49,42 @@ jobs:
         run: npm ci --prefer-offline --no-audit --progress=false
 
       - name: Lint
+        id: lint
         run: npm run lint
 
       - name: Typecheck
+        id: typecheck
         run: npm run typecheck
 
       - name: Test
+        id: test
         run: npm test
+
+      - name: CI summary
+        if: always()
+        working-directory: .
+        run: |
+          status_icon() {
+            case "$1" in
+              success) printf '✅ success' ;;
+              failure) printf '❌ failure' ;;
+              cancelled) printf '❌ cancelled' ;;
+              skipped) printf '⏭️ skipped' ;;
+              *) printf '❌ %s' "$1" ;;
+            esac
+          }
+
+          {
+            echo "## CI Summary"
+            echo
+            echo "| Check | Result |"
+            echo "| --- | --- |"
+            echo "| Format | ⏭️ skipped/not configured |"
+            echo "| Lint | $(status_icon '${{ steps.lint.outcome }}') |"
+            echo "| Typecheck | $(status_icon '${{ steps.typecheck.outcome }}') |"
+            echo "| Test | $(status_icon '${{ steps.test.outcome }}') |"
+            echo "| Browser Test | ⏭️ skipped/not configured |"
+            echo "| Build | ⏭️ release-only / skipped for PR CI |"
+            echo
+            echo "Job summary generated at run-time"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/opennow-stable/package-lock.json
+++ b/opennow-stable/package-lock.json
@@ -26,6 +26,7 @@
         "electron": "^41.1.1",
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
+        "oxlint": "^1.62.0",
         "react-scan": "^0.5.3",
         "tsx": "^4.20.6",
         "typescript": "^6.0.2",
@@ -63,6 +64,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -738,7 +740,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -760,7 +761,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -777,7 +777,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -792,7 +791,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1540,6 +1538,329 @@
         "node": ">=10"
       }
     },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.62.0.tgz",
+      "integrity": "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.62.0.tgz",
+      "integrity": "sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.62.0.tgz",
+      "integrity": "sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.62.0.tgz",
+      "integrity": "sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.62.0.tgz",
+      "integrity": "sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.62.0.tgz",
+      "integrity": "sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.62.0.tgz",
+      "integrity": "sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.62.0.tgz",
+      "integrity": "sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.62.0.tgz",
+      "integrity": "sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.62.0.tgz",
+      "integrity": "sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.62.0.tgz",
+      "integrity": "sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.62.0.tgz",
+      "integrity": "sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.62.0.tgz",
+      "integrity": "sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.62.0.tgz",
+      "integrity": "sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.62.0.tgz",
+      "integrity": "sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.62.0.tgz",
+      "integrity": "sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.62.0.tgz",
+      "integrity": "sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.62.0.tgz",
+      "integrity": "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.62.0.tgz",
+      "integrity": "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2146,6 +2467,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2277,6 +2599,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2722,6 +3045,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3238,8 +3562,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -3498,6 +3821,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -3899,7 +4223,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -3920,7 +4243,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3953,16 +4275,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -5399,7 +5711,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -5679,6 +5990,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oxlint": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.62.0.tgz",
+      "integrity": "sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.62.0",
+        "@oxlint/binding-android-arm64": "1.62.0",
+        "@oxlint/binding-darwin-arm64": "1.62.0",
+        "@oxlint/binding-darwin-x64": "1.62.0",
+        "@oxlint/binding-freebsd-x64": "1.62.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.62.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.62.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.62.0",
+        "@oxlint/binding-linux-arm64-musl": "1.62.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.62.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.62.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.62.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.62.0",
+        "@oxlint/binding-linux-x64-gnu": "1.62.0",
+        "@oxlint/binding-linux-x64-musl": "1.62.0",
+        "@oxlint/binding-openharmony-arm64": "1.62.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.62.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.62.0",
+        "@oxlint/binding-win32-x64-msvc": "1.62.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.18.0"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -5862,7 +6218,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -5880,7 +6235,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -5891,6 +6245,7 @@
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5995,6 +6350,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6004,6 +6360,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6201,7 +6558,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -6234,6 +6590,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6670,7 +7027,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -7474,6 +7830,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -20,6 +20,7 @@
     "preview": "electron-vite preview",
     "dist": "npm run build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
     "dist:signed": "npm run build && electron-builder",
+    "lint": "oxlint src",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json",
     "test": "node scripts/run-tests.mjs"
   },
@@ -42,6 +43,7 @@
     "electron": "^41.1.1",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
+    "oxlint": "^1.62.0",
     "react-scan": "^0.5.3",
     "tsx": "^4.20.6",
     "typescript": "^6.0.2",

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -21,7 +21,7 @@
     "dist": "npm run build && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
     "dist:signed": "npm run build && electron-builder",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json",
-    "test": "tsx --test src/shared/gfn.test.ts src/shared/networkError.test.ts src/renderer/src/lib/launchOwnership.test.ts src/renderer/src/components/GameCard.test.ts src/renderer/src/gfn/inputProtocol.test.ts src/renderer/src/gfn/webrtcClient.test.ts"
+    "test": "node scripts/run-tests.mjs"
   },
   "dependencies": {
     "discord-rpc": "^4.0.1",

--- a/opennow-stable/scripts/run-tests.mjs
+++ b/opennow-stable/scripts/run-tests.mjs
@@ -1,3 +1,4 @@
+import { appendFile } from "node:fs/promises";
 import { readdir } from "node:fs/promises";
 import { join, sep } from "node:path";
 import { spawn } from "node:child_process";
@@ -12,6 +13,60 @@ async function discoverTests(dir) {
   return files.flat();
 }
 
+function plural(count, singular, pluralName = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : pluralName}`;
+}
+
+function parseNodeTestSummary(output) {
+  const summary = {};
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/(?:ℹ|#)\s+(tests|pass|fail|skipped|todo|cancelled)\s+(\d+)/);
+    if (match) summary[match[1]] = Number.parseInt(match[2], 10);
+  }
+  return Number.isInteger(summary.tests) ? summary : null;
+}
+
+async function appendGitHubSummary({ tests, output, exitCode }) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const parsed = parseNodeTestSummary(output);
+  const fileIcon = exitCode === 0 ? "✅" : "❌";
+  const resultIcon = parsed?.fail || parsed?.cancelled || exitCode !== 0 ? "❌" : "✅";
+  const passedFiles = exitCode === 0 ? tests.length : 0;
+  const totalResults = parsed
+    ? parsed.pass + parsed.fail + parsed.skipped + parsed.todo + parsed.cancelled
+    : null;
+  const otherParts = parsed
+    ? [
+      ["fail", parsed.fail],
+      ["skipped", parsed.skipped],
+      ["todo", parsed.todo],
+      ["cancelled", parsed.cancelled],
+    ].filter(([, count]) => count > 0).map(([name, count]) => plural(count, name))
+    : [];
+
+  const lines = [
+    "## Node Test Report",
+    "",
+    "### Summary",
+    "",
+    parsed
+      ? `Test Files: ${fileIcon} ${plural(passedFiles, "pass", "passes")} · ${plural(tests.length, "total")}`
+      : `Test Files: ${fileIcon} ${plural(tests.length, "discovered")} · exit code ${exitCode}`,
+    parsed
+      ? `Test Results: ${resultIcon} ${plural(parsed.pass, "pass", "passes")} · ${plural(totalResults, "total")}`
+      : "Test Results: ❌ summary parsing unavailable; see action log for details",
+  ];
+
+  if (otherParts.length > 0) {
+    lines.push(`Other: ${otherParts.join(" · ")}`);
+  }
+
+  lines.push("", "Job summary generated at run-time", "");
+  await appendFile(summaryPath, `${lines.join("\n")}\n`);
+}
+
 const tests = (await discoverTests("src"))
   .map((path) => path.split(sep).join("/"))
   .sort();
@@ -21,14 +76,32 @@ if (tests.length === 0) {
   process.exit(1);
 }
 
+let output = "";
 const child = spawn(process.platform === "win32" ? "npx.cmd" : "npx", ["tsx", "--test", ...tests], {
-  stdio: "inherit",
+  stdio: ["inherit", "pipe", "pipe"],
 });
 
-child.on("exit", (code, signal) => {
+child.stdout.on("data", (chunk) => {
+  output += chunk.toString();
+  process.stdout.write(chunk);
+});
+
+child.stderr.on("data", (chunk) => {
+  output += chunk.toString();
+  process.stderr.write(chunk);
+});
+
+child.on("exit", async (code, signal) => {
+  const exitCode = signal ? 1 : code ?? 1;
   if (signal) {
     console.error(`Test runner terminated by signal ${signal}`);
-    process.exit(1);
   }
-  process.exit(code ?? 1);
+
+  try {
+    await appendGitHubSummary({ tests, output, exitCode });
+  } catch (error) {
+    console.error("Failed to append GitHub test summary:", error);
+  }
+
+  process.exit(exitCode);
 });

--- a/opennow-stable/scripts/run-tests.mjs
+++ b/opennow-stable/scripts/run-tests.mjs
@@ -1,0 +1,34 @@
+import { readdir } from "node:fs/promises";
+import { join, sep } from "node:path";
+import { spawn } from "node:child_process";
+
+async function discoverTests(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return discoverTests(path);
+    return entry.isFile() && entry.name.endsWith(".test.ts") ? [path] : [];
+  }));
+  return files.flat();
+}
+
+const tests = (await discoverTests("src"))
+  .map((path) => path.split(sep).join("/"))
+  .sort();
+
+if (tests.length === 0) {
+  console.error("No test files found under src/**/*.test.ts");
+  process.exit(1);
+}
+
+const child = spawn(process.platform === "win32" ? "npx.cmd" : "npx", ["tsx", "--test", ...tests], {
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    console.error(`Test runner terminated by signal ${signal}`);
+    process.exit(1);
+  }
+  process.exit(code ?? 1);
+});

--- a/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/actions/actionRouter.test.ts
+++ b/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/actions/actionRouter.test.ts
@@ -1,0 +1,311 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  routeCancel,
+  routeCategoryActivate,
+  routeOpenOptions,
+  routeOptionsActivate,
+  routeSecondaryActivate,
+} from "./actionRouter";
+
+const game = {
+  id: "game-1",
+  title: "Test Game",
+  selectedVariantIndex: 0,
+  variants: [
+    { id: "steam", store: "Steam", supportedControls: [] },
+    { id: "epic", store: "Epic", supportedControls: [] },
+  ],
+};
+
+function calls() {
+  const values: string[] = [];
+  return {
+    values,
+    fn: (name: string) => (...args: unknown[]) => values.push(`${name}:${args.map(String).join(",")}`),
+  };
+}
+
+function baseOptionsContext(overrides: Record<string, unknown> = {}) {
+  return {
+    gamesShelfBrowseActive: true,
+    mediaShelfBrowseActive: false,
+    topCategory: "all",
+    gameSubcategory: "all",
+    gamesRootPlane: "categories",
+    spotlightEntries: [],
+    spotlightIndex: 0,
+    selectedMediaIndex: 0,
+    mediaAssetItems: [],
+    selectedGame: game,
+    gamesHubDisplayGame: null,
+    gamesHubOpen: false,
+    currentStreamingGame: null,
+    favoriteGameIdSet: new Set<string>(),
+    localVideoFilePathForOptions: null,
+    spotlightEntryHasGame: (entry: unknown): entry is { kind: "recent"; game: typeof game } => Boolean(entry),
+    bumpMediaListRefresh: () => {},
+    closeLocalVideoPlayer: () => {},
+    setSelectedMediaIndex: () => {},
+    ...overrides,
+  } as any;
+}
+
+test("opening options for a selected game creates play/favorite/variant entries", () => {
+  const log = calls();
+  let entries: Array<{ id: string; label: string }> = [];
+  let focus = -1;
+  let open = false;
+
+  const handled = routeOpenOptions(baseOptionsContext({
+    setOptionsEntries: (next: typeof entries) => { entries = next; },
+    setOptionsFocusIndex: (index: number) => { focus = index; },
+    setOptionsOpen: (value: boolean) => { open = value; },
+    playUiSound: log.fn("sound"),
+  }));
+
+  assert.equal(handled, true);
+  assert.deepEqual(entries.map((entry) => entry.id), ["play", "favorite", "variant", "close"]);
+  assert.equal(entries[0]?.label, "Play");
+  assert.equal(focus, 0);
+  assert.equal(open, true);
+  assert.deepEqual(log.values, ["sound:move"]);
+});
+
+test("activating play option plays selected game and closes hub/options", () => {
+  const log = calls();
+  const snapshot = { current: { restoreSelectedGameId: "game-1" } };
+
+  const handled = routeOptionsActivate(baseOptionsContext({
+    optionsOpen: true,
+    optionsEntries: [{ id: "play", label: "Play" }],
+    optionsFocusIndex: 0,
+    selectedVariantId: "steam",
+    gamesHubReturnSnapshotRef: snapshot,
+    onPlayGame: (played: typeof game) => log.values.push(`play:${played.id}`),
+    onToggleFavoriteGame: log.fn("favorite"),
+    onSelectGameVariant: log.fn("variant"),
+    setGamesHubOpen: log.fn("hub"),
+    setOptionsOpen: log.fn("options"),
+    setLastRootGameIndex: log.fn("lastRoot"),
+    setGameSubcategory: log.fn("subcategory"),
+    throttledOnSelectGame: log.fn("select"),
+    setGamesHubFocusIndex: log.fn("hubFocus"),
+    setPs5Row: log.fn("row"),
+    playUiSound: log.fn("sound"),
+  }));
+
+  assert.equal(handled, true);
+  assert.equal(snapshot.current, null);
+  assert.deepEqual(log.values, ["play:game-1", "hub:false", "options:false", "sound:confirm"]);
+});
+
+test("root spotlight cloud resume only resumes when not busy", () => {
+  const idle = calls();
+  assert.equal(routeCategoryActivate({
+    topCategory: "all",
+    all: {
+      gameSubcategory: "root",
+      gamesRootPlane: "spotlight",
+      spotlightEntries: [{ kind: "cloudResume", title: "Resume", coverUrl: null, busy: false }],
+      spotlightIndex: 0,
+      onResumeCloudSession: idle.fn("resume"),
+      selectedGameSubcategoryIndex: 0,
+      displayItems: [],
+      selectedGame: null,
+      selectedGameId: "",
+      gamesHubReturnSnapshotRef: { current: null },
+      spotlightEntryHasGame: () => false,
+      setLastRootGameIndex: idle.fn("lastRoot"),
+      setGameSubcategory: idle.fn("subcategory"),
+      setSelectedGameSubcategoryIndex: idle.fn("selectedIndex"),
+      throttledOnSelectGame: idle.fn("select"),
+      setGamesHubOpen: idle.fn("hub"),
+      setGamesHubFocusIndex: idle.fn("hubFocus"),
+      setPs5Row: idle.fn("row"),
+      playUiSound: idle.fn("sound"),
+    } as any,
+  }), true);
+  assert.deepEqual(idle.values, ["resume:", "sound:confirm"]);
+
+  const busy = calls();
+  routeCategoryActivate({
+    topCategory: "all",
+    all: {
+      gameSubcategory: "root",
+      gamesRootPlane: "spotlight",
+      spotlightEntries: [{ kind: "cloudResume", title: "Resume", coverUrl: null, busy: true }],
+      spotlightIndex: 0,
+      onResumeCloudSession: busy.fn("resume"),
+      selectedGameSubcategoryIndex: 0,
+      displayItems: [],
+      selectedGame: null,
+      selectedGameId: "",
+      gamesHubReturnSnapshotRef: { current: null },
+      spotlightEntryHasGame: () => false,
+      setLastRootGameIndex: busy.fn("lastRoot"),
+      setGameSubcategory: busy.fn("subcategory"),
+      setSelectedGameSubcategoryIndex: busy.fn("selectedIndex"),
+      throttledOnSelectGame: busy.fn("select"),
+      setGamesHubOpen: busy.fn("hub"),
+      setGamesHubFocusIndex: busy.fn("hubFocus"),
+      setPs5Row: busy.fn("row"),
+      playUiSound: busy.fn("sound"),
+    } as any,
+  });
+  assert.deepEqual(busy.values, ["sound:move"]);
+});
+
+test("root spotlight game opens hub and stores return snapshot", () => {
+  const log = calls();
+  const snapshot = { current: null as unknown };
+
+  routeCategoryActivate({
+    topCategory: "all",
+    all: {
+      gameSubcategory: "root",
+      gamesRootPlane: "spotlight",
+      spotlightEntries: [{ kind: "recent", game }],
+      spotlightIndex: 0,
+      selectedGameSubcategoryIndex: 3,
+      displayItems: [],
+      selectedGame: null,
+      selectedGameId: "old-game",
+      gamesHubReturnSnapshotRef: snapshot,
+      spotlightEntryHasGame: (entry: unknown): entry is { kind: "recent"; game: typeof game } => (entry as any)?.kind === "recent",
+      setLastRootGameIndex: log.fn("lastRoot"),
+      setGameSubcategory: log.fn("subcategory"),
+      setSelectedGameSubcategoryIndex: log.fn("selectedIndex"),
+      throttledOnSelectGame: log.fn("select"),
+      setGamesHubOpen: log.fn("hub"),
+      setGamesHubFocusIndex: log.fn("hubFocus"),
+      setPs5Row: log.fn("row"),
+      playUiSound: log.fn("sound"),
+    } as any,
+  });
+
+  assert.deepEqual(snapshot.current, {
+    gameSubcategory: "root",
+    selectedGameSubcategoryIndex: 3,
+    gamesRootPlane: "spotlight",
+    spotlightIndex: 0,
+    restoreSelectedGameId: "game-1",
+  });
+  assert.deepEqual(log.values, ["lastRoot:3", "subcategory:all", "select:game-1", "hub:true", "hubFocus:0", "row:main", "sound:confirm"]);
+});
+
+test("cancel from open games hub restores snapshot fields and selected game", () => {
+  const log = calls();
+  const snapshot = { current: {
+    gameSubcategory: "favorites",
+    selectedGameSubcategoryIndex: 4,
+    gamesRootPlane: "categories",
+    spotlightIndex: 1,
+    restoreSelectedGameId: "restore-game",
+    restoreCategoryIndex: 2,
+    restoreHomeRootPlane: "actions",
+  } };
+
+  const handled = routeCancel({
+    topCategory: "all",
+    all: {
+      gamesHubOpen: true,
+      gameSubcategory: "all",
+      lastRootGameIndex: 0,
+      gamesHubReturnSnapshotRef: snapshot,
+      setGamesHubFocusIndex: log.fn("hubFocus"),
+      setGamesHubOpen: log.fn("hub"),
+      setGameSubcategory: log.fn("subcategory"),
+      setSelectedGameSubcategoryIndex: log.fn("selectedIndex"),
+      setGamesRootPlane: log.fn("plane"),
+      setSpotlightIndex: log.fn("spotlight"),
+      throttledOnSelectGame: log.fn("select"),
+      setCategoryIndex: log.fn("category"),
+      setHomeRootPlane: log.fn("homePlane"),
+      playUiSound: log.fn("sound"),
+    } as any,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(snapshot.current, null);
+  assert.deepEqual(log.values, [
+    "sound:move",
+    "hubFocus:0",
+    "hub:false",
+    "subcategory:favorites",
+    "selectedIndex:4",
+    "plane:categories",
+    "spotlight:1",
+    "select:restore-game",
+    "category:2",
+    "homePlane:actions",
+  ]);
+});
+
+test("all-games secondary cycles library sort only while browsing all games", () => {
+  let sort = "recent" as any;
+  const log = calls();
+  const setLibrarySortId = (updater: (prev: typeof sort) => typeof sort) => { sort = updater(sort); };
+
+  assert.equal(routeSecondaryActivate({
+    topCategory: "all",
+    all: { gamesShelfBrowseActive: true, gameSubcategory: "all", setLibrarySortId, playUiSound: log.fn("sound") } as any,
+  }), true);
+  assert.equal(sort, "favoritesFirst");
+  assert.deepEqual(log.values, ["sound:move"]);
+
+  assert.equal(routeSecondaryActivate({
+    topCategory: "all",
+    all: { gamesShelfBrowseActive: true, gameSubcategory: "favorites", setLibrarySortId, playUiSound: log.fn("sound") } as any,
+  }), false);
+});
+
+test("settings secondary cycles stream and controller settings used by streaming", () => {
+  const settings: Record<string, unknown> = {
+    resolution: "1280x720",
+    fps: 60,
+    codec: "H264",
+    enableL4S: false,
+    enableCloudGsync: true,
+    controllerUiSounds: true,
+    autoFullScreen: false,
+  };
+  const changes: Array<[string, unknown]> = [];
+  const log = calls();
+  const base = {
+    settingsSubcategory: "Video",
+    settings,
+    microphoneDevices: [],
+    aspectRatioOptions: [],
+    resolutionOptions: ["1280x720", "1920x1080"],
+    fpsOptions: [60, 120],
+    codecOptions: ["H264", "H265"],
+    setEditingThemeChannel: () => {},
+    setEditingBandwidth: log.fn("bandwidth"),
+    playUiSound: log.fn("sound"),
+    onSettingChange: (key: string, value: unknown) => {
+      settings[key] = value;
+      changes.push([key, value]);
+    },
+  };
+
+  for (const id of ["resolution", "fps", "codec", "l4s", "cloudGsync", "sounds", "autoFullScreen"] as const) {
+    routeSecondaryActivate({
+      topCategory: "settings",
+      settings: { ...base, displayItems: [{ id, label: id }], selectedSettingIndex: 0 } as any,
+    });
+  }
+
+  assert.deepEqual(changes, [
+    ["resolution", "1920x1080"],
+    ["fps", 120],
+    ["codec", "H265"],
+    ["enableL4S", true],
+    ["enableCloudGsync", false],
+    ["controllerUiSounds", false],
+    ["autoFullScreen", true],
+  ]);
+});

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
@@ -3,7 +3,38 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { codeMap, mapKeyboardEvent, mapTextCharToKeySpec } from "./inputProtocol";
+import {
+  GAMEPAD_A,
+  GAMEPAD_B,
+  GAMEPAD_BACK,
+  GAMEPAD_DPAD_UP,
+  GAMEPAD_GUIDE,
+  GAMEPAD_LB,
+  GAMEPAD_PACKET_SIZE,
+  GAMEPAD_RB,
+  GAMEPAD_RS,
+  GAMEPAD_START,
+  GAMEPAD_X,
+  GAMEPAD_Y,
+  INPUT_GAMEPAD,
+  INPUT_KEY_DOWN,
+  INPUT_KEY_UP,
+  INPUT_MOUSE_BUTTON_DOWN,
+  INPUT_MOUSE_REL,
+  INPUT_MOUSE_WHEEL,
+  InputEncoder,
+  codeMap,
+  isPartiallyReliableHidTransferEligible,
+  mapGamepadButtons,
+  mapKeyboardEvent,
+  mapTextCharToKeySpec,
+  modifierFlags,
+  normalizeToInt16,
+  normalizeToUint8,
+  partiallyReliableHidMaskForInputType,
+  readGamepadAxes,
+  toMouseButton,
+} from "./inputProtocol";
 
 function keyboardEvent(init: Partial<KeyboardEvent> & Pick<KeyboardEvent, "code" | "key">): KeyboardEvent {
   return {
@@ -17,6 +48,34 @@ function keyboardEvent(init: Partial<KeyboardEvent> & Pick<KeyboardEvent, "code"
     keyCode: init.keyCode ?? 0,
     getModifierState: init.getModifierState ?? (() => false),
   } as KeyboardEvent;
+}
+
+function gamepad(overrides: Partial<Gamepad> = {}): Gamepad {
+  const buttons = Array.from({ length: 17 }, () => ({ pressed: false, touched: false, value: 0 }));
+  return {
+    axes: [0, 0, 0, 0],
+    buttons,
+    connected: true,
+    hapticActuators: [],
+    id: "test-gamepad",
+    index: 0,
+    mapping: "standard",
+    timestamp: 0,
+    vibrationActuator: null,
+    ...overrides,
+  } as Gamepad;
+}
+
+function view(bytes: Uint8Array): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function assertV3BatchWrapper(bytes: Uint8Array, marker: number, lengthOffset: number, payloadOffset: number, payloadSize: number): DataView {
+  assert.equal(bytes[0], 0x23);
+  assert.equal(bytes[9], marker);
+  const data = view(bytes);
+  assert.equal(data.getUint16(lengthOffset, false), payloadSize);
+  return new DataView(bytes.buffer, bytes.byteOffset + payloadOffset, payloadSize);
 }
 
 test("maps representative physical keys to Windows set-1 scancodes", () => {
@@ -71,4 +130,155 @@ test("uses corrected scancodes for synthetic text injection", () => {
   assert.deepEqual(mapTextCharToKeySpec("<"), { ...codeMap.Comma, shift: true });
   assert.deepEqual(mapTextCharToKeySpec("/"), { ...codeMap.Slash });
   assert.deepEqual(mapTextCharToKeySpec("?"), { ...codeMap.Slash, shift: true });
+});
+
+test("modifierFlags includes keyboard modifiers and lock bits", () => {
+  const event = keyboardEvent({
+    code: "KeyA",
+    key: "a",
+    shiftKey: true,
+    ctrlKey: true,
+    altKey: true,
+    metaKey: true,
+    getModifierState: (key) => key === "CapsLock" || key === "NumLock",
+  });
+
+  assert.equal(modifierFlags(event), 0x3f);
+});
+
+test("encodes raw v2 key down and key up payload layout", () => {
+  const encoder = new InputEncoder();
+  const payload = { keycode: 0x41, modifiers: 0x13, scancode: 0x1e, timestampUs: 0x0102030405060708n };
+
+  for (const [bytes, type] of [[encoder.encodeKeyDown(payload), INPUT_KEY_DOWN], [encoder.encodeKeyUp(payload), INPUT_KEY_UP]] as const) {
+    const data = view(bytes);
+    assert.equal(bytes.byteLength, 18);
+    assert.equal(data.getUint32(0, true), type);
+    assert.equal(data.getUint16(4, false), 0x41);
+    assert.equal(data.getUint16(6, false), 0x13);
+    assert.equal(data.getUint16(8, false), 0x1e);
+    assert.equal(data.getBigUint64(10, false), payload.timestampUs);
+  }
+});
+
+test("maps browser mouse buttons to GFN buttons", () => {
+  assert.deepEqual([0, 1, 2, 3, 4].map(toMouseButton), [1, 2, 3, 4, 5]);
+});
+
+test("encodes mouse move with v3 cursor wrapper and inner payload", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(3);
+  const bytes = encoder.encodeMouseMove({ dx: -12, dy: 34, timestampUs: 99n });
+  const payload = assertV3BatchWrapper(bytes, 0x21, 10, 12, 22);
+
+  assert.equal(payload.getUint32(0, true), INPUT_MOUSE_REL);
+  assert.equal(payload.getInt16(4, false), -12);
+  assert.equal(payload.getInt16(6, false), 34);
+  assert.equal(payload.getBigUint64(14, false), 99n);
+});
+
+test("encodes mouse button and wheel with v3 single-event wrapper", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(3);
+
+  const buttonBytes = encoder.encodeMouseButtonDown({ button: 5, timestampUs: 123n });
+  assert.equal(buttonBytes[0], 0x23);
+  assert.equal(buttonBytes[9], 0x22);
+  const buttonPayload = new DataView(buttonBytes.buffer, buttonBytes.byteOffset + 10, 18);
+  assert.equal(buttonPayload.getUint32(0, true), INPUT_MOUSE_BUTTON_DOWN);
+  assert.equal(buttonPayload.getUint8(4), 5);
+  assert.equal(buttonPayload.getBigUint64(10, false), 123n);
+
+  const wheelBytes = encoder.encodeMouseWheel({ delta: -120, timestampUs: 456n });
+  assert.equal(wheelBytes[0], 0x23);
+  assert.equal(wheelBytes[9], 0x22);
+  const wheelPayload = new DataView(wheelBytes.buffer, wheelBytes.byteOffset + 10, 22);
+  assert.equal(wheelPayload.getUint32(0, true), INPUT_MOUSE_WHEEL);
+  assert.equal(wheelPayload.getInt16(4, false), 0);
+  assert.equal(wheelPayload.getInt16(6, false), -120);
+  assert.equal(wheelPayload.getBigUint64(14, false), 456n);
+});
+
+test("maps Gamepad API button values to XInput flags without pressed", () => {
+  const buttons = Array.from({ length: 17 }, () => ({ pressed: false, touched: false, value: 0 }));
+  for (const index of [0, 1, 2, 3, 4, 5, 8, 9, 11, 12, 16]) buttons[index] = { pressed: false, touched: false, value: 0.25 };
+
+  assert.equal(
+    mapGamepadButtons(gamepad({ buttons })),
+    GAMEPAD_A | GAMEPAD_B | GAMEPAD_X | GAMEPAD_Y | GAMEPAD_LB | GAMEPAD_RB | GAMEPAD_BACK | GAMEPAD_START | GAMEPAD_RS | GAMEPAD_DPAD_UP | GAMEPAD_GUIDE,
+  );
+});
+
+test("reads gamepad axes with radial deadzone, inverted Y, and trigger fallbacks", () => {
+  const fromButtons = readGamepadAxes(gamepad({
+    axes: [0.3, 0.4, 0.1, 0.1],
+    buttons: Array.from({ length: 8 }, (_, index) => ({ pressed: false, touched: false, value: index === 6 ? 0.5 : index === 7 ? 0.75 : 0 })),
+  }));
+  assert.ok(fromButtons.leftStickX > 0);
+  assert.ok(fromButtons.leftStickY < 0);
+  assert.equal(fromButtons.rightStickX, 0);
+  assert.equal(Object.is(fromButtons.rightStickY, -0) ? 0 : fromButtons.rightStickY, 0);
+  assert.equal(fromButtons.leftTrigger, 0.5);
+  assert.equal(fromButtons.rightTrigger, 0.75);
+
+  const fromAxes = readGamepadAxes(gamepad({ axes: [0, 0, 0, -1, 0.6, 0.7], buttons: [] }));
+  assert.equal(fromAxes.leftTrigger, 0.6);
+  assert.equal(fromAxes.rightTrigger, 0.7);
+  assert.equal(fromAxes.rightStickY, 1);
+});
+
+test("normalizers clamp extremes", () => {
+  assert.equal(normalizeToInt16(-2), -32768);
+  assert.equal(normalizeToInt16(2), 32767);
+  assert.equal(normalizeToUint8(-1), 0);
+  assert.equal(normalizeToUint8(2), 255);
+});
+
+test("encodes gamepad state with reliable and partially reliable v3 wrappers", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(3);
+  const payload = {
+    controllerId: 2,
+    buttons: GAMEPAD_A,
+    leftTrigger: 10,
+    rightTrigger: 20,
+    leftStickX: -100,
+    leftStickY: 200,
+    rightStickX: -300,
+    rightStickY: 400,
+    connected: true,
+    timestampUs: 0x0102030405060708n,
+  };
+
+  const reliablePayload = assertV3BatchWrapper(encoder.encodeGamepadState(payload, 0x0104, false), 0x21, 10, 12, GAMEPAD_PACKET_SIZE);
+  assert.equal(reliablePayload.getUint32(0, true), INPUT_GAMEPAD);
+  assert.equal(reliablePayload.getUint16(4, true), 26);
+  assert.equal(reliablePayload.getUint16(6, true), 2);
+  assert.equal(reliablePayload.getUint16(8, true), 0x0104);
+  assert.equal(reliablePayload.getUint16(12, true), GAMEPAD_A);
+  assert.equal(reliablePayload.getUint16(14, true), 0x140a);
+  assert.equal(reliablePayload.getInt16(16, true), -100);
+  assert.equal(reliablePayload.getBigUint64(30, true), payload.timestampUs);
+
+  const first = encoder.encodeGamepadState(payload, 0x0104, true);
+  const second = encoder.encodeGamepadState(payload, 0x0104, true);
+  for (const [bytes, sequence] of [[first, 1], [second, 2]] as const) {
+    assert.equal(bytes[0], 0x23);
+    assert.equal(bytes[9], 0x26);
+    assert.equal(bytes[10], 2);
+    const data = view(bytes);
+    assert.equal(data.getUint16(11, false), sequence);
+    assert.equal(bytes[13], 0x21);
+    assert.equal(data.getUint16(14, false), GAMEPAD_PACKET_SIZE);
+    assert.equal(new DataView(bytes.buffer, bytes.byteOffset + 16, GAMEPAD_PACKET_SIZE).getUint32(0, true), INPUT_GAMEPAD);
+  }
+});
+
+test("partially reliable HID helpers only mark mouse-relative input eligible", () => {
+  assert.equal(partiallyReliableHidMaskForInputType(INPUT_MOUSE_REL), 1 << INPUT_MOUSE_REL);
+  assert.equal(partiallyReliableHidMaskForInputType(-1), 0);
+  assert.equal(partiallyReliableHidMaskForInputType(32), 0);
+  assert.equal(isPartiallyReliableHidTransferEligible(INPUT_MOUSE_REL), true);
+  assert.equal(isPartiallyReliableHidTransferEligible(INPUT_MOUSE_BUTTON_DOWN), false);
+  assert.equal(isPartiallyReliableHidTransferEligible(INPUT_GAMEPAD), false);
 });

--- a/opennow-stable/src/renderer/src/gfn/sdp.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.test.ts
@@ -1,0 +1,138 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildNvstSdp,
+  fixServerIp,
+  mungeAnswerSdp,
+  preferCodec,
+  rewriteH265LevelIdByProfile,
+  rewriteH265TierFlag,
+} from "./sdp";
+
+test("fixServerIp replaces 0.0.0.0 connection and candidate IPs from GFN dashed hostnames", () => {
+  const sdp = [
+    "v=0",
+    "c=IN IP4 0.0.0.0",
+    "a=candidate:1 1 udp 2130706431 0.0.0.0 47998 typ host",
+    "a=candidate:2 1 tcp 1 192.168.1.5 9 typ host",
+  ].join("\n");
+
+  const fixed = fixServerIp(sdp, "161-248-11-132.bpc.geforcenow.nvidiagrid.net");
+
+  assert.match(fixed, /c=IN IP4 161\.248\.11\.132/);
+  assert.match(fixed, /a=candidate:1 1 udp 2130706431 161\.248\.11\.132 47998 typ host/);
+  assert.match(fixed, /a=candidate:2 1 tcp 1 192\.168\.1\.5 9 typ host/);
+  assert.equal(fixServerIp(sdp, "unparseable.example.com"), sdp);
+});
+
+test("preferCodec keeps selected video payloads and RTX apt payloads while leaving audio untouched", () => {
+  const sdp = [
+    "v=0",
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111 0",
+    "a=rtpmap:111 opus/48000/2",
+    "a=fmtp:111 minptime=10;useinbandfec=1",
+    "m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 102",
+    "a=rtpmap:96 H264/90000",
+    "a=rtcp-fb:96 nack",
+    "a=rtpmap:97 rtx/90000",
+    "a=fmtp:97 apt=96",
+    "a=rtpmap:98 H265/90000",
+    "a=fmtp:98 profile-id=1;tier-flag=0;level-id=153",
+    "a=rtcp-fb:98 nack pli",
+    "a=rtpmap:99 rtx/90000",
+    "a=fmtp:99 apt=98",
+    "a=rtpmap:100 AV1/90000",
+    "a=rtpmap:101 flexfec-03/90000",
+    "a=rtpmap:102 ulpfec/90000",
+  ].join("\n");
+
+  const filtered = preferCodec(sdp, "H265");
+
+  assert.match(filtered, /m=video 9 UDP\/TLS\/RTP\/SAVPF 98 99/);
+  assert.match(filtered, /a=rtpmap:98 H265\/90000/);
+  assert.match(filtered, /a=rtpmap:99 rtx\/90000/);
+  assert.match(filtered, /a=fmtp:99 apt=98/);
+  assert.doesNotMatch(filtered, /a=rtpmap:96 H264/);
+  assert.doesNotMatch(filtered, /a=rtpmap:100 AV1/);
+  assert.doesNotMatch(filtered, /flexfec|ulpfec/);
+  assert.match(filtered, /m=audio 9 UDP\/TLS\/RTP\/SAVPF 111 0/);
+  assert.match(filtered, /a=fmtp:111 minptime=10;useinbandfec=1/);
+});
+
+test("rewrites H265 tier flag and clamps oversized level by profile", () => {
+  const sdp = [
+    "m=video 9 UDP/TLS/RTP/SAVPF 98 99",
+    "a=rtpmap:98 H265/90000",
+    "a=fmtp:98 profile-id=1;tier-flag=1;level-id=186",
+    "a=rtpmap:99 H265/90000",
+    "a=fmtp:99 profile-id=2;tier-flag=1;level-id=255",
+  ].join("\n");
+
+  const tier = rewriteH265TierFlag(sdp, 0);
+  const level = rewriteH265LevelIdByProfile(tier.sdp, { 1: 153, 2: 186 });
+
+  assert.equal(tier.replacements, 2);
+  assert.equal(level.replacements, 2);
+  assert.match(level.sdp, /a=fmtp:98 profile-id=1;tier-flag=0;level-id=153/);
+  assert.match(level.sdp, /a=fmtp:99 profile-id=2;tier-flag=0;level-id=186/);
+});
+
+test("mungeAnswerSdp injects bitrate lines and appends opus stereo once", () => {
+  const sdp = [
+    "m=video 9 UDP/TLS/RTP/SAVPF 98",
+    "c=IN IP4 127.0.0.1",
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+    "a=fmtp:111 minptime=10;useinbandfec=1",
+  ].join("\n");
+
+  const munged = mungeAnswerSdp(sdp, 50000);
+  assert.match(munged, /m=video.*\nb=AS:50000\n/);
+  assert.match(munged, /m=audio.*\nb=AS:128\n/);
+  assert.match(munged, /a=fmtp:111 minptime=10;useinbandfec=1;stereo=1/);
+
+  const alreadyStereo = mungeAnswerSdp("m=audio 9 UDP/TLS/RTP/SAVPF 111\nb=AS:128\na=fmtp:111 minptime=10;stereo=1", 50000);
+  assert.equal((alreadyStereo.match(/stereo=1/g) ?? []).length, 1);
+  assert.equal((alreadyStereo.match(/b=AS:128/g) ?? []).length, 1);
+});
+
+test("buildNvstSdp includes stream quality and partially reliable input parameters", () => {
+  const sdp = buildNvstSdp({
+    width: 2560,
+    height: 1440,
+    fps: 120,
+    maxBitrateKbps: 80000,
+    partialReliableThresholdMs: 16,
+    codec: "AV1",
+    colorQuality: "10bit_444",
+    credentials: {
+      ufrag: "ufrag-test",
+      pwd: "password-test",
+      fingerprint: "AA:BB:CC",
+    },
+    hidDeviceMask: 128,
+    enablePartiallyReliableTransferGamepad: 15,
+    enablePartiallyReliableTransferHid: 128,
+  });
+
+  for (const line of [
+    "a=video.clientViewportWd:2560",
+    "a=video.clientViewportHt:1440",
+    "a=video.maxFPS:120",
+    "a=video.initialPeakBitrateKbps:80000",
+    "a=vqos.bw.maximumBitrateKbps:80000",
+    "a=vqos.bw.peakBitrateKbps:80000",
+    "a=video.bitDepth:10",
+    "a=vqos.drc.enable:0",
+    "a=vqos.dfc.enable:0",
+    "a=vqos.resControl.cpmRtc.enable:0",
+    "a=ri.partialReliableThresholdMs:16",
+    "a=ri.hidDeviceMask:128",
+    "a=ri.enablePartiallyReliableTransferGamepad:15",
+    "a=ri.enablePartiallyReliableTransferHid:128",
+  ]) {
+    assert.match(sdp, new RegExp(line.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+});


### PR DESCRIPTION
## Summary
- remove the 6-entry packaging matrix from the PR/push workflow
- replace with a single `ubuntu-24.04` job running `lint`, `typecheck`, and `test`
- drop Electron cache, packaging tools, `npm run build`, and `electron-builder` steps
- keep release.yml as the sole workflow for building/packaging artifacts

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/2cb789c3-862b-414a-ae50-b2c2101d3c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-090" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/2cb789c3-862b-414a-ae50-b2c2101d3c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-090&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-090"><img alt="OPE-090" src="https://capy.ai/api/badge/thread.svg?label=OPE-090"></picture></a>
<!-- capy-pr-badge:end -->