### PR TITLE
fix(electron): extract fallback archives with zip extractor on Linux

### DIFF
--- a/opennow-stable/scripts/ensure-electron-installed.mjs
+++ b/opennow-stable/scripts/ensure-electron-installed.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const require = createRequire(import.meta.url);
 
@@ -107,31 +108,14 @@ if (!hasElectronBinary()) {
   rmSync(resolvedDistRoot, { recursive: true, force: true });
   mkdirSync(resolvedDistRoot, { recursive: true });
 
-  const tarResult = spawnSync("tar", ["-xf", zipPath, "-C", resolvedDistRoot], {
-    stdio: "inherit",
-    shell: false,
-  });
+  const electronRequire = createRequire(electronPackageJson);
+  const { extract } = await import(pathToFileURL(electronRequire.resolve("@electron-internal/extract-zip")).href);
 
-  if (tarResult.status !== 0 && platform === "win32") {
-    const expandResult = spawnSync(
-      "powershell.exe",
-      [
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
-        zipPath,
-        resolvedDistRoot,
-      ],
-      { stdio: "inherit" },
-    );
-
-    if (expandResult.status !== 0) {
-      process.exit(expandResult.status ?? 1);
-    }
-  } else if (tarResult.status !== 0) {
-    process.exit(tarResult.status ?? 1);
+  try {
+    await extract(zipPath, { dir: resolvedDistRoot });
+  } catch (error) {
+    console.error("Failed to extract Electron archive:", error);
+    process.exit(1);
   }
 
   const extractedTypeDef = path.join(resolvedDistRoot, "electron.d.ts");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Electron archive fallback path in `ensure-electron-installed.mjs` when the primary installer exits successfully but leaves no runtime binary.

GNU `tar` cannot unpack Electron's `.zip` artifacts on Linux, so the fallback failed exactly in the CI/dev environments it was meant to repair. This change uses Electron's bundled `@electron-internal/extract-zip` helper (the same extractor used by `electron/install.js`) instead of `tar` or platform-specific shell extractors.

## Test plan

- [x] `node scripts/ensure-electron-installed.mjs` succeeds when Electron is already installed
- [x] Verified `@electron-internal/extract-zip` resolves and imports from the Electron package
- [x] `npm --prefix opennow-stable run typecheck`
- [x] `npm --prefix opennow-stable test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d3c36d3-27b6-49fd-8972-fe3479358b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d3c36d3-27b6-49fd-8972-fe3479358b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

