### PR TITLE
Gate native streamer to Windows-only availability

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -923,14 +923,15 @@ function registerIpcHandlers(): void {
       value: Settings[K],
     ) => {
       settingsManager.set(key, value);
+      const appliedValue = settingsManager.get(key);
       // React to certain setting changes immediately in main process
       try {
         if (key === "autoCheckForUpdates") {
-          appUpdater?.setAutomaticChecksEnabled(value as boolean);
+          appUpdater?.setAutomaticChecksEnabled(appliedValue as boolean);
         }
-        signalingCoordinator?.applySettingsChange(key, value);
+        signalingCoordinator?.applySettingsChange(key, appliedValue);
         if (key === "discordRichPresence") {
-          if (value) {
+          if (appliedValue) {
             void connectDiscordRpc().then(() => discordMonitor.start());
           } else {
             discordMonitor.stop();

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -16,6 +16,9 @@ import { dirname, resolve, join, delimiter, sep } from "node:path";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 
 import {
+  createUnsupportedNativeStreamerStatus,
+  isNativeStreamerSupportedPlatform,
+  NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
   nativeStreamerFeatureModeToEnvValue,
   type IceCandidatePayload,
   type KeyframeRequest,
@@ -588,6 +591,10 @@ export class NativeStreamerManager {
   }
 
   async probeStatus(): Promise<NativeStreamerStatus> {
+    if (!isNativeStreamerSupportedPlatform(process.platform)) {
+      return createUnsupportedNativeStreamerStatus();
+    }
+
     try {
       await this.ensureProcess();
       const backend = this.capabilities?.backend;
@@ -768,6 +775,10 @@ export class NativeStreamerManager {
   }
 
   private async ensureProcess(): Promise<void> {
+    if (!isNativeStreamerSupportedPlatform(process.platform)) {
+      throw new Error(NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE);
+    }
+
     if (this.child && this.capabilities) {
       return;
     }

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -17,7 +17,12 @@ import type {
   ControllerThemeRgb,
   ControllerThemeStyle,
 } from "@shared/gfn";
-import { DEFAULT_KEYBOARD_LAYOUT, getDefaultStreamPreferences, normalizeStreamPreferences } from "@shared/gfn";
+import {
+  DEFAULT_KEYBOARD_LAYOUT,
+  getDefaultStreamPreferences,
+  normalizeStreamClientModeForPlatform,
+  normalizeStreamPreferences,
+} from "@shared/gfn";
 
 export interface Settings {
   /** Video resolution (e.g., "1920x1080") */
@@ -308,6 +313,12 @@ export class SettingsManager {
       );
       settings.codec = normalized.codec;
       settings.colorQuality = normalized.colorQuality;
+      migrated = true;
+    }
+
+    const streamClientMode = normalizeStreamClientModeForPlatform(settings.streamClientMode, process.platform);
+    if (settings.streamClientMode !== streamClientMode) {
+      settings.streamClientMode = streamClientMode;
       migrated = true;
     }
 

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -22,6 +22,9 @@ import type {
     NativeVideoBackendPreference,
   } from "@shared/gfn";
 import {
+  createUnsupportedNativeStreamerStatus,
+  isNativeStreamerSupportedPlatform,
+  NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
   colorQualityRequiresHevc,
   keyboardLayoutOptions,
   USER_FACING_COLOR_QUALITY_OPTIONS,
@@ -303,6 +306,7 @@ const STATIC_FPS_PRESETS: FpsPreset[] = [
 ];
 
 const isMac = navigator.platform.toLowerCase().includes("mac");
+const isWindows = isNativeStreamerSupportedPlatform(`${navigator.platform} ${navigator.userAgent}`);
 const shortcutExamples = "Examples: F3, Ctrl+Shift+Q, Ctrl+Shift+K";
 const shortcutDefaults = {
   shortcutToggleStats: "F3",
@@ -744,6 +748,12 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   }, []);
 
   const refreshNativeStreamerStatus = useCallback(async () => {
+    if (!isWindows) {
+      setNativeStreamerStatus(createUnsupportedNativeStreamerStatus());
+      setNativeStreamerStatusLoading(false);
+      return;
+    }
+
     setNativeStreamerStatusLoading(true);
     try {
       setNativeStreamerStatus(await window.openNow.getNativeStreamerStatus());
@@ -2144,177 +2154,195 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
               <h2>Native Streamer</h2>
             </div>
             <div className="settings-rows">
-              <div className="settings-row settings-row--column">
-                <div className="settings-row-top settings-row-top--compact">
-                  <label className="settings-label settings-label--wrap">
-                    <span className="settings-label-title">
-                      Native Streaming
-                      <span className="settings-inline-badge settings-inline-badge--beta">Experimental</span>
-                    </span>
-                  </label>
-                  <label className="settings-toggle">
-                    <input
-                      type="checkbox"
-                      checked={settings.streamClientMode === "native"}
-                      onChange={(e) => handleChange("streamClientMode", e.target.checked ? "native" : "web")}
-                    />
-                    <span className="settings-toggle-track" />
-                  </label>
-                </div>
-                <span className="settings-subtle-hint">
-                  Native streaming is experimental and may have platform-specific bugs, glitches, or fallbacks to Chromium/WebRTC. Enable it only if you are comfortable testing the GStreamer-based desktop streamer for new sessions.
-                </span>
-                <div className="settings-chip-row">
-                  <a className="settings-chip" href="https://github.com/OpenCloudGaming/OpenNOW/issues" target="_blank" rel="noreferrer">
-                    <span>Report on GitHub Issues</span>
-                    <ExternalLink size={13} />
-                  </a>
-                  <a className="settings-chip" href="https://discord.gg/8EJYaJcNfD" target="_blank" rel="noreferrer">
-                    <span>Report on Discord</span>
-                    <ExternalLink size={13} />
-                  </a>
-                </div>
-              </div>
-
-              <div className="settings-row settings-row--column">
-                <div className="settings-row-top settings-row-top--compact">
-                  <label className="settings-label settings-label--wrap">
-                    <span className="settings-label-title">Streamer Status</span>
-                  </label>
-                  <button
-                    type="button"
-                    className="settings-icon-button"
-                    onClick={() => void refreshNativeStreamerStatus()}
-                    disabled={nativeStreamerStatusLoading}
-                    title="Check native streamer"
-                    aria-label="Check native streamer"
-                  >
-                    {nativeStreamerStatusLoading ? <Loader size={15} className="spin" /> : <RefreshCcw size={15} />}
-                  </button>
-                </div>
-                <div className="settings-chip-row">
-                  <span
-                    className={`settings-inline-badge ${
-                      nativeStreamerStatusLoading
-                        ? "settings-inline-badge--codec-testing"
-                        : nativeStreamerStatus?.gstreamerAvailable
-                          ? "settings-inline-badge--codec-gpu"
-                          : "settings-inline-badge--updater-error"
-                    }`}
-                  >
-                    {nativeStreamerStatusLoading
-                      ? "Checking"
-                      : nativeStreamerStatus?.gstreamerAvailable
-                        ? "GStreamer Ready"
-                        : "Not Ready"}
-                  </span>
-                </div>
-                <span className="settings-subtle-hint">
-                  {nativeStreamerStatus?.message ?? "OpenNOW will check the bundled GStreamer streamer when this tab opens."}
-                </span>
-              </div>
-
-              <div className="settings-row settings-row--column">
-                <label className="settings-label">GStreamer Runtime</label>
-                <div className="settings-chip-row">
-                  <span className={`settings-inline-badge ${getGstreamerRuntimeBadgeClass(nativeStreamerStatus)}`}>
-                    {formatGstreamerRuntimeLabel(nativeStreamerStatus)}
-                  </span>
-                  {nativeStreamerStatus?.gstreamerRuntime.path ? (
-                    <span className="settings-inline-badge settings-inline-badge--codec">
-                      Bundled path detected
-                    </span>
-                  ) : null}
-                </div>
-                <span className="settings-subtle-hint">
-                  {nativeStreamerStatus?.gstreamerRuntime.message ?? "Packaged Windows/macOS builds auto-detect a bundled runtime next to the native streamer. Linux uses distro packages."}
-                </span>
-                {!nativeStreamerStatus?.gstreamerAvailable && nativeStreamerStatus?.gstreamerRuntime.installInstructions?.length ? (
-                  <div className="settings-install-steps">
-                    <span className="settings-subtle-hint">
-                      Linux AppImage/private GStreamer bundling is intentionally not used by default because VAAPI/V4L2/Vulkan plugins must match the host distro and GPU driver stack. .deb packages declare Debian/Ubuntu dependencies automatically.
-                    </span>
-                    {nativeStreamerStatus.gstreamerRuntime.installInstructions.map((instruction) => (
-                      <div key={instruction.distro} className="settings-install-step">
-                        <span className="settings-install-step-title">{instruction.distro}</span>
-                        <code>{instruction.command}</code>
-                        {instruction.note ? <span className="settings-subtle-hint">{instruction.note}</span> : null}
-                      </div>
-                    ))}
+              {!isWindows ? (
+                <div className="settings-row settings-row--column">
+                  <div className="settings-row-top settings-row-top--compact">
+                    <label className="settings-label settings-label--wrap">
+                      <span className="settings-label-title">
+                        Native Streaming
+                        <span className="settings-inline-badge settings-inline-badge--beta">Experimental</span>
+                      </span>
+                    </label>
                   </div>
-                ) : null}
-              </div>
-
-              <div className="settings-row settings-row--column">
-                <label className="settings-label">Video Path</label>
-                <div className="settings-chip-row">
-                  <span
-                    className={`settings-inline-badge ${
-                      nativeStreamerStatus?.activeVideoBackend?.available
-                        ? nativeStreamerStatus.activeVideoBackend.backend === "software"
-                          ? "settings-inline-badge--codec-testing"
-                          : "settings-inline-badge--codec-gpu"
-                        : "settings-inline-badge--updater-error"
-                    }`}
-                  >
-                    {formatNativeVideoBackendName(nativeStreamerStatus?.activeVideoBackend?.backend)}
+                  <span className="settings-input-hint">
+                    {NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE}
                   </span>
-                  {getAvailableNativeCodecLabels(nativeStreamerStatus?.activeVideoBackend).map((codec) => (
-                    <span key={codec} className="settings-inline-badge settings-inline-badge--codec">
-                      {codec}
+                </div>
+              ) : (
+                <>
+                  <div className="settings-row settings-row--column">
+                    <div className="settings-row-top settings-row-top--compact">
+                      <label className="settings-label settings-label--wrap">
+                        <span className="settings-label-title">
+                          Native Streaming
+                          <span className="settings-inline-badge settings-inline-badge--beta">Experimental</span>
+                        </span>
+                      </label>
+                      <label className="settings-toggle">
+                        <input
+                          type="checkbox"
+                          checked={settings.streamClientMode === "native"}
+                          onChange={(e) => handleChange("streamClientMode", e.target.checked ? "native" : "web")}
+                        />
+                        <span className="settings-toggle-track" />
+                      </label>
+                    </div>
+                    <span className="settings-subtle-hint">
+                      Native streaming is experimental and may have platform-specific bugs, glitches, or fallbacks to Chromium/WebRTC. Enable it only if you are comfortable testing the GStreamer-based desktop streamer for new sessions.
                     </span>
-                  ))}
-                </div>
-                <span className="settings-subtle-hint">
-                  {nativeStreamerStatus?.gstreamerAvailable
-                    ? `${nativeStreamerStatus.codecSummary ?? "Codec support unknown"}. ${nativeStreamerStatus.zeroCopySummary ?? "Memory path unknown"}.`
-                    : nativeStreamerStatus?.activeVideoBackend?.reason
-                      ?? "OpenNOW will show the active hardware decode path after GStreamer is detected."}
-                </span>
-              </div>
+                    <div className="settings-chip-row">
+                      <a className="settings-chip" href="https://github.com/OpenCloudGaming/OpenNOW/issues" target="_blank" rel="noreferrer">
+                        <span>Report on GitHub Issues</span>
+                        <ExternalLink size={13} />
+                      </a>
+                      <a className="settings-chip" href="https://discord.gg/8EJYaJcNfD" target="_blank" rel="noreferrer">
+                        <span>Report on Discord</span>
+                        <ExternalLink size={13} />
+                      </a>
+                    </div>
+                  </div>
 
-              <div className="settings-row settings-row--column">
-                <label className="settings-label">DirectX Backend</label>
-                <div className="settings-chip-row">
-                  {nativeVideoBackendOptions.map((option) => (
-                    <button
-                      key={option.value}
-                      type="button"
-                      className={`settings-chip ${settings.nativeVideoBackend === option.value ? "active" : ""}`}
-                      onClick={() => handleChange("nativeVideoBackend", option.value)}
-                      title={option.description}
-                    >
-                      <span>{option.label}</span>
-                    </button>
-                  ))}
-                </div>
-                <span className="settings-subtle-hint">
-                  Applies to the next native streamer process. Auto uses the fastest default path; choose DirectX 11 or DirectX 12 to force a specific Windows renderer.
-                </span>
-              </div>
+                  <div className="settings-row settings-row--column">
+                    <div className="settings-row-top settings-row-top--compact">
+                      <label className="settings-label settings-label--wrap">
+                        <span className="settings-label-title">Streamer Status</span>
+                      </label>
+                      <button
+                        type="button"
+                        className="settings-icon-button"
+                        onClick={() => void refreshNativeStreamerStatus()}
+                        disabled={nativeStreamerStatusLoading}
+                        title="Check native streamer"
+                        aria-label="Check native streamer"
+                      >
+                        {nativeStreamerStatusLoading ? <Loader size={15} className="spin" /> : <RefreshCcw size={15} />}
+                      </button>
+                    </div>
+                    <div className="settings-chip-row">
+                      <span
+                        className={`settings-inline-badge ${
+                          nativeStreamerStatusLoading
+                            ? "settings-inline-badge--codec-testing"
+                            : nativeStreamerStatus?.gstreamerAvailable
+                              ? "settings-inline-badge--codec-gpu"
+                              : "settings-inline-badge--updater-error"
+                        }`}
+                      >
+                        {nativeStreamerStatusLoading
+                          ? "Checking"
+                          : nativeStreamerStatus?.gstreamerAvailable
+                            ? "GStreamer Ready"
+                            : "Not Ready"}
+                      </span>
+                    </div>
+                    <span className="settings-subtle-hint">
+                      {nativeStreamerStatus?.message ?? "OpenNOW will check the bundled GStreamer streamer when this tab opens."}
+                    </span>
+                  </div>
 
-              <div className="settings-row settings-row--column">
-                <label className="settings-label">Frame Pacing</label>
-                <div className="settings-chip-row">
-                  <button
-                    type="button"
-                    className={`settings-chip ${!settings.enableCloudGsync ? "active" : ""}`}
-                    onClick={() => setNativeFramePacing("low-latency")}
-                  >
-                    <span>Lowest Latency</span>
-                  </button>
-                  <button
-                    type="button"
-                    className={`settings-chip ${settings.enableCloudGsync ? "active" : ""}`}
-                    onClick={() => setNativeFramePacing("smooth")}
-                  >
-                    <span>Smooth G-Sync</span>
-                  </button>
-                </div>
-                <span className="settings-subtle-hint">
-                  Lowest Latency avoids G-Sync pacing and is best for mouse feel. Smooth G-Sync can reduce tearing, but may cap rendering to the monitor refresh rate.
-                </span>
-              </div>
+                  <div className="settings-row settings-row--column">
+                    <label className="settings-label">GStreamer Runtime</label>
+                    <div className="settings-chip-row">
+                      <span className={`settings-inline-badge ${getGstreamerRuntimeBadgeClass(nativeStreamerStatus)}`}>
+                        {formatGstreamerRuntimeLabel(nativeStreamerStatus)}
+                      </span>
+                      {nativeStreamerStatus?.gstreamerRuntime.path ? (
+                        <span className="settings-inline-badge settings-inline-badge--codec">
+                          Bundled path detected
+                        </span>
+                      ) : null}
+                    </div>
+                    <span className="settings-subtle-hint">
+                      {nativeStreamerStatus?.gstreamerRuntime.message ?? "Packaged Windows/macOS builds auto-detect a bundled runtime next to the native streamer. Linux uses distro packages."}
+                    </span>
+                    {!nativeStreamerStatus?.gstreamerAvailable && nativeStreamerStatus?.gstreamerRuntime.installInstructions?.length ? (
+                      <div className="settings-install-steps">
+                        <span className="settings-subtle-hint">
+                          Linux AppImage/private GStreamer bundling is intentionally not used by default because VAAPI/V4L2/Vulkan plugins must match the host distro and GPU driver stack. .deb packages declare Debian/Ubuntu dependencies automatically.
+                        </span>
+                        {nativeStreamerStatus.gstreamerRuntime.installInstructions.map((instruction) => (
+                          <div key={instruction.distro} className="settings-install-step">
+                            <span className="settings-install-step-title">{instruction.distro}</span>
+                            <code>{instruction.command}</code>
+                            {instruction.note ? <span className="settings-subtle-hint">{instruction.note}</span> : null}
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className="settings-row settings-row--column">
+                    <label className="settings-label">Video Path</label>
+                    <div className="settings-chip-row">
+                      <span
+                        className={`settings-inline-badge ${
+                          nativeStreamerStatus?.activeVideoBackend?.available
+                            ? nativeStreamerStatus.activeVideoBackend.backend === "software"
+                              ? "settings-inline-badge--codec-testing"
+                              : "settings-inline-badge--codec-gpu"
+                            : "settings-inline-badge--updater-error"
+                        }`}
+                      >
+                        {formatNativeVideoBackendName(nativeStreamerStatus?.activeVideoBackend?.backend)}
+                      </span>
+                      {getAvailableNativeCodecLabels(nativeStreamerStatus?.activeVideoBackend).map((codec) => (
+                        <span key={codec} className="settings-inline-badge settings-inline-badge--codec">
+                          {codec}
+                        </span>
+                      ))}
+                    </div>
+                    <span className="settings-subtle-hint">
+                      {nativeStreamerStatus?.gstreamerAvailable
+                        ? `${nativeStreamerStatus.codecSummary ?? "Codec support unknown"}. ${nativeStreamerStatus.zeroCopySummary ?? "Memory path unknown"}.`
+                        : nativeStreamerStatus?.activeVideoBackend?.reason
+                          ?? "OpenNOW will show the active hardware decode path after GStreamer is detected."}
+                    </span>
+                  </div>
+
+                  <div className="settings-row settings-row--column">
+                    <label className="settings-label">DirectX Backend</label>
+                    <div className="settings-chip-row">
+                      {nativeVideoBackendOptions.map((option) => (
+                        <button
+                          key={option.value}
+                          type="button"
+                          className={`settings-chip ${settings.nativeVideoBackend === option.value ? "active" : ""}`}
+                          onClick={() => handleChange("nativeVideoBackend", option.value)}
+                          title={option.description}
+                        >
+                          <span>{option.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                    <span className="settings-subtle-hint">
+                      Applies to the next native streamer process. Auto uses the fastest default path; choose DirectX 11 or DirectX 12 to force a specific Windows renderer.
+                    </span>
+                  </div>
+
+                  <div className="settings-row settings-row--column">
+                    <label className="settings-label">Frame Pacing</label>
+                    <div className="settings-chip-row">
+                      <button
+                        type="button"
+                        className={`settings-chip ${!settings.enableCloudGsync ? "active" : ""}`}
+                        onClick={() => setNativeFramePacing("low-latency")}
+                      >
+                        <span>Lowest Latency</span>
+                      </button>
+                      <button
+                        type="button"
+                        className={`settings-chip ${settings.enableCloudGsync ? "active" : ""}`}
+                        onClick={() => setNativeFramePacing("smooth")}
+                      >
+                        <span>Smooth G-Sync</span>
+                      </button>
+                    </div>
+                    <span className="settings-subtle-hint">
+                      Lowest Latency avoids G-Sync pacing and is best for mouse feel. Smooth G-Sync can reduce tearing, but may cap rendering to the monitor refresh rate.
+                    </span>
+                  </div>
+                </>
+              )}
             </div>
           </section>
         )}

--- a/opennow-stable/src/shared/gfn.test.ts
+++ b/opennow-stable/src/shared/gfn.test.ts
@@ -7,10 +7,14 @@ import type { GameInfo, GameVariant } from "./gfn";
 import {
   OWNED_LIBRARY_STATUSES,
   buildNativeStreamerSessionContext,
+  createUnsupportedNativeStreamerStatus,
   isEpicStore,
   isGameInLibrary,
+  isNativeStreamerSupportedPlatform,
   isOwnedLibraryStatus,
   isOwnedVariant,
+  NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+  normalizeStreamClientModeForPlatform,
 } from "./gfn";
 
 function makeVariant(overrides: Partial<GameVariant> = {}): GameVariant {
@@ -154,4 +158,23 @@ test("buildNativeStreamerSessionContext forwards requested/finalized streaming f
   assert.equal(context.session.negotiatedStreamProfile?.codec, "H265");
   assert.equal(context.settings.enableCloudGsync, false);
   assert.equal(context.settings.nativeTransitionDiagnostics?.forceQueueMode, "adaptive");
+});
+
+test("normalizes native stream client mode to web on non-Windows platforms", () => {
+  assert.equal(normalizeStreamClientModeForPlatform("native", "linux"), "web");
+  assert.equal(normalizeStreamClientModeForPlatform("native", "darwin"), "web");
+  assert.equal(normalizeStreamClientModeForPlatform("web", "linux"), "web");
+  assert.equal(normalizeStreamClientModeForPlatform("native", "win32"), "native");
+});
+
+test("uses the exact Windows-only unsupported native streamer status message", () => {
+  assert.equal(isNativeStreamerSupportedPlatform("win32"), true);
+  assert.equal(isNativeStreamerSupportedPlatform("linux"), false);
+
+  const status = createUnsupportedNativeStreamerStatus();
+  assert.equal(status.detected, false);
+  assert.equal(status.gstreamerAvailable, false);
+  assert.equal(status.supportsOfferAnswer, false);
+  assert.equal(status.message, NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE);
+  assert.equal(status.gstreamerRuntime.message, NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE);
 });

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -9,6 +9,17 @@ export type NativeStreamerFeatureMode = "auto" | "disabled" | "forced";
 export type NativeVideoBackendPreference = "auto" | "d3d11" | "d3d12";
 export type NativeQueueMode = "auto" | "fixed" | "adaptive" | "vrr";
 
+export const NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE = "experimental feature: Windows only. Mac and Linux support is being worked on";
+
+export function isNativeStreamerSupportedPlatform(platform: string): boolean {
+  const normalized = platform.toLowerCase();
+  return normalized === "win32" || normalized.startsWith("win") || normalized.includes("windows");
+}
+
+export function normalizeStreamClientModeForPlatform(mode: StreamClientMode, platform: string): StreamClientMode {
+  return mode === "native" && !isNativeStreamerSupportedPlatform(platform) ? "web" : mode;
+}
+
 export function nativeStreamerFeatureModeToEnvValue(mode: NativeStreamerFeatureMode): "auto" | "0" | "1" {
   switch (mode) {
     case "disabled":
@@ -182,6 +193,20 @@ export interface NativeStreamerStatus {
   zeroCopySummary?: string;
   gstreamerRuntime: NativeGstreamerRuntimeStatus;
   message: string;
+}
+
+export function createUnsupportedNativeStreamerStatus(): NativeStreamerStatus {
+  return {
+    detected: false,
+    gstreamerAvailable: false,
+    supportsOfferAnswer: false,
+    gstreamerRuntime: {
+      source: "unknown",
+      bundled: false,
+      message: NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+    },
+    message: NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+  };
 }
 
 export type NativeVideoBackendId =


### PR DESCRIPTION
This PR gates the native GStreamer streamer to Windows-only availability, normalizing `streamClientMode: "native"` back to "web" on non-Windows platforms during settings load/save/reset, and displaying the exact unsupported message in Settings while preventing process probing and native UI controls on macOS/Linux.

- Add `NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE` constant and `isNativeStreamerSupportedPlatform`/`normalizeStreamClientModeForPlatform` helpers in `src/shared/gfn.ts` with `createUnsupportedNativeStreamerStatus` factory.
- Enforce `streamClientMode: "web"` on non-Windows in `SettingsManager.enforceCompatibility` at `src/main/settings.ts` to reject persisted/IPC attempts.
- Early-return `createUnsupportedNativeStreamerStatus` in `NativeStreamerManager.probeStatus` and throw in `ensureProcess` for non-Windows at `src/main/nativeStreamer/manager.ts` to avoid spawning native processes.
- Fix `SETTINGS_SET` IPC in `src/main/index.ts` to use post-migration applied values instead of raw input for consistent main-process side effects.
- Add Windows detection and skip IPC probe on non-Windows in `SettingsPage.refreshNativeStreamerStatus`, rendering the unsupported panel/message instead of interactive controls at `src/renderer/src/components/SettingsPage.tsx`.
- Add tests for platform normalization and exact unsupported status message in `src/shared/gfn.test.ts`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/246c37cd-207a-445a-9728-6aee26c4d953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-106" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/246c37cd-207a-445a-9728-6aee26c4d953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-106&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-106"><img alt="OPE-106" src="https://capy.ai/api/badge/thread.svg?label=OPE-106"></picture></a>
<!-- capy-pr-badge:end -->