### PR TITLE
fix(build): fix native streamer verification

### DIFF
--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, chmodSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { copyFileSync, chmodSync, existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -9,8 +9,10 @@ const packageRoot = resolve(__dirname, "..");
 const repoRoot = resolve(packageRoot, "..");
 const crateRoot = join(repoRoot, "native", "opennow-streamer");
 const manifestPath = join(crateRoot, "Cargo.toml");
+const protocolSourcePath = join(crateRoot, "src", "protocol.rs");
 const exeName = process.platform === "win32" ? "opennow-streamer.exe" : "opennow-streamer";
-const nativeStreamerProtocolVersion = 2;
+const verifyCommandId = "verify";
+const nativeStreamerProtocolVersion = readNativeStreamerProtocolVersion();
 const nativeTarget = process.env.OPENNOW_NATIVE_STREAMER_TARGET?.trim() || "";
 const platformKey = process.env.OPENNOW_NATIVE_STREAMER_PLATFORM_KEY?.trim() || `${process.platform}-${process.arch}`;
 const targetReleaseDir = nativeTarget
@@ -28,6 +30,15 @@ function hasFeature(features, feature) {
     .map((value) => value.trim().toLowerCase())
     .filter(Boolean)
     .includes(feature);
+}
+
+function readNativeStreamerProtocolVersion() {
+  const source = readFileSync(protocolSourcePath, "utf8");
+  const match = source.match(/pub\s+const\s+PROTOCOL_VERSION\s*:\s*u64\s*=\s*(\d+)\s*;/);
+  if (!match) {
+    throw new Error(`Unable to read native streamer protocol version from ${protocolSourcePath}`);
+  }
+  return Number.parseInt(match[1], 10);
 }
 
 function isWindowsBuild() {
@@ -260,9 +271,36 @@ function buildBundledGstreamerEnv(baseEnv, binaryPath) {
   return env;
 }
 
+function parseNativeStreamerResponse(stdout) {
+  const messages = [];
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    try {
+      messages.push(JSON.parse(line));
+    } catch {
+      console.error(`Native streamer verification returned invalid JSON: ${line}`);
+      process.exit(1);
+    }
+  }
+
+  const response = messages.find((message) => message?.id === verifyCommandId);
+  if (!response) {
+    console.error(
+      `Native streamer verification did not return a response to ${verifyCommandId}: ${JSON.stringify(messages)}`,
+    );
+    process.exit(1);
+  }
+
+  return response;
+}
+
 function verifyGstreamerBinary(binaryPath, env) {
   const result = spawnSync(binaryPath, {
-    input: `${JSON.stringify({ id: "verify", type: "hello", protocolVersion: nativeStreamerProtocolVersion })}\n`,
+    input: `${JSON.stringify({ id: verifyCommandId, type: "hello", protocolVersion: nativeStreamerProtocolVersion })}\n`,
     encoding: "utf8",
     env: {
       ...env,
@@ -276,16 +314,11 @@ function verifyGstreamerBinary(binaryPath, env) {
     process.exit(result.status ?? 1);
   }
 
-  const responseLine = result.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean);
-
-  let response;
-  try {
-    response = JSON.parse(responseLine ?? "");
-  } catch (error) {
-    console.error(`Native streamer verification returned invalid JSON: ${responseLine}`);
+  const response = parseNativeStreamerResponse(result.stdout);
+  if (response.type === "error") {
+    console.error(
+      `Native streamer verification failed: ${response.code ?? "error"}${response.message ? `: ${response.message}` : ""}`,
+    );
     process.exit(1);
   }
 

--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -10,9 +10,10 @@ const repoRoot = resolve(packageRoot, "..");
 const crateRoot = join(repoRoot, "native", "opennow-streamer");
 const manifestPath = join(crateRoot, "Cargo.toml");
 const protocolSourcePath = join(crateRoot, "src", "protocol.rs");
+const appProtocolSourcePath = join(packageRoot, "src", "shared", "nativeStreamer.ts");
 const exeName = process.platform === "win32" ? "opennow-streamer.exe" : "opennow-streamer";
 const verifyCommandId = "verify";
-const nativeStreamerProtocolVersion = readNativeStreamerProtocolVersion();
+const nativeStreamerProtocolVersion = readVerifiedNativeStreamerProtocolVersion();
 const nativeTarget = process.env.OPENNOW_NATIVE_STREAMER_TARGET?.trim() || "";
 const platformKey = process.env.OPENNOW_NATIVE_STREAMER_PLATFORM_KEY?.trim() || `${process.platform}-${process.arch}`;
 const targetReleaseDir = nativeTarget
@@ -32,13 +33,35 @@ function hasFeature(features, feature) {
     .includes(feature);
 }
 
-function readNativeStreamerProtocolVersion() {
-  const source = readFileSync(protocolSourcePath, "utf8");
-  const match = source.match(/pub\s+const\s+PROTOCOL_VERSION\s*:\s*u64\s*=\s*(\d+)\s*;/);
+function readProtocolVersion(sourcePath, pattern, label) {
+  const source = readFileSync(sourcePath, "utf8");
+  const match = source.match(pattern);
   if (!match) {
-    throw new Error(`Unable to read native streamer protocol version from ${protocolSourcePath}`);
+    throw new Error(`Unable to read ${label} protocol version from ${sourcePath}`);
   }
   return Number.parseInt(match[1], 10);
+}
+
+function readVerifiedNativeStreamerProtocolVersion() {
+  const appProtocolVersion = readProtocolVersion(
+    appProtocolSourcePath,
+    /export\s+const\s+NATIVE_STREAMER_PROTOCOL_VERSION\s*=\s*(\d+)\s*;/,
+    "app",
+  );
+  const nativeProtocolVersion = readProtocolVersion(
+    protocolSourcePath,
+    /pub\s+const\s+PROTOCOL_VERSION\s*:\s*u64\s*=\s*(\d+)\s*;/,
+    "native",
+  );
+
+  if (appProtocolVersion !== nativeProtocolVersion) {
+    throw new Error(
+      `Native streamer protocol mismatch: app sends ${appProtocolVersion} from ${appProtocolSourcePath}, `
+      + `native expects ${nativeProtocolVersion} from ${protocolSourcePath}.`,
+    );
+  }
+
+  return appProtocolVersion;
 }
 
 function isWindowsBuild() {


### PR DESCRIPTION
This PR fixes native streamer build verification failures in CI caused by hardcoded protocol version and response parsing issues.

- **Protocol version**: Changed from hardcoded `2` to dynamically reading `PROTOCOL_VERSION` from `native/opennow-streamer/src/protocol.rs` (currently `3`)
- **Response parsing**: Updated to parse all stdout lines and locate the verification response by command ID instead of assuming the first line is the response
- **Error handling**: Added explicit check for error-type responses before capability validation

### Changes
- `opennow-stable/scripts/build-native-streamer.mjs`: Added `readNativeStreamerProtocolVersion()` function and `parseNativeStreamerResponse()` helper to correctly extract and validate native streamer capabilities

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/314fc870-84d1-4705-b2d9-a149ef2cf775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-220" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/314fc870-84d1-4705-b2d9-a149ef2cf775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-220&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-220"><img alt="OPE-220" src="https://capy.ai/api/badge/thread.svg?label=OPE-220"></picture></a>
<!-- capy-pr-badge:end -->