### PR TITLE
auth: hide ended au provider from login list

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -19,47 +19,88 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  select-builds:
+    name: select-builds
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Select build matrix
+        id: matrix
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const builds = [
+            {
+              label: "windows-x64",
+              os: "blacksmith-4vcpu-windows-2025",
+              builder_args: "--win nsis portable --x64",
+              artifact_paths: "opennow-stable/dist-release/*-x64.exe\n",
+            },
+            {
+              label: "windows-arm64",
+              os: "blacksmith-4vcpu-windows-2025",
+              builder_args: "--win nsis portable --arm64",
+              artifact_paths: "opennow-stable/dist-release/*-arm64.exe\n",
+            },
+            {
+              label: "macos-x64",
+              os: "blacksmith-6vcpu-macos-latest",
+              builder_args: "--mac dmg zip --x64",
+              artifact_paths:
+                "opennow-stable/dist-release/*.dmg\n" +
+                "opennow-stable/dist-release/*-x64.zip\n",
+            },
+            {
+              label: "macos-arm64",
+              os: "blacksmith-6vcpu-macos-latest",
+              builder_args: "--mac dmg zip --arm64",
+              artifact_paths:
+                "opennow-stable/dist-release/*.dmg\n" +
+                "opennow-stable/dist-release/*-arm64.zip\n",
+            },
+            {
+              label: "linux-x64",
+              os: "blacksmith-4vcpu-ubuntu-2404",
+              builder_args: "--linux AppImage deb --x64",
+              artifact_paths:
+                "opennow-stable/dist-release/*-x86_64.AppImage\n" +
+                "opennow-stable/dist-release/*-amd64.deb\n",
+            },
+            {
+              label: "linux-arm64",
+              os: "blacksmith-4vcpu-ubuntu-2404-arm",
+              builder_args: "--linux AppImage deb --arm64",
+              artifact_paths:
+                "opennow-stable/dist-release/*-arm64.AppImage\n" +
+                "opennow-stable/dist-release/*-arm64.deb\n",
+            },
+          ];
+
+          const isPr = process.env.GITHUB_EVENT_NAME === "pull_request";
+          const include = isPr
+            ? builds.filter(
+                ({ label }) => label.startsWith("windows-") || label.startsWith("linux-"),
+              )
+            : builds;
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify({ include })}\n`);
+          NODE
+
   build:
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
+    needs: select-builds
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - label: windows-x64
-            os: blacksmith-4vcpu-windows-2025
-            builder_args: "--win nsis portable --x64"
-            artifact_paths: |
-              opennow-stable/dist-release/*-x64.exe
-          - label: windows-arm64
-            os: blacksmith-4vcpu-windows-2025
-            builder_args: "--win nsis portable --arm64"
-            artifact_paths: |
-              opennow-stable/dist-release/*-arm64.exe
-          - label: macos-x64
-            os: blacksmith-6vcpu-macos-latest
-            builder_args: "--mac dmg zip --x64"
-            artifact_paths: |
-              opennow-stable/dist-release/*.dmg
-              opennow-stable/dist-release/*-x64.zip
-          - label: macos-arm64
-            os: blacksmith-6vcpu-macos-latest
-            builder_args: "--mac dmg zip --arm64"
-            artifact_paths: |
-              opennow-stable/dist-release/*.dmg
-              opennow-stable/dist-release/*-arm64.zip
-          - label: linux-x64
-            os: blacksmith-4vcpu-ubuntu-2404
-            builder_args: "--linux AppImage deb --x64"
-            artifact_paths: |
-              opennow-stable/dist-release/*-x86_64.AppImage
-              opennow-stable/dist-release/*-amd64.deb
-          - label: linux-arm64
-            os: blacksmith-4vcpu-ubuntu-2404-arm
-            builder_args: "--linux AppImage deb --arm64"
-            artifact_paths: |
-              opennow-stable/dist-release/*-arm64.AppImage
-              opennow-stable/dist-release/*-arm64.deb
+      matrix: ${{ fromJSON(needs.select-builds.outputs.matrix) }}
 
     defaults:
       run:

--- a/opennow-stable/src/main/gfn/auth.ts
+++ b/opennow-stable/src/main/gfn/auth.ts
@@ -25,6 +25,8 @@ const TOKEN_ENDPOINT = "https://login.nvidia.com/token";
 const CLIENT_TOKEN_ENDPOINT = "https://login.nvidia.com/client_token";
 const USERINFO_ENDPOINT = "https://login.nvidia.com/userinfo";
 const AUTH_ENDPOINT = "https://login.nvidia.com/authorize";
+const PROVIDER_DISCOVERY_REDIRECT_URI = "https://play.geforcenow.com/redirect/starfleet-oauth-redirect.html";
+const PROVIDER_DISCOVERY_CLIENT_ID = "W1Z7DwzG1dcpXFxv0pmeatjnf0uK3ICySganqdMx2nU";
 
 const CLIENT_ID = "ZU7sPN-miLujMD95LfOQ453IB0AtjM8sMyvgJ9wCXEQ";
 const SCOPES = "openid consent email tk_client age";
@@ -179,6 +181,54 @@ function buildAuthUrl(provider: LoginProvider, challenge: string, port: number):
     idp_id: provider.idpId,
   });
   return `${AUTH_ENDPOINT}?${params.toString()}`;
+}
+
+function parseIdpIdsFromLocation(location: string): Set<string> {
+  const parsed = new URL(location);
+  const values = parsed.searchParams.getAll("idp_ids");
+  const ids = new Set<string>();
+  for (const value of values) {
+    for (const token of value.split(/[\s,]+/)) {
+      const id = token.trim();
+      if (id.length > 0) {
+        ids.add(id);
+      }
+    }
+  }
+  return ids;
+}
+
+async function fetchAvailableProviderIdpIds(): Promise<Set<string> | null> {
+  const params = new URLSearchParams({
+    response_type: "code",
+    device_id: crypto.randomUUID(),
+    scope: SCOPES,
+    client_id: PROVIDER_DISCOVERY_CLIENT_ID,
+    redirect_uri: PROVIDER_DISCOVERY_REDIRECT_URI,
+    nonce: crypto.randomUUID(),
+    prompt: "select_account",
+  });
+
+  try {
+    const response = await fetch(`${AUTH_ENDPOINT}?${params.toString()}`, {
+      method: "GET",
+      redirect: "manual",
+      headers: {
+        "User-Agent": GFN_USER_AGENT,
+      },
+    });
+
+    const location = response.headers.get("location");
+    if (!location) {
+      return null;
+    }
+
+    const ids = parseIdpIdsFromLocation(location);
+    return ids.size > 0 ? ids : null;
+  } catch (error) {
+    console.warn("Failed to discover provider idp_ids from authorize redirect:", error);
+    return null;
+  }
 }
 
 async function isPortAvailable(port: number): Promise<boolean> {
@@ -561,6 +611,8 @@ export class AuthService {
       const payload = (await response.json()) as ServiceUrlsResponse;
       const endpoints = payload.gfnServiceInfo?.gfnServiceEndpoints ?? [];
 
+      const availableIdpIds = await fetchAvailableProviderIdpIds();
+
       const providers = endpoints
         .map<LoginProvider>((entry) => ({
           idpId: entry.idpId,
@@ -570,6 +622,7 @@ export class AuthService {
           streamingServiceUrl: entry.streamingServiceUrl,
           priority: entry.loginProviderPriority ?? 0,
         }))
+        .filter((provider) => !availableIdpIds || availableIdpIds.has(provider.idpId))
         .sort((a, b) => a.priority - b.priority)
         .map(normalizeProvider);
 


### PR DESCRIPTION
## Summary
- discover available provider idp_ids from the NVIDIA authorize redirect
- filter provider list to only show providers present in idp_ids
- effectively hide ended providers such as au (KDD) when not returned by idp_ids

## Validation
- npm --prefix opennow-stable run typecheck
<img width="482" height="637" alt="image" src="https://github.com/user-attachments/assets/0f5dfb86-eacf-49f2-8c2d-89b0fb9eec17" />
<img width="1030" height="944" alt="image" src="https://github.com/user-attachments/assets/6b71727e-84d4-4fce-8b1a-96e078d68f74" />
<img width="1027" height="933" alt="image" src="https://github.com/user-attachments/assets/6fb9987a-dff3-49cc-882b-e34ff230f596" />
(Google Translated)