### PR TITLE
Fix reversed analog-stick Y-axis on iOS controllers

### DIFF
--- a/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
+++ b/ios/OpenNOWiOS/OpenNOWiOS/StreamerView.swift
@@ -3907,9 +3907,9 @@ private final class NativeControllerBridge {
 
         let axes: [Double] = [
             clampAxis(gamepad.leftThumbstick.xAxis.value),
-            clampAxis(gamepad.leftThumbstick.yAxis.value),
+            clampAxis(-gamepad.leftThumbstick.yAxis.value),
             clampAxis(gamepad.rightThumbstick.xAxis.value),
-            clampAxis(gamepad.rightThumbstick.yAxis.value)
+            clampAxis(-gamepad.rightThumbstick.yAxis.value)
         ]
 
         return [


### PR DESCRIPTION
The native GameController bridge in StreamerView.payload(for:) forwarded raw thumbstick Y values to the embedded streamer JS. Apple's GameController framework reports Y as up = +1, but the streamer JS (normalizeGamepadAxis(-(axes[1]))) expects the W3C browser convention (up = -1) and negates Y itself — so the value was double-inverted, reversing Y on both sticks.

Negating Y in the Swift bridge converts to the browser convention at the source, so up/down match again. Verified on a device build: both sticks now correct.

## Description

<!-- Provide a brief description of the changes in this PR -->
