### PR TITLE
Fix Z/Y key swap on German keyboard layouts

### DIFF
--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -4,12 +4,13 @@ use crate::gstreamer_platform::win32_renderer_window;
 use crate::input::InputEncoder;
 #[cfg(target_os = "windows")]
 use crate::input::{
-    GamepadInput, KeyboardPayload, MouseButtonPayload, MouseMovePayload, MouseWheelPayload,
-    GAMEPAD_MAX_CONTROLLERS, PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
+    layout_mapped_keyboard_scancode, GamepadInput, KeyboardPayload, MouseButtonPayload,
+    MouseMovePayload, MouseWheelPayload, GAMEPAD_MAX_CONTROLLERS,
+    PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
 };
+use crate::protocol::Event;
 #[cfg(target_os = "windows")]
 use crate::protocol::NativeStreamerShortcutAction;
-use crate::protocol::Event;
 use gst::glib;
 use gst::prelude::*;
 use gstreamer as gst;
@@ -484,7 +485,7 @@ fn send_encoded_native_window_input_event(
         } => {
             let payload = KeyboardPayload {
                 keycode,
-                scancode,
+                scancode: layout_mapped_keyboard_scancode(scancode),
                 modifiers,
                 timestamp_us,
             };

--- a/native/opennow-streamer/src/input.rs
+++ b/native/opennow-streamer/src/input.rs
@@ -204,6 +204,12 @@ pub fn is_partially_reliable_hid_transfer_eligible(input_type: u32) -> bool {
     input_type == INPUT_MOUSE_REL
 }
 
+pub(crate) fn layout_mapped_keyboard_scancode(_physical_scancode: u16) -> u16 {
+    // GFN keyboard events use the selected remote layout plus VK; sending the local physical
+    // scancode makes QWERTZ-only keys such as Y/Z resolve as their US physical positions.
+    0
+}
+
 fn encode_gamepad_payload(bitmap: u16, input: GamepadInput) -> Vec<u8> {
     let mut payload = Vec::with_capacity(GAMEPAD_PACKET_SIZE);
     put_u32_le(&mut payload, INPUT_GAMEPAD);
@@ -453,5 +459,11 @@ mod tests {
         assert_eq!(partially_reliable_hid_mask_for_input_type(32), 0);
         assert!(is_partially_reliable_hid_transfer_eligible(INPUT_MOUSE_REL));
         assert!(!is_partially_reliable_hid_transfer_eligible(INPUT_KEY_DOWN));
+    }
+
+    #[test]
+    fn layout_mapped_keyboard_input_omits_physical_scancodes() {
+        assert_eq!(layout_mapped_keyboard_scancode(0x0015), 0);
+        assert_eq!(layout_mapped_keyboard_scancode(0x002c), 0);
     }
 }


### PR DESCRIPTION
This PR fixes issue #500 where Z and Y keys were swapped when using the German (QWERTZ) keyboard layout. The native Windows streamer was sending local physical scancodes along with virtual keycodes, which caused the remote GFN server to interpret key positions incorrectly for non-US layouts.

## Description

* Add `layout_mapped_keyboard_scancode()` function to native input module that always returns 0 for layout-mapped keyboard events
* Update `send_encoded_native_window_input_event()` in `gstreamer_input.rs` to use layout-mapped scancodes instead of raw physical scancodes from Windows RawInput
* Add unit test `layout_mapped_keyboard_input_omits_physical_scancodes` to verify the fix

This matches the behavior of the existing Electron/WebRTC client (`mapKeyboardEvent` in `inputProtocol.ts`), which always sends `scancode: 0` for keyboard events and relies on the remote layout (e.g., de-DE) plus VK to determine the correct character. Sending the physical scancode causes QWERTZ keys like Z and Y to resolve as their US QWERTY physical positions.

## Verification

* `npm --prefix opennow-stable run native:check`
* `npm --prefix opennow-stable run typecheck`
* `cargo test --manifest-path native/opennow-streamer/Cargo.toml --no-default-features` (42 tests passed)

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/7bcf5bbe-2605-4d67-b3ae-100e4a04dc17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-172" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/7bcf5bbe-2605-4d67-b3ae-100e4a04dc17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-172&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-172"><img alt="OPE-172" src="https://capy.ai/api/badge/thread.svg?label=OPE-172"></picture></a>
<!-- capy-pr-badge:end -->