### PR TITLE
Fix F10 fullscreen shortcut triggering synthetic ESC

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1014,6 +1014,9 @@ export function App(): JSX.Element {
 
   const setSessionFullscreen = useCallback(async (nextFullscreen: boolean) => {
     const canUseNativeFullscreen = typeof window.openNow?.setFullscreen === "function";
+    if (document.pointerLockElement) {
+      clientRef.current?.suppressNextSyntheticEscapeOnPointerLockLoss();
+    }
 
     if (canUseNativeFullscreen) {
       try {
@@ -3343,13 +3346,7 @@ export function App(): JSX.Element {
 
   const releasePointerLockIfNeeded = useCallback(async () => {
     if (document.pointerLockElement) {
-      // Tell the client to suppress synthetic Escape/reactive re-acquisition
-      try {
-        // clientRef is a mutable ref to the GfnWebRtcClient instance; access runtime property
-        (clientRef.current as any).suppressNextSyntheticEscape = true;
-      } catch (e) {
-        // ignore
-      }
+      clientRef.current?.suppressNextSyntheticEscapeOnPointerLockLoss();
       document.exitPointerLock();
       await sleep(75);
     }
@@ -3388,10 +3385,7 @@ export function App(): JSX.Element {
           const targetVideo = videoRef.current;
           if (streamStatus === "streaming" && targetVideo) {
             if (document.pointerLockElement === targetVideo) {
-              const client = clientRef.current as { suppressNextSyntheticEscape?: boolean } | null;
-              if (client) {
-                client.suppressNextSyntheticEscape = true;
-              }
+              clientRef.current?.suppressNextSyntheticEscapeOnPointerLockLoss();
               document.exitPointerLock();
             } else {
               void requestPointerLockCapture(targetVideo);

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -685,6 +685,7 @@ export class GfnWebRtcClient {
   private pointerLockRelockTimer: number | null = null;
   // Skip one synthetic Escape on pointer loss when lock was released intentionally (e.g. F8).
   private suppressNextSyntheticEscape = false;
+  private syntheticEscapeSuppressionTimer: number | null = null;
   private keyboardLockState: "unknown" | "unsupported" | "locked" | "failed" = "unknown";
   private lastLockKeysState = -1;
   private mouseBackpressureLoggedAtMs = 0;
@@ -879,6 +880,32 @@ export class GfnWebRtcClient {
   public setAutoFullScreen(value: boolean): void {
     this.autoFullScreenEnabled = Boolean(value);
     this.log(`Auto fullscreen ${this.autoFullScreenEnabled ? "enabled" : "disabled"}`);
+  }
+
+  public suppressNextSyntheticEscapeOnPointerLockLoss(durationMs = 1000): void {
+    this.suppressNextSyntheticEscape = true;
+    if (this.syntheticEscapeSuppressionTimer !== null) {
+      window.clearTimeout(this.syntheticEscapeSuppressionTimer);
+    }
+    this.syntheticEscapeSuppressionTimer = window.setTimeout(() => {
+      this.clearSyntheticEscapeSuppression();
+    }, Math.max(0, durationMs));
+  }
+
+  private clearSyntheticEscapeSuppression(): void {
+    this.suppressNextSyntheticEscape = false;
+    if (this.syntheticEscapeSuppressionTimer !== null) {
+      window.clearTimeout(this.syntheticEscapeSuppressionTimer);
+      this.syntheticEscapeSuppressionTimer = null;
+    }
+  }
+
+  private consumeSyntheticEscapeSuppression(): boolean {
+    if (!this.suppressNextSyntheticEscape) {
+      return false;
+    }
+    this.clearSyntheticEscapeSuppression();
+    return true;
   }
 
   /**
@@ -1193,6 +1220,7 @@ export class GfnWebRtcClient {
       window.clearTimeout(this.gamepadPollTimer);
       this.gamepadPollTimer = null;
     }
+    this.clearSyntheticEscapeSuppression();
   }
 
   private setupStatsPolling(): void {
@@ -3601,7 +3629,7 @@ export class GfnWebRtcClient {
           window.clearTimeout(this.pointerLockRelockTimer);
           this.pointerLockRelockTimer = null;
         }
-        this.suppressNextSyntheticEscape = false;
+        this.clearSyntheticEscapeSuppression();
         // Try to acquire keyboard lock for low-level key capture (best-effort).
         try {
           this.requestEscapeKeyboardLock();
@@ -3627,8 +3655,7 @@ export class GfnWebRtcClient {
       // Pointer lock was lost
       if (!this.inputReady) return;
 
-      if (this.suppressNextSyntheticEscape) {
-        this.suppressNextSyntheticEscape = false;
+      if (this.consumeSyntheticEscapeSuppression()) {
         this.releasePressedKeys("pointer lock intentionally released");
         return;
       }
@@ -3914,6 +3941,7 @@ export class GfnWebRtcClient {
         window.clearTimeout(this.pointerLockRelockTimer);
         this.pointerLockRelockTimer = null;
       }
+      this.clearSyntheticEscapeSuppression();
       this.releasePressedKeys("input cleanup");
       this.pendingMouseDxFloat = 0;
       this.pendingMouseDyFloat = 0;


### PR DESCRIPTION
This PR fixes issue #508 where pressing the F10 fullscreen shortcut caused an unwanted ESC keypress to be sent to the stream. The root cause was that the browser's pointer lock loss triggered a synthetic Escape injection, intended for cases where the browser intercepts Escape, but this also fired when using the F10 shortcut to toggle fullscreen.

## Changes

- Add `suppressNextSyntheticEscapeOnPointerLockLoss()` method to `GfnWebRtcClient` with configurable suppression duration (default 1000ms)
- Add `clearSyntheticEscapeSuppression()` and `consumeSyntheticEscapeSuppression()` helpers for timer cleanup and one-time consumption
- Call suppression before fullscreen toggle, before pointer lock release on stream stop, and before toggle-pointer-lock shortcut
- Synthetic suppression state is consumed once on intentional release and cleared on cleanup/timer expiry

## Files

- `opennow-stable/src/renderer/src/gfn/webrtcClient.ts`: Add suppression API and integrate with pointer lock change handler
- `opennow-stable/src/renderer/src/App.tsx`: Call suppression before fullscreen toggle and pointer lock release actions

## Tests

- npm --prefix opennow-stable run typecheck
- npm --prefix opennow-stable test

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/8cf4092d-da14-427c-b634-612ca6f7e8e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-188" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/8cf4092d-da14-427c-b634-612ca6f7e8e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-188&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-188"><img alt="OPE-188" src="https://capy.ai/api/badge/thread.svg?label=OPE-188"></picture></a>
<!-- capy-pr-badge:end -->