### PR TITLE
Implement native macOS input for GStreamer backend

### DIFF
--- a/native/opennow-streamer/Cargo.lock
+++ b/native/opennow-streamer/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-expr"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +74,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-channel"
@@ -117,6 +135,40 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa85c2e35dc565c90511917897ea4eae16b77f2773d5223536f7b602536d462"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23f2cc5144060a7f8d9e02d3fce5d06705376568256a509cdbc3c24d47e4f04"
+dependencies = [
+ "inotify",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "windows",
 ]
 
 [[package]]
@@ -353,6 +405,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +438,18 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kstring"
@@ -383,6 +467,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +493,18 @@ name = "muldiv"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-integer"
@@ -423,10 +535,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags",
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "opennow-streamer"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "gilrs",
  "gstreamer",
  "gstreamer-sdp",
  "gstreamer-video",
@@ -509,6 +648,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
@@ -676,10 +821,148 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"
@@ -688,10 +971,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]

--- a/native/opennow-streamer/Cargo.toml
+++ b/native/opennow-streamer/Cargo.toml
@@ -23,3 +23,6 @@ gstreamer-webrtc = { version = "0.25.0", optional = true }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+gilrs = "0.11"

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -2,12 +2,16 @@ use crate::backend::{
     normalize_bitrate_kbps, prepare_native_offer, prepared_offer_events,
     update_context_bitrate_limit, BackendReply, NativeStreamerBackend,
 };
+use crate::input::InputEncoder;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use crate::input::{
-    GamepadInput, InputEncoder, KeyboardPayload, MouseButtonPayload, MouseMovePayload,
-    MouseWheelPayload, GAMEPAD_MAX_CONTROLLERS, PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
+    GamepadInput, KeyboardPayload, MouseButtonPayload, MouseMovePayload, MouseWheelPayload,
+    GAMEPAD_MAX_CONTROLLERS, PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
 };
+#[cfg(target_os = "windows")]
+use crate::protocol::NativeRenderRect;
 use crate::protocol::{
-    missing_field, CommandEnvelope, Event, IceCandidatePayload, NativeQueueMode, NativeRenderRect,
+    missing_field, CommandEnvelope, Event, IceCandidatePayload, NativeQueueMode,
     NativeRenderSurface, NativeStreamerCapabilities, NativeStreamerSessionContext,
     NativeVideoBackendCapability, NativeVideoCodecCapability, Response, SendAnswerRequest,
     StreamSettings, VideoStallEvent, VideoTransitionEvent, PROTOCOL_VERSION,
@@ -17,16 +21,24 @@ use crate::sdp::{
 };
 use gst::glib;
 use gst::prelude::*;
-use gst_video::prelude::*;
 use gstreamer as gst;
 use gstreamer_sdp as gst_sdp;
+#[cfg(target_os = "windows")]
 use gstreamer_video as gst_video;
 use gstreamer_webrtc as gst_webrtc;
 use std::collections::HashSet;
-use std::ffi::{c_void, CString};
+#[cfg(target_os = "windows")]
+use std::ffi::c_void;
+use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
-use std::sync::mpsc::{self, RecvTimeoutError, Sender, TryRecvError};
-use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use std::sync::mpsc;
+use std::sync::mpsc::Sender;
+#[cfg(target_os = "windows")]
+use std::sync::mpsc::{RecvTimeoutError, TryRecvError};
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use std::sync::OnceLock;
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -51,9 +63,13 @@ const VIDEO_STARTUP_FATAL_MS: u64 = 8_000;
 const VIDEO_LIVENESS_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 const HEARTBEAT_STOP_POLL_INTERVAL: Duration = Duration::from_millis(50);
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const NATIVE_INPUT_BRIDGE_POLL_INTERVAL: Duration = Duration::from_millis(1);
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const NATIVE_INPUT_DRAIN_MAX_EVENTS: usize = 512;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const NATIVE_GAMEPAD_POLL_INTERVAL: Duration = Duration::from_millis(4);
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const NATIVE_GAMEPAD_KEEPALIVE_INTERVAL: Duration = Duration::from_millis(100);
 const EXTERNAL_RENDERER_ENV: &str = "OPENNOW_NATIVE_EXTERNAL_RENDERER";
 const NATIVE_VIDEO_API_ENV: &str = "OPENNOW_NATIVE_VIDEO_API";
@@ -63,7 +79,7 @@ const NATIVE_PRESENT_MAX_FPS_ENV: &str = "OPENNOW_NATIVE_PRESENT_MAX_FPS";
 const NATIVE_D3D_FULLSCREEN_ENV: &str = "OPENNOW_NATIVE_D3D_FULLSCREEN";
 const PRESENT_LIMITER_AUTO_SENTINEL: u32 = u32::MAX;
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 static NATIVE_INPUT_STARTED_AT: OnceLock<Instant> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1031,7 +1047,7 @@ impl GstreamerInputState {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 #[derive(Debug, Clone, Copy)]
 enum NativeWindowInputEvent {
     Key {
@@ -1309,7 +1325,71 @@ impl Drop for NativeWindowInputBridge {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+struct NativeWindowInputBridge {
+    stop: Arc<AtomicBool>,
+    input_thread: Option<JoinHandle<()>>,
+    gamepad_thread: Option<JoinHandle<()>>,
+}
+
+#[cfg(target_os = "macos")]
+impl NativeWindowInputBridge {
+    fn start(
+        input_state: GstreamerInputState,
+        input_channels: GstreamerInputChannels,
+        event_sender: Option<Sender<Event>>,
+    ) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (sender, receiver) =
+            mpsc::sync_channel::<NativeWindowInputEvent>(NATIVE_INPUT_DRAIN_MAX_EVENTS);
+        let input_thread = macos_native_input::spawn_keyboard_mouse_thread(
+            input_state.clone(),
+            input_channels.clone(),
+            event_sender.clone(),
+            stop.clone(),
+            sender,
+            receiver,
+        );
+        let gamepad_thread = Some(macos_native_input::spawn_gamepad_thread(
+            input_state,
+            input_channels,
+            event_sender,
+            stop.clone(),
+        ));
+
+        Self {
+            stop,
+            input_thread: Some(input_thread),
+            gamepad_thread,
+        }
+    }
+
+    fn stop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        macos_native_input::stop_keyboard_mouse_capture();
+
+        if let Some(thread) = self.input_thread.take() {
+            if let Err(error) = thread.join() {
+                eprintln!("[NativeStreamer] Native macOS input bridge thread panicked: {error:?}");
+            }
+        }
+        if let Some(thread) = self.gamepad_thread.take() {
+            if let Err(error) = thread.join() {
+                eprintln!("[NativeStreamer] Native macOS gamepad thread panicked: {error:?}");
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for NativeWindowInputBridge {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn send_native_window_input_events(
     input_state: &GstreamerInputState,
     input_channels: &GstreamerInputChannels,
@@ -1345,7 +1425,7 @@ fn send_native_window_input_events(
     flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn flush_pending_mouse_move(
     encoder: &InputEncoder,
     input_channels: &GstreamerInputChannels,
@@ -1369,7 +1449,7 @@ fn flush_pending_mouse_move(
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn send_encoded_native_window_input_event(
     encoder: &InputEncoder,
     input_channels: &GstreamerInputChannels,
@@ -1439,7 +1519,7 @@ fn send_encoded_native_window_input_event(
     let _ = input_channels.send_packet(&payload, partially_reliable);
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct NativeGamepadSnapshot {
     connected: bool,
@@ -1548,7 +1628,7 @@ fn spawn_native_gamepad_thread(
     })
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn send_native_gamepad_snapshot(
     input_state: &GstreamerInputState,
     input_channels: &GstreamerInputChannels,
@@ -1584,7 +1664,7 @@ fn send_native_gamepad_snapshot(
     let _ = input_channels.send_packet(&payload, use_partially_reliable);
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn native_input_timestamp_us() -> u64 {
     NATIVE_INPUT_STARTED_AT
         .get_or_init(Instant::now)
@@ -1671,7 +1751,7 @@ struct GstreamerPipeline {
     webrtc: gst::Element,
     input_state: GstreamerInputState,
     input_channels: Option<GstreamerInputChannels>,
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     native_window_input_bridge: Option<NativeWindowInputBridge>,
     render_state: GstreamerRenderState,
     present_max_fps: Arc<AtomicU32>,
@@ -1730,7 +1810,7 @@ impl GstreamerPipeline {
             webrtc,
             input_state,
             input_channels: None,
-            #[cfg(target_os = "windows")]
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
             native_window_input_bridge: None,
             render_state,
             present_max_fps,
@@ -1785,7 +1865,7 @@ impl GstreamerPipeline {
         Ok(())
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     fn ensure_native_window_input_bridge(&mut self) {
         if self.native_window_input_bridge.is_some() {
             return;
@@ -1801,7 +1881,7 @@ impl GstreamerPipeline {
         ));
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     fn ensure_native_window_input_bridge(&mut self) {
         send_log(
             &self.event_sender,
@@ -2088,13 +2168,25 @@ impl GstreamerPipeline {
         self.render_state.set_surface(surface, &self.event_sender);
     }
 
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     fn stop(mut self) -> Result<(), String> {
         self.video_liveness.set_stats_overlay_visible(false);
         self.render_state.stop_external_renderer_window_guard();
-        #[cfg(target_os = "windows")]
         if let Some(mut bridge) = self.native_window_input_bridge.take() {
             bridge.stop();
         }
+        self.input_state.stop_heartbeat();
+        self.video_liveness.stop();
+        self.pipeline
+            .set_state(gst::State::Null)
+            .map(|_| ())
+            .map_err(|error| format!("Failed to stop GStreamer pipeline: {error:?}"))
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    fn stop(self) -> Result<(), String> {
+        self.video_liveness.set_stats_overlay_visible(false);
+        self.render_state.stop_external_renderer_window_guard();
         self.input_state.stop_heartbeat();
         self.video_liveness.stop();
         self.pipeline
@@ -2337,6 +2429,948 @@ fn start_external_renderer_window_guard(
     _event_sender: Option<Sender<Event>>,
     _stop: Arc<AtomicBool>,
 ) {
+}
+
+#[cfg(target_os = "macos")]
+mod macos_native_input {
+    use super::{
+        native_input_timestamp_us, send_log, send_native_window_input_events, Event,
+        GstreamerInputChannels, GstreamerInputState, NativeGamepadSnapshot, NativeWindowInputEvent,
+        GAMEPAD_MAX_CONTROLLERS, NATIVE_GAMEPAD_KEEPALIVE_INTERVAL, NATIVE_GAMEPAD_POLL_INTERVAL,
+        NATIVE_INPUT_BRIDGE_POLL_INTERVAL, NATIVE_INPUT_DRAIN_MAX_EVENTS,
+    };
+    use gilrs::{Axis, Button, Gilrs};
+    use std::collections::HashMap;
+    use std::ffi::c_void;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc::{Receiver, Sender, SyncSender, TryRecvError};
+    use std::sync::{Arc, Mutex};
+    use std::thread::{self, JoinHandle};
+    use std::time::{Duration, Instant};
+
+    type Boolean = u8;
+    type CFAllocatorRef = *const c_void;
+    type CFRunLoopRef = *mut c_void;
+    type CFRunLoopSourceRef = *mut c_void;
+    type CFStringRef = *const c_void;
+    type CFMachPortRef = *mut c_void;
+    type CGEventRef = *mut c_void;
+    type CGEventTapProxy = *mut c_void;
+    type CGEventMask = u64;
+    type CGEventTapCallBack =
+        unsafe extern "C" fn(CGEventTapProxy, u32, CGEventRef, *mut c_void) -> CGEventRef;
+
+    const K_CG_HEAD_INSERT_EVENT_TAP: u32 = 0;
+    const K_CG_EVENT_TAP_OPTION_LISTEN_ONLY: u32 = 1;
+    const K_CG_EVENT_LEFT_MOUSE_DOWN: u32 = 1;
+    const K_CG_EVENT_LEFT_MOUSE_UP: u32 = 2;
+    const K_CG_EVENT_RIGHT_MOUSE_DOWN: u32 = 3;
+    const K_CG_EVENT_RIGHT_MOUSE_UP: u32 = 4;
+    const K_CG_EVENT_MOUSE_MOVED: u32 = 5;
+    const K_CG_EVENT_LEFT_MOUSE_DRAGGED: u32 = 6;
+    const K_CG_EVENT_RIGHT_MOUSE_DRAGGED: u32 = 7;
+    const K_CG_EVENT_KEY_DOWN: u32 = 10;
+    const K_CG_EVENT_KEY_UP: u32 = 11;
+    const K_CG_EVENT_FLAGS_CHANGED: u32 = 12;
+    const K_CG_EVENT_SCROLL_WHEEL: u32 = 22;
+    const K_CG_EVENT_OTHER_MOUSE_DOWN: u32 = 25;
+    const K_CG_EVENT_OTHER_MOUSE_UP: u32 = 26;
+    const K_CG_EVENT_OTHER_MOUSE_DRAGGED: u32 = 27;
+    const K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT: u32 = 0xFFFF_FFFE;
+    const K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT: u32 = 0xFFFF_FFFF;
+    const K_CG_MOUSE_EVENT_BUTTON_NUMBER: u32 = 3;
+    const K_CG_MOUSE_EVENT_DELTA_X: u32 = 4;
+    const K_CG_MOUSE_EVENT_DELTA_Y: u32 = 5;
+    const K_CG_KEYBOARD_EVENT_AUTOREPEAT: u32 = 8;
+    const K_CG_KEYBOARD_EVENT_KEYCODE: u32 = 9;
+    const K_CG_SCROLL_WHEEL_EVENT_DELTA_AXIS1: u32 = 11;
+    const K_CG_SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS1: u32 = 96;
+    const K_CG_EVENT_FLAG_MASK_ALPHA_SHIFT: u64 = 1 << 16;
+    const K_CG_EVENT_FLAG_MASK_SHIFT: u64 = 1 << 17;
+    const K_CG_EVENT_FLAG_MASK_CONTROL: u64 = 1 << 18;
+    const K_CG_EVENT_FLAG_MASK_ALTERNATE: u64 = 1 << 19;
+    const K_CG_EVENT_FLAG_MASK_COMMAND: u64 = 1 << 20;
+    const K_CG_EVENT_FLAG_MASK_NUMERIC_PAD: u64 = 1 << 21;
+    const K_CG_EVENT_FLAG_MASK_SECONDARY_FN: u64 = 1 << 23;
+    const GAMEPAD_TRIGGER_DEADZONE: u8 = 30;
+    const GAMEPAD_STICK_DEADZONE: f32 = 0.15;
+
+    static EVENT_TAP_RUN_LOOP: AtomicUsize = AtomicUsize::new(0);
+    static EVENT_TAP_PORT: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Clone, Copy)]
+    struct KeyMapping {
+        keycode: u16,
+        scancode: u16,
+    }
+
+    #[derive(Clone, Copy)]
+    struct PressedKey {
+        keycode: u16,
+        scancode: u16,
+    }
+
+    struct MacosKeyboardMouseState {
+        sender: SyncSender<NativeWindowInputEvent>,
+        pressed_keys: Mutex<HashMap<u16, PressedKey>>,
+        dropped_events: AtomicUsize,
+    }
+
+    struct TapResources {
+        tap: CFMachPortRef,
+        source: CFRunLoopSourceRef,
+        context: *mut MacosKeyboardMouseState,
+    }
+
+    impl Drop for TapResources {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.tap.is_null() {
+                    CGEventTapEnable(self.tap, 0);
+                    CFMachPortInvalidate(self.tap);
+                }
+                if !self.source.is_null() {
+                    CFRelease(self.source.cast());
+                }
+                if !self.tap.is_null() {
+                    CFRelease(self.tap.cast());
+                }
+                if !self.context.is_null() {
+                    drop(Box::from_raw(self.context));
+                }
+            }
+        }
+    }
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    unsafe extern "C" {
+        fn CGEventTapCreateForPid(
+            pid: i32,
+            place: u32,
+            options: u32,
+            events_of_interest: CGEventMask,
+            callback: CGEventTapCallBack,
+            user_info: *mut c_void,
+        ) -> CFMachPortRef;
+        fn CGEventTapEnable(tap: CFMachPortRef, enable: Boolean);
+        fn CGEventGetIntegerValueField(event: CGEventRef, field: u32) -> i64;
+        fn CGEventGetFlags(event: CGEventRef) -> u64;
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        static kCFRunLoopCommonModes: CFStringRef;
+        fn CFRelease(cf: *const c_void);
+        fn CFMachPortCreateRunLoopSource(
+            allocator: CFAllocatorRef,
+            port: CFMachPortRef,
+            order: isize,
+        ) -> CFRunLoopSourceRef;
+        fn CFMachPortInvalidate(port: CFMachPortRef);
+        fn CFRunLoopAddSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
+        fn CFRunLoopGetCurrent() -> CFRunLoopRef;
+        fn CFRunLoopRun();
+        fn CFRunLoopStop(rl: CFRunLoopRef);
+    }
+
+    pub fn spawn_keyboard_mouse_thread(
+        input_state: GstreamerInputState,
+        input_channels: GstreamerInputChannels,
+        event_sender: Option<Sender<Event>>,
+        stop: Arc<std::sync::atomic::AtomicBool>,
+        sender: SyncSender<NativeWindowInputEvent>,
+        receiver: Receiver<NativeWindowInputEvent>,
+    ) -> JoinHandle<()> {
+        thread::spawn(move || {
+            let tap_state = Arc::new(Mutex::new(Vec::<PressedKey>::with_capacity(32)));
+            let tap_thread_stop = stop.clone();
+            let tap_thread_sender = sender.clone();
+            let tap_thread_events = event_sender.clone();
+            let tap_thread_state = tap_state.clone();
+            let tap_thread = thread::spawn(move || {
+                run_event_tap(
+                    tap_thread_sender,
+                    tap_thread_state,
+                    tap_thread_events,
+                    tap_thread_stop,
+                );
+            });
+            drop(sender);
+
+            let mut pending_events = Vec::with_capacity(NATIVE_INPUT_DRAIN_MAX_EVENTS);
+            while !stop.load(Ordering::SeqCst) {
+                match receiver.recv_timeout(NATIVE_INPUT_BRIDGE_POLL_INTERVAL) {
+                    Ok(event) => {
+                        pending_events.clear();
+                        pending_events.push(event);
+                        drain_pending_events(&receiver, &mut pending_events);
+                        send_native_window_input_events(
+                            &input_state,
+                            &input_channels,
+                            &pending_events,
+                        );
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                }
+            }
+
+            stop_keyboard_mouse_capture();
+            if let Err(error) = tap_thread.join() {
+                eprintln!("[NativeStreamer] Native macOS event tap thread panicked: {error:?}");
+            }
+
+            pending_events.clear();
+            drain_pending_events(&receiver, &mut pending_events);
+            append_pressed_key_releases(&tap_state, &mut pending_events);
+            send_native_window_input_events(&input_state, &input_channels, &pending_events);
+        })
+    }
+
+    pub fn stop_keyboard_mouse_capture() {
+        let run_loop = EVENT_TAP_RUN_LOOP.swap(0, Ordering::SeqCst);
+        let tap = EVENT_TAP_PORT.load(Ordering::SeqCst);
+        if tap != 0 {
+            unsafe {
+                CGEventTapEnable(tap as CFMachPortRef, 0);
+            }
+        }
+        if run_loop != 0 {
+            unsafe {
+                CFRunLoopStop(run_loop as CFRunLoopRef);
+            }
+        }
+    }
+
+    fn run_event_tap(
+        sender: SyncSender<NativeWindowInputEvent>,
+        mirror_pressed_keys: Arc<Mutex<Vec<PressedKey>>>,
+        event_sender: Option<Sender<Event>>,
+        stop: Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        let context = Box::new(MacosKeyboardMouseState {
+            sender,
+            pressed_keys: Mutex::new(HashMap::with_capacity(32)),
+            dropped_events: AtomicUsize::new(0),
+        });
+        let context = Box::into_raw(context);
+        let pid = std::process::id().min(i32::MAX as u32) as i32;
+        let tap = unsafe {
+            CGEventTapCreateForPid(
+                pid,
+                K_CG_HEAD_INSERT_EVENT_TAP,
+                K_CG_EVENT_TAP_OPTION_LISTEN_ONLY,
+                event_mask(),
+                event_tap_callback,
+                context.cast(),
+            )
+        };
+        if tap.is_null() {
+            unsafe {
+                drop(Box::from_raw(context));
+            }
+            send_log(
+                &event_sender,
+                "warn",
+                "Native macOS keyboard/mouse bridge unavailable; grant Input Monitoring/Accessibility or use the web renderer fallback.".to_owned(),
+            );
+            return;
+        }
+
+        let source = unsafe { CFMachPortCreateRunLoopSource(std::ptr::null(), tap, 0) };
+        if source.is_null() {
+            unsafe {
+                CFMachPortInvalidate(tap);
+                CFRelease(tap.cast());
+                drop(Box::from_raw(context));
+            }
+            send_log(
+                &event_sender,
+                "warn",
+                "Native macOS keyboard/mouse bridge unavailable; failed to create event tap run-loop source.".to_owned(),
+            );
+            return;
+        }
+
+        let resources = TapResources {
+            tap,
+            source,
+            context,
+        };
+        let run_loop = unsafe { CFRunLoopGetCurrent() };
+        EVENT_TAP_PORT.store(tap as usize, Ordering::SeqCst);
+        EVENT_TAP_RUN_LOOP.store(run_loop as usize, Ordering::SeqCst);
+        unsafe {
+            CFRunLoopAddSource(run_loop, source, kCFRunLoopCommonModes);
+            CGEventTapEnable(tap, 1);
+        }
+        send_log(
+            &event_sender,
+            "info",
+            "Native macOS keyboard/mouse bridge armed for this application.".to_owned(),
+        );
+
+        if !stop.load(Ordering::SeqCst) {
+            unsafe {
+                CFRunLoopRun();
+            }
+        }
+        EVENT_TAP_RUN_LOOP.store(0, Ordering::SeqCst);
+        EVENT_TAP_PORT.store(0, Ordering::SeqCst);
+        let final_state = unsafe { &*resources.context };
+        let dropped_events = final_state.dropped_events.load(Ordering::SeqCst);
+        if dropped_events > 0 {
+            send_log(
+                &event_sender,
+                "warn",
+                format!(
+                    "Native macOS keyboard/mouse bridge dropped {dropped_events} event(s) during shutdown."
+                ),
+            );
+        }
+        if let Ok(keys) = final_state.pressed_keys.lock() {
+            if let Ok(mut mirror) = mirror_pressed_keys.lock() {
+                mirror.clear();
+                mirror.extend(keys.values().copied());
+            }
+        }
+        drop(resources);
+    }
+
+    fn event_mask() -> CGEventMask {
+        [
+            K_CG_EVENT_LEFT_MOUSE_DOWN,
+            K_CG_EVENT_LEFT_MOUSE_UP,
+            K_CG_EVENT_RIGHT_MOUSE_DOWN,
+            K_CG_EVENT_RIGHT_MOUSE_UP,
+            K_CG_EVENT_MOUSE_MOVED,
+            K_CG_EVENT_LEFT_MOUSE_DRAGGED,
+            K_CG_EVENT_RIGHT_MOUSE_DRAGGED,
+            K_CG_EVENT_KEY_DOWN,
+            K_CG_EVENT_KEY_UP,
+            K_CG_EVENT_FLAGS_CHANGED,
+            K_CG_EVENT_SCROLL_WHEEL,
+            K_CG_EVENT_OTHER_MOUSE_DOWN,
+            K_CG_EVENT_OTHER_MOUSE_UP,
+            K_CG_EVENT_OTHER_MOUSE_DRAGGED,
+        ]
+        .iter()
+        .fold(0_u64, |mask, event_type| mask | (1_u64 << event_type))
+    }
+
+    fn drain_pending_events(
+        receiver: &Receiver<NativeWindowInputEvent>,
+        pending_events: &mut Vec<NativeWindowInputEvent>,
+    ) {
+        while pending_events.len() < NATIVE_INPUT_DRAIN_MAX_EVENTS {
+            match receiver.try_recv() {
+                Ok(event) => pending_events.push(event),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            }
+        }
+    }
+
+    fn append_pressed_key_releases(
+        tap_state: &Arc<Mutex<Vec<PressedKey>>>,
+        pending_events: &mut Vec<NativeWindowInputEvent>,
+    ) {
+        let Ok(mut keys) = tap_state.lock() else {
+            return;
+        };
+        let timestamp_us = native_input_timestamp_us();
+        for key in keys.drain(..) {
+            if pending_events.len() >= NATIVE_INPUT_DRAIN_MAX_EVENTS {
+                break;
+            }
+            pending_events.push(NativeWindowInputEvent::Key {
+                pressed: false,
+                keycode: key.keycode,
+                scancode: key.scancode,
+                modifiers: 0,
+                timestamp_us,
+            });
+        }
+    }
+
+    unsafe extern "C" fn event_tap_callback(
+        _proxy: CGEventTapProxy,
+        event_type: u32,
+        event: CGEventRef,
+        user_info: *mut c_void,
+    ) -> CGEventRef {
+        if matches!(
+            event_type,
+            K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT | K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT
+        ) {
+            let tap = EVENT_TAP_PORT.load(Ordering::SeqCst);
+            if tap != 0 {
+                CGEventTapEnable(tap as CFMachPortRef, 1);
+            }
+            return event;
+        }
+
+        if user_info.is_null() || event.is_null() {
+            return event;
+        }
+
+        let state = &*(user_info as *mut MacosKeyboardMouseState);
+        match event_type {
+            K_CG_EVENT_KEY_DOWN | K_CG_EVENT_KEY_UP => {
+                handle_key_event(state, event, event_type == K_CG_EVENT_KEY_DOWN);
+            }
+            K_CG_EVENT_FLAGS_CHANGED => handle_flags_changed_event(state, event),
+            K_CG_EVENT_MOUSE_MOVED
+            | K_CG_EVENT_LEFT_MOUSE_DRAGGED
+            | K_CG_EVENT_RIGHT_MOUSE_DRAGGED
+            | K_CG_EVENT_OTHER_MOUSE_DRAGGED => handle_mouse_move_event(state, event),
+            K_CG_EVENT_LEFT_MOUSE_DOWN | K_CG_EVENT_LEFT_MOUSE_UP => {
+                emit_mouse_button(state, 1, event_type == K_CG_EVENT_LEFT_MOUSE_DOWN);
+            }
+            K_CG_EVENT_RIGHT_MOUSE_DOWN | K_CG_EVENT_RIGHT_MOUSE_UP => {
+                emit_mouse_button(state, 3, event_type == K_CG_EVENT_RIGHT_MOUSE_DOWN);
+            }
+            K_CG_EVENT_OTHER_MOUSE_DOWN | K_CG_EVENT_OTHER_MOUSE_UP => {
+                if let Some(button) = map_other_mouse_button(event) {
+                    emit_mouse_button(state, button, event_type == K_CG_EVENT_OTHER_MOUSE_DOWN);
+                }
+            }
+            K_CG_EVENT_SCROLL_WHEEL => handle_scroll_wheel_event(state, event),
+            _ => {}
+        }
+
+        event
+    }
+
+    unsafe fn handle_key_event(state: &MacosKeyboardMouseState, event: CGEventRef, pressed: bool) {
+        if pressed && CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_AUTOREPEAT) != 0 {
+            return;
+        }
+        let mac_keycode = CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE) as u16;
+        let Some(mapping) = map_macos_keycode(mac_keycode) else {
+            return;
+        };
+        handle_keyboard_state(state, mapping, pressed, CGEventGetFlags(event));
+    }
+
+    unsafe fn handle_flags_changed_event(state: &MacosKeyboardMouseState, event: CGEventRef) {
+        let mac_keycode = CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE) as u16;
+        let Some(mapping) = map_macos_keycode(mac_keycode) else {
+            return;
+        };
+        if !is_modifier_key(mapping.keycode) {
+            return;
+        }
+        let Ok(keys) = state.pressed_keys.lock() else {
+            return;
+        };
+        let pressed = !keys.contains_key(&mapping.scancode);
+        drop(keys);
+        handle_keyboard_state(state, mapping, pressed, CGEventGetFlags(event));
+    }
+
+    fn handle_keyboard_state(
+        state: &MacosKeyboardMouseState,
+        mapping: KeyMapping,
+        pressed: bool,
+        flags: u64,
+    ) {
+        let Ok(mut keys) = state.pressed_keys.lock() else {
+            return;
+        };
+        let was_pressed = keys.contains_key(&mapping.scancode);
+        if pressed {
+            if was_pressed {
+                return;
+            }
+            keys.insert(
+                mapping.scancode,
+                PressedKey {
+                    keycode: mapping.keycode,
+                    scancode: mapping.scancode,
+                },
+            );
+        } else if !was_pressed {
+            return;
+        } else {
+            keys.remove(&mapping.scancode);
+        }
+        let modifiers = current_modifier_flags(&keys, flags);
+        drop(keys);
+
+        send_or_count_drop(
+            state,
+            NativeWindowInputEvent::Key {
+                pressed,
+                keycode: mapping.keycode,
+                scancode: mapping.scancode,
+                modifiers,
+                timestamp_us: native_input_timestamp_us(),
+            },
+        );
+    }
+
+    fn send_or_count_drop(state: &MacosKeyboardMouseState, event: NativeWindowInputEvent) {
+        if state.sender.try_send(event).is_err() {
+            state.dropped_events.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    unsafe fn handle_mouse_move_event(state: &MacosKeyboardMouseState, event: CGEventRef) {
+        let dx = clamp_i64_to_i16(CGEventGetIntegerValueField(event, K_CG_MOUSE_EVENT_DELTA_X));
+        let dy = clamp_i64_to_i16(CGEventGetIntegerValueField(event, K_CG_MOUSE_EVENT_DELTA_Y));
+        if dx == 0 && dy == 0 {
+            return;
+        }
+        send_or_count_drop(
+            state,
+            NativeWindowInputEvent::MouseMove {
+                dx,
+                dy,
+                timestamp_us: native_input_timestamp_us(),
+            },
+        );
+    }
+
+    unsafe fn handle_scroll_wheel_event(state: &MacosKeyboardMouseState, event: CGEventRef) {
+        let point_delta =
+            CGEventGetIntegerValueField(event, K_CG_SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS1);
+        let delta = if point_delta != 0 {
+            point_delta
+        } else {
+            CGEventGetIntegerValueField(event, K_CG_SCROLL_WHEEL_EVENT_DELTA_AXIS1)
+                .saturating_mul(120)
+        };
+        let delta = clamp_i64_to_i16(delta);
+        if delta == 0 {
+            return;
+        }
+        send_or_count_drop(
+            state,
+            NativeWindowInputEvent::MouseWheel {
+                delta,
+                timestamp_us: native_input_timestamp_us(),
+            },
+        );
+    }
+
+    unsafe fn map_other_mouse_button(event: CGEventRef) -> Option<u8> {
+        match CGEventGetIntegerValueField(event, K_CG_MOUSE_EVENT_BUTTON_NUMBER) {
+            2 => Some(2),
+            3 => Some(4),
+            4 => Some(5),
+            _ => None,
+        }
+    }
+
+    fn emit_mouse_button(state: &MacosKeyboardMouseState, button: u8, pressed: bool) {
+        send_or_count_drop(
+            state,
+            NativeWindowInputEvent::MouseButton {
+                pressed,
+                button,
+                timestamp_us: native_input_timestamp_us(),
+            },
+        );
+    }
+
+    fn current_modifier_flags(keys: &HashMap<u16, PressedKey>, flags: u64) -> u16 {
+        let mut modifiers = 0u16;
+        if keys
+            .values()
+            .any(|key| matches!(key.keycode, 0xA0 | 0xA1 | 0x10))
+            || (flags & K_CG_EVENT_FLAG_MASK_SHIFT) != 0
+        {
+            modifiers |= 0x01;
+        }
+        if keys
+            .values()
+            .any(|key| matches!(key.keycode, 0xA2 | 0xA3 | 0x11))
+            || (flags & K_CG_EVENT_FLAG_MASK_CONTROL) != 0
+        {
+            modifiers |= 0x02;
+        }
+        if keys
+            .values()
+            .any(|key| matches!(key.keycode, 0xA4 | 0xA5 | 0x12))
+            || (flags & K_CG_EVENT_FLAG_MASK_ALTERNATE) != 0
+        {
+            modifiers |= 0x04;
+        }
+        if keys.values().any(|key| matches!(key.keycode, 0x5B | 0x5C))
+            || (flags & K_CG_EVENT_FLAG_MASK_COMMAND) != 0
+        {
+            modifiers |= 0x08;
+        }
+        if (flags & K_CG_EVENT_FLAG_MASK_ALPHA_SHIFT) != 0 {
+            modifiers |= 0x10;
+        }
+        if (flags & (K_CG_EVENT_FLAG_MASK_NUMERIC_PAD | K_CG_EVENT_FLAG_MASK_SECONDARY_FN)) != 0 {
+            modifiers |= 0x20;
+        }
+        modifiers
+    }
+
+    fn is_modifier_key(keycode: u16) -> bool {
+        matches!(
+            keycode,
+            0x10 | 0x11 | 0x12 | 0x14 | 0x5B | 0x5C | 0xA0 | 0xA1 | 0xA2 | 0xA3 | 0xA4 | 0xA5
+        )
+    }
+
+    fn map_macos_keycode(keycode: u16) -> Option<KeyMapping> {
+        let (vk, scancode) = match keycode {
+            0x00 => (0x41, 0x001e),
+            0x01 => (0x53, 0x001f),
+            0x02 => (0x44, 0x0020),
+            0x03 => (0x46, 0x0021),
+            0x04 => (0x48, 0x0023),
+            0x05 => (0x47, 0x0022),
+            0x06 => (0x5a, 0x002c),
+            0x07 => (0x58, 0x002d),
+            0x08 => (0x43, 0x002e),
+            0x09 => (0x56, 0x002f),
+            0x0b => (0x42, 0x0030),
+            0x0c => (0x51, 0x0010),
+            0x0d => (0x57, 0x0011),
+            0x0e => (0x45, 0x0012),
+            0x0f => (0x52, 0x0013),
+            0x10 => (0x59, 0x0015),
+            0x11 => (0x54, 0x0014),
+            0x12 => (0x31, 0x0002),
+            0x13 => (0x32, 0x0003),
+            0x14 => (0x33, 0x0004),
+            0x15 => (0x34, 0x0005),
+            0x16 => (0x36, 0x0007),
+            0x17 => (0x35, 0x0006),
+            0x18 => (0xbb, 0x000d),
+            0x19 => (0x39, 0x000a),
+            0x1a => (0x37, 0x0008),
+            0x1b => (0xbd, 0x000c),
+            0x1c => (0x38, 0x0009),
+            0x1d => (0x30, 0x000b),
+            0x1e => (0xdd, 0x001b),
+            0x1f => (0x4f, 0x0018),
+            0x20 => (0x55, 0x0016),
+            0x21 => (0xdb, 0x001a),
+            0x22 => (0x49, 0x0017),
+            0x23 => (0x50, 0x0019),
+            0x24 => (0x0d, 0x001c),
+            0x25 => (0x4c, 0x0026),
+            0x26 => (0x4a, 0x0024),
+            0x27 => (0xde, 0x0028),
+            0x28 => (0x4b, 0x0025),
+            0x29 => (0xba, 0x0027),
+            0x2a => (0xdc, 0x002b),
+            0x2b => (0xbc, 0x0033),
+            0x2c => (0xbf, 0x0035),
+            0x2d => (0x4e, 0x0031),
+            0x2e => (0x4d, 0x0032),
+            0x2f => (0xbe, 0x0034),
+            0x30 => (0x09, 0x000f),
+            0x31 => (0x20, 0x0039),
+            0x32 => (0xc0, 0x0029),
+            0x33 => (0x08, 0x000e),
+            0x35 => (0x1b, 0x0001),
+            0x37 => (0x5b, 0xe05b),
+            0x38 => (0xa0, 0x002a),
+            0x39 => (0x14, 0x003a),
+            0x3a => (0xa4, 0x0038),
+            0x3b => (0xa2, 0x001d),
+            0x3c => (0xa1, 0x0036),
+            0x3d => (0xa5, 0xe038),
+            0x3e => (0xa3, 0xe01d),
+            0x40 => (0x80, 0x0064),
+            0x41 => (0x6e, 0x0053),
+            0x43 => (0x6a, 0x0037),
+            0x45 => (0x6b, 0x004e),
+            0x47 => (0x90, 0xe045),
+            0x4b => (0x6f, 0xe035),
+            0x4c => (0x0d, 0xe01c),
+            0x4e => (0x6d, 0x004a),
+            0x4f => (0x81, 0x0065),
+            0x50 => (0x82, 0x0066),
+            0x51 => (0xbb, 0x0059),
+            0x52 => (0x60, 0x0052),
+            0x53 => (0x61, 0x004f),
+            0x54 => (0x62, 0x0050),
+            0x55 => (0x63, 0x0051),
+            0x56 => (0x64, 0x004b),
+            0x57 => (0x65, 0x004c),
+            0x58 => (0x66, 0x004d),
+            0x59 => (0x67, 0x0047),
+            0x5a => (0x83, 0x0067),
+            0x5b => (0x68, 0x0048),
+            0x5c => (0x69, 0x0049),
+            0x60 => (0x74, 0x003f),
+            0x61 => (0x75, 0x0040),
+            0x62 => (0x76, 0x0041),
+            0x63 => (0x72, 0x003d),
+            0x64 => (0x77, 0x0042),
+            0x65 => (0x78, 0x0043),
+            0x67 => (0x7a, 0x0057),
+            0x69 => (0x7c, 0x0064),
+            0x6a => (0x7f, 0x0067),
+            0x6b => (0x7d, 0x0065),
+            0x6d => (0x79, 0x0044),
+            0x6f => (0x7b, 0x0058),
+            0x71 => (0x7e, 0x0066),
+            0x72 => (0x2d, 0xe052),
+            0x73 => (0x24, 0xe047),
+            0x74 => (0x21, 0xe049),
+            0x75 => (0x2e, 0xe053),
+            0x76 => (0x73, 0x003e),
+            0x77 => (0x23, 0xe04f),
+            0x78 => (0x71, 0x003c),
+            0x79 => (0x22, 0xe051),
+            0x7a => (0x70, 0x003b),
+            0x7b => (0x25, 0xe04b),
+            0x7c => (0x27, 0xe04d),
+            0x7d => (0x28, 0xe050),
+            0x7e => (0x26, 0xe048),
+            _ => return None,
+        };
+        Some(KeyMapping {
+            keycode: vk,
+            scancode,
+        })
+    }
+
+    pub fn spawn_gamepad_thread(
+        input_state: GstreamerInputState,
+        input_channels: GstreamerInputChannels,
+        event_sender: Option<Sender<Event>>,
+        stop: Arc<std::sync::atomic::AtomicBool>,
+    ) -> JoinHandle<()> {
+        thread::spawn(move || {
+            let mut gilrs = match Gilrs::new() {
+                Ok(gilrs) => gilrs,
+                Err(error) => {
+                    send_log(
+                        &event_sender,
+                        "warn",
+                        format!(
+                            "Native macOS gamepad bridge unavailable ({error}); controller input will require the web renderer fallback."
+                        ),
+                    );
+                    return;
+                }
+            };
+
+            send_log(
+                &event_sender,
+                "info",
+                "Native macOS gamepad bridge armed.".to_owned(),
+            );
+
+            let mut previous = [NativeGamepadSnapshot::default(); GAMEPAD_MAX_CONTROLLERS as usize];
+            let mut last_sent = [Instant::now(); GAMEPAD_MAX_CONTROLLERS as usize];
+            let mut ids_by_slot: [Option<usize>; GAMEPAD_MAX_CONTROLLERS as usize] =
+                [None; GAMEPAD_MAX_CONTROLLERS as usize];
+            let mut slot_by_id =
+                HashMap::<usize, usize>::with_capacity(GAMEPAD_MAX_CONTROLLERS as usize);
+
+            while !stop.load(Ordering::SeqCst) {
+                while gilrs.next_event().is_some() {}
+
+                if input_state.ready.load(Ordering::SeqCst) {
+                    let snapshots = poll_gamepads(&gilrs, &mut ids_by_slot, &mut slot_by_id);
+                    let bitmap =
+                        snapshots
+                            .iter()
+                            .enumerate()
+                            .fold(0u16, |bitmap, (slot, snapshot)| {
+                                if snapshot.connected {
+                                    bitmap | (1 << slot)
+                                } else {
+                                    bitmap
+                                }
+                            });
+
+                    for controller_id in 0..GAMEPAD_MAX_CONTROLLERS as usize {
+                        let snapshot = snapshots[controller_id];
+                        let state_changed = snapshot != previous[controller_id];
+                        let keepalive_due = snapshot.connected
+                            && last_sent[controller_id].elapsed()
+                                >= NATIVE_GAMEPAD_KEEPALIVE_INTERVAL;
+
+                        if state_changed || keepalive_due {
+                            super::send_native_gamepad_snapshot(
+                                &input_state,
+                                &input_channels,
+                                controller_id as u8,
+                                bitmap,
+                                snapshot,
+                            );
+                            last_sent[controller_id] = Instant::now();
+
+                            if snapshot.connected != previous[controller_id].connected {
+                                send_log(
+                                    &event_sender,
+                                    "info",
+                                    format!(
+                                        "Native macOS controller {controller_id} {}.",
+                                        if snapshot.connected {
+                                            "connected"
+                                        } else {
+                                            "disconnected"
+                                        }
+                                    ),
+                                );
+                            }
+                        }
+
+                        previous[controller_id] = snapshot;
+                        if !snapshot.connected {
+                            if let Some(id) = ids_by_slot[controller_id].take() {
+                                slot_by_id.remove(&id);
+                            }
+                        }
+                    }
+                }
+
+                thread::sleep(NATIVE_GAMEPAD_POLL_INTERVAL);
+            }
+        })
+    }
+
+    fn poll_gamepads(
+        gilrs: &Gilrs,
+        ids_by_slot: &mut [Option<usize>; GAMEPAD_MAX_CONTROLLERS as usize],
+        slot_by_id: &mut HashMap<usize, usize>,
+    ) -> [NativeGamepadSnapshot; GAMEPAD_MAX_CONTROLLERS as usize] {
+        let mut snapshots = [NativeGamepadSnapshot::default(); GAMEPAD_MAX_CONTROLLERS as usize];
+        let connected = gilrs
+            .gamepads()
+            .map(|(id, gamepad)| (usize::from(id), gamepad))
+            .collect::<Vec<_>>();
+
+        for (id, _) in &connected {
+            if slot_by_id.contains_key(id) {
+                continue;
+            }
+            if let Some(slot) = ids_by_slot.iter().position(Option::is_none) {
+                ids_by_slot[slot] = Some(*id);
+                slot_by_id.insert(*id, slot);
+            }
+        }
+
+        for (id, gamepad) in connected {
+            let Some(&slot) = slot_by_id.get(&id) else {
+                continue;
+            };
+            snapshots[slot] = snapshot_from_gamepad(&gamepad);
+        }
+
+        snapshots
+    }
+
+    fn snapshot_from_gamepad(gamepad: &gilrs::Gamepad<'_>) -> NativeGamepadSnapshot {
+        NativeGamepadSnapshot {
+            connected: true,
+            buttons: gamepad_buttons(gamepad),
+            left_trigger: gamepad_trigger(gamepad, Button::LeftTrigger2, Axis::LeftZ),
+            right_trigger: gamepad_trigger(gamepad, Button::RightTrigger2, Axis::RightZ),
+            left_stick_x: normalize_stick_axis(gamepad.value(Axis::LeftStickX)),
+            left_stick_y: normalize_stick_axis(-gamepad.value(Axis::LeftStickY)),
+            right_stick_x: normalize_stick_axis(gamepad.value(Axis::RightStickX)),
+            right_stick_y: normalize_stick_axis(-gamepad.value(Axis::RightStickY)),
+        }
+    }
+
+    fn gamepad_buttons(gamepad: &gilrs::Gamepad<'_>) -> u16 {
+        let mut buttons = 0u16;
+        if gamepad.is_pressed(Button::DPadUp) || gamepad.value(Axis::DPadY) > 0.5 {
+            buttons |= 0x0001;
+        }
+        if gamepad.is_pressed(Button::DPadDown) || gamepad.value(Axis::DPadY) < -0.5 {
+            buttons |= 0x0002;
+        }
+        if gamepad.is_pressed(Button::DPadLeft) || gamepad.value(Axis::DPadX) < -0.5 {
+            buttons |= 0x0004;
+        }
+        if gamepad.is_pressed(Button::DPadRight) || gamepad.value(Axis::DPadX) > 0.5 {
+            buttons |= 0x0008;
+        }
+        if gamepad.is_pressed(Button::Start) {
+            buttons |= 0x0010;
+        }
+        if gamepad.is_pressed(Button::Select) {
+            buttons |= 0x0020;
+        }
+        if gamepad.is_pressed(Button::LeftThumb) {
+            buttons |= 0x0040;
+        }
+        if gamepad.is_pressed(Button::RightThumb) {
+            buttons |= 0x0080;
+        }
+        if gamepad.is_pressed(Button::LeftTrigger) {
+            buttons |= 0x0100;
+        }
+        if gamepad.is_pressed(Button::RightTrigger) {
+            buttons |= 0x0200;
+        }
+        if gamepad.is_pressed(Button::Mode) {
+            buttons |= 0x0400;
+        }
+        if gamepad.is_pressed(Button::South) {
+            buttons |= 0x1000;
+        }
+        if gamepad.is_pressed(Button::East) {
+            buttons |= 0x2000;
+        }
+        if gamepad.is_pressed(Button::West) {
+            buttons |= 0x4000;
+        }
+        if gamepad.is_pressed(Button::North) {
+            buttons |= 0x8000;
+        }
+        buttons
+    }
+
+    fn gamepad_trigger(gamepad: &gilrs::Gamepad<'_>, button: Button, axis: Axis) -> u8 {
+        let value = gamepad
+            .button_data(button)
+            .map(|button| button.value())
+            .filter(|value| *value > 0.0)
+            .unwrap_or_else(|| {
+                let axis_value = gamepad.value(axis);
+                if axis_value < 0.0 {
+                    (axis_value + 1.0) * 0.5
+                } else {
+                    axis_value
+                }
+            });
+        let value = normalize_to_u8(value);
+        if value <= GAMEPAD_TRIGGER_DEADZONE {
+            0
+        } else {
+            value
+        }
+    }
+
+    fn normalize_stick_axis(value: f32) -> i16 {
+        let value = if value.abs() < GAMEPAD_STICK_DEADZONE {
+            0.0
+        } else {
+            let sign = value.signum();
+            let scaled = (value.abs() - GAMEPAD_STICK_DEADZONE) / (1.0 - GAMEPAD_STICK_DEADZONE);
+            sign * scaled.clamp(0.0, 1.0)
+        };
+        (value.clamp(-1.0, 1.0) * 32767.0).round() as i16
+    }
+
+    fn normalize_to_u8(value: f32) -> u8 {
+        (value.clamp(0.0, 1.0) * 255.0).round() as u8
+    }
+
+    fn clamp_i64_to_i16(value: i64) -> i16 {
+        value.clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16
+    }
+
+    #[allow(dead_code)]
+    fn _assert_poll_interval_floor() {
+        let _ = Duration::from_millis(0);
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -1548,8 +1548,13 @@ fn normalize_macos_gamepad_stick_axis(value: f32) -> i16 {
 }
 
 #[cfg(any(test, target_os = "macos"))]
-fn macos_mouse_delta_y_for_native_input(delta_y: i64) -> i16 {
-    clamp_i64_to_i16(delta_y.saturating_neg())
+fn macos_gamepad_stick_y_for_renderer_direction(raw_y: f32) -> i16 {
+    normalize_macos_gamepad_stick_axis(-raw_y)
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn macos_mouse_delta_y_positive_down_for_native_input(delta_y: i64) -> i16 {
+    clamp_i64_to_i16(delta_y)
 }
 
 #[cfg(any(test, target_os = "macos"))]
@@ -2471,11 +2476,12 @@ fn start_external_renderer_window_guard(
 #[cfg(target_os = "macos")]
 mod macos_native_input {
     use super::{
-        clamp_i64_to_i16, macos_gamepad_dpad_y_buttons, macos_mouse_delta_y_for_native_input,
-        native_input_timestamp_us, normalize_macos_gamepad_stick_axis, send_log,
-        send_native_window_input_events, Event, GstreamerInputChannels, GstreamerInputState,
-        NativeGamepadSnapshot, NativeWindowInputEvent, GAMEPAD_MAX_CONTROLLERS,
-        NATIVE_GAMEPAD_KEEPALIVE_INTERVAL, NATIVE_GAMEPAD_POLL_INTERVAL,
+        clamp_i64_to_i16, macos_gamepad_dpad_y_buttons,
+        macos_gamepad_stick_y_for_renderer_direction,
+        macos_mouse_delta_y_positive_down_for_native_input, native_input_timestamp_us,
+        normalize_macos_gamepad_stick_axis, send_log, send_native_window_input_events, Event,
+        GstreamerInputChannels, GstreamerInputState, NativeGamepadSnapshot, NativeWindowInputEvent,
+        GAMEPAD_MAX_CONTROLLERS, NATIVE_GAMEPAD_KEEPALIVE_INTERVAL, NATIVE_GAMEPAD_POLL_INTERVAL,
         NATIVE_INPUT_BRIDGE_POLL_INTERVAL, NATIVE_INPUT_DRAIN_MAX_EVENTS,
     };
     use gilrs::{Axis, Button, Gilrs};
@@ -2955,7 +2961,7 @@ mod macos_native_input {
 
     unsafe fn handle_mouse_move_event(state: &MacosKeyboardMouseState, event: CGEventRef) {
         let dx = clamp_i64_to_i16(CGEventGetIntegerValueField(event, K_CG_MOUSE_EVENT_DELTA_X));
-        let dy = macos_mouse_delta_y_for_native_input(CGEventGetIntegerValueField(
+        let dy = macos_mouse_delta_y_positive_down_for_native_input(CGEventGetIntegerValueField(
             event,
             K_CG_MOUSE_EVENT_DELTA_Y,
         ));
@@ -3312,9 +3318,13 @@ mod macos_native_input {
             left_trigger: gamepad_trigger(gamepad, Button::LeftTrigger2, Axis::LeftZ),
             right_trigger: gamepad_trigger(gamepad, Button::RightTrigger2, Axis::RightZ),
             left_stick_x: normalize_macos_gamepad_stick_axis(gamepad.value(Axis::LeftStickX)),
-            left_stick_y: normalize_macos_gamepad_stick_axis(gamepad.value(Axis::LeftStickY)),
+            left_stick_y: macos_gamepad_stick_y_for_renderer_direction(
+                gamepad.value(Axis::LeftStickY),
+            ),
             right_stick_x: normalize_macos_gamepad_stick_axis(gamepad.value(Axis::RightStickX)),
-            right_stick_y: normalize_macos_gamepad_stick_axis(gamepad.value(Axis::RightStickY)),
+            right_stick_y: macos_gamepad_stick_y_for_renderer_direction(
+                gamepad.value(Axis::RightStickY),
+            ),
         }
     }
 
@@ -8088,17 +8098,24 @@ mod tests {
     }
 
     #[test]
-    fn macos_native_gamepad_y_axes_match_xinput_direction() {
-        assert!(normalize_macos_gamepad_stick_axis(1.0) > 0);
-        assert!(normalize_macos_gamepad_stick_axis(-1.0) < 0);
-        assert_eq!(normalize_macos_gamepad_stick_axis(0.05), 0);
+    fn macos_native_gamepad_stick_y_negates_gilrs_browser_positive_down_for_renderer() {
+        assert_eq!(macos_gamepad_stick_y_for_renderer_direction(1.0), -32767);
+        assert_eq!(macos_gamepad_stick_y_for_renderer_direction(-1.0), 32767);
+        assert_eq!(macos_gamepad_stick_y_for_renderer_direction(0.05), 0);
     }
 
     #[test]
-    fn macos_native_mouse_vertical_delta_matches_windows_direction() {
-        assert_eq!(macos_mouse_delta_y_for_native_input(12), -12);
-        assert_eq!(macos_mouse_delta_y_for_native_input(-12), 12);
-        assert_eq!(macos_mouse_delta_y_for_native_input(i64::MIN), i16::MAX);
+    fn macos_native_mouse_delta_y_preserves_cg_event_positive_down_for_renderer() {
+        assert_eq!(macos_mouse_delta_y_positive_down_for_native_input(12), 12);
+        assert_eq!(macos_mouse_delta_y_positive_down_for_native_input(-12), -12);
+        assert_eq!(
+            macos_mouse_delta_y_positive_down_for_native_input(i64::MAX),
+            i16::MAX
+        );
+        assert_eq!(
+            macos_mouse_delta_y_positive_down_for_native_input(i64::MIN),
+            i16::MIN
+        );
     }
 
     #[test]

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -71,6 +71,8 @@ const NATIVE_INPUT_DRAIN_MAX_EVENTS: usize = 512;
 const NATIVE_GAMEPAD_POLL_INTERVAL: Duration = Duration::from_millis(4);
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 const NATIVE_GAMEPAD_KEEPALIVE_INTERVAL: Duration = Duration::from_millis(100);
+#[cfg(any(test, target_os = "macos"))]
+const MACOS_GAMEPAD_STICK_DEADZONE: f32 = 0.15;
 const EXTERNAL_RENDERER_ENV: &str = "OPENNOW_NATIVE_EXTERNAL_RENDERER";
 const NATIVE_VIDEO_API_ENV: &str = "OPENNOW_NATIVE_VIDEO_API";
 const NATIVE_VIDEO_BACKEND_ENV: &str = "OPENNOW_NATIVE_VIDEO_BACKEND";
@@ -1532,6 +1534,41 @@ struct NativeGamepadSnapshot {
     right_stick_y: i16,
 }
 
+#[cfg(any(test, target_os = "macos"))]
+fn normalize_macos_gamepad_stick_axis(value: f32) -> i16 {
+    let value = if value.abs() < MACOS_GAMEPAD_STICK_DEADZONE {
+        0.0
+    } else {
+        let sign = value.signum();
+        let scaled =
+            (value.abs() - MACOS_GAMEPAD_STICK_DEADZONE) / (1.0 - MACOS_GAMEPAD_STICK_DEADZONE);
+        sign * scaled.clamp(0.0, 1.0)
+    };
+    (value.clamp(-1.0, 1.0) * 32767.0).round() as i16
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn macos_mouse_delta_y_for_native_input(delta_y: i64) -> i16 {
+    clamp_i64_to_i16(delta_y.saturating_neg())
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn macos_gamepad_dpad_y_buttons(axis_y: f32, up_pressed: bool, down_pressed: bool) -> u16 {
+    let mut buttons = 0u16;
+    if up_pressed || axis_y > 0.5 {
+        buttons |= 0x0001;
+    }
+    if down_pressed || axis_y < -0.5 {
+        buttons |= 0x0002;
+    }
+    buttons
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn clamp_i64_to_i16(value: i64) -> i16 {
+    value.clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16
+}
+
 #[cfg(target_os = "windows")]
 impl NativeGamepadSnapshot {
     fn from_xinput(snapshot: win32_xinput::XInputGamepadSnapshot) -> Self {
@@ -2434,9 +2471,11 @@ fn start_external_renderer_window_guard(
 #[cfg(target_os = "macos")]
 mod macos_native_input {
     use super::{
-        native_input_timestamp_us, send_log, send_native_window_input_events, Event,
-        GstreamerInputChannels, GstreamerInputState, NativeGamepadSnapshot, NativeWindowInputEvent,
-        GAMEPAD_MAX_CONTROLLERS, NATIVE_GAMEPAD_KEEPALIVE_INTERVAL, NATIVE_GAMEPAD_POLL_INTERVAL,
+        clamp_i64_to_i16, macos_gamepad_dpad_y_buttons, macos_mouse_delta_y_for_native_input,
+        native_input_timestamp_us, normalize_macos_gamepad_stick_axis, send_log,
+        send_native_window_input_events, Event, GstreamerInputChannels, GstreamerInputState,
+        NativeGamepadSnapshot, NativeWindowInputEvent, GAMEPAD_MAX_CONTROLLERS,
+        NATIVE_GAMEPAD_KEEPALIVE_INTERVAL, NATIVE_GAMEPAD_POLL_INTERVAL,
         NATIVE_INPUT_BRIDGE_POLL_INTERVAL, NATIVE_INPUT_DRAIN_MAX_EVENTS,
     };
     use gilrs::{Axis, Button, Gilrs};
@@ -2493,7 +2532,6 @@ mod macos_native_input {
     const K_CG_EVENT_FLAG_MASK_NUMERIC_PAD: u64 = 1 << 21;
     const K_CG_EVENT_FLAG_MASK_SECONDARY_FN: u64 = 1 << 23;
     const GAMEPAD_TRIGGER_DEADZONE: u8 = 30;
-    const GAMEPAD_STICK_DEADZONE: f32 = 0.15;
 
     static EVENT_TAP_RUN_LOOP: AtomicUsize = AtomicUsize::new(0);
     static EVENT_TAP_PORT: AtomicUsize = AtomicUsize::new(0);
@@ -2917,7 +2955,10 @@ mod macos_native_input {
 
     unsafe fn handle_mouse_move_event(state: &MacosKeyboardMouseState, event: CGEventRef) {
         let dx = clamp_i64_to_i16(CGEventGetIntegerValueField(event, K_CG_MOUSE_EVENT_DELTA_X));
-        let dy = clamp_i64_to_i16(CGEventGetIntegerValueField(event, K_CG_MOUSE_EVENT_DELTA_Y));
+        let dy = macos_mouse_delta_y_for_native_input(CGEventGetIntegerValueField(
+            event,
+            K_CG_MOUSE_EVENT_DELTA_Y,
+        ));
         if dx == 0 && dy == 0 {
             return;
         }
@@ -3270,21 +3311,20 @@ mod macos_native_input {
             buttons: gamepad_buttons(gamepad),
             left_trigger: gamepad_trigger(gamepad, Button::LeftTrigger2, Axis::LeftZ),
             right_trigger: gamepad_trigger(gamepad, Button::RightTrigger2, Axis::RightZ),
-            left_stick_x: normalize_stick_axis(gamepad.value(Axis::LeftStickX)),
-            left_stick_y: normalize_stick_axis(-gamepad.value(Axis::LeftStickY)),
-            right_stick_x: normalize_stick_axis(gamepad.value(Axis::RightStickX)),
-            right_stick_y: normalize_stick_axis(-gamepad.value(Axis::RightStickY)),
+            left_stick_x: normalize_macos_gamepad_stick_axis(gamepad.value(Axis::LeftStickX)),
+            left_stick_y: normalize_macos_gamepad_stick_axis(gamepad.value(Axis::LeftStickY)),
+            right_stick_x: normalize_macos_gamepad_stick_axis(gamepad.value(Axis::RightStickX)),
+            right_stick_y: normalize_macos_gamepad_stick_axis(gamepad.value(Axis::RightStickY)),
         }
     }
 
     fn gamepad_buttons(gamepad: &gilrs::Gamepad<'_>) -> u16 {
         let mut buttons = 0u16;
-        if gamepad.is_pressed(Button::DPadUp) || gamepad.value(Axis::DPadY) > 0.5 {
-            buttons |= 0x0001;
-        }
-        if gamepad.is_pressed(Button::DPadDown) || gamepad.value(Axis::DPadY) < -0.5 {
-            buttons |= 0x0002;
-        }
+        buttons |= macos_gamepad_dpad_y_buttons(
+            gamepad.value(Axis::DPadY),
+            gamepad.is_pressed(Button::DPadUp),
+            gamepad.is_pressed(Button::DPadDown),
+        );
         if gamepad.is_pressed(Button::DPadLeft) || gamepad.value(Axis::DPadX) < -0.5 {
             buttons |= 0x0004;
         }
@@ -3348,23 +3388,8 @@ mod macos_native_input {
         }
     }
 
-    fn normalize_stick_axis(value: f32) -> i16 {
-        let value = if value.abs() < GAMEPAD_STICK_DEADZONE {
-            0.0
-        } else {
-            let sign = value.signum();
-            let scaled = (value.abs() - GAMEPAD_STICK_DEADZONE) / (1.0 - GAMEPAD_STICK_DEADZONE);
-            sign * scaled.clamp(0.0, 1.0)
-        };
-        (value.clamp(-1.0, 1.0) * 32767.0).round() as i16
-    }
-
     fn normalize_to_u8(value: f32) -> u8 {
         (value.clamp(0.0, 1.0) * 255.0).round() as u8
-    }
-
-    fn clamp_i64_to_i16(value: i64) -> i16 {
-        value.clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16
     }
 
     #[allow(dead_code)]
@@ -8060,6 +8085,28 @@ mod tests {
         assert_eq!(automatic_present_max_fps(240, Some(240)), 0);
         assert_eq!(automatic_present_max_fps(240, Some(1)), 0);
         assert_eq!(automatic_present_max_fps(240, None), 0);
+    }
+
+    #[test]
+    fn macos_native_gamepad_y_axes_match_xinput_direction() {
+        assert!(normalize_macos_gamepad_stick_axis(1.0) > 0);
+        assert!(normalize_macos_gamepad_stick_axis(-1.0) < 0);
+        assert_eq!(normalize_macos_gamepad_stick_axis(0.05), 0);
+    }
+
+    #[test]
+    fn macos_native_mouse_vertical_delta_matches_windows_direction() {
+        assert_eq!(macos_mouse_delta_y_for_native_input(12), -12);
+        assert_eq!(macos_mouse_delta_y_for_native_input(-12), 12);
+        assert_eq!(macos_mouse_delta_y_for_native_input(i64::MIN), i16::MAX);
+    }
+
+    #[test]
+    fn macos_native_dpad_y_axis_maps_up_positive_down_negative() {
+        assert_eq!(macos_gamepad_dpad_y_buttons(0.75, false, false), 0x0001);
+        assert_eq!(macos_gamepad_dpad_y_buttons(-0.75, false, false), 0x0002);
+        assert_eq!(macos_gamepad_dpad_y_buttons(0.0, true, false), 0x0001);
+        assert_eq!(macos_gamepad_dpad_y_buttons(0.0, false, true), 0x0002);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds macOS native input forwarding for keyboard, mouse, and gamepad to the GStreamer backend.

* macOS keyboard/mouse input via CoreGraphics event taps
* macOS gamepad polling via gilrs shared with Windows logic
* Coalesced mouse movement and stateful key release on stop
* Graceful degradation to Electron/stdin on permission failure
* Target-specific `gilrs` dependency for macOS only

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/0f7080bf-3f93-443d-a82b-a4b54bbdcc6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-101" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/0f7080bf-3f93-443d-a82b-a4b54bbdcc6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-101&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-101"><img alt="OPE-101" src="https://capy.ai/api/badge/thread.svg?label=OPE-101"></picture></a>
<!-- capy-pr-badge:end -->