### PR TITLE
Show GStreamer status in in-stream stats HUD

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -4722,6 +4722,7 @@ export function App(): JSX.Element {
             audioRef={audioRef}
             diagnosticsStore={diagnosticsStore}
             showStats={showStatsOverlay}
+            gstreamerEnabled={settings.streamClientMode === "native"}
             shortcuts={{
               toggleStats: formatShortcutForDisplay(settings.shortcutToggleStats, isMac),
               togglePointerLock: formatShortcutForDisplay(settings.shortcutTogglePointerLock, isMac),

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -20,6 +20,7 @@ interface StreamViewProps {
   audioRef: React.Ref<HTMLAudioElement>;
   diagnosticsStore: StreamDiagnosticsStore;
   showStats: boolean;
+  gstreamerEnabled: boolean;
   shortcuts: {
     toggleStats: string;
     togglePointerLock: string;
@@ -188,9 +189,11 @@ function isMicBadgeStateEqual(prev: MicBadgeState, next: MicBadgeState): boolean
 
 function StreamStatsHud({
   diagnosticsStore,
+  gstreamerEnabled,
   serverRegion,
 }: {
   diagnosticsStore: StreamDiagnosticsStore;
+  gstreamerEnabled: boolean;
   serverRegion?: string;
 }): JSX.Element {
   const stats = useStreamDiagnosticsStore(diagnosticsStore);
@@ -230,6 +233,9 @@ function StreamStatsHud({
   const inputQueueText = `${(stats.inputQueueBufferedBytes / 1024).toFixed(1)}KB`;
   const partiallyReliableQueueText = `${(stats.partiallyReliableInputQueueBufferedBytes / 1024).toFixed(1)}KB`;
   const mouseResidualText = `${stats.mouseResidualMagnitude.toFixed(2)}px`;
+  const gstreamerStatusText = gstreamerEnabled
+    ? `GStreamer enabled · ${stats.nativeRendererActive ? "in use" : "not active"}`
+    : "GStreamer disabled · Chromium WebRTC";
 
   return (
     <div className="sv-stats">
@@ -293,6 +299,10 @@ function StreamStatsHud({
 
       <div className="sv-stats-foot">
         Input queue peak {(stats.inputQueuePeakBufferedBytes / 1024).toFixed(1)}KB · PR peak {(stats.partiallyReliableInputQueuePeakBufferedBytes / 1024).toFixed(1)}KB · drops {stats.inputQueueDropCount} · sched {stats.inputQueueMaxSchedulingDelayMs.toFixed(1)}ms · residual {mouseResidualText}
+      </div>
+
+      <div className="sv-stats-foot">
+        {gstreamerStatusText}
       </div>
 
       {(stats.hardwareAcceleration || stats.colorCodec) && (
@@ -614,6 +624,7 @@ export function StreamView({
   audioRef,
   diagnosticsStore,
   showStats,
+  gstreamerEnabled,
   shortcuts,
   serverRegion,
   antiAfkEnabled,
@@ -2059,7 +2070,11 @@ export function StreamView({
 
       {/* Stats HUD (top-right) */}
       {(showStatsHud || showStats) && !isConnecting && (
-        <StreamStatsHud diagnosticsStore={diagnosticsStore} serverRegion={serverRegion} />
+        <StreamStatsHud
+          diagnosticsStore={diagnosticsStore}
+          gstreamerEnabled={gstreamerEnabled}
+          serverRegion={serverRegion}
+        />
       )}
 
       {/* Controller indicator (top-left) */}


### PR DESCRIPTION
## Summary

Adds a footer line to the in-stream stats HUD that displays GStreamer configuration and active usage state, allowing users to verify whether the native pipeline is enabled and actually being used for the current stream.

## Changes

- Add `gstreamerEnabled: boolean` prop to `StreamViewProps` in `src/renderer/src/components/StreamView.tsx`
- Pass `settings.streamClientMode === "native"` as `gstreamerEnabled` from `src/renderer/src/App.tsx`
- Render status text in `StreamStatsHud` footer: `GStreamer enabled · in use`, `GStreamer enabled · not active`, or `GStreamer disabled · Chromium WebRTC` based on prop and `stats.nativeRendererActive`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/9a719558-7469-4933-b410-7d1999303a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-094" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/9a719558-7469-4933-b410-7d1999303a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-094&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-094"><img alt="OPE-094" src="https://capy.ai/api/badge/thread.svg?label=OPE-094"></picture></a>
<!-- capy-pr-badge:end -->