### PR TITLE
Add session time remaining feature to stats overlay

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -511,6 +511,8 @@
       "discordRichPresenceHint": "Show the game you are streaming as your Discord activity, including elapsed time.",
       "posterSize": "Poster Size",
       "posterSizeHint": "Adjusts game posters in real time across the library.",
+      "showSessionTimeRemainingInStatsOverlay": "Session Time in Stats Overlay",
+      "showSessionTimeRemainingInStatsOverlayHint": "The session countdown appears in the in-stream sidebar by default. Enable this to also show it in the stats overlay.",
       "sessionElapsedCounter": "Session Elapsed Counter",
       "sessionElapsedCounterHint": "Enable or disable the live session elapsed counter while streaming.",
       "sessionTimerReappear": "Session Timer Reappear",

--- a/locales/en.json
+++ b/locales/en.json
@@ -310,6 +310,7 @@
       "jitterBuffer": "JB = jitter buffer delay",
       "packetLoss": "Packet loss percentage",
       "packetLossValue": "{{value}}% loss",
+      "timeRemainingShort": "Left",
       "inputQueuePressure": "Input queue pressure (buffered bytes and delayed flush)",
       "inputChannelState": "Partially reliable input channel state and queued bytes",
       "mouseFlushCadence": "Mouse flush cadence and packet rate"
@@ -364,7 +365,11 @@
   },
   "sidebar": {
     "title": "Sidebar",
-    "closeSettings": "Close settings"
+    "closeSettings": "Close settings",
+    "sessionTimeRemaining": "Session Time Left",
+    "sessionTimeRemainingTitle": "Session time remaining",
+    "showSessionTimeRemainingInStatsOverlay": "Show session time remaining in stats overlay",
+    "statsOverlay": "Stats overlay"
   },
   "settings": {
     "title": "Settings",

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -111,6 +111,8 @@ export interface Settings {
   favoriteGameIds: string[];
   /** Enable the live elapsed session counter */
   sessionCounterEnabled: boolean;
+  /** Also show the session-limit countdown in the stats overlay while streaming */
+  showSessionTimeRemainingInStatsOverlay: boolean;
   /** Window width */
   windowWidth: number;
   /** Window height */
@@ -196,6 +198,7 @@ const DEFAULT_SETTINGS: Settings = {
   autoFullScreen: false,
   favoriteGameIds: [],
   sessionCounterEnabled: false,
+  showSessionTimeRemainingInStatsOverlay: false,
   sessionClockShowEveryMinutes: 60,
   sessionClockShowDurationSeconds: 30,
   windowWidth: 1400,
@@ -251,6 +254,12 @@ export class SettingsManager {
       // Migrate legacy boolean accelerator setting to percentage slider.
       if (typeof (parsed as { mouseAcceleration?: unknown }).mouseAcceleration === "boolean") {
         merged.mouseAcceleration = (parsed as { mouseAcceleration?: boolean }).mouseAcceleration ? 100 : 1;
+        migrated = true;
+      }
+
+      const legacySessionTimeDisplay = (parsed as { sessionTimeRemainingDisplay?: unknown }).sessionTimeRemainingDisplay;
+      if (legacySessionTimeDisplay === "stats" || legacySessionTimeDisplay === "both") {
+        merged.showSessionTimeRemainingInStatsOverlay = true;
         migrated = true;
       }
 

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -234,12 +234,19 @@ export class SettingsManager {
       }
 
       const content = readFileSync(this.settingsPath, "utf-8");
-      const parsed = JSON.parse(content) as Partial<Settings>;
+      type PersistedSettings = Partial<Settings> & {
+        sessionTimeRemainingDisplay?: unknown;
+      };
+      const parsed = JSON.parse(content) as PersistedSettings;
+      const {
+        sessionTimeRemainingDisplay: legacySessionTimeDisplay,
+        ...parsedSettings
+      } = parsed;
 
       // Merge with defaults to ensure all fields exist
       const merged: Settings = {
         ...DEFAULT_SETTINGS,
-        ...parsed,
+        ...parsedSettings,
       };
 
       let migrated = this.migrateLegacyShortcutDefaults(merged);
@@ -257,7 +264,7 @@ export class SettingsManager {
         migrated = true;
       }
 
-      const legacySessionTimeDisplay = (parsed as { sessionTimeRemainingDisplay?: unknown }).sessionTimeRemainingDisplay;
+      // Migrate a short-lived prerelease display enum while keeping the old key out of saved settings.
       if (legacySessionTimeDisplay === "stats" || legacySessionTimeDisplay === "both") {
         merged.showSessionTimeRemainingInStatsOverlay = true;
         migrated = true;

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -64,6 +64,7 @@ import {
 } from "./lib/queueAds";
 import { clearRuntimeSnapshot, loadRuntimeSnapshot, saveRuntimeSnapshot, type RuntimeSnapshot } from "./lib/runtimeSnapshot";
 import {
+  getSessionLimitSecondsForTier,
   getLocalSessionTimerWarning,
   hasCrossedWarningThreshold,
   shouldShowFreeTierSessionWarnings,
@@ -110,7 +111,6 @@ function isNvidiaProvider(provider: LoginProvider | null | undefined): boolean {
 const SESSION_READY_POLL_INTERVAL_MS = 2000;
 const SESSION_AD_POLL_INTERVAL_MS = 30000;
 const PLAYTIME_RESYNC_INTERVAL_MS = 5 * 60 * 1000;
-const FREE_TIER_SESSION_LIMIT_SECONDS = 60 * 60;
 const FREE_TIER_30_MIN_WARNING_SECONDS = 30 * 60;
 const FREE_TIER_15_MIN_WARNING_SECONDS = 15 * 60;
 const FREE_TIER_FINAL_MINUTE_WARNING_SECONDS = 60;
@@ -264,6 +264,7 @@ export function App(): JSX.Element {
     autoFullScreen: false,
     favoriteGameIds: [],
     sessionCounterEnabled: false,
+    showSessionTimeRemainingInStatsOverlay: false,
     sessionClockShowEveryMinutes: 60,
     sessionClockShowDurationSeconds: 30,
     windowWidth: 1400,
@@ -313,8 +314,17 @@ export function App(): JSX.Element {
   const isStreaming = streamStatus === "streaming";
   const freeTierSessionWarningsActive =
     isStreaming && sessionStartedAtMs !== null && shouldShowFreeTierSessionWarnings(subscriptionInfo);
+  const sessionLimitTier = useMemo(() => {
+    const subscriptionTier = normalizeMembershipTier(subscriptionInfo?.membershipTier);
+    const authTier = normalizeMembershipTier(authSession?.user.membershipTier);
+    return subscriptionTier ?? (authTier !== "FREE" ? authTier : null);
+  }, [authSession?.user.membershipTier, subscriptionInfo?.membershipTier]);
+  const sessionLimitSeconds = getSessionLimitSecondsForTier(sessionLimitTier);
+  const sessionTimeRemainingSeconds = isStreaming && sessionStartedAtMs !== null && sessionLimitSeconds !== null
+    ? Math.max(0, sessionLimitSeconds - sessionElapsedSeconds)
+    : null;
   const freeTierSessionRemainingSeconds = freeTierSessionWarningsActive
-    ? Math.max(0, FREE_TIER_SESSION_LIMIT_SECONDS - sessionElapsedSeconds)
+    ? sessionTimeRemainingSeconds
     : null;
   const visibleLocalSessionTimerWarning = useMemo(() => {
     if (localSessionTimerWarning === null || freeTierSessionRemainingSeconds === null) {
@@ -3443,6 +3453,8 @@ export function App(): JSX.Element {
             exitPrompt={exitPrompt}
             sessionStartedAtMs={sessionStartedAtMs}
             sessionCounterEnabled={settings.sessionCounterEnabled}
+            showSessionTimeRemainingInStatsOverlay={settings.showSessionTimeRemainingInStatsOverlay}
+            sessionTimeRemainingSeconds={sessionTimeRemainingSeconds}
             sessionClockShowEveryMinutes={settings.sessionClockShowEveryMinutes}
             sessionClockShowDurationSeconds={settings.sessionClockShowDurationSeconds}
             streamWarning={streamWarning}
@@ -3473,6 +3485,9 @@ export function App(): JSX.Element {
             }}
             onRecordingShortcutChange={(value) => {
               void updateSetting("shortcutToggleRecording", value);
+            }}
+            onShowSessionTimeRemainingInStatsOverlayChange={(value) => {
+              void updateSetting("showSessionTimeRemainingInStatsOverlay", value);
             }}
             subscriptionInfo={subscriptionInfo}
             micTrack={clientRef.current?.getMicTrack() ?? null}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -317,7 +317,7 @@ export function App(): JSX.Element {
   const sessionLimitTier = useMemo(() => {
     const subscriptionTier = normalizeMembershipTier(subscriptionInfo?.membershipTier);
     const authTier = normalizeMembershipTier(authSession?.user.membershipTier);
-    return subscriptionTier ?? (authTier !== "FREE" ? authTier : null);
+    return subscriptionTier ?? authTier;
   }, [authSession?.user.membershipTier, subscriptionInfo?.membershipTier]);
   const sessionLimitSeconds = getSessionLimitSecondsForTier(sessionLimitTier);
   const sessionTimeRemainingSeconds = isStreaming && sessionStartedAtMs !== null && sessionLimitSeconds !== null

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -10,17 +10,17 @@ import type {
   EntitledResolution,
   VideoAccelerationPreference,
   MicrophoneMode,
-    PingResult,
-    GameLanguage,
-    MicrophonePermissionResult,
-    ThankYouDataResult,
-    ThankYouContributor,
-    ThankYouSupporter,
-    AppUpdaterState,
-    NativeStreamerStatus,
-    NativeVideoBackendCapability,
-    NativeVideoBackendPreference,
-  } from "@shared/gfn";
+  PingResult,
+  GameLanguage,
+  MicrophonePermissionResult,
+  ThankYouDataResult,
+  ThankYouContributor,
+  ThankYouSupporter,
+  AppUpdaterState,
+  NativeStreamerStatus,
+  NativeVideoBackendCapability,
+  NativeVideoBackendPreference,
+} from "@shared/gfn";
 import {
   createUnsupportedNativeStreamerStatus,
   isNativeStreamerSupportedPlatform,
@@ -158,6 +158,11 @@ const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string
     "rich presence",
     "poster",
     "session timer",
+    "session time left",
+    "session countdown",
+    "free tier time",
+    "priority time",
+    "ultimate time",
     "counter",
     "controller",
     "gamepad",
@@ -3370,6 +3375,21 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                     onChange={(e) => handleChange("posterSizeScale", Number(e.target.value) / 100)}
                   />
                   <span className="settings-subtle-hint">{t("settings.interface.posterSizeHint")}</span>
+                </div>
+
+                <div className="settings-row">
+                  <label className="settings-label">
+                    {t("settings.interface.showSessionTimeRemainingInStatsOverlay")}
+                    <span className="settings-hint">{t("settings.interface.showSessionTimeRemainingInStatsOverlayHint")}</span>
+                  </label>
+                  <label className="settings-toggle">
+                    <input
+                      type="checkbox"
+                      checked={settings.showSessionTimeRemainingInStatsOverlay}
+                      onChange={(e) => handleChange("showSessionTimeRemainingInStatsOverlay", e.target.checked)}
+                    />
+                    <span className="settings-toggle-track" />
+                  </label>
                 </div>
 
                 {/* Session Counter */}

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -52,6 +52,8 @@ interface StreamViewProps {
   sessionStartedAtMs: number | null;
   isStreaming: boolean;
   sessionCounterEnabled: boolean;
+  showSessionTimeRemainingInStatsOverlay: boolean;
+  sessionTimeRemainingSeconds: number | null;
   sessionClockShowEveryMinutes: number;
   sessionClockShowDurationSeconds: number;
   streamWarning: {
@@ -79,6 +81,7 @@ interface StreamViewProps {
   onMicrophoneModeChange: (value: MicrophoneMode) => void;
   onScreenshotShortcutChange: (value: string) => void;
   onRecordingShortcutChange: (value: string) => void;
+  onShowSessionTimeRemainingInStatsOverlayChange: (value: boolean) => void;
   subscriptionInfo: SubscriptionInfo | null;
   micTrack?: MediaStreamTrack | null;
   className?: string;
@@ -138,6 +141,13 @@ function formatWarningSeconds(value: number | undefined): string | null {
   return `${seconds}s`;
 }
 
+function formatSessionTimeRemaining(value: number | null): string | null {
+  if (value === null || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return formatElapsed(value);
+}
+
 type MicBadgeState = {
   connectedGamepads: number;
   micState: MicState;
@@ -156,10 +166,12 @@ function StreamStatsHud({
   diagnosticsStore,
   gstreamerEnabled,
   serverRegion,
+  sessionTimeRemainingText,
 }: {
   diagnosticsStore: StreamDiagnosticsStore;
   gstreamerEnabled: boolean;
   serverRegion?: string;
+  sessionTimeRemainingText: string | null;
 }): JSX.Element {
   const stats = useStreamDiagnosticsStore(diagnosticsStore);
   const hasLiveBitrate = stats.bitrateKbps > 0;
@@ -227,6 +239,11 @@ function StreamStatsHud({
         <span className="sv-stats-chip" title="Round-trip network latency">
           RTT <span className="sv-stats-chip-val" style={{ color: getRttColor(stats.rttMs) }}>{stats.rttMs > 0 ? `${stats.rttMs.toFixed(0)}ms` : "--"}</span>
         </span>
+        {sessionTimeRemainingText && (
+          <span className="sv-stats-chip sv-stats-chip--time" title="Session time remaining">
+            Left <span className="sv-stats-chip-val">{sessionTimeRemainingText}</span>
+          </span>
+        )}
         <span className="sv-stats-chip" title="D = decode time">
           D <span className="sv-stats-chip-val" style={{ color: decodeColor }}>{dText}</span>
         </span>
@@ -548,6 +565,8 @@ export function StreamView({
   sessionStartedAtMs,
   isStreaming,
   sessionCounterEnabled,
+  showSessionTimeRemainingInStatsOverlay,
+  sessionTimeRemainingSeconds,
   sessionClockShowEveryMinutes,
   sessionClockShowDurationSeconds,
   streamWarning,
@@ -570,6 +589,7 @@ export function StreamView({
   onMicrophoneModeChange,
   onScreenshotShortcutChange,
   onRecordingShortcutChange,
+  onShowSessionTimeRemainingInStatsOverlayChange,
   subscriptionInfo,
   micTrack,
   hideStreamButtons = false,
@@ -727,6 +747,9 @@ export function StreamView({
   }, [antiAfkAckNonce, antiAfkEnabled, showAntiAfkIndicator, isConnecting]);
 
   const warningSeconds = formatWarningSeconds(streamWarning?.secondsLeft);
+  const sessionTimeRemainingText = formatSessionTimeRemaining(sessionTimeRemainingSeconds);
+  const showSessionTimeRemainingInStats =
+    sessionTimeRemainingText !== null && showSessionTimeRemainingInStatsOverlay;
   const platformName = platformStore ? getStoreDisplayName(platformStore) : "";
   const PlatformIcon = platformStore ? getStoreIconComponent(platformStore) : null;
   const isMacClient = navigator.platform?.toLowerCase().includes("mac") || navigator.userAgent.includes("Macintosh");
@@ -1503,6 +1526,26 @@ export function StreamView({
               <span className="sidebar-stat-label">Remaining Playtime</span>
               <RemainingPlaytimeIndicator subscriptionInfo={subscriptionInfo} startedAtMs={sessionStartedAtMs} active={isStreaming} className="settings-value-badge" />
             </div>
+            {sessionTimeRemainingText !== null && (
+              <div className="sidebar-stat-line sidebar-stat-line--stacked" title="Session time remaining">
+                <span className="sidebar-stat-label">Session Time Left</span>
+                <div className="sidebar-session-time-controls">
+                  <span className="settings-value-badge sidebar-session-time-left">
+                    <Clock3 size={10} />
+                    <span>{sessionTimeRemainingText}</span>
+                  </span>
+                  <label className="sidebar-mini-toggle">
+                    <input
+                      type="checkbox"
+                      checked={showSessionTimeRemainingInStatsOverlay}
+                      onChange={(event) => onShowSessionTimeRemainingInStatsOverlayChange(event.target.checked)}
+                    />
+                    <span className="sidebar-mini-toggle-track" />
+                    <span>Stats overlay</span>
+                  </label>
+                </div>
+              </div>
+            )}
             <div className="sidebar-tabs" role="tablist" aria-label="Sidebar sections">
               <button
                 type="button"
@@ -1987,6 +2030,7 @@ export function StreamView({
           diagnosticsStore={diagnosticsStore}
           gstreamerEnabled={gstreamerEnabled}
           serverRegion={serverRegion}
+          sessionTimeRemainingText={showSessionTimeRemainingInStats ? sessionTimeRemainingText : null}
         />
       )}
 

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -20,6 +20,7 @@ import {
   getTimingColor,
 } from "../utils/streamDiagnosticsFormat";
 import { formatElapsed } from "../utils/timeFormat";
+import { useTranslation } from "../i18n";
 
 const ANTI_AFK_TOGGLE_ACK_MS = 5000;
 
@@ -173,6 +174,7 @@ function StreamStatsHud({
   serverRegion?: string;
   sessionTimeRemainingText: string | null;
 }): JSX.Element {
+  const { t } = useTranslation();
   const stats = useStreamDiagnosticsStore(diagnosticsStore);
   const hasLiveBitrate = stats.bitrateKbps > 0;
   const bitrateKbps = hasLiveBitrate ? stats.bitrateKbps : stats.targetBitrateKbps;
@@ -240,8 +242,8 @@ function StreamStatsHud({
           RTT <span className="sv-stats-chip-val" style={{ color: getRttColor(stats.rttMs) }}>{stats.rttMs > 0 ? `${stats.rttMs.toFixed(0)}ms` : "--"}</span>
         </span>
         {sessionTimeRemainingText && (
-          <span className="sv-stats-chip sv-stats-chip--time" title="Session time remaining">
-            Left <span className="sv-stats-chip-val">{sessionTimeRemainingText}</span>
+          <span className="sv-stats-chip sv-stats-chip--time" title={t("sidebar.sessionTimeRemainingTitle")}>
+            {t("stream.stats.timeRemainingShort")} <span className="sv-stats-chip-val">{sessionTimeRemainingText}</span>
           </span>
         )}
         <span className="sv-stats-chip" title="D = decode time">
@@ -596,6 +598,7 @@ export function StreamView({
   allowEscapeToExitFullscreen,
   className,
 }: StreamViewProps): JSX.Element {
+  const { t } = useTranslation();
   const [showHints, setShowHints] = useState(true);
   const [showSessionClock, setShowSessionClock] = useState(false);
   const [antiAfkToggleAck, setAntiAfkToggleAck] = useState<"on" | "off" | null>(null);
@@ -1527,21 +1530,25 @@ export function StreamView({
               <RemainingPlaytimeIndicator subscriptionInfo={subscriptionInfo} startedAtMs={sessionStartedAtMs} active={isStreaming} className="settings-value-badge" />
             </div>
             {sessionTimeRemainingText !== null && (
-              <div className="sidebar-stat-line sidebar-stat-line--stacked" title="Session time remaining">
-                <span className="sidebar-stat-label">Session Time Left</span>
+              <div className="sidebar-stat-line sidebar-stat-line--stacked" title={t("sidebar.sessionTimeRemainingTitle")}>
+                <span className="sidebar-stat-label">{t("sidebar.sessionTimeRemaining")}</span>
                 <div className="sidebar-session-time-controls">
                   <span className="settings-value-badge sidebar-session-time-left">
                     <Clock3 size={10} />
                     <span>{sessionTimeRemainingText}</span>
                   </span>
-                  <label className="sidebar-mini-toggle">
+                  <label
+                    className="sidebar-mini-toggle"
+                    title={t("sidebar.showSessionTimeRemainingInStatsOverlay")}
+                  >
                     <input
                       type="checkbox"
                       checked={showSessionTimeRemainingInStatsOverlay}
+                      aria-label={t("sidebar.showSessionTimeRemainingInStatsOverlay")}
                       onChange={(event) => onShowSessionTimeRemainingInStatsOverlayChange(event.target.checked)}
                     />
                     <span className="sidebar-mini-toggle-track" />
-                    <span>Stats overlay</span>
+                    <span>{t("sidebar.statsOverlay")}</span>
                   </label>
                 </div>
               </div>

--- a/opennow-stable/src/renderer/src/lib/sessionWarnings.ts
+++ b/opennow-stable/src/renderer/src/lib/sessionWarnings.ts
@@ -22,6 +22,20 @@ export function shouldShowFreeTierSessionWarnings(subscription: SubscriptionInfo
   return normalizeMembershipTier(subscription?.membershipTier) === "FREE";
 }
 
+export function getSessionLimitSecondsForTier(tier: string | null | undefined): number | null {
+  switch (normalizeMembershipTier(tier)) {
+    case "FREE":
+      return 60 * 60;
+    case "PRIORITY":
+    case "PERFORMANCE":
+      return 6 * 60 * 60;
+    case "ULTIMATE":
+      return 8 * 60 * 60;
+    default:
+      return null;
+  }
+}
+
 export function hasCrossedWarningThreshold(
   previousSeconds: number | null,
   currentSeconds: number,

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -5940,6 +5940,16 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--ink-soft);
 }
 
+.sv-stats-chip--time {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--panel-border));
+  background: var(--accent-surface);
+}
+
+.sv-stats-chip--time .sv-stats-chip-val {
+  color: var(--accent);
+}
+
 .sv-stats-foot {
   font-size: 0.64rem;
   color: var(--ink-muted);
@@ -7253,12 +7263,78 @@ button.game-card-store-chip.owned.active:hover {
   gap: 8px;
 }
 
+.sidebar-stat-line--stacked {
+  align-items: flex-start;
+}
+
 .sidebar-stat-label {
   font-size: 0.82rem;
   font-weight: 600;
   color: var(--ink-soft);
   text-transform: uppercase;
   letter-spacing: 0.06em;
+}
+
+.sidebar-session-time-controls {
+  display: flex;
+  align-items: flex-end;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.sidebar-session-time-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sidebar-mini-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--ink-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.sidebar-mini-toggle input {
+  display: none;
+}
+
+.sidebar-mini-toggle-track {
+  position: relative;
+  width: 28px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--chip);
+  border: 1px solid var(--panel-border);
+  transition: background var(--t-fast), border-color var(--t-fast);
+}
+
+.sidebar-mini-toggle-track::before {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--ink-muted);
+  transition: transform var(--t-fast), background var(--t-fast);
+}
+
+.sidebar-mini-toggle input:checked+.sidebar-mini-toggle-track {
+  background: var(--accent-surface);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--panel-border));
+}
+
+.sidebar-mini-toggle input:checked+.sidebar-mini-toggle-track::before {
+  transform: translateX(12px);
+  background: var(--accent);
 }
 
 .sidebar-tabs {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -129,7 +129,6 @@ export function colorQualityIs10Bit(cq: ColorQuality): boolean {
 }
 
 export type AppAccentColor = "green" | "blue" | "violet" | "amber" | "rose";
-
 export type MicrophoneMode = "disabled" | "push-to-talk" | "voice-activity";
 export type AspectRatio = "16:9" | "16:10" | "21:9" | "32:9";
 export type RuntimePlatform =
@@ -291,6 +290,8 @@ export interface Settings {
   autoFullScreen: boolean;
   favoriteGameIds: string[];
   sessionCounterEnabled: boolean;
+  /** Also show the session-limit countdown in the stats overlay while streaming */
+  showSessionTimeRemainingInStatsOverlay: boolean;
   sessionClockShowEveryMinutes: number;
   sessionClockShowDurationSeconds: number;
   windowWidth: number;


### PR DESCRIPTION
This pull request introduces a new feature that allows users to display the session time remaining in the stats overlay, in addition to the existing sidebar display. It adds a user-facing toggle for this option in the settings and sidebar, updates the settings schema and migration logic, and enhances the UI and styles to support the new functionality.

**Feature: Session Time Remaining in Stats Overlay**

- Added a new setting (`showSessionTimeRemainingInStatsOverlay`) that enables users to show the session time remaining in the in-stream stats overlay, not just the sidebar. This includes UI controls in both the settings page and the sidebar for toggling the feature. [[1]](diffhunk://#diff-9e21436da0b6d81822084b113a549037d9f7d4a36105cd77576ee46a7201586aR114-R115) [[2]](diffhunk://#diff-9e21436da0b6d81822084b113a549037d9f7d4a36105cd77576ee46a7201586aR201) [[3]](diffhunk://#diff-97d53cd553e4cbd15865eb38a5d39ce11cc1d0ab7e93d51957ccc2fe6716d643R3380-R3394) [[4]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R568-R569) [[5]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R592) [[6]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R1529-R1548)
- Updated the settings migration logic to carry over legacy session time display preferences to the new setting, ensuring a smooth upgrade path for existing users.

**Session Time Calculation and Display**

- Centralized session limit logic by introducing `getSessionLimitSecondsForTier`, which determines session limits based on subscription tier, and updated all relevant calculations and usages to rely on this function. [[1]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR67) [[2]](diffhunk://#diff-6c7d7bf0bae2534bed6bd3f95c0e9409471597e4c9d8becf04a789ce174d4e3bR317-R327) [[3]](diffhunk://#diff-7c229b1335f655622e93b2785b09c30edf6094e41d53bf84f4f5301652bfe914R25-R38)
- Updated `StreamView` and `StreamStatsHud` components to accept and display the session time remaining when enabled, including formatting helpers and conditional rendering logic for the new stats chip. [[1]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R55-R56) [[2]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R144-R150) [[3]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R169-R174) [[4]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R242-R246) [[5]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R750-R752) [[6]](diffhunk://#diff-374734bfe6dfd2326577296c0c5b89aa0aabd92503b46f5ed9446babab0935f3R2033)

**User Interface and Styling Enhancements**

- Added new styles for the session time remaining chip in the stats overlay and for the sidebar controls, including a compact toggle switch and improved layout for the session time display. [[1]](diffhunk://#diff-4457fe7c22e7ebc4729bb30df05a55bb28aab26bde7c24d36b570792f7c9bf0fR5943-R5952) [[2]](diffhunk://#diff-4457fe7c22e7ebc4729bb30df05a55bb28aab26bde7c24d36b570792f7c9bf0fR7266-R7269) [[3]](diffhunk://#diff-4457fe7c22e7ebc4729bb30df05a55bb28aab26bde7c24d36b570792f7c9bf0fR7278-R7339)
- Updated localization strings and search terms to support the new setting and improve discoverability. [[1]](diffhunk://#diff-c9218bed23f0aeb93d7e1a7d5f6e1345fae20f4b8692b27fb97fd0f37b3d26d7R514-R515) [[2]](diffhunk://#diff-97d53cd553e4cbd15865eb38a5d39ce11cc1d0ab7e93d51957ccc2fe6716d643R161-R165)

These changes collectively improve user awareness of remaining session time and provide a more customizable streaming experience.

Closes: #452 