### PR TITLE
Add toggle for native streamer stats overlay

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -537,6 +537,8 @@
       "enablePromptEsc": "cancel",
       "reportOnGithubIssues": "Report on GitHub Issues",
       "reportOnDiscord": "Report on Discord",
+      "showNativeStreamerStats": "Show Native Streamer Stats",
+      "showNativeStreamerStatsHint": "Display the native streamer's own diagnostics overlay during native sessions.",
       "streamerStatus": "Streamer Status",
       "checkNativeStreamer": "Check native streamer",
       "gstreamerReady": "GStreamer Ready",

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -50,6 +50,8 @@ export interface Settings {
   nativeD3dFullscreenMode: NativeStreamerFeatureMode;
   /** Use the native GStreamer renderer window instead of Electron HWND embedding */
   nativeExternalRenderer: boolean;
+  /** Show the native streamer's own stats overlay while native streaming */
+  showNativeStreamerStats: boolean;
   /** Preferred video codec */
   codec: VideoCodec;
   /** Preferred video decode acceleration mode */
@@ -199,6 +201,7 @@ const DEFAULT_SETTINGS: Settings = {
   nativeCloudGsyncMode: "auto",
   nativeD3dFullscreenMode: "auto",
   nativeExternalRenderer: true,
+  showNativeStreamerStats: false,
   codec: DEFAULT_STREAM_PREFERENCES.codec,
   decoderPreference: "auto",
   encoderPreference: "auto",

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -218,6 +218,7 @@ export function App(): JSX.Element {
     nativeCloudGsyncMode: "auto",
     nativeD3dFullscreenMode: "auto",
     nativeExternalRenderer: true,
+    showNativeStreamerStats: false,
     codec: DEFAULT_STREAM_PREFERENCES.codec,
     decoderPreference: "auto",
     encoderPreference: "auto",
@@ -3585,6 +3586,7 @@ export function App(): JSX.Element {
             audioRef={audioRef}
             diagnosticsStore={diagnosticsStore}
             showStats={showStatsOverlay}
+            showNativeStats={settings.showNativeStreamerStats}
             gstreamerEnabled={settings.streamClientMode === "native"}
             shortcuts={{
               toggleStats: formatShortcutForDisplay(settings.shortcutToggleStats, isMac),

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -115,6 +115,8 @@ const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string
     "dx12",
     "cloud gsync",
     "diagnostics",
+    "stats",
+    "overlay",
     "experimental",
     "shortcuts",
     "alt-tab",
@@ -2459,6 +2461,21 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                         <ExternalLink size={13} />
                       </a>
                     </div>
+                  </div>
+
+                  <div className="settings-row">
+                    <label className="settings-label">
+                      {t("settings.nativeStreamer.showNativeStreamerStats")}
+                      <span className="settings-hint">{t("settings.nativeStreamer.showNativeStreamerStatsHint")}</span>
+                    </label>
+                    <label className="settings-toggle">
+                      <input
+                        type="checkbox"
+                        checked={settings.showNativeStreamerStats}
+                        onChange={(e) => handleChange("showNativeStreamerStats", e.target.checked)}
+                      />
+                      <span className="settings-toggle-track" />
+                    </label>
                   </div>
 
                   <div className="settings-row settings-row--column">

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -28,6 +28,7 @@ interface StreamViewProps {
   audioRef: React.Ref<HTMLAudioElement>;
   diagnosticsStore: StreamDiagnosticsStore;
   showStats: boolean;
+  showNativeStats?: boolean;
   gstreamerEnabled: boolean;
   shortcuts: {
     toggleStats: string;
@@ -590,6 +591,7 @@ export function StreamView({
   audioRef,
   diagnosticsStore,
   showStats,
+  showNativeStats = false,
   gstreamerEnabled,
   shortcuts,
   serverRegion,
@@ -653,6 +655,7 @@ export function StreamView({
     (stats) => stats.nativeRendererActive,
   );
   const showStatsHud = showStats && !nativeRendererActive && !isConnecting;
+  const showNativeStatsOverlay = showStats || showNativeStats;
 
   // Recording state
   const [isRecording, setIsRecording] = useState(false);
@@ -1330,7 +1333,7 @@ export function StreamView({
       updateSurface({
         deviceScaleFactor: dpr,
         visible,
-        showStats,
+        showStats: showNativeStatsOverlay,
         rect: visible
           ? {
               x: Math.round(rect.left * dpr),
@@ -1381,7 +1384,7 @@ export function StreamView({
         showStats: false,
       });
     };
-  }, [showStats]);
+  }, [showNativeStatsOverlay]);
 
   useEffect(() => {
     const handlePointerLockChange = () => {

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -655,7 +655,6 @@ export function StreamView({
     (stats) => stats.nativeRendererActive,
   );
   const showStatsHud = showStats && !nativeRendererActive && !isConnecting;
-  const showNativeStatsOverlay = showStats || showNativeStats;
 
   // Recording state
   const [isRecording, setIsRecording] = useState(false);
@@ -1333,7 +1332,7 @@ export function StreamView({
       updateSurface({
         deviceScaleFactor: dpr,
         visible,
-        showStats: showNativeStatsOverlay,
+        showStats: showNativeStats,
         rect: visible
           ? {
               x: Math.round(rect.left * dpr),
@@ -1384,7 +1383,7 @@ export function StreamView({
         showStats: false,
       });
     };
-  }, [showNativeStatsOverlay]);
+  }, [showNativeStats]);
 
   useEffect(() => {
     const handlePointerLockChange = () => {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -267,6 +267,7 @@ export interface Settings {
   nativeCloudGsyncMode: NativeStreamerFeatureMode;
   nativeD3dFullscreenMode: NativeStreamerFeatureMode;
   nativeExternalRenderer: boolean;
+  showNativeStreamerStats: boolean;
   codec: VideoCodec;
   decoderPreference: VideoAccelerationPreference;
   encoderPreference: VideoAccelerationPreference;


### PR DESCRIPTION
This PR adds a persisted setting to display the native GStreamer streamer's diagnostics overlay during native streaming sessions. The toggle defaults to disabled and appears in the Native Streamer settings section, allowing users to opt-in to the native renderer's built-in stats display.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/9acfe240-c0ca-4577-a536-652021b36c17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-150" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/9acfe240-c0ca-4577-a536-652021b36c17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-150&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-150"><img alt="OPE-150" src="https://capy.ai/api/badge/thread.svg?label=OPE-150"></picture></a>
<!-- capy-pr-badge:end -->