### PR TITLE
fix: quit app on macOS when main window closes

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -1,8 +1,27 @@
-import { app, BrowserWindow, ipcMain, dialog, shell, systemPreferences, session, protocol } from "electron";
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  dialog,
+  shell,
+  systemPreferences,
+  session,
+  protocol,
+} from "electron";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import { existsSync, readFileSync, createWriteStream } from "node:fs";
-import { copyFile, mkdir, readdir, readFile, rename, stat, unlink, writeFile, realpath } from "node:fs/promises";
+import {
+  copyFile,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+  realpath,
+} from "node:fs/promises";
 import * as net from "node:net";
 import { randomUUID, createHash } from "node:crypto";
 import { spawn } from "node:child_process";
@@ -46,9 +65,9 @@ import type {
   SessionCreateRequest,
   SessionPollRequest,
   SessionStopRequest,
-    SessionClaimRequest,
-    StreamSettings,
-    SignalingConnectRequest,
+  SessionClaimRequest,
+  StreamSettings,
+  SignalingConnectRequest,
   SendAnswerRequest,
   IceCandidatePayload,
   NativeInputPacket,
@@ -74,19 +93,32 @@ import type {
   RecordingFinishRequest,
   RecordingAbortRequest,
   RecordingDeleteRequest,
-    MicrophonePermissionResult,
-    NativeStreamerStatus,
-    ThankYouContributor,
+  MicrophonePermissionResult,
+  NativeStreamerStatus,
+  ThankYouContributor,
   ThankYouDataResult,
   ThankYouSupporter,
 } from "@shared/gfn";
 import { serializeSessionErrorTransport } from "@shared/sessionError";
-import { normalizeCloudGsyncOverride, resolveCloudGsync } from "@shared/cloudGsync";
-import { enrichErrorForIpc, formatErrorChainForLog } from "@shared/networkError";
+import {
+  normalizeCloudGsyncOverride,
+  resolveCloudGsync,
+} from "@shared/cloudGsync";
+import {
+  enrichErrorForIpc,
+  formatErrorChainForLog,
+} from "@shared/networkError";
 
 import { getSettingsManager, type SettingsManager } from "./settings";
 
-import { createSession, pollSession, reportSessionAd, stopSession, getActiveSessions, claimSession } from "./gfn/cloudmatch";
+import {
+  createSession,
+  pollSession,
+  reportSessionAd,
+  stopSession,
+  getActiveSessions,
+  claimSession,
+} from "./gfn/cloudmatch";
 import { AuthService } from "./gfn/auth";
 import {
   browseCatalog,
@@ -98,8 +130,18 @@ import {
 import { fetchSubscription, fetchDynamicRegions } from "./gfn/subscription";
 import { GfnSignalingClient } from "./gfn/signaling";
 import { isSessionError, SessionError, GfnErrorCode } from "./gfn/errorCodes";
-import { connectDiscordRpc, setActivity, clearActivity, destroyDiscordRpc, getCurrentActivity, isDiscordRpcConnected } from "./discordRpc";
-import { createAppUpdaterController, type AppUpdaterController } from "./updater";
+import {
+  connectDiscordRpc,
+  setActivity,
+  clearActivity,
+  destroyDiscordRpc,
+  getCurrentActivity,
+  isDiscordRpcConnected,
+} from "./discordRpc";
+import {
+  createAppUpdaterController,
+  type AppUpdaterController,
+} from "./updater";
 import { NativeStreamerManager } from "./nativeStreamer/manager";
 import { getNativeCloudGsyncCapabilities } from "./nativeCloudGsync";
 
@@ -113,7 +155,9 @@ interface BootstrapVideoPreferences {
   encoderPreference: VideoAccelerationPreference;
 }
 
-function isAccelerationPreference(value: unknown): value is VideoAccelerationPreference {
+function isAccelerationPreference(
+  value: unknown,
+): value is VideoAccelerationPreference {
   return value === "auto" || value === "hardware" || value === "software";
 }
 
@@ -127,7 +171,9 @@ function loadBootstrapVideoPreferences(): BootstrapVideoPreferences {
     if (!existsSync(settingsPath)) {
       return defaults;
     }
-    const parsed = JSON.parse(readFileSync(settingsPath, "utf-8")) as Partial<BootstrapVideoPreferences>;
+    const parsed = JSON.parse(
+      readFileSync(settingsPath, "utf-8"),
+    ) as Partial<BootstrapVideoPreferences>;
     return {
       decoderPreference: isAccelerationPreference(parsed.decoderPreference)
         ? parsed.decoderPreference
@@ -148,7 +194,9 @@ console.log(
 
 // --- Platform-specific HW video decode features ---
 const platformFeatures: string[] = [];
-const isLinuxArm = process.platform === "linux" && (process.arch === "arm64" || process.arch === "arm");
+const isLinuxArm =
+  process.platform === "linux" &&
+  (process.arch === "arm64" || process.arch === "arm");
 
 if (process.platform === "win32") {
   // Windows: D3D11 + Media Foundation path for HW decode/encode acceleration
@@ -185,7 +233,8 @@ if (process.platform === "win32") {
 }
 // macOS: VideoToolbox handles HW acceleration natively, no extra feature flags needed
 
-app.commandLine.appendSwitch("enable-features",
+app.commandLine.appendSwitch(
+  "enable-features",
   [
     // --- MP4 recording via MediaRecorder (Chromium 127+) ---
     "MediaRecorderEnableMp4Muxer",
@@ -208,7 +257,8 @@ if (process.platform === "linux" && !isLinuxArm) {
 }
 app.commandLine.appendSwitch("disable-features", disableFeatures.join(","));
 
-app.commandLine.appendSwitch("force-fieldtrials",
+app.commandLine.appendSwitch(
+  "force-fieldtrials",
   [
     // Disable send-side pacing — we are receive-only, pacing adds latency to RTCP feedback
     "WebRTC-Video-Pacing/Disabled/",
@@ -317,14 +367,20 @@ function runShutdownCleanup(reason = "app-quit"): void {
     try {
       windowToClose.close();
     } catch (error) {
-      console.warn("[Main] Failed to close main window during shutdown:", error);
+      console.warn(
+        "[Main] Failed to close main window during shutdown:",
+        error,
+      );
     }
 
     if (!windowToClose.isDestroyed()) {
       try {
         windowToClose.destroy();
       } catch (error) {
-        console.warn("[Main] Failed to destroy main window during shutdown:", error);
+        console.warn(
+          "[Main] Failed to destroy main window during shutdown:",
+          error,
+        );
       }
     }
   }
@@ -337,14 +393,26 @@ function scheduleExplicitShutdownFallback(reason: string, exitCode = 0): void {
 
   explicitShutdownFallbackTimer = setTimeout(() => {
     explicitShutdownFallbackTimer = null;
-    console.warn(`[Main] Explicit shutdown fallback triggered (${reason}); forcing process exit.`);
+    console.warn(
+      `[Main] Explicit shutdown fallback triggered (${reason}); forcing process exit.`,
+    );
     app.exit(exitCode);
   }, EXPLICIT_SHUTDOWN_FORCE_EXIT_DELAY_MS);
   explicitShutdownFallbackTimer.unref?.();
 }
 
-function requestAppShutdown(options: { reason?: string; forceExitFallback?: boolean; exitCode?: number } = {}): void {
-  const { reason = "app-quit", forceExitFallback = false, exitCode = 0 } = options;
+function requestAppShutdown(
+  options: {
+    reason?: string;
+    forceExitFallback?: boolean;
+    exitCode?: number;
+  } = {},
+): void {
+  const {
+    reason = "app-quit",
+    forceExitFallback = false,
+    exitCode = 0,
+  } = options;
 
   if (!isShutdownRequested) {
     isShutdownRequested = true;
@@ -410,9 +478,14 @@ class DiscordStatusMonitor {
 
       const provider = authService.getSelectedProvider();
       const streamingBaseUrl = provider.streamingServiceUrl;
-      const activeSessions = await getActiveSessions(token, streamingBaseUrl).catch(() => []);
+      const activeSessions = await getActiveSessions(
+        token,
+        streamingBaseUrl,
+      ).catch(() => []);
 
-      const activeSession = activeSessions.find((s) => [1, 2, 3].includes(s.status));
+      const activeSession = activeSessions.find((s) =>
+        [1, 2, 3].includes(s.status),
+      );
       const currentActivity = getCurrentActivity();
 
       if (activeSession) {
@@ -454,14 +527,19 @@ function sanitizeTitleForFileName(value: string | undefined): string {
   return compact.slice(0, 48);
 }
 
-function dataUrlToBuffer(dataUrl: string): { ext: "png" | "jpg" | "webp"; buffer: Buffer } {
-  const match = /^data:image\/(png|jpeg|jpg|webp);base64,([a-z0-9+/=\s]+)$/i.exec(dataUrl);
+function dataUrlToBuffer(dataUrl: string): {
+  ext: "png" | "jpg" | "webp";
+  buffer: Buffer;
+} {
+  const match =
+    /^data:image\/(png|jpeg|jpg|webp);base64,([a-z0-9+/=\s]+)$/i.exec(dataUrl);
   if (!match || !match[1] || !match[2]) {
     throw new Error("Invalid screenshot payload");
   }
 
   const rawExt = match[1].toLowerCase();
-  const ext: "png" | "jpg" | "webp" = rawExt === "jpeg" ? "jpg" : (rawExt as "png" | "jpg" | "webp");
+  const ext: "png" | "jpg" | "webp" =
+    rawExt === "jpeg" ? "jpg" : (rawExt as "png" | "jpg" | "webp");
   const buffer = Buffer.from(match[2].replace(/\s+/g, ""), "base64");
   if (!buffer.length) {
     throw new Error("Empty screenshot payload");
@@ -471,7 +549,8 @@ function dataUrlToBuffer(dataUrl: string): { ext: "png" | "jpg" | "webp"; buffer
 }
 
 function buildScreenshotDataUrl(ext: string, buffer: Buffer): string {
-  const mime = ext === "jpg" ? "image/jpeg" : ext === "webp" ? "image/webp" : "image/png";
+  const mime =
+    ext === "jpg" ? "image/jpeg" : ext === "webp" ? "image/webp" : "image/png";
   return `data:${mime};base64,${buffer.toString("base64")}`;
 }
 
@@ -518,7 +597,9 @@ async function listScreenshots(): Promise<ScreenshotEntry[]> {
     .slice(0, SCREENSHOT_LIMIT);
 }
 
-async function saveScreenshot(input: ScreenshotSaveRequest): Promise<ScreenshotEntry> {
+async function saveScreenshot(
+  input: ScreenshotSaveRequest,
+): Promise<ScreenshotEntry> {
   const { ext, buffer } = dataUrlToBuffer(input.dataUrl);
   const dir = await ensureScreenshotDirectory();
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -545,7 +626,9 @@ async function deleteScreenshot(input: ScreenshotDeleteRequest): Promise<void> {
   await unlink(filePath);
 }
 
-async function saveScreenshotAs(input: ScreenshotSaveAsRequest): Promise<ScreenshotSaveAsResult> {
+async function saveScreenshotAs(
+  input: ScreenshotSaveAsRequest,
+): Promise<ScreenshotSaveAsResult> {
   assertSafeScreenshotId(input.id);
   const dir = await ensureScreenshotDirectory();
   const sourcePath = join(dir, input.id);
@@ -606,7 +689,9 @@ function md5(input: string): string {
 }
 
 /** Seconds; null if ffprobe missing or unreadable. */
-async function probeVideoDurationSeconds(sourcePath: string): Promise<number | null> {
+async function probeVideoDurationSeconds(
+  sourcePath: string,
+): Promise<number | null> {
   return new Promise((resolve) => {
     const args = [
       "-v",
@@ -617,7 +702,9 @@ async function probeVideoDurationSeconds(sourcePath: string): Promise<number | n
       "default=noprint_wrappers=1:nokey=1",
       sourcePath,
     ];
-    const child = spawn("ffprobe", args, { stdio: ["ignore", "pipe", "ignore"] });
+    const child = spawn("ffprobe", args, {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
     let out = "";
     child.stdout?.on("data", (chunk: Buffer) => {
       out += chunk.toString();
@@ -644,10 +731,25 @@ function randomThumbnailSeekSeconds(durationSec: number | null): number {
   return 0.2 + Math.random() * 4.8;
 }
 
-function ffmpegExtractOneFrame(sourcePath: string, outPath: string, seekSec: number): Promise<boolean> {
+function ffmpegExtractOneFrame(
+  sourcePath: string,
+  outPath: string,
+  seekSec: number,
+): Promise<boolean> {
   const ss = seekSec.toFixed(3);
   return new Promise<boolean>((resolve) => {
-    const args = ["-y", "-ss", ss, "-i", sourcePath, "-frames:v", "1", "-q:v", "2", outPath];
+    const args = [
+      "-y",
+      "-ss",
+      ss,
+      "-i",
+      sourcePath,
+      "-frames:v",
+      "1",
+      "-q:v",
+      "2",
+      outPath,
+    ];
     const child = spawn("ffmpeg", args, { stdio: "ignore" });
     child.on("error", () => resolve(false));
     child.on("close", (code) => {
@@ -656,7 +758,10 @@ function ffmpegExtractOneFrame(sourcePath: string, outPath: string, seekSec: num
   });
 }
 
-async function generateVideoThumbnail(sourcePath: string, outPath: string): Promise<boolean> {
+async function generateVideoThumbnail(
+  sourcePath: string,
+  outPath: string,
+): Promise<boolean> {
   const durationSec = await probeVideoDurationSeconds(sourcePath);
   const seekSec = randomThumbnailSeekSeconds(durationSec);
   if (await ffmpegExtractOneFrame(sourcePath, outPath, seekSec)) return true;
@@ -664,7 +769,9 @@ async function generateVideoThumbnail(sourcePath: string, outPath: string): Prom
   return false;
 }
 
-async function ensureThumbnailForMedia(filePath: string): Promise<string | null> {
+async function ensureThumbnailForMedia(
+  filePath: string,
+): Promise<string | null> {
   try {
     const stats = await stat(filePath);
     const key = md5(`${filePath}|${stats.mtimeMs}`);
@@ -679,7 +786,12 @@ async function ensureThumbnailForMedia(filePath: string): Promise<string | null>
     }
 
     const lower = filePath.toLowerCase();
-    if (lower.endsWith(".mp4") || lower.endsWith(".webm") || lower.endsWith(".mkv") || lower.endsWith(".mov")) {
+    if (
+      lower.endsWith(".mp4") ||
+      lower.endsWith(".webm") ||
+      lower.endsWith(".mkv") ||
+      lower.endsWith(".mov")
+    ) {
       const ok = await generateVideoThumbnail(filePath, outPath);
       if (ok) return outPath;
       // generation failed
@@ -687,7 +799,12 @@ async function ensureThumbnailForMedia(filePath: string): Promise<string | null>
     }
 
     // For images, copy into cache (no re-encoding)
-    if (lower.endsWith(".png") || lower.endsWith(".jpg") || lower.endsWith(".jpeg") || lower.endsWith(".webp")) {
+    if (
+      lower.endsWith(".png") ||
+      lower.endsWith(".jpg") ||
+      lower.endsWith(".jpeg") ||
+      lower.endsWith(".webp")
+    ) {
       try {
         const buf = await readFile(filePath);
         await writeFile(outPath, buf);
@@ -750,8 +867,13 @@ async function listRecordings(): Promise<RecordingEntry[]> {
         const durationMs = durMatch ? Number(durMatch[1]) : 0;
 
         // Parse game title from filename: {stamp}-{title}-{rand}[-dur{ms}].{ext}
-        const titleMatch = /^[^-]+-[^-]+-([^-]+(?:-[^-]+)*?)-[a-f0-9]{6}(?:-dur\d+)?\.(mp4|webm)$/i.exec(fileName);
-        const gameTitle = titleMatch ? titleMatch[1].replace(/-/g, " ") : undefined;
+        const titleMatch =
+          /^[^-]+-[^-]+-([^-]+(?:-[^-]+)*?)-[a-f0-9]{6}(?:-dur\d+)?\.(mp4|webm)$/i.exec(
+            fileName,
+          );
+        const gameTitle = titleMatch
+          ? titleMatch[1].replace(/-/g, " ")
+          : undefined;
 
         return {
           id: fileName,
@@ -785,10 +907,14 @@ function getNativeStreamerManager(): NativeStreamerManager {
   nativeStreamerManager ??= new NativeStreamerManager({
     mainDir: __dirname,
     getBackendPreference: () => "gstreamer",
-    getVideoBackendPreference: () => settingsManager?.get("nativeVideoBackend") ?? "auto",
-    getExecutablePathOverride: () => settingsManager?.get("nativeStreamerExecutablePath") ?? "",
-    getCloudGsyncMode: () => settingsManager?.get("nativeCloudGsyncMode") ?? "auto",
-    getD3dFullscreenMode: () => settingsManager?.get("nativeD3dFullscreenMode") ?? "auto",
+    getVideoBackendPreference: () =>
+      settingsManager?.get("nativeVideoBackend") ?? "auto",
+    getExecutablePathOverride: () =>
+      settingsManager?.get("nativeStreamerExecutablePath") ?? "",
+    getCloudGsyncMode: () =>
+      settingsManager?.get("nativeCloudGsyncMode") ?? "auto",
+    getD3dFullscreenMode: () =>
+      settingsManager?.get("nativeD3dFullscreenMode") ?? "auto",
     getExternalRendererEnabled: () => true,
     emit: emitToRenderer,
     sendAnswer: async (payload) => {
@@ -872,14 +998,15 @@ function normalizeNativeRenderSurface(
     ? Math.min(8, Math.max(0.25, input.deviceScaleFactor))
     : 1;
   const rect = input.rect;
-  const visible = input.visible === true
-    && rect !== null
-    && Number.isFinite(rect.x)
-    && Number.isFinite(rect.y)
-    && Number.isFinite(rect.width)
-    && Number.isFinite(rect.height)
-    && rect.width >= 2
-    && rect.height >= 2;
+  const visible =
+    input.visible === true &&
+    rect !== null &&
+    Number.isFinite(rect.x) &&
+    Number.isFinite(rect.y) &&
+    Number.isFinite(rect.width) &&
+    Number.isFinite(rect.height) &&
+    rect.width >= 2 &&
+    rect.height >= 2;
 
   return {
     windowHandle,
@@ -897,7 +1024,9 @@ function normalizeNativeRenderSurface(
   };
 }
 
-function normalizeNativeInputPacket(input: unknown): NativeStreamerInputPacket | null {
+function normalizeNativeInputPacket(
+  input: unknown,
+): NativeStreamerInputPacket | null {
   if (!input || typeof input !== "object") {
     return null;
   }
@@ -909,12 +1038,18 @@ function normalizeNativeInputPacket(input: unknown): NativeStreamerInputPacket |
   if (rawPayload instanceof ArrayBuffer) {
     bytes = new Uint8Array(rawPayload);
   } else if (ArrayBuffer.isView(rawPayload)) {
-    bytes = new Uint8Array(rawPayload.buffer, rawPayload.byteOffset, rawPayload.byteLength);
+    bytes = new Uint8Array(
+      rawPayload.buffer,
+      rawPayload.byteOffset,
+      rawPayload.byteLength,
+    );
   } else if (Array.isArray(rawPayload)) {
     if (
-      rawPayload.length === 0
-      || rawPayload.length > MAX_NATIVE_INPUT_PACKET_BYTES
-      || rawPayload.some((byte) => !Number.isInteger(byte) || byte < 0 || byte > 255)
+      rawPayload.length === 0 ||
+      rawPayload.length > MAX_NATIVE_INPUT_PACKET_BYTES ||
+      rawPayload.some(
+        (byte) => !Number.isInteger(byte) || byte < 0 || byte > 255,
+      )
     ) {
       return null;
     }
@@ -923,12 +1058,19 @@ function normalizeNativeInputPacket(input: unknown): NativeStreamerInputPacket |
     return null;
   }
 
-  if (bytes.byteLength === 0 || bytes.byteLength > MAX_NATIVE_INPUT_PACKET_BYTES) {
+  if (
+    bytes.byteLength === 0 ||
+    bytes.byteLength > MAX_NATIVE_INPUT_PACKET_BYTES
+  ) {
     return null;
   }
 
   return {
-    payloadBase64: Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("base64"),
+    payloadBase64: Buffer.from(
+      bytes.buffer,
+      bytes.byteOffset,
+      bytes.byteLength,
+    ).toString("base64"),
     partiallyReliable: packet.partiallyReliable === true,
   };
 }
@@ -944,7 +1086,8 @@ function routeSignalingEvent(event: MainToRendererSignalingEvent): void {
 
   const context = nativeStreamerContext;
   const nativeFallbackActive =
-    context !== null && nativeStreamerFallbackSessionId === context.session.sessionId;
+    context !== null &&
+    nativeStreamerFallbackSessionId === context.session.sessionId;
 
   if (!isNativeStreamerSelected() || !context || nativeFallbackActive) {
     emitToRenderer(event);
@@ -957,24 +1100,36 @@ function routeSignalingEvent(event: MainToRendererSignalingEvent): void {
   }
 
   if (event.type === "remote-ice") {
-    void getNativeStreamerManager().addRemoteIce(event.candidate, context).catch((error) => {
-      emitToRenderer({ type: "error", message: `Native streamer ICE failed: ${String(error)}` });
-    });
+    void getNativeStreamerManager()
+      .addRemoteIce(event.candidate, context)
+      .catch((error) => {
+        emitToRenderer({
+          type: "error",
+          message: `Native streamer ICE failed: ${String(error)}`,
+        });
+      });
     return;
   }
 
   emitToRenderer(event);
 }
 
-async function handleNativeStreamerOffer(sdp: string, context: NativeStreamerSessionContext): Promise<void> {
+async function handleNativeStreamerOffer(
+  sdp: string,
+  context: NativeStreamerSessionContext,
+): Promise<void> {
   try {
     await getNativeStreamerManager().handleOffer(sdp, context);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn("[NativeStreamer] Falling back to web streamer:", message);
     nativeStreamerFallbackSessionId = context.session.sessionId;
-    const queuedRemoteIce = nativeStreamerManager?.drainQueuedRemoteIce(context.session.sessionId) ?? [];
-    await nativeStreamerManager?.stop("native streamer fallback").catch(() => undefined);
+    const queuedRemoteIce =
+      nativeStreamerManager?.drainQueuedRemoteIce(context.session.sessionId) ??
+      [];
+    await nativeStreamerManager
+      ?.stop("native streamer fallback")
+      .catch(() => undefined);
     emitToRenderer({
       type: "error",
       message: `Native streamer failed: ${message}. Falling back to web streamer.`,
@@ -991,7 +1146,11 @@ async function resetNativeStreamerForSignalingReconnect(): Promise<void> {
     return;
   }
 
-  if (!isNativeStreamerSelected() || !nativeStreamerContext || nativeStreamerManager.hasActiveSession()) {
+  if (
+    !isNativeStreamerSelected() ||
+    !nativeStreamerContext ||
+    nativeStreamerManager.hasActiveSession()
+  ) {
     await nativeStreamerManager.stop("signaling reconnect");
   }
 }
@@ -1010,9 +1169,14 @@ async function prepareNativeStreamerBeforeSignaling(): Promise<void> {
     await getNativeStreamerManager().prepareForSession(context);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn("[NativeStreamer] Pre-attach startup failed; falling back to web streamer:", message);
+    console.warn(
+      "[NativeStreamer] Pre-attach startup failed; falling back to web streamer:",
+      message,
+    );
     nativeStreamerFallbackSessionId = context.session.sessionId;
-    await nativeStreamerManager?.stop("native streamer pre-attach fallback").catch(() => undefined);
+    await nativeStreamerManager
+      ?.stop("native streamer pre-attach fallback")
+      .catch(() => undefined);
     emitToRenderer({
       type: "error",
       message: `Native streamer failed before signaling attach: ${message}. Falling back to web streamer.`,
@@ -1029,7 +1193,9 @@ function emitUpdaterStateToRenderer(state: AppUpdaterState): void {
 async function createMainWindow(): Promise<void> {
   const preloadMjsPath = join(__dirname, "../preload/index.mjs");
   const preloadJsPath = join(__dirname, "../preload/index.js");
-  const preloadPath = existsSync(preloadMjsPath) ? preloadMjsPath : preloadJsPath;
+  const preloadPath = existsSync(preloadMjsPath)
+    ? preloadMjsPath
+    : preloadJsPath;
 
   const settings = settingsManager.getAll();
 
@@ -1052,7 +1218,11 @@ async function createMainWindow(): Promise<void> {
     // Keep native window fullscreen in sync with HTML fullscreen so Windows treats
     // stream playback like a real fullscreen window instead of only DOM fullscreen.
     mainWindow.webContents.on("enter-html-full-screen", () => {
-      if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isFullScreen()) {
+      if (
+        mainWindow &&
+        !mainWindow.isDestroyed() &&
+        !mainWindow.isFullScreen()
+      ) {
         mainWindow.setFullScreen(true);
       }
     });
@@ -1061,7 +1231,11 @@ async function createMainWindow(): Promise<void> {
       if (rendererControlledFullscreen) {
         return;
       }
-      if (mainWindow && !mainWindow.isDestroyed() && mainWindow.isFullScreen()) {
+      if (
+        mainWindow &&
+        !mainWindow.isDestroyed() &&
+        mainWindow.isFullScreen()
+      ) {
         mainWindow.setFullScreen(false);
       }
     });
@@ -1160,25 +1334,32 @@ function rethrowSerializedSessionError(error: unknown): never {
 const AUTO_RESUME_SESSION_STATUSES = new Set([2, 3]);
 const ACTIVE_CREATE_SESSION_STATUSES = new Set([1, 2, 3]);
 
-function shouldForceNewSession(strategy: ExistingSessionStrategy | undefined): boolean {
+function shouldForceNewSession(
+  strategy: ExistingSessionStrategy | undefined,
+): boolean {
   return strategy === "force-new";
 }
 
 function isAutoResumeReadySession(entry: ActiveSessionInfo): boolean {
-  return entry.serverIp != null && AUTO_RESUME_SESSION_STATUSES.has(entry.status);
+  return (
+    entry.serverIp != null && AUTO_RESUME_SESSION_STATUSES.has(entry.status)
+  );
 }
 
 function isActiveCreateSessionConflict(entry: ActiveSessionInfo): boolean {
   return ACTIVE_CREATE_SESSION_STATUSES.has(entry.status);
 }
 
-async function resolveSessionCloudGsyncSettings(settings: StreamSettings): Promise<StreamSettings> {
+async function resolveSessionCloudGsyncSettings(
+  settings: StreamSettings,
+): Promise<StreamSettings> {
   const userRequested = settings.enableCloudGsync;
   const clientMode = settings.clientMode ?? "web";
   const cloudGsyncMode = settings.nativeCloudGsyncMode ?? "auto";
-  const capabilities = clientMode === "native"
-    ? await getNativeCloudGsyncCapabilities(cloudGsyncMode)
-    : undefined;
+  const capabilities =
+    clientMode === "native"
+      ? await getNativeCloudGsyncCapabilities(cloudGsyncMode)
+      : undefined;
   const resolution = resolveCloudGsync({
     userRequested,
     fps: settings.fps,
@@ -1193,7 +1374,9 @@ async function resolveSessionCloudGsyncSettings(settings: StreamSettings): Promi
   );
 
   if (resolution.enabled) {
-    console.log("[CloudGsync] Native Cloud G-Sync/VRR mode is resolved on; keeping low-latency unthrottled presentation.");
+    console.log(
+      "[CloudGsync] Native Cloud G-Sync/VRR mode is resolved on; keeping low-latency unthrottled presentation.",
+    );
   }
 
   return {
@@ -1204,18 +1387,34 @@ async function resolveSessionCloudGsyncSettings(settings: StreamSettings): Promi
   };
 }
 
-function selectReadySessionToClaim(activeSessions: ActiveSessionInfo[], numericAppId: number): ActiveSessionInfo | null {
+function selectReadySessionToClaim(
+  activeSessions: ActiveSessionInfo[],
+  numericAppId: number,
+): ActiveSessionInfo | null {
   return (
-    activeSessions.find((session) => isAutoResumeReadySession(session) && session.appId === numericAppId) ??
+    activeSessions.find(
+      (session) =>
+        isAutoResumeReadySession(session) && session.appId === numericAppId,
+    ) ??
     activeSessions.find((session) => isAutoResumeReadySession(session)) ??
     null
   );
 }
 
-function selectLaunchingSession(activeSessions: ActiveSessionInfo[], numericAppId: number): ActiveSessionInfo | null {
+function selectLaunchingSession(
+  activeSessions: ActiveSessionInfo[],
+  numericAppId: number,
+): ActiveSessionInfo | null {
   return (
-    activeSessions.find((session) => session.serverIp && session.appId === numericAppId && session.status === 1) ??
-    activeSessions.find((session) => session.serverIp && session.status === 1) ??
+    activeSessions.find(
+      (session) =>
+        session.serverIp &&
+        session.appId === numericAppId &&
+        session.status === 1,
+    ) ??
+    activeSessions.find(
+      (session) => session.serverIp && session.status === 1,
+    ) ??
     null
   );
 }
@@ -1259,7 +1458,8 @@ async function stopActiveSessionsForCreate(params: {
   }
 }
 
-const THANKS_CONTRIBUTORS_URL = "https://api.github.com/repos/OpenCloudGaming/OpenNOW/contributors?per_page=100";
+const THANKS_CONTRIBUTORS_URL =
+  "https://api.github.com/repos/OpenCloudGaming/OpenNOW/contributors?per_page=100";
 const THANKS_SUPPORTERS_URL = "https://github.com/sponsors/zortos293";
 const THANKS_REQUEST_HEADERS = {
   Accept: "application/vnd.github+json",
@@ -1277,9 +1477,16 @@ interface GitHubContributorResponse {
   name?: string | null;
 }
 
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    const timeout = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
     promise.then(
       (value) => {
         clearTimeout(timeout);
@@ -1293,9 +1500,18 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): 
   });
 }
 
-async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number, label: string): Promise<Response> {
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  label: string,
+): Promise<Response> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+  const timeout = setTimeout(
+    () =>
+      controller.abort(new Error(`${label} timed out after ${timeoutMs}ms`)),
+    timeoutMs,
+  );
 
   try {
     return await fetch(url, {
@@ -1303,9 +1519,15 @@ async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: numbe
       signal: controller.signal,
     });
   } catch (error) {
-    if ((error instanceof Error && error.name === "AbortError") || controller.signal.aborted) {
+    if (
+      (error instanceof Error && error.name === "AbortError") ||
+      controller.signal.aborted
+    ) {
       const reason = controller.signal.reason;
-      const message = reason instanceof Error ? reason.message : `${label} timed out after ${timeoutMs}ms`;
+      const message =
+        reason instanceof Error
+          ? reason.message
+          : `${label} timed out after ${timeoutMs}ms`;
       throw new Error(message);
     }
     throw error;
@@ -1324,7 +1546,9 @@ function decodeHtmlEntities(value: string): string {
 }
 
 function stripHtml(value: string): string {
-  return decodeHtmlEntities(value.replace(/<[^>]+>/g, " ")).replace(/\s+/g, " ").trim();
+  return decodeHtmlEntities(value.replace(/<[^>]+>/g, " "))
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function normalizeUrl(value: string | undefined): string | undefined {
@@ -1336,13 +1560,16 @@ function normalizeUrl(value: string | undefined): string | undefined {
   return decoded;
 }
 
-function shouldExcludeContributor(contributor: GitHubContributorResponse): boolean {
+function shouldExcludeContributor(
+  contributor: GitHubContributorResponse,
+): boolean {
   const login = contributor.login?.trim() ?? "";
   const name = contributor.name?.trim() ?? "";
   if (!login || !contributor.avatar_url || !contributor.html_url) return true;
   if (contributor.type === "Bot") return true;
   if (/\[bot\]$/i.test(login)) return true;
-  if (THANKS_EXCLUDED_PATTERN.test(login) || THANKS_EXCLUDED_PATTERN.test(name)) return true;
+  if (THANKS_EXCLUDED_PATTERN.test(login) || THANKS_EXCLUDED_PATTERN.test(name))
+    return true;
   return false;
 }
 
@@ -1357,7 +1584,11 @@ async function fetchThanksContributors(): Promise<ThankYouContributor[]> {
     throw new Error(`GitHub contributors request failed (${response.status})`);
   }
 
-  const payload = (await withTimeout(response.json() as Promise<GitHubContributorResponse[]>, THANKS_FETCH_TIMEOUT_MS, "GitHub contributors response")) as GitHubContributorResponse[];
+  const payload = (await withTimeout(
+    response.json() as Promise<GitHubContributorResponse[]>,
+    THANKS_FETCH_TIMEOUT_MS,
+    "GitHub contributors response",
+  )) as GitHubContributorResponse[];
   if (!Array.isArray(payload)) {
     throw new Error("GitHub contributors response was not an array");
   }
@@ -1368,15 +1599,28 @@ async function fetchThanksContributors(): Promise<ThankYouContributor[]> {
       login: contributor.login!.trim(),
       avatarUrl: contributor.avatar_url!,
       profileUrl: contributor.html_url!,
-      contributions: typeof contributor.contributions === "number" ? contributor.contributions : 0,
+      contributions:
+        typeof contributor.contributions === "number"
+          ? contributor.contributions
+          : 0,
     }))
-    .sort((a, b) => b.contributions - a.contributions || a.login.localeCompare(b.login));
+    .sort(
+      (a, b) =>
+        b.contributions - a.contributions || a.login.localeCompare(b.login),
+    );
   return contributors;
 }
 
-function parseSupporterName(entryHtml: string): { name: string; isPrivate: boolean } {
-  const privateHrefMatch = entryHtml.match(/href="https:\/\/docs\.github\.com\/sponsors\/sponsoring-open-source-contributors\/managing-your-sponsorship#managing-the-privacy-setting-for-your-sponsorship"/i);
-  const privateTooltipMatch = entryHtml.match(/<tool-tip[^>]*>\s*Private Sponsor\s*<\/tool-tip>/i);
+function parseSupporterName(entryHtml: string): {
+  name: string;
+  isPrivate: boolean;
+} {
+  const privateHrefMatch = entryHtml.match(
+    /href="https:\/\/docs\.github\.com\/sponsors\/sponsoring-open-source-contributors\/managing-your-sponsorship#managing-the-privacy-setting-for-your-sponsorship"/i,
+  );
+  const privateTooltipMatch = entryHtml.match(
+    /<tool-tip[^>]*>\s*Private Sponsor\s*<\/tool-tip>/i,
+  );
   const privateAriaMatch = entryHtml.match(/aria-label="Private Sponsor"/i);
   if (privateHrefMatch || privateTooltipMatch || privateAriaMatch) {
     return { name: "Private", isPrivate: true };
@@ -1397,7 +1641,9 @@ function parseSupporterName(entryHtml: string): { name: string; isPrivate: boole
   }
 
   const hrefMatch = entryHtml.match(/<a[^>]+href="\/([^"/?#]+)"/i);
-  const normalizedHref = hrefMatch ? decodeHtmlEntities(hrefMatch[1]).trim() : "";
+  const normalizedHref = hrefMatch
+    ? decodeHtmlEntities(hrefMatch[1]).trim()
+    : "";
   if (normalizedHref && !/sponsors/i.test(normalizedHref)) {
     return { name: normalizedHref.replace(/^@/, ""), isPrivate: false };
   }
@@ -1406,13 +1652,17 @@ function parseSupporterName(entryHtml: string): { name: string; isPrivate: boole
 }
 
 function parseSupportersFromHtml(html: string): ThankYouSupporter[] {
-  const sponsorsSectionMatch = html.match(/<div class="tmp-mt-3 tmp-pb-4" id="sponsors">([\s\S]*?)<\/remote-pagination>/i);
+  const sponsorsSectionMatch = html.match(
+    /<div class="tmp-mt-3 tmp-pb-4" id="sponsors">([\s\S]*?)<\/remote-pagination>/i,
+  );
   if (!sponsorsSectionMatch) {
     return [];
   }
 
   const listHtml = sponsorsSectionMatch[1];
-  const entryMatches = listHtml.match(/<div class="d-flex mb-1 mr-1"[^>]*>[\s\S]*?<\/div>/gi) ?? [];
+  const entryMatches =
+    listHtml.match(/<div class="d-flex mb-1 mr-1"[^>]*>[\s\S]*?<\/div>/gi) ??
+    [];
   const supporters: ThankYouSupporter[] = [];
   const seenKeys = new Set<string>();
 
@@ -1452,7 +1702,11 @@ async function fetchThanksSupporters(): Promise<ThankYouSupporter[]> {
     throw new Error(`GitHub sponsors page request failed (${response.status})`);
   }
 
-  const html = await withTimeout(response.text(), THANKS_FETCH_TIMEOUT_MS, "GitHub sponsors response");
+  const html = await withTimeout(
+    response.text(),
+    THANKS_FETCH_TIMEOUT_MS,
+    "GitHub sponsors response",
+  );
   const supporters = parseSupportersFromHtml(html);
   return supporters;
 }
@@ -1471,41 +1725,55 @@ async function fetchThanksData(): Promise<ThankYouDataResult> {
   if (contributorsResult.status === "fulfilled") {
     result.contributors = contributorsResult.value;
   } else {
-    result.contributorsError = contributorsResult.reason instanceof Error
-      ? contributorsResult.reason.message
-      : "Unable to load contributors right now.";
+    result.contributorsError =
+      contributorsResult.reason instanceof Error
+        ? contributorsResult.reason.message
+        : "Unable to load contributors right now.";
   }
 
   if (supportersResult.status === "fulfilled") {
     result.supporters = supportersResult.value;
     if (result.supporters.length === 0) {
-      result.supportersError = "No public supporters were found on GitHub Sponsors.";
+      result.supportersError =
+        "No public supporters were found on GitHub Sponsors.";
     }
   } else {
-    result.supportersError = supportersResult.reason instanceof Error
-      ? supportersResult.reason.message
-      : "Unable to load supporters right now.";
+    result.supportersError =
+      supportersResult.reason instanceof Error
+        ? supportersResult.reason.message
+        : "Unable to load supporters right now.";
   }
 
   return result;
 }
 
 function registerIpcHandlers(): void {
-  ipcMain.handle(IPC_CHANNELS.AUTH_GET_SESSION, async (_event, payload: AuthSessionRequest = {}) => {
-    return authService.ensureValidSessionWithStatus(Boolean(payload.forceRefresh));
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_GET_SESSION,
+    async (_event, payload: AuthSessionRequest = {}) => {
+      return authService.ensureValidSessionWithStatus(
+        Boolean(payload.forceRefresh),
+      );
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.AUTH_GET_PROVIDERS, async () => {
     return authService.getProviders();
   });
 
-  ipcMain.handle(IPC_CHANNELS.AUTH_GET_REGIONS, async (_event, payload: RegionsFetchRequest) => {
-    return authService.getRegions(payload?.token);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_GET_REGIONS,
+    async (_event, payload: RegionsFetchRequest) => {
+      return authService.getRegions(payload?.token);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.AUTH_LOGIN, async (_event, payload: AuthLoginRequest) => {
-    return authService.login(payload);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_LOGIN,
+    async (_event, payload: AuthLoginRequest) => {
+      return authService.login(payload);
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.AUTH_LOGOUT, async () => {
     await authService.logout();
@@ -1519,260 +1787,365 @@ function registerIpcHandlers(): void {
     return authService.getSavedAccounts();
   });
 
-  ipcMain.handle(IPC_CHANNELS.AUTH_SWITCH_ACCOUNT, async (_event, userId: string) => {
-    return authService.switchAccount(userId);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_SWITCH_ACCOUNT,
+    async (_event, userId: string) => {
+      return authService.switchAccount(userId);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.AUTH_REMOVE_ACCOUNT, async (_event, userId: string) => {
-    await authService.removeAccount(userId);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_REMOVE_ACCOUNT,
+    async (_event, userId: string) => {
+      await authService.removeAccount(userId);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.SUBSCRIPTION_FETCH, async (_event, payload: SubscriptionFetchRequest) => {
-    const token = await resolveJwt(payload?.token);
-    const streamingBaseUrl =
-      payload?.providerStreamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
-    const userId = payload.userId;
+  ipcMain.handle(
+    IPC_CHANNELS.SUBSCRIPTION_FETCH,
+    async (_event, payload: SubscriptionFetchRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      const userId = payload.userId;
 
-    // Fetch dynamic regions to get the VPC ID (handles Alliance partners correctly)
-    const { vpcId } = await fetchDynamicRegions(token, streamingBaseUrl);
+      // Fetch dynamic regions to get the VPC ID (handles Alliance partners correctly)
+      const { vpcId } = await fetchDynamicRegions(token, streamingBaseUrl);
 
-    return fetchSubscription(token, userId, vpcId ?? undefined);
-  });
+      return fetchSubscription(token, userId, vpcId ?? undefined);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.GAMES_FETCH_MAIN, async (_event, payload: GamesFetchRequest) => {
-    const token = await resolveJwt(payload?.token);
-    const streamingBaseUrl =
-      payload?.providerStreamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
-    refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-    return fetchMainGames(token, streamingBaseUrl);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_FETCH_MAIN,
+    async (_event, payload: GamesFetchRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+      return fetchMainGames(token, streamingBaseUrl);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.GAMES_FETCH_LIBRARY, async (_event, payload: GamesFetchRequest) => {
-    const token = await resolveJwt(payload?.token);
-    const streamingBaseUrl =
-      payload?.providerStreamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
-    refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-    return fetchLibraryGames(token, streamingBaseUrl);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_FETCH_LIBRARY,
+    async (_event, payload: GamesFetchRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+      return fetchLibraryGames(token, streamingBaseUrl);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.GAMES_BROWSE_CATALOG, async (_event, payload: CatalogBrowseRequest) => {
-    const token = await resolveJwt(payload?.token);
-    const streamingBaseUrl =
-      payload?.providerStreamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
-    refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-    return browseCatalog({ ...payload, token, providerStreamingBaseUrl: streamingBaseUrl });
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_BROWSE_CATALOG,
+    async (_event, payload: CatalogBrowseRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+      return browseCatalog({
+        ...payload,
+        token,
+        providerStreamingBaseUrl: streamingBaseUrl,
+      });
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.GAMES_FETCH_PUBLIC, async () => {
     return fetchPublicGames();
   });
 
-  ipcMain.handle(IPC_CHANNELS.GAMES_RESOLVE_LAUNCH_ID, async (_event, payload: ResolveLaunchIdRequest) => {
-    const token = await resolveJwt(payload?.token);
-    const streamingBaseUrl =
-      payload?.providerStreamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
-    return resolveLaunchAppId(token, payload.appIdOrUuid, streamingBaseUrl);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_RESOLVE_LAUNCH_ID,
+    async (_event, payload: ResolveLaunchIdRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      return resolveLaunchAppId(token, payload.appIdOrUuid, streamingBaseUrl);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.CREATE_SESSION, async (_event, payload: SessionCreateRequest) => {
-    const token = await resolveJwt(payload.token);
-    const streamingBaseUrl = payload.streamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
-    const forceNewSession = shouldForceNewSession(payload.existingSessionStrategy);
-    const resolvedSettings = await resolveSessionCloudGsyncSettings(payload.settings);
-    const resolvedPayload: SessionCreateRequest = { ...payload, settings: resolvedSettings };
+  ipcMain.handle(
+    IPC_CHANNELS.CREATE_SESSION,
+    async (_event, payload: SessionCreateRequest) => {
+      const token = await resolveJwt(payload.token);
+      const streamingBaseUrl =
+        payload.streamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      const forceNewSession = shouldForceNewSession(
+        payload.existingSessionStrategy,
+      );
+      const resolvedSettings = await resolveSessionCloudGsyncSettings(
+        payload.settings,
+      );
+      const resolvedPayload: SessionCreateRequest = {
+        ...payload,
+        settings: resolvedSettings,
+      };
 
-    /**
-     * Attempt to find and claim an existing active session.
-     * Prefers a session whose appId matches the requested game; falls back to
-     * any claimable session (serverIp present) if no exact match is found.
-     * Returns null when no claimable session exists or the lookup fails.
-     *
-     * IMPORTANT: Only status=2/3 (ready/streaming) sessions are sent a RESUME claim PUT.
-     * Status=1 sessions (still in queue/setup) must NOT receive a RESUME — the server
-     * rejects it with SESSION_NOT_PAUSED, and even if we polled past it internally we
-     * would bypass the renderer's queue/ad polling loop entirely. Instead, status=1
-     * sessions are returned as a minimal SessionInfo so the renderer enters its own
-     * polling loop which shows queue position and ads correctly.
-     */
-    const tryClaimExisting = async (): Promise<SessionInfo | null> => {
-      if (!token) return null;
-      try {
-        const activeSessions = await getActiveSessions(token, streamingBaseUrl);
-        if (activeSessions.length === 0) return null;
-        const numericAppId = parseInt(resolvedPayload.appId, 10);
-
-        // First prefer a paused/ready session (status 2 or 3) that can be RESUME'd.
-        const readyCandidate = selectReadySessionToClaim(activeSessions, numericAppId);
-        if (readyCandidate) {
-          console.log(
-            `[CreateSession] Resuming existing session (id=${readyCandidate.sessionId}, appId=${readyCandidate.appId}, status=${readyCandidate.status}) instead of creating new.`,
-          );
-          return claimSession({
+      /**
+       * Attempt to find and claim an existing active session.
+       * Prefers a session whose appId matches the requested game; falls back to
+       * any claimable session (serverIp present) if no exact match is found.
+       * Returns null when no claimable session exists or the lookup fails.
+       *
+       * IMPORTANT: Only status=2/3 (ready/streaming) sessions are sent a RESUME claim PUT.
+       * Status=1 sessions (still in queue/setup) must NOT receive a RESUME — the server
+       * rejects it with SESSION_NOT_PAUSED, and even if we polled past it internally we
+       * would bypass the renderer's queue/ad polling loop entirely. Instead, status=1
+       * sessions are returned as a minimal SessionInfo so the renderer enters its own
+       * polling loop which shows queue position and ads correctly.
+       */
+      const tryClaimExisting = async (): Promise<SessionInfo | null> => {
+        if (!token) return null;
+        try {
+          const activeSessions = await getActiveSessions(
             token,
             streamingBaseUrl,
-            sessionId: readyCandidate.sessionId,
-            serverIp: readyCandidate.serverIp!,
-            appId: resolvedPayload.appId,
-            settings: resolvedPayload.settings,
-          });
-        }
-
-        // A status=1 session is still in queue/setup. Return it so the renderer's
-        // polling loop handles queue position and ads — do NOT send a RESUME claim.
-        const launchingCandidate = selectLaunchingSession(activeSessions, numericAppId);
-        if (launchingCandidate) {
-          console.log(
-            `[CreateSession] Found launching session (id=${launchingCandidate.sessionId}, appId=${launchingCandidate.appId}, status=1); returning for renderer queue/ad polling.`,
           );
-          try {
-            return await pollSession({
+          if (activeSessions.length === 0) return null;
+          const numericAppId = parseInt(resolvedPayload.appId, 10);
+
+          // First prefer a paused/ready session (status 2 or 3) that can be RESUME'd.
+          const readyCandidate = selectReadySessionToClaim(
+            activeSessions,
+            numericAppId,
+          );
+          if (readyCandidate) {
+            console.log(
+              `[CreateSession] Resuming existing session (id=${readyCandidate.sessionId}, appId=${readyCandidate.appId}, status=${readyCandidate.status}) instead of creating new.`,
+            );
+            return claimSession({
               token,
               streamingBaseUrl,
-              serverIp: launchingCandidate.serverIp!,
-              zone: resolvedPayload.zone,
-              sessionId: launchingCandidate.sessionId,
-              proxyUrl: payload.proxyUrl,
+              sessionId: readyCandidate.sessionId,
+              serverIp: readyCandidate.serverIp!,
+              appId: resolvedPayload.appId,
+              settings: resolvedPayload.settings,
             });
-          } catch (hydrateError) {
-            console.warn(
-              `[CreateSession] Failed to hydrate launching session ${launchingCandidate.sessionId}; falling back to minimal handoff: ${formatErrorChainForLog(hydrateError)}`,
-            );
-            return {
-              sessionId: launchingCandidate.sessionId,
-              status: 1,
-              zone: resolvedPayload.zone,
-              streamingBaseUrl,
-              serverIp: launchingCandidate.serverIp!,
-              signalingServer: launchingCandidate.serverIp!,
-              signalingUrl: launchingCandidate.signalingUrl ?? `wss://${launchingCandidate.serverIp}:443/nvst/`,
-              iceServers: [],
-            } satisfies SessionInfo;
           }
+
+          // A status=1 session is still in queue/setup. Return it so the renderer's
+          // polling loop handles queue position and ads — do NOT send a RESUME claim.
+          const launchingCandidate = selectLaunchingSession(
+            activeSessions,
+            numericAppId,
+          );
+          if (launchingCandidate) {
+            console.log(
+              `[CreateSession] Found launching session (id=${launchingCandidate.sessionId}, appId=${launchingCandidate.appId}, status=1); returning for renderer queue/ad polling.`,
+            );
+            try {
+              return await pollSession({
+                token,
+                streamingBaseUrl,
+                serverIp: launchingCandidate.serverIp!,
+                zone: resolvedPayload.zone,
+                sessionId: launchingCandidate.sessionId,
+                proxyUrl: payload.proxyUrl,
+              });
+            } catch (hydrateError) {
+              console.warn(
+                `[CreateSession] Failed to hydrate launching session ${launchingCandidate.sessionId}; falling back to minimal handoff: ${formatErrorChainForLog(hydrateError)}`,
+              );
+              return {
+                sessionId: launchingCandidate.sessionId,
+                status: 1,
+                zone: resolvedPayload.zone,
+                streamingBaseUrl,
+                serverIp: launchingCandidate.serverIp!,
+                signalingServer: launchingCandidate.serverIp!,
+                signalingUrl:
+                  launchingCandidate.signalingUrl ??
+                  `wss://${launchingCandidate.serverIp}:443/nvst/`,
+                iceServers: [],
+              } satisfies SessionInfo;
+            }
+          }
+
+          return null;
+        } catch (claimError) {
+          console.warn(
+            `[CreateSession] Failed to claim existing session: ${formatErrorChainForLog(claimError)}`,
+          );
+          return null;
         }
+      };
 
-        return null;
-      } catch (claimError) {
-        console.warn(`[CreateSession] Failed to claim existing session: ${formatErrorChainForLog(claimError)}`);
-        return null;
-      }
-    };
-
-    // Pre-flight check: resume an active session before trying to create a new one.
-    if (!forceNewSession) {
-      const preChecked = await tryClaimExisting();
-      if (preChecked) {
-        if (settingsManager.get("discordRichPresence")) {
-          void setActivity(payload.internalTitle || payload.appId, new Date(), payload.appId);
+      // Pre-flight check: resume an active session before trying to create a new one.
+      if (!forceNewSession) {
+        const preChecked = await tryClaimExisting();
+        if (preChecked) {
+          if (settingsManager.get("discordRichPresence")) {
+            void setActivity(
+              payload.internalTitle || payload.appId,
+              new Date(),
+              payload.appId,
+            );
+          }
+          return preChecked;
         }
-        return preChecked;
       }
-    }
 
-    try {
-      if (forceNewSession && token) {
-        await stopActiveSessionsForCreate({
+      try {
+        if (forceNewSession && token) {
+          await stopActiveSessionsForCreate({
+            token,
+            streamingBaseUrl,
+            zone: resolvedPayload.zone,
+            appId: resolvedPayload.appId,
+          });
+        }
+        const sessionResult = await createSession({
+          ...resolvedPayload,
           token,
           streamingBaseUrl,
-          zone: resolvedPayload.zone,
-          appId: resolvedPayload.appId,
         });
-      }
-      const sessionResult = await createSession({ ...resolvedPayload, token, streamingBaseUrl });
-      if (settingsManager.get("discordRichPresence")) {
-        void setActivity(payload.internalTitle || payload.appId, new Date(), payload.appId);
-      }
-      return sessionResult;
-    } catch (error) {
-      // If the backend rejected the create because a session is already running,
-      // attempt a claim now (the pre-flight may have missed a session whose appId
-      // was not populated in the list response, or that had no serverIp at the
-      // time of the pre-flight but is ready now).
-      if (!forceNewSession && error instanceof SessionError && error.statusCode === 11) {
-        console.warn("[CreateSession] SESSION_LIMIT_EXCEEDED — retrying as session claim.");
-        const fallback = await tryClaimExisting();
-        if (fallback) {
-          if (settingsManager.get("discordRichPresence")) {
-            void setActivity(payload.internalTitle || payload.appId, new Date(), payload.appId);
-          }
-          return fallback;
+        if (settingsManager.get("discordRichPresence")) {
+          void setActivity(
+            payload.internalTitle || payload.appId,
+            new Date(),
+            payload.appId,
+          );
         }
+        return sessionResult;
+      } catch (error) {
+        // If the backend rejected the create because a session is already running,
+        // attempt a claim now (the pre-flight may have missed a session whose appId
+        // was not populated in the list response, or that had no serverIp at the
+        // time of the pre-flight but is ready now).
+        if (
+          !forceNewSession &&
+          error instanceof SessionError &&
+          error.statusCode === 11
+        ) {
+          console.warn(
+            "[CreateSession] SESSION_LIMIT_EXCEEDED — retrying as session claim.",
+          );
+          const fallback = await tryClaimExisting();
+          if (fallback) {
+            if (settingsManager.get("discordRichPresence")) {
+              void setActivity(
+                payload.internalTitle || payload.appId,
+                new Date(),
+                payload.appId,
+              );
+            }
+            return fallback;
+          }
+        }
+        rethrowSerializedSessionError(error);
       }
-      rethrowSerializedSessionError(error);
-    }
-  });
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.POLL_SESSION, async (_event, payload: SessionPollRequest) => {
-    try {
-      const token = await resolveJwt(payload.token);
-      return pollSession({
-        ...payload,
-        token,
-        streamingBaseUrl: payload.streamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl,
-      });
-    } catch (error) {
-      rethrowSerializedSessionError(error);
-    }
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.POLL_SESSION,
+    async (_event, payload: SessionPollRequest) => {
+      try {
+        const token = await resolveJwt(payload.token);
+        return pollSession({
+          ...payload,
+          token,
+          streamingBaseUrl:
+            payload.streamingBaseUrl ??
+            authService.getSelectedProvider().streamingServiceUrl,
+        });
+      } catch (error) {
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.REPORT_SESSION_AD, async (_event, payload: SessionAdReportRequest) => {
-    try {
-      const token = await resolveJwt(payload.token);
-      return reportSessionAd({
-        ...payload,
-        token,
-        streamingBaseUrl: payload.streamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl,
-      });
-    } catch (error) {
-      rethrowSerializedSessionError(error);
-    }
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.REPORT_SESSION_AD,
+    async (_event, payload: SessionAdReportRequest) => {
+      try {
+        const token = await resolveJwt(payload.token);
+        return reportSessionAd({
+          ...payload,
+          token,
+          streamingBaseUrl:
+            payload.streamingBaseUrl ??
+            authService.getSelectedProvider().streamingServiceUrl,
+        });
+      } catch (error) {
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.STOP_SESSION, async (_event, payload: SessionStopRequest) => {
-    try {
-      const token = await resolveJwt(payload.token);
-      const result = await stopSession({
-        ...payload,
-        token,
-        streamingBaseUrl: payload.streamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl,
-      });
-      void clearActivity();
-      return result;
-    } catch (error) {
-      rethrowSerializedSessionError(error);
-    }
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.STOP_SESSION,
+    async (_event, payload: SessionStopRequest) => {
+      try {
+        const token = await resolveJwt(payload.token);
+        const result = await stopSession({
+          ...payload,
+          token,
+          streamingBaseUrl:
+            payload.streamingBaseUrl ??
+            authService.getSelectedProvider().streamingServiceUrl,
+        });
+        void clearActivity();
+        return result;
+      } catch (error) {
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.GET_ACTIVE_SESSIONS, async (_event, token?: string, streamingBaseUrl?: string) => {
-    const jwt = await resolveJwt(token);
-    const baseUrl = streamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
-    return getActiveSessions(jwt, baseUrl);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.GET_ACTIVE_SESSIONS,
+    async (_event, token?: string, streamingBaseUrl?: string) => {
+      const jwt = await resolveJwt(token);
+      const baseUrl =
+        streamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      return getActiveSessions(jwt, baseUrl);
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.DISCORD_CLEAR_ACTIVITY, async () => {
     void clearActivity();
   });
 
-  ipcMain.handle(IPC_CHANNELS.CLAIM_SESSION, async (_event, payload: SessionClaimRequest) => {
-    try {
-      const token = await resolveJwt(payload.token);
-      const streamingBaseUrl = payload.streamingBaseUrl ?? authService.getSelectedProvider().streamingServiceUrl;
-      const resolvedSettings = payload.settings
-        ? await resolveSessionCloudGsyncSettings(payload.settings)
-        : undefined;
-      return claimSession({
-        ...payload,
-        token,
-        streamingBaseUrl,
-        settings: resolvedSettings,
-      });
-    } catch (error) {
-      rethrowSerializedSessionError(error);
-    }
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.CLAIM_SESSION,
+    async (_event, payload: SessionClaimRequest) => {
+      try {
+        const token = await resolveJwt(payload.token);
+        const streamingBaseUrl =
+          payload.streamingBaseUrl ??
+          authService.getSelectedProvider().streamingServiceUrl;
+        const resolvedSettings = payload.settings
+          ? await resolveSessionCloudGsyncSettings(payload.settings)
+          : undefined;
+        return claimSession({
+          ...payload,
+          token,
+          streamingBaseUrl,
+          settings: resolvedSettings,
+        });
+      } catch (error) {
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.SESSION_CONFLICT_DIALOG, async (): Promise<SessionConflictChoice> => {
-    return showSessionConflictDialog();
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.SESSION_CONFLICT_DIALOG,
+    async (): Promise<SessionConflictChoice> => {
+      return showSessionConflictDialog();
+    },
+  );
 
   ipcMain.handle(
     IPC_CHANNELS.CONNECT_SIGNALING,
@@ -1781,19 +2154,27 @@ function registerIpcHandlers(): void {
       nativeStreamerContext = payload.nativeStreamer ?? null;
       nativeStreamerFallbackSessionId = null;
       if (nativeStreamerContext) {
-        console.log("[NativeStreamer] Signaling connect context:", JSON.stringify({
-          sessionId: nativeStreamerContext.session.sessionId,
-          resolution: nativeStreamerContext.settings.resolution,
-          fps: nativeStreamerContext.settings.fps,
-          codec: nativeStreamerContext.settings.codec,
-          negotiatedStreamProfile: nativeStreamerContext.session.negotiatedStreamProfile,
-          requestedStreamingFeatures: nativeStreamerContext.session.requestedStreamingFeatures,
-          finalizedStreamingFeatures: nativeStreamerContext.session.finalizedStreamingFeatures,
-        }));
+        console.log(
+          "[NativeStreamer] Signaling connect context:",
+          JSON.stringify({
+            sessionId: nativeStreamerContext.session.sessionId,
+            resolution: nativeStreamerContext.settings.resolution,
+            fps: nativeStreamerContext.settings.fps,
+            codec: nativeStreamerContext.settings.codec,
+            negotiatedStreamProfile:
+              nativeStreamerContext.session.negotiatedStreamProfile,
+            requestedStreamingFeatures:
+              nativeStreamerContext.session.requestedStreamingFeatures,
+            finalizedStreamingFeatures:
+              nativeStreamerContext.session.finalizedStreamingFeatures,
+          }),
+        );
       }
 
       if (signalingClient && signalingClientKey === nextKey) {
-        console.log("[Signaling] Reuse existing signaling connection (duplicate connect request ignored)");
+        console.log(
+          "[Signaling] Reuse existing signaling connection (duplicate connect request ignored)",
+        );
         return;
       }
 
@@ -1813,7 +2194,9 @@ function registerIpcHandlers(): void {
       try {
         await signalingClient.connect();
       } catch (error) {
-        await nativeStreamerManager?.stop("signaling connect failed").catch(() => undefined);
+        await nativeStreamerManager
+          ?.stop("signaling connect failed")
+          .catch(() => undefined);
         signalingClient = null;
         signalingClientKey = null;
         throw error;
@@ -1830,62 +2213,80 @@ function registerIpcHandlers(): void {
     signalingClientKey = null;
   });
 
-  ipcMain.handle(IPC_CHANNELS.SEND_ANSWER, async (_event, payload: SendAnswerRequest) => {
-    if (!signalingClient) {
-      throw new Error("Signaling is not connected");
-    }
-    return signalingClient.sendAnswer(payload);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.SEND_ANSWER,
+    async (_event, payload: SendAnswerRequest) => {
+      if (!signalingClient) {
+        throw new Error("Signaling is not connected");
+      }
+      return signalingClient.sendAnswer(payload);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.SEND_ICE_CANDIDATE, async (_event, payload: IceCandidatePayload) => {
-    if (!signalingClient) {
-      throw new Error("Signaling is not connected");
-    }
-    return signalingClient.sendIceCandidate(payload);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.SEND_ICE_CANDIDATE,
+    async (_event, payload: IceCandidatePayload) => {
+      if (!signalingClient) {
+        throw new Error("Signaling is not connected");
+      }
+      return signalingClient.sendIceCandidate(payload);
+    },
+  );
 
-  ipcMain.on(IPC_CHANNELS.NATIVE_INPUT, (_event, payload: NativeInputPacket) => {
-    if (!isNativeStreamerSelected()) {
-      return;
-    }
+  ipcMain.on(
+    IPC_CHANNELS.NATIVE_INPUT,
+    (_event, payload: NativeInputPacket) => {
+      if (!isNativeStreamerSelected()) {
+        return;
+      }
 
-    const context = nativeStreamerContext;
-    if (!context || nativeStreamerFallbackSessionId === context.session.sessionId) {
-      return;
-    }
+      const context = nativeStreamerContext;
+      if (
+        !context ||
+        nativeStreamerFallbackSessionId === context.session.sessionId
+      ) {
+        return;
+      }
 
-    const packet = normalizeNativeInputPacket(payload);
-    if (!packet) {
-      return;
-    }
+      const packet = normalizeNativeInputPacket(payload);
+      if (!packet) {
+        return;
+      }
 
-    nativeStreamerManager?.sendInput(packet);
-  });
+      nativeStreamerManager?.sendInput(packet);
+    },
+  );
 
-  ipcMain.on(IPC_CHANNELS.NATIVE_RENDER_SURFACE, (event, payload: NativeRenderSurfaceUpdate) => {
-    if (!isNativeStreamerSelected()) {
-      return;
-    }
+  ipcMain.on(
+    IPC_CHANNELS.NATIVE_RENDER_SURFACE,
+    (event, payload: NativeRenderSurfaceUpdate) => {
+      if (!isNativeStreamerSelected()) {
+        return;
+      }
 
-    const window = BrowserWindow.fromWebContents(event.sender);
-    if (!window || window.isDestroyed()) {
-      return;
-    }
+      const window = BrowserWindow.fromWebContents(event.sender);
+      if (!window || window.isDestroyed()) {
+        return;
+      }
 
-    const surface = normalizeNativeRenderSurface(window, payload);
-    if (!surface) {
-      return;
-    }
+      const surface = normalizeNativeRenderSurface(window, payload);
+      if (!surface) {
+        return;
+      }
 
-    getNativeStreamerManager().updateSurface(surface);
-  });
+      getNativeStreamerManager().updateSurface(surface);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.REQUEST_KEYFRAME, async (_event, payload: KeyframeRequest) => {
-    if (!signalingClient) {
-      throw new Error("Signaling is not connected");
-    }
-    return signalingClient.requestKeyframe(payload);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.REQUEST_KEYFRAME,
+    async (_event, payload: KeyframeRequest) => {
+      if (!signalingClient) {
+        throw new Error("Signaling is not connected");
+      }
+      return signalingClient.requestKeyframe(payload);
+    },
+  );
 
   // Toggle fullscreen via IPC (for completeness)
   ipcMain.handle(IPC_CHANNELS.TOGGLE_FULLSCREEN, async () => {
@@ -1897,17 +2298,20 @@ function registerIpcHandlers(): void {
     }
   });
 
-  ipcMain.handle(IPC_CHANNELS.SET_FULLSCREEN, async (_event, value: boolean) => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      try {
-        const nextFullscreen = Boolean(value);
-        mainWindow.setFullScreen(nextFullscreen);
-        rendererControlledFullscreen = nextFullscreen;
-      } catch (err) {
-        console.warn("Failed to set fullscreen:", err);
+  ipcMain.handle(
+    IPC_CHANNELS.SET_FULLSCREEN,
+    async (_event, value: boolean) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        try {
+          const nextFullscreen = Boolean(value);
+          mainWindow.setFullScreen(nextFullscreen);
+          rendererControlledFullscreen = nextFullscreen;
+        } catch (err) {
+          console.warn("Failed to set fullscreen:", err);
+        }
       }
-    }
-  });
+    },
+  );
 
   // Toggle pointer lock via IPC (F8 shortcut)
   ipcMain.handle(IPC_CHANNELS.TOGGLE_POINTER_LOCK, async () => {
@@ -1923,116 +2327,145 @@ function registerIpcHandlers(): void {
     });
   });
 
-  ipcMain.handle(IPC_CHANNELS.APP_UPDATER_GET_STATE, async (): Promise<AppUpdaterState> => {
-    return appUpdater?.getState() ?? {
-      status: "disabled",
-      currentVersion: app.getVersion(),
-      updateSource: "github-releases",
-      canCheck: false,
-      canDownload: false,
-      canInstall: false,
-      isPackaged: app.isPackaged,
-      message: "Updater is unavailable.",
-    };
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.APP_UPDATER_GET_STATE,
+    async (): Promise<AppUpdaterState> => {
+      return (
+        appUpdater?.getState() ?? {
+          status: "disabled",
+          currentVersion: app.getVersion(),
+          updateSource: "github-releases",
+          canCheck: false,
+          canDownload: false,
+          canInstall: false,
+          isPackaged: app.isPackaged,
+          message: "Updater is unavailable.",
+        }
+      );
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.APP_UPDATER_CHECK, async (): Promise<AppUpdaterState> => {
-    return appUpdater?.checkForUpdates("manual") ?? {
-      status: "disabled",
-      currentVersion: app.getVersion(),
-      updateSource: "github-releases",
-      canCheck: false,
-      canDownload: false,
-      canInstall: false,
-      isPackaged: app.isPackaged,
-      message: "Updater is unavailable.",
-    };
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.APP_UPDATER_CHECK,
+    async (): Promise<AppUpdaterState> => {
+      return (
+        appUpdater?.checkForUpdates("manual") ?? {
+          status: "disabled",
+          currentVersion: app.getVersion(),
+          updateSource: "github-releases",
+          canCheck: false,
+          canDownload: false,
+          canInstall: false,
+          isPackaged: app.isPackaged,
+          message: "Updater is unavailable.",
+        }
+      );
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.APP_UPDATER_DOWNLOAD, async (): Promise<AppUpdaterState> => {
-    return appUpdater?.downloadUpdate() ?? {
-      status: "disabled",
-      currentVersion: app.getVersion(),
-      updateSource: "github-releases",
-      canCheck: false,
-      canDownload: false,
-      canInstall: false,
-      isPackaged: app.isPackaged,
-      message: "Updater is unavailable.",
-    };
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.APP_UPDATER_DOWNLOAD,
+    async (): Promise<AppUpdaterState> => {
+      return (
+        appUpdater?.downloadUpdate() ?? {
+          status: "disabled",
+          currentVersion: app.getVersion(),
+          updateSource: "github-releases",
+          canCheck: false,
+          canDownload: false,
+          canInstall: false,
+          isPackaged: app.isPackaged,
+          message: "Updater is unavailable.",
+        }
+      );
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.APP_UPDATER_INSTALL, async (): Promise<AppUpdaterState> => {
-    return appUpdater?.quitAndInstall() ?? {
-      status: "disabled",
-      currentVersion: app.getVersion(),
-      updateSource: "github-releases",
-      canCheck: false,
-      canDownload: false,
-      canInstall: false,
-      isPackaged: app.isPackaged,
-      message: "Updater is unavailable.",
-    };
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.APP_UPDATER_INSTALL,
+    async (): Promise<AppUpdaterState> => {
+      return (
+        appUpdater?.quitAndInstall() ?? {
+          status: "disabled",
+          currentVersion: app.getVersion(),
+          updateSource: "github-releases",
+          canCheck: false,
+          canDownload: false,
+          canInstall: false,
+          isPackaged: app.isPackaged,
+          message: "Updater is unavailable.",
+        }
+      );
+    },
+  );
 
   // Settings IPC handlers
   ipcMain.handle(IPC_CHANNELS.SETTINGS_GET, async (): Promise<Settings> => {
     return settingsManager.getAll();
   });
 
-  ipcMain.handle(IPC_CHANNELS.SETTINGS_SET, async <K extends keyof Settings>(_event: Electron.IpcMainInvokeEvent, key: K, value: Settings[K]) => {
-    settingsManager.set(key, value);
-    // React to certain setting changes immediately in main process
-    try {
-      if (key === "autoCheckForUpdates") {
-        appUpdater?.setAutomaticChecksEnabled(value as boolean);
-      }
-      if (
-        (key === "streamClientMode" && value !== "native")
-        || key === "nativeStreamerBackend"
-        || key === "nativeStreamerExecutablePath"
-        || key === "nativeCloudGsyncMode"
-        || key === "nativeD3dFullscreenMode"
-        || key === "nativeExternalRenderer"
-      ) {
-        void nativeStreamerManager?.stop(
-          key === "nativeStreamerBackend"
-            ? "native streamer backend changed"
-            : key === "nativeStreamerExecutablePath"
-              ? "native streamer executable changed"
-              : key === "nativeCloudGsyncMode"
-                ? "native Cloud G-Sync mode changed"
-                : key === "nativeD3dFullscreenMode"
-                  ? "native D3D fullscreen mode changed"
-                  : key === "nativeExternalRenderer"
-                    ? "native external renderer setting changed"
-                    : "native streamer disabled",
-        );
-        nativeStreamerContext = null;
-        nativeStreamerFallbackSessionId = null;
-      }
-      if (key === "nativeVideoBackend") {
-        if (nativeStreamerManager?.hasActiveSession()) {
-          console.log("[NativeStreamer] Native video backend changed; active session will keep its current backend until the next native streamer restart.");
-        } else {
-          void nativeStreamerManager?.stop("native video backend changed");
+  ipcMain.handle(
+    IPC_CHANNELS.SETTINGS_SET,
+    async <K extends keyof Settings>(
+      _event: Electron.IpcMainInvokeEvent,
+      key: K,
+      value: Settings[K],
+    ) => {
+      settingsManager.set(key, value);
+      // React to certain setting changes immediately in main process
+      try {
+        if (key === "autoCheckForUpdates") {
+          appUpdater?.setAutomaticChecksEnabled(value as boolean);
         }
-      }
-      if (key === "maxBitrateMbps") {
-        updateNativeStreamerBitrateSetting(value);
-      }
-      if (key === "discordRichPresence") {
-        if (value) {
-          void connectDiscordRpc().then(() => discordMonitor.start());
-        } else {
-          discordMonitor.stop();
-          void destroyDiscordRpc();
+        if (
+          (key === "streamClientMode" && value !== "native") ||
+          key === "nativeStreamerBackend" ||
+          key === "nativeStreamerExecutablePath" ||
+          key === "nativeCloudGsyncMode" ||
+          key === "nativeD3dFullscreenMode" ||
+          key === "nativeExternalRenderer"
+        ) {
+          void nativeStreamerManager?.stop(
+            key === "nativeStreamerBackend"
+              ? "native streamer backend changed"
+              : key === "nativeStreamerExecutablePath"
+                ? "native streamer executable changed"
+                : key === "nativeCloudGsyncMode"
+                  ? "native Cloud G-Sync mode changed"
+                  : key === "nativeD3dFullscreenMode"
+                    ? "native D3D fullscreen mode changed"
+                    : key === "nativeExternalRenderer"
+                      ? "native external renderer setting changed"
+                      : "native streamer disabled",
+          );
+          nativeStreamerContext = null;
+          nativeStreamerFallbackSessionId = null;
         }
+        if (key === "nativeVideoBackend") {
+          if (nativeStreamerManager?.hasActiveSession()) {
+            console.log(
+              "[NativeStreamer] Native video backend changed; active session will keep its current backend until the next native streamer restart.",
+            );
+          } else {
+            void nativeStreamerManager?.stop("native video backend changed");
+          }
+        }
+        if (key === "maxBitrateMbps") {
+          updateNativeStreamerBitrateSetting(value);
+        }
+        if (key === "discordRichPresence") {
+          if (value) {
+            void connectDiscordRpc().then(() => discordMonitor.start());
+          } else {
+            discordMonitor.stop();
+            void destroyDiscordRpc();
+          }
+        }
+      } catch (err) {
+        console.warn("Failed to apply setting change in main process:", err);
       }
-    } catch (err) {
-      console.warn("Failed to apply setting change in main process:", err);
-    }
-  });
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.SETTINGS_RESET, async (): Promise<Settings> => {
     const resetSettings = settingsManager.reset();
@@ -2043,357 +2476,459 @@ function registerIpcHandlers(): void {
     return resetSettings;
   });
 
-  ipcMain.handle(IPC_CHANNELS.SETTINGS_SELECT_NATIVE_STREAMER_EXECUTABLE, async (): Promise<string | null> => {
-    const filters = process.platform === "win32"
-      ? [
-          { name: "Executable", extensions: ["exe"] },
-          { name: "All Files", extensions: ["*"] },
-        ]
-      : [{ name: "All Files", extensions: ["*"] }];
+  ipcMain.handle(
+    IPC_CHANNELS.SETTINGS_SELECT_NATIVE_STREAMER_EXECUTABLE,
+    async (): Promise<string | null> => {
+      const filters =
+        process.platform === "win32"
+          ? [
+              { name: "Executable", extensions: ["exe"] },
+              { name: "All Files", extensions: ["*"] },
+            ]
+          : [{ name: "All Files", extensions: ["*"] }];
 
-    const options: Electron.OpenDialogOptions = {
-      title: "Select OpenNOW streamer executable",
-      properties: ["openFile"],
-      filters,
-    };
-    const result = mainWindow && !mainWindow.isDestroyed()
-      ? await dialog.showOpenDialog(mainWindow, options)
-      : await dialog.showOpenDialog(options);
+      const options: Electron.OpenDialogOptions = {
+        title: "Select OpenNOW streamer executable",
+        properties: ["openFile"],
+        filters,
+      };
+      const result =
+        mainWindow && !mainWindow.isDestroyed()
+          ? await dialog.showOpenDialog(mainWindow, options)
+          : await dialog.showOpenDialog(options);
 
-    if (result.canceled || result.filePaths.length === 0) {
-      return null;
-    }
-    return result.filePaths[0] ?? null;
-  });
+      if (result.canceled || result.filePaths.length === 0) {
+        return null;
+      }
+      return result.filePaths[0] ?? null;
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.NATIVE_STREAMER_STATUS, async (): Promise<NativeStreamerStatus> => {
-    return getNativeStreamerManager().probeStatus();
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.NATIVE_STREAMER_STATUS,
+    async (): Promise<NativeStreamerStatus> => {
+      return getNativeStreamerManager().probeStatus();
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.NATIVE_CLOUD_GSYNC_CAPABILITIES, async () => {
-    const capabilities = await getNativeCloudGsyncCapabilities(settingsManager?.get("nativeCloudGsyncMode") ?? "auto");
-    console.log(`[CloudGsync] capability probe: ${JSON.stringify(capabilities)}`);
+    const capabilities = await getNativeCloudGsyncCapabilities(
+      settingsManager?.get("nativeCloudGsyncMode") ?? "auto",
+    );
+    console.log(
+      `[CloudGsync] capability probe: ${JSON.stringify(capabilities)}`,
+    );
     return capabilities;
   });
 
-  ipcMain.handle(IPC_CHANNELS.MICROPHONE_PERMISSION_GET, async (): Promise<MicrophonePermissionResult> => {
-    if (process.platform !== "darwin") {
+  ipcMain.handle(
+    IPC_CHANNELS.MICROPHONE_PERMISSION_GET,
+    async (): Promise<MicrophonePermissionResult> => {
+      if (process.platform !== "darwin") {
+        return {
+          platform: process.platform,
+          isMacOs: false,
+          status: "not-applicable",
+          granted: false,
+          canRequest: false,
+          shouldUseBrowserApi: true,
+        };
+      }
+
+      const currentStatus =
+        systemPreferences.getMediaAccessStatus("microphone");
+      console.log("[Main] macOS microphone permission status:", currentStatus);
+
+      if (currentStatus === "granted") {
+        return {
+          platform: process.platform,
+          isMacOs: true,
+          status: "granted",
+          granted: true,
+          canRequest: false,
+          shouldUseBrowserApi: true,
+        };
+      }
+
+      if (currentStatus === "not-determined") {
+        const granted = await systemPreferences.askForMediaAccess("microphone");
+        const nextStatus = systemPreferences.getMediaAccessStatus("microphone");
+        console.log(
+          "[Main] Requested macOS microphone permission:",
+          granted,
+          nextStatus,
+        );
+        return {
+          platform: process.platform,
+          isMacOs: true,
+          status: nextStatus,
+          granted,
+          canRequest: nextStatus === "not-determined",
+          shouldUseBrowserApi: granted,
+        };
+      }
+
       return {
         platform: process.platform,
-        isMacOs: false,
-        status: "not-applicable",
+        isMacOs: true,
+        status: currentStatus,
         granted: false,
         canRequest: false,
-        shouldUseBrowserApi: true,
+        shouldUseBrowserApi: false,
       };
-    }
-
-    const currentStatus = systemPreferences.getMediaAccessStatus("microphone");
-    console.log("[Main] macOS microphone permission status:", currentStatus);
-
-    if (currentStatus === "granted") {
-      return {
-        platform: process.platform,
-        isMacOs: true,
-        status: "granted",
-        granted: true,
-        canRequest: false,
-        shouldUseBrowserApi: true,
-      };
-    }
-
-    if (currentStatus === "not-determined") {
-      const granted = await systemPreferences.askForMediaAccess("microphone");
-      const nextStatus = systemPreferences.getMediaAccessStatus("microphone");
-      console.log("[Main] Requested macOS microphone permission:", granted, nextStatus);
-      return {
-        platform: process.platform,
-        isMacOs: true,
-        status: nextStatus,
-        granted,
-        canRequest: nextStatus === "not-determined",
-        shouldUseBrowserApi: granted,
-      };
-    }
-
-    return {
-      platform: process.platform,
-      isMacOs: true,
-      status: currentStatus,
-      granted: false,
-      canRequest: false,
-      shouldUseBrowserApi: false,
-    };
-  });
+    },
+  );
 
   // Logs export IPC handler
-  ipcMain.handle(IPC_CHANNELS.LOGS_EXPORT, async (_event, format: "text" | "json" = "text"): Promise<string> => {
-    return exportLogs(format);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.LOGS_EXPORT,
+    async (_event, format: "text" | "json" = "text"): Promise<string> => {
+      return exportLogs(format);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.SCREENSHOT_SAVE, async (_event, input: ScreenshotSaveRequest): Promise<ScreenshotEntry> => {
-    return saveScreenshot(input);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.SCREENSHOT_SAVE,
+    async (_event, input: ScreenshotSaveRequest): Promise<ScreenshotEntry> => {
+      return saveScreenshot(input);
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.SCREENSHOT_LIST, async (): Promise<ScreenshotEntry[]> => {
-    return listScreenshots();
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.SCREENSHOT_LIST,
+    async (): Promise<ScreenshotEntry[]> => {
+      return listScreenshots();
+    },
+  );
 
   // Media: per-game listing (screenshots + recordings). Best-effort title matching.
-  ipcMain.handle(IPC_CHANNELS.MEDIA_LIST_BY_GAME, async (_event, payload: { gameTitle?: string } = {}) => {
-    const title = (payload?.gameTitle || "").trim().toLowerCase();
-    const screenshots = await listScreenshots();
-    const recordings = await listRecordings();
+  ipcMain.handle(
+    IPC_CHANNELS.MEDIA_LIST_BY_GAME,
+    async (_event, payload: { gameTitle?: string } = {}) => {
+      const title = (payload?.gameTitle || "").trim().toLowerCase();
+      const screenshots = await listScreenshots();
+      const recordings = await listRecordings();
 
-    const normalize = (s?: string) => (s || "").replace(/[^a-z0-9]+/gi, "").toLowerCase();
-    const needle = normalize(title);
+      const normalize = (s?: string) =>
+        (s || "").replace(/[^a-z0-9]+/gi, "").toLowerCase();
+      const needle = normalize(title);
 
-    const matchedScreens = screenshots.filter((s) => {
-      if (!needle) return true;
-      const candidate = normalize(s.fileName) + normalize(s.filePath || "");
-      return candidate.includes(needle);
-    });
+      const matchedScreens = screenshots.filter((s) => {
+        if (!needle) return true;
+        const candidate = normalize(s.fileName) + normalize(s.filePath || "");
+        return candidate.includes(needle);
+      });
 
-    const matchedRecordings = recordings.filter((r) => {
-      if (!needle) return true;
-      const candidate = normalize(r.gameTitle ?? r.fileName ?? "");
-      return candidate.includes(needle);
-    });
+      const matchedRecordings = recordings.filter((r) => {
+        if (!needle) return true;
+        const candidate = normalize(r.gameTitle ?? r.fileName ?? "");
+        return candidate.includes(needle);
+      });
 
-    return {
-      screenshots: matchedScreens,
-      videos: matchedRecordings,
-    };
-  });
+      return {
+        screenshots: matchedScreens,
+        videos: matchedRecordings,
+      };
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.SCREENSHOT_DELETE, async (_event, input: ScreenshotDeleteRequest): Promise<void> => {
-    return deleteScreenshot(input);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.SCREENSHOT_DELETE,
+    async (_event, input: ScreenshotDeleteRequest): Promise<void> => {
+      return deleteScreenshot(input);
+    },
+  );
 
   ipcMain.handle(
     IPC_CHANNELS.SCREENSHOT_SAVE_AS,
-    async (_event, input: ScreenshotSaveAsRequest): Promise<ScreenshotSaveAsResult> => {
+    async (
+      _event,
+      input: ScreenshotSaveAsRequest,
+    ): Promise<ScreenshotSaveAsResult> => {
       return saveScreenshotAs(input);
     },
   );
 
-  ipcMain.handle(IPC_CHANNELS.RECORDING_BEGIN, async (_event, input: RecordingBeginRequest): Promise<RecordingBeginResult> => {
-    const dir = await ensureRecordingsDirectory();
-    const recordingId = randomUUID();
-    const ext = extFromMimeType(input.mimeType);
-    const tempPath = join(dir, `${recordingId}${ext}.tmp`);
-    const writeStream = createWriteStream(tempPath);
-    activeRecordings.set(recordingId, { writeStream, tempPath, mimeType: input.mimeType });
-    return { recordingId };
-  });
-
-  ipcMain.handle(IPC_CHANNELS.RECORDING_CHUNK, async (_event, input: RecordingChunkRequest): Promise<void> => {
-    const rec = activeRecordings.get(input.recordingId);
-    if (!rec) {
-      throw new Error("Unknown recording id");
-    }
-    await new Promise<void>((resolve, reject) => {
-      rec.writeStream.write(Buffer.from(input.chunk), (err) => {
-        if (err) reject(err);
-        else resolve();
+  ipcMain.handle(
+    IPC_CHANNELS.RECORDING_BEGIN,
+    async (
+      _event,
+      input: RecordingBeginRequest,
+    ): Promise<RecordingBeginResult> => {
+      const dir = await ensureRecordingsDirectory();
+      const recordingId = randomUUID();
+      const ext = extFromMimeType(input.mimeType);
+      const tempPath = join(dir, `${recordingId}${ext}.tmp`);
+      const writeStream = createWriteStream(tempPath);
+      activeRecordings.set(recordingId, {
+        writeStream,
+        tempPath,
+        mimeType: input.mimeType,
       });
-    });
-  });
+      return { recordingId };
+    },
+  );
 
-  ipcMain.handle(IPC_CHANNELS.RECORDING_FINISH, async (_event, input: RecordingFinishRequest): Promise<RecordingEntry> => {
-    const rec = activeRecordings.get(input.recordingId);
-    if (!rec) {
-      throw new Error("Unknown recording id");
-    }
-    activeRecordings.delete(input.recordingId);
-
-    await new Promise<void>((resolve, reject) => {
-      rec.writeStream.end((err?: Error | null) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
-
-    const dir = getRecordingsDirectory();
-    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const title = sanitizeTitleForFileName(input.gameTitle);
-    const rand = Math.random().toString(16).slice(2, 8);
-    const durSuffix = input.durationMs > 0 ? `-dur${Math.round(input.durationMs)}` : "";
-    const ext = extFromMimeType(rec.mimeType);
-    const fileName = `${stamp}-${title}-${rand}${durSuffix}${ext}`;
-    const finalPath = join(dir, fileName);
-
-    await rename(rec.tempPath, finalPath);
-
-    // Save thumbnail if provided
-    let thumbnailDataUrl: string | undefined;
-    if (input.thumbnailDataUrl) {
-      try {
-        const { buffer } = dataUrlToBuffer(input.thumbnailDataUrl);
-        const stem = fileName.replace(/\.(mp4|webm)$/i, "");
-        const thumbPath = join(dir, `${stem}-thumb.jpg`);
-        await writeFile(thumbPath, buffer);
-        thumbnailDataUrl = input.thumbnailDataUrl;
-      } catch {
-        // Thumbnail save is best-effort — don't fail the recording
+  ipcMain.handle(
+    IPC_CHANNELS.RECORDING_CHUNK,
+    async (_event, input: RecordingChunkRequest): Promise<void> => {
+      const rec = activeRecordings.get(input.recordingId);
+      if (!rec) {
+        throw new Error("Unknown recording id");
       }
-    }
+      await new Promise<void>((resolve, reject) => {
+        rec.writeStream.write(Buffer.from(input.chunk), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    },
+  );
 
-    // Enforce recording limit: delete oldest entries beyond RECORDING_LIMIT
-    const all = await listRecordings();
-    if (all.length > RECORDING_LIMIT) {
-      const toDelete = all.slice(RECORDING_LIMIT);
-      await Promise.all(
-        toDelete.map(async (entry) => {
-          await unlink(entry.filePath).catch(() => undefined);
-          const stem = entry.fileName.replace(/\.(mp4|webm)$/i, "");
-          await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
-        }),
-      );
-    }
+  ipcMain.handle(
+    IPC_CHANNELS.RECORDING_FINISH,
+    async (_event, input: RecordingFinishRequest): Promise<RecordingEntry> => {
+      const rec = activeRecordings.get(input.recordingId);
+      if (!rec) {
+        throw new Error("Unknown recording id");
+      }
+      activeRecordings.delete(input.recordingId);
 
-    const fileStats = await stat(finalPath);
-    return {
-      id: fileName,
-      fileName,
-      filePath: finalPath,
-      createdAtMs: Date.now(),
-      sizeBytes: fileStats.size,
-      durationMs: input.durationMs,
-      gameTitle: input.gameTitle,
-      thumbnailDataUrl,
-    };
-  });
+      await new Promise<void>((resolve, reject) => {
+        rec.writeStream.end((err?: Error | null) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
 
-  ipcMain.handle(IPC_CHANNELS.RECORDING_ABORT, async (_event, input: RecordingAbortRequest): Promise<void> => {
-    const rec = activeRecordings.get(input.recordingId);
-    if (!rec) {
-      return;
-    }
-    activeRecordings.delete(input.recordingId);
-    rec.writeStream.destroy();
-    await unlink(rec.tempPath).catch(() => undefined);
-  });
+      const dir = getRecordingsDirectory();
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const title = sanitizeTitleForFileName(input.gameTitle);
+      const rand = Math.random().toString(16).slice(2, 8);
+      const durSuffix =
+        input.durationMs > 0 ? `-dur${Math.round(input.durationMs)}` : "";
+      const ext = extFromMimeType(rec.mimeType);
+      const fileName = `${stamp}-${title}-${rand}${durSuffix}${ext}`;
+      const finalPath = join(dir, fileName);
 
-  ipcMain.handle(IPC_CHANNELS.RECORDING_LIST, async (): Promise<RecordingEntry[]> => {
-    return listRecordings();
-  });
+      await rename(rec.tempPath, finalPath);
 
-  ipcMain.handle(IPC_CHANNELS.RECORDING_DELETE, async (_event, input: RecordingDeleteRequest): Promise<void> => {
-    assertSafeRecordingId(input.id);
-    const dir = await ensureRecordingsDirectory();
-    const filePath = join(dir, input.id);
-    await unlink(filePath);
-    const stem = input.id.replace(/\.(mp4|webm)$/i, "");
-    await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
-  });
+      // Save thumbnail if provided
+      let thumbnailDataUrl: string | undefined;
+      if (input.thumbnailDataUrl) {
+        try {
+          const { buffer } = dataUrlToBuffer(input.thumbnailDataUrl);
+          const stem = fileName.replace(/\.(mp4|webm)$/i, "");
+          const thumbPath = join(dir, `${stem}-thumb.jpg`);
+          await writeFile(thumbPath, buffer);
+          thumbnailDataUrl = input.thumbnailDataUrl;
+        } catch {
+          // Thumbnail save is best-effort — don't fail the recording
+        }
+      }
 
-  ipcMain.handle(IPC_CHANNELS.RECORDING_SHOW_IN_FOLDER, async (_event, id: string): Promise<void> => {
-    assertSafeRecordingId(id);
-    const dir = await ensureRecordingsDirectory();
-    shell.showItemInFolder(join(dir, id));
-  });
+      // Enforce recording limit: delete oldest entries beyond RECORDING_LIMIT
+      const all = await listRecordings();
+      if (all.length > RECORDING_LIMIT) {
+        const toDelete = all.slice(RECORDING_LIMIT);
+        await Promise.all(
+          toDelete.map(async (entry) => {
+            await unlink(entry.filePath).catch(() => undefined);
+            const stem = entry.fileName.replace(/\.(mp4|webm)$/i, "");
+            await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
+          }),
+        );
+      }
+
+      const fileStats = await stat(finalPath);
+      return {
+        id: fileName,
+        fileName,
+        filePath: finalPath,
+        createdAtMs: Date.now(),
+        sizeBytes: fileStats.size,
+        durationMs: input.durationMs,
+        gameTitle: input.gameTitle,
+        thumbnailDataUrl,
+      };
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.RECORDING_ABORT,
+    async (_event, input: RecordingAbortRequest): Promise<void> => {
+      const rec = activeRecordings.get(input.recordingId);
+      if (!rec) {
+        return;
+      }
+      activeRecordings.delete(input.recordingId);
+      rec.writeStream.destroy();
+      await unlink(rec.tempPath).catch(() => undefined);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.RECORDING_LIST,
+    async (): Promise<RecordingEntry[]> => {
+      return listRecordings();
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.RECORDING_DELETE,
+    async (_event, input: RecordingDeleteRequest): Promise<void> => {
+      assertSafeRecordingId(input.id);
+      const dir = await ensureRecordingsDirectory();
+      const filePath = join(dir, input.id);
+      await unlink(filePath);
+      const stem = input.id.replace(/\.(mp4|webm)$/i, "");
+      await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.RECORDING_SHOW_IN_FOLDER,
+    async (_event, id: string): Promise<void> => {
+      assertSafeRecordingId(id);
+      const dir = await ensureRecordingsDirectory();
+      shell.showItemInFolder(join(dir, id));
+    },
+  );
 
   // Return a thumbnail data URL for a given media file path (images or companion thumbs for videos).
-  ipcMain.handle(IPC_CHANNELS.MEDIA_THUMBNAIL, async (_event, payload: { filePath: string }): Promise<string | null> => {
-    const rawFp = payload?.filePath;
-    if (typeof rawFp !== "string") return null;
-    try {
-      const fpReal = await resolveTrustedOpenNowMediaPath(rawFp);
-      if (!fpReal) return null;
+  ipcMain.handle(
+    IPC_CHANNELS.MEDIA_THUMBNAIL,
+    async (_event, payload: { filePath: string }): Promise<string | null> => {
+      const rawFp = payload?.filePath;
+      if (typeof rawFp !== "string") return null;
+      try {
+        const fpReal = await resolveTrustedOpenNowMediaPath(rawFp);
+        if (!fpReal) return null;
 
-      const lower = fpReal.toLowerCase();
-      if (lower.endsWith(".png") || lower.endsWith(".jpg") || lower.endsWith(".jpeg") || lower.endsWith(".webp")) {
-        const buf = await readFile(fpReal);
-        const extMatch = /\.([^.]+)$/.exec(fpReal);
-        const ext = (extMatch?.[1] || "png").toLowerCase();
-        const mime = ext === "jpg" || ext === "jpeg" ? "image/jpeg" : ext === "webp" ? "image/webp" : "image/png";
-        return `data:${mime};base64,${buf.toString("base64")}`;
-      }
-
-      if (lower.endsWith(".mp4") || lower.endsWith(".webm") || lower.endsWith(".mkv") || lower.endsWith(".mov")) {
-        // Prefer an existing companion thumb next to the video
-        const stem = fpReal.replace(/\.(mp4|webm|mkv|mov)$/i, "");
-        const thumbPath = `${stem}-thumb.jpg`;
-        try {
-          const b = await readFile(thumbPath);
-          return `data:image/jpeg;base64,${b.toString("base64")}`;
-        } catch {
-          // Try generating a cached thumbnail via ffmpeg
+        const lower = fpReal.toLowerCase();
+        if (
+          lower.endsWith(".png") ||
+          lower.endsWith(".jpg") ||
+          lower.endsWith(".jpeg") ||
+          lower.endsWith(".webp")
+        ) {
+          const buf = await readFile(fpReal);
+          const extMatch = /\.([^.]+)$/.exec(fpReal);
+          const ext = (extMatch?.[1] || "png").toLowerCase();
+          const mime =
+            ext === "jpg" || ext === "jpeg"
+              ? "image/jpeg"
+              : ext === "webp"
+                ? "image/webp"
+                : "image/png";
+          return `data:${mime};base64,${buf.toString("base64")}`;
         }
 
-        const gen = await ensureThumbnailForMedia(fpReal);
-        if (gen) {
+        if (
+          lower.endsWith(".mp4") ||
+          lower.endsWith(".webm") ||
+          lower.endsWith(".mkv") ||
+          lower.endsWith(".mov")
+        ) {
+          // Prefer an existing companion thumb next to the video
+          const stem = fpReal.replace(/\.(mp4|webm|mkv|mov)$/i, "");
+          const thumbPath = `${stem}-thumb.jpg`;
           try {
-            const b2 = await readFile(gen);
-            return `data:image/jpeg;base64,${b2.toString("base64")}`;
+            const b = await readFile(thumbPath);
+            return `data:image/jpeg;base64,${b.toString("base64")}`;
           } catch {
-            return null;
+            // Try generating a cached thumbnail via ffmpeg
           }
+
+          const gen = await ensureThumbnailForMedia(fpReal);
+          if (gen) {
+            try {
+              const b2 = await readFile(gen);
+              return `data:image/jpeg;base64,${b2.toString("base64")}`;
+            } catch {
+              return null;
+            }
+          }
+          return null;
         }
+
+        return null;
+      } catch (err) {
+        console.warn("MEDIA_THUMBNAIL error:", err);
         return null;
       }
+    },
+  );
 
-      return null;
-    } catch (err) {
-      console.warn("MEDIA_THUMBNAIL error:", err);
-      return null;
-    }
-  });
-
-  ipcMain.handle(IPC_CHANNELS.MEDIA_SHOW_IN_FOLDER, async (_event, payload: { filePath: string }): Promise<void> => {
-    const rawFp = payload?.filePath;
-    if (typeof rawFp !== "string") return;
-    try {
-      const fpReal = await resolveTrustedOpenNowMediaPath(rawFp);
-      if (!fpReal) return;
-      shell.showItemInFolder(fpReal);
-    } catch {
-      return;
-    }
-  });
-
-  ipcMain.handle(IPC_CHANNELS.MEDIA_PLAYBACK_URL, async (_event, payload: { filePath: string }): Promise<string | null> => {
-    const rawFp = payload?.filePath;
-    if (typeof rawFp !== "string") return null;
-    try {
-      return await getTrustedVideoPlaybackFileUrl(rawFp);
-    } catch (err) {
-      console.warn("MEDIA_PLAYBACK_URL error:", err);
-      return null;
-    }
-  });
-
-  ipcMain.handle(IPC_CHANNELS.MEDIA_DELETE_FILE, async (_event, payload: { filePath: string }): Promise<{ ok: boolean }> => {
-    const rawFp = payload?.filePath;
-    if (typeof rawFp !== "string") return { ok: false };
-    try {
-      const fpReal = await resolveTrustedOpenNowMediaPath(rawFp);
-      if (!fpReal) return { ok: false };
-      let st: Awaited<ReturnType<typeof stat>>;
+  ipcMain.handle(
+    IPC_CHANNELS.MEDIA_SHOW_IN_FOLDER,
+    async (_event, payload: { filePath: string }): Promise<void> => {
+      const rawFp = payload?.filePath;
+      if (typeof rawFp !== "string") return;
       try {
-        st = await stat(fpReal);
+        const fpReal = await resolveTrustedOpenNowMediaPath(rawFp);
+        if (!fpReal) return;
+        shell.showItemInFolder(fpReal);
       } catch {
+        return;
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.MEDIA_PLAYBACK_URL,
+    async (_event, payload: { filePath: string }): Promise<string | null> => {
+      const rawFp = payload?.filePath;
+      if (typeof rawFp !== "string") return null;
+      try {
+        return await getTrustedVideoPlaybackFileUrl(rawFp);
+      } catch (err) {
+        console.warn("MEDIA_PLAYBACK_URL error:", err);
+        return null;
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.MEDIA_DELETE_FILE,
+    async (_event, payload: { filePath: string }): Promise<{ ok: boolean }> => {
+      const rawFp = payload?.filePath;
+      if (typeof rawFp !== "string") return { ok: false };
+      try {
+        const fpReal = await resolveTrustedOpenNowMediaPath(rawFp);
+        if (!fpReal) return { ok: false };
+        let st: Awaited<ReturnType<typeof stat>>;
+        try {
+          st = await stat(fpReal);
+        } catch {
+          return { ok: false };
+        }
+        const key = md5(`${fpReal}|${st.mtimeMs}`);
+        const cacheDir = await ensureThumbnailCacheDirectory();
+        await unlink(join(cacheDir, `${key}.jpg`)).catch(() => undefined);
+        const stem = fpReal.replace(
+          /\.(mp4|webm|mkv|mov|png|jpg|jpeg|webp)$/i,
+          "",
+        );
+        await unlink(`${stem}-thumb.jpg`).catch(() => undefined);
+        await unlink(fpReal);
+        return { ok: true };
+      } catch (err) {
+        console.warn("MEDIA_DELETE_FILE error:", err);
         return { ok: false };
       }
-      const key = md5(`${fpReal}|${st.mtimeMs}`);
-      const cacheDir = await ensureThumbnailCacheDirectory();
-      await unlink(join(cacheDir, `${key}.jpg`)).catch(() => undefined);
-      const stem = fpReal.replace(/\.(mp4|webm|mkv|mov|png|jpg|jpeg|webp)$/i, "");
-      await unlink(`${stem}-thumb.jpg`).catch(() => undefined);
-      await unlink(fpReal);
-      return { ok: true };
-    } catch (err) {
-      console.warn("MEDIA_DELETE_FILE error:", err);
-      return { ok: false };
-    }
-  });
+    },
+  );
 
   ipcMain.handle(
     IPC_CHANNELS.MEDIA_REGEN_THUMBNAIL,
-    async (_event, payload: { filePath: string }): Promise<{ ok: boolean; thumbnailDataUrl: string | null }> => {
+    async (
+      _event,
+      payload: { filePath: string },
+    ): Promise<{ ok: boolean; thumbnailDataUrl: string | null }> => {
       const rawFp = payload?.filePath;
-      if (typeof rawFp !== "string") return { ok: false, thumbnailDataUrl: null };
+      if (typeof rawFp !== "string")
+        return { ok: false, thumbnailDataUrl: null };
       try {
         const fpReal = await resolveTrustedOpenNowMediaPath(rawFp);
         if (!fpReal) return { ok: false, thumbnailDataUrl: null };
@@ -2437,88 +2972,100 @@ function registerIpcHandlers(): void {
     console.log("[IPC] Cache deletion completed successfully");
   });
 
-  ipcMain.handle(IPC_CHANNELS.COMMUNITY_GET_THANKS, async (): Promise<ThankYouDataResult> => {
-    return fetchThanksData();
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.COMMUNITY_GET_THANKS,
+    async (): Promise<ThankYouDataResult> => {
+      return fetchThanksData();
+    },
+  );
 
   // TCP-based ping function - more accurate than HTTP as it only measures connection time
-  async function tcpPing(hostname: string, port: number, timeoutMs: number = 3000): Promise<number | null> {
+  async function tcpPing(
+    hostname: string,
+    port: number,
+    timeoutMs: number = 3000,
+  ): Promise<number | null> {
     return new Promise((resolve) => {
       const startTime = Date.now();
       const socket = new net.Socket();
-      
+
       socket.setTimeout(timeoutMs);
-      
-      socket.once('connect', () => {
+
+      socket.once("connect", () => {
         const pingMs = Date.now() - startTime;
         socket.destroy();
         resolve(pingMs);
       });
-      
-      socket.once('timeout', () => {
+
+      socket.once("timeout", () => {
         socket.destroy();
         resolve(null);
       });
-      
-      socket.once('error', () => {
+
+      socket.once("error", () => {
         socket.destroy();
         resolve(null);
       });
-      
+
       socket.connect(port, hostname);
     });
   }
 
   // Ping regions IPC handler - uses TCP connection timing for accurate latency measurement
   // Runs 3 tests and averages the results
-  ipcMain.handle(IPC_CHANNELS.PING_REGIONS, async (_event, regions: StreamRegion[]): Promise<PingResult[]> => {
-    const pingPromises = regions.map(async (region) => {
-      try {
-        const url = new URL(region.url);
-        const hostname = url.hostname;
-        const port = url.protocol === 'https:' ? 443 : 80;
-        
-        const validPings: number[] = [];
+  ipcMain.handle(
+    IPC_CHANNELS.PING_REGIONS,
+    async (_event, regions: StreamRegion[]): Promise<PingResult[]> => {
+      const pingPromises = regions.map(async (region) => {
+        try {
+          const url = new URL(region.url);
+          const hostname = url.hostname;
+          const port = url.protocol === "https:" ? 443 : 80;
 
-        // Warm-up ping (result discarded) to prime the TCP path before measuring.
-        // The first cold-start connect includes DNS resolution and TCP SYN overhead
-        // which inflates subsequent measurements if not accounted for.
-        await tcpPing(hostname, port, 3000);
+          const validPings: number[] = [];
 
-        // Run 3 measured ping tests with a brief delay between each to allow
-        // the previous socket to fully close before opening the next connection.
-        for (let i = 0; i < 3; i++) {
-          if (i > 0) {
-            await new Promise<void>((resolve) => setTimeout(resolve, 100));
+          // Warm-up ping (result discarded) to prime the TCP path before measuring.
+          // The first cold-start connect includes DNS resolution and TCP SYN overhead
+          // which inflates subsequent measurements if not accounted for.
+          await tcpPing(hostname, port, 3000);
+
+          // Run 3 measured ping tests with a brief delay between each to allow
+          // the previous socket to fully close before opening the next connection.
+          for (let i = 0; i < 3; i++) {
+            if (i > 0) {
+              await new Promise<void>((resolve) => setTimeout(resolve, 100));
+            }
+            const pingMs = await tcpPing(hostname, port, 3000);
+            if (pingMs !== null) {
+              validPings.push(pingMs);
+            }
           }
-          const pingMs = await tcpPing(hostname, port, 3000);
-          if (pingMs !== null) {
-            validPings.push(pingMs);
+
+          // Calculate average of successful pings
+          if (validPings.length > 0) {
+            const avgPing = Math.round(
+              validPings.reduce((a, b) => a + b, 0) / validPings.length,
+            );
+            return { url: region.url, pingMs: avgPing };
+          } else {
+            return {
+              url: region.url,
+              pingMs: null,
+              error: "All ping tests failed",
+            };
           }
-        }
-        
-        // Calculate average of successful pings
-        if (validPings.length > 0) {
-          const avgPing = Math.round(validPings.reduce((a, b) => a + b, 0) / validPings.length);
-          return { url: region.url, pingMs: avgPing };
-        } else {
-          return { 
-            url: region.url, 
-            pingMs: null, 
-            error: 'All ping tests failed'
+        } catch {
+          return {
+            url: region.url,
+            pingMs: null,
+            error: "Invalid URL",
           };
         }
-      } catch {
-        return { 
-          url: region.url, 
-          pingMs: null, 
-          error: 'Invalid URL'
-        };
-      }
-    });
-    
-    return Promise.all(pingPromises);
-  });
+      });
+
+      return Promise.all(pingPromises);
+    },
+  );
 
   // PrintedWaste queue API — fetched from main process so User-Agent can be set
   ipcMain.handle(IPC_CHANNELS.PRINTEDWASTE_QUEUE_FETCH, async () => {
@@ -2555,12 +3102,26 @@ function registerIpcHandlers(): void {
     if (!apiBody.status) {
       throw new Error("PrintedWaste API returned status:false");
     }
-    if (!apiBody.data || typeof apiBody.data !== "object" || Array.isArray(apiBody.data)) {
+    if (
+      !apiBody.data ||
+      typeof apiBody.data !== "object" ||
+      Array.isArray(apiBody.data)
+    ) {
       throw new Error("PrintedWaste API response missing data object");
     }
 
-    const normalizedData: Record<string, { QueuePosition: number; "Last Updated": number; Region: string; eta?: number }> = {};
-    for (const [zoneId, rawZone] of Object.entries(apiBody.data as Record<string, unknown>)) {
+    const normalizedData: Record<
+      string,
+      {
+        QueuePosition: number;
+        "Last Updated": number;
+        Region: string;
+        eta?: number;
+      }
+    > = {};
+    for (const [zoneId, rawZone] of Object.entries(
+      apiBody.data as Record<string, unknown>,
+    )) {
       if (!rawZone || typeof rawZone !== "object" || Array.isArray(rawZone)) {
         continue;
       }
@@ -2570,7 +3131,10 @@ function registerIpcHandlers(): void {
       const region = zone.Region;
       const eta = zone.eta;
 
-      if (typeof queuePosition !== "number" || !Number.isFinite(queuePosition)) {
+      if (
+        typeof queuePosition !== "number" ||
+        !Number.isFinite(queuePosition)
+      ) {
         continue;
       }
       if (typeof lastUpdated !== "number" || !Number.isFinite(lastUpdated)) {
@@ -2579,7 +3143,10 @@ function registerIpcHandlers(): void {
       if (typeof region !== "string" || region.length === 0) {
         continue;
       }
-      if (eta !== undefined && (typeof eta !== "number" || !Number.isFinite(eta))) {
+      if (
+        eta !== undefined &&
+        (typeof eta !== "number" || !Number.isFinite(eta))
+      ) {
         continue;
       }
 
@@ -2612,7 +3179,9 @@ function registerIpcHandlers(): void {
       "PrintedWaste server mapping request",
     );
     if (!response.ok) {
-      throw new Error(`PrintedWaste server mapping returned HTTP ${response.status}`);
+      throw new Error(
+        `PrintedWaste server mapping returned HTTP ${response.status}`,
+      );
     }
 
     const body = await withTimeout(
@@ -2626,21 +3195,37 @@ function registerIpcHandlers(): void {
 
     const apiBody = body as { status?: unknown; data?: unknown };
     if (typeof apiBody.status !== "boolean") {
-      throw new Error("PrintedWaste server mapping response missing boolean status");
+      throw new Error(
+        "PrintedWaste server mapping response missing boolean status",
+      );
     }
     if (!apiBody.status) {
       throw new Error("PrintedWaste server mapping returned status:false");
     }
-    if (!apiBody.data || typeof apiBody.data !== "object" || Array.isArray(apiBody.data)) {
-      throw new Error("PrintedWaste server mapping response missing data object");
+    if (
+      !apiBody.data ||
+      typeof apiBody.data !== "object" ||
+      Array.isArray(apiBody.data)
+    ) {
+      throw new Error(
+        "PrintedWaste server mapping response missing data object",
+      );
     }
 
     const normalizedData: Record<
       string,
-      { title?: string; region?: string; is4080Server?: boolean; is5080Server?: boolean; nuked?: boolean }
+      {
+        title?: string;
+        region?: string;
+        is4080Server?: boolean;
+        is5080Server?: boolean;
+        nuked?: boolean;
+      }
     > = {};
 
-    for (const [zoneId, rawZone] of Object.entries(apiBody.data as Record<string, unknown>)) {
+    for (const [zoneId, rawZone] of Object.entries(
+      apiBody.data as Record<string, unknown>,
+    )) {
       if (!rawZone || typeof rawZone !== "object" || Array.isArray(rawZone)) {
         continue;
       }
@@ -2679,7 +3264,9 @@ app.whenReady().then(async () => {
 
   await cacheManager.initialize();
 
-  authService = new AuthService(join(app.getPath("userData"), "auth-state.json"));
+  authService = new AuthService(
+    join(app.getPath("userData"), "auth-state.json"),
+  );
   await authService.initialize();
 
   settingsManager = getSettingsManager();
@@ -2701,38 +3288,42 @@ app.whenReady().then(async () => {
   }
 
   // Set up permission handlers for getUserMedia, fullscreen, pointer lock
-  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
-    const allowedPermissions = new Set([
-      "media",
-      "microphone",
-      "fullscreen",
-      "automatic-fullscreen",
-      "pointerLock",
-      "keyboardLock",
-      "speaker-selection",
-    ]);
+  session.defaultSession.setPermissionRequestHandler(
+    (webContents, permission, callback) => {
+      const allowedPermissions = new Set([
+        "media",
+        "microphone",
+        "fullscreen",
+        "automatic-fullscreen",
+        "pointerLock",
+        "keyboardLock",
+        "speaker-selection",
+      ]);
 
-    if (allowedPermissions.has(permission)) {
-      callback(true);
-      return;
-    }
+      if (allowedPermissions.has(permission)) {
+        callback(true);
+        return;
+      }
 
-    callback(false);
-  });
+      callback(false);
+    },
+  );
 
-  session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
-    const allowedPermissions = new Set([
-      "media",
-      "microphone",
-      "fullscreen",
-      "automatic-fullscreen",
-      "pointerLock",
-      "keyboardLock",
-      "speaker-selection",
-    ]);
+  session.defaultSession.setPermissionCheckHandler(
+    (webContents, permission, requestingOrigin) => {
+      const allowedPermissions = new Set([
+        "media",
+        "microphone",
+        "fullscreen",
+        "automatic-fullscreen",
+        "pointerLock",
+        "keyboardLock",
+        "speaker-selection",
+      ]);
 
-    return allowedPermissions.has(permission);
-  });
+      return allowedPermissions.has(permission);
+    },
+  );
 
   registerOpenNowMediaProtocol();
   registerIpcHandlers();
@@ -2745,21 +3336,31 @@ app.whenReady().then(async () => {
 
   cacheEventBus.on("cache:refresh-start", () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(IPC_CHANNELS.CACHE_STATUS_UPDATE, { event: "refresh-start" });
+      mainWindow.webContents.send(IPC_CHANNELS.CACHE_STATUS_UPDATE, {
+        event: "refresh-start",
+      });
     }
   });
 
   cacheEventBus.on("cache:refresh-success", () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(IPC_CHANNELS.CACHE_STATUS_UPDATE, { event: "refresh-success" });
+      mainWindow.webContents.send(IPC_CHANNELS.CACHE_STATUS_UPDATE, {
+        event: "refresh-success",
+      });
     }
   });
 
-  cacheEventBus.on("cache:refresh-error", (details: { key: string; error: string }) => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(IPC_CHANNELS.CACHE_STATUS_UPDATE, { event: "refresh-error", ...details });
-    }
-  });
+  cacheEventBus.on(
+    "cache:refresh-error",
+    (details: { key: string; error: string }) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send(IPC_CHANNELS.CACHE_STATUS_UPDATE, {
+          event: "refresh-error",
+          ...details,
+        });
+      }
+    },
+  );
 
   refreshScheduler.start();
 
@@ -2777,14 +3378,16 @@ app.whenReady().then(async () => {
 });
 
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
-    requestAppShutdown({ reason: "window-all-closed" });
-  }
+  requestAppShutdown({ reason: "window-all-closed" });
 });
 
 app.on("before-quit", () => {
   isShutdownRequested = true;
-  runShutdownCleanup(isUpdaterInstallQuitInProgress ? "before-quit-updater-install" : "before-quit");
+  runShutdownCleanup(
+    isUpdaterInstallQuitInProgress
+      ? "before-quit-updater-install"
+      : "before-quit",
+  );
 });
 
 app.on("will-quit", () => {


### PR DESCRIPTION
## Summary

Removes the `process.platform !== 'darwin'` guard from the `window-all-closed` handler so that closing the main window on macOS triggers `requestAppShutdown` → `app.quit()`, instead of leaving the app lingering in the dock.

## Before

```ts
app.on("window-all-closed", () => {
  if (process.platform !== "darwin") {
    requestAppShutdown({ reason: "window-all-closed" });
  }
});
```

## After

```ts
app.on("window-all-closed", () => {
  requestAppShutdown({ reason: "window-all-closed" });
});
```

## Testing

- `npm run typecheck` passes with zero errors
- On macOS, closing the main window will now quit the application entirely