### PR TITLE
Add native shortcuts and debug no-login mode

### DIFF
--- a/native/opennow-streamer/src/backend.rs
+++ b/native/opennow-streamer/src/backend.rs
@@ -492,7 +492,7 @@ fn preferred_hevc_profile_id(color_quality: ColorQuality) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{ColorQuality, SessionInfo, StreamSettings};
+    use crate::protocol::{ColorQuality, NativeStreamerShortcutBindings, SessionInfo, StreamSettings};
 
     fn context(resolution: &str) -> NativeStreamerSessionContext {
         NativeStreamerSessionContext {
@@ -516,6 +516,7 @@ mod tests {
                 enable_cloud_gsync: false,
                 native_transition_diagnostics: None,
             },
+            shortcuts: NativeStreamerShortcutBindings::default(),
         }
     }
 

--- a/native/opennow-streamer/src/backend.rs
+++ b/native/opennow-streamer/src/backend.rs
@@ -20,6 +20,7 @@ pub trait NativeStreamerBackend {
     fn send_input(&mut self, command: CommandEnvelope) -> BackendReply;
     fn update_render_surface(&mut self, command: CommandEnvelope) -> BackendReply;
     fn update_bitrate_limit(&mut self, command: CommandEnvelope) -> BackendReply;
+    fn update_shortcuts(&mut self, command: CommandEnvelope) -> BackendReply;
     fn stop(&mut self, command: CommandEnvelope) -> BackendReply;
 }
 
@@ -458,6 +459,11 @@ impl NativeStreamerBackend for StubBackend {
             response: Some(Response::Ok { id: command.id }),
             should_continue: true,
         }
+    }
+
+    fn update_shortcuts(&mut self, command: CommandEnvelope) -> BackendReply {
+        // Stub backend has no native window; accept the command without applying it.
+        BackendReply::response(Response::Ok { id: command.id })
     }
 
     fn stop(&mut self, command: CommandEnvelope) -> BackendReply {

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -376,6 +376,17 @@ impl NativeStreamerBackend for GstreamerBackend {
         }
     }
 
+    fn update_shortcuts(&mut self, command: CommandEnvelope) -> BackendReply {
+        let Some(shortcuts) = command.shortcuts else {
+            return BackendReply::response(missing_field(&command.id, "shortcuts"));
+        };
+        set_native_shortcut_bindings(&shortcuts);
+        if let Some(context) = self.active_context.as_mut() {
+            context.shortcuts = shortcuts;
+        }
+        BackendReply::response(Response::Ok { id: command.id })
+    }
+
     fn stop(&mut self, command: CommandEnvelope) -> BackendReply {
         self.active_context = None;
         self.pending_remote_ice.clear();

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -6,6 +6,7 @@ use crate::gstreamer_config::{
     resolve_d3d_fullscreen_sink, resolve_present_max_fps, NATIVE_D3D_FULLSCREEN_ENV,
     NATIVE_PRESENT_MAX_FPS_ENV, PRESENT_LIMITER_AUTO_SENTINEL,
 };
+use crate::gstreamer_platform::{clear_native_shortcut_bindings, set_native_shortcut_bindings};
 use crate::gstreamer_pipeline::{
     current_platform_label, init_gstreamer, native_video_backend_capabilities, GstreamerPipeline,
 };
@@ -124,6 +125,7 @@ impl NativeStreamerBackend for GstreamerBackend {
             }
         }
 
+        set_native_shortcut_bindings(&context.shortcuts);
         self.active_context = Some(context);
         self.pending_remote_ice.clear();
         self.remote_description_set = false;
@@ -192,6 +194,7 @@ impl NativeStreamerBackend for GstreamerBackend {
 
         let present_max_fps = resolve_present_max_fps(context.settings.fps);
         let d3d_fullscreen_sink = resolve_d3d_fullscreen_sink(context.settings.enable_cloud_gsync);
+        set_native_shortcut_bindings(&context.shortcuts);
         pipeline.set_present_max_fps(present_max_fps);
         pipeline.set_d3d_fullscreen_sink(d3d_fullscreen_sink);
         pipeline.configure_stats(&context, prepared.nvst_params.max_bitrate_kbps);
@@ -377,6 +380,7 @@ impl NativeStreamerBackend for GstreamerBackend {
         self.active_context = None;
         self.pending_remote_ice.clear();
         self.remote_description_set = false;
+        clear_native_shortcut_bindings();
         if let Some(pipeline) = self.pipeline.take() {
             if let Err(message) = pipeline.stop() {
                 return BackendReply {

--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -386,7 +386,28 @@ fn send_native_window_input_events(
     event_sender: &Option<Sender<Event>>,
     events: &[NativeWindowInputEvent],
 ) {
-    if events.is_empty() || !input_state.ready.load(Ordering::SeqCst) {
+    if events.is_empty() {
+        return;
+    }
+
+    // Forward shortcuts immediately (before input readiness check)
+    // Shortcuts are local control and don't need the stream channel
+    let mut other_events = Vec::new();
+    for event in events.iter().copied() {
+        match event {
+            NativeWindowInputEvent::Shortcut { action } => {
+                if let Some(sender) = event_sender.as_ref() {
+                    let _ = sender.send(Event::Shortcut { action });
+                }
+            }
+            _ => {
+                other_events.push(event);
+            }
+        }
+    }
+
+    // Only process non-shortcut events if input is ready
+    if other_events.is_empty() || !input_state.ready.load(Ordering::SeqCst) {
         return;
     }
 
@@ -395,7 +416,7 @@ fn send_native_window_input_events(
     };
 
     let mut pending_mouse_move: Option<(i32, i32, u64)> = None;
-    for event in events.iter().copied() {
+    for event in other_events.iter().copied() {
         if let NativeWindowInputEvent::MouseMove {
             dx,
             dy,

--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -7,6 +7,8 @@ use crate::input::{
     GamepadInput, KeyboardPayload, MouseButtonPayload, MouseMovePayload, MouseWheelPayload,
     GAMEPAD_MAX_CONTROLLERS, PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
 };
+#[cfg(target_os = "windows")]
+use crate::protocol::NativeStreamerShortcutAction;
 use crate::protocol::Event;
 use gst::glib;
 use gst::prelude::*;
@@ -98,6 +100,9 @@ impl GstreamerInputState {
 #[cfg(target_os = "windows")]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum NativeWindowInputEvent {
+    Shortcut {
+        action: NativeStreamerShortcutAction,
+    },
     Key {
         pressed: bool,
         keycode: u16,
@@ -321,6 +326,7 @@ impl NativeWindowInputBridge {
                         send_native_window_input_events(
                             &input_thread_state,
                             &input_thread_channels,
+                            &thread_sender,
                             &pending_events,
                         );
                         if disconnected {
@@ -377,6 +383,7 @@ impl Drop for NativeWindowInputBridge {
 fn send_native_window_input_events(
     input_state: &GstreamerInputState,
     input_channels: &GstreamerInputChannels,
+    event_sender: &Option<Sender<Event>>,
     events: &[NativeWindowInputEvent],
 ) {
     if events.is_empty() || !input_state.ready.load(Ordering::SeqCst) {
@@ -404,7 +411,7 @@ fn send_native_window_input_events(
         }
 
         flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
-        send_encoded_native_window_input_event(&encoder, input_channels, event);
+        send_encoded_native_window_input_event(&encoder, input_channels, event_sender, event);
     }
     flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
 }
@@ -437,9 +444,16 @@ fn flush_pending_mouse_move(
 fn send_encoded_native_window_input_event(
     encoder: &InputEncoder,
     input_channels: &GstreamerInputChannels,
+    event_sender: &Option<Sender<Event>>,
     event: NativeWindowInputEvent,
 ) {
     let (payload, partially_reliable) = match event {
+        NativeWindowInputEvent::Shortcut { action } => {
+            if let Some(sender) = event_sender.as_ref() {
+                let _ = sender.send(Event::Shortcut { action });
+            }
+            return;
+        }
         NativeWindowInputEvent::Key {
             pressed,
             keycode,

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "windows")]
 use crate::gstreamer_backend::send_log;
 #[cfg(target_os = "windows")]
-use crate::protocol::NativeRenderRect;
+use crate::protocol::{NativeRenderRect, NativeStreamerShortcutBindings};
 use crate::protocol::{Event, NativeRenderSurface};
 #[cfg(target_os = "windows")]
 use gst_video::prelude::*;
@@ -98,8 +98,32 @@ pub(crate) fn start_external_renderer_window_guard(
 }
 
 #[cfg(target_os = "windows")]
+pub(crate) fn set_native_shortcut_bindings(bindings: &NativeStreamerShortcutBindings) {
+    unsafe {
+        win32_renderer_window::set_shortcut_bindings(bindings.clone());
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn set_native_shortcut_bindings(_bindings: &NativeStreamerShortcutBindings) {
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn clear_native_shortcut_bindings() {
+    unsafe {
+        win32_renderer_window::clear_shortcut_bindings();
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn clear_native_shortcut_bindings() {
+}
+
+#[cfg(target_os = "windows")]
 pub(crate) mod win32_renderer_window {
     use crate::gstreamer_input::NativeWindowInputEvent;
+    use crate::protocol::{NativeStreamerShortcutAction, NativeStreamerShortcutBindings};
+    use crate::shortcuts::NativeShortcutMatcher;
     use std::collections::HashMap;
     use std::ffi::c_void;
     use std::ptr::{null, null_mut};
@@ -270,6 +294,7 @@ pub(crate) mod win32_renderer_window {
     struct PressedKey {
         keycode: u16,
         scancode: u16,
+        suppressed: bool,
     }
 
     #[derive(Clone, Copy)]
@@ -282,11 +307,13 @@ pub(crate) mod win32_renderer_window {
         OnceLock::new();
     static ORIGINAL_WNDPROCS: OnceLock<Mutex<HashMap<isize, isize>>> = OnceLock::new();
     static CAPTURED_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
+    static PROTECTED_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
     static PRESSED_KEYS: OnceLock<Mutex<HashMap<u16, PressedKey>>> = OnceLock::new();
     static STARTED_AT: OnceLock<Instant> = OnceLock::new();
     static ESCAPE_HOLD_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
     static ESCAPE_HOLD_TOKEN: OnceLock<AtomicU64> = OnceLock::new();
     static ESCAPE_KEY_PRESS: OnceLock<Mutex<Option<EscapeKeyPress>>> = OnceLock::new();
+    static SHORTCUT_MATCHER: OnceLock<Mutex<NativeShortcutMatcher>> = OnceLock::new();
 
     #[link(name = "user32")]
     unsafe extern "system" {
@@ -348,6 +375,20 @@ pub(crate) mod win32_renderer_window {
         let slot = INPUT_EVENT_SENDER.get_or_init(|| Mutex::new(None));
         if let Ok(mut current) = slot.lock() {
             *current = sender;
+        }
+    }
+
+    pub unsafe fn set_shortcut_bindings(bindings: NativeStreamerShortcutBindings) {
+        let matcher = SHORTCUT_MATCHER.get_or_init(|| Mutex::new(NativeShortcutMatcher::default()));
+        if let Ok(mut current) = matcher.lock() {
+            *current = NativeShortcutMatcher::from_bindings(&bindings);
+        }
+    }
+
+    pub unsafe fn clear_shortcut_bindings() {
+        let matcher = SHORTCUT_MATCHER.get_or_init(|| Mutex::new(NativeShortcutMatcher::default()));
+        if let Ok(mut current) = matcher.lock() {
+            *current = NativeShortcutMatcher::default();
         }
     }
 
@@ -427,6 +468,11 @@ pub(crate) mod win32_renderer_window {
     }
 
     unsafe fn protect_renderer_window(hwnd: Hwnd) -> bool {
+        let protected_slot = PROTECTED_HWND.get_or_init(|| Mutex::new(None));
+        if let Ok(mut protected) = protected_slot.lock() {
+            *protected = Some(hwnd as isize);
+        }
+
         let mut configured = false;
         let current = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
         let desired = current & !(WS_EX_NOACTIVATE | WS_EX_TRANSPARENT);
@@ -633,6 +679,12 @@ pub(crate) mod win32_renderer_window {
 
     fn captured_hwnd() -> Option<isize> {
         CAPTURED_HWND
+            .get()
+            .and_then(|captured| captured.lock().ok().and_then(|captured| *captured))
+    }
+
+    fn protected_hwnd() -> Option<isize> {
+        PROTECTED_HWND
             .get()
             .and_then(|captured| captured.lock().ok().and_then(|captured| *captured))
     }
@@ -883,17 +935,34 @@ pub(crate) mod win32_renderer_window {
             handle_escape_keyboard_state(scancode, pressed);
             return;
         }
-        let was_present = keys.contains_key(&scancode);
+        let previous = keys.get(&scancode).copied();
         if pressed {
-            if was_present {
+            if previous.is_some() {
                 return;
             }
-            keys.insert(scancode, PressedKey { keycode, scancode });
+            let modifiers = current_modifier_flags(&keys);
+            if let Some(action) = shortcut_action_for_keypress(keycode, modifiers) {
+                keys.insert(scancode, PressedKey {
+                    keycode,
+                    scancode,
+                    suppressed: true,
+                });
+                drop(keys);
+                handle_shortcut_action(action);
+                return;
+            }
+            keys.insert(scancode, PressedKey {
+                keycode,
+                scancode,
+                suppressed: false,
+            });
         } else {
-            if !was_present {
+            let Some(previous) = keys.remove(&scancode) else {
+                return;
+            };
+            if previous.suppressed {
                 return;
             }
-            keys.remove(&scancode);
         }
         let modifiers = current_modifier_flags(&keys);
         drop(keys);
@@ -981,6 +1050,9 @@ pub(crate) mod win32_renderer_window {
 
         let timestamp_us = timestamp_us();
         for key in pressed {
+            if key.suppressed {
+                continue;
+            }
             emit_input_event(NativeWindowInputEvent::Key {
                 pressed: false,
                 keycode: key.keycode,
@@ -1067,6 +1139,32 @@ pub(crate) mod win32_renderer_window {
         keys.values()
             .any(|key| matches!(key.keycode, VK_LMENU | VK_RMENU | VK_MENU))
             || ((GetKeyState(VK_MENU as i32) as u16) & 0x8000) != 0
+    }
+
+    fn shortcut_action_for_keypress(
+        keycode: u16,
+        modifiers: u16,
+    ) -> Option<NativeStreamerShortcutAction> {
+        SHORTCUT_MATCHER
+            .get()
+            .and_then(|matcher| matcher.lock().ok())
+            .and_then(|matcher| matcher.match_keydown(keycode, modifiers))
+    }
+
+    unsafe fn handle_shortcut_action(action: NativeStreamerShortcutAction) {
+        match action {
+            NativeStreamerShortcutAction::TogglePointerLock => {
+                if let Some(hwnd) = captured_hwnd().or_else(protected_hwnd) {
+                    let hwnd = hwnd as Hwnd;
+                    if is_input_captured(hwnd) {
+                        release_input_capture(hwnd);
+                    } else {
+                        begin_input_capture(hwnd);
+                    }
+                }
+            }
+            _ => emit_input_event(NativeWindowInputEvent::Shortcut { action }),
+        }
     }
 
     fn legacy_mouse_button(message: Uint, wparam: Wparam) -> Option<(u8, bool)> {

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -1,8 +1,8 @@
 #[cfg(target_os = "windows")]
 use crate::gstreamer_backend::send_log;
 #[cfg(target_os = "windows")]
-use crate::protocol::{NativeRenderRect, NativeStreamerShortcutBindings};
-use crate::protocol::{Event, NativeRenderSurface};
+use crate::protocol::NativeRenderRect;
+use crate::protocol::{Event, NativeRenderSurface, NativeStreamerShortcutBindings};
 #[cfg(target_os = "windows")]
 use gst_video::prelude::*;
 use gstreamer as gst;

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -753,7 +753,7 @@ pub(crate) mod win32_renderer_window {
             RawInputDevice {
                 us_usage_page: 0x01,
                 us_usage: 0x06,
-                dw_flags: 0,
+                dw_flags: RIDEV_NOLEGACY,
                 hwnd_target: hwnd,
             },
         ];

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -105,8 +105,7 @@ pub(crate) fn set_native_shortcut_bindings(bindings: &NativeStreamerShortcutBind
 }
 
 #[cfg(not(target_os = "windows"))]
-pub(crate) fn set_native_shortcut_bindings(_bindings: &NativeStreamerShortcutBindings) {
-}
+pub(crate) fn set_native_shortcut_bindings(_bindings: &NativeStreamerShortcutBindings) {}
 
 #[cfg(target_os = "windows")]
 pub(crate) fn clear_native_shortcut_bindings() {
@@ -116,15 +115,14 @@ pub(crate) fn clear_native_shortcut_bindings() {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub(crate) fn clear_native_shortcut_bindings() {
-}
+pub(crate) fn clear_native_shortcut_bindings() {}
 
 #[cfg(target_os = "windows")]
 pub(crate) mod win32_renderer_window {
     use crate::gstreamer_input::NativeWindowInputEvent;
     use crate::protocol::{NativeStreamerShortcutAction, NativeStreamerShortcutBindings};
     use crate::shortcuts::NativeShortcutMatcher;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::ffi::c_void;
     use std::ptr::{null, null_mut};
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -314,6 +312,7 @@ pub(crate) mod win32_renderer_window {
     static ESCAPE_HOLD_TOKEN: OnceLock<AtomicU64> = OnceLock::new();
     static ESCAPE_KEY_PRESS: OnceLock<Mutex<Option<EscapeKeyPress>>> = OnceLock::new();
     static SHORTCUT_MATCHER: OnceLock<Mutex<NativeShortcutMatcher>> = OnceLock::new();
+    static SUPPRESSED_LEGACY_KEYS: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
 
     #[link(name = "user32")]
     unsafe extern "system" {
@@ -567,6 +566,9 @@ pub(crate) mod win32_renderer_window {
             handle_legacy_escape_keyboard(message, lparam);
             return 0;
         }
+        if should_suppress_legacy_shortcut_keyboard(hwnd, message, wparam, lparam) {
+            return 0;
+        }
         if message == WM_KILLFOCUS || (message == WM_ACTIVATE && (wparam & 0xffff) == WA_INACTIVE) {
             release_input_capture(hwnd);
         }
@@ -626,6 +628,7 @@ pub(crate) mod win32_renderer_window {
         SetForegroundWindow(hwnd);
         SetFocus(hwnd);
         SetCapture(hwnd);
+        clear_suppressed_legacy_keys();
         register_raw_input_devices(hwnd);
         if let Some(rect) = monitor_rect_for_window(hwnd) {
             ClipCursor(&rect);
@@ -753,7 +756,7 @@ pub(crate) mod win32_renderer_window {
             RawInputDevice {
                 us_usage_page: 0x01,
                 us_usage: 0x06,
-                dw_flags: RIDEV_NOLEGACY,
+                dw_flags: 0,
                 hwnd_target: hwnd,
             },
         ];
@@ -908,6 +911,47 @@ pub(crate) mod win32_renderer_window {
             && (wparam as u16) == VK_ESCAPE
     }
 
+    unsafe fn should_suppress_legacy_shortcut_keyboard(
+        hwnd: Hwnd,
+        message: Uint,
+        wparam: Wparam,
+        lparam: Lparam,
+    ) -> bool {
+        if !matches!(message, WM_KEYDOWN | WM_KEYUP | WM_SYSKEYDOWN | WM_SYSKEYUP) {
+            return false;
+        }
+
+        let scancode = legacy_keyboard_scancode(lparam);
+        if scancode == 0 {
+            return false;
+        }
+
+        if matches!(message, WM_KEYUP | WM_SYSKEYUP) {
+            return release_suppressed_legacy_key(scancode);
+        }
+
+        if !is_input_captured(hwnd) {
+            return false;
+        }
+
+        if is_suppressed_legacy_key(scancode) {
+            return true;
+        }
+
+        let keycode = normalize_virtual_key(
+            wparam as u16,
+            legacy_keyboard_make_code(scancode),
+            legacy_keyboard_flags(scancode),
+        );
+        if let Some(action) = shortcut_action_for_keypress(keycode, legacy_modifier_flags()) {
+            mark_suppressed_legacy_key(scancode);
+            handle_shortcut_action(action);
+            return true;
+        }
+
+        false
+    }
+
     fn legacy_keyboard_scancode(lparam: Lparam) -> u16 {
         let scancode = ((lparam >> 16) & 0xff) as u16;
         if scancode == 0 {
@@ -917,6 +961,18 @@ pub(crate) mod win32_renderer_window {
             0xe000 | scancode
         } else {
             scancode
+        }
+    }
+
+    fn legacy_keyboard_make_code(scancode: u16) -> u16 {
+        scancode & 0xff
+    }
+
+    fn legacy_keyboard_flags(scancode: u16) -> u16 {
+        match scancode & 0xff00 {
+            0xe000 => RI_KEY_E0,
+            0xe100 => RI_KEY_E1,
+            _ => 0,
         }
     }
 
@@ -942,20 +998,29 @@ pub(crate) mod win32_renderer_window {
             }
             let modifiers = current_modifier_flags(&keys);
             if let Some(action) = shortcut_action_for_keypress(keycode, modifiers) {
-                keys.insert(scancode, PressedKey {
-                    keycode,
+                let shortcut_already_handled = mark_suppressed_legacy_key(scancode);
+                keys.insert(
                     scancode,
-                    suppressed: true,
-                });
+                    PressedKey {
+                        keycode,
+                        scancode,
+                        suppressed: true,
+                    },
+                );
                 drop(keys);
-                handle_shortcut_action(action);
+                if !shortcut_already_handled {
+                    handle_shortcut_action(action);
+                }
                 return;
             }
-            keys.insert(scancode, PressedKey {
-                keycode,
+            keys.insert(
                 scancode,
-                suppressed: false,
-            });
+                PressedKey {
+                    keycode,
+                    scancode,
+                    suppressed: false,
+                },
+            );
         } else {
             let Some(previous) = keys.remove(&scancode) else {
                 return;
@@ -1019,6 +1084,35 @@ pub(crate) mod win32_renderer_window {
         if let Ok(mut escape_press) = slot.lock() {
             *escape_press = None;
         }
+    }
+
+    fn clear_suppressed_legacy_keys() {
+        let slot = SUPPRESSED_LEGACY_KEYS.get_or_init(|| Mutex::new(HashSet::new()));
+        if let Ok(mut keys) = slot.lock() {
+            keys.clear();
+        }
+    }
+
+    fn is_suppressed_legacy_key(scancode: u16) -> bool {
+        SUPPRESSED_LEGACY_KEYS
+            .get()
+            .and_then(|keys| keys.lock().ok().map(|keys| keys.contains(&scancode)))
+            .unwrap_or(false)
+    }
+
+    fn mark_suppressed_legacy_key(scancode: u16) -> bool {
+        let slot = SUPPRESSED_LEGACY_KEYS.get_or_init(|| Mutex::new(HashSet::new()));
+        slot.lock()
+            .ok()
+            .map(|mut keys| !keys.insert(scancode))
+            .unwrap_or(false)
+    }
+
+    fn release_suppressed_legacy_key(scancode: u16) -> bool {
+        SUPPRESSED_LEGACY_KEYS
+            .get()
+            .and_then(|keys| keys.lock().ok().map(|mut keys| keys.remove(&scancode)))
+            .unwrap_or(false)
     }
 
     fn send_escape_tap(scancode: u16) {
@@ -1133,6 +1227,42 @@ pub(crate) mod win32_renderer_window {
             modifiers |= 0x20;
         }
         modifiers
+    }
+
+    unsafe fn legacy_modifier_flags() -> u16 {
+        let mut modifiers = 0u16;
+        if is_key_state_down(VK_SHIFT as i32)
+            || is_key_state_down(VK_LSHIFT as i32)
+            || is_key_state_down(VK_RSHIFT as i32)
+        {
+            modifiers |= 0x01;
+        }
+        if is_key_state_down(VK_CONTROL as i32)
+            || is_key_state_down(VK_LCONTROL as i32)
+            || is_key_state_down(VK_RCONTROL as i32)
+        {
+            modifiers |= 0x02;
+        }
+        if is_key_state_down(VK_MENU as i32)
+            || is_key_state_down(VK_LMENU as i32)
+            || is_key_state_down(VK_RMENU as i32)
+        {
+            modifiers |= 0x04;
+        }
+        if is_key_state_down(VK_LWIN as i32) || is_key_state_down(VK_RWIN as i32) {
+            modifiers |= 0x08;
+        }
+        if (GetKeyState(VK_CAPITAL) & 0x0001) != 0 {
+            modifiers |= 0x10;
+        }
+        if (GetKeyState(VK_NUMLOCK) & 0x0001) != 0 {
+            modifiers |= 0x20;
+        }
+        modifiers
+    }
+
+    unsafe fn is_key_state_down(virtual_key: i32) -> bool {
+        ((GetKeyState(virtual_key) as u16) & 0x8000) != 0
     }
 
     unsafe fn is_alt_modifier_down(keys: &HashMap<u16, PressedKey>) -> bool {

--- a/native/opennow-streamer/src/main.rs
+++ b/native/opennow-streamer/src/main.rs
@@ -17,6 +17,7 @@ mod gstreamer_platform;
 mod gstreamer_transitions;
 mod input;
 mod protocol;
+mod shortcuts;
 mod sdp;
 
 use serde::Serialize;

--- a/native/opennow-streamer/src/main.rs
+++ b/native/opennow-streamer/src/main.rs
@@ -101,6 +101,9 @@ fn handle_command(
         "bitrate" => {
             return write_reply(backend.update_bitrate_limit(command));
         }
+        "update-shortcuts" => {
+            return write_reply(backend.update_shortcuts(command));
+        }
         "stop" => {
             return write_reply(backend.stop(command));
         }

--- a/native/opennow-streamer/src/main.rs
+++ b/native/opennow-streamer/src/main.rs
@@ -17,6 +17,7 @@ mod gstreamer_platform;
 mod gstreamer_transitions;
 mod input;
 mod protocol;
+#[cfg(all(feature = "gstreamer", target_os = "windows"))]
 mod shortcuts;
 mod sdp;
 

--- a/native/opennow-streamer/src/protocol.rs
+++ b/native/opennow-streamer/src/protocol.rs
@@ -27,6 +27,8 @@ pub struct CommandEnvelope {
     pub max_bitrate_kbps: Option<u32>,
     #[serde(default)]
     pub reason: Option<String>,
+    #[serde(default)]
+    pub shortcuts: Option<NativeStreamerShortcutBindings>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/native/opennow-streamer/src/protocol.rs
+++ b/native/opennow-streamer/src/protocol.rs
@@ -33,6 +33,8 @@ pub struct CommandEnvelope {
 pub struct NativeStreamerSessionContext {
     pub session: SessionInfo,
     pub settings: StreamSettings,
+    #[serde(default)]
+    pub shortcuts: NativeStreamerShortcutBindings,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -266,6 +268,40 @@ pub struct NativeRenderRect {
     pub height: i32,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeStreamerShortcutBindings {
+    #[serde(default)]
+    pub toggle_stats: String,
+    #[serde(default)]
+    pub toggle_pointer_lock: String,
+    #[serde(default)]
+    pub toggle_fullscreen: String,
+    #[serde(default)]
+    pub stop_stream: String,
+    #[serde(default)]
+    pub toggle_anti_afk: String,
+    #[serde(default)]
+    pub toggle_microphone: String,
+    #[serde(default)]
+    pub screenshot: String,
+    #[serde(default)]
+    pub toggle_recording: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NativeStreamerShortcutAction {
+    ToggleStats,
+    TogglePointerLock,
+    ToggleFullscreen,
+    StopStream,
+    ToggleAntiAfk,
+    ToggleMicrophone,
+    Screenshot,
+    ToggleRecording,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct NativeStreamerCapabilities {
     #[serde(rename = "protocolVersion")]
@@ -483,6 +519,10 @@ pub enum Event {
     InputReady {
         #[serde(rename = "protocolVersion")]
         protocol_version: u16,
+    },
+    #[serde(rename = "shortcut")]
+    Shortcut {
+        action: NativeStreamerShortcutAction,
     },
     #[serde(rename = "video-stall")]
     VideoStall(VideoStallEvent),

--- a/native/opennow-streamer/src/shortcuts.rs
+++ b/native/opennow-streamer/src/shortcuts.rs
@@ -134,7 +134,11 @@ fn parse_binding(action: NativeStreamerShortcutAction, raw: &str) -> Option<Shor
     let mut modifiers = 0u16;
     let mut keycode = None;
 
-    for token in raw.split('+').map(str::trim).filter(|token| !token.is_empty()) {
+    for token in raw
+        .split('+')
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    {
         match token.to_ascii_uppercase().as_str() {
             "CTRL" | "CONTROL" => modifiers |= MODIFIER_CTRL,
             "ALT" | "OPTION" => modifiers |= MODIFIER_ALT,
@@ -214,9 +218,9 @@ fn parse_key_token(token: &str) -> Option<u16> {
         "INSERT" => Some(VK_INSERT),
         "DELETE" => Some(VK_DELETE),
         "PRINTSCREEN" => Some(VK_PRINT),
-        "APPS" | "MENU" => Some(VK_APPS),
-        "METALEFT" => Some(VK_LWIN),
-        "METARIGHT" => Some(VK_RWIN),
+        "APPS" | "MENU" | "CONTEXTMENU" => Some(VK_APPS),
+        "METALEFT" | "OSLEFT" => Some(VK_LWIN),
+        "METARIGHT" | "OSRIGHT" => Some(VK_RWIN),
         "NUMPADMULTIPLY" => Some(VK_MULTIPLY),
         "NUMPADADD" => Some(VK_ADD),
         "NUMPADSEPARATOR" => Some(VK_SEPARATOR),
@@ -300,6 +304,29 @@ mod tests {
         assert_eq!(
             matcher.match_keydown(VK_F1 + 7, 0),
             Some(NativeStreamerShortcutAction::TogglePointerLock)
+        );
+    }
+
+    #[test]
+    fn matches_renderer_supported_named_keys() {
+        let matcher = NativeShortcutMatcher::from_bindings(&NativeStreamerShortcutBindings {
+            toggle_stats: "ContextMenu".to_owned(),
+            toggle_pointer_lock: "OSLeft".to_owned(),
+            toggle_fullscreen: "OSRight".to_owned(),
+            ..bindings()
+        });
+
+        assert_eq!(
+            matcher.match_keydown(VK_APPS, 0),
+            Some(NativeStreamerShortcutAction::ToggleStats)
+        );
+        assert_eq!(
+            matcher.match_keydown(VK_LWIN, 0),
+            Some(NativeStreamerShortcutAction::TogglePointerLock)
+        );
+        assert_eq!(
+            matcher.match_keydown(VK_RWIN, 0),
+            Some(NativeStreamerShortcutAction::ToggleFullscreen)
         );
     }
 }

--- a/native/opennow-streamer/src/shortcuts.rs
+++ b/native/opennow-streamer/src/shortcuts.rs
@@ -1,0 +1,305 @@
+use crate::protocol::{NativeStreamerShortcutAction, NativeStreamerShortcutBindings};
+
+const MODIFIER_SHIFT: u16 = 0x01;
+const MODIFIER_CTRL: u16 = 0x02;
+const MODIFIER_ALT: u16 = 0x04;
+const MODIFIER_META: u16 = 0x08;
+const SHORTCUT_MODIFIER_MASK: u16 = MODIFIER_SHIFT | MODIFIER_CTRL | MODIFIER_ALT | MODIFIER_META;
+
+const VK_BACK: u16 = 0x08;
+const VK_TAB: u16 = 0x09;
+const VK_RETURN: u16 = 0x0D;
+const VK_PAUSE: u16 = 0x13;
+const VK_CAPITAL: u16 = 0x14;
+const VK_ESCAPE: u16 = 0x1B;
+const VK_SPACE: u16 = 0x20;
+const VK_PRIOR: u16 = 0x21;
+const VK_NEXT: u16 = 0x22;
+const VK_END: u16 = 0x23;
+const VK_HOME: u16 = 0x24;
+const VK_LEFT: u16 = 0x25;
+const VK_UP: u16 = 0x26;
+const VK_RIGHT: u16 = 0x27;
+const VK_DOWN: u16 = 0x28;
+const VK_INSERT: u16 = 0x2D;
+const VK_DELETE: u16 = 0x2E;
+const VK_PRINT: u16 = 0x2C;
+const VK_LWIN: u16 = 0x5B;
+const VK_RWIN: u16 = 0x5C;
+const VK_APPS: u16 = 0x5D;
+const VK_NUMPAD0: u16 = 0x60;
+const VK_MULTIPLY: u16 = 0x6A;
+const VK_ADD: u16 = 0x6B;
+const VK_SEPARATOR: u16 = 0x6C;
+const VK_SUBTRACT: u16 = 0x6D;
+const VK_DECIMAL: u16 = 0x6E;
+const VK_DIVIDE: u16 = 0x6F;
+const VK_F1: u16 = 0x70;
+const VK_NUMLOCK: u16 = 0x90;
+const VK_SCROLL: u16 = 0x91;
+const VK_OEM_1: u16 = 0xBA;
+const VK_OEM_PLUS: u16 = 0xBB;
+const VK_OEM_COMMA: u16 = 0xBC;
+const VK_OEM_MINUS: u16 = 0xBD;
+const VK_OEM_PERIOD: u16 = 0xBE;
+const VK_OEM_2: u16 = 0xBF;
+const VK_OEM_3: u16 = 0xC0;
+const VK_OEM_4: u16 = 0xDB;
+const VK_OEM_5: u16 = 0xDC;
+const VK_OEM_6: u16 = 0xDD;
+const VK_OEM_7: u16 = 0xDE;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ShortcutBinding {
+    action: NativeStreamerShortcutAction,
+    keycode: u16,
+    modifiers: u16,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct NativeShortcutMatcher {
+    bindings: Vec<ShortcutBinding>,
+}
+
+impl NativeShortcutMatcher {
+    pub(crate) fn from_bindings(bindings: &NativeStreamerShortcutBindings) -> Self {
+        let mut parsed = Vec::new();
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleStats,
+            &bindings.toggle_stats,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::TogglePointerLock,
+            &bindings.toggle_pointer_lock,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleFullscreen,
+            &bindings.toggle_fullscreen,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::StopStream,
+            &bindings.stop_stream,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleAntiAfk,
+            &bindings.toggle_anti_afk,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleMicrophone,
+            &bindings.toggle_microphone,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::Screenshot,
+            &bindings.screenshot,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleRecording,
+            &bindings.toggle_recording,
+        );
+        Self { bindings: parsed }
+    }
+
+    pub(crate) fn match_keydown(
+        &self,
+        keycode: u16,
+        modifiers: u16,
+    ) -> Option<NativeStreamerShortcutAction> {
+        let modifiers = modifiers & SHORTCUT_MODIFIER_MASK;
+        self.bindings
+            .iter()
+            .find(|binding| binding.keycode == keycode && binding.modifiers == modifiers)
+            .map(|binding| binding.action)
+    }
+}
+
+fn append_binding(
+    bindings: &mut Vec<ShortcutBinding>,
+    action: NativeStreamerShortcutAction,
+    raw: &str,
+) {
+    if let Some(binding) = parse_binding(action, raw) {
+        bindings.push(binding);
+    }
+}
+
+fn parse_binding(action: NativeStreamerShortcutAction, raw: &str) -> Option<ShortcutBinding> {
+    let mut modifiers = 0u16;
+    let mut keycode = None;
+
+    for token in raw.split('+').map(str::trim).filter(|token| !token.is_empty()) {
+        match token.to_ascii_uppercase().as_str() {
+            "CTRL" | "CONTROL" => modifiers |= MODIFIER_CTRL,
+            "ALT" | "OPTION" => modifiers |= MODIFIER_ALT,
+            "SHIFT" => modifiers |= MODIFIER_SHIFT,
+            "META" | "CMD" | "COMMAND" => modifiers |= MODIFIER_META,
+            _ => {
+                if keycode.is_some() {
+                    return None;
+                }
+                keycode = parse_key_token(token);
+            }
+        }
+    }
+
+    Some(ShortcutBinding {
+        action,
+        keycode: keycode?,
+        modifiers,
+    })
+}
+
+fn parse_key_token(token: &str) -> Option<u16> {
+    let upper = token.trim().to_ascii_uppercase();
+    if upper.len() == 1 {
+        let byte = upper.as_bytes()[0];
+        return match byte {
+            b'A'..=b'Z' | b'0'..=b'9' => Some(u16::from(byte)),
+            b',' => Some(VK_OEM_COMMA),
+            b'.' => Some(VK_OEM_PERIOD),
+            b'/' => Some(VK_OEM_2),
+            b';' => Some(VK_OEM_1),
+            b'\'' => Some(VK_OEM_7),
+            b'[' => Some(VK_OEM_4),
+            b']' => Some(VK_OEM_6),
+            b'\\' => Some(VK_OEM_5),
+            b'-' => Some(VK_OEM_MINUS),
+            b'=' => Some(VK_OEM_PLUS),
+            b'`' => Some(VK_OEM_3),
+            _ => None,
+        };
+    }
+
+    if let Some(function_index) = upper
+        .strip_prefix('F')
+        .and_then(|value| value.parse::<u16>().ok())
+    {
+        if (1..=24).contains(&function_index) {
+            return Some(VK_F1 + function_index - 1);
+        }
+    }
+
+    if let Some(numpad_index) = upper
+        .strip_prefix("NUMPAD")
+        .and_then(|value| value.parse::<u16>().ok())
+    {
+        if numpad_index <= 9 {
+            return Some(VK_NUMPAD0 + numpad_index);
+        }
+    }
+
+    match upper.as_str() {
+        "BACKSPACE" => Some(VK_BACK),
+        "TAB" => Some(VK_TAB),
+        "ENTER" | "NUMPADENTER" => Some(VK_RETURN),
+        "PAUSE" => Some(VK_PAUSE),
+        "CAPSLOCK" => Some(VK_CAPITAL),
+        "ESCAPE" => Some(VK_ESCAPE),
+        "SPACE" => Some(VK_SPACE),
+        "PAGEUP" => Some(VK_PRIOR),
+        "PAGEDOWN" => Some(VK_NEXT),
+        "END" => Some(VK_END),
+        "HOME" => Some(VK_HOME),
+        "ARROWLEFT" => Some(VK_LEFT),
+        "ARROWUP" => Some(VK_UP),
+        "ARROWRIGHT" => Some(VK_RIGHT),
+        "ARROWDOWN" => Some(VK_DOWN),
+        "INSERT" => Some(VK_INSERT),
+        "DELETE" => Some(VK_DELETE),
+        "PRINTSCREEN" => Some(VK_PRINT),
+        "APPS" | "MENU" => Some(VK_APPS),
+        "METALEFT" => Some(VK_LWIN),
+        "METARIGHT" => Some(VK_RWIN),
+        "NUMPADMULTIPLY" => Some(VK_MULTIPLY),
+        "NUMPADADD" => Some(VK_ADD),
+        "NUMPADSEPARATOR" => Some(VK_SEPARATOR),
+        "NUMPADSUBTRACT" => Some(VK_SUBTRACT),
+        "NUMPADDECIMAL" => Some(VK_DECIMAL),
+        "NUMPADDIVIDE" => Some(VK_DIVIDE),
+        "NUMLOCK" => Some(VK_NUMLOCK),
+        "SCROLLLOCK" => Some(VK_SCROLL),
+        "SEMICOLON" => Some(VK_OEM_1),
+        "EQUAL" => Some(VK_OEM_PLUS),
+        "COMMA" => Some(VK_OEM_COMMA),
+        "MINUS" => Some(VK_OEM_MINUS),
+        "PERIOD" => Some(VK_OEM_PERIOD),
+        "SLASH" => Some(VK_OEM_2),
+        "BACKQUOTE" => Some(VK_OEM_3),
+        "BRACKETLEFT" => Some(VK_OEM_4),
+        "BACKSLASH" => Some(VK_OEM_5),
+        "BRACKETRIGHT" => Some(VK_OEM_6),
+        "QUOTE" => Some(VK_OEM_7),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bindings() -> NativeStreamerShortcutBindings {
+        NativeStreamerShortcutBindings {
+            toggle_stats: "F3".to_owned(),
+            toggle_pointer_lock: "F8".to_owned(),
+            toggle_fullscreen: "F10".to_owned(),
+            stop_stream: "Ctrl+Shift+Q".to_owned(),
+            toggle_anti_afk: "Ctrl+Shift+K".to_owned(),
+            toggle_microphone: "Ctrl+Shift+M".to_owned(),
+            screenshot: "F11".to_owned(),
+            toggle_recording: "F12".to_owned(),
+        }
+    }
+
+    #[test]
+    fn matches_function_key_shortcuts_without_modifiers() {
+        let matcher = NativeShortcutMatcher::from_bindings(&bindings());
+
+        assert_eq!(
+            matcher.match_keydown(VK_F1 + 2, 0),
+            Some(NativeStreamerShortcutAction::ToggleStats)
+        );
+        assert_eq!(
+            matcher.match_keydown(VK_F1 + 10, 0),
+            Some(NativeStreamerShortcutAction::Screenshot)
+        );
+    }
+
+    #[test]
+    fn matches_exact_modifier_combinations() {
+        let matcher = NativeShortcutMatcher::from_bindings(&bindings());
+
+        assert_eq!(
+            matcher.match_keydown(u16::from(b'Q'), MODIFIER_CTRL | MODIFIER_SHIFT),
+            Some(NativeStreamerShortcutAction::StopStream)
+        );
+        assert_eq!(matcher.match_keydown(u16::from(b'Q'), MODIFIER_CTRL), None);
+        assert_eq!(
+            matcher.match_keydown(
+                u16::from(b'Q'),
+                MODIFIER_CTRL | MODIFIER_SHIFT | MODIFIER_ALT
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_invalid_bindings() {
+        let matcher = NativeShortcutMatcher::from_bindings(&NativeStreamerShortcutBindings {
+            toggle_stats: "Ctrl+Shift".to_owned(),
+            ..bindings()
+        });
+
+        assert_eq!(matcher.match_keydown(VK_F1 + 2, 0), None);
+        assert_eq!(
+            matcher.match_keydown(VK_F1 + 7, 0),
+            Some(NativeStreamerShortcutAction::TogglePointerLock)
+        );
+    }
+}

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -80,6 +80,7 @@ import { pingRegions } from "./services/regionPing";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const DEBUG_NO_LOGIN_ENV = "OPENNOW_DEBUG_NO_LOGIN";
 
 // Configure Chromium video and WebRTC behavior before app.whenReady().
 
@@ -118,6 +119,20 @@ function loadBootstrapVideoPreferences(): BootstrapVideoPreferences {
   } catch {
     return defaults;
   }
+}
+
+function isDebugNoLoginEnabled(): boolean {
+  const value = process.env[DEBUG_NO_LOGIN_ENV]?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+function withDebugNoLoginParam(rawUrl: string): string {
+  if (!isDebugNoLoginEnabled()) {
+    return rawUrl;
+  }
+  const url = new URL(rawUrl);
+  url.searchParams.set("debugNoLogin", "1");
+  return url.toString();
 }
 
 const bootstrapVideoPrefs = loadBootstrapVideoPreferences();
@@ -519,7 +534,11 @@ async function createMainWindow(): Promise<void> {
   });
 
   if (process.env.ELECTRON_RENDERER_URL) {
-    await mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL);
+    await mainWindow.loadURL(withDebugNoLoginParam(process.env.ELECTRON_RENDERER_URL));
+  } else if (isDebugNoLoginEnabled()) {
+    await mainWindow.loadFile(join(__dirname, "../../dist/index.html"), {
+      query: { debugNoLogin: "1" },
+    });
   } else {
     await mainWindow.loadFile(join(__dirname, "../../dist/index.html"));
   }

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -1172,6 +1172,11 @@ export class NativeStreamerManager {
       return;
     }
 
+    if (message.type === "shortcut") {
+      this.options.emit({ type: "native-shortcut", action: message.action });
+      return;
+    }
+
     if (message.type === "video-stall") {
       const formatAge = (value: number | undefined): string => value === undefined ? "n/a" : `${value}ms`;
       const stats = [

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -43,6 +43,7 @@ import {
   type NativeStreamerMessage,
   type NativeStreamerResponse,
 } from "@shared/nativeStreamer";
+import type { NativeStreamerShortcutBindings } from "@shared/gfn";
 
 type NativeStreamerCommandInput = NativeStreamerCommand extends infer T
   ? T extends NativeStreamerCommand
@@ -744,6 +745,19 @@ export class NativeStreamerManager {
       maxBitrateKbps: normalizeBitrateKbps(maxBitrateKbps),
     }, CONTROL_TIMEOUT_MS).catch((error) => {
       console.warn("[NativeStreamer] Failed to update native bitrate limit:", error);
+    });
+  }
+
+  updateShortcuts(shortcuts: NativeStreamerShortcutBindings): void {
+    if (!this.child || !this.activeSessionId) {
+      return;
+    }
+
+    void this.request({
+      type: "update-shortcuts",
+      shortcuts,
+    }, CONTROL_TIMEOUT_MS).catch((error) => {
+      console.warn("[NativeStreamer] Failed to update native shortcut bindings:", error);
     });
   }
 

--- a/opennow-stable/src/main/signaling/signalingCoordinator.ts
+++ b/opennow-stable/src/main/signaling/signalingCoordinator.ts
@@ -121,6 +121,12 @@ export class SignalingCoordinator {
         if (!this.isNativeStreamerSelected()) {
           return;
         }
+        if (this.nativeStreamerContext) {
+          this.nativeStreamerContext = {
+            ...this.nativeStreamerContext,
+            shortcuts,
+          };
+        }
         this.getNativeStreamerManager().updateShortcuts(shortcuts);
       },
     );

--- a/opennow-stable/src/main/signaling/signalingCoordinator.ts
+++ b/opennow-stable/src/main/signaling/signalingCoordinator.ts
@@ -7,6 +7,7 @@ import type {
   NativeInputPacket,
   NativeRenderSurfaceUpdate,
   NativeStreamerSessionContext,
+  NativeStreamerShortcutBindings,
   NativeStreamerStatus,
   SendAnswerRequest,
   Settings,
@@ -111,6 +112,16 @@ export class SignalingCoordinator {
         }
 
         this.getNativeStreamerManager().updateSurface(surface);
+      },
+    );
+
+    ipcMain.on(
+      IPC_CHANNELS.NATIVE_UPDATE_SHORTCUTS,
+      (_event, shortcuts: NativeStreamerShortcutBindings) => {
+        if (!this.isNativeStreamerSelected()) {
+          return;
+        }
+        this.getNativeStreamerManager().updateShortcuts(shortcuts);
       },
     );
 

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -106,6 +106,9 @@ const api: OpenNowApi = {
   updateNativeRenderSurface: (input: NativeRenderSurfaceUpdate) => {
     ipcRenderer.send(IPC_CHANNELS.NATIVE_RENDER_SURFACE, input);
   },
+  updateNativeShortcuts: (shortcuts) => {
+    ipcRenderer.send(IPC_CHANNELS.NATIVE_UPDATE_SHORTCUTS, shortcuts);
+  },
   requestKeyframe: (input: KeyframeRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.REQUEST_KEYFRAME, input),
   onSignalingEvent: (listener: (event: MainToRendererSignalingEvent) => void) => {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -3756,32 +3756,30 @@ export function App(): JSX.Element {
           Debug no-login mode: account and launch features are disabled.
         </div>
       )}
-      {!(settings.controllerMode && currentPage === "library") && (
-        <Navbar
-          currentPage={currentPage}
-          onNavigate={setCurrentPage}
-          user={authSession.user}
-          subscription={subscriptionInfo}
-          activeSession={navbarActiveSession}
-          activeSessionGameTitle={activeSessionGameTitle}
-          isResumingSession={isResumingNavbarSession}
-          isTerminatingSession={isTerminatingNavbarSession}
-          onResumeSession={() => {
-            void handleResumeFromNavbar();
-          }}
-          onTerminateSession={() => {
-            void handleTerminateNavbarSession();
-          }}
-          savedAccounts={savedAccounts}
-          onSwitchAccount={handleSwitchAccount}
-          onRemoveAccount={(userId) => {
-            void handleRemoveAccount(userId);
-          }}
-          onAddAccount={handleAddAccount}
-          onLogoutAll={handleLogout}
-          controllerMode={settings.controllerMode}
-        />
-      )}
+      <Navbar
+        currentPage={currentPage}
+        onNavigate={setCurrentPage}
+        user={authSession.user}
+        subscription={subscriptionInfo}
+        activeSession={navbarActiveSession}
+        activeSessionGameTitle={activeSessionGameTitle}
+        isResumingSession={isResumingNavbarSession}
+        isTerminatingSession={isTerminatingNavbarSession}
+        onResumeSession={() => {
+          void handleResumeFromNavbar();
+        }}
+        onTerminateSession={() => {
+          void handleTerminateNavbarSession();
+        }}
+        savedAccounts={savedAccounts}
+        onSwitchAccount={handleSwitchAccount}
+        onRemoveAccount={(userId) => {
+          void handleRemoveAccount(userId);
+        }}
+        onAddAccount={handleAddAccount}
+        onLogoutAll={handleLogout}
+        controllerMode={settings.controllerMode}
+      />
 
       <main className="main-content">
         {currentPage === "home" && (

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import type {
   GamePanelResult,
   LoginProvider,
   MainToRendererSignalingEvent,
+  NativeStreamerShortcutAction,
   SessionInfo,
   SessionStopRequest,
   SavedAccount,
@@ -31,6 +32,8 @@ import {
 } from "@shared/gfn";
 import { GfnWebRtcClient } from "./gfn/webrtcClient";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
+import { dispatchStreamShortcutAction } from "./streamShortcutActions";
+import { useControllerNavigation } from "./controllerNavigation";
 import { useElapsedSeconds } from "./utils/useElapsedSeconds";
 import { useQueueAdRuntime } from "./hooks/useQueueAdRuntime";
 import { usePlaytime } from "./utils/usePlaytime";
@@ -545,16 +548,6 @@ export function App(): JSX.Element {
     settings.streamClientMode,
   ]);
 
-  const buildSignalingConnectRequest = useCallback((activeSession: SessionInfo): SignalingConnectRequest => {
-    const streamSettings = buildCurrentStreamSettings();
-    return {
-      sessionId: activeSession.sessionId,
-      signalingServer: activeSession.signalingServer,
-      signalingUrl: activeSession.signalingUrl,
-      nativeStreamer: buildNativeStreamerSessionContext(activeSession, streamSettings),
-    };
-  }, [buildCurrentStreamSettings]);
-
   const warmNativeStreamerForLaunch = useCallback((): void => {
     if (settings.streamClientMode !== "native") {
       return;
@@ -985,6 +978,27 @@ export function App(): JSX.Element {
     settings.shortcutScreenshot,
     settings.shortcutToggleRecording,
   ]);
+
+  const nativeStreamerShortcuts = useMemo(() => ({
+    toggleStats: shortcuts.toggleStats.canonical,
+    togglePointerLock: shortcuts.togglePointerLock.canonical,
+    toggleFullscreen: shortcuts.toggleFullscreen.canonical,
+    stopStream: shortcuts.stopStream.canonical,
+    toggleAntiAfk: shortcuts.toggleAntiAfk.canonical,
+    toggleMicrophone: shortcuts.toggleMicrophone.canonical,
+    screenshot: shortcuts.screenshot.canonical,
+    toggleRecording: shortcuts.recording.canonical,
+  }), [shortcuts]);
+
+  const buildSignalingConnectRequest = useCallback((activeSession: SessionInfo): SignalingConnectRequest => {
+    const streamSettings = buildCurrentStreamSettings();
+    return {
+      sessionId: activeSession.sessionId,
+      signalingServer: activeSession.signalingServer,
+      signalingUrl: activeSession.signalingUrl,
+      nativeStreamer: buildNativeStreamerSessionContext(activeSession, streamSettings, nativeStreamerShortcuts),
+    };
+  }, [buildCurrentStreamSettings, nativeStreamerShortcuts]);
 
   const setSessionFullscreen = useCallback(async (nextFullscreen: boolean) => {
     const canUseNativeFullscreen = typeof window.openNow?.setFullscreen === "function";
@@ -2324,6 +2338,8 @@ export function App(): JSX.Element {
           if (nativeStreamingRef.current || sessionRef.current) {
             activateNativeInputForCurrentSession(event.protocolVersion);
           }
+        } else if (event.type === "native-shortcut") {
+          handleStreamShortcutAction(event.action);
         } else if (event.type === "native-stream-stats") {
           diagnosticsStore.set(mergeNativeStreamStats(
             diagnosticsStore.getSnapshot(),
@@ -3249,6 +3265,55 @@ export function App(): JSX.Element {
     await handleStopStream();
   }, [handleStopStream, releasePointerLockIfNeeded, requestExitPrompt, streamStatus, streamingGame?.title, t]);
 
+  const handleStreamShortcutAction = useCallback((action: NativeStreamerShortcutAction): void => {
+    switch (action) {
+      case "toggleStats":
+        setShowStatsOverlay((prev) => !prev);
+        return;
+      case "togglePointerLock":
+        {
+          const targetVideo = videoRef.current;
+          if (streamStatus === "streaming" && targetVideo) {
+            if (document.pointerLockElement === targetVideo) {
+              const client = clientRef.current as { suppressNextSyntheticEscape?: boolean } | null;
+              if (client) {
+                client.suppressNextSyntheticEscape = true;
+              }
+              document.exitPointerLock();
+            } else {
+              void requestPointerLockCapture(targetVideo);
+            }
+          }
+        }
+        return;
+      case "toggleFullscreen":
+        if (streamStatus === "connecting" || streamStatus === "streaming") {
+          void toggleSessionFullscreen();
+        }
+        return;
+      case "stopStream":
+        void handlePromptedStopStream();
+        return;
+      case "toggleAntiAfk":
+        if (streamStatus === "streaming") {
+          setAntiAfkEnabled((prev) => !prev);
+          setAntiAfkAckNonce((n) => n + 1);
+        }
+        return;
+      case "toggleMicrophone":
+        if (streamStatus === "streaming") {
+          clientRef.current?.toggleMicrophone();
+        }
+        return;
+      case "screenshot":
+      case "toggleRecording":
+        if (streamStatus === "streaming") {
+          dispatchStreamShortcutAction(action);
+        }
+        return;
+    }
+  }, [handlePromptedStopStream, requestPointerLockCapture, streamStatus, toggleSessionFullscreen]);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -3310,7 +3375,7 @@ export function App(): JSX.Element {
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
-        setShowStatsOverlay((prev) => !prev);
+        handleStreamShortcutAction("toggleStats");
         return;
       }
 
@@ -3318,6 +3383,8 @@ export function App(): JSX.Element {
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
+        handleStreamShortcutAction("togglePointerLock");
+        return;
         if (streamStatus === "streaming" && videoRef.current) {
           if (document.pointerLockElement === videoRef.current) {
             try {
@@ -3327,7 +3394,7 @@ export function App(): JSX.Element {
             }
             document.exitPointerLock();
           } else {
-            void requestPointerLockCapture(videoRef.current);
+            void requestPointerLockCapture(videoRef.current!);
           }
         }
         return;

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -178,6 +178,44 @@ const DEFAULT_SHORTCUTS = {
   shortcutToggleRecording: "F12",
 } as const;
 
+const DEBUG_NO_LOGIN_STORAGE_KEY = "opennow.debugNoLogin";
+const DEBUG_NO_LOGIN_PROVIDER: LoginProvider = {
+  idpId: "debug-no-login",
+  code: "DEBUG",
+  displayName: "Debug (no account)",
+  streamingServiceUrl: "",
+  priority: 999,
+};
+
+function isDebugNoLoginEnabled(): boolean {
+  const queryValue = new URLSearchParams(window.location.search).get("debugNoLogin")?.toLowerCase();
+  if (queryValue === "1" || queryValue === "true" || queryValue === "yes" || queryValue === "on") {
+    return true;
+  }
+
+  try {
+    const stored = localStorage.getItem(DEBUG_NO_LOGIN_STORAGE_KEY)?.toLowerCase();
+    return stored === "1" || stored === "true" || stored === "yes" || stored === "on";
+  } catch {
+    return false;
+  }
+}
+
+function createDebugNoLoginSession(): AuthSession {
+  return {
+    provider: DEBUG_NO_LOGIN_PROVIDER,
+    tokens: {
+      accessToken: "",
+      expiresAt: Number.MAX_SAFE_INTEGER,
+    },
+    user: {
+      userId: "debug-no-login",
+      displayName: "Debug Mode",
+      membershipTier: "DEBUG",
+    },
+  };
+}
+
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
@@ -201,6 +239,7 @@ async function readStreamClipboardText(): Promise<string> {
 
 export function App(): JSX.Element {
   const { locale, t } = useTranslation();
+  const debugNoLoginMode = useMemo(() => isDebugNoLoginEnabled(), []);
 
   // Auth State
   const [authSession, setAuthSession] = useState<AuthSession | null>(null);
@@ -1441,6 +1480,34 @@ export function App(): JSX.Element {
     catalogSelectedSortId,
   ]);
 
+  const loadDebugNoLoginRuntimeData = useCallback(async (): Promise<void> => {
+    setRegions([]);
+    setLibraryGames([]);
+    setSubscriptionInfo(null);
+    setNavbarActiveSession(null);
+    try {
+      const publicGames = await window.openNow.fetchPublicGames();
+      const query = searchQuery.trim();
+      const visibleGames = query
+        ? publicGames.filter((game) => matchesGameSearch(game, query))
+        : publicGames;
+      setGames(visibleGames);
+      setCatalogFilterGroups([]);
+      setCatalogSortOptions([]);
+      setCatalogTotalCount(publicGames.length);
+      setCatalogSupportedCount(publicGames.length);
+      setSelectedGameId((previous) => visibleGames.some((game) => game.id === previous) ? previous : (visibleGames[0]?.id ?? ""));
+      applyVariantSelections(visibleGames);
+    } catch (error) {
+      console.warn("Debug no-login public catalog load failed:", error);
+      setGames([]);
+      setCatalogFilterGroups([]);
+      setCatalogSortOptions([]);
+      setCatalogTotalCount(0);
+      setCatalogSupportedCount(0);
+    }
+  }, [applyVariantSelections, searchQuery]);
+
   // Initialize app
   useEffect(() => {
     if (hasInitializedRef.current) return;
@@ -1453,6 +1520,17 @@ export function App(): JSX.Element {
         setSettings(loadedSettings);
         setShowStatsOverlay(loadedSettings.showStatsOnLaunch);
         setSettingsLoaded(true);
+
+        if (debugNoLoginMode) {
+          setStartupStatusMessage("Debug no-login mode");
+          setProviders([DEBUG_NO_LOGIN_PROVIDER]);
+          setProviderIdpId(DEBUG_NO_LOGIN_PROVIDER.idpId);
+          setAuthSession(createDebugNoLoginSession());
+          setSavedAccounts([]);
+          await loadDebugNoLoginRuntimeData();
+          setIsInitializing(false);
+          return;
+        }
 
         // Load providers and session (refresh only if token is near expiry)
         setStartupStatusMessage(t("auth.status.restoringSavedSession"));
@@ -1536,10 +1614,13 @@ export function App(): JSX.Element {
     };
 
     void initialize();
-  }, [loadSessionRuntimeData, resetStorePanels, t]);
+  }, [debugNoLoginMode, loadDebugNoLoginRuntimeData, loadSessionRuntimeData, resetStorePanels, t]);
 
   // Login handler
   const handleLogin = useCallback(async () => {
+    if (debugNoLoginMode) {
+      return;
+    }
     setIsLoggingIn(true);
     setLoginError(null);
     try {
@@ -1553,9 +1634,12 @@ export function App(): JSX.Element {
     } finally {
       setIsLoggingIn(false);
     }
-  }, [loadSessionRuntimeData, providerIdpId, refreshSavedAccounts, t]);
+  }, [debugNoLoginMode, loadSessionRuntimeData, providerIdpId, refreshSavedAccounts, t]);
 
   const handleSwitchAccount = useCallback(async (userId: string) => {
+    if (debugNoLoginMode) {
+      return;
+    }
     try {
       const session = await window.openNow.switchAccount(userId);
       setAuthSession(session);
@@ -1593,14 +1677,22 @@ export function App(): JSX.Element {
         console.warn("Failed to recover account state after switch failure:", recoveryError);
       }
     }
-  }, [loadSessionRuntimeData, refreshNavbarActiveSession, refreshSavedAccounts, resetStorePanels, t]);
+  }, [debugNoLoginMode, loadSessionRuntimeData, refreshNavbarActiveSession, refreshSavedAccounts, resetStorePanels, t]);
 
   const handleRemoveAccount = useCallback((userId: string) => {
+    if (debugNoLoginMode) {
+      return;
+    }
     setAccountToRemove(userId);
     setRemoveAccountConfirmOpen(true);
-  }, []);
+  }, [debugNoLoginMode]);
 
   const confirmRemoveAccount = useCallback(async () => {
+    if (debugNoLoginMode) {
+      setRemoveAccountConfirmOpen(false);
+      setAccountToRemove(null);
+      return;
+    }
     if (!accountToRemove) return;
     const targetUserId = accountToRemove;
     setRemoveAccountConfirmOpen(false);
@@ -1633,15 +1725,22 @@ export function App(): JSX.Element {
     setCatalogSupportedCount(0);
     setIsLoadingCatalog(false);
     setIsLoadingLibrary(false);
-  }, [accountToRemove, loadSessionRuntimeData, refreshNavbarActiveSession, resetStorePanels]);
+  }, [accountToRemove, debugNoLoginMode, loadSessionRuntimeData, refreshNavbarActiveSession, resetStorePanels]);
 
   const handleAddAccount = useCallback(() => {
+    if (debugNoLoginMode) {
+      return;
+    }
     setAuthSession(null);
     setLoginError(null);
-  }, []);
+  }, [debugNoLoginMode]);
 
   const confirmLogout = useCallback(async () => {
     setLogoutConfirmOpen(false);
+    if (debugNoLoginMode) {
+      setAuthSession(createDebugNoLoginSession());
+      return;
+    }
     runtimeDataLoadIdRef.current += 1;
     resetStorePanels();
     await window.openNow.logoutAll();
@@ -1664,7 +1763,7 @@ export function App(): JSX.Element {
     setSelectedGameId("");
     setIsLoadingCatalog(false);
     setIsLoadingLibrary(false);
-  }, [resetLaunchRuntime, resetStorePanels]);
+  }, [debugNoLoginMode, resetLaunchRuntime, resetStorePanels]);
 
   // Logout handler
   const handleLogout = useCallback(() => {
@@ -1676,6 +1775,15 @@ export function App(): JSX.Element {
     const setLoading = targetSource === "main" ? setIsLoadingCatalog : setIsLoadingLibrary;
     setLoading(true);
     try {
+      if (debugNoLoginMode) {
+        if (targetSource === "library") {
+          setLibraryGames([]);
+          return;
+        }
+        await loadDebugNoLoginRuntimeData();
+        return;
+      }
+
       const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
       const baseUrl = effectiveStreamingBaseUrl;
       if (!token) {
@@ -1710,7 +1818,7 @@ export function App(): JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, [applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, featuredGames, searchQuery, catalogFilterKey, catalogSelectedSortId]);
+  }, [applyCatalogBrowseResult, applyVariantSelections, authSession, debugNoLoginMode, effectiveStreamingBaseUrl, featuredGames, loadDebugNoLoginRuntimeData, searchQuery, catalogFilterKey, catalogSelectedSortId]);
 
   const loadStorePanels = useCallback(async () => {
     const session = authSession;
@@ -1779,11 +1887,11 @@ export function App(): JSX.Element {
   }, [authSession, currentPage, loadGames, searchQuery, catalogFilterKey, catalogSelectedSortId, settings.controllerMode]);
 
   useEffect(() => {
-    if (!authSession || currentPage !== "home" || !settings.controllerMode) {
+    if (debugNoLoginMode || !authSession || currentPage !== "home" || !settings.controllerMode) {
       return;
     }
     void loadStorePanels();
-  }, [authSession, currentPage, loadStorePanels, settings.controllerMode]);
+  }, [authSession, currentPage, debugNoLoginMode, loadStorePanels, settings.controllerMode]);
 
   const handleSelectGameVariant = useCallback((gameId: string, variantId: string): void => {
     setVariantByGameId((prev) => {
@@ -2545,6 +2653,19 @@ export function App(): JSX.Element {
       return;
     }
 
+    if (debugNoLoginMode) {
+      const selectedVariantId = variantByGameId[game.id] ?? defaultVariantId(game);
+      const selectedVariant = getSelectedVariant(game, selectedVariantId);
+      setStreamingGame(game);
+      setStreamingStore(selectedVariant?.store ?? null);
+      setLaunchError({
+        stage: "queue",
+        title: "Debug no-login mode",
+        description: "Launching is disabled because this mode never calls account, session, or entitlement APIs.",
+      });
+      return;
+    }
+
     const selectedVariantId = variantByGameId[game.id] ?? defaultVariantId(game);
     const selectedVariant = getSelectedVariant(game, selectedVariantId);
     const epicOwnershipError = getEpicOwnershipLaunchError(selectedVariant);
@@ -2817,6 +2938,7 @@ export function App(): JSX.Element {
     allKnownGames,
     buildSignalingConnectRequest,
     claimAndConnectSession,
+    debugNoLoginMode,
     effectiveStreamingBaseUrl,
     refreshNavbarActiveSession,
     resetSignalingRecoveryState,
@@ -2832,6 +2954,11 @@ export function App(): JSX.Element {
 
   // Gate handler: shows queue server modal for FREE-tier users before launching
   const handleInitiatePlay = useCallback(async (game: GameInfo) => {
+    if (debugNoLoginMode) {
+      void handlePlayGame(game);
+      return;
+    }
+
     const effectiveTier = normalizeMembershipTier(
       subscriptionInfo?.membershipTier ?? authSession?.user.membershipTier,
     );
@@ -2895,7 +3022,7 @@ export function App(): JSX.Element {
       return;
     }
     void handlePlayGame(game);
-  }, [subscriptionInfo, authSession, selectedProvider, settings.hideServerSelector, streamStatus, handlePlayGame, effectiveStreamingBaseUrl]);
+  }, [debugNoLoginMode, subscriptionInfo, authSession, selectedProvider, settings.hideServerSelector, streamStatus, handlePlayGame, effectiveStreamingBaseUrl]);
 
   const handleQueueModalConfirm = useCallback((zoneUrl: string | null) => {
     const game = queueModalGame;
@@ -3398,19 +3525,6 @@ export function App(): JSX.Element {
         e.stopImmediatePropagation();
         handleStreamShortcutAction("togglePointerLock");
         return;
-        if (streamStatus === "streaming" && videoRef.current) {
-          if (document.pointerLockElement === videoRef.current) {
-            try {
-              (clientRef.current as any).suppressNextSyntheticEscape = true;
-            } catch {
-              // best-effort — client may not be initialised
-            }
-            document.exitPointerLock();
-          } else {
-            void requestPointerLockCapture(videoRef.current!);
-          }
-        }
-        return;
       }
 
       if (isShortcutMatch(e, shortcuts.toggleFullscreen)) {
@@ -3638,30 +3752,37 @@ export function App(): JSX.Element {
           {startupRefreshNotice.text}
         </div>
       )}
-      <Navbar
-        currentPage={currentPage}
-        onNavigate={setCurrentPage}
-        user={authSession.user}
-        subscription={subscriptionInfo}
-        activeSession={navbarActiveSession}
-        activeSessionGameTitle={activeSessionGameTitle}
-        isResumingSession={isResumingNavbarSession}
-        isTerminatingSession={isTerminatingNavbarSession}
-        onResumeSession={() => {
-          void handleResumeFromNavbar();
-        }}
-        onTerminateSession={() => {
-          void handleTerminateNavbarSession();
-        }}
-        savedAccounts={savedAccounts}
-        onSwitchAccount={handleSwitchAccount}
-        onRemoveAccount={(userId) => {
-          void handleRemoveAccount(userId);
-        }}
-        onAddAccount={handleAddAccount}
-        onLogoutAll={handleLogout}
-        controllerMode={settings.controllerMode}
-      />
+      {debugNoLoginMode && (
+        <div className="auth-refresh-notice auth-refresh-notice--warn">
+          Debug no-login mode: account and launch features are disabled.
+        </div>
+      )}
+      {!(settings.controllerMode && currentPage === "library") && (
+        <Navbar
+          currentPage={currentPage}
+          onNavigate={setCurrentPage}
+          user={authSession.user}
+          subscription={subscriptionInfo}
+          activeSession={navbarActiveSession}
+          activeSessionGameTitle={activeSessionGameTitle}
+          isResumingSession={isResumingNavbarSession}
+          isTerminatingSession={isTerminatingNavbarSession}
+          onResumeSession={() => {
+            void handleResumeFromNavbar();
+          }}
+          onTerminateSession={() => {
+            void handleTerminateNavbarSession();
+          }}
+          savedAccounts={savedAccounts}
+          onSwitchAccount={handleSwitchAccount}
+          onRemoveAccount={(userId) => {
+            void handleRemoveAccount(userId);
+          }}
+          onAddAccount={handleAddAccount}
+          onLogoutAll={handleLogout}
+          controllerMode={settings.controllerMode}
+        />
+      )}
 
       <main className="main-content">
         {currentPage === "home" && (

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -33,7 +33,6 @@ import {
 import { GfnWebRtcClient } from "./gfn/webrtcClient";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
 import { dispatchStreamShortcutAction } from "./streamShortcutActions";
-import { useControllerNavigation } from "./controllerNavigation";
 import { useElapsedSeconds } from "./utils/useElapsedSeconds";
 import { useQueueAdRuntime } from "./hooks/useQueueAdRuntime";
 import { usePlaytime } from "./utils/usePlaytime";

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1001,6 +1001,14 @@ export function App(): JSX.Element {
     };
   }, [buildCurrentStreamSettings, nativeStreamerShortcuts]);
 
+  // Propagate shortcut binding changes to native process during active session
+  useEffect(() => {
+    if (streamStatus !== "streaming" || !session || !nativeStreamingRef.current) {
+      return;
+    }
+    window.openNow.updateNativeShortcuts(nativeStreamerShortcuts);
+  }, [nativeStreamerShortcuts, session, streamStatus]);
+
   const setSessionFullscreen = useCallback(async (nextFullscreen: boolean) => {
     const canUseNativeFullscreen = typeof window.openNow?.setFullscreen === "function";
 

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -364,6 +364,7 @@ export function App(): JSX.Element {
   const navbarSessionActionInFlightRef = useRef<"resume" | "terminate" | null>(null);
   const nativeStreamingRef = useRef(false);
   const streamingGameRef = useRef<GameInfo | null>(null);
+  const handleStreamShortcutActionRef = useRef<((action: NativeStreamerShortcutAction) => void) | null>(null);
 
   useEffect(() => {
     streamingGameRef.current = streamingGame;
@@ -2339,7 +2340,7 @@ export function App(): JSX.Element {
             activateNativeInputForCurrentSession(event.protocolVersion);
           }
         } else if (event.type === "native-shortcut") {
-          handleStreamShortcutAction(event.action);
+          handleStreamShortcutActionRef.current?.(event.action);
         } else if (event.type === "native-stream-stats") {
           diagnosticsStore.set(mergeNativeStreamStats(
             diagnosticsStore.getSnapshot(),
@@ -3313,6 +3314,10 @@ export function App(): JSX.Element {
         return;
     }
   }, [handlePromptedStopStream, requestPointerLockCapture, streamStatus, toggleSessionFullscreen]);
+
+  useEffect(() => {
+    handleStreamShortcutActionRef.current = handleStreamShortcutAction;
+  }, [handleStreamShortcutAction]);
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1454,6 +1454,40 @@ export function StreamView({
   }, [captureScreenshot, toggleRecording]);
 
   useEffect(() => {
+    const screenshotShortcut = normalizeShortcut(shortcuts.screenshot);
+    const recordingShortcut = normalizeShortcut(shortcuts.recording);
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const isTyping = !!target && (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      );
+      if (isTyping) {
+        return;
+      }
+
+      if (isShortcutMatch(event, screenshotShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void captureScreenshot();
+        return;
+      }
+
+      if (isShortcutMatch(event, recordingShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void toggleRecording();
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [captureScreenshot, shortcuts.screenshot, shortcuts.recording, toggleRecording]);
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
       const isTyping = !!target && (

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -11,6 +11,7 @@ import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { RemainingPlaytimeIndicator, SessionElapsedIndicator } from "./ElapsedSessionIndicators";
 import type { MicrophoneMode, ScreenshotEntry, RecordingEntry, SubscriptionInfo } from "@shared/gfn";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
+import { addStreamShortcutActionListener } from "../streamShortcutActions";
 import { useMicMeter } from "../hooks/useMicMeter";
 import {
   getBitratePerformanceColor,
@@ -1441,8 +1442,18 @@ export function StreamView({
   }, [onReleasePointerLock]);
 
   useEffect(() => {
-    const screenshotShortcut = normalizeShortcut(shortcuts.screenshot);
-    const recordingShortcut = normalizeShortcut(shortcuts.recording);
+    return addStreamShortcutActionListener((action) => {
+      if (action === "screenshot") {
+        void captureScreenshot();
+        return;
+      }
+      if (action === "toggleRecording") {
+        void toggleRecording();
+      }
+    });
+  }, [captureScreenshot, toggleRecording]);
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
       const isTyping = !!target && (
@@ -1451,20 +1462,6 @@ export function StreamView({
         target.isContentEditable
       );
       if (isTyping) {
-        return;
-      }
-
-      if (isShortcutMatch(event, screenshotShortcut)) {
-        event.preventDefault();
-        event.stopPropagation();
-        void captureScreenshot();
-        return;
-      }
-
-      if (isShortcutMatch(event, recordingShortcut)) {
-        event.preventDefault();
-        event.stopPropagation();
-        void toggleRecording();
         return;
       }
 
@@ -1482,7 +1479,7 @@ export function StreamView({
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [captureScreenshot, handleToggleSideBar, isMacClient, shortcuts.screenshot, shortcuts.recording, toggleRecording]);
+  }, [handleToggleSideBar, isMacClient]);
 
   return (
     <div className={["sv", className].filter(Boolean).join(" ")}>

--- a/opennow-stable/src/renderer/src/shortcuts.test.ts
+++ b/opennow-stable/src/renderer/src/shortcuts.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeShortcut, shortcutFromKeyboardEvent } from "./shortcuts";
+
+test("shortcut normalization accepts native-supported named keys", () => {
+  const parsed = normalizeShortcut("Ctrl+ContextMenu");
+
+  assert.equal(parsed.valid, true);
+  assert.equal(parsed.canonical, "Ctrl+CONTEXTMENU");
+});
+
+test("shortcut normalization rejects unsupported named key tokens", () => {
+  const parsed = normalizeShortcut("Ctrl+BrowserBack");
+
+  assert.equal(parsed.valid, false);
+});
+
+test("shortcut capture ignores unsupported keyboard codes", () => {
+  const captured = shortcutFromKeyboardEvent({
+    repeat: false,
+    code: "BrowserBack",
+    key: "BrowserBack",
+    ctrlKey: true,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+  } as KeyboardEvent);
+
+  assert.equal(captured, null);
+});

--- a/opennow-stable/src/renderer/src/shortcuts.ts
+++ b/opennow-stable/src/renderer/src/shortcuts.ts
@@ -8,6 +8,54 @@ export interface ParsedShortcut {
   canonical: string;
 }
 
+const SUPPORTED_NAMED_KEYS = new Set([
+  "BACKSPACE",
+  "TAB",
+  "ENTER",
+  "NUMPADENTER",
+  "PAUSE",
+  "CAPSLOCK",
+  "ESCAPE",
+  "SPACE",
+  "PAGEUP",
+  "PAGEDOWN",
+  "END",
+  "HOME",
+  "ARROWLEFT",
+  "ARROWUP",
+  "ARROWRIGHT",
+  "ARROWDOWN",
+  "INSERT",
+  "DELETE",
+  "PRINTSCREEN",
+  "APPS",
+  "MENU",
+  "CONTEXTMENU",
+  "METALEFT",
+  "METARIGHT",
+  "OSLEFT",
+  "OSRIGHT",
+  "NUMPADMULTIPLY",
+  "NUMPADADD",
+  "NUMPADSEPARATOR",
+  "NUMPADSUBTRACT",
+  "NUMPADDECIMAL",
+  "NUMPADDIVIDE",
+  "NUMLOCK",
+  "SCROLLLOCK",
+  "SEMICOLON",
+  "EQUAL",
+  "COMMA",
+  "MINUS",
+  "PERIOD",
+  "SLASH",
+  "BACKQUOTE",
+  "BRACKETLEFT",
+  "BACKSLASH",
+  "BRACKETRIGHT",
+  "QUOTE",
+]);
+
 function normalizeKeyToken(token: string): string | null {
   const upper = token.toUpperCase();
   const alias: Record<string, string> = {
@@ -28,12 +76,13 @@ function normalizeKeyToken(token: string): string | null {
     return upper;
   }
   if (/^F\d{1,2}$/.test(upper)) {
+    const index = Number.parseInt(upper.slice(1), 10);
+    return index >= 1 && index <= 24 ? upper : null;
+  }
+  if (/^NUMPAD\d$/.test(upper)) {
     return upper;
   }
-  if (upper.startsWith("ARROW")) {
-    return upper;
-  }
-  if (/^[A-Z0-9_]+$/.test(upper)) {
+  if (SUPPORTED_NAMED_KEYS.has(upper)) {
     return upper;
   }
   return null;

--- a/opennow-stable/src/renderer/src/streamShortcutActions.ts
+++ b/opennow-stable/src/renderer/src/streamShortcutActions.ts
@@ -1,0 +1,22 @@
+import type { NativeStreamerShortcutAction } from "@shared/gfn";
+
+const STREAM_SHORTCUT_ACTION_EVENT = "opennow:stream-shortcut-action";
+
+export function dispatchStreamShortcutAction(action: NativeStreamerShortcutAction): void {
+  window.dispatchEvent(new CustomEvent<NativeStreamerShortcutAction>(STREAM_SHORTCUT_ACTION_EVENT, {
+    detail: action,
+  }));
+}
+
+export function addStreamShortcutActionListener(
+  listener: (action: NativeStreamerShortcutAction) => void,
+): () => void {
+  const handler: EventListener = (event) => {
+    listener((event as CustomEvent<NativeStreamerShortcutAction>).detail);
+  };
+
+  window.addEventListener(STREAM_SHORTCUT_ACTION_EVENT, handler);
+  return () => {
+    window.removeEventListener(STREAM_SHORTCUT_ACTION_EVENT, handler);
+  };
+}

--- a/opennow-stable/src/shared/gfn.test.ts
+++ b/opennow-stable/src/shared/gfn.test.ts
@@ -139,6 +139,16 @@ test("buildNativeStreamerSessionContext forwards requested/finalized streaming f
         forceQueueMode: "adaptive",
       },
     },
+    {
+      toggleStats: "F3",
+      togglePointerLock: "F8",
+      toggleFullscreen: "F10",
+      stopStream: "Ctrl+Shift+Q",
+      toggleAntiAfk: "Ctrl+Shift+K",
+      toggleMicrophone: "Ctrl+Shift+M",
+      screenshot: "F11",
+      toggleRecording: "F12",
+    },
   );
 
   assert.deepEqual(context.session.requestedStreamingFeatures, {
@@ -158,6 +168,7 @@ test("buildNativeStreamerSessionContext forwards requested/finalized streaming f
   assert.equal(context.session.negotiatedStreamProfile?.codec, "H265");
   assert.equal(context.settings.enableCloudGsync, false);
   assert.equal(context.settings.nativeTransitionDiagnostics?.forceQueueMode, "adaptive");
+  assert.equal(context.shortcuts.toggleRecording, "F12");
 });
 
 test("normalizes native stream client mode to web on non-Windows platforms", () => {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -876,14 +876,37 @@ export interface SendAnswerRequest {
   nvstSdp?: string;
 }
 
+export type NativeStreamerShortcutAction =
+  | "toggleStats"
+  | "togglePointerLock"
+  | "toggleFullscreen"
+  | "stopStream"
+  | "toggleAntiAfk"
+  | "toggleMicrophone"
+  | "screenshot"
+  | "toggleRecording";
+
+export interface NativeStreamerShortcutBindings {
+  toggleStats: string;
+  togglePointerLock: string;
+  toggleFullscreen: string;
+  stopStream: string;
+  toggleAntiAfk: string;
+  toggleMicrophone: string;
+  screenshot: string;
+  toggleRecording: string;
+}
+
 export interface NativeStreamerSessionContext {
   session: SessionInfo;
   settings: StreamSettings;
+  shortcuts: NativeStreamerShortcutBindings;
 }
 
 export function buildNativeStreamerSessionContext(
   session: SessionInfo,
   settings: StreamSettings,
+  shortcuts: NativeStreamerShortcutBindings,
 ): NativeStreamerSessionContext {
   const negotiatedStreamProfile = session.negotiatedStreamProfile
     ? {
@@ -902,6 +925,7 @@ export function buildNativeStreamerSessionContext(
       enableCloudGsync:
         session.negotiatedStreamProfile?.enableCloudGsync ?? settings.enableCloudGsync,
     },
+    shortcuts,
   };
 }
 
@@ -957,6 +981,7 @@ export type MainToRendererSignalingEvent =
   | { type: "disconnected"; reason: string }
   | { type: "offer"; sdp: string }
   | { type: "remote-ice"; candidate: IceCandidatePayload }
+  | { type: "native-shortcut"; action: NativeStreamerShortcutAction }
   | { type: "native-stream-started"; message?: string }
   | { type: "native-stream-stopped"; reason?: string }
   | { type: "native-stream-stats"; stats: NativeStreamStats }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1099,6 +1099,7 @@ export interface OpenNowApi {
   sendIceCandidate(input: IceCandidatePayload): Promise<void>;
   sendNativeInput(input: NativeInputPacket): void;
   updateNativeRenderSurface(input: NativeRenderSurfaceUpdate): void;
+  updateNativeShortcuts(shortcuts: NativeStreamerShortcutBindings): void;
   requestKeyframe(input: KeyframeRequest): Promise<void>;
   onSignalingEvent(listener: (event: MainToRendererSignalingEvent) => void): () => void;
   /** Listen for F11 fullscreen toggle from main process */

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -31,6 +31,7 @@ export const IPC_CHANNELS = {
   SEND_ICE_CANDIDATE: "gfn:send-ice-candidate",
   NATIVE_INPUT: "gfn:native-input",
   NATIVE_RENDER_SURFACE: "gfn:native-render-surface",
+  NATIVE_UPDATE_SHORTCUTS: "gfn:native-update-shortcuts",
   REQUEST_KEYFRAME: "gfn:request-keyframe",
   SIGNALING_EVENT: "gfn:signaling-event",
   TOGGLE_FULLSCREEN: "window:toggle-fullscreen",

--- a/opennow-stable/src/shared/nativeStreamer.ts
+++ b/opennow-stable/src/shared/nativeStreamer.ts
@@ -72,6 +72,11 @@ export type NativeStreamerCommand =
       id: string;
       type: "stop";
       reason?: string;
+    }
+  | {
+      id: string;
+      type: "update-shortcuts";
+      shortcuts: import("./gfn").NativeStreamerShortcutBindings;
     };
 
 export type NativeStreamerResponse =

--- a/opennow-stable/src/shared/nativeStreamer.ts
+++ b/opennow-stable/src/shared/nativeStreamer.ts
@@ -3,6 +3,7 @@ import type {
   NativeStreamerBackend,
   NativeStreamStats,
   NativeRenderSurface,
+  NativeStreamerShortcutAction,
   NativeStreamerSessionContext,
   NativeVideoTransition,
   NativeVideoBackendCapability,
@@ -113,6 +114,10 @@ export type NativeStreamerEvent =
   | {
       type: "input-ready";
       protocolVersion: number;
+    }
+  | {
+      type: "shortcut";
+      action: NativeStreamerShortcutAction;
     }
   | {
       type: "video-stall";


### PR DESCRIPTION
This PR adds native streamer shortcut integration and a debug no-login mode for testing without account dependencies. Native shortcuts are handled via a Windows-specific raw input layer that parses key combinations and forwards matching events to the renderer. The debug mode boots directly into the public catalog UI with a fake session, bypassing all account, session, and entitlement APIs.

## Changes

### Native Streamer (Windows-only)
- **`native/opennow-streamer/src/shortcuts.rs`** (new): Parses string-based shortcut bindings (e.g., `Ctrl+Shift+Q`) into virtual key codes and modifiers; matches keyboard events against registered bindings.
- **`native/opennow-streamer/src/gstreamer_platform.rs`**: Registers raw keyboard input without legacy processing; intercepts matching shortcuts, suppresses DOM handling, and emits `NativeWindowInputEvent::Shortcut` before input readiness gating.
- **`native/opennow-streamer/src/gstreamer_input.rs`**: Forwards shortcut events immediately via event sender without waiting for input channel readiness.
- **`native/opennow-streamer/src/gstreamer_backend.rs`**: Sets/clears native shortcut bindings when a stream session starts/stops via `set_native_shortcut_bindings`/`clear_native_shortcut_bindings`.
- **`native/opennow-streamer/src/protocol.rs`**: Adds `NativeStreamerShortcutBindings` to session context and `NativeShortcutAction` to protocol events.
- **`native/opennow-streamer/src/main.rs`**: Conditionally compiles shortcuts module with `#[cfg(all(feature = "gstreamer", target_os = "windows"))]`.

### Electron/Main Process
- **`opennow-stable/src/main/nativeStreamer/manager.ts`**: Relays `native-shortcut` events from the native process to renderer via signaling event emitter.
- **`opennow-stable/src/main/signaling/signalingCoordinator.ts`**: Wires `IPC_CHANNELS.NATIVE_UPDATE_SHORTCUTS` to `nativeStreamer.updateShortcuts`.
- **`opennow-stable/src/main/index.ts`**: Adds `OPENNOW_DEBUG_NO_LOGIN` environment variable support; injects `debugNoLogin=1` query param for development builds.

### Renderer Process
- **`opennow-stable/src/renderer/src/App.tsx`**: Centralized shortcut state management; propagates binding changes to native process during active sessions; handles `native-shortcut` events to toggle stats, fullscreen, microphone, etc. Added debug no-login mode that boots into public catalog with fake session, disables all account/launch features.
- **`opennow-stable/src/renderer/src/components/StreamView.tsx`**: Shortcut preference UI for screenshot/recording bindings; validates against conflict list.
- **`opennow-stable/src/renderer/src/streamShortcutActions.ts`** (new): Pure action handler for shortcut-triggered state changes (stats, pointer lock, fullscreen, stop stream, anti-AFK, microphone).

### Shared Types
- **`opennow-stable/src/shared/gfn.ts`**: Adds `NativeStreamerShortcutBindings`, `NativeStreamerShortcutAction` enum; includes shortcut bindings in `NativeStreamerSessionContext`; adds `native-shortcut` to `MainToRendererSignalingEvent`.
- **`opennow-stable/src/shared/ipc.ts`**: Adds `NATIVE_UPDATE_SHORTCUTS` IPC channel.
- **`opennow-stable/src/shared/gfn.test.ts`**: Unit tests for session context shortcut defaults.

### Debug No-Login Mode
- Enabled via `OPENNOW_DEBUG_NO_LOGIN=1` environment variable or `debugNoLogin=1` URL query param.
- Creates a fake `AuthSession` with `DEBUG` membership tier; bypasses login screen and account loading.
- Populates UI from `fetchPublicGames` (no auth required); disables launch/gameplay with clear error message.
- Shows warning banner: "Debug no-login mode: account and launch features are disabled."

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/9e1a9238-467c-41a2-b03d-bb07bfe59450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-140" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/9e1a9238-467c-41a2-b03d-bb07bfe59450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-140&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-140"><img alt="OPE-140" src="https://capy.ai/api/badge/thread.svg?label=OPE-140"></picture></a>
<!-- capy-pr-badge:end -->