### PR TITLE
Mark native streamer experimental in UI and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@
 
 > [!WARNING]
 > OpenNOW is under active development. Expect occasional bugs, rough edges, and platform-specific issues while the client matures.
+>
+> Native streamer / native streaming is experimental. It defaults to the web streamer path unless enabled, issues can be platform-specific, and users may see fallback to Chromium/WebRTC. Report native-streamer problems on [GitHub Issues](https://github.com/OpenCloudGaming/OpenNOW/issues) or [Discord](https://discord.gg/8EJYaJcNfD).
 
 > [!IMPORTANT]
 > OpenNOW is an independent community project and is not affiliated with, endorsed by, or sponsored by NVIDIA. NVIDIA and GeForce NOW are trademarks of NVIDIA Corporation. You must use your own GeForce NOW account.

--- a/native/opennow-streamer/README.md
+++ b/native/opennow-streamer/README.md
@@ -2,4 +2,7 @@
 
 This crate contains OpenNOW's native Rust streaming infrastructure.
 
+> [!NOTE]
+> Native streamer / native streaming is experimental. Issues can be platform-specific and users may see fallback to Chromium/WebRTC; report problems on [GitHub Issues](https://github.com/OpenCloudGaming/OpenNOW/issues) or [Discord](https://discord.gg/8EJYaJcNfD).
+
 Canonical native streamer, WebRTC, GStreamer, packaging, and development documentation lives at [opennow.zortos.me](https://opennow.zortos.me). This README is intentionally only a pointer so repository docs do not drift from the site.

--- a/opennow-stable/README.md
+++ b/opennow-stable/README.md
@@ -2,4 +2,7 @@
 
 This directory contains the active Electron-based OpenNOW desktop client.
 
+> [!NOTE]
+> Native streamer / native streaming is experimental, can have platform-specific issues, and may fall back to Chromium/WebRTC; report problems on [GitHub Issues](https://github.com/OpenCloudGaming/OpenNOW/issues) or [Discord](https://discord.gg/8EJYaJcNfD).
+
 Canonical setup, development, configuration, and architecture documentation lives at [opennow.zortos.me](https://opennow.zortos.me). This README is intentionally only a pointer so repository docs do not drift from the site.

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -94,7 +94,24 @@ const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string
     "cpu",
     "test codecs",
   ],
-  "native-streamer": ["native", "streamer", "gstreamer", "backend", "directx", "dx11", "dx12", "cloud gsync", "diagnostics"],
+  "native-streamer": [
+    "native",
+    "streamer",
+    "native streaming",
+    "gstreamer",
+    "backend",
+    "directx",
+    "dx11",
+    "dx12",
+    "cloud gsync",
+    "diagnostics",
+    "experimental",
+    "issue",
+    "github",
+    "discord",
+    "report",
+    "bug",
+  ],
   game: ["game", "language", "keyboard layout", "store", "launch"],
   audio: ["audio", "microphone", "mic", "push to talk", "voice activity"],
   input: [
@@ -2138,8 +2155,18 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                   </label>
                 </div>
                 <span className="settings-subtle-hint">
-                  Uses the faster GStreamer-based desktop streamer for new sessions. If it cannot start, OpenNOW falls back to the web streamer.
+                  Native streaming is experimental and may have platform-specific bugs, glitches, or fallbacks to Chromium/WebRTC. Enable it only if you are comfortable testing the GStreamer-based desktop streamer for new sessions.
                 </span>
+                <div className="settings-chip-row">
+                  <a className="settings-chip" href="https://github.com/OpenCloudGaming/OpenNOW/issues" target="_blank" rel="noreferrer">
+                    <span>Report on GitHub Issues</span>
+                    <ExternalLink size={13} />
+                  </a>
+                  <a className="settings-chip" href="https://discord.gg/8EJYaJcNfD" target="_blank" rel="noreferrer">
+                    <span>Report on Discord</span>
+                    <ExternalLink size={13} />
+                  </a>
+                </div>
               </div>
 
               <div className="settings-row settings-row--column">

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3678,6 +3678,7 @@ button.game-card-store-chip.owned.active:hover {
   border: 1px solid var(--panel-border);
   background: var(--chip);
   color: var(--ink-muted);
+  text-decoration: none;
   font-size: 0.84rem;
   font-weight: 600;
   font-family: inherit;


### PR DESCRIPTION
This PR updates the OpenNOW UI and README files to clearly communicate that native streaming is experimental. It adds explicit warnings about platform-specific bugs, glitches, or fallbacks to Chromium/WebRTC, and provides direct links for users to report issues on GitHub Issues or Discord.

## Changes

- Update Native Streamer settings hint in `SettingsPage.tsx` to explicitly state experimental status and potential issues
- Add GitHub Issues and Discord report links using existing `settings-chip` patterns and `ExternalLink` icon
- Expand `SETTINGS_SCOPE_SEARCH_TERMS["native-streamer"]` with experimental, issue, github, discord, report, and bug terms
- Add `text-decoration: none` to `.settings-chip` in `styles.css` for linked chips
- Add experimental-status notes to `README.md`, `native/opennow-streamer/README.md`, and `opennow-stable/README.md`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/dcbc0f02-3968-4d93-a3c4-0f72579b3c9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-099" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/dcbc0f02-3968-4d93-a3c4-0f72579b3c9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-099&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-099"><img alt="OPE-099" src="https://capy.ai/api/badge/thread.svg?label=OPE-099"></picture></a>
<!-- capy-pr-badge:end -->