### PR TITLE
fix(gfn): implement serverInfo region fallback

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -103,7 +103,7 @@ test("CloudMatch extracts local serverInfo region before fallback regions", () =
   ]);
 });
 
-test("CloudMatch falls back to serverInfo local region when active-session fetch fails", async () => {
+test("CloudMatch falls back to serverInfo local region when active-session HTTP request fails", async () => {
   const originalFetch = globalThis.fetch;
   const originalWarn = console.warn;
   const calls: string[] = [];
@@ -114,7 +114,7 @@ test("CloudMatch falls back to serverInfo local region when active-session fetch
     calls.push(url);
 
     if (url === "https://prod.bpc.geforcenow.nvidiagrid.net/v2/session") {
-      throw new TypeError("fetch failed");
+      return new Response("bad gateway", { status: 502 });
     }
 
     if (url === "https://prod.bpc.geforcenow.nvidiagrid.net/v2/serverInfo") {

--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { StreamSettings } from "@shared/gfn";
-import { buildRequestedStreamingFeatures } from "./cloudmatch";
+import { buildRequestedStreamingFeatures, extractServerInfoRegionBases, getActiveSessions } from "./cloudmatch";
 
 function makeSettings(overrides: Partial<StreamSettings> = {}): StreamSettings {
   return {
@@ -83,4 +83,84 @@ test("CloudMatch uses resolver Reflex decision when present", () => {
 
   assert.equal(features.cloudGsync, true);
   assert.equal(features.reflex, false);
+});
+
+test("CloudMatch extracts local serverInfo region before fallback regions", () => {
+  const bases = extractServerInfoRegionBases({
+    metaData: [
+      { key: "local-region", value: "TH BPC" },
+      { key: "gfn-regions", value: "EU West, TH BPC, US East" },
+      { key: "EU West", value: "https://np-eu.example.nvidiagrid.net/" },
+      { key: "TH BPC", value: "https://th.bpc.geforcenow.nvidiagrid.net" },
+      { key: "US East", value: "https://np-us.example.nvidiagrid.net/" },
+    ],
+  });
+
+  assert.deepEqual(bases, [
+    "https://th.bpc.geforcenow.nvidiagrid.net",
+    "https://np-eu.example.nvidiagrid.net",
+    "https://np-us.example.nvidiagrid.net",
+  ]);
+});
+
+test("CloudMatch falls back to serverInfo local region when active-session fetch fails", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const calls: string[] = [];
+
+  console.warn = () => {};
+  globalThis.fetch = (async (input) => {
+    const url = String(input);
+    calls.push(url);
+
+    if (url === "https://prod.bpc.geforcenow.nvidiagrid.net/v2/session") {
+      throw new TypeError("fetch failed");
+    }
+
+    if (url === "https://prod.bpc.geforcenow.nvidiagrid.net/v2/serverInfo") {
+      return new Response(JSON.stringify({
+        metaData: [
+          { key: "local-region", value: "TH BPC" },
+          { key: "gfn-regions", value: "TH BPC" },
+          { key: "TH BPC", value: "https://th.bpc.geforcenow.nvidiagrid.net" },
+        ],
+      }), { status: 200 });
+    }
+
+    if (url === "https://th.bpc.geforcenow.nvidiagrid.net/v2/session") {
+      return new Response(JSON.stringify({
+        requestStatus: {
+          statusCode: 1,
+          statusDescription: "SUCCESS_STATUS",
+        },
+        sessions: [{
+          sessionId: "session-1",
+          status: 3,
+          gpuType: "RTX",
+          sessionRequestData: { appId: "1001" },
+          sessionControlInfo: { ip: "th.bpc.geforcenow.nvidiagrid.net" },
+          connectionInfo: [{ ip: "161.248.11.132", port: 443, usage: 14 }],
+          monitorSettings: [{ widthInPixels: 1920, heightInPixels: 1080, framesPerSecond: 60 }],
+        }],
+      }), { status: 200 });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const sessions = await getActiveSessions("token", "https://prod.bpc.geforcenow.nvidiagrid.net/");
+
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].sessionId, "session-1");
+    assert.equal(sessions[0].serverIp, "161.248.11.132");
+    assert.deepEqual(calls, [
+      "https://prod.bpc.geforcenow.nvidiagrid.net/v2/session",
+      "https://prod.bpc.geforcenow.nvidiagrid.net/v2/serverInfo",
+      "https://th.bpc.geforcenow.nvidiagrid.net/v2/session",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
 });

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -1313,9 +1313,8 @@ async function fetchActiveSessionsFromBase(
   const text = await response.text();
 
   if (!response.ok) {
-    // Return empty list on failure (matching Rust behavior)
     console.warn(`Get sessions failed: ${response.status} - ${text.slice(0, 200)}`);
-    return [];
+    return null;
   }
 
   let sessionsResponse: GetSessionsResponse;

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -49,6 +49,49 @@ const GFN_DEVICE_ID_FILENAME = "gfn-device-id.json";
 let cachedStableDeviceId: string | null = null;
 const require = createRequire(import.meta.url);
 
+interface CloudMatchServerInfoResponse {
+  metaData?: Array<{
+    key: string;
+    value: string;
+  }>;
+}
+
+function normalizeCloudMatchBaseUrl(url: string): string {
+  const trimmed = url.trim();
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  return withProtocol.endsWith("/") ? withProtocol.slice(0, -1) : withProtocol;
+}
+
+export function extractServerInfoRegionBases(payload: CloudMatchServerInfoResponse): string[] {
+  const metadata = payload.metaData ?? [];
+  const byKey = new Map(metadata.map((entry) => [entry.key, entry.value]));
+  const regionNames = byKey.get("gfn-regions")
+    ?.split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean) ?? [];
+  const localRegionName = byKey.get("local-region")?.trim();
+  const orderedRegionNames = [
+    ...(localRegionName ? [localRegionName] : []),
+    ...regionNames,
+  ];
+  const bases: string[] = [];
+  const seen = new Set<string>();
+
+  for (const regionName of orderedRegionNames) {
+    const regionUrl = byKey.get(regionName);
+    if (!regionUrl?.startsWith("http")) {
+      continue;
+    }
+    const normalized = normalizeCloudMatchBaseUrl(regionUrl);
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      bases.push(normalized);
+    }
+  }
+
+  return bases;
+}
+
 function getElectronApp(): Electron.App | null {
   try {
     return require("electron").app ?? null;
@@ -1207,15 +1250,65 @@ export async function getActiveSessions(
     throw new Error("Missing token for getting active sessions");
   }
 
-  const base = streamingBaseUrl.trim().endsWith("/")
-    ? streamingBaseUrl.trim().slice(0, -1)
-    : streamingBaseUrl.trim();
+  const base = normalizeCloudMatchBaseUrl(streamingBaseUrl);
+  const headers = buildGfnCloudMatchHeaders({
+    token,
+    deviceId: getStableDeviceId(),
+    includeOrigin: false,
+  });
+  const primary = await fetchActiveSessionsFromBase(base, headers);
+  if (primary) {
+    return primary;
+  }
+
+  for (const fallbackBase of await discoverActiveSessionFallbackBases(base, headers)) {
+    if (fallbackBase === base) {
+      continue;
+    }
+    const fallback = await fetchActiveSessionsFromBase(fallbackBase, headers);
+    if (fallback) {
+      return fallback;
+    }
+  }
+
+  return [];
+}
+
+async function discoverActiveSessionFallbackBases(
+  base: string,
+  headers: Record<string, string>,
+): Promise<string[]> {
+  try {
+    const response = await fetch(`${base}/v2/serverInfo`, {
+      method: "GET",
+      headers,
+    });
+    if (!response.ok) {
+      return [];
+    }
+    return extractServerInfoRegionBases((await response.json()) as CloudMatchServerInfoResponse);
+  } catch (error) {
+    console.warn(`[CloudMatch] getActiveSessions fallback discovery failed: ${formatErrorForLog(error)}`);
+    return [];
+  }
+}
+
+async function fetchActiveSessionsFromBase(
+  base: string,
+  headers: Record<string, string>,
+): Promise<ActiveSessionInfo[] | null> {
   const url = `${base}/v2/session`;
 
-  const response = await fetch(url, {
-    method: "GET",
-    headers: buildGfnCloudMatchHeaders({ token, includeOrigin: false }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers,
+    });
+  } catch (error) {
+    console.warn(`[CloudMatch] getActiveSessions fetch failed for ${base}: ${formatErrorForLog(error)}`);
+    return null;
+  }
 
   const text = await response.text();
 
@@ -1286,6 +1379,14 @@ export async function getActiveSessions(
     });
 
   return activeSessions;
+}
+
+function formatErrorForLog(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = error.cause instanceof Error ? `: ${error.cause.message}` : "";
+    return `${error.message}${cause}`;
+  }
+  return String(error);
 }
 
 /**


### PR DESCRIPTION
This PR implements a fallback mechanism for `getActiveSessions` to prevent failures when the primary CloudMatch region endpoint is unreachable.

-   Refactored `getActiveSessions` in `src/main/gfn/cloudmatch.ts` to query `v2/serverInfo` for fallback region URLs (`local-region`, `gfn-regions`) if the primary fetch fails.
-   Added `extractServerInfoRegionBases` to parse and prioritize local region metadata from `serverInfo` response.
-   Added `discoverActiveSessionFallbackBases` and `fetchActiveSessionsFromBase` to manage the retry logic and error handling.
-   Updated `getActiveSessions` to include the stable `deviceId` in request headers.
-   Added tests in `src/main/gfn/cloudmatch.test.ts` for region metadata extraction and the fallback fetch flow.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/7dc50ea1-97ad-4dc8-8312-83c8b644f839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-217" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/7dc50ea1-97ad-4dc8-8312-83c8b644f839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-217&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-217"><img alt="OPE-217" src="https://capy.ai/api/badge/thread.svg?label=OPE-217"></picture></a>
<!-- capy-pr-badge:end -->