### PR TITLE
Add session proxy support for Nvidia CloudMatch queue admission

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -983,13 +983,15 @@ export async function pollSession(input: SessionPollRequest): Promise<SessionInf
   const deviceId = input.deviceId ?? crypto.randomUUID();
 
   const base = resolvePollStopBase(input.zone, input.streamingBaseUrl, input.serverIp);
+  const baseHost = new URL(base).hostname;
+  const pollProxyUrl = isZoneHostname(baseHost) ? input.proxyUrl : undefined;
   const url = `${base}/v2/session/${input.sessionId}`;
   // Polling should NOT include Origin/Referer headers (matches claimSession polling pattern)
   const headers = requestHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
   const response = await fetchWithOptionalProxy(url, {
     method: "GET",
     headers,
-  }, input.proxyUrl);
+  }, pollProxyUrl);
 
   const text = await response.text();
   if (!response.ok) {
@@ -997,7 +999,6 @@ export async function pollSession(input: SessionPollRequest): Promise<SessionInf
   }
 
   const payload = JSON.parse(text) as CloudMatchResponse;
-  const baseHost = new URL(base).hostname;
 
   // Match Rust behavior: if the poll was routed through the zone load balancer
   // and the response now contains a real server IP in connectionInfo, re-poll

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -30,6 +30,7 @@ import {
 
 import type { CloudMatchRequest, CloudMatchResponse, GetSessionsResponse } from "./types";
 import { SessionError } from "./errorCodes";
+import { fetchWithOptionalProxy } from "./proxyFetch";
 
 const GFN_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 NVIDIACEFClient/HEAD/debb5919f6 GFN-PC/2.0.80.173";
@@ -956,11 +957,11 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
   const keyboardLayout = resolveGfnKeyboardLayout(input.settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = input.settings.gameLanguage ?? "en_US";
   const url = `${base}/v2/session?${new URLSearchParams({ keyboardLayout, languageCode }).toString()}`;
-  const response = await fetch(url, {
+  const response = await fetchWithOptionalProxy(url, {
     method: "POST",
     headers: requestHeaders({ token: input.token, clientId, deviceId, includeOrigin: true }),
     body: JSON.stringify(body),
-  });
+  }, input.proxyUrl);
 
   const text = await response.text();
   if (!response.ok) {
@@ -985,10 +986,10 @@ export async function pollSession(input: SessionPollRequest): Promise<SessionInf
   const url = `${base}/v2/session/${input.sessionId}`;
   // Polling should NOT include Origin/Referer headers (matches claimSession polling pattern)
   const headers = requestHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
-  const response = await fetch(url, {
+  const response = await fetchWithOptionalProxy(url, {
     method: "GET",
     headers,
-  });
+  }, input.proxyUrl);
 
   const text = await response.text();
   if (!response.ok) {
@@ -1019,6 +1020,7 @@ export async function pollSession(input: SessionPollRequest): Promise<SessionInf
     const directBase = `https://${realServerIp}`;
     const directUrl = `${directBase}/v2/session/${input.sessionId}`;
     try {
+      // The ready-session direct real-IP re-poll intentionally bypasses the session proxy.
       const directResponse = await fetch(directUrl, {
         method: "GET",
         headers,

--- a/opennow-stable/src/main/gfn/proxyFetch.test.ts
+++ b/opennow-stable/src/main/gfn/proxyFetch.test.ts
@@ -3,7 +3,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { normalizeSessionProxyUrl } from "./proxyUrl";
+import { normalizeSessionProxyUrl, sessionProxyPartitionForUrl } from "./proxyUrl";
 
 test("normalizes scheme-less session proxy host:port values as http proxies", () => {
   assert.equal(normalizeSessionProxyUrl("localhost:8080"), "http://localhost:8080");
@@ -20,4 +20,16 @@ test("rejects unsupported explicit session proxy schemes", () => {
     () => normalizeSessionProxyUrl("ftp://proxy.example.com:21"),
     /Invalid session proxy URL/,
   );
+});
+
+test("derives stable redacted proxy session partitions", () => {
+  const withCredentials = sessionProxyPartitionForUrl("http://user:secret@proxy.example.com:8080");
+  const sameProxy = sessionProxyPartitionForUrl("http://user:secret@proxy.example.com:8080");
+  const differentProxy = sessionProxyPartitionForUrl("http://other.example.com:8080");
+
+  assert.equal(withCredentials, sameProxy);
+  assert.notEqual(withCredentials, differentProxy);
+  assert.match(withCredentials, /^opennow:gfn-session-proxy:[a-f0-9]{32}$/);
+  assert.equal(withCredentials.includes("proxy.example.com"), false);
+  assert.equal(withCredentials.includes("secret"), false);
 });

--- a/opennow-stable/src/main/gfn/proxyFetch.test.ts
+++ b/opennow-stable/src/main/gfn/proxyFetch.test.ts
@@ -22,14 +22,12 @@ test("rejects unsupported explicit session proxy schemes", () => {
   );
 });
 
-test("derives stable redacted proxy session partitions", () => {
+test("derives stable opaque proxy session partitions", () => {
   const withCredentials = sessionProxyPartitionForUrl("http://user:secret@proxy.example.com:8080");
   const sameProxy = sessionProxyPartitionForUrl("http://user:secret@proxy.example.com:8080");
   const differentProxy = sessionProxyPartitionForUrl("http://other.example.com:8080");
 
   assert.equal(withCredentials, sameProxy);
   assert.notEqual(withCredentials, differentProxy);
-  assert.match(withCredentials, /^opennow:gfn-session-proxy:[a-f0-9]{32}$/);
-  assert.equal(withCredentials.includes("proxy.example.com"), false);
-  assert.equal(withCredentials.includes("secret"), false);
+  assert.match(withCredentials, /^opennow:gfn-session-proxy:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
 });

--- a/opennow-stable/src/main/gfn/proxyFetch.test.ts
+++ b/opennow-stable/src/main/gfn/proxyFetch.test.ts
@@ -1,0 +1,23 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeSessionProxyUrl } from "./proxyUrl";
+
+test("normalizes scheme-less session proxy host:port values as http proxies", () => {
+  assert.equal(normalizeSessionProxyUrl("localhost:8080"), "http://localhost:8080");
+  assert.equal(normalizeSessionProxyUrl("proxy.example.com:8080"), "http://proxy.example.com:8080");
+  assert.equal(normalizeSessionProxyUrl("127.0.0.1:8080"), "http://127.0.0.1:8080");
+});
+
+test("accepts supported explicit session proxy schemes", () => {
+  assert.equal(normalizeSessionProxyUrl("socks5://proxy.example.com:1080"), "socks5://proxy.example.com:1080");
+});
+
+test("rejects unsupported explicit session proxy schemes", () => {
+  assert.throws(
+    () => normalizeSessionProxyUrl("ftp://proxy.example.com:21"),
+    /Invalid session proxy URL/,
+  );
+});

--- a/opennow-stable/src/main/gfn/proxyFetch.ts
+++ b/opennow-stable/src/main/gfn/proxyFetch.ts
@@ -1,0 +1,29 @@
+import { session as electronSession } from "electron";
+
+import { normalizeSessionProxyUrl } from "./proxyUrl";
+
+const CLOUDMATCH_PROXY_PARTITION = "opennow:gfn-session-proxy";
+
+type ElectronSessionWithFetch = Electron.Session & {
+  fetch?: typeof fetch;
+};
+
+export async function fetchWithOptionalProxy(
+  input: string,
+  init: RequestInit | undefined,
+  proxyUrl?: string,
+): Promise<Response> {
+  const normalizedProxyUrl = normalizeSessionProxyUrl(proxyUrl);
+  if (!normalizedProxyUrl) {
+    return fetch(input, init);
+  }
+
+  const proxySession = electronSession.fromPartition(CLOUDMATCH_PROXY_PARTITION, { cache: false }) as ElectronSessionWithFetch;
+  await proxySession.setProxy({ proxyRules: normalizedProxyUrl });
+
+  if (typeof proxySession.fetch === "function") {
+    return proxySession.fetch(input, init);
+  }
+
+  throw new Error("Electron session fetch is unavailable for session proxy requests.");
+}

--- a/opennow-stable/src/main/gfn/proxyFetch.ts
+++ b/opennow-stable/src/main/gfn/proxyFetch.ts
@@ -1,8 +1,6 @@
 import { session as electronSession } from "electron";
 
-import { normalizeSessionProxyUrl } from "./proxyUrl";
-
-const CLOUDMATCH_PROXY_PARTITION = "opennow:gfn-session-proxy";
+import { normalizeSessionProxyUrl, sessionProxyPartitionForUrl } from "./proxyUrl";
 
 type ElectronSessionWithFetch = Electron.Session & {
   fetch?: typeof fetch;
@@ -18,7 +16,7 @@ export async function fetchWithOptionalProxy(
     return fetch(input, init);
   }
 
-  const proxySession = electronSession.fromPartition(CLOUDMATCH_PROXY_PARTITION, { cache: false }) as ElectronSessionWithFetch;
+  const proxySession = electronSession.fromPartition(sessionProxyPartitionForUrl(normalizedProxyUrl), { cache: false }) as ElectronSessionWithFetch;
   await proxySession.setProxy({ proxyRules: normalizedProxyUrl });
 
   if (typeof proxySession.fetch === "function") {

--- a/opennow-stable/src/main/gfn/proxyUrl.ts
+++ b/opennow-stable/src/main/gfn/proxyUrl.ts
@@ -1,6 +1,14 @@
+import crypto from "node:crypto";
+
 const INVALID_PROXY_MESSAGE =
   "Invalid session proxy URL. Use http://host:port, https://host:port, socks4://host:port, or socks5://host:port.";
 const SUPPORTED_PROXY_PROTOCOLS = new Set(["http:", "https:", "socks4:", "socks5:"]);
+const CLOUDMATCH_PROXY_PARTITION_PREFIX = "opennow:gfn-session-proxy";
+
+export function sessionProxyPartitionForUrl(normalizedProxyUrl: string): string {
+  const hash = crypto.createHash("sha256").update(normalizedProxyUrl).digest("hex").slice(0, 32);
+  return `${CLOUDMATCH_PROXY_PARTITION_PREFIX}:${hash}`;
+}
 
 export function normalizeSessionProxyUrl(raw?: string): string | null {
   const trimmed = raw?.trim() ?? "";

--- a/opennow-stable/src/main/gfn/proxyUrl.ts
+++ b/opennow-stable/src/main/gfn/proxyUrl.ts
@@ -4,10 +4,15 @@ const INVALID_PROXY_MESSAGE =
   "Invalid session proxy URL. Use http://host:port, https://host:port, socks4://host:port, or socks5://host:port.";
 const SUPPORTED_PROXY_PROTOCOLS = new Set(["http:", "https:", "socks4:", "socks5:"]);
 const CLOUDMATCH_PROXY_PARTITION_PREFIX = "opennow:gfn-session-proxy";
+const proxyPartitions = new Map<string, string>();
 
 export function sessionProxyPartitionForUrl(normalizedProxyUrl: string): string {
-  const hash = crypto.createHash("sha256").update(normalizedProxyUrl).digest("hex").slice(0, 32);
-  return `${CLOUDMATCH_PROXY_PARTITION_PREFIX}:${hash}`;
+  const existing = proxyPartitions.get(normalizedProxyUrl);
+  if (existing) return existing;
+
+  const partition = `${CLOUDMATCH_PROXY_PARTITION_PREFIX}:${crypto.randomUUID()}`;
+  proxyPartitions.set(normalizedProxyUrl, partition);
+  return partition;
 }
 
 export function normalizeSessionProxyUrl(raw?: string): string | null {

--- a/opennow-stable/src/main/gfn/proxyUrl.ts
+++ b/opennow-stable/src/main/gfn/proxyUrl.ts
@@ -1,0 +1,25 @@
+const INVALID_PROXY_MESSAGE =
+  "Invalid session proxy URL. Use http://host:port, https://host:port, socks4://host:port, or socks5://host:port.";
+const SUPPORTED_PROXY_PROTOCOLS = new Set(["http:", "https:", "socks4:", "socks5:"]);
+
+export function normalizeSessionProxyUrl(raw?: string): string | null {
+  const trimmed = raw?.trim() ?? "";
+  if (!trimmed) return null;
+
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    throw new Error(INVALID_PROXY_MESSAGE);
+  }
+
+  if (!SUPPORTED_PROXY_PROTOCOLS.has(parsed.protocol) || !parsed.hostname || !parsed.port) {
+    throw new Error(INVALID_PROXY_MESSAGE);
+  }
+
+  const username = parsed.username ? encodeURIComponent(decodeURIComponent(parsed.username)) : "";
+  const password = parsed.password ? encodeURIComponent(decodeURIComponent(parsed.password)) : "";
+  const credentials = username ? `${username}${password ? `:${password}` : ""}@` : "";
+  return `${parsed.protocol}//${credentials}${parsed.host}`;
+}

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -1339,6 +1339,7 @@ function registerIpcHandlers(): void {
               serverIp: launchingCandidate.serverIp!,
               zone: payload.zone,
               sessionId: launchingCandidate.sessionId,
+              proxyUrl: payload.proxyUrl,
             });
           } catch (hydrateError) {
             console.warn(

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -35,6 +35,8 @@ export interface Settings {
   colorQuality: ColorQuality;
   /** Preferred region URL (empty = auto) */
   region: string;
+  /** Optional proxy used only for Nvidia session creation and queue polling */
+  sessionProxyUrl: string;
   /** Enable clipboard paste into stream */
   clipboardPaste: boolean;
   /** Mouse sensitivity multiplier */
@@ -152,6 +154,7 @@ const DEFAULT_SETTINGS: Settings = {
   encoderPreference: "auto",
   colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
   region: "",
+  sessionProxyUrl: "",
   clipboardPaste: false,
   mouseSensitivity: 1,
   mouseAcceleration: 1,

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -35,6 +35,8 @@ export interface Settings {
   colorQuality: ColorQuality;
   /** Preferred region URL (empty = auto) */
   region: string;
+  /** Enable the optional proxy for Nvidia session creation and queue polling */
+  sessionProxyEnabled: boolean;
   /** Optional proxy used only for Nvidia session creation and queue polling */
   sessionProxyUrl: string;
   /** Enable clipboard paste into stream */
@@ -154,6 +156,7 @@ const DEFAULT_SETTINGS: Settings = {
   encoderPreference: "auto",
   colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
   region: "",
+  sessionProxyEnabled: false,
   sessionProxyUrl: "",
   clipboardPaste: false,
   mouseSensitivity: 1,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -919,6 +919,7 @@ export function App(): JSX.Element {
     encoderPreference: "auto",
     colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
     region: "",
+    sessionProxyUrl: "",
     clipboardPaste: false,
     mouseSensitivity: 1,
     mouseAcceleration: 1,
@@ -3647,6 +3648,7 @@ export function App(): JSX.Element {
         internalTitle: game.title,
         accountLinked: chooseAccountLinked(game, selectedVariant),
         existingSessionStrategy,
+        proxyUrl: settings.sessionProxyUrl || undefined,
         zone: "prod",
         settings: {
           resolution: settings.resolution,
@@ -3731,6 +3733,7 @@ export function App(): JSX.Element {
           sessionId: newSession.sessionId,
           clientId: newSession.clientId,
           deviceId: newSession.deviceId,
+          proxyUrl: settings.sessionProxyUrl || undefined,
         });
 
         if (launchAbortRef.current) {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -919,6 +919,7 @@ export function App(): JSX.Element {
     encoderPreference: "auto",
     colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
     region: "",
+    sessionProxyEnabled: false,
     sessionProxyUrl: "",
     clipboardPaste: false,
     mouseSensitivity: 1,
@@ -3640,6 +3641,8 @@ export function App(): JSX.Element {
         }
       }
 
+      const sessionProxyUrl = settings.sessionProxyEnabled ? settings.sessionProxyUrl.trim() : "";
+
       // Create new session
       const newSession = await window.openNow.createSession({
         token: token || undefined,
@@ -3648,7 +3651,7 @@ export function App(): JSX.Element {
         internalTitle: game.title,
         accountLinked: chooseAccountLinked(game, selectedVariant),
         existingSessionStrategy,
-        proxyUrl: settings.sessionProxyUrl || undefined,
+        proxyUrl: sessionProxyUrl || undefined,
         zone: "prod",
         settings: {
           resolution: settings.resolution,
@@ -3733,7 +3736,7 @@ export function App(): JSX.Element {
           sessionId: newSession.sessionId,
           clientId: newSession.clientId,
           deviceId: newSession.deviceId,
-          proxyUrl: settings.sessionProxyUrl || undefined,
+          proxyUrl: sessionProxyUrl || undefined,
         });
 
         if (launchAbortRef.current) {

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -51,7 +51,7 @@ type SettingsSearchScopeId =
   | "thanks";
 
 const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string[]> = {
-  "stream-region": ["stream", "region", "latency", "ping", "server", "route", "auto best"],
+  "stream-region": ["stream", "region", "latency", "ping", "server", "route", "auto best", "proxy", "vpn", "queue", "session"],
   "stream-video": [
     "stream",
     "video",
@@ -1832,6 +1832,25 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                     value={settings.maxBitrateMbps}
                     onChange={(e) => handleChange("maxBitrateMbps", parseInt(e.target.value, 10))}
                   />
+                </div>
+
+                <div className="settings-row settings-row--column">
+                  <label className="settings-label settings-label--wrap">
+                    <span className="settings-label-title">
+                      Session proxy
+                      <span className="settings-inline-badge settings-inline-badge--beta">Beta</span>
+                    </span>
+                  </label>
+                  <input
+                    type="text"
+                    className="settings-text-input"
+                    placeholder="http://127.0.0.1:8080"
+                    value={settings.sessionProxyUrl}
+                    onChange={(e) => handleChange("sessionProxyUrl", e.target.value)}
+                  />
+                  <span className="settings-subtle-hint">
+                    Used only for Nvidia session creation and queue polling. Streaming/signaling traffic is not proxied.
+                  </span>
                 </div>
 
                 <div className="settings-row settings-row--column">

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -51,7 +51,22 @@ type SettingsSearchScopeId =
   | "thanks";
 
 const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string[]> = {
-  "stream-region": ["stream", "region", "latency", "ping", "server", "route", "auto best", "proxy", "vpn", "queue", "session"],
+  "stream-region": [
+    "stream",
+    "region",
+    "latency",
+    "ping",
+    "server",
+    "route",
+    "auto best",
+    "proxy",
+    "vpn",
+    "queue",
+    "session",
+    "sponsor",
+    "github sponsor",
+    "supporter",
+  ],
   "stream-video": [
     "stream",
     "video",
@@ -1835,22 +1850,34 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                 </div>
 
                 <div className="settings-row settings-row--column">
-                  <label className="settings-label settings-label--wrap">
-                    <span className="settings-label-title">
-                      Session proxy
-                      <span className="settings-inline-badge settings-inline-badge--beta">Beta</span>
-                    </span>
-                  </label>
-                  <input
-                    type="text"
-                    className="settings-text-input"
-                    placeholder="http://127.0.0.1:8080"
-                    value={settings.sessionProxyUrl}
-                    onChange={(e) => handleChange("sessionProxyUrl", e.target.value)}
-                  />
+                  <div className="settings-row-top settings-row-top--compact">
+                    <label className="settings-label settings-label--wrap">
+                      <span className="settings-label-title">
+                        Session proxy
+                        <span className="settings-inline-badge settings-inline-badge--beta">Beta</span>
+                      </span>
+                    </label>
+                    <label className="settings-toggle">
+                      <input
+                        type="checkbox"
+                        checked={settings.sessionProxyEnabled}
+                        onChange={(e) => handleChange("sessionProxyEnabled", e.target.checked)}
+                      />
+                      <span className="settings-toggle-track" />
+                    </label>
+                  </div>
                   <span className="settings-subtle-hint">
-                    Used only for Nvidia session creation and queue polling. Streaming/signaling traffic is not proxied.
+                    Used only for Nvidia session creation and queue polling. Streaming/signaling traffic is not proxied. Zortos provides a proxy for GitHub Sponsors/supporters.
                   </span>
+                  {settings.sessionProxyEnabled && (
+                    <input
+                      type="text"
+                      className="settings-text-input"
+                      placeholder="http://127.0.0.1:8080"
+                      value={settings.sessionProxyUrl}
+                      onChange={(e) => handleChange("sessionProxyUrl", e.target.value)}
+                    />
+                  )}
                 </div>
 
                 <div className="settings-row settings-row--column">

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -146,6 +146,7 @@ export interface Settings {
   encoderPreference: VideoAccelerationPreference;
   colorQuality: ColorQuality;
   region: string;
+  sessionProxyUrl: string;
   clipboardPaste: boolean;
   mouseSensitivity: number;
   mouseAcceleration: number;
@@ -497,6 +498,7 @@ export interface SessionCreateRequest {
   existingSessionStrategy?: ExistingSessionStrategy;
   zone: string;
   settings: StreamSettings;
+  proxyUrl?: string;
 }
 
 export interface SessionPollRequest {
@@ -507,6 +509,7 @@ export interface SessionPollRequest {
   sessionId: string;
   clientId?: string;
   deviceId?: string;
+  proxyUrl?: string;
 }
 
 export interface SessionStopRequest {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -146,6 +146,7 @@ export interface Settings {
   encoderPreference: VideoAccelerationPreference;
   colorQuality: ColorQuality;
   region: string;
+  sessionProxyEnabled: boolean;
   sessionProxyUrl: string;
   clipboardPaste: boolean;
   mouseSensitivity: number;


### PR DESCRIPTION
## Summary
This PR adds selective proxy support for Nvidia CloudMatch session creation and queue polling requests, addressing #335. The proxy is only used during session admission/queue phases, bypassed for direct server connections and never applied to WebRTC/media/signaling traffic.

## Changes

**Core implementation**
- add `sessionProxyUrl` setting field with empty-string default in `src/shared/gfn.ts` and `src/main/settings.ts`
- add `proxyUrl?: string` to `SessionCreateRequest` and `SessionPollRequest` interfaces
- create `src/main/gfn/proxyUrl.ts` with normalization logic that accepts http/https/socks4/socks5 and defaults scheme-less `host:port` to `http://`
- create `src/main/gfn/proxyFetch.ts` using isolated Electron session partition `opennow:gfn-session-proxy` to keep proxy separate from default session

**Integration**
- update `createSession()` in `src/main/gfn/cloudmatch.ts` to use proxy helper
- update initial `pollSession()` to use proxy helper
- keep ready-session direct real-IP re-poll on plain `fetch` to bypass proxy after queue clears
- pass `settings.sessionProxyUrl` from renderer to main IPC in `src/renderer/src/App.tsx`
- carry `payload.proxyUrl` through `CREATE_SESSION` handler in `src/main/index.ts`, including queued existing-session hydration

**Settings UI**
- add `Session proxy` Beta input row in Stream settings in `src/renderer/src/components/SettingsPage.tsx`
- add search terms `proxy`, `vpn`, `region`, `queue`, `session` to stream-region scope
- helper text clarifies scope is session creation/queue only, not streaming/signaling

**Testing**
- add `src/main/gfn/proxyFetch.test.ts` covering scheme-less defaults and supported/unsupported schemes
- pass `npm run typecheck`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/4b10f435-c91c-44f0-9dfe-fb553ec04dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-089" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/4b10f435-c91c-44f0-9dfe-fb553ec04dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-089&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-089"><img alt="OPE-089" src="https://capy.ai/api/badge/thread.svg?label=OPE-089"></picture></a>
<!-- capy-pr-badge:end -->