### PR TITLE
Fix controller mode button mapping regression

### DIFF
--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -442,7 +442,7 @@ export function HomePage({
       if (pressed & controllerButton.west) setControllerSearchOpen(true);
       if (pressed & controllerButton.leftShoulder) onPreviousControllerPage?.();
       if (pressed & controllerButton.rightShoulder) onNextControllerPage?.();
-      if (pressed & controllerButton.guide) cycleControllerVariant();
+      if (pressed & controllerButton.menu) cycleControllerVariant();
       if (pressed & controllerButton.up) focusControllerTile(rowIndex - 1, columnIndex);
       if (pressed & controllerButton.down) focusControllerTile(rowIndex + 1, columnIndex);
       if (pressed & controllerButton.left) focusControllerTile(rowIndex, columnIndex - 1);

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -5,9 +5,10 @@ import { isOwnedLibraryStatus } from "@shared/gfn";
 import type { CatalogFilterGroup, CatalogSortOption, GameInfo, GamePanelResult, GameVariant } from "@shared/gfn";
 import { GameCard, getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { useTranslation } from "../i18n";
+import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
 
 const CONTROLLER_STORE_HERO_ROTATION_MS = 7000;
-const CONTROLLER_MOVE_REPEAT_MS = 220;
+const CONTROLLER_MOVE_REPEAT_MS = 140;
 
 const CONTROLLER_STORE_PROMINENT_IMAGE_KEYS = [
   "MARQUEE_HERO_IMAGE",
@@ -246,12 +247,16 @@ export function HomePage({
   storeHeroGames = [],
   activeSessionAppIds = [],
   onBuyGame,
+  onPreviousControllerPage,
+  onNextControllerPage,
 }: HomePageProps): JSX.Element {
   const { t } = useTranslation();
   const [controllerHeroIndex, setControllerHeroIndex] = useState(0);
   const [focusedRowIndex, setFocusedRowIndex] = useState(0);
   const [focusedColumnIndex, setFocusedColumnIndex] = useState(0);
+  const [controllerSearchOpen, setControllerSearchOpen] = useState(false);
   const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const controllerSearchInputRef = useRef<HTMLInputElement | null>(null);
   const gamepadPreviousButtonsRef = useRef(0);
   const gamepadLastMoveAtRef = useRef(0);
   const gamepadFrameRef = useRef<number | null>(null);
@@ -323,6 +328,11 @@ export function HomePage({
   }, [cycleFocusedVariant, focusedColumnIndex, focusedRowIndex, focusTile, launchFocusedTile]);
 
   useEffect(() => {
+    if (!controllerMode || !controllerSearchOpen) return;
+    controllerSearchInputRef.current?.focus();
+  }, [controllerMode, controllerSearchOpen]);
+
+  useEffect(() => {
     if (!controllerMode) return;
     setControllerHeroIndex(0);
   }, [controllerHeroGames, controllerMode]);
@@ -345,6 +355,13 @@ export function HomePage({
   useEffect(() => {
     if (!controllerMode) return;
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (controllerSearchOpen) {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setControllerSearchOpen(false);
+        }
+        return;
+      }
       if (event.key === "ArrowLeft") {
         event.preventDefault();
         focusTile(focusedRowIndex, focusedColumnIndex - 1);
@@ -357,7 +374,22 @@ export function HomePage({
       } else if (event.key === "ArrowDown") {
         event.preventDefault();
         focusTile(focusedRowIndex + 1, focusedColumnIndex);
-      } else if (event.key.toLowerCase() === "y") {
+      } else if (event.key.toLowerCase() === "x") {
+        event.preventDefault();
+        setControllerSearchOpen(true);
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        onPreviousControllerPage?.();
+      } else if (event.key.toLowerCase() === "b") {
+        event.preventDefault();
+        onPreviousControllerPage?.();
+      } else if (event.key === "[") {
+        event.preventDefault();
+        onPreviousControllerPage?.();
+      } else if (event.key === "]") {
+        event.preventDefault();
+        onNextControllerPage?.();
+      } else if (event.key.toLowerCase() === "m" || event.key.toLowerCase() === "y") {
         event.preventDefault();
         cycleFocusedVariant();
       } else if (event.key === "Enter" || event.key === " ") {
@@ -367,27 +399,19 @@ export function HomePage({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [controllerMode, cycleFocusedVariant, focusedColumnIndex, focusedRowIndex, focusTile, launchFocusedTile]);
+  }, [controllerMode, controllerSearchOpen, cycleFocusedVariant, focusedColumnIndex, focusedRowIndex, focusTile, launchFocusedTile, onNextControllerPage, onPreviousControllerPage]);
 
   useEffect(() => {
     if (!controllerMode) return;
     const readButtons = (): number => {
       const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
-      if (!pad) return 0;
-      let buttons = 0;
-      if (pad.buttons[0]?.pressed) buttons |= 1 << 0;
-      if (pad.buttons[3]?.pressed) buttons |= 1 << 1;
-      if (pad.buttons[12]?.pressed || (pad.axes[1] ?? 0) < -0.65) buttons |= 1 << 2;
-      if (pad.buttons[13]?.pressed || (pad.axes[1] ?? 0) > 0.65) buttons |= 1 << 3;
-      if (pad.buttons[14]?.pressed || (pad.axes[0] ?? 0) < -0.65) buttons |= 1 << 4;
-      if (pad.buttons[15]?.pressed || (pad.axes[0] ?? 0) > 0.65) buttons |= 1 << 5;
-      return buttons;
+      return readControllerGamepadButtons(pad);
     };
 
     const handleGamepadFrame = () => {
       const buttons = readButtons();
       let pressed = buttons & ~gamepadPreviousButtonsRef.current;
-      const moveMask = (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5);
+      const moveMask = controllerButton.up | controllerButton.down | controllerButton.left | controllerButton.right;
       const now = performance.now();
       const activeMoves = buttons & moveMask;
       const pressedMoves = pressed & moveMask;
@@ -406,12 +430,23 @@ export function HomePage({
         focusedColumnIndex: columnIndex,
       } = controllerInputStateRef.current;
 
-      if (pressed & (1 << 0)) launchControllerTile();
-      if (pressed & (1 << 1)) cycleControllerVariant();
-      if (pressed & (1 << 2)) focusControllerTile(rowIndex - 1, columnIndex);
-      if (pressed & (1 << 3)) focusControllerTile(rowIndex + 1, columnIndex);
-      if (pressed & (1 << 4)) focusControllerTile(rowIndex, columnIndex - 1);
-      if (pressed & (1 << 5)) focusControllerTile(rowIndex, columnIndex + 1);
+      if (controllerSearchOpen) {
+        if (pressed & controllerButton.east) setControllerSearchOpen(false);
+        gamepadPreviousButtonsRef.current = buttons;
+        gamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+        return;
+      }
+
+      if (pressed & controllerButton.south) launchControllerTile();
+      if (pressed & controllerButton.east) onPreviousControllerPage?.();
+      if (pressed & controllerButton.west) setControllerSearchOpen(true);
+      if (pressed & controllerButton.leftShoulder) onPreviousControllerPage?.();
+      if (pressed & controllerButton.rightShoulder) onNextControllerPage?.();
+      if (pressed & controllerButton.guide) cycleControllerVariant();
+      if (pressed & controllerButton.up) focusControllerTile(rowIndex - 1, columnIndex);
+      if (pressed & controllerButton.down) focusControllerTile(rowIndex + 1, columnIndex);
+      if (pressed & controllerButton.left) focusControllerTile(rowIndex, columnIndex - 1);
+      if (pressed & controllerButton.right) focusControllerTile(rowIndex, columnIndex + 1);
       gamepadPreviousButtonsRef.current = buttons;
       gamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
     };
@@ -446,7 +481,7 @@ export function HomePage({
       window.removeEventListener("gamepaddisconnected", handleDisconnect);
       stopGamepadNavigation();
     };
-  }, [controllerMode]);
+  }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage]);
 
   if (controllerMode) {
     const showInitialLoading = isLoading && controllerSections.length === 0;
@@ -539,6 +574,23 @@ export function HomePage({
               <div className="controller-hint"><span className="controller-button controller-button--x">X</span><span>{t("app.actions.search")}</span></div>
               <div className="controller-hint controller-hint--more"><span className="controller-menu-button"><Menu size={22} /></span><span>{t("library.moreOptions")}</span></div>
             </div>
+
+            {controllerSearchOpen && (
+              <div className="controller-search-overlay" role="dialog" aria-modal="true" aria-label={t("app.actions.search")}>
+                <div className="controller-search-panel">
+                  <span className="controller-search-eyebrow">{t("app.actions.search")}</span>
+                  <input
+                    ref={controllerSearchInputRef}
+                    type="text"
+                    value={searchQuery}
+                    onChange={(event) => onSearchChange(event.target.value)}
+                    placeholder={t("home.searchPlaceholder")}
+                    className="controller-search-input"
+                  />
+                  <p>{t("app.actions.back")}</p>
+                </div>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -482,7 +482,7 @@ export function LibraryPage({
         if (pressed & controllerButton.west) setControllerSearchOpen(true);
         if (pressed & controllerButton.leftShoulder) onPreviousControllerPage?.();
         if (pressed & controllerButton.rightShoulder) onNextControllerPage?.();
-        if (pressed & controllerButton.guide) {
+        if (pressed & controllerButton.menu) {
           if (currentSelectedGame) setDetailsGame(currentSelectedGame);
         }
         if (pressed & controllerButton.left) focusGame(currentSelectedIndex - 1);

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -5,9 +5,10 @@ import type { CatalogSortOption, GameInfo } from "@shared/gfn";
 import { GameCard, getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { useTranslation } from "../i18n";
 import { formatCatalogLastPlayed } from "../utils/lastPlayedFormat";
+import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
 
 const CONTROLLER_HERO_ROTATION_MS = 8000;
-const CONTROLLER_MOVE_REPEAT_MS = 220;
+const CONTROLLER_MOVE_REPEAT_MS = 140;
 const CONTROLLER_Y_HOLD_MS = 350;
 
 const CONTROLLER_HERO_BACKGROUND_KEYS = [
@@ -193,13 +194,17 @@ export function LibraryPage({
   controllerMode = false,
   featuredGames = [],
   activeSessionAppIds = [],
+  onPreviousControllerPage,
+  onNextControllerPage,
 }: LibraryPageProps): JSX.Element {
   const { t } = useTranslation();
   const [controllerHeroIndex, setControllerHeroIndex] = useState(0);
   const [detailsGame, setDetailsGame] = useState<GameInfo | null>(null);
   const [controllerStoreFilterId, setControllerStoreFilterId] = useState("library");
   const [controllerStoreFilterOpen, setControllerStoreFilterOpen] = useState(false);
+  const [controllerSearchOpen, setControllerSearchOpen] = useState(false);
   const [focusedControllerStoreFilterIndex, setFocusedControllerStoreFilterIndex] = useState(0);
+  const controllerSearchInputRef = useRef<HTMLInputElement | null>(null);
   const gamepadPreviousButtonsRef = useRef(0);
   const gamepadLastMoveAtRef = useRef(0);
   const gamepadFrameRef = useRef<number | null>(null);
@@ -221,6 +226,11 @@ export function LibraryPage({
     showControllerStoreFilterOverlay: (): void => {},
     onPlayGame: (_game: GameInfo): void => {},
   });
+
+  useEffect(() => {
+    if (!controllerMode || !controllerSearchOpen) return;
+    controllerSearchInputRef.current?.focus();
+  }, [controllerMode, controllerSearchOpen]);
 
   const controllerStoreFilterItems = useMemo(
     () => getControllerStoreFilterItems(games, t("library.allStores")),
@@ -356,50 +366,59 @@ export function LibraryPage({
         }
         return;
       }
+      if (controllerSearchOpen) {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setControllerSearchOpen(false);
+        }
+        return;
+      }
       if (event.key === "ArrowLeft") {
         event.preventDefault();
         focusControllerGame(selectedControllerGameIndex - 1);
       } else if (event.key === "ArrowRight") {
         event.preventDefault();
         focusControllerGame(selectedControllerGameIndex + 1);
-      } else if (event.key === "ArrowDown" || event.key.toLowerCase() === "x") {
+      } else if (event.key === "ArrowDown") {
         event.preventDefault();
         cycleSelectedVariant();
       } else if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
         if (selectedControllerGame) onPlayGame(selectedControllerGame);
-      } else if (event.key.toLowerCase() === "i") {
+      } else if (event.key.toLowerCase() === "x") {
+        event.preventDefault();
+        setControllerSearchOpen(true);
+      } else if (event.key.toLowerCase() === "b" || event.key === "Escape") {
+        event.preventDefault();
+        onPreviousControllerPage?.();
+      } else if (event.key === "[") {
+        event.preventDefault();
+        onPreviousControllerPage?.();
+      } else if (event.key === "]") {
+        event.preventDefault();
+        onNextControllerPage?.();
+      } else if (event.key.toLowerCase() === "i" || event.key.toLowerCase() === "m") {
         event.preventDefault();
         if (selectedControllerGame) setDetailsGame(selectedControllerGame);
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [controllerMode, detailsGame, games, onPlayGame, selectedControllerGame, selectedControllerGameIndex]);
+  }, [controllerMode, controllerSearchOpen, detailsGame, onNextControllerPage, onPlayGame, onPreviousControllerPage, selectedControllerGame, selectedControllerGameIndex]);
 
   useEffect(() => {
     if (!controllerMode) return;
     const readButtons = (): number => {
       const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
-      if (!pad) return 0;
-      let buttons = 0;
-      if (pad.buttons[0]?.pressed) buttons |= 1 << 0;
-      if (pad.buttons[1]?.pressed) buttons |= 1 << 1;
-      if (pad.buttons[3]?.pressed) buttons |= 1 << 2;
-      if (pad.buttons[12]?.pressed || (pad.axes[1] ?? 0) < -0.65) buttons |= 1 << 5;
-      if (pad.buttons[13]?.pressed || (pad.axes[1] ?? 0) > 0.65) buttons |= 1 << 6;
-      if (pad.buttons[14]?.pressed || (pad.axes[0] ?? 0) < -0.65) buttons |= 1 << 7;
-      if (pad.buttons[15]?.pressed || (pad.axes[0] ?? 0) > 0.65) buttons |= 1 << 8;
-      if (pad.buttons[2]?.pressed) buttons |= 1 << 9;
-      return buttons;
+      return readControllerGamepadButtons(pad);
     };
 
     const handleGamepadFrame = () => {
       const buttons = readButtons();
       let pressed = buttons & ~gamepadPreviousButtonsRef.current;
       const released = gamepadPreviousButtonsRef.current & ~buttons;
-      const moveMask = (1 << 5) | (1 << 6) | (1 << 7) | (1 << 8);
-      const yButton = 1 << 2;
+      const moveMask = controllerButton.up | controllerButton.down | controllerButton.left | controllerButton.right;
+      const yButton = controllerButton.north;
       const now = performance.now();
       const activeMoves = buttons & moveMask;
       const pressedMoves = pressed & moveMask;
@@ -434,10 +453,17 @@ export function LibraryPage({
         showStoreFilter();
       }
 
+      if (controllerSearchOpen) {
+        if (pressed & controllerButton.east) setControllerSearchOpen(false);
+        gamepadPreviousButtonsRef.current = buttons;
+        gamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+        return;
+      }
+
       if (storeFilterOpen) {
-        if (pressed & (1 << 5)) moveStoreFilter(-1);
-        if (pressed & (1 << 6)) moveStoreFilter(1);
-        if (pressed & (1 << 1)) hideStoreFilter(false);
+        if (pressed & controllerButton.up) moveStoreFilter(-1);
+        if (pressed & controllerButton.down) moveStoreFilter(1);
+        if (pressed & controllerButton.east) hideStoreFilter(false);
         if (released & yButton) hideStoreFilter(true);
         gamepadPreviousButtonsRef.current = buttons;
         gamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
@@ -445,16 +471,23 @@ export function LibraryPage({
       }
 
       if (currentDetailsGame) {
-        if (pressed & (1 << 0)) playGame(currentDetailsGame);
-        if (pressed & (1 << 1)) setDetailsGame(null);
+        if (pressed & controllerButton.south) playGame(currentDetailsGame);
+        if (pressed & controllerButton.east) setDetailsGame(null);
       } else {
         if ((released & yButton) && !controllerYConsumedByHoldRef.current) cycleStoreFilter();
-        if (pressed & (1 << 0)) {
+        if (pressed & controllerButton.south) {
           if (currentSelectedGame) playGame(currentSelectedGame);
         }
-        if (pressed & (1 << 7)) focusGame(currentSelectedIndex - 1);
-        if (pressed & (1 << 8)) focusGame(currentSelectedIndex + 1);
-        if ((pressed & (1 << 6)) || (pressed & (1 << 9))) cycleVariant();
+        if (pressed & controllerButton.east) onPreviousControllerPage?.();
+        if (pressed & controllerButton.west) setControllerSearchOpen(true);
+        if (pressed & controllerButton.leftShoulder) onPreviousControllerPage?.();
+        if (pressed & controllerButton.rightShoulder) onNextControllerPage?.();
+        if (pressed & controllerButton.guide) {
+          if (currentSelectedGame) setDetailsGame(currentSelectedGame);
+        }
+        if (pressed & controllerButton.left) focusGame(currentSelectedIndex - 1);
+        if (pressed & controllerButton.right) focusGame(currentSelectedIndex + 1);
+        if (pressed & controllerButton.down) cycleVariant();
       }
       gamepadPreviousButtonsRef.current = buttons;
 
@@ -491,7 +524,7 @@ export function LibraryPage({
       window.removeEventListener("gamepaddisconnected", handleDisconnect);
       stopGamepadNavigation();
     };
-  }, [controllerMode]);
+  }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage]);
 
   if (controllerMode) {
     const featuredGame = controllerFeaturedGames[controllerHeroIndex] ?? selectedControllerGame;
@@ -618,6 +651,23 @@ export function LibraryPage({
                       </button>
                     ))}
                   </div>
+                </div>
+              </div>
+            )}
+
+            {controllerSearchOpen && (
+              <div className="controller-search-overlay" role="dialog" aria-modal="true" aria-label={t("app.actions.search")}>
+                <div className="controller-search-panel">
+                  <span className="controller-search-eyebrow">{t("app.actions.search")}</span>
+                  <input
+                    ref={controllerSearchInputRef}
+                    type="text"
+                    value={searchQuery}
+                    onChange={(event) => onSearchChange(event.target.value)}
+                    placeholder={t("library.searchPlaceholder")}
+                    className="controller-search-input"
+                  />
+                  <p>{t("app.actions.back")}</p>
                 </div>
               </div>
             )}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3139,7 +3139,8 @@ body,
   background: #e7e7e7;
 }
 
-.controller-store-filter-overlay {
+.controller-store-filter-overlay,
+.controller-search-overlay {
   position: fixed;
   inset: 0;
   z-index: 2190;
@@ -3151,7 +3152,8 @@ body,
   backdrop-filter: blur(8px);
 }
 
-.controller-store-filter-panel {
+.controller-store-filter-panel,
+.controller-search-panel {
   width: min(520px, calc(100vw - 96px));
   padding: 30px 34px 34px;
   border-radius: 26px;
@@ -3160,7 +3162,8 @@ body,
   box-shadow: 0 0 42px rgba(var(--accent-rgb), 0.32), 0 32px 90px rgba(0, 0, 0, 0.58);
 }
 
-.controller-store-filter-eyebrow {
+.controller-store-filter-eyebrow,
+.controller-search-eyebrow {
   color: #4ee887;
   font-size: 0.78rem;
   font-weight: 900;
@@ -3175,11 +3178,31 @@ body,
   line-height: 1.05;
 }
 
-.controller-store-filter-panel p {
+.controller-store-filter-panel p,
+.controller-search-panel p {
   margin: 8px 0 22px;
   color: rgba(255, 255, 255, 0.58);
   font-size: 0.88rem;
   font-weight: 650;
+}
+
+.controller-search-input {
+  width: 100%;
+  min-height: 56px;
+  margin-top: 14px;
+  padding: 0 18px;
+  border-radius: 16px;
+  border: 1.5px solid rgba(var(--accent-rgb), 0.62);
+  outline: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--ink);
+  font: inherit;
+  font-size: 1.1rem;
+  font-weight: 750;
+}
+
+.controller-search-input:focus {
+  box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.2);
 }
 
 .controller-store-filter-options {

--- a/opennow-stable/src/renderer/src/utils/controllerGamepad.test.ts
+++ b/opennow-stable/src/renderer/src/utils/controllerGamepad.test.ts
@@ -13,7 +13,8 @@ function makePad(pressedButtonIndexes: number[], axes = [0, 0]): Gamepad {
 }
 
 test("maps standard gamepad action buttons used by controller mode", () => {
-  const buttons = readControllerGamepadButtons(makePad([0, 1, 2, 3, 4, 5, 16]));
+  const buttons = readControllerGamepadButtons(makePad([0, 1, 2, 3, 4, 5, 9]));
+  const guideAliasButtons = readControllerGamepadButtons(makePad([16]));
 
   assert.equal(buttons & controllerButton.south, controllerButton.south);
   assert.equal(buttons & controllerButton.east, controllerButton.east);
@@ -21,7 +22,8 @@ test("maps standard gamepad action buttons used by controller mode", () => {
   assert.equal(buttons & controllerButton.north, controllerButton.north);
   assert.equal(buttons & controllerButton.leftShoulder, controllerButton.leftShoulder);
   assert.equal(buttons & controllerButton.rightShoulder, controllerButton.rightShoulder);
-  assert.equal(buttons & controllerButton.guide, controllerButton.guide);
+  assert.equal(buttons & controllerButton.menu, controllerButton.menu);
+  assert.equal(guideAliasButtons & controllerButton.menu, controllerButton.menu);
 });
 
 test("maps standard d-pad buttons and left-stick fallback axes", () => {

--- a/opennow-stable/src/renderer/src/utils/controllerGamepad.test.ts
+++ b/opennow-stable/src/renderer/src/utils/controllerGamepad.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { controllerButton, readControllerGamepadButtons } from "./controllerGamepad";
+
+function makePad(pressedButtonIndexes: number[], axes = [0, 0]): Gamepad {
+  return {
+    axes,
+    buttons: Array.from({ length: 17 }, (_, index) => ({ pressed: pressedButtonIndexes.includes(index) })),
+  } as unknown as Gamepad;
+}
+
+test("maps standard gamepad action buttons used by controller mode", () => {
+  const buttons = readControllerGamepadButtons(makePad([0, 1, 2, 3, 4, 5, 16]));
+
+  assert.equal(buttons & controllerButton.south, controllerButton.south);
+  assert.equal(buttons & controllerButton.east, controllerButton.east);
+  assert.equal(buttons & controllerButton.west, controllerButton.west);
+  assert.equal(buttons & controllerButton.north, controllerButton.north);
+  assert.equal(buttons & controllerButton.leftShoulder, controllerButton.leftShoulder);
+  assert.equal(buttons & controllerButton.rightShoulder, controllerButton.rightShoulder);
+  assert.equal(buttons & controllerButton.guide, controllerButton.guide);
+});
+
+test("maps standard d-pad buttons and left-stick fallback axes", () => {
+  const dpadButtons = readControllerGamepadButtons(makePad([12, 13, 14, 15]));
+  const axes = readControllerGamepadButtons(makePad([], [-0.8, 0.9]));
+
+  assert.equal(dpadButtons & controllerButton.up, controllerButton.up);
+  assert.equal(dpadButtons & controllerButton.down, controllerButton.down);
+  assert.equal(dpadButtons & controllerButton.left, controllerButton.left);
+  assert.equal(dpadButtons & controllerButton.right, controllerButton.right);
+  assert.equal(axes & controllerButton.left, controllerButton.left);
+  assert.equal(axes & controllerButton.down, controllerButton.down);
+});

--- a/opennow-stable/src/renderer/src/utils/controllerGamepad.ts
+++ b/opennow-stable/src/renderer/src/utils/controllerGamepad.ts
@@ -1,0 +1,30 @@
+export const controllerButton = {
+  south: 1 << 0,
+  east: 1 << 1,
+  west: 1 << 2,
+  north: 1 << 3,
+  leftShoulder: 1 << 4,
+  rightShoulder: 1 << 5,
+  up: 1 << 6,
+  down: 1 << 7,
+  left: 1 << 8,
+  right: 1 << 9,
+  guide: 1 << 10,
+} as const;
+
+export function readControllerGamepadButtons(pad: Gamepad | undefined): number {
+  if (!pad) return 0;
+  let buttons = 0;
+  if (pad.buttons[0]?.pressed) buttons |= controllerButton.south;
+  if (pad.buttons[1]?.pressed) buttons |= controllerButton.east;
+  if (pad.buttons[2]?.pressed) buttons |= controllerButton.west;
+  if (pad.buttons[3]?.pressed) buttons |= controllerButton.north;
+  if (pad.buttons[4]?.pressed) buttons |= controllerButton.leftShoulder;
+  if (pad.buttons[5]?.pressed) buttons |= controllerButton.rightShoulder;
+  if (pad.buttons[12]?.pressed || (pad.axes[1] ?? 0) < -0.65) buttons |= controllerButton.up;
+  if (pad.buttons[13]?.pressed || (pad.axes[1] ?? 0) > 0.65) buttons |= controllerButton.down;
+  if (pad.buttons[14]?.pressed || (pad.axes[0] ?? 0) < -0.65) buttons |= controllerButton.left;
+  if (pad.buttons[15]?.pressed || (pad.axes[0] ?? 0) > 0.65) buttons |= controllerButton.right;
+  if (pad.buttons[16]?.pressed) buttons |= controllerButton.guide;
+  return buttons;
+}

--- a/opennow-stable/src/renderer/src/utils/controllerGamepad.ts
+++ b/opennow-stable/src/renderer/src/utils/controllerGamepad.ts
@@ -9,7 +9,7 @@ export const controllerButton = {
   down: 1 << 7,
   left: 1 << 8,
   right: 1 << 9,
-  guide: 1 << 10,
+  menu: 1 << 10,
 } as const;
 
 export function readControllerGamepadButtons(pad: Gamepad | undefined): number {
@@ -25,6 +25,6 @@ export function readControllerGamepadButtons(pad: Gamepad | undefined): number {
   if (pad.buttons[13]?.pressed || (pad.axes[1] ?? 0) > 0.65) buttons |= controllerButton.down;
   if (pad.buttons[14]?.pressed || (pad.axes[0] ?? 0) < -0.65) buttons |= controllerButton.left;
   if (pad.buttons[15]?.pressed || (pad.axes[0] ?? 0) > 0.65) buttons |= controllerButton.right;
-  if (pad.buttons[16]?.pressed) buttons |= controllerButton.guide;
+  if (pad.buttons[9]?.pressed || pad.buttons[16]?.pressed) buttons |= controllerButton.menu;
   return buttons;
 }


### PR DESCRIPTION
This PR fixes the v0.4.0 controller mode regression where L1, R1, B, X, and Mode buttons were unresponsive despite correctly reaching the renderer. The issue stemmed from inconsistent bit-shift mappings between the gamepad reader (using HTML5 Gamepad API indices) and the button handlers in both `HomePage.tsx` and `LibraryPage.tsx`.

**Button mapping changes:**

* Centralized gamepad reading into `controllerGamepad.ts` with named bit masks for all standard controls
* Updated both `HomePage` and `LibraryPage` to use the shared mapping, fixing B (back navigation), X (search overlay), L1/R1 (page navigation), and Mode (details/variant cycle)
* Added controller search overlay UI and CSS styling to both pages
* Reduced move repeat latency from 220ms to 140ms for more responsive D-pad navigation
* Added unit tests for the button mapping utility

**Verification:**

* `npm --prefix opennow-stable run typecheck`
* `npm --prefix opennow-stable test` (84 tests passing)
* `npm --prefix opennow-stable run lint` (no new errors introduced)

Resolves #498.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/d5f2785e-921f-49b8-927f-ba9fadb8ef7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-170" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/d5f2785e-921f-49b8-927f-ba9fadb8ef7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-170&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-170"><img alt="OPE-170" src="https://capy.ai/api/badge/thread.svg?label=OPE-170"></picture></a>
<!-- capy-pr-badge:end -->