### PR TITLE
Set up Cursor Cloud dev environment for OpenNOW

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,12 @@ Crowdin owns generated translations. When changing localized copy, edit only `lo
 - For main-process GFN/session changes, also run `npm --prefix opennow-stable test -- --test-name-pattern gfn` or the closest targeted test command available; if scripts do not support filtering, run `npm --prefix opennow-stable test`.
 - For localization changes, run `npm --prefix opennow-stable run locales:check`.
 - Do not claim completion if the relevant acceptance check fails. Report the failing command and failure point.
+
+## Cursor Cloud specific instructions
+
+- All commands run from `opennow-stable/` (or use the root `npm run <script>` wrappers). Dependencies are managed with npm (`package-lock.json`); the `bun.lock` is secondary — do not use bun. Node 22 is required.
+- Standard scripts are defined in `opennow-stable/package.json`: `dev`, `build`, `lint`, `typecheck`, `test`, `locales:check`. Don't duplicate them; use those.
+- Running the app: `npm run dev` (root) launches `electron-vite dev` and opens the Electron window on the desktop `DISPLAY` (`:1`). It is a long-running process — start it in a background/tmux session, not a blocking foreground call.
+- Benign startup noise: in this container Electron logs `Failed to connect to the bus` (dbus) and `vkCreateInstance() failed: -9` / `Failed to create and initialize Vulkan` (GPU). These are expected with no real GPU/dbus and do not indicate failure — the UI still renders and networks fine.
+- OpenNOW is a bring-your-own-account GeForce NOW client: there is no local backend. Full end-to-end gameplay/login requires a real NVIDIA/GFN account. Clicking "Sign in" opens NVIDIA's OAuth page (`login.nvgs.nvidia.com`); the auth/networking path can be exercised up to that external login without credentials.
+- The native Rust streamer in `native/opennow-streamer` is optional and Windows-focused (`npm run native:check` / `native:build` need the Cargo toolchain). It is not required to run or develop the Electron client; the default stream path uses embedded Chromium WebRTC.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the development environment for the OpenNOW Electron client and documents non-obvious cloud caveats for future agents.

- Verified install via `npm ci` in `opennow-stable/` (Node 22, npm).
- Ran lint, typecheck, tests, build, and locales check — all pass.
- Launched the app in dev mode (`npm run dev`) and exercised the core auth flow end-to-end up to NVIDIA's OAuth page.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` (run commands, benign dbus/Vulkan startup noise, BYO-account auth flow, optional native streamer).

## Walkthrough

Demo of the app launching and the sign-in flow reaching NVIDIA's real OAuth login page:

[opennow_signin_flow_demo.mp4](https://cursor.com/agents/bc-29c3a25f-40c5-40bd-9be8-1705ddb316ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopennow_signin_flow_demo.mp4)

[OpenNOW login screen](https://cursor.com/agents/bc-29c3a25f-40c5-40bd-9be8-1705ddb316ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopennow_login_screen.webp)
[NVIDIA OAuth page loaded](https://cursor.com/agents/bc-29c3a25f-40c5-40bd-9be8-1705ddb316ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopennow_nvidia_oauth.webp)

## Testing

- `npm run lint` — pass (warnings only)
- `npm run typecheck` — pass
- `npm test` — 82 pass
- `npm run build` — pass
- `npm run locales:check` — pass
- `npm run dev` — app launches and sign-in flow reaches NVIDIA OAuth (manual)

Note: full gameplay/login requires a real NVIDIA GeForce NOW account (bring-your-own-account app), so the flow was validated up to the external NVIDIA login page.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29c3a25f-40c5-40bd-9be8-1705ddb316ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29c3a25f-40c5-40bd-9be8-1705ddb316ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

