### PR TITLE
fix(gfn): update session creation payload to match official endpoints

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -5,8 +5,10 @@ import assert from "node:assert/strict";
 
 import type { StreamSettings } from "@shared/gfn";
 import {
+  DEFAULT_KEYBOARD_LAYOUT,
   colorQualityBitDepth,
   colorQualityChromaFormat,
+  resolveGfnKeyboardLayout,
 } from "@shared/gfn";
 import {
   buildRequestedStreamingFeatures,
@@ -148,6 +150,10 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
     };
   };
   let requestBody: CapturedSessionRequestBody | null = null;
+  const expectedSessionUrl = `https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?${new URLSearchParams({
+    keyboardLayout: resolveGfnKeyboardLayout(DEFAULT_KEYBOARD_LAYOUT, process.platform),
+    languageCode: "en_US",
+  }).toString()}`;
 
   console.warn = () => {};
   globalThis.fetch = (async (input, init) => {
@@ -166,7 +172,7 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
       }), { status: 200 });
     }
 
-    if (url === "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?keyboardLayout=en-US&languageCode=en_US") {
+    if (url === expectedSessionUrl) {
       requestBody = JSON.parse(String(init?.body));
       const createdRequestBody = requestBody;
       if (!createdRequestBody) {
@@ -208,7 +214,7 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
     assert.equal(session.streamingBaseUrl, "https://np-lax-01.cloudmatchbeta.nvidiagrid.net");
     assert.deepEqual(calls, [
       "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
-      "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?keyboardLayout=en-US&languageCode=en_US",
+      expectedSessionUrl,
     ]);
     const capturedRequestBody = requestBody as CapturedSessionRequestBody | null;
     assert.ok(capturedRequestBody);

--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -4,7 +4,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { StreamSettings } from "@shared/gfn";
-import { buildRequestedStreamingFeatures, extractServerInfoRegionBases, getActiveSessions } from "./cloudmatch";
+import {
+  colorQualityBitDepth,
+  colorQualityChromaFormat,
+} from "@shared/gfn";
+import {
+  buildRequestedStreamingFeatures,
+  createSession,
+  extractServerInfoRegionBases,
+  getActiveSessions,
+} from "./cloudmatch";
 
 function makeSettings(overrides: Partial<StreamSettings> = {}): StreamSettings {
   return {
@@ -85,6 +94,29 @@ test("CloudMatch uses resolver Reflex decision when present", () => {
   assert.equal(features.reflex, false);
 });
 
+test("CloudMatch uses official streaming feature enum values", () => {
+  assert.equal(colorQualityBitDepth("8bit_420"), 0);
+  assert.equal(colorQualityBitDepth("10bit_420"), 1);
+  assert.equal(colorQualityChromaFormat("8bit_420"), 0);
+  assert.equal(colorQualityChromaFormat("8bit_444"), 1);
+
+  const features = buildRequestedStreamingFeatures(makeSettings({ enableL4S: true }), 1, 1, false);
+  assert.deepEqual(features, {
+    reflex: true,
+    bitDepth: 1,
+    cloudGsync: false,
+    enabledL4S: true,
+    supportedHidDevices: 0,
+    profile: 0,
+    fallbackToLogicalResolution: false,
+    chromaFormat: 1,
+    prefilterMode: 0,
+    prefilterSharpness: 0,
+    prefilterNoiseReduction: 0,
+    hudStreamingMode: 0,
+  });
+});
+
 test("CloudMatch extracts local serverInfo region before fallback regions", () => {
   const bases = extractServerInfoRegionBases({
     metaData: [
@@ -101,6 +133,91 @@ test("CloudMatch extracts local serverInfo region before fallback regions", () =
     "https://np-eu.example.nvidiagrid.net",
     "https://np-us.example.nvidiagrid.net",
   ]);
+});
+
+test("CloudMatch resolves default prod endpoint to serverInfo local region before creating a session", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const calls: string[] = [];
+  type CapturedSessionRequestBody = {
+    sessionRequestData: {
+      requestedStreamingFeatures: {
+        bitDepth?: number;
+        chromaFormat?: number;
+      };
+    };
+  };
+  let requestBody: CapturedSessionRequestBody | null = null;
+
+  console.warn = () => {};
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    calls.push(url);
+
+    if (url === "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo") {
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
+        metaData: [
+          { key: "local-region", value: "US West" },
+          { key: "gfn-regions", value: "US West, US East" },
+          { key: "US West", value: "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/" },
+          { key: "US East", value: "https://np-ash-01.cloudmatchbeta.nvidiagrid.net/" },
+        ],
+      }), { status: 200 });
+    }
+
+    if (url === "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?keyboardLayout=en-US&languageCode=en_US") {
+      requestBody = JSON.parse(String(init?.body));
+      const createdRequestBody = requestBody;
+      if (!createdRequestBody) {
+        throw new Error("Session request body was not captured");
+      }
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS" },
+        session: {
+          sessionId: "session-1",
+          status: 1,
+          seatSetupInfo: { seatSetupStep: 0 },
+          sessionControlInfo: { ip: "np-lax-01.cloudmatchbeta.nvidiagrid.net" },
+          connectionInfo: [],
+          iceServerConfiguration: {
+            iceServers: [{ urls: "stun:127.0.0.1:19302" }],
+          },
+          sessionRequestData: {
+            clientRequestMonitorSettings: [{ widthInPixels: 2560, heightInPixels: 1440, framesPerSecond: 240 }],
+            requestedStreamingFeatures: createdRequestBody.sessionRequestData.requestedStreamingFeatures,
+          },
+        },
+      }), { status: 200 });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const session = await createSession({
+      token: "token",
+      streamingBaseUrl: "https://prod.cloudmatchbeta.nvidiagrid.net/",
+      appId: "1001",
+      internalTitle: "Test Game",
+      accountLinked: true,
+      zone: "prod",
+      settings: makeSettings({ colorQuality: "10bit_444", enableL4S: true }),
+    });
+
+    assert.equal(session.streamingBaseUrl, "https://np-lax-01.cloudmatchbeta.nvidiagrid.net");
+    assert.deepEqual(calls, [
+      "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
+      "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?keyboardLayout=en-US&languageCode=en_US",
+    ]);
+    const capturedRequestBody = requestBody as CapturedSessionRequestBody | null;
+    assert.ok(capturedRequestBody);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.bitDepth, 1);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.chromaFormat, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
 });
 
 test("CloudMatch falls back to serverInfo local region when active-session HTTP request fails", async () => {

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -92,6 +92,51 @@ export function extractServerInfoRegionBases(payload: CloudMatchServerInfoRespon
   return bases;
 }
 
+function isDefaultStreamingServiceBase(baseUrl: string): boolean {
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return hostname === "prod.cloudmatchbeta.nvidiagrid.net" ||
+      (hostname.startsWith("prod.") && hostname.endsWith(".nvidiagrid.net"));
+  } catch {
+    return false;
+  }
+}
+
+async function resolveCreateSessionBase(
+  base: string,
+  token: string,
+  clientId: string,
+  deviceId: string,
+  proxyUrl?: string,
+): Promise<string> {
+  if (!isDefaultStreamingServiceBase(base)) {
+    return base;
+  }
+
+  try {
+    const response = await fetchWithOptionalProxy(`${base}/v2/serverInfo`, {
+      method: "GET",
+      headers: buildGfnCloudMatchHeaders({ token, clientId, deviceId, includeOrigin: false }),
+    }, proxyUrl);
+    if (!response.ok) {
+      return base;
+    }
+
+    const [localRegionBase] = extractServerInfoRegionBases(
+      (await response.json()) as CloudMatchServerInfoResponse,
+    );
+    if (!localRegionBase || localRegionBase === base) {
+      return base;
+    }
+
+    console.log(`[CloudMatch] createSession resolved ${base} to local region ${localRegionBase}`);
+    return localRegionBase;
+  } catch (error) {
+    console.warn(`[CloudMatch] createSession local-region discovery failed: ${formatErrorForLog(error)}`);
+    return base;
+  }
+}
+
 function getElectronApp(): Electron.App | null {
   try {
     return require("electron").app ?? null;
@@ -118,7 +163,7 @@ export function buildRequestedStreamingFeatures(
   settings: StreamSettings,
   bitDepth: number,
   chromaFormat: number,
-  hdrEnabled: boolean,
+  _hdrEnabled: boolean,
 ): CloudMatchRequest["sessionRequestData"]["requestedStreamingFeatures"] {
   const cloudGsync = settings.enableCloudGsync;
 
@@ -127,19 +172,14 @@ export function buildRequestedStreamingFeatures(
     bitDepth,
     cloudGsync,
     enabledL4S: settings.enableL4S,
-    mouseMovementFlags: 0,
-    trueHdr: hdrEnabled,
     supportedHidDevices: 0,
     profile: 0,
     fallbackToLogicalResolution: false,
-    hidDevices: null,
     chromaFormat,
     prefilterMode: 0,
     prefilterSharpness: 0,
     prefilterNoiseReduction: 0,
     hudStreamingMode: 0,
-    sdrColorSpace: 2,
-    hdrColorSpace: hdrEnabled ? 4 : 0,
   };
 }
 
@@ -612,9 +652,9 @@ function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: stri
                 desiredContentMinLuminance: 0,
                 desiredContentMaxFrameAverageLuminance: 500,
               }
-            : null,
+            : {},
           hdr10PlusGamingData: null,
-          dpi: 100,
+          dpi: 0,
         },
       ],
       useOps: true,
@@ -887,18 +927,21 @@ function extractAdState(payload: CloudMatchResponse): SessionAdState | undefined
 }
 
 function toColorQuality(bitDepth?: number, chromaFormat?: number): ColorQuality | undefined {
-  if (bitDepth !== 0 && bitDepth !== 10) {
+  const normalizedBitDepth = bitDepth === 10 ? 1 : bitDepth;
+  const normalizedChromaFormat = chromaFormat === 2 ? 1 : chromaFormat;
+
+  if (normalizedBitDepth !== 0 && normalizedBitDepth !== 1) {
     return undefined;
   }
-  if (chromaFormat !== 0 && chromaFormat !== 2) {
+  if (normalizedChromaFormat !== 0 && normalizedChromaFormat !== 1) {
     return undefined;
   }
 
-  if (bitDepth === 10) {
-    return chromaFormat === 2 ? "10bit_444" : "10bit_420";
+  if (normalizedBitDepth === 1) {
+    return normalizedChromaFormat === 1 ? "10bit_444" : "10bit_420";
   }
 
-  return chromaFormat === 2 ? "8bit_444" : "8bit_420";
+  return normalizedChromaFormat === 1 ? "8bit_444" : "8bit_420";
 }
 
 function normalizeStreamingFeatures(
@@ -1074,7 +1117,14 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
 
   const body = buildSessionRequestBody(input, deviceId);
 
-  const base = resolveStreamingBaseUrl(input.zone, input.streamingBaseUrl);
+  const requestedBase = resolveStreamingBaseUrl(input.zone, input.streamingBaseUrl);
+  const base = await resolveCreateSessionBase(
+    requestedBase,
+    input.token,
+    clientId,
+    deviceId,
+    input.proxyUrl,
+  );
   const keyboardLayout = resolveGfnKeyboardLayout(input.settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = input.settings.gameLanguage ?? "en_US";
   const url = `${base}/v2/session?${new URLSearchParams({ keyboardLayout, languageCode }).toString()}`;

--- a/opennow-stable/src/main/gfn/types.ts
+++ b/opennow-stable/src/main/gfn/types.ts
@@ -23,9 +23,9 @@ export interface CloudMatchRequest {
       framesPerSecond: number;
       sdrHdrMode: number;
       displayData: {
-        desiredContentMaxLuminance: number;
-        desiredContentMinLuminance: number;
-        desiredContentMaxFrameAverageLuminance: number;
+        desiredContentMaxLuminance?: number;
+        desiredContentMinLuminance?: number;
+        desiredContentMaxFrameAverageLuminance?: number;
       } | null;
       hdr10PlusGamingData?: unknown;
       dpi: number;
@@ -54,19 +54,19 @@ export interface CloudMatchRequest {
       bitDepth: number;
       cloudGsync: boolean;
       enabledL4S: boolean;
-      trueHdr: boolean;
-      mouseMovementFlags: number;
-      supportedHidDevices: number;
-      profile: number;
-      fallbackToLogicalResolution: boolean;
-      hidDevices: string | null;
+      trueHdr?: boolean;
+      mouseMovementFlags?: number;
+      supportedHidDevices?: number;
+      profile?: number;
+      fallbackToLogicalResolution?: boolean;
+      hidDevices?: string | null;
       chromaFormat: number;
-      prefilterMode: number;
-      prefilterSharpness: number;
-      prefilterNoiseReduction: number;
-      hudStreamingMode: number;
-      sdrColorSpace: number;
-      hdrColorSpace: number;
+      prefilterMode?: number;
+      prefilterSharpness?: number;
+      prefilterNoiseReduction?: number;
+      hudStreamingMode?: number;
+      sdrColorSpace?: number;
+      hdrColorSpace?: number;
     };
   };
 }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -82,14 +82,14 @@ export function resolveGfnKeyboardLayout(layout: KeyboardLayout, platform: strin
   return option?.value ?? DEFAULT_KEYBOARD_LAYOUT;
 }
 
-/** Helper: get CloudMatch bitDepth value (0 = 8-bit SDR, 10 = 10-bit HDR capable) */
+/** Helper: get CloudMatch bitDepth value (0 = 8-bit, 1 = 10-bit) */
 export function colorQualityBitDepth(cq: ColorQuality): number {
-  return cq.startsWith("10bit") ? 10 : 0;
+  return cq.startsWith("10bit") ? 1 : 0;
 }
 
-/** Helper: get CloudMatch chromaFormat value (0 = 4:2:0, 2 = 4:4:4) */
+/** Helper: get CloudMatch chromaFormat value (0 = 4:2:0, 1 = 4:4:4) */
 export function colorQualityChromaFormat(cq: ColorQuality): number {
-  return cq.endsWith("444") ? 2 : 0;
+  return cq.endsWith("444") ? 1 : 0;
 }
 
 /** Helper: does this color quality mode require HEVC or AV1? */


### PR DESCRIPTION
## Description

This PR fixes the HTTP 400 error during session creation by updating GFN CloudMatch request handling to match the official endpoint behavior and payload structure found in the provided official bundle.

### Changes

- `opennow-stable/src/main/gfn/cloudmatch.ts`: Added `resolveCreateSessionBase` to probe `/v2/serverInfo` for default prod base and route session creation to local region; trimmed `requestedStreamingFeatures` to official-style fields; set monitor `displayData` to empty object and `dpi` to 0 for SDR
- `opennow-stable/src/shared/gfn.ts`: Updated `colorQualityBitDepth` to return 1 for 10-bit (was 10) and `colorQualityChromaFormat` to return 1 for 4:4:4 (was 2)
- `opennow-stable/src/main/gfn/types.ts`: Made `displayData` fields optional and `requestedStreamingFeatures` fields optional to match official request structure
- `opennow-stable/src/main/gfn/cloudmatch.test.ts`: Added tests for official enum values and serverInfo local-region resolution; fixed TypeScript narrowing with explicit type alias

### Verification

- Targeted CloudMatch tests pass (7/7)
- Full test suite passes (98/98)
- TypeScript typecheck passes

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/07851840-29bb-4f41-ace4-e6551fdc6596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-221" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/07851840-29bb-4f41-ace4-e6551fdc6596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-221&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-221"><img alt="OPE-221" src="https://capy.ai/api/badge/thread.svg?label=OPE-221"></picture></a>
<!-- capy-pr-badge:end -->