### PR TITLE
Fix npm audit vulnerabilities via lockfile updates

### DIFF
--- a/opennow-stable/package-lock.json
+++ b/opennow-stable/package-lock.json
@@ -5138,9 +5138,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6183,9 +6183,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -7825,9 +7825,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "peer": true,


### PR DESCRIPTION
## Summary
This PR updates dependency lockfiles across both repositories to address security advisories and outdated transitive dependencies, reducing vulnerability counts without breaking changes.

## Changes

### OpenNOW (`opennow-stable/package-lock.json`)
- `vite` 7.3.1 → 7.3.3 (fixes high-severity dev server vulnerabilities)
- `postcss` 8.5.8 → 8.5.14 (fixes moderate XSS advisory)
- `ip-address` 10.1.0 → 10.2.0 (fixes moderate XSS advisory)
- **Result**: 0 vulnerabilities (down from 1 high + 2 moderate)

### OpenNOW-Site (`package-lock.json`)
- `vite` 6.4.1 → 6.4.2
- `rollup` 4.55.2 → 4.60.4 (fixes high path-traversal advisory)
- `h3` 1.15.5 → 1.15.11 (fixes high SSE injection and path-traversal advisories)
- `postcss` 8.5.6 → 8.5.14
- `picomatch` 4.0.3 → 4.0.4 (fixes high ReDoS advisory)
- `svgo` 4.0.0 → 4.0.1 (fixes high DoS advisory)
- `smol-toml` 1.6.0 → 1.6.1
- `devalue` 5.6.2 → 5.8.1
- `defu` 6.1.4 → 6.1.7 (fixes high prototype pollution advisory)
- `@astrojs/starlight` 0.37.3 → 0.37.7
- `astro` 5.16.11 → 5.18.1
- **Result**: 3 vulnerabilities (2 low + 1 moderate, down from 6 high + 4 moderate + 2 low)

Remaining advisories require the Astro 5 → 6 / Starlight 0.37 → 0.39 major upgrade and are deferred to a separate PR.

### Rust Native Dependencies
No action required—OSV audit found 0 advisories across `Cargo.lock`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/58eceb8e-5b86-4639-9f73-dc359628d196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-125" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/58eceb8e-5b86-4639-9f73-dc359628d196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-125&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-125"><img alt="OPE-125" src="https://capy.ai/api/badge/thread.svg?label=OPE-125"></picture></a>
<!-- capy-pr-badge:end -->