### PR TITLE
Alliance server queue fix

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -109,7 +109,7 @@ function getAppStyle(posterSizeScale: number): AppStyle {
 }
 
 function isNvidiaProvider(provider: LoginProvider | null | undefined): boolean {
-  return provider?.code.trim().toUpperCase() === "NVIDIA";
+  return (provider?.code ?? "").trim().toUpperCase() === "NVIDIA";
 }
 
 const SESSION_READY_POLL_INTERVAL_MS = 2000;

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -107,6 +107,11 @@ function getAppStyle(posterSizeScale: number): AppStyle {
     "--game-poster-scale": String(posterSizeScale),
   };
 }
+
+function isNvidiaProvider(provider: LoginProvider | null | undefined): boolean {
+  return provider?.code.trim().toUpperCase() === "NVIDIA";
+}
+
 const SESSION_READY_POLL_INTERVAL_MS = 2000;
 const SESSION_AD_POLL_INTERVAL_MS = 30000;
 const PLAYTIME_RESYNC_INTERVAL_MS = 5 * 60 * 1000;
@@ -2910,8 +2915,10 @@ export function App(): JSX.Element {
       subscriptionInfo?.membershipTier ?? authSession?.user.membershipTier,
     );
     const isFreeUser = effectiveTier === "FREE";
+    const activeProvider = authSession?.provider ?? selectedProvider;
+    const isNvidiaAccount = isNvidiaProvider(activeProvider);
     const isAllianceServer = isAllianceStreamingBaseUrl(effectiveStreamingBaseUrl);
-    if (isAllianceServer) {
+    if (!isNvidiaAccount || isAllianceServer) {
       setQueueModalData(null);
       void handlePlayGame(game);
       return;
@@ -2967,7 +2974,7 @@ export function App(): JSX.Element {
       return;
     }
     void handlePlayGame(game);
-  }, [subscriptionInfo, authSession, streamStatus, handlePlayGame, effectiveStreamingBaseUrl]);
+  }, [subscriptionInfo, authSession, selectedProvider, settings.hideServerSelector, streamStatus, handlePlayGame, effectiveStreamingBaseUrl]);
 
   const handleQueueModalConfirm = useCallback((zoneUrl: string | null) => {
     const game = queueModalGame;


### PR DESCRIPTION
This pull request refines the logic for handling game play sessions based on the user's login provider, with a specific focus on distinguishing NVIDIA accounts. The main changes introduce a utility function to identify NVIDIA providers and update the play session logic to use this check, ensuring correct behavior for NVIDIA and alliance server users.

**Provider detection and play session logic:**

* Added a new utility function `isNvidiaProvider` to reliably detect if the current login provider is NVIDIA, standardizing the check across the codebase.
* Updated the logic in the main `App` component to use `isNvidiaProvider` when determining whether to show the queue modal or immediately start a game, ensuring NVIDIA users are handled correctly.

**Dependency management:**

* Expanded the dependency array of the relevant `useCallback` to include `selectedProvider` and `settings.hideServerSelector`, ensuring the callback updates appropriately when these values change.

Closes: #465 