### PR TITLE
Rewire in-stream recording for GStreamer and Electron backends

### DIFF
--- a/native/opennow-streamer/src/backend.rs
+++ b/native/opennow-streamer/src/backend.rs
@@ -20,6 +20,9 @@ pub trait NativeStreamerBackend {
     fn send_input(&mut self, command: CommandEnvelope) -> BackendReply;
     fn update_render_surface(&mut self, command: CommandEnvelope) -> BackendReply;
     fn update_bitrate_limit(&mut self, command: CommandEnvelope) -> BackendReply;
+    fn start_recording(&mut self, command: CommandEnvelope) -> BackendReply;
+    fn stop_recording(&mut self, command: CommandEnvelope) -> BackendReply;
+    fn abort_recording(&mut self, command: CommandEnvelope) -> BackendReply;
     fn stop(&mut self, command: CommandEnvelope) -> BackendReply;
 }
 
@@ -458,6 +461,26 @@ impl NativeStreamerBackend for StubBackend {
             response: Some(Response::Ok { id: command.id }),
             should_continue: true,
         }
+    }
+
+    fn start_recording(&mut self, command: CommandEnvelope) -> BackendReply {
+        BackendReply::response(Response::Error {
+            id: Some(command.id),
+            code: "recording-unsupported".to_owned(),
+            message: "Native recording is not supported by the stub backend.".to_owned(),
+        })
+    }
+
+    fn stop_recording(&mut self, command: CommandEnvelope) -> BackendReply {
+        BackendReply::response(Response::Error {
+            id: Some(command.id),
+            code: "recording-unsupported".to_owned(),
+            message: "Native recording is not supported by the stub backend.".to_owned(),
+        })
+    }
+
+    fn abort_recording(&mut self, command: CommandEnvelope) -> BackendReply {
+        BackendReply::response(Response::Ok { id: command.id })
     }
 
     fn stop(&mut self, command: CommandEnvelope) -> BackendReply {

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -9,8 +9,8 @@ use crate::input::{
 use crate::protocol::{
     missing_field, CommandEnvelope, Event, IceCandidatePayload, NativeQueueMode, NativeRenderRect,
     NativeRenderSurface, NativeStreamerCapabilities, NativeStreamerSessionContext,
-    NativeVideoBackendCapability, NativeVideoCodecCapability, Response, SendAnswerRequest,
-    StreamSettings, VideoStallEvent, VideoTransitionEvent, PROTOCOL_VERSION,
+    NativeVideoBackendCapability, NativeVideoCodecCapability, RecordingContainer, Response,
+    SendAnswerRequest, StreamSettings, VideoStallEvent, VideoTransitionEvent, PROTOCOL_VERSION,
 };
 use crate::sdp::{
     build_nvst_sdp_for_answer, extract_negotiated_video_codec, munge_answer_sdp, IceCredentials,
@@ -1576,6 +1576,15 @@ struct GstreamerPipeline {
     event_sender: Option<Sender<Event>>,
     original_remote_ice_credentials: Option<IceCredentials>,
     original_remote_ice_credentials_restored: bool,
+    recording: Option<GstreamerRecordingBranch>,
+}
+
+#[derive(Debug)]
+struct GstreamerRecordingBranch {
+    recording_id: String,
+    elements: Vec<gst::Element>,
+    src_pad: gst::Pad,
+    probe_id: gst::PadProbeId,
 }
 
 impl GstreamerPipeline {
@@ -1635,7 +1644,156 @@ impl GstreamerPipeline {
             event_sender,
             original_remote_ice_credentials: None,
             original_remote_ice_credentials_restored: false,
+            recording: None,
         })
+    }
+
+    fn start_recording(
+        &mut self,
+        recording_id: String,
+        temp_path: String,
+        container: RecordingContainer,
+    ) -> Result<(), String> {
+        if self.recording.is_some() {
+            return Err("A native GStreamer recording is already active.".to_owned());
+        }
+        if container != RecordingContainer::Matroska {
+            return Err("Native GStreamer recording currently supports only Matroska.".to_owned());
+        }
+
+        let video_src = self.video_liveness.state.rtp_video_src_pad().ok_or_else(|| {
+            "Native video RTP is not connected yet; wait until the stream is visible before recording.".to_owned()
+        })?;
+        let encoding = rtp_video_encoding(&video_src)
+            .unwrap_or_else(|| "H264".to_owned())
+            .to_ascii_uppercase();
+        let depay = rtp_video_depayloader_factory(&encoding)
+            .ok_or_else(|| format!("Native recording does not support RTP {encoding}."))?;
+        let parser = rtp_video_parser_factory(&encoding)
+            .ok_or_else(|| format!("Native recording does not support RTP {encoding}."))?;
+        let elements = vec![
+            make_element("appsrc")?,
+            make_element("queue")?,
+            make_element("rtpjitterbuffer")?,
+            make_element(depay)?,
+            make_element(parser)?,
+            make_element("matroskamux")?,
+            make_element("filesink")?,
+        ];
+        if let Some(caps) = video_src.current_caps() {
+            elements[0].set_property("caps", &caps);
+        }
+        elements[0].set_property("is-live", true);
+        elements[0].set_property_from_str("format", "time");
+        elements[6].set_property("location", &temp_path);
+        for element in &elements {
+            self.pipeline
+                .add(element)
+                .map_err(|error| format!("Failed to add recording element: {error}"))?;
+        }
+        let result = (|| -> Result<(), String> {
+            for pair in elements.windows(2) {
+                pair[0]
+                    .link(&pair[1])
+                    .map_err(|error| format!("Failed to link recording branch: {error:?}"))?;
+            }
+            for element in &elements {
+                element
+                    .sync_state_with_parent()
+                    .map_err(|error| format!("Failed to sync recording element state: {error}"))?;
+            }
+            Ok(())
+        })();
+        if let Err(error) = result {
+            for element in &elements {
+                let _ = element.set_state(gst::State::Null);
+                let _ = self.pipeline.remove(element);
+            }
+            return Err(error);
+        }
+        let appsrc = elements[0].clone();
+        let probe_id = video_src.add_probe(gst::PadProbeType::BUFFER, move |_pad, info| {
+            if let Some(buffer) = info.buffer() {
+                let _ = appsrc.emit_by_name::<gst::FlowSuccess>("push-buffer", &[&buffer.copy()]);
+            }
+            gst::PadProbeReturn::Ok
+        });
+        send_log(&self.event_sender, "info", "Native recording started. Audio recording is not yet available on this path; saving video-only Matroska.".to_owned());
+        self.recording = Some(GstreamerRecordingBranch {
+            recording_id,
+            elements,
+            src_pad: video_src,
+            probe_id,
+        });
+        Ok(())
+    }
+
+    fn stop_recording(&mut self, recording_id: &str) -> Result<(), String> {
+        let Some(branch) = self.recording.take() else {
+            return Err("No native recording is active.".to_owned());
+        };
+        if branch.recording_id != recording_id {
+            self.recording = Some(branch);
+            return Err("Native recording id does not match the active recording.".to_owned());
+        }
+        self.finalize_recording_branch(branch)
+    }
+
+    fn finalize_recording_branch(&self, branch: GstreamerRecordingBranch) -> Result<(), String> {
+        branch.src_pad.remove_probe(branch.probe_id);
+        let filesink = branch
+            .elements
+            .last()
+            .ok_or_else(|| "Recording branch has no filesink.".to_owned())?;
+        let filesink_sink_pad = filesink
+            .static_pad("sink")
+            .ok_or_else(|| "Recording filesink has no sink pad.".to_owned())?;
+        let (eos_sender, eos_receiver) = mpsc::channel::<()>();
+        let eos_probe_id =
+            filesink_sink_pad.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
+                if info
+                    .event()
+                    .is_some_and(|event| event.type_() == gst::EventType::Eos)
+                {
+                    let _ = eos_sender.send(());
+                }
+                gst::PadProbeReturn::Ok
+            });
+
+        let eos_result = branch
+            .elements
+            .first()
+            .map(|appsrc| appsrc.emit_by_name::<gst::FlowSuccess>("end-of-stream", &[]));
+        if eos_result.is_none() {
+            filesink_sink_pad.remove_probe(eos_probe_id);
+            self.teardown_recording_branch(branch);
+            return Err("Recording branch has no appsrc.".to_owned());
+        }
+
+        let wait_result = eos_receiver.recv_timeout(Duration::from_secs(5));
+        filesink_sink_pad.remove_probe(eos_probe_id);
+        self.teardown_recording_branch(branch);
+        wait_result.map_err(|error| {
+            format!("Timed out waiting for native recording EOS finalization: {error}")
+        })
+    }
+
+    fn abort_recording(&mut self, recording_id: &str) {
+        if let Some(branch) = self.recording.take() {
+            if branch.recording_id == recording_id {
+                self.teardown_recording_branch(branch);
+            } else {
+                self.recording = Some(branch);
+            }
+        }
+    }
+
+    fn teardown_recording_branch(&self, branch: GstreamerRecordingBranch) {
+        branch.src_pad.remove_probe(branch.probe_id);
+        for element in branch.elements.iter().rev() {
+            let _ = element.set_state(gst::State::Null);
+            let _ = self.pipeline.remove(element);
+        }
     }
 
     fn parse_offer_sdp(sdp: &str) -> Result<gst_sdp::SDPMessage, String> {
@@ -1985,6 +2143,9 @@ impl GstreamerPipeline {
     }
 
     fn stop(mut self) -> Result<(), String> {
+        if let Some(branch) = self.recording.take() {
+            self.teardown_recording_branch(branch);
+        }
         self.video_liveness.set_stats_overlay_visible(false);
         self.render_state.stop_external_renderer_window_guard();
         #[cfg(target_os = "windows")]
@@ -6545,6 +6706,63 @@ impl NativeStreamerBackend for GstreamerBackend {
             response: Some(Response::Ok { id: command.id }),
             should_continue: true,
         }
+    }
+
+    fn start_recording(&mut self, command: CommandEnvelope) -> BackendReply {
+        let id = command.id.clone();
+        let Some(recording) = command.recording else {
+            return BackendReply::response(missing_field(&id, "recording"));
+        };
+        let Some(temp_path) = recording.temp_path else {
+            return BackendReply::response(missing_field(&id, "recording.tempPath"));
+        };
+        let Some(container) = recording.container else {
+            return BackendReply::response(missing_field(&id, "recording.container"));
+        };
+        let Some(pipeline) = self.pipeline.as_mut() else {
+            return BackendReply::response(Response::Error {
+                id: Some(id),
+                code: "gstreamer-not-started".to_owned(),
+                message: "GStreamer pipeline is not started.".to_owned(),
+            });
+        };
+        match pipeline.start_recording(recording.recording_id, temp_path, container) {
+            Ok(()) => BackendReply::response(Response::Ok { id }),
+            Err(message) => BackendReply::response(Response::Error {
+                id: Some(id),
+                code: "gstreamer-recording-start-failed".to_owned(),
+                message,
+            }),
+        }
+    }
+
+    fn stop_recording(&mut self, command: CommandEnvelope) -> BackendReply {
+        let id = command.id.clone();
+        let Some(recording) = command.recording else {
+            return BackendReply::response(missing_field(&id, "recording"));
+        };
+        let Some(pipeline) = self.pipeline.as_mut() else {
+            return BackendReply::response(Response::Error {
+                id: Some(id),
+                code: "gstreamer-not-started".to_owned(),
+                message: "GStreamer pipeline is not started.".to_owned(),
+            });
+        };
+        match pipeline.stop_recording(&recording.recording_id) {
+            Ok(()) => BackendReply::response(Response::Ok { id }),
+            Err(message) => BackendReply::response(Response::Error {
+                id: Some(id),
+                code: "gstreamer-recording-stop-failed".to_owned(),
+                message,
+            }),
+        }
+    }
+
+    fn abort_recording(&mut self, command: CommandEnvelope) -> BackendReply {
+        if let (Some(recording), Some(pipeline)) = (command.recording, self.pipeline.as_mut()) {
+            pipeline.abort_recording(&recording.recording_id);
+        }
+        BackendReply::response(Response::Ok { id: command.id })
     }
 
     fn stop(&mut self, command: CommandEnvelope) -> BackendReply {

--- a/native/opennow-streamer/src/main.rs
+++ b/native/opennow-streamer/src/main.rs
@@ -88,6 +88,15 @@ fn handle_command(
         "bitrate" => {
             return write_reply(backend.update_bitrate_limit(command));
         }
+        "recording-start" => {
+            return write_reply(backend.start_recording(command));
+        }
+        "recording-stop" => {
+            return write_reply(backend.stop_recording(command));
+        }
+        "recording-abort" => {
+            return write_reply(backend.abort_recording(command));
+        }
         "stop" => {
             return write_reply(backend.stop(command));
         }

--- a/native/opennow-streamer/src/protocol.rs
+++ b/native/opennow-streamer/src/protocol.rs
@@ -27,6 +27,24 @@ pub struct CommandEnvelope {
     pub max_bitrate_kbps: Option<u32>,
     #[serde(default)]
     pub reason: Option<String>,
+    #[serde(default)]
+    pub recording: Option<RecordingCommandPayload>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingCommandPayload {
+    pub recording_id: String,
+    #[serde(default)]
+    pub temp_path: Option<String>,
+    #[serde(default)]
+    pub container: Option<RecordingContainer>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RecordingContainer {
+    Matroska,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -536,6 +554,26 @@ mod tests {
             packet.payload_bytes().expect("legacy payload").as_ref(),
             &[7, 8, 9]
         );
+    }
+
+    #[test]
+    fn recording_start_command_parses_typed_matroska_payload() {
+        let command = parse_command(serde_json::json!({
+            "id": "req-1",
+            "type": "recording-start",
+            "recording": {
+                "recordingId": "rec-1",
+                "tempPath": "/tmp/rec.mkv.tmp",
+                "container": "matroska"
+            }
+        }))
+        .expect("recording command parses");
+
+        assert_eq!(command.command_type, "recording-start");
+        let recording = command.recording.expect("recording payload");
+        assert_eq!(recording.recording_id, "rec-1");
+        assert_eq!(recording.temp_path.as_deref(), Some("/tmp/rec.mkv.tmp"));
+        assert_eq!(recording.container, Some(RecordingContainer::Matroska));
     }
 
     #[test]

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -303,6 +303,7 @@ function runShutdownCleanup(reason = "app-quit"): void {
   }
   signalingClient = null;
   signalingClientKey = null;
+  void cleanupNativeActiveRecordings(reason, true);
   nativeStreamerManager?.dispose(reason);
   nativeStreamerManager = null;
   nativeStreamerContext = null;
@@ -580,12 +581,15 @@ async function saveScreenshotAs(input: ScreenshotSaveAsRequest): Promise<Screens
 const RECORDING_LIMIT = 20;
 
 interface ActiveRecording {
-  writeStream: ReturnType<typeof createWriteStream>;
+  backend: "media-recorder" | "native-gstreamer";
+  writeStream?: ReturnType<typeof createWriteStream>;
   tempPath: string;
   mimeType: string;
+  container?: "matroska";
 }
 
 const activeRecordings = new Map<string, ActiveRecording>();
+let nativeRecordingCleanupInFlight = false;
 
 function getRecordingsDirectory(): string {
   return join(app.getPath("pictures"), "OpenNOW", "Recordings");
@@ -716,8 +720,13 @@ function assertSafeRecordingId(id: string): void {
   }
 }
 
-function extFromMimeType(mimeType: string): ".mp4" | ".webm" {
+function extFromMimeType(mimeType: string): ".mp4" | ".webm" | ".mkv" {
+  if (mimeType === "video/x-matroska" || mimeType === "video/matroska") return ".mkv";
   return mimeType.startsWith("video/mp4") ? ".mp4" : ".webm";
+}
+
+function recordingStem(fileName: string): string {
+  return fileName.replace(/\.(mp4|webm|mkv)$/i, "");
 }
 
 async function listRecordings(): Promise<RecordingEntry[]> {
@@ -726,14 +735,14 @@ async function listRecordings(): Promise<RecordingEntry[]> {
   const webmFiles = entries
     .filter((e) => e.isFile())
     .map((e) => e.name)
-    .filter((name) => /\.(mp4|webm)$/i.test(name));
+    .filter((name) => /\.(mp4|webm|mkv)$/i.test(name));
 
   const loaded = await Promise.all(
     webmFiles.map(async (fileName): Promise<RecordingEntry | null> => {
       const filePath = join(dir, fileName);
       try {
         const fileStats = await stat(filePath);
-        const stem = fileName.replace(/\.(mp4|webm)$/i, "");
+        const stem = recordingStem(fileName);
         const thumbName = `${stem}-thumb.jpg`;
         const thumbPath = join(dir, thumbName);
 
@@ -746,11 +755,11 @@ async function listRecordings(): Promise<RecordingEntry[]> {
         }
 
         // Parse durationMs encoded in filename as last numeric segment before extension
-        const durMatch = /-dur(\d+)\.(mp4|webm)$/i.exec(fileName);
+        const durMatch = /-dur(\d+)\.(mp4|webm|mkv)$/i.exec(fileName);
         const durationMs = durMatch ? Number(durMatch[1]) : 0;
 
         // Parse game title from filename: {stamp}-{title}-{rand}[-dur{ms}].{ext}
-        const titleMatch = /^[^-]+-[^-]+-([^-]+(?:-[^-]+)*?)-[a-f0-9]{6}(?:-dur\d+)?\.(mp4|webm)$/i.exec(fileName);
+        const titleMatch = /^[^-]+-[^-]+-([^-]+(?:-[^-]+)*?)-[a-f0-9]{6}(?:-dur\d+)?\.(mp4|webm|mkv)$/i.exec(fileName);
         const gameTitle = titleMatch ? titleMatch[1].replace(/-/g, " ") : undefined;
 
         return {
@@ -775,6 +784,33 @@ async function listRecordings(): Promise<RecordingEntry[]> {
     .slice(0, RECORDING_LIMIT);
 }
 
+async function cleanupNativeActiveRecordings(reason: string, abortNative = true): Promise<void> {
+  if (nativeRecordingCleanupInFlight) return;
+  const nativeEntries = Array.from(activeRecordings.entries()).filter(([, rec]) => rec.backend === "native-gstreamer");
+  if (nativeEntries.length === 0) return;
+  nativeRecordingCleanupInFlight = true;
+  try {
+    await Promise.all(nativeEntries.map(async ([recordingId, rec]) => {
+      if (activeRecordings.get(recordingId) !== rec) return;
+      activeRecordings.delete(recordingId);
+      if (abortNative) {
+        await nativeStreamerManager?.abortRecording(recordingId).catch(() => undefined);
+      }
+      await unlink(rec.tempPath).catch(() => undefined);
+      console.warn(`[Main] Removed incomplete native recording ${recordingId} after ${reason}.`);
+    }));
+  } finally {
+    nativeRecordingCleanupInFlight = false;
+  }
+}
+
+function emitNativeStreamerEvent(event: MainToRendererSignalingEvent): void {
+  if (event.type === "native-stream-stopped" || event.type === "error") {
+    void cleanupNativeActiveRecordings(event.type === "native-stream-stopped" ? (event.reason ?? "native stream stopped") : event.message, false);
+  }
+  emitToRenderer(event);
+}
+
 function emitToRenderer(event: MainToRendererSignalingEvent): void {
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send(IPC_CHANNELS.SIGNALING_EVENT, event);
@@ -789,7 +825,7 @@ function getNativeStreamerManager(): NativeStreamerManager {
     getCloudGsyncMode: () => settingsManager?.get("nativeCloudGsyncMode") ?? "auto",
     getD3dFullscreenMode: () => settingsManager?.get("nativeD3dFullscreenMode") ?? "auto",
     getExternalRendererEnabled: () => true,
-    emit: emitToRenderer,
+    emit: emitNativeStreamerEvent,
     sendAnswer: async (payload) => {
       if (!signalingClient) {
         throw new Error("Signaling is not connected");
@@ -934,6 +970,7 @@ function normalizeNativeInputPacket(input: unknown): NativeStreamerInputPacket |
 
 function routeSignalingEvent(event: MainToRendererSignalingEvent): void {
   if (event.type === "disconnected") {
+    void cleanupNativeActiveRecordings(`signaling disconnected: ${event.reason}`, true);
     void nativeStreamerManager?.stop(`signaling disconnected: ${event.reason}`);
     nativeStreamerContext = null;
     nativeStreamerFallbackSessionId = null;
@@ -973,6 +1010,7 @@ async function handleNativeStreamerOffer(sdp: string, context: NativeStreamerSes
     console.warn("[NativeStreamer] Falling back to web streamer:", message);
     nativeStreamerFallbackSessionId = context.session.sessionId;
     const queuedRemoteIce = nativeStreamerManager?.drainQueuedRemoteIce(context.session.sessionId) ?? [];
+    await cleanupNativeActiveRecordings("native streamer fallback", true);
     await nativeStreamerManager?.stop("native streamer fallback").catch(() => undefined);
     emitToRenderer({
       type: "error",
@@ -1765,6 +1803,7 @@ function registerIpcHandlers(): void {
       if (signalingClient) {
         signalingClient.disconnect();
       }
+      await cleanupNativeActiveRecordings("signaling reconnect", true);
       await nativeStreamerManager?.stop("signaling reconnect");
 
       signalingClient = new GfnSignalingClient(
@@ -1779,6 +1818,7 @@ function registerIpcHandlers(): void {
   );
 
   ipcMain.handle(IPC_CHANNELS.DISCONNECT_SIGNALING, async (): Promise<void> => {
+    await cleanupNativeActiveRecordings("signaling disconnect", true);
     await nativeStreamerManager?.stop("signaling disconnect");
     nativeStreamerContext = null;
     nativeStreamerFallbackSessionId = null;
@@ -1952,6 +1992,7 @@ function registerIpcHandlers(): void {
         || key === "nativeD3dFullscreenMode"
         || key === "nativeExternalRenderer"
       ) {
+        void cleanupNativeActiveRecordings(`setting changed: ${key}`, true);
         void nativeStreamerManager?.stop(
           key === "nativeStreamerBackend"
             ? "native streamer backend changed"
@@ -1987,6 +2028,7 @@ function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.SETTINGS_RESET, async (): Promise<Settings> => {
     const resetSettings = settingsManager.reset();
     appUpdater?.setAutomaticChecksEnabled(resetSettings.autoCheckForUpdates);
+    void cleanupNativeActiveRecordings("settings reset", true);
     void nativeStreamerManager?.stop("settings reset");
     nativeStreamerContext = null;
     nativeStreamerFallbackSessionId = null;
@@ -2130,10 +2172,23 @@ function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.RECORDING_BEGIN, async (_event, input: RecordingBeginRequest): Promise<RecordingBeginResult> => {
     const dir = await ensureRecordingsDirectory();
     const recordingId = randomUUID();
-    const ext = extFromMimeType(input.mimeType);
+    const backend = input.backend ?? "media-recorder";
+    const mimeType = backend === "native-gstreamer" ? "video/x-matroska" : input.mimeType;
+    const ext = extFromMimeType(mimeType);
     const tempPath = join(dir, `${recordingId}${ext}.tmp`);
+    if (backend === "native-gstreamer") {
+      activeRecordings.set(recordingId, { backend, tempPath, mimeType, container: "matroska" });
+      try {
+        await getNativeStreamerManager().startRecording({ recordingId, tempPath, container: "matroska" });
+      } catch (error) {
+        activeRecordings.delete(recordingId);
+        await unlink(tempPath).catch(() => undefined);
+        throw error;
+      }
+      return { recordingId };
+    }
     const writeStream = createWriteStream(tempPath);
-    activeRecordings.set(recordingId, { writeStream, tempPath, mimeType: input.mimeType });
+    activeRecordings.set(recordingId, { backend, writeStream, tempPath, mimeType });
     return { recordingId };
   });
 
@@ -2142,8 +2197,12 @@ function registerIpcHandlers(): void {
     if (!rec) {
       throw new Error("Unknown recording id");
     }
+    if (rec.backend !== "media-recorder" || !rec.writeStream) {
+      throw new Error("Recording does not accept renderer chunks");
+    }
+    const writeStream = rec.writeStream;
     await new Promise<void>((resolve, reject) => {
-      rec.writeStream.write(Buffer.from(input.chunk), (err) => {
+      writeStream.write(Buffer.from(input.chunk), (err) => {
         if (err) reject(err);
         else resolve();
       });
@@ -2157,12 +2216,16 @@ function registerIpcHandlers(): void {
     }
     activeRecordings.delete(input.recordingId);
 
-    await new Promise<void>((resolve, reject) => {
-      rec.writeStream.end((err?: Error | null) => {
-        if (err) reject(err);
-        else resolve();
+    if (rec.backend === "native-gstreamer") {
+      await getNativeStreamerManager().stopRecording(input.recordingId);
+    } else if (rec.writeStream) {
+      await new Promise<void>((resolve, reject) => {
+        rec.writeStream?.end((err?: Error | null) => {
+          if (err) reject(err);
+          else resolve();
+        });
       });
-    });
+    }
 
     const dir = getRecordingsDirectory();
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -2180,7 +2243,7 @@ function registerIpcHandlers(): void {
     if (input.thumbnailDataUrl) {
       try {
         const { buffer } = dataUrlToBuffer(input.thumbnailDataUrl);
-        const stem = fileName.replace(/\.(mp4|webm)$/i, "");
+        const stem = recordingStem(fileName);
         const thumbPath = join(dir, `${stem}-thumb.jpg`);
         await writeFile(thumbPath, buffer);
         thumbnailDataUrl = input.thumbnailDataUrl;
@@ -2196,7 +2259,7 @@ function registerIpcHandlers(): void {
       await Promise.all(
         toDelete.map(async (entry) => {
           await unlink(entry.filePath).catch(() => undefined);
-          const stem = entry.fileName.replace(/\.(mp4|webm)$/i, "");
+          const stem = recordingStem(entry.fileName);
           await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
         }),
       );
@@ -2221,7 +2284,11 @@ function registerIpcHandlers(): void {
       return;
     }
     activeRecordings.delete(input.recordingId);
-    rec.writeStream.destroy();
+    if (rec.backend === "native-gstreamer") {
+      await getNativeStreamerManager().abortRecording(input.recordingId);
+    } else {
+      rec.writeStream?.destroy();
+    }
     await unlink(rec.tempPath).catch(() => undefined);
   });
 
@@ -2234,7 +2301,7 @@ function registerIpcHandlers(): void {
     const dir = await ensureRecordingsDirectory();
     const filePath = join(dir, input.id);
     await unlink(filePath);
-    const stem = input.id.replace(/\.(mp4|webm)$/i, "");
+    const stem = recordingStem(input.id);
     await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
   });
 

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -805,8 +805,8 @@ async function cleanupNativeActiveRecordings(reason: string, abortNative = true)
 }
 
 function emitNativeStreamerEvent(event: MainToRendererSignalingEvent): void {
-  if (event.type === "native-stream-stopped" || event.type === "error") {
-    void cleanupNativeActiveRecordings(event.type === "native-stream-stopped" ? (event.reason ?? "native stream stopped") : event.message, false);
+  if (event.type === "native-stream-stopped") {
+    void cleanupNativeActiveRecordings(event.reason ?? "native stream stopped", false);
   }
   emitToRenderer(event);
 }
@@ -2214,11 +2214,10 @@ function registerIpcHandlers(): void {
     if (!rec) {
       throw new Error("Unknown recording id");
     }
-    activeRecordings.delete(input.recordingId);
-
     if (rec.backend === "native-gstreamer") {
       await getNativeStreamerManager().stopRecording(input.recordingId);
     } else if (rec.writeStream) {
+      activeRecordings.delete(input.recordingId);
       await new Promise<void>((resolve, reject) => {
         rec.writeStream?.end((err?: Error | null) => {
           if (err) reject(err);
@@ -2236,7 +2235,17 @@ function registerIpcHandlers(): void {
     const fileName = `${stamp}-${title}-${rand}${durSuffix}${ext}`;
     const finalPath = join(dir, fileName);
 
-    await rename(rec.tempPath, finalPath);
+    try {
+      await rename(rec.tempPath, finalPath);
+    } catch (error) {
+      if (rec.backend === "native-gstreamer") {
+        await getNativeStreamerManager().abortRecording(input.recordingId).catch(() => undefined);
+        activeRecordings.delete(input.recordingId);
+        await unlink(rec.tempPath).catch(() => undefined);
+      }
+      throw error;
+    }
+    activeRecordings.delete(input.recordingId);
 
     // Save thumbnail if provided
     let thumbnailDataUrl: string | undefined;

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -64,6 +64,8 @@ const SESSION_START_TIMEOUT_MS = 45000;
 const SURFACE_UPDATE_TIMEOUT_MS = 15000;
 const OFFER_TIMEOUT_MS = 20000;
 const STOP_TIMEOUT_MS = 1200;
+const RECORDING_START_TIMEOUT_MS = 10000;
+const RECORDING_STOP_TIMEOUT_MS = 15000;
 const MAX_INPUT_STDIN_BUFFER_BYTES = 64 * 1024;
 const MIN_NATIVE_BITRATE_KBPS = 5_000;
 const MAX_NATIVE_BITRATE_KBPS = 150_000;
@@ -865,6 +867,25 @@ export class NativeStreamerManager {
         }
       });
     });
+  }
+
+  async startRecording(input: { recordingId: string; tempPath: string; container: "matroska" }): Promise<void> {
+    if (!this.activeSessionId) {
+      throw new Error("No active native streaming session is running.");
+    }
+    await this.request({ type: "recording-start", recording: input }, RECORDING_START_TIMEOUT_MS);
+  }
+
+  async stopRecording(recordingId: string): Promise<void> {
+    await this.request({ type: "recording-stop", recording: { recordingId } }, RECORDING_STOP_TIMEOUT_MS);
+  }
+
+  async abortRecording(recordingId: string): Promise<void> {
+    try {
+      await this.request({ type: "recording-abort", recording: { recordingId } }, CONTROL_TIMEOUT_MS);
+    } catch (error) {
+      console.warn("[NativeStreamer] Failed to abort native recording:", error);
+    }
   }
 
   private async flushSurfaceUpdate(): Promise<void> {

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -687,6 +687,8 @@ export function StreamView({
   const [recordingShortcutError, setRecordingShortcutError] = useState<string | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const recordingIdRef = useRef<string | null>(null);
+  const recordingBackendRef = useRef<"media-recorder" | "native-gstreamer" | null>(null);
+  const recordingStopInFlightRef = useRef(false);
   const recordingStartTimeRef = useRef<number>(0);
   const recordingTimerRef = useRef<number | undefined>(undefined);
   const thumbnailDataUrlRef = useRef<string | null>(null);
@@ -1125,12 +1127,60 @@ export function StreamView({
     setRecordingError(null);
 
     if (isRecording) {
+      if (recordingStopInFlightRef.current) return;
+      if (recordingBackendRef.current === "native-gstreamer") {
+        const id = recordingIdRef.current;
+        if (!id) return;
+        recordingStopInFlightRef.current = true;
+        window.clearInterval(recordingTimerRef.current);
+        recordingTimerRef.current = undefined;
+        const durationMs = Date.now() - recordingStartTimeRef.current;
+        try {
+          const entry = await window.openNow.finishRecording({ recordingId: id, durationMs, gameTitle });
+          setRecordings((prev) => [entry, ...prev].slice(0, 20));
+        } catch (err) {
+          console.error("[StreamView] Failed to finish native recording:", err);
+          setRecordingError("Native recording could not be saved.");
+        } finally {
+          recordingIdRef.current = null;
+          recordingBackendRef.current = null;
+          recordingStopInFlightRef.current = false;
+          thumbnailDataUrlRef.current = null;
+          setIsRecording(false);
+        }
+        return;
+      }
       mediaRecorderRef.current?.stop();
       return;
     }
 
     if (!recordingApiAvailable) {
       setRecordingError("Recording API unavailable. Restart OpenNOW to enable recording.");
+      return;
+    }
+
+    if (nativeRendererActive) {
+      setUsedMimeType("video/x-matroska");
+      try {
+        const result = await window.openNow.beginRecording({
+          backend: "native-gstreamer",
+          mimeType: "video/x-matroska",
+          container: "matroska",
+        });
+        recordingIdRef.current = result.recordingId;
+        recordingBackendRef.current = "native-gstreamer";
+        thumbnailDataUrlRef.current = null;
+        recordingStartTimeRef.current = Date.now();
+        setRecordingDurationMs(0);
+        setIsRecording(true);
+        recordingTimerRef.current = window.setInterval(() => {
+          setRecordingDurationMs(Date.now() - recordingStartTimeRef.current);
+        }, 500);
+      } catch (error) {
+        console.error("[StreamView] Failed to begin native recording:", error);
+        setUsedMimeType(null);
+        setRecordingError(error instanceof Error ? error.message : "Native recording could not start.");
+      }
       return;
     }
 
@@ -1178,7 +1228,7 @@ export function StreamView({
 
     let recordingId: string;
     try {
-      const result = await window.openNow.beginRecording({ mimeType });
+      const result = await window.openNow.beginRecording({ backend: "media-recorder", mimeType });
       recordingId = result.recordingId;
     } catch (error) {
       console.error("[StreamView] Failed to begin recording:", error);
@@ -1189,6 +1239,7 @@ export function StreamView({
     }
 
     recordingIdRef.current = recordingId;
+    recordingBackendRef.current = "media-recorder";
     thumbnailDataUrlRef.current = null;
     recordingStartTimeRef.current = Date.now();
     setRecordingDurationMs(0);
@@ -1254,6 +1305,7 @@ export function StreamView({
       audioCtxRef.current = null;
       const id = recordingIdRef.current;
       recordingIdRef.current = null;
+      recordingBackendRef.current = null;
       setIsRecording(false);
 
       if (!id) return;
@@ -1283,6 +1335,7 @@ export function StreamView({
       audioCtxRef.current = null;
       const id = recordingIdRef.current;
       recordingIdRef.current = null;
+      recordingBackendRef.current = null;
       setIsRecording(false);
       thumbnailDataUrlRef.current = null;
       if (id) {
@@ -1293,7 +1346,7 @@ export function StreamView({
 
     mediaRecorderRef.current = recorder;
     recorder.start(2000);
-  }, [gameTitle, isRecording, micTrack, recordingApiAvailable]);
+  }, [gameTitle, isRecording, micTrack, nativeRendererActive, recordingApiAvailable]);
 
   // Cleanup: abort any active recording on unmount
   useEffect(() => {
@@ -1301,12 +1354,14 @@ export function StreamView({
       window.clearInterval(recordingTimerRef.current);
       const recorder = mediaRecorderRef.current;
       const id = recordingIdRef.current;
-      if (recorder && recorder.state !== "inactive") {
+      const backend = recordingBackendRef.current;
+      if (backend === "media-recorder" && recorder && recorder.state !== "inactive") {
         recorder.stop();
       }
       if (id) {
         window.openNow.abortRecording({ recordingId: id }).catch(() => undefined);
         recordingIdRef.current = null;
+        recordingBackendRef.current = null;
       }
       audioCtxRef.current?.close().catch(() => undefined);
       audioCtxRef.current = null;

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1138,15 +1138,19 @@ export function StreamView({
         try {
           const entry = await window.openNow.finishRecording({ recordingId: id, durationMs, gameTitle });
           setRecordings((prev) => [entry, ...prev].slice(0, 20));
-        } catch (err) {
-          console.error("[StreamView] Failed to finish native recording:", err);
-          setRecordingError("Native recording could not be saved.");
-        } finally {
           recordingIdRef.current = null;
           recordingBackendRef.current = null;
-          recordingStopInFlightRef.current = false;
           thumbnailDataUrlRef.current = null;
           setIsRecording(false);
+        } catch (err) {
+          console.error("[StreamView] Failed to finish native recording:", err);
+          setRecordingError("Native recording could not be saved. Try stopping again or end the stream to discard it.");
+          recordingTimerRef.current = window.setInterval(() => {
+            setRecordingDurationMs(Date.now() - recordingStartTimeRef.current);
+          }, 500);
+          setIsRecording(true);
+        } finally {
+          recordingStopInFlightRef.current = false;
         }
         return;
       }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1152,6 +1152,8 @@ export interface RecordingEntry {
 
 export interface RecordingBeginRequest {
   mimeType: string;
+  backend?: "media-recorder" | "native-gstreamer";
+  container?: "mp4" | "webm" | "matroska";
 }
 
 export interface RecordingBeginResult {

--- a/opennow-stable/src/shared/nativeStreamer.ts
+++ b/opennow-stable/src/shared/nativeStreamer.ts
@@ -30,6 +30,16 @@ export interface NativeStreamerInputPacket {
   partiallyReliable?: boolean;
 }
 
+export interface NativeStreamerRecordingStartRequest {
+  recordingId: string;
+  tempPath: string;
+  container: "matroska";
+}
+
+export interface NativeStreamerRecordingRequest {
+  recordingId: string;
+}
+
 export type NativeStreamerCommand =
   | {
       id: string;
@@ -66,6 +76,21 @@ export type NativeStreamerCommand =
       id: string;
       type: "bitrate";
       maxBitrateKbps: number;
+    }
+  | {
+      id: string;
+      type: "recording-start";
+      recording: NativeStreamerRecordingStartRequest;
+    }
+  | {
+      id: string;
+      type: "recording-stop";
+      recording: NativeStreamerRecordingRequest;
+    }
+  | {
+      id: string;
+      type: "recording-abort";
+      recording: NativeStreamerRecordingRequest;
     }
   | {
       id: string;


### PR DESCRIPTION
This PR implements in-stream recording support for native GStreamer alongside the existing Electron MediaRecorder backend, allowing StreamView recording controls to work for both rendering paths.

**GStreamer backend**
- Add typed recording commands (`recording-start`, `recording-stop`, `recording-abort`) to Rust protocol with `RecordingContainer::Matroska`
- Implement video-only recording branch in `GstreamerPipeline` using `appsrc -> queue -> rtpjitterbuffer -> depay -> parser -> matroskamux -> filesink`
- `stop_recording` waits up to 5s for EOS finalization at `filesink` before returning OK; abort/session teardown fast-removes elements

**Main process**
- `RECORDING_BEGIN` accepts `backend` discriminator; MediaRecorder keeps chunked write-stream, native allocates recording ID/temp path and dispatches to native manager
- Add `cleanupNativeActiveRecordings` to orphan `.mkv.tmp` files on native stream stop/error, signaling disconnect/reconnect, fallback, settings changes, and shutdown
- Extend `listRecordings`, `deleteRecording`, and thumbnail stem handling to include `.mkv`

**Renderer**
- `StreamView.toggleRecording` switches backend based on `nativeRendererActive`; native path uses same API/state/UI without `video.srcObject`
- Add `recordingBackendRef` and `recordingStopInFlightRef` guards to prevent duplicate stop/abort races
- Preserve microphone mixing for MediaRecorder path, show `video/x-matroska` container for native

**Testing**
- Add `recording_start_command_parses_typed_matroska_payload` protocol test
- `npm run typecheck` and `cargo check` pass; `cargo check --features gstreamer` skipped due to missing system pkg-config

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/856b19bb-5385-431f-950c-1949eb3d3c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-093" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/856b19bb-5385-431f-950c-1949eb3d3c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-093&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-093"><img alt="OPE-093" src="https://capy.ai/api/badge/thread.svg?label=OPE-093"></picture></a>
<!-- capy-pr-badge:end -->