### PR TITLE
Fix in-stream menu meta toggle for both WebRTC and native streaming

### DIFF
--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -2092,7 +2092,7 @@ export class GfnWebRtcClient {
   }
 
   private getGamepadPollIntervalMs(): number {
-    if (!this.shouldPollGamepads() || document.visibilityState !== "visible") {
+    if (!this.shouldPollGamepads()) {
       return 100;
     }
 
@@ -2100,13 +2100,15 @@ export class GfnWebRtcClient {
       return 100;
     }
 
-    return 4;
+    // Poll at reduced rate while input is paused (dashboard open) — fast enough
+    // to catch the Meta button release and next press, but not burning CPU at
+    // the full 4 ms stream-input rate.
+    return this.inputPaused ? 16 : 4;
   }
 
   private shouldPollGamepads(): boolean {
     return this.inputReady
-      && document.visibilityState === "visible"
-      && !this.inputPaused;
+      && document.visibilityState === "visible";
   }
 
   private gamepadSendCount = 0;

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -1892,7 +1892,11 @@ export class GfnWebRtcClient {
     this.emitStats();
     this.detachInputCapture();
     this.inputPaused = false;
-    this.log(`Native DX11 input forwarding active (protocol v${nativeProtocolVersion}); controller polling is handled by the native renderer.`);
+    // Restart the polling loop for Meta/Home button detection. Full gamepad
+    // state forwarding is suppressed inside pollGamepads() when nativeInputActive
+    // is true so the native renderer remains the sole source for controller input.
+    this.setupGamepadPolling();
+    this.log(`Native DX11 input forwarding active (protocol v${nativeProtocolVersion}); controller meta detection active, gamepad forwarding handled by native renderer.`);
   }
 
   public setNativeInputProtocolVersion(protocolVersion: number): void {
@@ -2168,7 +2172,9 @@ export class GfnWebRtcClient {
         }
 
         // Read and encode gamepad state
-        if (streamInputBlocked) {
+        // Skip forwarding to the stream if input is blocked (dashboard open) or
+        // the native renderer is handling controller input directly.
+        if (streamInputBlocked || this.nativeInputActive) {
           continue;
         }
         const gamepadInput = this.readGamepadState(gamepad, i);


### PR DESCRIPTION
Native streamer merge disabled Meta/Home button detection in two ways, making the dashboard impossible to close after opening.

**WebRTC mode**
- `shouldPollGamepads()` returned false when `inputPaused` was true, so polling stopped when the dashboard opened and Meta was never detected.
- Remove `!this.inputPaused` from `shouldPollGamepads()` to keep meta detection alive.
- Drop poll interval to 16ms while paused (from 100ms) for responsive Meta presses.

**Native mode**
- `activateNativeInput()` called `cleanupPeerConnection()` which cleared the gamepad poll timer, then never restarted it.
- Call `setupGamepadPolling()` after native activation.
- Guard gamepad forwarding with `nativeInputActive` to avoid double-sending state already forwarded by the native renderer.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/95c1e75d-d2c5-4bea-bb81-158ea065e7d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-092" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/95c1e75d-d2c5-4bea-bb81-158ea065e7d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-092&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-092"><img alt="OPE-092" src="https://capy.ai/api/badge/thread.svg?label=OPE-092"></picture></a>
<!-- capy-pr-badge:end -->