### PR TITLE
refactor(main): extract session/signaling IPC into focused modules

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -11,7 +11,6 @@ import {
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
-import { Buffer } from "node:buffer";
 
 // Keyboard shortcuts reference (matching Rust implementation):
 // Screenshot keybind - configurable, handled in renderer
@@ -22,7 +21,6 @@ import { Buffer } from "node:buffer";
 import { IPC_CHANNELS } from "@shared/ipc";
 import { registerOpenNowMediaProtocol } from "./mediaPaths";
 import { initLogCapture, exportLogs } from "@shared/logger";
-import type { NativeStreamerInputPacket } from "@shared/nativeStreamer";
 import { cacheManager } from "./services/cacheManager";
 import { refreshScheduler } from "./services/refreshScheduler";
 import { cacheEventBus } from "./services/cacheEventBus";
@@ -32,74 +30,22 @@ import {
   fetchPublicGamesUncached,
 } from "./gfn/games";
 import type {
-  ActiveSessionInfo,
-  ExistingSessionStrategy,
-  MainToRendererSignalingEvent,
   AppUpdaterState,
-  AuthLoginRequest,
-  SessionInfo,
-  AuthSessionRequest,
-  GamesFetchRequest,
-  CatalogBrowseRequest,
-  ResolveLaunchIdRequest,
-  RegionsFetchRequest,
-  SessionAdReportRequest,
-  SessionCreateRequest,
-  SessionPollRequest,
-  SessionStopRequest,
-  SessionClaimRequest,
-  StreamSettings,
-  SignalingConnectRequest,
-  SendAnswerRequest,
-  IceCandidatePayload,
-  NativeInputPacket,
-  NativeRenderSurface,
-  NativeRenderSurfaceUpdate,
-  KeyframeRequest,
-  Settings,
-  NativeStreamerSessionContext,
-  SubscriptionFetchRequest,
   SessionConflictChoice,
+  Settings,
   PingResult,
   StreamRegion,
   VideoAccelerationPreference,
   MicrophonePermissionResult,
-  NativeStreamerStatus,
   ThankYouContributor,
   ThankYouDataResult,
   ThankYouSupporter,
 } from "@shared/gfn";
-import { serializeSessionErrorTransport } from "@shared/sessionError";
-import {
-  normalizeCloudGsyncOverride,
-  resolveCloudGsync,
-} from "@shared/cloudGsync";
-import {
-  enrichErrorForIpc,
-  formatErrorChainForLog,
-} from "@shared/networkError";
 
 import { getSettingsManager, type SettingsManager } from "./settings";
 
-import {
-  createSession,
-  pollSession,
-  reportSessionAd,
-  stopSession,
-  getActiveSessions,
-  claimSession,
-} from "./gfn/cloudmatch";
+import { getActiveSessions } from "./gfn/cloudmatch";
 import { AuthService } from "./gfn/auth";
-import {
-  browseCatalog,
-  fetchLibraryGames,
-  fetchMainGames,
-  fetchPublicGames,
-  resolveLaunchAppId,
-} from "./gfn/games";
-import { fetchSubscription, fetchDynamicRegions } from "./gfn/subscription";
-import { GfnSignalingClient } from "./gfn/signaling";
-import { isSessionError, SessionError, GfnErrorCode } from "./gfn/errorCodes";
 import {
   connectDiscordRpc,
   setActivity,
@@ -112,9 +58,17 @@ import {
   createAppUpdaterController,
   type AppUpdaterController,
 } from "./updater";
-import { NativeStreamerManager } from "./nativeStreamer/manager";
-import { getNativeCloudGsyncCapabilities } from "./nativeCloudGsync";
+import { registerAccountCatalogIpcHandlers } from "./ipc/accountCatalogHandlers";
 import { registerMediaIpcHandlers } from "./ipc/mediaHandlers";
+import { registerSessionIpcHandlers } from "./ipc/sessionHandlers";
+import {
+  registerSignalingIpcHandlers,
+  type SignalingCoordinator,
+} from "./signaling/signalingCoordinator";
+import {
+  isSessionConflictError,
+  showSessionConflictDialog as showSessionConflictDialogWithDeps,
+} from "./session/sessionConflict";
 import { fetchWithTimeout, withTimeout } from "./services/requestTimeout";
 import {
   fetchPrintedWasteQueue,
@@ -282,12 +236,7 @@ protocol.registerSchemesAsPrivileged([
 
 let mainWindow: BrowserWindow | null = null;
 let rendererControlledFullscreen = false;
-let signalingClient: GfnSignalingClient | null = null;
-let signalingClientKey: string | null = null;
-let nativeStreamerManager: NativeStreamerManager | null = null;
-let nativeStreamerContext: NativeStreamerSessionContext | null = null;
-let nativeStreamerFallbackSessionId: string | null = null;
-const MAX_NATIVE_INPUT_PACKET_BYTES = 4096;
+let signalingCoordinator: SignalingCoordinator | null = null;
 let authService: AuthService;
 let settingsManager: SettingsManager;
 let appUpdater: AppUpdaterController | null = null;
@@ -324,15 +273,11 @@ function runShutdownCleanup(reason = "app-quit"): void {
     reason === "app-quit" ||
     reason === "before-quit" ||
     reason === "window-all-closed";
-  if (!shouldSkipExplicitSignalingDisconnect) {
-    signalingClient?.disconnect();
-  }
-  signalingClient = null;
-  signalingClientKey = null;
-  nativeStreamerManager?.dispose(reason);
-  nativeStreamerManager = null;
-  nativeStreamerContext = null;
-  nativeStreamerFallbackSessionId = null;
+  signalingCoordinator?.disconnectForShutdown({
+    emitDisconnectEvent: !shouldSkipExplicitSignalingDisconnect,
+    reason,
+  });
+  signalingCoordinator = null;
   void destroyDiscordRpc();
   appUpdater?.dispose();
   appUpdater = null;
@@ -486,293 +431,6 @@ class DiscordStatusMonitor {
 
 const discordMonitor = new DiscordStatusMonitor();
 
-function emitToRenderer(event: MainToRendererSignalingEvent): void {
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send(IPC_CHANNELS.SIGNALING_EVENT, event);
-  }
-}
-
-function getNativeStreamerManager(): NativeStreamerManager {
-  nativeStreamerManager ??= new NativeStreamerManager({
-    mainDir: __dirname,
-    getBackendPreference: () => "gstreamer",
-    getVideoBackendPreference: () =>
-      settingsManager?.get("nativeVideoBackend") ?? "auto",
-    getExecutablePathOverride: () =>
-      settingsManager?.get("nativeStreamerExecutablePath") ?? "",
-    getCloudGsyncMode: () =>
-      settingsManager?.get("nativeCloudGsyncMode") ?? "auto",
-    getD3dFullscreenMode: () =>
-      settingsManager?.get("nativeD3dFullscreenMode") ?? "auto",
-    getExternalRendererEnabled: () => true,
-    emit: emitToRenderer,
-    sendAnswer: async (payload) => {
-      if (!signalingClient) {
-        throw new Error("Signaling is not connected");
-      }
-      await signalingClient.sendAnswer(payload);
-    },
-    sendIceCandidate: async (candidate) => {
-      if (!signalingClient) {
-        throw new Error("Signaling is not connected");
-      }
-      await signalingClient.sendIceCandidate(candidate);
-    },
-    requestKeyframe: async (payload) => {
-      if (!signalingClient) {
-        throw new Error("Signaling is not connected");
-      }
-      await signalingClient.requestKeyframe(payload);
-    },
-  });
-  return nativeStreamerManager;
-}
-
-function isNativeStreamerSelected(): boolean {
-  return settingsManager?.get("streamClientMode") === "native";
-}
-
-function normalizeMaxBitrateMbps(value: unknown): number | null {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return null;
-  }
-
-  return Math.min(150, Math.max(5, Math.round(value)));
-}
-
-function updateNativeStreamerBitrateSetting(value: unknown): void {
-  const maxBitrateMbps = normalizeMaxBitrateMbps(value);
-  if (maxBitrateMbps === null) {
-    return;
-  }
-
-  if (nativeStreamerContext) {
-    nativeStreamerContext = {
-      ...nativeStreamerContext,
-      settings: {
-        ...nativeStreamerContext.settings,
-        maxBitrateMbps,
-      },
-    };
-  }
-
-  nativeStreamerManager?.updateBitrateLimit(maxBitrateMbps * 1000);
-}
-
-function nativeWindowHandleToHex(window: BrowserWindow): string | null {
-  const handle = window.getNativeWindowHandle();
-  if (handle.byteLength >= 8) {
-    return `0x${handle.readBigUInt64LE(0).toString(16)}`;
-  }
-  if (handle.byteLength >= 4) {
-    return `0x${handle.readUInt32LE(0).toString(16)}`;
-  }
-  return null;
-}
-
-function normalizeNativeRenderSurface(
-  window: BrowserWindow,
-  input: NativeRenderSurfaceUpdate,
-): NativeRenderSurface | null {
-  if (!input || typeof input !== "object") {
-    return null;
-  }
-
-  const windowHandle = nativeWindowHandleToHex(window);
-  if (!windowHandle) {
-    return null;
-  }
-
-  const deviceScaleFactor = Number.isFinite(input.deviceScaleFactor)
-    ? Math.min(8, Math.max(0.25, input.deviceScaleFactor))
-    : 1;
-  const rect = input.rect;
-  const visible =
-    input.visible === true &&
-    rect !== null &&
-    Number.isFinite(rect.x) &&
-    Number.isFinite(rect.y) &&
-    Number.isFinite(rect.width) &&
-    Number.isFinite(rect.height) &&
-    rect.width >= 2 &&
-    rect.height >= 2;
-
-  return {
-    windowHandle,
-    deviceScaleFactor,
-    visible,
-    showStats: input.showStats === true,
-    rect: visible
-      ? {
-          x: Math.round(rect.x),
-          y: Math.round(rect.y),
-          width: Math.max(2, Math.round(rect.width)),
-          height: Math.max(2, Math.round(rect.height)),
-        }
-      : null,
-  };
-}
-
-function normalizeNativeInputPacket(
-  input: unknown,
-): NativeStreamerInputPacket | null {
-  if (!input || typeof input !== "object") {
-    return null;
-  }
-
-  const packet = input as { payload?: unknown; partiallyReliable?: unknown };
-  const rawPayload = packet.payload;
-  let bytes: Uint8Array;
-
-  if (rawPayload instanceof ArrayBuffer) {
-    bytes = new Uint8Array(rawPayload);
-  } else if (ArrayBuffer.isView(rawPayload)) {
-    bytes = new Uint8Array(
-      rawPayload.buffer,
-      rawPayload.byteOffset,
-      rawPayload.byteLength,
-    );
-  } else if (Array.isArray(rawPayload)) {
-    if (
-      rawPayload.length === 0 ||
-      rawPayload.length > MAX_NATIVE_INPUT_PACKET_BYTES ||
-      rawPayload.some(
-        (byte) => !Number.isInteger(byte) || byte < 0 || byte > 255,
-      )
-    ) {
-      return null;
-    }
-    bytes = Uint8Array.from(rawPayload);
-  } else {
-    return null;
-  }
-
-  if (
-    bytes.byteLength === 0 ||
-    bytes.byteLength > MAX_NATIVE_INPUT_PACKET_BYTES
-  ) {
-    return null;
-  }
-
-  return {
-    payloadBase64: Buffer.from(
-      bytes.buffer,
-      bytes.byteOffset,
-      bytes.byteLength,
-    ).toString("base64"),
-    partiallyReliable: packet.partiallyReliable === true,
-  };
-}
-
-function routeSignalingEvent(event: MainToRendererSignalingEvent): void {
-  if (event.type === "disconnected") {
-    void nativeStreamerManager?.stop(`signaling disconnected: ${event.reason}`);
-    nativeStreamerContext = null;
-    nativeStreamerFallbackSessionId = null;
-    emitToRenderer(event);
-    return;
-  }
-
-  const context = nativeStreamerContext;
-  const nativeFallbackActive =
-    context !== null &&
-    nativeStreamerFallbackSessionId === context.session.sessionId;
-
-  if (!isNativeStreamerSelected() || !context || nativeFallbackActive) {
-    emitToRenderer(event);
-    return;
-  }
-
-  if (event.type === "offer") {
-    void handleNativeStreamerOffer(event.sdp, context);
-    return;
-  }
-
-  if (event.type === "remote-ice") {
-    void getNativeStreamerManager()
-      .addRemoteIce(event.candidate, context)
-      .catch((error) => {
-        emitToRenderer({
-          type: "error",
-          message: `Native streamer ICE failed: ${String(error)}`,
-        });
-      });
-    return;
-  }
-
-  emitToRenderer(event);
-}
-
-async function handleNativeStreamerOffer(
-  sdp: string,
-  context: NativeStreamerSessionContext,
-): Promise<void> {
-  try {
-    await getNativeStreamerManager().handleOffer(sdp, context);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn("[NativeStreamer] Falling back to web streamer:", message);
-    nativeStreamerFallbackSessionId = context.session.sessionId;
-    const queuedRemoteIce =
-      nativeStreamerManager?.drainQueuedRemoteIce(context.session.sessionId) ??
-      [];
-    await nativeStreamerManager
-      ?.stop("native streamer fallback")
-      .catch(() => undefined);
-    emitToRenderer({
-      type: "error",
-      message: `Native streamer failed: ${message}. Falling back to web streamer.`,
-    });
-    emitToRenderer({ type: "offer", sdp });
-    for (const candidate of queuedRemoteIce) {
-      emitToRenderer({ type: "remote-ice", candidate });
-    }
-  }
-}
-
-async function resetNativeStreamerForSignalingReconnect(): Promise<void> {
-  if (!nativeStreamerManager) {
-    return;
-  }
-
-  if (
-    !isNativeStreamerSelected() ||
-    !nativeStreamerContext ||
-    nativeStreamerManager.hasActiveSession()
-  ) {
-    await nativeStreamerManager.stop("signaling reconnect");
-  }
-}
-
-async function prepareNativeStreamerBeforeSignaling(): Promise<void> {
-  const context = nativeStreamerContext;
-  if (!isNativeStreamerSelected() || !context) {
-    return;
-  }
-
-  try {
-    emitToRenderer({
-      type: "log",
-      message: "Preparing native streamer before signaling attach.",
-    });
-    await getNativeStreamerManager().prepareForSession(context);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(
-      "[NativeStreamer] Pre-attach startup failed; falling back to web streamer:",
-      message,
-    );
-    nativeStreamerFallbackSessionId = context.session.sessionId;
-    await nativeStreamerManager
-      ?.stop("native streamer pre-attach fallback")
-      .catch(() => undefined);
-    emitToRenderer({
-      type: "error",
-      message: `Native streamer failed before signaling attach: ${message}. Falling back to web streamer.`,
-    });
-  }
-}
-
 function emitUpdaterStateToRenderer(state: AppUpdaterState): void {
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send(IPC_CHANNELS.APP_UPDATER_STATE_CHANGED, state);
@@ -853,7 +511,7 @@ async function createMainWindow(): Promise<void> {
           mainWindow.webContents.send(IPC_CHANNELS.EXTERNAL_ESCAPE);
         }
       }
-    } catch (err) {
+    } catch {
       // ignore errors - interception is best-effort
     }
   });
@@ -874,177 +532,11 @@ async function resolveJwt(token?: string): Promise<string> {
   return authService.resolveJwtToken(token);
 }
 
-/**
- * Show a dialog asking the user how to handle a session conflict
- * Returns the user's choice: "resume", "new", or "cancel"
- */
 async function showSessionConflictDialog(): Promise<SessionConflictChoice> {
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    return "cancel";
-  }
-
-  const result = await dialog.showMessageBox(mainWindow, {
-    type: "question",
-    buttons: ["Resume", "Start New", "Cancel"],
-    defaultId: 0,
-    cancelId: 2,
-    title: "Active Session Detected",
-    message: "You have an active session running.",
-    detail: "Resume it or start a new one?",
+  return showSessionConflictDialogWithDeps({
+    dialog,
+    getMainWindow: () => mainWindow,
   });
-
-  switch (result.response) {
-    case 0:
-      return "resume";
-    case 1:
-      return "new";
-    default:
-      return "cancel";
-  }
-}
-
-/**
- * Check if an error indicates a session conflict
- */
-function isSessionConflictError(error: unknown): boolean {
-  if (isSessionError(error)) {
-    return error.isSessionConflict();
-  }
-  return false;
-}
-
-function rethrowSerializedSessionError(error: unknown): never {
-  if (error instanceof SessionError) {
-    throw new Error(serializeSessionErrorTransport(error.toJSON()));
-  }
-  throw enrichErrorForIpc(error);
-}
-
-const AUTO_RESUME_SESSION_STATUSES = new Set([2, 3]);
-const ACTIVE_CREATE_SESSION_STATUSES = new Set([1, 2, 3]);
-
-function shouldForceNewSession(
-  strategy: ExistingSessionStrategy | undefined,
-): boolean {
-  return strategy === "force-new";
-}
-
-function isAutoResumeReadySession(entry: ActiveSessionInfo): boolean {
-  return (
-    entry.serverIp != null && AUTO_RESUME_SESSION_STATUSES.has(entry.status)
-  );
-}
-
-function isActiveCreateSessionConflict(entry: ActiveSessionInfo): boolean {
-  return ACTIVE_CREATE_SESSION_STATUSES.has(entry.status);
-}
-
-async function resolveSessionCloudGsyncSettings(
-  settings: StreamSettings,
-): Promise<StreamSettings> {
-  const userRequested = settings.enableCloudGsync;
-  const clientMode = settings.clientMode ?? "web";
-  const cloudGsyncMode = settings.nativeCloudGsyncMode ?? "auto";
-  const capabilities =
-    clientMode === "native"
-      ? await getNativeCloudGsyncCapabilities(cloudGsyncMode)
-      : undefined;
-  const resolution = resolveCloudGsync({
-    userRequested,
-    fps: settings.fps,
-    clientMode,
-    nativeBackendAvailable: clientMode === "native",
-    capabilities,
-    override: normalizeCloudGsyncOverride(cloudGsyncMode),
-  });
-
-  console.log(
-    `[CloudGsync] requested=${resolution.requested} resolved=${resolution.enabled} reflex=${resolution.reflexEnabled} reason=${resolution.reason} clientMode=${clientMode} fps=${settings.fps} capabilities=${JSON.stringify(resolution.capabilities)}`,
-  );
-
-  if (resolution.enabled) {
-    console.log(
-      "[CloudGsync] Native Cloud G-Sync/VRR mode is resolved on; keeping low-latency unthrottled presentation.",
-    );
-  }
-
-  return {
-    ...settings,
-    requestedCloudGsync: userRequested,
-    enableCloudGsync: resolution.enabled,
-    cloudGsyncResolution: resolution,
-  };
-}
-
-function selectReadySessionToClaim(
-  activeSessions: ActiveSessionInfo[],
-  numericAppId: number,
-): ActiveSessionInfo | null {
-  return (
-    activeSessions.find(
-      (session) =>
-        isAutoResumeReadySession(session) && session.appId === numericAppId,
-    ) ??
-    activeSessions.find((session) => isAutoResumeReadySession(session)) ??
-    null
-  );
-}
-
-function selectLaunchingSession(
-  activeSessions: ActiveSessionInfo[],
-  numericAppId: number,
-): ActiveSessionInfo | null {
-  return (
-    activeSessions.find(
-      (session) =>
-        session.serverIp &&
-        session.appId === numericAppId &&
-        session.status === 1,
-    ) ??
-    activeSessions.find(
-      (session) => session.serverIp && session.status === 1,
-    ) ??
-    null
-  );
-}
-
-async function stopActiveSessionsForCreate(params: {
-  token: string;
-  streamingBaseUrl: string;
-  zone: string;
-  appId: string;
-}): Promise<void> {
-  const { token, streamingBaseUrl, zone, appId } = params;
-  const numericAppId = Number.parseInt(appId, 10);
-  const activeSessions = await getActiveSessions(token, streamingBaseUrl);
-  const sessionsToStop = activeSessions.filter(isActiveCreateSessionConflict);
-  if (sessionsToStop.length === 0) {
-    return;
-  }
-
-  console.log(
-    `[CreateSession] Force-new requested; stopping ${sessionsToStop.length} existing active session(s) before create.`,
-  );
-
-  for (const activeSession of sessionsToStop) {
-    if (!activeSession.serverIp) {
-      console.warn(
-        `[CreateSession] Cannot stop existing session ${activeSession.sessionId} (appId=${activeSession.appId}, status=${activeSession.status}) because serverIp is missing.`,
-      );
-      continue;
-    }
-    console.log(
-      `[CreateSession] Stopping existing session id=${activeSession.sessionId}, appId=${activeSession.appId}, status=${activeSession.status}` +
-        `${activeSession.appId === numericAppId ? " (same app)" : ""}.`,
-    );
-    await stopSession({
-      token,
-      streamingBaseUrl,
-      serverIp: activeSession.serverIp,
-      zone,
-      sessionId: activeSession.sessionId,
-    });
-  }
 }
 
 const THANKS_CONTRIBUTORS_URL =
@@ -1278,545 +770,34 @@ async function fetchThanksData(): Promise<ThankYouDataResult> {
 }
 
 function registerIpcHandlers(): void {
-  ipcMain.handle(
-    IPC_CHANNELS.AUTH_GET_SESSION,
-    async (_event, payload: AuthSessionRequest = {}) => {
-      return authService.ensureValidSessionWithStatus(
-        Boolean(payload.forceRefresh),
-      );
-    },
-  );
-
-  ipcMain.handle(IPC_CHANNELS.AUTH_GET_PROVIDERS, async () => {
-    return authService.getProviders();
+  registerAccountCatalogIpcHandlers({
+    ipcMain,
+    authService,
+    resolveJwt,
+    refreshScheduler,
   });
 
-  ipcMain.handle(
-    IPC_CHANNELS.AUTH_GET_REGIONS,
-    async (_event, payload: RegionsFetchRequest) => {
-      return authService.getRegions(payload?.token);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.AUTH_LOGIN,
-    async (_event, payload: AuthLoginRequest) => {
-      return authService.login(payload);
-    },
-  );
-
-  ipcMain.handle(IPC_CHANNELS.AUTH_LOGOUT, async () => {
-    await authService.logout();
+  registerSessionIpcHandlers({
+    ipcMain,
+    dialog,
+    authService,
+    settingsManager,
+    resolveJwt,
+    setActivity,
+    clearActivity,
+    getMainWindow: () => mainWindow,
   });
 
-  ipcMain.handle(IPC_CHANNELS.AUTH_LOGOUT_ALL, async () => {
-    await authService.logoutAll();
+  signalingCoordinator = registerSignalingIpcHandlers({
+    ipcMain,
+    mainDir: __dirname,
+    settingsManager,
+    getMainWindow: () => mainWindow,
   });
-
-  ipcMain.handle(IPC_CHANNELS.AUTH_GET_SAVED_ACCOUNTS, async () => {
-    return authService.getSavedAccounts();
-  });
-
-  ipcMain.handle(
-    IPC_CHANNELS.AUTH_SWITCH_ACCOUNT,
-    async (_event, userId: string) => {
-      return authService.switchAccount(userId);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.AUTH_REMOVE_ACCOUNT,
-    async (_event, userId: string) => {
-      await authService.removeAccount(userId);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.SUBSCRIPTION_FETCH,
-    async (_event, payload: SubscriptionFetchRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      const userId = payload.userId;
-
-      // Fetch dynamic regions to get the VPC ID (handles Alliance partners correctly)
-      const { vpcId } = await fetchDynamicRegions(token, streamingBaseUrl);
-
-      return fetchSubscription(token, userId, vpcId ?? undefined);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.GAMES_FETCH_MAIN,
-    async (_event, payload: GamesFetchRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-      return fetchMainGames(token, streamingBaseUrl);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.GAMES_FETCH_LIBRARY,
-    async (_event, payload: GamesFetchRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-      return fetchLibraryGames(token, streamingBaseUrl);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.GAMES_BROWSE_CATALOG,
-    async (_event, payload: CatalogBrowseRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-      return browseCatalog({
-        ...payload,
-        token,
-        providerStreamingBaseUrl: streamingBaseUrl,
-      });
-    },
-  );
-
-  ipcMain.handle(IPC_CHANNELS.GAMES_FETCH_PUBLIC, async () => {
-    return fetchPublicGames();
-  });
-
-  ipcMain.handle(
-    IPC_CHANNELS.GAMES_RESOLVE_LAUNCH_ID,
-    async (_event, payload: ResolveLaunchIdRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      return resolveLaunchAppId(token, payload.appIdOrUuid, streamingBaseUrl);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.CREATE_SESSION,
-    async (_event, payload: SessionCreateRequest) => {
-      const token = await resolveJwt(payload.token);
-      const streamingBaseUrl =
-        payload.streamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      const forceNewSession = shouldForceNewSession(
-        payload.existingSessionStrategy,
-      );
-      const resolvedSettings = await resolveSessionCloudGsyncSettings(
-        payload.settings,
-      );
-      const resolvedPayload: SessionCreateRequest = {
-        ...payload,
-        settings: resolvedSettings,
-      };
-
-      /**
-       * Attempt to find and claim an existing active session.
-       * Prefers a session whose appId matches the requested game; falls back to
-       * any claimable session (serverIp present) if no exact match is found.
-       * Returns null when no claimable session exists or the lookup fails.
-       *
-       * IMPORTANT: Only status=2/3 (ready/streaming) sessions are sent a RESUME claim PUT.
-       * Status=1 sessions (still in queue/setup) must NOT receive a RESUME — the server
-       * rejects it with SESSION_NOT_PAUSED, and even if we polled past it internally we
-       * would bypass the renderer's queue/ad polling loop entirely. Instead, status=1
-       * sessions are returned as a minimal SessionInfo so the renderer enters its own
-       * polling loop which shows queue position and ads correctly.
-       */
-      const tryClaimExisting = async (): Promise<SessionInfo | null> => {
-        if (!token) return null;
-        try {
-          const activeSessions = await getActiveSessions(
-            token,
-            streamingBaseUrl,
-          );
-          if (activeSessions.length === 0) return null;
-          const numericAppId = parseInt(resolvedPayload.appId, 10);
-
-          // First prefer a paused/ready session (status 2 or 3) that can be RESUME'd.
-          const readyCandidate = selectReadySessionToClaim(
-            activeSessions,
-            numericAppId,
-          );
-          if (readyCandidate) {
-            console.log(
-              `[CreateSession] Resuming existing session (id=${readyCandidate.sessionId}, appId=${readyCandidate.appId}, status=${readyCandidate.status}) instead of creating new.`,
-            );
-            return claimSession({
-              token,
-              streamingBaseUrl,
-              sessionId: readyCandidate.sessionId,
-              serverIp: readyCandidate.serverIp!,
-              appId: resolvedPayload.appId,
-              settings: resolvedPayload.settings,
-            });
-          }
-
-          // A status=1 session is still in queue/setup. Return it so the renderer's
-          // polling loop handles queue position and ads — do NOT send a RESUME claim.
-          const launchingCandidate = selectLaunchingSession(
-            activeSessions,
-            numericAppId,
-          );
-          if (launchingCandidate) {
-            console.log(
-              `[CreateSession] Found launching session (id=${launchingCandidate.sessionId}, appId=${launchingCandidate.appId}, status=1); returning for renderer queue/ad polling.`,
-            );
-            try {
-              return await pollSession({
-                token,
-                streamingBaseUrl,
-                serverIp: launchingCandidate.serverIp!,
-                zone: resolvedPayload.zone,
-                sessionId: launchingCandidate.sessionId,
-                proxyUrl: payload.proxyUrl,
-              });
-            } catch (hydrateError) {
-              console.warn(
-                `[CreateSession] Failed to hydrate launching session ${launchingCandidate.sessionId}; falling back to minimal handoff: ${formatErrorChainForLog(hydrateError)}`,
-              );
-              return {
-                sessionId: launchingCandidate.sessionId,
-                status: 1,
-                zone: resolvedPayload.zone,
-                streamingBaseUrl,
-                serverIp: launchingCandidate.serverIp!,
-                signalingServer: launchingCandidate.serverIp!,
-                signalingUrl:
-                  launchingCandidate.signalingUrl ??
-                  `wss://${launchingCandidate.serverIp}:443/nvst/`,
-                iceServers: [],
-              } satisfies SessionInfo;
-            }
-          }
-
-          return null;
-        } catch (claimError) {
-          console.warn(
-            `[CreateSession] Failed to claim existing session: ${formatErrorChainForLog(claimError)}`,
-          );
-          return null;
-        }
-      };
-
-      // Pre-flight check: resume an active session before trying to create a new one.
-      if (!forceNewSession) {
-        const preChecked = await tryClaimExisting();
-        if (preChecked) {
-          if (settingsManager.get("discordRichPresence")) {
-            void setActivity(
-              payload.internalTitle || payload.appId,
-              new Date(),
-              payload.appId,
-            );
-          }
-          return preChecked;
-        }
-      }
-
-      try {
-        if (forceNewSession && token) {
-          await stopActiveSessionsForCreate({
-            token,
-            streamingBaseUrl,
-            zone: resolvedPayload.zone,
-            appId: resolvedPayload.appId,
-          });
-        }
-        const sessionResult = await createSession({
-          ...resolvedPayload,
-          token,
-          streamingBaseUrl,
-        });
-        if (settingsManager.get("discordRichPresence")) {
-          void setActivity(
-            payload.internalTitle || payload.appId,
-            new Date(),
-            payload.appId,
-          );
-        }
-        return sessionResult;
-      } catch (error) {
-        // If the backend rejected the create because a session is already running,
-        // attempt a claim now (the pre-flight may have missed a session whose appId
-        // was not populated in the list response, or that had no serverIp at the
-        // time of the pre-flight but is ready now).
-        if (
-          !forceNewSession &&
-          error instanceof SessionError &&
-          error.statusCode === 11
-        ) {
-          console.warn(
-            "[CreateSession] SESSION_LIMIT_EXCEEDED — retrying as session claim.",
-          );
-          const fallback = await tryClaimExisting();
-          if (fallback) {
-            if (settingsManager.get("discordRichPresence")) {
-              void setActivity(
-                payload.internalTitle || payload.appId,
-                new Date(),
-                payload.appId,
-              );
-            }
-            return fallback;
-          }
-        }
-        rethrowSerializedSessionError(error);
-      }
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.POLL_SESSION,
-    async (_event, payload: SessionPollRequest) => {
-      try {
-        const token = await resolveJwt(payload.token);
-        return pollSession({
-          ...payload,
-          token,
-          streamingBaseUrl:
-            payload.streamingBaseUrl ??
-            authService.getSelectedProvider().streamingServiceUrl,
-        });
-      } catch (error) {
-        rethrowSerializedSessionError(error);
-      }
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.REPORT_SESSION_AD,
-    async (_event, payload: SessionAdReportRequest) => {
-      try {
-        const token = await resolveJwt(payload.token);
-        return reportSessionAd({
-          ...payload,
-          token,
-          streamingBaseUrl:
-            payload.streamingBaseUrl ??
-            authService.getSelectedProvider().streamingServiceUrl,
-        });
-      } catch (error) {
-        rethrowSerializedSessionError(error);
-      }
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.STOP_SESSION,
-    async (_event, payload: SessionStopRequest) => {
-      try {
-        const token = await resolveJwt(payload.token);
-        const result = await stopSession({
-          ...payload,
-          token,
-          streamingBaseUrl:
-            payload.streamingBaseUrl ??
-            authService.getSelectedProvider().streamingServiceUrl,
-        });
-        void clearActivity();
-        return result;
-      } catch (error) {
-        rethrowSerializedSessionError(error);
-      }
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.GET_ACTIVE_SESSIONS,
-    async (_event, token?: string, streamingBaseUrl?: string) => {
-      const jwt = await resolveJwt(token);
-      const baseUrl =
-        streamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      return getActiveSessions(jwt, baseUrl);
-    },
-  );
 
   ipcMain.handle(IPC_CHANNELS.DISCORD_CLEAR_ACTIVITY, async () => {
     void clearActivity();
   });
-
-  ipcMain.handle(
-    IPC_CHANNELS.CLAIM_SESSION,
-    async (_event, payload: SessionClaimRequest) => {
-      try {
-        const token = await resolveJwt(payload.token);
-        const streamingBaseUrl =
-          payload.streamingBaseUrl ??
-          authService.getSelectedProvider().streamingServiceUrl;
-        const resolvedSettings = payload.settings
-          ? await resolveSessionCloudGsyncSettings(payload.settings)
-          : undefined;
-        return claimSession({
-          ...payload,
-          token,
-          streamingBaseUrl,
-          settings: resolvedSettings,
-        });
-      } catch (error) {
-        rethrowSerializedSessionError(error);
-      }
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.SESSION_CONFLICT_DIALOG,
-    async (): Promise<SessionConflictChoice> => {
-      return showSessionConflictDialog();
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.CONNECT_SIGNALING,
-    async (_event, payload: SignalingConnectRequest): Promise<void> => {
-      const nextKey = `${payload.sessionId}|${payload.signalingServer}|${payload.signalingUrl ?? ""}`;
-      nativeStreamerContext = payload.nativeStreamer ?? null;
-      nativeStreamerFallbackSessionId = null;
-      if (nativeStreamerContext) {
-        console.log(
-          "[NativeStreamer] Signaling connect context:",
-          JSON.stringify({
-            sessionId: nativeStreamerContext.session.sessionId,
-            resolution: nativeStreamerContext.settings.resolution,
-            fps: nativeStreamerContext.settings.fps,
-            codec: nativeStreamerContext.settings.codec,
-            negotiatedStreamProfile:
-              nativeStreamerContext.session.negotiatedStreamProfile,
-            requestedStreamingFeatures:
-              nativeStreamerContext.session.requestedStreamingFeatures,
-            finalizedStreamingFeatures:
-              nativeStreamerContext.session.finalizedStreamingFeatures,
-          }),
-        );
-      }
-
-      if (signalingClient && signalingClientKey === nextKey) {
-        console.log(
-          "[Signaling] Reuse existing signaling connection (duplicate connect request ignored)",
-        );
-        return;
-      }
-
-      if (signalingClient) {
-        signalingClient.disconnect();
-      }
-      await resetNativeStreamerForSignalingReconnect();
-      await prepareNativeStreamerBeforeSignaling();
-
-      signalingClient = new GfnSignalingClient(
-        payload.signalingServer,
-        payload.sessionId,
-        payload.signalingUrl,
-      );
-      signalingClientKey = nextKey;
-      signalingClient.onEvent(routeSignalingEvent);
-      try {
-        await signalingClient.connect();
-      } catch (error) {
-        await nativeStreamerManager
-          ?.stop("signaling connect failed")
-          .catch(() => undefined);
-        signalingClient = null;
-        signalingClientKey = null;
-        throw error;
-      }
-    },
-  );
-
-  ipcMain.handle(IPC_CHANNELS.DISCONNECT_SIGNALING, async (): Promise<void> => {
-    await nativeStreamerManager?.stop("signaling disconnect");
-    nativeStreamerContext = null;
-    nativeStreamerFallbackSessionId = null;
-    signalingClient?.disconnect();
-    signalingClient = null;
-    signalingClientKey = null;
-  });
-
-  ipcMain.handle(
-    IPC_CHANNELS.SEND_ANSWER,
-    async (_event, payload: SendAnswerRequest) => {
-      if (!signalingClient) {
-        throw new Error("Signaling is not connected");
-      }
-      return signalingClient.sendAnswer(payload);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.SEND_ICE_CANDIDATE,
-    async (_event, payload: IceCandidatePayload) => {
-      if (!signalingClient) {
-        throw new Error("Signaling is not connected");
-      }
-      return signalingClient.sendIceCandidate(payload);
-    },
-  );
-
-  ipcMain.on(
-    IPC_CHANNELS.NATIVE_INPUT,
-    (_event, payload: NativeInputPacket) => {
-      if (!isNativeStreamerSelected()) {
-        return;
-      }
-
-      const context = nativeStreamerContext;
-      if (
-        !context ||
-        nativeStreamerFallbackSessionId === context.session.sessionId
-      ) {
-        return;
-      }
-
-      const packet = normalizeNativeInputPacket(payload);
-      if (!packet) {
-        return;
-      }
-
-      nativeStreamerManager?.sendInput(packet);
-    },
-  );
-
-  ipcMain.on(
-    IPC_CHANNELS.NATIVE_RENDER_SURFACE,
-    (event, payload: NativeRenderSurfaceUpdate) => {
-      if (!isNativeStreamerSelected()) {
-        return;
-      }
-
-      const window = BrowserWindow.fromWebContents(event.sender);
-      if (!window || window.isDestroyed()) {
-        return;
-      }
-
-      const surface = normalizeNativeRenderSurface(window, payload);
-      if (!surface) {
-        return;
-      }
-
-      getNativeStreamerManager().updateSurface(surface);
-    },
-  );
-
-  ipcMain.handle(
-    IPC_CHANNELS.REQUEST_KEYFRAME,
-    async (_event, payload: KeyframeRequest) => {
-      if (!signalingClient) {
-        throw new Error("Signaling is not connected");
-      }
-      return signalingClient.requestKeyframe(payload);
-    },
-  );
 
   // Toggle fullscreen via IPC (for completeness)
   ipcMain.handle(IPC_CHANNELS.TOGGLE_FULLSCREEN, async () => {
@@ -1947,42 +928,7 @@ function registerIpcHandlers(): void {
         if (key === "autoCheckForUpdates") {
           appUpdater?.setAutomaticChecksEnabled(value as boolean);
         }
-        if (
-          (key === "streamClientMode" && value !== "native") ||
-          key === "nativeStreamerBackend" ||
-          key === "nativeStreamerExecutablePath" ||
-          key === "nativeCloudGsyncMode" ||
-          key === "nativeD3dFullscreenMode" ||
-          key === "nativeExternalRenderer"
-        ) {
-          void nativeStreamerManager?.stop(
-            key === "nativeStreamerBackend"
-              ? "native streamer backend changed"
-              : key === "nativeStreamerExecutablePath"
-                ? "native streamer executable changed"
-                : key === "nativeCloudGsyncMode"
-                  ? "native Cloud G-Sync mode changed"
-                  : key === "nativeD3dFullscreenMode"
-                    ? "native D3D fullscreen mode changed"
-                    : key === "nativeExternalRenderer"
-                      ? "native external renderer setting changed"
-                      : "native streamer disabled",
-          );
-          nativeStreamerContext = null;
-          nativeStreamerFallbackSessionId = null;
-        }
-        if (key === "nativeVideoBackend") {
-          if (nativeStreamerManager?.hasActiveSession()) {
-            console.log(
-              "[NativeStreamer] Native video backend changed; active session will keep its current backend until the next native streamer restart.",
-            );
-          } else {
-            void nativeStreamerManager?.stop("native video backend changed");
-          }
-        }
-        if (key === "maxBitrateMbps") {
-          updateNativeStreamerBitrateSetting(value);
-        }
+        signalingCoordinator?.applySettingsChange(key, value);
         if (key === "discordRichPresence") {
           if (value) {
             void connectDiscordRpc().then(() => discordMonitor.start());
@@ -2000,9 +946,8 @@ function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.SETTINGS_RESET, async (): Promise<Settings> => {
     const resetSettings = settingsManager.reset();
     appUpdater?.setAutomaticChecksEnabled(resetSettings.autoCheckForUpdates);
-    void nativeStreamerManager?.stop("settings reset");
-    nativeStreamerContext = null;
-    nativeStreamerFallbackSessionId = null;
+    signalingCoordinator?.stopNativeStreamer("settings reset");
+    signalingCoordinator?.resetNativeStreamerContext();
     return resetSettings;
   });
 
@@ -2033,23 +978,6 @@ function registerIpcHandlers(): void {
       return result.filePaths[0] ?? null;
     },
   );
-
-  ipcMain.handle(
-    IPC_CHANNELS.NATIVE_STREAMER_STATUS,
-    async (): Promise<NativeStreamerStatus> => {
-      return getNativeStreamerManager().probeStatus();
-    },
-  );
-
-  ipcMain.handle(IPC_CHANNELS.NATIVE_CLOUD_GSYNC_CAPABILITIES, async () => {
-    const capabilities = await getNativeCloudGsyncCapabilities(
-      settingsManager?.get("nativeCloudGsyncMode") ?? "auto",
-    );
-    console.log(
-      `[CloudGsync] capability probe: ${JSON.stringify(capabilities)}`,
-    );
-    return capabilities;
-  });
 
   ipcMain.handle(
     IPC_CHANNELS.MICROPHONE_PERMISSION_GET,
@@ -2218,7 +1146,7 @@ app.whenReady().then(async () => {
   );
 
   session.defaultSession.setPermissionCheckHandler(
-    (webContents, permission, requestingOrigin) => {
+    (_webContents, permission, _requestingOrigin) => {
       const allowedPermissions = new Set([
         "media",
         "microphone",

--- a/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
+++ b/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
@@ -1,0 +1,160 @@
+import type { IpcMain } from "electron";
+import { IPC_CHANNELS } from "@shared/ipc";
+import type {
+  AuthLoginRequest,
+  AuthSessionRequest,
+  CatalogBrowseRequest,
+  GamesFetchRequest,
+  RegionsFetchRequest,
+  ResolveLaunchIdRequest,
+  SubscriptionFetchRequest,
+} from "@shared/gfn";
+import type { AuthService } from "../gfn/auth";
+import {
+  browseCatalog,
+  fetchLibraryGames,
+  fetchMainGames,
+  fetchPublicGames,
+  resolveLaunchAppId,
+} from "../gfn/games";
+import { fetchSubscription, fetchDynamicRegions } from "../gfn/subscription";
+
+interface RefreshSchedulerAuthContextUpdater {
+  updateAuthContext(token: string, providerStreamingBaseUrl?: string): void;
+}
+
+export interface AccountCatalogIpcHandlerDeps {
+  ipcMain: IpcMain;
+  authService: AuthService;
+  resolveJwt(token?: string): Promise<string>;
+  refreshScheduler: RefreshSchedulerAuthContextUpdater;
+}
+
+export function registerAccountCatalogIpcHandlers(
+  deps: AccountCatalogIpcHandlerDeps,
+): void {
+  const { ipcMain, authService, refreshScheduler, resolveJwt } = deps;
+
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_GET_SESSION,
+    async (_event, payload: AuthSessionRequest = {}) => {
+      return authService.ensureValidSessionWithStatus(
+        Boolean(payload.forceRefresh),
+      );
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.AUTH_GET_PROVIDERS, async () => {
+    return authService.getProviders();
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_GET_REGIONS,
+    async (_event, payload: RegionsFetchRequest) => {
+      return authService.getRegions(payload?.token);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_LOGIN,
+    async (_event, payload: AuthLoginRequest) => {
+      return authService.login(payload);
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.AUTH_LOGOUT, async () => {
+    await authService.logout();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.AUTH_LOGOUT_ALL, async () => {
+    await authService.logoutAll();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.AUTH_GET_SAVED_ACCOUNTS, async () => {
+    return authService.getSavedAccounts();
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_SWITCH_ACCOUNT,
+    async (_event, userId: string) => {
+      return authService.switchAccount(userId);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.AUTH_REMOVE_ACCOUNT,
+    async (_event, userId: string) => {
+      await authService.removeAccount(userId);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.SUBSCRIPTION_FETCH,
+    async (_event, payload: SubscriptionFetchRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      const userId = payload.userId;
+
+      const { vpcId } = await fetchDynamicRegions(token, streamingBaseUrl);
+
+      return fetchSubscription(token, userId, vpcId ?? undefined);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_FETCH_MAIN,
+    async (_event, payload: GamesFetchRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+      return fetchMainGames(token, streamingBaseUrl);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_FETCH_LIBRARY,
+    async (_event, payload: GamesFetchRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+      return fetchLibraryGames(token, streamingBaseUrl);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_BROWSE_CATALOG,
+    async (_event, payload: CatalogBrowseRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+      return browseCatalog({
+        ...payload,
+        token,
+        providerStreamingBaseUrl: streamingBaseUrl,
+      });
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.GAMES_FETCH_PUBLIC, async () => {
+    return fetchPublicGames();
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_RESOLVE_LAUNCH_ID,
+    async (_event, payload: ResolveLaunchIdRequest) => {
+      const token = await resolveJwt(payload?.token);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      return resolveLaunchAppId(token, payload.appIdOrUuid, streamingBaseUrl);
+    },
+  );
+}

--- a/opennow-stable/src/main/ipc/sessionHandlers.ts
+++ b/opennow-stable/src/main/ipc/sessionHandlers.ts
@@ -1,0 +1,307 @@
+import type { IpcMain } from "electron";
+import { IPC_CHANNELS } from "@shared/ipc";
+import type {
+  SessionAdReportRequest,
+  SessionClaimRequest,
+  SessionConflictChoice,
+  SessionCreateRequest,
+  SessionInfo,
+  SessionPollRequest,
+  SessionStopRequest,
+} from "@shared/gfn";
+import { formatErrorChainForLog } from "@shared/networkError";
+import type { AuthService } from "../gfn/auth";
+import {
+  claimSession,
+  createSession,
+  getActiveSessions,
+  pollSession,
+  reportSessionAd,
+  stopSession,
+} from "../gfn/cloudmatch";
+import { SessionError } from "../gfn/errorCodes";
+import type { SettingsManager } from "../settings";
+import {
+  rethrowSerializedSessionError,
+  showSessionConflictDialog,
+  type SessionConflictDialogDeps,
+} from "../session/sessionConflict";
+import {
+  resolveSessionCloudGsyncSettings,
+  shouldForceNewSession,
+} from "../session/cloudGsyncSettings";
+import { stopActiveSessionsForCreate } from "../session/sessionLifecycle";
+import {
+  selectLaunchingSession,
+  selectReadySessionToClaim,
+} from "../session/sessionSelection";
+
+export interface SessionIpcHandlerDeps extends SessionConflictDialogDeps {
+  ipcMain: IpcMain;
+  authService: AuthService;
+  settingsManager: SettingsManager;
+  resolveJwt(token?: string): Promise<string>;
+  setActivity(gameName: string, startTimestamp: Date, appId?: string): Promise<void>;
+  clearActivity(): Promise<void>;
+}
+
+export function registerSessionIpcHandlers(deps: SessionIpcHandlerDeps): void {
+  const {
+    ipcMain,
+    authService,
+    settingsManager,
+    resolveJwt,
+    setActivity,
+    clearActivity,
+  } = deps;
+
+  ipcMain.handle(
+    IPC_CHANNELS.CREATE_SESSION,
+    async (_event, payload: SessionCreateRequest) => {
+      const token = await resolveJwt(payload.token);
+      const streamingBaseUrl =
+        payload.streamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      const forceNewSession = shouldForceNewSession(
+        payload.existingSessionStrategy,
+      );
+      const resolvedSettings = await resolveSessionCloudGsyncSettings(
+        payload.settings,
+      );
+      const resolvedPayload: SessionCreateRequest = {
+        ...payload,
+        settings: resolvedSettings,
+      };
+
+      const tryClaimExisting = async (): Promise<SessionInfo | null> => {
+        if (!token) return null;
+        try {
+          const activeSessions = await getActiveSessions(
+            token,
+            streamingBaseUrl,
+          );
+          if (activeSessions.length === 0) return null;
+          const numericAppId = parseInt(resolvedPayload.appId, 10);
+
+          const readyCandidate = selectReadySessionToClaim(
+            activeSessions,
+            numericAppId,
+          );
+          if (readyCandidate) {
+            console.log(
+              `[CreateSession] Resuming existing session (id=${readyCandidate.sessionId}, appId=${readyCandidate.appId}, status=${readyCandidate.status}) instead of creating new.`,
+            );
+            return claimSession({
+              token,
+              streamingBaseUrl,
+              sessionId: readyCandidate.sessionId,
+              serverIp: readyCandidate.serverIp!,
+              appId: resolvedPayload.appId,
+              settings: resolvedPayload.settings,
+            });
+          }
+
+          const launchingCandidate = selectLaunchingSession(
+            activeSessions,
+            numericAppId,
+          );
+          if (launchingCandidate) {
+            console.log(
+              `[CreateSession] Found launching session (id=${launchingCandidate.sessionId}, appId=${launchingCandidate.appId}, status=1); returning for renderer queue/ad polling.`,
+            );
+            try {
+              return await pollSession({
+                token,
+                streamingBaseUrl,
+                serverIp: launchingCandidate.serverIp!,
+                zone: resolvedPayload.zone,
+                sessionId: launchingCandidate.sessionId,
+                proxyUrl: payload.proxyUrl,
+              });
+            } catch (hydrateError) {
+              console.warn(
+                `[CreateSession] Failed to hydrate launching session ${launchingCandidate.sessionId}; falling back to minimal handoff: ${formatErrorChainForLog(hydrateError)}`,
+              );
+              return {
+                sessionId: launchingCandidate.sessionId,
+                status: 1,
+                zone: resolvedPayload.zone,
+                streamingBaseUrl,
+                serverIp: launchingCandidate.serverIp!,
+                signalingServer: launchingCandidate.serverIp!,
+                signalingUrl:
+                  launchingCandidate.signalingUrl ??
+                  `wss://${launchingCandidate.serverIp}:443/nvst/`,
+                iceServers: [],
+              } satisfies SessionInfo;
+            }
+          }
+
+          return null;
+        } catch (claimError) {
+          console.warn(
+            `[CreateSession] Failed to claim existing session: ${formatErrorChainForLog(claimError)}`,
+          );
+          return null;
+        }
+      };
+
+      if (!forceNewSession) {
+        const preChecked = await tryClaimExisting();
+        if (preChecked) {
+          if (settingsManager.get("discordRichPresence")) {
+            void setActivity(
+              payload.internalTitle || payload.appId,
+              new Date(),
+              payload.appId,
+            );
+          }
+          return preChecked;
+        }
+      }
+
+      try {
+        if (forceNewSession && token) {
+          await stopActiveSessionsForCreate({
+            token,
+            streamingBaseUrl,
+            zone: resolvedPayload.zone,
+            appId: resolvedPayload.appId,
+          });
+        }
+        const sessionResult = await createSession({
+          ...resolvedPayload,
+          token,
+          streamingBaseUrl,
+        });
+        if (settingsManager.get("discordRichPresence")) {
+          void setActivity(
+            payload.internalTitle || payload.appId,
+            new Date(),
+            payload.appId,
+          );
+        }
+        return sessionResult;
+      } catch (error) {
+        if (
+          !forceNewSession &&
+          error instanceof SessionError &&
+          error.statusCode === 11
+        ) {
+          console.warn(
+            "[CreateSession] SESSION_LIMIT_EXCEEDED — retrying as session claim.",
+          );
+          const fallback = await tryClaimExisting();
+          if (fallback) {
+            if (settingsManager.get("discordRichPresence")) {
+              void setActivity(
+                payload.internalTitle || payload.appId,
+                new Date(),
+                payload.appId,
+              );
+            }
+            return fallback;
+          }
+        }
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.POLL_SESSION,
+    async (_event, payload: SessionPollRequest) => {
+      try {
+        const token = await resolveJwt(payload.token);
+        return pollSession({
+          ...payload,
+          token,
+          streamingBaseUrl:
+            payload.streamingBaseUrl ??
+            authService.getSelectedProvider().streamingServiceUrl,
+        });
+      } catch (error) {
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.REPORT_SESSION_AD,
+    async (_event, payload: SessionAdReportRequest) => {
+      try {
+        const token = await resolveJwt(payload.token);
+        return reportSessionAd({
+          ...payload,
+          token,
+          streamingBaseUrl:
+            payload.streamingBaseUrl ??
+            authService.getSelectedProvider().streamingServiceUrl,
+        });
+      } catch (error) {
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.STOP_SESSION,
+    async (_event, payload: SessionStopRequest) => {
+      try {
+        const token = await resolveJwt(payload.token);
+        const result = await stopSession({
+          ...payload,
+          token,
+          streamingBaseUrl:
+            payload.streamingBaseUrl ??
+            authService.getSelectedProvider().streamingServiceUrl,
+        });
+        void clearActivity();
+        return result;
+      } catch (error) {
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.GET_ACTIVE_SESSIONS,
+    async (_event, token?: string, streamingBaseUrl?: string) => {
+      const jwt = await resolveJwt(token);
+      const baseUrl =
+        streamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      return getActiveSessions(jwt, baseUrl);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.CLAIM_SESSION,
+    async (_event, payload: SessionClaimRequest) => {
+      try {
+        const token = await resolveJwt(payload.token);
+        const streamingBaseUrl =
+          payload.streamingBaseUrl ??
+          authService.getSelectedProvider().streamingServiceUrl;
+        const resolvedSettings = payload.settings
+          ? await resolveSessionCloudGsyncSettings(payload.settings)
+          : undefined;
+        return claimSession({
+          ...payload,
+          token,
+          streamingBaseUrl,
+          settings: resolvedSettings,
+        });
+      } catch (error) {
+        rethrowSerializedSessionError(error);
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.SESSION_CONFLICT_DIALOG,
+    async (): Promise<SessionConflictChoice> => {
+      return showSessionConflictDialog(deps);
+    },
+  );
+}

--- a/opennow-stable/src/main/nativeStreamer/input.ts
+++ b/opennow-stable/src/main/nativeStreamer/input.ts
@@ -1,0 +1,54 @@
+import type { NativeStreamerInputPacket } from "@shared/nativeStreamer";
+
+const MAX_NATIVE_INPUT_PACKET_BYTES = 4096;
+
+export function normalizeNativeInputPacket(
+  input: unknown,
+): NativeStreamerInputPacket | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+
+  const packet = input as { payload?: unknown; partiallyReliable?: unknown };
+  const rawPayload = packet.payload;
+  let bytes: Uint8Array;
+
+  if (rawPayload instanceof ArrayBuffer) {
+    bytes = new Uint8Array(rawPayload);
+  } else if (ArrayBuffer.isView(rawPayload)) {
+    bytes = new Uint8Array(
+      rawPayload.buffer,
+      rawPayload.byteOffset,
+      rawPayload.byteLength,
+    );
+  } else if (Array.isArray(rawPayload)) {
+    if (
+      rawPayload.length === 0 ||
+      rawPayload.length > MAX_NATIVE_INPUT_PACKET_BYTES ||
+      rawPayload.some(
+        (byte) => !Number.isInteger(byte) || byte < 0 || byte > 255,
+      )
+    ) {
+      return null;
+    }
+    bytes = Uint8Array.from(rawPayload);
+  } else {
+    return null;
+  }
+
+  if (
+    bytes.byteLength === 0 ||
+    bytes.byteLength > MAX_NATIVE_INPUT_PACKET_BYTES
+  ) {
+    return null;
+  }
+
+  return {
+    payloadBase64: Buffer.from(
+      bytes.buffer,
+      bytes.byteOffset,
+      bytes.byteLength,
+    ).toString("base64"),
+    partiallyReliable: packet.partiallyReliable === true,
+  };
+}

--- a/opennow-stable/src/main/nativeStreamer/surface.ts
+++ b/opennow-stable/src/main/nativeStreamer/surface.ts
@@ -1,0 +1,59 @@
+import type { BrowserWindow } from "electron";
+import type {
+  NativeRenderSurface,
+  NativeRenderSurfaceUpdate,
+} from "@shared/gfn";
+
+export function nativeWindowHandleToHex(window: BrowserWindow): string | null {
+  const handle = window.getNativeWindowHandle();
+  if (handle.byteLength >= 8) {
+    return `0x${handle.readBigUInt64LE(0).toString(16)}`;
+  }
+  if (handle.byteLength >= 4) {
+    return `0x${handle.readUInt32LE(0).toString(16)}`;
+  }
+  return null;
+}
+
+export function normalizeNativeRenderSurface(
+  window: BrowserWindow,
+  input: NativeRenderSurfaceUpdate,
+): NativeRenderSurface | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+
+  const windowHandle = nativeWindowHandleToHex(window);
+  if (!windowHandle) {
+    return null;
+  }
+
+  const deviceScaleFactor = Number.isFinite(input.deviceScaleFactor)
+    ? Math.min(8, Math.max(0.25, input.deviceScaleFactor))
+    : 1;
+  const rect = input.rect;
+  const visible =
+    input.visible === true &&
+    rect !== null &&
+    Number.isFinite(rect.x) &&
+    Number.isFinite(rect.y) &&
+    Number.isFinite(rect.width) &&
+    Number.isFinite(rect.height) &&
+    rect.width >= 2 &&
+    rect.height >= 2;
+
+  return {
+    windowHandle,
+    deviceScaleFactor,
+    visible,
+    showStats: input.showStats === true,
+    rect: visible
+      ? {
+          x: Math.round(rect.x),
+          y: Math.round(rect.y),
+          width: Math.max(2, Math.round(rect.width)),
+          height: Math.max(2, Math.round(rect.height)),
+        }
+      : null,
+  };
+}

--- a/opennow-stable/src/main/session/cloudGsyncSettings.ts
+++ b/opennow-stable/src/main/session/cloudGsyncSettings.ts
@@ -1,0 +1,49 @@
+import type { ExistingSessionStrategy, StreamSettings } from "@shared/gfn";
+import {
+  normalizeCloudGsyncOverride,
+  resolveCloudGsync,
+} from "@shared/cloudGsync";
+import { getNativeCloudGsyncCapabilities } from "../nativeCloudGsync";
+
+export function shouldForceNewSession(
+  strategy: ExistingSessionStrategy | undefined,
+): boolean {
+  return strategy === "force-new";
+}
+
+export async function resolveSessionCloudGsyncSettings(
+  settings: StreamSettings,
+): Promise<StreamSettings> {
+  const userRequested = settings.enableCloudGsync;
+  const clientMode = settings.clientMode ?? "web";
+  const cloudGsyncMode = settings.nativeCloudGsyncMode ?? "auto";
+  const capabilities =
+    clientMode === "native"
+      ? await getNativeCloudGsyncCapabilities(cloudGsyncMode)
+      : undefined;
+  const resolution = resolveCloudGsync({
+    userRequested,
+    fps: settings.fps,
+    clientMode,
+    nativeBackendAvailable: clientMode === "native",
+    capabilities,
+    override: normalizeCloudGsyncOverride(cloudGsyncMode),
+  });
+
+  console.log(
+    `[CloudGsync] requested=${resolution.requested} resolved=${resolution.enabled} reflex=${resolution.reflexEnabled} reason=${resolution.reason} clientMode=${clientMode} fps=${settings.fps} capabilities=${JSON.stringify(resolution.capabilities)}`,
+  );
+
+  if (resolution.enabled) {
+    console.log(
+      "[CloudGsync] Native Cloud G-Sync/VRR mode is resolved on; keeping low-latency unthrottled presentation.",
+    );
+  }
+
+  return {
+    ...settings,
+    requestedCloudGsync: userRequested,
+    enableCloudGsync: resolution.enabled,
+    cloudGsyncResolution: resolution,
+  };
+}

--- a/opennow-stable/src/main/session/sessionConflict.ts
+++ b/opennow-stable/src/main/session/sessionConflict.ts
@@ -1,0 +1,52 @@
+import type { BrowserWindow } from "electron";
+import { serializeSessionErrorTransport } from "@shared/sessionError";
+import type { SessionConflictChoice } from "@shared/gfn";
+import { enrichErrorForIpc } from "@shared/networkError";
+import { isSessionError, SessionError } from "../gfn/errorCodes";
+
+export interface SessionConflictDialogDeps {
+  dialog: Electron.Dialog;
+  getMainWindow(): BrowserWindow | null;
+}
+
+export async function showSessionConflictDialog(
+  deps: SessionConflictDialogDeps,
+): Promise<SessionConflictChoice> {
+  const mainWindow = deps.getMainWindow();
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return "cancel";
+  }
+
+  const result = await deps.dialog.showMessageBox(mainWindow, {
+    type: "question",
+    buttons: ["Resume", "Start New", "Cancel"],
+    defaultId: 0,
+    cancelId: 2,
+    title: "Active Session Detected",
+    message: "You have an active session running.",
+    detail: "Resume it or start a new one?",
+  });
+
+  switch (result.response) {
+    case 0:
+      return "resume";
+    case 1:
+      return "new";
+    default:
+      return "cancel";
+  }
+}
+
+export function isSessionConflictError(error: unknown): boolean {
+  if (isSessionError(error)) {
+    return error.isSessionConflict();
+  }
+  return false;
+}
+
+export function rethrowSerializedSessionError(error: unknown): never {
+  if (error instanceof SessionError) {
+    throw new Error(serializeSessionErrorTransport(error.toJSON()));
+  }
+  throw enrichErrorForIpc(error);
+}

--- a/opennow-stable/src/main/session/sessionLifecycle.ts
+++ b/opennow-stable/src/main/session/sessionLifecycle.ts
@@ -1,0 +1,41 @@
+import { stopSession, getActiveSessions } from "../gfn/cloudmatch";
+import { isActiveCreateSessionConflict } from "./sessionSelection";
+
+export async function stopActiveSessionsForCreate(params: {
+  token: string;
+  streamingBaseUrl: string;
+  zone: string;
+  appId: string;
+}): Promise<void> {
+  const { token, streamingBaseUrl, zone, appId } = params;
+  const numericAppId = Number.parseInt(appId, 10);
+  const activeSessions = await getActiveSessions(token, streamingBaseUrl);
+  const sessionsToStop = activeSessions.filter(isActiveCreateSessionConflict);
+  if (sessionsToStop.length === 0) {
+    return;
+  }
+
+  console.log(
+    `[CreateSession] Force-new requested; stopping ${sessionsToStop.length} existing active session(s) before create.`,
+  );
+
+  for (const activeSession of sessionsToStop) {
+    if (!activeSession.serverIp) {
+      console.warn(
+        `[CreateSession] Cannot stop existing session ${activeSession.sessionId} (appId=${activeSession.appId}, status=${activeSession.status}) because serverIp is missing.`,
+      );
+      continue;
+    }
+    console.log(
+      `[CreateSession] Stopping existing session id=${activeSession.sessionId}, appId=${activeSession.appId}, status=${activeSession.status}` +
+        `${activeSession.appId === numericAppId ? " (same app)" : ""}.`,
+    );
+    await stopSession({
+      token,
+      streamingBaseUrl,
+      serverIp: activeSession.serverIp,
+      zone,
+      sessionId: activeSession.sessionId,
+    });
+  }
+}

--- a/opennow-stable/src/main/session/sessionSelection.ts
+++ b/opennow-stable/src/main/session/sessionSelection.ts
@@ -1,0 +1,46 @@
+import type { ActiveSessionInfo } from "@shared/gfn";
+
+const AUTO_RESUME_SESSION_STATUSES = new Set([2, 3]);
+const ACTIVE_CREATE_SESSION_STATUSES = new Set([1, 2, 3]);
+
+export function isAutoResumeReadySession(entry: ActiveSessionInfo): boolean {
+  return (
+    entry.serverIp != null && AUTO_RESUME_SESSION_STATUSES.has(entry.status)
+  );
+}
+
+export function isActiveCreateSessionConflict(entry: ActiveSessionInfo): boolean {
+  return ACTIVE_CREATE_SESSION_STATUSES.has(entry.status);
+}
+
+export function selectReadySessionToClaim(
+  activeSessions: ActiveSessionInfo[],
+  numericAppId: number,
+): ActiveSessionInfo | null {
+  return (
+    activeSessions.find(
+      (session) =>
+        isAutoResumeReadySession(session) && session.appId === numericAppId,
+    ) ??
+    activeSessions.find((session) => isAutoResumeReadySession(session)) ??
+    null
+  );
+}
+
+export function selectLaunchingSession(
+  activeSessions: ActiveSessionInfo[],
+  numericAppId: number,
+): ActiveSessionInfo | null {
+  return (
+    activeSessions.find(
+      (session) =>
+        session.serverIp &&
+        session.appId === numericAppId &&
+        session.status === 1,
+    ) ??
+    activeSessions.find(
+      (session) => session.serverIp && session.status === 1,
+    ) ??
+    null
+  );
+}

--- a/opennow-stable/src/main/signaling/signalingCoordinator.ts
+++ b/opennow-stable/src/main/signaling/signalingCoordinator.ts
@@ -1,0 +1,470 @@
+import { BrowserWindow, type IpcMain } from "electron";
+import { IPC_CHANNELS } from "@shared/ipc";
+import type {
+  IceCandidatePayload,
+  KeyframeRequest,
+  MainToRendererSignalingEvent,
+  NativeInputPacket,
+  NativeRenderSurfaceUpdate,
+  NativeStreamerSessionContext,
+  NativeStreamerStatus,
+  SendAnswerRequest,
+  Settings,
+  SignalingConnectRequest,
+} from "@shared/gfn";
+import { GfnSignalingClient } from "../gfn/signaling";
+import { NativeStreamerManager } from "../nativeStreamer/manager";
+import { normalizeNativeInputPacket } from "../nativeStreamer/input";
+import { normalizeNativeRenderSurface } from "../nativeStreamer/surface";
+import { getNativeCloudGsyncCapabilities } from "../nativeCloudGsync";
+import type { SettingsManager } from "../settings";
+
+export interface SignalingCoordinatorDeps {
+  ipcMain: IpcMain;
+  mainDir: string;
+  settingsManager: SettingsManager;
+  getMainWindow(): BrowserWindow | null;
+}
+
+export class SignalingCoordinator {
+  private signalingClient: GfnSignalingClient | null = null;
+  private signalingClientKey: string | null = null;
+  private nativeStreamerManager: NativeStreamerManager | null = null;
+  private nativeStreamerContext: NativeStreamerSessionContext | null = null;
+  private nativeStreamerFallbackSessionId: string | null = null;
+
+  constructor(private readonly deps: SignalingCoordinatorDeps) {}
+
+  registerIpcHandlers(): void {
+    const { ipcMain } = this.deps;
+
+    ipcMain.handle(
+      IPC_CHANNELS.CONNECT_SIGNALING,
+      async (_event, payload: SignalingConnectRequest): Promise<void> => {
+        await this.connectSignaling(payload);
+      },
+    );
+
+    ipcMain.handle(IPC_CHANNELS.DISCONNECT_SIGNALING, async (): Promise<void> => {
+      await this.disconnectSignaling();
+    });
+
+    ipcMain.handle(
+      IPC_CHANNELS.SEND_ANSWER,
+      async (_event, payload: SendAnswerRequest) => {
+        if (!this.signalingClient) {
+          throw new Error("Signaling is not connected");
+        }
+        return this.signalingClient.sendAnswer(payload);
+      },
+    );
+
+    ipcMain.handle(
+      IPC_CHANNELS.SEND_ICE_CANDIDATE,
+      async (_event, payload: IceCandidatePayload) => {
+        if (!this.signalingClient) {
+          throw new Error("Signaling is not connected");
+        }
+        return this.signalingClient.sendIceCandidate(payload);
+      },
+    );
+
+    ipcMain.on(
+      IPC_CHANNELS.NATIVE_INPUT,
+      (_event, payload: NativeInputPacket) => {
+        if (!this.isNativeStreamerSelected()) {
+          return;
+        }
+
+        const context = this.nativeStreamerContext;
+        if (
+          !context ||
+          this.nativeStreamerFallbackSessionId === context.session.sessionId
+        ) {
+          return;
+        }
+
+        const packet = normalizeNativeInputPacket(payload);
+        if (!packet) {
+          return;
+        }
+
+        this.nativeStreamerManager?.sendInput(packet);
+      },
+    );
+
+    ipcMain.on(
+      IPC_CHANNELS.NATIVE_RENDER_SURFACE,
+      (event, payload: NativeRenderSurfaceUpdate) => {
+        if (!this.isNativeStreamerSelected()) {
+          return;
+        }
+
+        const window = BrowserWindow.fromWebContents(event.sender);
+        if (!window || window.isDestroyed()) {
+          return;
+        }
+
+        const surface = normalizeNativeRenderSurface(window, payload);
+        if (!surface) {
+          return;
+        }
+
+        this.getNativeStreamerManager().updateSurface(surface);
+      },
+    );
+
+    ipcMain.handle(
+      IPC_CHANNELS.REQUEST_KEYFRAME,
+      async (_event, payload: KeyframeRequest) => {
+        if (!this.signalingClient) {
+          throw new Error("Signaling is not connected");
+        }
+        return this.signalingClient.requestKeyframe(payload);
+      },
+    );
+
+    ipcMain.handle(
+      IPC_CHANNELS.NATIVE_STREAMER_STATUS,
+      async (): Promise<NativeStreamerStatus> => {
+        return this.getNativeStreamerManager().probeStatus();
+      },
+    );
+
+    ipcMain.handle(IPC_CHANNELS.NATIVE_CLOUD_GSYNC_CAPABILITIES, async () => {
+      const capabilities = await getNativeCloudGsyncCapabilities(
+        this.deps.settingsManager?.get("nativeCloudGsyncMode") ?? "auto",
+      );
+      console.log(
+        `[CloudGsync] capability probe: ${JSON.stringify(capabilities)}`,
+      );
+      return capabilities;
+    });
+  }
+
+  disconnectForShutdown(options: {
+    emitDisconnectEvent: boolean;
+    reason: string;
+  }): void {
+    if (options.emitDisconnectEvent) {
+      this.signalingClient?.disconnect();
+    }
+    this.signalingClient = null;
+    this.signalingClientKey = null;
+    this.nativeStreamerManager?.dispose(options.reason);
+    this.nativeStreamerManager = null;
+    this.nativeStreamerContext = null;
+    this.nativeStreamerFallbackSessionId = null;
+  }
+
+  stopNativeStreamer(reason: string): void {
+    void this.nativeStreamerManager?.stop(reason);
+  }
+
+  resetNativeStreamerContext(): void {
+    this.nativeStreamerContext = null;
+    this.nativeStreamerFallbackSessionId = null;
+  }
+
+  nativeStreamerHasActiveSession(): boolean {
+    return this.nativeStreamerManager?.hasActiveSession() ?? false;
+  }
+
+  updateNativeStreamerBitrateSetting(value: unknown): void {
+    const maxBitrateMbps = normalizeMaxBitrateMbps(value);
+    if (maxBitrateMbps === null) {
+      return;
+    }
+
+    if (this.nativeStreamerContext) {
+      this.nativeStreamerContext = {
+        ...this.nativeStreamerContext,
+        settings: {
+          ...this.nativeStreamerContext.settings,
+          maxBitrateMbps,
+        },
+      };
+    }
+
+    this.nativeStreamerManager?.updateBitrateLimit(maxBitrateMbps * 1000);
+  }
+
+  applySettingsChange<K extends keyof Settings>(
+    key: K,
+    value: Settings[K],
+  ): void {
+    if (
+      (key === "streamClientMode" && value !== "native") ||
+      key === "nativeStreamerBackend" ||
+      key === "nativeStreamerExecutablePath" ||
+      key === "nativeCloudGsyncMode" ||
+      key === "nativeD3dFullscreenMode" ||
+      key === "nativeExternalRenderer"
+    ) {
+      this.stopNativeStreamer(
+        key === "nativeStreamerBackend"
+          ? "native streamer backend changed"
+          : key === "nativeStreamerExecutablePath"
+            ? "native streamer executable changed"
+            : key === "nativeCloudGsyncMode"
+              ? "native Cloud G-Sync mode changed"
+              : key === "nativeD3dFullscreenMode"
+                ? "native D3D fullscreen mode changed"
+                : key === "nativeExternalRenderer"
+                  ? "native external renderer setting changed"
+                  : "native streamer disabled",
+      );
+      this.resetNativeStreamerContext();
+    }
+    if (key === "nativeVideoBackend") {
+      if (this.nativeStreamerHasActiveSession()) {
+        console.log(
+          "[NativeStreamer] Native video backend changed; active session will keep its current backend until the next native streamer restart.",
+        );
+      } else {
+        this.stopNativeStreamer("native video backend changed");
+      }
+    }
+    if (key === "maxBitrateMbps") {
+      this.updateNativeStreamerBitrateSetting(value);
+    }
+  }
+
+  private async connectSignaling(payload: SignalingConnectRequest): Promise<void> {
+    const nextKey = `${payload.sessionId}|${payload.signalingServer}|${payload.signalingUrl ?? ""}`;
+    this.nativeStreamerContext = payload.nativeStreamer ?? null;
+    this.nativeStreamerFallbackSessionId = null;
+    if (this.nativeStreamerContext) {
+      console.log(
+        "[NativeStreamer] Signaling connect context:",
+        JSON.stringify({
+          sessionId: this.nativeStreamerContext.session.sessionId,
+          resolution: this.nativeStreamerContext.settings.resolution,
+          fps: this.nativeStreamerContext.settings.fps,
+          codec: this.nativeStreamerContext.settings.codec,
+          negotiatedStreamProfile:
+            this.nativeStreamerContext.session.negotiatedStreamProfile,
+          requestedStreamingFeatures:
+            this.nativeStreamerContext.session.requestedStreamingFeatures,
+          finalizedStreamingFeatures:
+            this.nativeStreamerContext.session.finalizedStreamingFeatures,
+        }),
+      );
+    }
+
+    if (this.signalingClient && this.signalingClientKey === nextKey) {
+      console.log(
+        "[Signaling] Reuse existing signaling connection (duplicate connect request ignored)",
+      );
+      return;
+    }
+
+    if (this.signalingClient) {
+      this.signalingClient.disconnect();
+    }
+    await this.resetNativeStreamerForSignalingReconnect();
+    await this.prepareNativeStreamerBeforeSignaling();
+
+    this.signalingClient = new GfnSignalingClient(
+      payload.signalingServer,
+      payload.sessionId,
+      payload.signalingUrl,
+    );
+    this.signalingClientKey = nextKey;
+    this.signalingClient.onEvent((event) => this.routeSignalingEvent(event));
+    try {
+      await this.signalingClient.connect();
+    } catch (error) {
+      await this.nativeStreamerManager
+        ?.stop("signaling connect failed")
+        .catch(() => undefined);
+      this.signalingClient = null;
+      this.signalingClientKey = null;
+      throw error;
+    }
+  }
+
+  private async disconnectSignaling(): Promise<void> {
+    await this.nativeStreamerManager?.stop("signaling disconnect");
+    this.nativeStreamerContext = null;
+    this.nativeStreamerFallbackSessionId = null;
+    this.signalingClient?.disconnect();
+    this.signalingClient = null;
+    this.signalingClientKey = null;
+  }
+
+  private emitToRenderer(event: MainToRendererSignalingEvent): void {
+    const mainWindow = this.deps.getMainWindow();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(IPC_CHANNELS.SIGNALING_EVENT, event);
+    }
+  }
+
+  private getNativeStreamerManager(): NativeStreamerManager {
+    this.nativeStreamerManager ??= new NativeStreamerManager({
+      mainDir: this.deps.mainDir,
+      getBackendPreference: () => "gstreamer",
+      getVideoBackendPreference: () =>
+        this.deps.settingsManager?.get("nativeVideoBackend") ?? "auto",
+      getExecutablePathOverride: () =>
+        this.deps.settingsManager?.get("nativeStreamerExecutablePath") ?? "",
+      getCloudGsyncMode: () =>
+        this.deps.settingsManager?.get("nativeCloudGsyncMode") ?? "auto",
+      getD3dFullscreenMode: () =>
+        this.deps.settingsManager?.get("nativeD3dFullscreenMode") ?? "auto",
+      getExternalRendererEnabled: () => true,
+      emit: (event) => this.emitToRenderer(event),
+      sendAnswer: async (payload) => {
+        if (!this.signalingClient) {
+          throw new Error("Signaling is not connected");
+        }
+        await this.signalingClient.sendAnswer(payload);
+      },
+      sendIceCandidate: async (candidate) => {
+        if (!this.signalingClient) {
+          throw new Error("Signaling is not connected");
+        }
+        await this.signalingClient.sendIceCandidate(candidate);
+      },
+      requestKeyframe: async (payload) => {
+        if (!this.signalingClient) {
+          throw new Error("Signaling is not connected");
+        }
+        await this.signalingClient.requestKeyframe(payload);
+      },
+    });
+    return this.nativeStreamerManager;
+  }
+
+  private isNativeStreamerSelected(): boolean {
+    return this.deps.settingsManager?.get("streamClientMode") === "native";
+  }
+
+  private routeSignalingEvent(event: MainToRendererSignalingEvent): void {
+    if (event.type === "disconnected") {
+      void this.nativeStreamerManager?.stop(
+        `signaling disconnected: ${event.reason}`,
+      );
+      this.nativeStreamerContext = null;
+      this.nativeStreamerFallbackSessionId = null;
+      this.emitToRenderer(event);
+      return;
+    }
+
+    const context = this.nativeStreamerContext;
+    const nativeFallbackActive =
+      context !== null &&
+      this.nativeStreamerFallbackSessionId === context.session.sessionId;
+
+    if (!this.isNativeStreamerSelected() || !context || nativeFallbackActive) {
+      this.emitToRenderer(event);
+      return;
+    }
+
+    if (event.type === "offer") {
+      void this.handleNativeStreamerOffer(event.sdp, context);
+      return;
+    }
+
+    if (event.type === "remote-ice") {
+      void this.getNativeStreamerManager()
+        .addRemoteIce(event.candidate, context)
+        .catch((error) => {
+          this.emitToRenderer({
+            type: "error",
+            message: `Native streamer ICE failed: ${String(error)}`,
+          });
+        });
+      return;
+    }
+
+    this.emitToRenderer(event);
+  }
+
+  private async handleNativeStreamerOffer(
+    sdp: string,
+    context: NativeStreamerSessionContext,
+  ): Promise<void> {
+    try {
+      await this.getNativeStreamerManager().handleOffer(sdp, context);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn("[NativeStreamer] Falling back to web streamer:", message);
+      this.nativeStreamerFallbackSessionId = context.session.sessionId;
+      const queuedRemoteIce =
+        this.nativeStreamerManager?.drainQueuedRemoteIce(
+          context.session.sessionId,
+        ) ?? [];
+      await this.nativeStreamerManager
+        ?.stop("native streamer fallback")
+        .catch(() => undefined);
+      this.emitToRenderer({
+        type: "error",
+        message: `Native streamer failed: ${message}. Falling back to web streamer.`,
+      });
+      this.emitToRenderer({ type: "offer", sdp });
+      for (const candidate of queuedRemoteIce) {
+        this.emitToRenderer({ type: "remote-ice", candidate });
+      }
+    }
+  }
+
+  private async resetNativeStreamerForSignalingReconnect(): Promise<void> {
+    if (!this.nativeStreamerManager) {
+      return;
+    }
+
+    if (
+      !this.isNativeStreamerSelected() ||
+      !this.nativeStreamerContext ||
+      this.nativeStreamerManager.hasActiveSession()
+    ) {
+      await this.nativeStreamerManager.stop("signaling reconnect");
+    }
+  }
+
+  private async prepareNativeStreamerBeforeSignaling(): Promise<void> {
+    const context = this.nativeStreamerContext;
+    if (!this.isNativeStreamerSelected() || !context) {
+      return;
+    }
+
+    try {
+      this.emitToRenderer({
+        type: "log",
+        message: "Preparing native streamer before signaling attach.",
+      });
+      await this.getNativeStreamerManager().prepareForSession(context);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        "[NativeStreamer] Pre-attach startup failed; falling back to web streamer:",
+        message,
+      );
+      this.nativeStreamerFallbackSessionId = context.session.sessionId;
+      await this.nativeStreamerManager
+        ?.stop("native streamer pre-attach fallback")
+        .catch(() => undefined);
+      this.emitToRenderer({
+        type: "error",
+        message: `Native streamer failed before signaling attach: ${message}. Falling back to web streamer.`,
+      });
+    }
+  }
+}
+
+export function registerSignalingIpcHandlers(
+  deps: SignalingCoordinatorDeps,
+): SignalingCoordinator {
+  const coordinator = new SignalingCoordinator(deps);
+  coordinator.registerIpcHandlers();
+  return coordinator;
+}
+
+export function normalizeMaxBitrateMbps(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return Math.min(150, Math.max(5, Math.round(value)));
+}


### PR DESCRIPTION
This PR extracts the remaining large session and signaling IPC logic from `opennow-stable/src/main/index.ts` into focused modules with dependency injection.

- Add `opennow-stable/src/main/ipc/accountCatalogHandlers.ts` for auth, providers, regions, subscriptions, games, and catalog IPC registration.
- Add `opennow-stable/src/main/ipc/sessionHandlers.ts` for session create/poll/stop/claim/ad/conflict orchestration, preserving preflight claim, launching-session handoff, force-new stopping, and Discord activity integration.
- Add `opennow-stable/src/main/session/sessionConflict.ts` for conflict dialog helpers and session error serialization.
- Add `opennow-stable/src/main/session/sessionSelection.ts` for active-session ready/launching selection.
- Add `opennow-stable/src/main/session/sessionLifecycle.ts` for stop-active-sessions-before-create logic.
- Add `opennow-stable/src/main/signaling/signalingCoordinator.ts` owning signaling client, native-streamer manager, context/key state, renderer emission, ICE fallback, status/capability queries, and settings change reactions.
- Add `opennow-stable/src/main/nativeStreamer/input.ts` for native input packet normalization.
- Add `opennow-stable/src/main/nativeStreamer/surface.ts` for native render surface normalization.
- Update `opennow-stable/src/main/index.ts` to register handlers via the new modules and delegate shutdown/cleanup.

All IPC channel names, payload shapes, algorithmic behavior, and Discord Rich Presence integration remain unchanged.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/8236c14a-1c8e-46c8-a03a-6dc077bec8e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-104" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/8236c14a-1c8e-46c8-a03a-6dc077bec8e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-104&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-104"><img alt="OPE-104" src="https://capy.ai/api/badge/thread.svg?label=OPE-104"></picture></a>
<!-- capy-pr-badge:end -->