### PR TITLE
Extract renderer duplicate utilities into focused modules

### DIFF
--- a/opennow-stable/src/renderer/src/components/ElapsedSessionIndicators.tsx
+++ b/opennow-stable/src/renderer/src/components/ElapsedSessionIndicators.tsx
@@ -4,19 +4,9 @@ import { Calendar, Clock3, Clock } from "lucide-react";
 
 import type { SubscriptionInfo } from "@shared/gfn";
 
-import { formatRemainingPlaytimeFromSubscription } from "../utils/usePlaytime";
 import { useTranslation } from "../i18n";
-
-function formatElapsed(totalSeconds: number): string {
-  const safe = Math.max(0, Math.floor(totalSeconds));
-  const hours = Math.floor(safe / 3600);
-  const minutes = Math.floor((safe % 3600) / 60);
-  const seconds = safe % 60;
-  if (hours > 0) {
-    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-  }
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-}
+import { formatElapsed } from "../utils/timeFormat";
+import { formatRemainingPlaytimeFromSubscription } from "../utils/usePlaytime";
 
 interface SessionElapsedIndicatorProps {
   startedAtMs: number | null;

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -3,8 +3,7 @@ import type { JSX } from "react";
 import type { CatalogSortOption, GameInfo } from "@shared/gfn";
 import { GameCard } from "./GameCard";
 import { useTranslation } from "../i18n";
-
-type TranslateFunction = typeof import("../i18n").t;
+import { formatCatalogLastPlayed } from "../utils/lastPlayedFormat";
 
 export interface LibraryPageProps {
   games: GameInfo[];
@@ -20,25 +19,6 @@ export interface LibraryPageProps {
   sortOptions: CatalogSortOption[];
   selectedSortId: string;
   onSortChange: (sortId: string) => void;
-}
-
-function formatLastPlayed(t: TranslateFunction, date?: string): string {
-  if (!date) return t("library.lastPlayed.never");
-
-  const lastPlayed = new Date(date);
-  const now = new Date();
-  const diffMs = now.getTime() - lastPlayed.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return t("library.lastPlayed.justNow");
-  if (diffMins < 60) return t("library.lastPlayed.minutesAgo", { count: diffMins });
-  if (diffHours < 24) return t("library.lastPlayed.hoursAgo", { count: diffHours });
-  if (diffDays < 7) return t("library.lastPlayed.daysAgo", { count: diffDays });
-  if (diffDays < 30) return t("library.lastPlayed.weeksAgo", { count: Math.floor(diffDays / 7) });
-
-  return lastPlayed.toLocaleDateString();
 }
 
 export function LibraryPage({
@@ -123,7 +103,7 @@ export function LibraryPage({
                 {game.lastPlayed && (
                   <div className="library-last-played">
                     <Clock size={12} />
-                    <span>{formatLastPlayed(t, game.lastPlayed)}</span>
+                    <span>{formatCatalogLastPlayed(t, game.lastPlayed)}</span>
                   </div>
                 )}
               </div>

--- a/opennow-stable/src/renderer/src/components/QueueServerSelectModal.tsx
+++ b/opennow-stable/src/renderer/src/components/QueueServerSelectModal.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import type { GameInfo, PrintedWasteQueueData, PrintedWasteZone } from "@shared/gfn";
+import {
+  loadStoredPrintedWastePingResults,
+  saveStoredPrintedWastePingResults,
+} from "../utils/pingResultsStorage";
 
 // ── Constants / helpers ───────────────────────────────────────────────────────
 
@@ -56,43 +60,9 @@ const REGION_META: Record<string, { label: string; flag: string }> = {
   MY:   { label: "Malaysia",       flag: "🇲🇾" },
 };
 const REGION_ORDER = ["US", "CA", "EU", "JP", "KR", "THAI", "MY"];
-const PRINTEDWASTE_PING_CACHE_KEY = "opennow.printedwaste-pings.v1";
 const QUEUE_REFRESH_INTERVAL_MS = 2 * 60 * 1000;
 const AUTO_PING_WEIGHT = 0.75;
 const AUTO_QUEUE_WEIGHT = 0.25;
-
-interface PingCacheEntry {
-  url: string;
-  pingMs: number | null;
-}
-
-function loadStoredPingResults(): Map<string, number | null> {
-  try {
-    const raw = window.sessionStorage.getItem(PRINTEDWASTE_PING_CACHE_KEY);
-    if (!raw) return new Map();
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return new Map();
-    const results = new Map<string, number | null>();
-    for (const entry of parsed as PingCacheEntry[]) {
-      results.set(entry.url, entry.pingMs);
-    }
-    return results;
-  } catch {
-    return new Map();
-  }
-}
-
-function saveStoredPingResults(results: Map<string, number | null>): void {
-  try {
-    const entries: PingCacheEntry[] = [];
-    results.forEach((pingMs, url) => {
-      entries.push({ url, pingMs });
-    });
-    window.sessionStorage.setItem(PRINTEDWASTE_PING_CACHE_KEY, JSON.stringify(entries));
-  } catch {
-    // Ignore storage failures
-  }
-}
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -227,7 +197,7 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
     }
 
     let cancelled = false;
-    const cachedPings = loadStoredPingResults();
+    const cachedPings = loadStoredPrintedWastePingResults();
     const seedMap = new Map<string, number | null>();
     for (const zone of allStandardZones) {
       if (cachedPings.has(zone.routingUrl)) {
@@ -272,7 +242,7 @@ export function QueueServerSelectModal({ game, initialQueueData = null, onConfir
         const map = new Map(seedMap);
         for (const r of results) map.set(r.url, r.pingMs);
         setZonePings(map);
-        saveStoredPingResults(map);
+        saveStoredPrintedWastePingResults(map);
       } catch {
         // Ping failures are non-fatal
       } finally {

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -30,6 +30,11 @@ import {
 import { formatShortcutForDisplay, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
 import { getCodecDecodeBadgeState, type CodecTestResult } from "../lib/codecDiagnostics";
 import { useTranslation } from "../i18n";
+import {
+  clearStoredRegionPingResults,
+  loadStoredRegionPingResults,
+  saveStoredRegionPingResults,
+} from "../utils/pingResultsStorage";
 
 interface SettingsPageProps {
   settings: Settings;
@@ -478,45 +483,11 @@ function getFpsForResolution(entitled: EntitledResolution[], resolution: string)
   return [...new Set(fpsList)].sort((a, b) => a - b);
 }
 
-const PING_RESULTS_STORAGE_KEY = "opennow.ping-results.v1";
 const ENTITLED_RESOLUTIONS_STORAGE_KEY = "opennow.entitled-resolutions.v1";
 
 interface EntitledResolutionsCache {
   userId: string;
   entitledResolutions: EntitledResolution[];
-}
-
-interface PingCacheEntry {
-  url: string;
-  pingMs: number | null;
-}
-
-function loadStoredPingResults(): Map<string, number | null> | null {
-  try {
-    const raw = window.sessionStorage.getItem(PING_RESULTS_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return null;
-    const results = new Map<string, number | null>();
-    for (const entry of parsed as PingCacheEntry[]) {
-      results.set(entry.url, entry.pingMs);
-    }
-    return results;
-  } catch {
-    return null;
-  }
-}
-
-function saveStoredPingResults(results: Map<string, number | null>): void {
-  try {
-    const entries: PingCacheEntry[] = [];
-    results.forEach((pingMs, url) => {
-      entries.push({ url, pingMs });
-    });
-    window.sessionStorage.setItem(PING_RESULTS_STORAGE_KEY, JSON.stringify(entries));
-  } catch {
-    // Ignore storage failures
-  }
 }
 
 function loadCachedEntitledResolutions(): EntitledResolutionsCache | null {
@@ -606,7 +577,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   const codecTestOpen = codecResults !== null || codecTesting;
 
   // Region ping state
-  const initialPingResults = useMemo(() => loadStoredPingResults(), []);
+  const initialPingResults = useMemo(() => loadStoredRegionPingResults(), []);
   const [pingResults, setPingResults] = useState<Map<string, number | null>>(initialPingResults ?? new Map());
   const [isPinging, setIsPinging] = useState(false);
   const [bestRegionUrl, setBestRegionUrl] = useState<string | null>(() => {
@@ -641,7 +612,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
 
       setPingResults(pingMap);
       setBestRegionUrl(bestUrl);
-      saveStoredPingResults(pingMap);
+      saveStoredRegionPingResults(pingMap);
     } catch (err) {
       console.error("Ping test failed:", err);
     } finally {
@@ -658,11 +629,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
         // Regions changed, clear cache and re-test
         setPingResults(new Map());
         setBestRegionUrl(null);
-        try {
-          window.sessionStorage.removeItem(PING_RESULTS_STORAGE_KEY);
-        } catch {
-          // Ignore
-        }
+        clearStoredRegionPingResults();
       }
     }
   }, [regions, pingResults]);

--- a/opennow-stable/src/renderer/src/components/StatsOverlay.tsx
+++ b/opennow-stable/src/renderer/src/components/StatsOverlay.tsx
@@ -2,24 +2,13 @@ import { Monitor, Wifi, Activity, Gamepad2, AlertTriangle } from "lucide-react";
 import type { StreamDiagnostics } from "../gfn/webrtcClient";
 import type { JSX } from "react";
 import { useTranslation } from "../i18n";
+import { formatBitrate, getRttColor } from "../utils/streamDiagnosticsFormat";
 
 interface StatsOverlayProps {
   stats: StreamDiagnostics;
   isVisible: boolean;
   serverRegion?: string;
   connectedControllers: number;
-}
-
-function getRttColor(rttMs: number): string {
-  if (rttMs <= 0) return "var(--ink-muted)";
-  if (rttMs < 30) return "var(--success)";
-  if (rttMs < 60) return "var(--warning)";
-  return "var(--error)";
-}
-
-function formatBitrate(kbps: number): string {
-  if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
-  return `${kbps.toFixed(0)} kbps`;
 }
 
 export function StatsOverlay({

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -12,6 +12,14 @@ import { RemainingPlaytimeIndicator, SessionElapsedIndicator } from "./ElapsedSe
 import type { MicrophoneMode, ScreenshotEntry, RecordingEntry, SubscriptionInfo } from "@shared/gfn";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
 import { useMicMeter } from "../hooks/useMicMeter";
+import {
+  getBitratePerformanceColor,
+  getInputQueueColor,
+  getPacketLossColor,
+  getRttColor,
+  getTimingColor,
+} from "../utils/streamDiagnosticsFormat";
+import { formatElapsed } from "../utils/timeFormat";
 
 const ANTI_AFK_TOGGLE_ACK_MS = 5000;
 
@@ -78,38 +86,6 @@ interface StreamViewProps {
   hideConnectingOverlay?: boolean;
 }
 
-function getRttColor(rttMs: number): string {
-  if (rttMs <= 0) return "var(--ink-muted)";
-  if (rttMs < 30) return "var(--success)";
-  if (rttMs < 60) return "var(--warning)";
-  return "var(--error)";
-}
-
-function getPacketLossColor(lossPercent: number): string {
-  if (lossPercent <= 0.15) return "var(--success)";
-  if (lossPercent < 1) return "var(--warning)";
-  return "var(--error)";
-}
-
-function getTimingColor(valueMs: number, goodMax: number, warningMax: number): string {
-  if (valueMs <= 0) return "var(--ink-muted)";
-  if (valueMs <= goodMax) return "var(--success)";
-  if (valueMs <= warningMax) return "var(--warning)";
-  return "var(--error)";
-}
-
-function getInputQueueColor(bufferedBytes: number, dropCount: number): string {
-  if (dropCount > 0 || bufferedBytes >= 65536) return "var(--error)";
-  if (bufferedBytes >= 32768) return "var(--warning)";
-  return "var(--success)";
-}
-
-function getBitratePerformanceColor(percent: number): string {
-  if (percent <= 0) return "var(--ink-muted)";
-  if (percent >= 70 && percent <= 110) return "var(--success)";
-  if (percent >= 45 && percent < 130) return "var(--warning)";
-  return "var(--error)";
-}
 
 function getLagReasonLabel(reason: StreamLagReason): string {
   switch (reason) {
@@ -143,16 +119,6 @@ function getLagReasonColor(reason: StreamLagReason): string {
   }
 }
 
-function formatElapsed(totalSeconds: number): string {
-  const safe = Math.max(0, Math.floor(totalSeconds));
-  const hours = Math.floor(safe / 3600);
-  const minutes = Math.floor((safe % 3600) / 60);
-  const seconds = safe % 60;
-  if (hours > 0) {
-    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-  }
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-}
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;

--- a/opennow-stable/src/renderer/src/components/controllerMode/ControllerGameHub.tsx
+++ b/opennow-stable/src/renderer/src/components/controllerMode/ControllerGameHub.tsx
@@ -2,7 +2,9 @@ import type { JSX } from "react";
 import type { GameInfo } from "@shared/gfn";
 import { Clock, Calendar, Repeat2 } from "lucide-react";
 import { getStoreDisplayName } from "../GameCard";
-import { formatPlaytime, formatLastPlayed, type PlaytimeStore } from "../../utils/usePlaytime";
+import { formatPlaytime, type PlaytimeStore } from "../../utils/usePlaytime";
+import { formatPlaytimeLastPlayed } from "../../utils/lastPlayedFormat";
+import { sanitizeGenreName } from "./controllerLibrary/genreHelpers";
 
 export type GameHubTile = {
   id: string;
@@ -10,12 +12,6 @@ export type GameHubTile = {
   subtitle: string;
   disabled?: boolean;
 };
-
-function sanitizeGenreName(raw: string): string {
-  return raw
-    .replace(/_/g, " ")
-    .replace(/\b\w/g, (ch) => ch.toUpperCase());
-}
 
 export interface ControllerGameHubProps {
   game: GameInfo;
@@ -50,7 +46,7 @@ export function ControllerGameHub({
   const lastPlayedAt = record?.lastPlayedAt ?? null;
   const sessionCount = record?.sessionCount ?? 0;
   const playtimeLabel = formatPlaytime(totalSecs);
-  const lastPlayedLabel = formatLastPlayed(lastPlayedAt);
+  const lastPlayedLabel = formatPlaytimeLastPlayed(lastPlayedAt);
   const variant = game.variants.find((v) => v.id === selectedVariantId) || game.variants[0];
   const storeName = getStoreDisplayName(variant?.store || "");
   const genres = game.genres?.slice(0, 4) ?? [];

--- a/opennow-stable/src/renderer/src/components/controllerMode/ControllerLibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/controllerMode/ControllerLibraryPage.tsx
@@ -5,7 +5,6 @@ import { Star, Clock, Calendar, Repeat2 } from "lucide-react";
 import { ButtonA, ButtonX, ButtonY, ButtonPSCross, ButtonPSSquare, ButtonPSTriangle } from "./ControllerButtons";
 import { getStoreDisplayName } from "../GameCard";
 import { SessionElapsedIndicator } from "../ElapsedSessionIndicators";
-import { formatPlaytime, formatLastPlayed } from "../../utils/usePlaytime";
 import { playControllerUiSound } from "../../utils/controllerUiSound";
 import {
   type ControllerOverlayNavSnapshot,
@@ -192,14 +191,6 @@ export function ControllerLibraryPage({
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   };
 
-  const formatElapsed = (totalSeconds: number) => {
-    const safe = Math.max(0, Math.floor(totalSeconds));
-    const hours = Math.floor(safe / 3600);
-    const minutes = Math.floor((safe % 3600) / 60);
-    const seconds = safe % 60;
-    if (hours > 0) return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-  };
 
   const playUiSound = useCallback((kind: SoundKind): void => {
     playControllerUiSound(kind, uiSoundsEnabled);

--- a/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/AllGamesBrowseSection.tsx
+++ b/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/AllGamesBrowseSection.tsx
@@ -2,9 +2,11 @@ import type { JSX, RefObject } from "react";
 import type { GameInfo } from "@shared/gfn";
 import { Star, Clock, Calendar, Repeat2 } from "lucide-react";
 import { getStoreDisplayName } from "../../GameCard";
-import { formatLastPlayed, formatPlaytime, type PlaytimeStore } from "../../../utils/usePlaytime";
+import { formatPlaytime, type PlaytimeStore } from "../../../utils/usePlaytime";
+import { formatPlaytimeLastPlayed } from "../../../utils/lastPlayedFormat";
 import { LIBRARY_SORT_LABEL, SHELF_IMAGE_PROPS } from "./constants";
-import { isWithinContentWindow, isWithinImageWindow, sanitizeGenreName } from "./helpers";
+import { isWithinContentWindow, isWithinImageWindow } from "./helpers";
+import { sanitizeGenreName } from "./genreHelpers";
 import type { LibrarySortId } from "./types";
 
 interface AllGamesBrowseSectionProps {
@@ -60,7 +62,7 @@ export function AllGamesBrowseSection({
               const lastPlayedAt = record?.lastPlayedAt ?? null;
               const sessionCount = record?.sessionCount ?? 0;
               const playtimeLabel = formatPlaytime(totalSecs);
-              const lastPlayedLabel = formatLastPlayed(lastPlayedAt);
+              const lastPlayedLabel = formatPlaytimeLastPlayed(lastPlayedAt);
               const vId = selectedVariantByGameId[selectedGame.id] || selectedGame.variants[0]?.id;
               const variant = selectedGame.variants.find((v) => v.id === vId) || selectedGame.variants[0];
               const storeName = getStoreDisplayName(variant?.store || "");

--- a/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/TopLevelShelfSection.tsx
+++ b/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/TopLevelShelfSection.tsx
@@ -3,7 +3,8 @@ import type { GameInfo, SubscriptionInfo } from "@shared/gfn";
 import { Clock, Calendar, Repeat2, Star } from "lucide-react";
 import { spotlightEntryHasGame } from "./helpers";
 import type { HomeRootPlane, SpotlightEntry } from "./types";
-import { formatLastPlayed, formatPlaytime, type PlaytimeStore } from "../../../utils/usePlaytime";
+import { formatPlaytime, type PlaytimeStore } from "../../../utils/usePlaytime";
+import { formatPlaytimeLastPlayed } from "../../../utils/lastPlayedFormat";
 import { HomeSubscriptionMeta } from "./HomeSubscriptionMeta";
 import { SpotlightShelfBand } from "./SpotlightShelfBand";
 
@@ -123,7 +124,7 @@ export function TopLevelShelfSection({
                   </span>
                   <span className="xmb-game-meta-chip xmb-game-meta-chip--last-played">
                     <Calendar size={10} className="xmb-meta-icon" />
-                    {formatLastPlayed(lastPlayedAt)}
+                    {formatPlaytimeLastPlayed(lastPlayedAt)}
                   </span>
                   {sessionCount > 0 ? (
                     <span className="xmb-game-meta-chip xmb-game-meta-chip--sessions">

--- a/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/genreHelpers.ts
+++ b/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/genreHelpers.ts
@@ -1,0 +1,5 @@
+export function sanitizeGenreName(raw: string): string {
+  return raw
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}

--- a/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/helpers.tsx
+++ b/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/helpers.tsx
@@ -61,12 +61,6 @@ export function clampRgbByte(n: number): number {
   return Math.max(0, Math.min(255, Math.round(Number.isFinite(n) ? n : 0)));
 }
 
-export function sanitizeGenreName(raw: string): string {
-  return raw
-    .replace(/_/g, " ")
-    .replace(/\b\w/g, (ch) => ch.toUpperCase());
-}
-
 export function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   if (target.isContentEditable) return true;

--- a/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/useControllerLibraryGameDerivations.ts
+++ b/opennow-stable/src/renderer/src/components/controllerMode/controllerLibrary/useControllerLibraryGameDerivations.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import type { GameInfo } from "@shared/gfn";
 import { PREVIEW_TILE_COUNT, SPOTLIGHT_RECENT_COUNT } from "./constants";
-import { sanitizeGenreName } from "./helpers";
+import { sanitizeGenreName } from "./genreHelpers";
 import type {
   GameSubcategory,
   LibrarySortId,

--- a/opennow-stable/src/renderer/src/utils/lastPlayedFormat.ts
+++ b/opennow-stable/src/renderer/src/utils/lastPlayedFormat.ts
@@ -1,0 +1,38 @@
+type TranslateFunction = typeof import("../i18n").t;
+
+export function formatCatalogLastPlayed(t: TranslateFunction, date?: string): string {
+  if (!date) return t("library.lastPlayed.never");
+
+  const lastPlayed = new Date(date);
+  const now = new Date();
+  const diffMs = now.getTime() - lastPlayed.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return t("library.lastPlayed.justNow");
+  if (diffMins < 60) return t("library.lastPlayed.minutesAgo", { count: diffMins });
+  if (diffHours < 24) return t("library.lastPlayed.hoursAgo", { count: diffHours });
+  if (diffDays < 7) return t("library.lastPlayed.daysAgo", { count: diffDays });
+  if (diffDays < 30) return t("library.lastPlayed.weeksAgo", { count: Math.floor(diffDays / 7) });
+
+  return lastPlayed.toLocaleDateString();
+}
+
+export function formatPlaytimeLastPlayed(isoString: string | null): string {
+  if (!isoString) return "Never";
+  const then = new Date(isoString);
+  const now = new Date();
+
+  const thenDay = new Date(then.getFullYear(), then.getMonth(), then.getDate()).getTime();
+  const todayDay = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+
+  const diffDays = Math.round((todayDay - thenDay) / 86_400_000);
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} wk ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} mo ago`;
+  return `${Math.floor(diffDays / 365)} yr ago`;
+}

--- a/opennow-stable/src/renderer/src/utils/pingResultsStorage.ts
+++ b/opennow-stable/src/renderer/src/utils/pingResultsStorage.ts
@@ -1,0 +1,62 @@
+const REGION_PING_RESULTS_STORAGE_KEY = "opennow.ping-results.v1";
+const PRINTEDWASTE_PING_RESULTS_STORAGE_KEY = "opennow.printedwaste-pings.v1";
+
+interface PingCacheEntry {
+  url: string;
+  pingMs: number | null;
+}
+
+function loadPingResults(storageKey: string, fallback: null): Map<string, number | null> | null;
+function loadPingResults(storageKey: string, fallback: Map<string, number | null>): Map<string, number | null>;
+function loadPingResults(
+  storageKey: string,
+  fallback: Map<string, number | null> | null,
+): Map<string, number | null> | null {
+  try {
+    const raw = window.sessionStorage.getItem(storageKey);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return fallback;
+    const results = new Map<string, number | null>();
+    for (const entry of parsed as PingCacheEntry[]) {
+      results.set(entry.url, entry.pingMs);
+    }
+    return results;
+  } catch {
+    return fallback;
+  }
+}
+
+function savePingResults(storageKey: string, results: Map<string, number | null>): void {
+  try {
+    const entries: PingCacheEntry[] = [];
+    results.forEach((pingMs, url) => {
+      entries.push({ url, pingMs });
+    });
+    window.sessionStorage.setItem(storageKey, JSON.stringify(entries));
+  } catch {
+  }
+}
+
+export function loadStoredRegionPingResults(): Map<string, number | null> | null {
+  return loadPingResults(REGION_PING_RESULTS_STORAGE_KEY, null);
+}
+
+export function saveStoredRegionPingResults(results: Map<string, number | null>): void {
+  savePingResults(REGION_PING_RESULTS_STORAGE_KEY, results);
+}
+
+export function clearStoredRegionPingResults(): void {
+  try {
+    window.sessionStorage.removeItem(REGION_PING_RESULTS_STORAGE_KEY);
+  } catch {
+  }
+}
+
+export function loadStoredPrintedWastePingResults(): Map<string, number | null> {
+  return loadPingResults(PRINTEDWASTE_PING_RESULTS_STORAGE_KEY, new Map());
+}
+
+export function saveStoredPrintedWastePingResults(results: Map<string, number | null>): void {
+  savePingResults(PRINTEDWASTE_PING_RESULTS_STORAGE_KEY, results);
+}

--- a/opennow-stable/src/renderer/src/utils/streamDiagnosticsFormat.ts
+++ b/opennow-stable/src/renderer/src/utils/streamDiagnosticsFormat.ts
@@ -1,0 +1,37 @@
+export function getRttColor(rttMs: number): string {
+  if (rttMs <= 0) return "var(--ink-muted)";
+  if (rttMs < 30) return "var(--success)";
+  if (rttMs < 60) return "var(--warning)";
+  return "var(--error)";
+}
+
+export function getPacketLossColor(lossPercent: number): string {
+  if (lossPercent <= 0.15) return "var(--success)";
+  if (lossPercent < 1) return "var(--warning)";
+  return "var(--error)";
+}
+
+export function getTimingColor(valueMs: number, goodMax: number, warningMax: number): string {
+  if (valueMs <= 0) return "var(--ink-muted)";
+  if (valueMs <= goodMax) return "var(--success)";
+  if (valueMs <= warningMax) return "var(--warning)";
+  return "var(--error)";
+}
+
+export function getInputQueueColor(bufferedBytes: number, dropCount: number): string {
+  if (dropCount > 0 || bufferedBytes >= 65536) return "var(--error)";
+  if (bufferedBytes >= 32768) return "var(--warning)";
+  return "var(--success)";
+}
+
+export function getBitratePerformanceColor(percent: number): string {
+  if (percent <= 0) return "var(--ink-muted)";
+  if (percent >= 70 && percent <= 110) return "var(--success)";
+  if (percent >= 45 && percent < 130) return "var(--warning)";
+  return "var(--error)";
+}
+
+export function formatBitrate(kbps: number): string {
+  if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
+  return `${kbps.toFixed(0)} kbps`;
+}

--- a/opennow-stable/src/renderer/src/utils/timeFormat.ts
+++ b/opennow-stable/src/renderer/src/utils/timeFormat.ts
@@ -1,0 +1,10 @@
+export function formatElapsed(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const seconds = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+  }
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}

--- a/opennow-stable/src/renderer/src/utils/usePlaytime.ts
+++ b/opennow-stable/src/renderer/src/utils/usePlaytime.ts
@@ -44,24 +44,6 @@ export function formatPlaytime(totalSeconds: number): string {
   return `${h} h ${m} m`;
 }
 
-export function formatLastPlayed(isoString: string | null): string {
-  if (!isoString) return "Never";
-  const then = new Date(isoString);
-  const now = new Date();
-
-  const thenDay = new Date(then.getFullYear(), then.getMonth(), then.getDate()).getTime();
-  const todayDay = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-
-  const diffDays = Math.round((todayDay - thenDay) / 86_400_000);
-
-  if (diffDays === 0) return "Today";
-  if (diffDays === 1) return "Yesterday";
-  if (diffDays < 7) return `${diffDays} days ago`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} wk ago`;
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)} mo ago`;
-  return `${Math.floor(diffDays / 365)} yr ago`;
-}
-
 export function formatRemainingPlaytimeFromSubscription(
   subscription: { isUnlimited: boolean; remainingHours: number } | null,
   consumedHours = 0,


### PR DESCRIPTION
This PR extracts duplicated renderer formatting, color, and storage helpers into focused shared modules to reduce duplication and improve maintainability.

- Extract `formatElapsed` to `src/renderer/src/utils/timeFormat.ts` and reuse from `ElapsedSessionIndicators` and `StreamView`
- Consolidate stream diagnostics helpers (RTT, packet loss, timing, queue, bitrate color, bitrate format) into `src/renderer/src/utils/streamDiagnosticsFormat.ts` and reuse from `StatsOverlay` and `StreamView`
- Unify region and PrintedWaste ping result session storage in `src/renderer/src/utils/pingResultsStorage.ts`, preserving keys, fallback behavior, and error handling
- Separate catalog and playtime last-played formatters into `src/renderer/src/utils/lastPlayedFormat.ts` with semantic naming differences, importing appropriately in `LibraryPage` and controller library components
- Move `sanitizeGenreName` to `src/renderer/src/components/controllerMode/controllerLibrary/genreHelpers.ts` and update imports in controller library consumers

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/8236c14a-1c8e-46c8-a03a-6dc077bec8e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-104" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/8236c14a-1c8e-46c8-a03a-6dc077bec8e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-104&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-104"><img alt="OPE-104" src="https://capy.ai/api/badge/thread.svg?label=OPE-104"></picture></a>
<!-- capy-pr-badge:end -->