### PR TITLE
Migrate CI to Blacksmith runners

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   select-builds:
     name: select-builds
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
@@ -37,19 +37,19 @@ jobs:
           const builds = [
             {
               label: "windows-x64",
-              os: "windows-2025",
+              os: "blacksmith-2vcpu-windows-2025",
               builder_args: "--win nsis portable --x64",
               artifact_paths: "opennow-stable/dist-release/*-x64.exe\n",
             },
             {
               label: "windows-arm64",
-              os: "windows-2025",
+              os: "blacksmith-2vcpu-windows-2025",
               builder_args: "--win nsis portable --arm64",
               artifact_paths: "opennow-stable/dist-release/*-arm64.exe\n",
             },
             {
               label: "macos-x64",
-              os: "macos-15-intel",
+              os: "blacksmith-6vcpu-macos-15",
               builder_args: "--mac dmg zip --x64",
               artifact_paths:
                 "opennow-stable/dist-release/*.dmg\n" +
@@ -57,7 +57,7 @@ jobs:
             },
             {
               label: "macos-arm64",
-              os: "macos-15",
+              os: "blacksmith-6vcpu-macos-15",
               builder_args: "--mac dmg zip --arm64",
               artifact_paths:
                 "opennow-stable/dist-release/*.dmg\n" +
@@ -65,7 +65,7 @@ jobs:
             },
             {
               label: "linux-x64",
-              os: "ubuntu-24.04",
+              os: "blacksmith-2vcpu-ubuntu-2404",
               builder_args: "--linux AppImage deb --x64",
               artifact_paths:
                 "opennow-stable/dist-release/*-x86_64.AppImage\n" +
@@ -73,7 +73,7 @@ jobs:
             },
             {
               label: "linux-arm64",
-              os: "ubuntu-24.04-arm",
+              os: "blacksmith-2vcpu-ubuntu-2404-arm",
               builder_args: "--linux AppImage deb --arm64",
               artifact_paths:
                 "opennow-stable/dist-release/*-arm64.AppImage\n" +

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'blacksmith-6vcpu-macos-latest') || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   preflight:
     name: preflight
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
@@ -97,7 +97,7 @@ jobs:
 
   prepare-source:
     name: prepare-source
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: preflight
     permissions:
       contents: write
@@ -155,7 +155,7 @@ jobs:
       matrix:
         include:
           - label: windows-x64
-            os: windows-2025
+            os: blacksmith-2vcpu-windows-2025
             builder_args: "--win nsis portable --x64"
             native_build: "true"
             bundle_gstreamer: "1"
@@ -166,7 +166,7 @@ jobs:
               opennow-stable/dist-release/latest*.yml
               opennow-stable/dist-release/*.blockmap
           - label: windows-arm64
-            os: windows-2025
+            os: blacksmith-2vcpu-windows-2025
             builder_args: "--win nsis portable --arm64"
             native_build: "false"
             bundle_gstreamer: "0"
@@ -175,7 +175,7 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*-arm64.exe
           - label: macos-x64
-            os: macos-15-intel
+            os: blacksmith-6vcpu-macos-15
             builder_args: "--mac dmg zip --x64"
             native_build: "true"
             bundle_gstreamer: "1"
@@ -185,7 +185,7 @@ jobs:
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
           - label: macos-arm64
-            os: macos-15
+            os: blacksmith-6vcpu-macos-15
             builder_args: "--mac dmg zip --arm64"
             native_build: "true"
             bundle_gstreamer: "1"
@@ -195,7 +195,7 @@ jobs:
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-arm64.zip
           - label: linux-x64
-            os: ubuntu-24.04
+            os: blacksmith-2vcpu-ubuntu-2404
             builder_args: "--linux AppImage deb --x64"
             native_build: "true"
             bundle_gstreamer: "0"
@@ -206,7 +206,7 @@ jobs:
               opennow-stable/dist-release/*-amd64.deb
               opennow-stable/dist-release/latest-linux.yml
           - label: linux-arm64
-            os: ubuntu-24.04-arm
+            os: blacksmith-2vcpu-ubuntu-2404-arm
             builder_args: "--linux AppImage deb --arm64"
             native_build: "true"
             bundle_gstreamer: "0"
@@ -543,7 +543,7 @@ jobs:
 
   release:
     name: publish-release
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs:
       - preflight
       - prepare-source
@@ -571,7 +571,7 @@ jobs:
 
   finalize:
     name: finalize-version-bump
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs:
       - preflight
       - release


### PR DESCRIPTION
## Summary
This PR migrates all GitHub Actions workflows to sponsored Blacksmith runners across Linux, Windows, and macOS platforms. Updated `runs-on` labels in `auto-build.yml`, `codeql.yml`, and `release.yml` to use `blacksmith-*` variants, replacing `ubuntu-24.04`, `windows-2025`, `macos-15`, and `ubuntu-latest` with their corresponding Blacksmith runner tags.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/ea424711-ea8c-431e-8662-aef8a5da4b49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-116" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/ea424711-ea8c-431e-8662-aef8a5da4b49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-116&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-116"><img alt="OPE-116" src="https://capy.ai/api/badge/thread.svg?label=OPE-116"></picture></a>
<!-- capy-pr-badge:end -->