### PR TITLE
Release v0.4.1 — QR login, settings overhaul, GFN fixes, and platform improvements

### DIFF
--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, chmodSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { copyFileSync, chmodSync, existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -9,8 +9,11 @@ const packageRoot = resolve(__dirname, "..");
 const repoRoot = resolve(packageRoot, "..");
 const crateRoot = join(repoRoot, "native", "opennow-streamer");
 const manifestPath = join(crateRoot, "Cargo.toml");
+const protocolSourcePath = join(crateRoot, "src", "protocol.rs");
+const appProtocolSourcePath = join(packageRoot, "src", "shared", "nativeStreamer.ts");
 const exeName = process.platform === "win32" ? "opennow-streamer.exe" : "opennow-streamer";
-const nativeStreamerProtocolVersion = 2;
+const verifyCommandId = "verify";
+const nativeStreamerProtocolVersion = readVerifiedNativeStreamerProtocolVersion();
 const nativeTarget = process.env.OPENNOW_NATIVE_STREAMER_TARGET?.trim() || "";
 const platformKey = process.env.OPENNOW_NATIVE_STREAMER_PLATFORM_KEY?.trim() || `${process.platform}-${process.arch}`;
 const targetReleaseDir = nativeTarget
@@ -28,6 +31,37 @@ function hasFeature(features, feature) {
     .map((value) => value.trim().toLowerCase())
     .filter(Boolean)
     .includes(feature);
+}
+
+function readProtocolVersion(sourcePath, pattern, label) {
+  const source = readFileSync(sourcePath, "utf8");
+  const match = source.match(pattern);
+  if (!match) {
+    throw new Error(`Unable to read ${label} protocol version from ${sourcePath}`);
+  }
+  return Number.parseInt(match[1], 10);
+}
+
+function readVerifiedNativeStreamerProtocolVersion() {
+  const appProtocolVersion = readProtocolVersion(
+    appProtocolSourcePath,
+    /export\s+const\s+NATIVE_STREAMER_PROTOCOL_VERSION\s*=\s*(\d+)\s*;/,
+    "app",
+  );
+  const nativeProtocolVersion = readProtocolVersion(
+    protocolSourcePath,
+    /pub\s+const\s+PROTOCOL_VERSION\s*:\s*u64\s*=\s*(\d+)\s*;/,
+    "native",
+  );
+
+  if (appProtocolVersion !== nativeProtocolVersion) {
+    throw new Error(
+      `Native streamer protocol mismatch: app sends ${appProtocolVersion} from ${appProtocolSourcePath}, `
+      + `native expects ${nativeProtocolVersion} from ${protocolSourcePath}.`,
+    );
+  }
+
+  return appProtocolVersion;
 }
 
 function isWindowsBuild() {
@@ -260,9 +294,36 @@ function buildBundledGstreamerEnv(baseEnv, binaryPath) {
   return env;
 }
 
+function parseNativeStreamerResponse(stdout) {
+  const messages = [];
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    try {
+      messages.push(JSON.parse(line));
+    } catch {
+      console.error(`Native streamer verification returned invalid JSON: ${line}`);
+      process.exit(1);
+    }
+  }
+
+  const response = messages.find((message) => message?.id === verifyCommandId);
+  if (!response) {
+    console.error(
+      `Native streamer verification did not return a response to ${verifyCommandId}: ${JSON.stringify(messages)}`,
+    );
+    process.exit(1);
+  }
+
+  return response;
+}
+
 function verifyGstreamerBinary(binaryPath, env) {
   const result = spawnSync(binaryPath, {
-    input: `${JSON.stringify({ id: "verify", type: "hello", protocolVersion: nativeStreamerProtocolVersion })}\n`,
+    input: `${JSON.stringify({ id: verifyCommandId, type: "hello", protocolVersion: nativeStreamerProtocolVersion })}\n`,
     encoding: "utf8",
     env: {
       ...env,
@@ -276,16 +337,11 @@ function verifyGstreamerBinary(binaryPath, env) {
     process.exit(result.status ?? 1);
   }
 
-  const responseLine = result.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean);
-
-  let response;
-  try {
-    response = JSON.parse(responseLine ?? "");
-  } catch (error) {
-    console.error(`Native streamer verification returned invalid JSON: ${responseLine}`);
+  const response = parseNativeStreamerResponse(result.stdout);
+  if (response.type === "error") {
+    console.error(
+      `Native streamer verification failed: ${response.code ?? "error"}${response.message ? `: ${response.message}` : ""}`,
+    );
     process.exit(1);
   }
 

--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -4,7 +4,18 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { StreamSettings } from "@shared/gfn";
-import { buildRequestedStreamingFeatures, extractServerInfoRegionBases, getActiveSessions } from "./cloudmatch";
+import {
+  DEFAULT_KEYBOARD_LAYOUT,
+  colorQualityBitDepth,
+  colorQualityChromaFormat,
+  resolveGfnKeyboardLayout,
+} from "@shared/gfn";
+import {
+  buildRequestedStreamingFeatures,
+  createSession,
+  extractServerInfoRegionBases,
+  getActiveSessions,
+} from "./cloudmatch";
 
 function makeSettings(overrides: Partial<StreamSettings> = {}): StreamSettings {
   return {
@@ -85,6 +96,29 @@ test("CloudMatch uses resolver Reflex decision when present", () => {
   assert.equal(features.reflex, false);
 });
 
+test("CloudMatch uses official streaming feature enum values", () => {
+  assert.equal(colorQualityBitDepth("8bit_420"), 0);
+  assert.equal(colorQualityBitDepth("10bit_420"), 1);
+  assert.equal(colorQualityChromaFormat("8bit_420"), 0);
+  assert.equal(colorQualityChromaFormat("8bit_444"), 1);
+
+  const features = buildRequestedStreamingFeatures(makeSettings({ enableL4S: true }), 1, 1, false);
+  assert.deepEqual(features, {
+    reflex: true,
+    bitDepth: 1,
+    cloudGsync: false,
+    enabledL4S: true,
+    supportedHidDevices: 0,
+    profile: 0,
+    fallbackToLogicalResolution: false,
+    chromaFormat: 1,
+    prefilterMode: 0,
+    prefilterSharpness: 0,
+    prefilterNoiseReduction: 0,
+    hudStreamingMode: 0,
+  });
+});
+
 test("CloudMatch extracts local serverInfo region before fallback regions", () => {
   const bases = extractServerInfoRegionBases({
     metaData: [
@@ -101,6 +135,95 @@ test("CloudMatch extracts local serverInfo region before fallback regions", () =
     "https://np-eu.example.nvidiagrid.net",
     "https://np-us.example.nvidiagrid.net",
   ]);
+});
+
+test("CloudMatch resolves default prod endpoint to serverInfo local region before creating a session", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const calls: string[] = [];
+  type CapturedSessionRequestBody = {
+    sessionRequestData: {
+      requestedStreamingFeatures: {
+        bitDepth?: number;
+        chromaFormat?: number;
+      };
+    };
+  };
+  let requestBody: CapturedSessionRequestBody | null = null;
+  const expectedSessionUrl = `https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?${new URLSearchParams({
+    keyboardLayout: resolveGfnKeyboardLayout(DEFAULT_KEYBOARD_LAYOUT, process.platform),
+    languageCode: "en_US",
+  }).toString()}`;
+
+  console.warn = () => {};
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    calls.push(url);
+
+    if (url === "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo") {
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
+        metaData: [
+          { key: "local-region", value: "US West" },
+          { key: "gfn-regions", value: "US West, US East" },
+          { key: "US West", value: "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/" },
+          { key: "US East", value: "https://np-ash-01.cloudmatchbeta.nvidiagrid.net/" },
+        ],
+      }), { status: 200 });
+    }
+
+    if (url === expectedSessionUrl) {
+      requestBody = JSON.parse(String(init?.body));
+      const createdRequestBody = requestBody;
+      if (!createdRequestBody) {
+        throw new Error("Session request body was not captured");
+      }
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS" },
+        session: {
+          sessionId: "session-1",
+          status: 1,
+          seatSetupInfo: { seatSetupStep: 0 },
+          sessionControlInfo: { ip: "np-lax-01.cloudmatchbeta.nvidiagrid.net" },
+          connectionInfo: [],
+          iceServerConfiguration: {
+            iceServers: [{ urls: "stun:127.0.0.1:19302" }],
+          },
+          sessionRequestData: {
+            clientRequestMonitorSettings: [{ widthInPixels: 2560, heightInPixels: 1440, framesPerSecond: 240 }],
+            requestedStreamingFeatures: createdRequestBody.sessionRequestData.requestedStreamingFeatures,
+          },
+        },
+      }), { status: 200 });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const session = await createSession({
+      token: "token",
+      streamingBaseUrl: "https://prod.cloudmatchbeta.nvidiagrid.net/",
+      appId: "1001",
+      internalTitle: "Test Game",
+      accountLinked: true,
+      zone: "prod",
+      settings: makeSettings({ colorQuality: "10bit_444", enableL4S: true }),
+    });
+
+    assert.equal(session.streamingBaseUrl, "https://np-lax-01.cloudmatchbeta.nvidiagrid.net");
+    assert.deepEqual(calls, [
+      "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
+      expectedSessionUrl,
+    ]);
+    const capturedRequestBody = requestBody as CapturedSessionRequestBody | null;
+    assert.ok(capturedRequestBody);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.bitDepth, 1);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.chromaFormat, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
 });
 
 test("CloudMatch falls back to serverInfo local region when active-session HTTP request fails", async () => {

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -92,6 +92,51 @@ export function extractServerInfoRegionBases(payload: CloudMatchServerInfoRespon
   return bases;
 }
 
+function isDefaultStreamingServiceBase(baseUrl: string): boolean {
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return hostname === "prod.cloudmatchbeta.nvidiagrid.net" ||
+      (hostname.startsWith("prod.") && hostname.endsWith(".nvidiagrid.net"));
+  } catch {
+    return false;
+  }
+}
+
+async function resolveCreateSessionBase(
+  base: string,
+  token: string,
+  clientId: string,
+  deviceId: string,
+  proxyUrl?: string,
+): Promise<string> {
+  if (!isDefaultStreamingServiceBase(base)) {
+    return base;
+  }
+
+  try {
+    const response = await fetchWithOptionalProxy(`${base}/v2/serverInfo`, {
+      method: "GET",
+      headers: buildGfnCloudMatchHeaders({ token, clientId, deviceId, includeOrigin: false }),
+    }, proxyUrl);
+    if (!response.ok) {
+      return base;
+    }
+
+    const [localRegionBase] = extractServerInfoRegionBases(
+      (await response.json()) as CloudMatchServerInfoResponse,
+    );
+    if (!localRegionBase || localRegionBase === base) {
+      return base;
+    }
+
+    console.log(`[CloudMatch] createSession resolved ${base} to local region ${localRegionBase}`);
+    return localRegionBase;
+  } catch (error) {
+    console.warn(`[CloudMatch] createSession local-region discovery failed: ${formatErrorForLog(error)}`);
+    return base;
+  }
+}
+
 function getElectronApp(): Electron.App | null {
   try {
     return require("electron").app ?? null;
@@ -118,7 +163,7 @@ export function buildRequestedStreamingFeatures(
   settings: StreamSettings,
   bitDepth: number,
   chromaFormat: number,
-  hdrEnabled: boolean,
+  _hdrEnabled: boolean,
 ): CloudMatchRequest["sessionRequestData"]["requestedStreamingFeatures"] {
   const cloudGsync = settings.enableCloudGsync;
 
@@ -127,19 +172,14 @@ export function buildRequestedStreamingFeatures(
     bitDepth,
     cloudGsync,
     enabledL4S: settings.enableL4S,
-    mouseMovementFlags: 0,
-    trueHdr: hdrEnabled,
     supportedHidDevices: 0,
     profile: 0,
     fallbackToLogicalResolution: false,
-    hidDevices: null,
     chromaFormat,
     prefilterMode: 0,
     prefilterSharpness: 0,
     prefilterNoiseReduction: 0,
     hudStreamingMode: 0,
-    sdrColorSpace: 2,
-    hdrColorSpace: hdrEnabled ? 4 : 0,
   };
 }
 
@@ -612,9 +652,9 @@ function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: stri
                 desiredContentMinLuminance: 0,
                 desiredContentMaxFrameAverageLuminance: 500,
               }
-            : null,
+            : {},
           hdr10PlusGamingData: null,
-          dpi: 100,
+          dpi: 0,
         },
       ],
       useOps: true,
@@ -887,18 +927,21 @@ function extractAdState(payload: CloudMatchResponse): SessionAdState | undefined
 }
 
 function toColorQuality(bitDepth?: number, chromaFormat?: number): ColorQuality | undefined {
-  if (bitDepth !== 0 && bitDepth !== 10) {
+  const normalizedBitDepth = bitDepth === 10 ? 1 : bitDepth;
+  const normalizedChromaFormat = chromaFormat === 2 ? 1 : chromaFormat;
+
+  if (normalizedBitDepth !== 0 && normalizedBitDepth !== 1) {
     return undefined;
   }
-  if (chromaFormat !== 0 && chromaFormat !== 2) {
+  if (normalizedChromaFormat !== 0 && normalizedChromaFormat !== 1) {
     return undefined;
   }
 
-  if (bitDepth === 10) {
-    return chromaFormat === 2 ? "10bit_444" : "10bit_420";
+  if (normalizedBitDepth === 1) {
+    return normalizedChromaFormat === 1 ? "10bit_444" : "10bit_420";
   }
 
-  return chromaFormat === 2 ? "8bit_444" : "8bit_420";
+  return normalizedChromaFormat === 1 ? "8bit_444" : "8bit_420";
 }
 
 function normalizeStreamingFeatures(
@@ -1074,7 +1117,14 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
 
   const body = buildSessionRequestBody(input, deviceId);
 
-  const base = resolveStreamingBaseUrl(input.zone, input.streamingBaseUrl);
+  const requestedBase = resolveStreamingBaseUrl(input.zone, input.streamingBaseUrl);
+  const base = await resolveCreateSessionBase(
+    requestedBase,
+    input.token,
+    clientId,
+    deviceId,
+    input.proxyUrl,
+  );
   const keyboardLayout = resolveGfnKeyboardLayout(input.settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = input.settings.gameLanguage ?? "en_US";
   const url = `${base}/v2/session?${new URLSearchParams({ keyboardLayout, languageCode }).toString()}`;

--- a/opennow-stable/src/main/gfn/types.ts
+++ b/opennow-stable/src/main/gfn/types.ts
@@ -23,9 +23,9 @@ export interface CloudMatchRequest {
       framesPerSecond: number;
       sdrHdrMode: number;
       displayData: {
-        desiredContentMaxLuminance: number;
-        desiredContentMinLuminance: number;
-        desiredContentMaxFrameAverageLuminance: number;
+        desiredContentMaxLuminance?: number;
+        desiredContentMinLuminance?: number;
+        desiredContentMaxFrameAverageLuminance?: number;
       } | null;
       hdr10PlusGamingData?: unknown;
       dpi: number;
@@ -54,19 +54,19 @@ export interface CloudMatchRequest {
       bitDepth: number;
       cloudGsync: boolean;
       enabledL4S: boolean;
-      trueHdr: boolean;
-      mouseMovementFlags: number;
-      supportedHidDevices: number;
-      profile: number;
-      fallbackToLogicalResolution: boolean;
-      hidDevices: string | null;
+      trueHdr?: boolean;
+      mouseMovementFlags?: number;
+      supportedHidDevices?: number;
+      profile?: number;
+      fallbackToLogicalResolution?: boolean;
+      hidDevices?: string | null;
       chromaFormat: number;
-      prefilterMode: number;
-      prefilterSharpness: number;
-      prefilterNoiseReduction: number;
-      hudStreamingMode: number;
-      sdrColorSpace: number;
-      hdrColorSpace: number;
+      prefilterMode?: number;
+      prefilterSharpness?: number;
+      prefilterNoiseReduction?: number;
+      hudStreamingMode?: number;
+      sdrColorSpace?: number;
+      hdrColorSpace?: number;
     };
   };
 }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -82,14 +82,14 @@ export function resolveGfnKeyboardLayout(layout: KeyboardLayout, platform: strin
   return option?.value ?? DEFAULT_KEYBOARD_LAYOUT;
 }
 
-/** Helper: get CloudMatch bitDepth value (0 = 8-bit SDR, 10 = 10-bit HDR capable) */
+/** Helper: get CloudMatch bitDepth value (0 = 8-bit, 1 = 10-bit) */
 export function colorQualityBitDepth(cq: ColorQuality): number {
-  return cq.startsWith("10bit") ? 10 : 0;
+  return cq.startsWith("10bit") ? 1 : 0;
 }
 
-/** Helper: get CloudMatch chromaFormat value (0 = 4:2:0, 2 = 4:4:4) */
+/** Helper: get CloudMatch chromaFormat value (0 = 4:2:0, 1 = 4:4:4) */
 export function colorQualityChromaFormat(cq: ColorQuality): number {
-  return cq.endsWith("444") ? 2 : 0;
+  return cq.endsWith("444") ? 1 : 0;
 }
 
 /** Helper: does this color quality mode require HEVC or AV1? */


### PR DESCRIPTION
## Summary

This release merges **dev → main** for **OpenNOW v0.4.1**, bundling new login and settings features, native streamer improvements, GFN protocol fixes, and a set of Linux/input reliability fixes.

### New features

- **QR code login** — Device authorization flow as an alternative to browser OAuth (`#496`).
- **Recording bitrate control** — Configurable local recording video bitrate with an Auto option.
- **Native streamer app shortcuts** — Shortcut integration for the experimental native streamer window (`#469`).
- **Settings modernization** — Redesigned settings modal, appearance layout improvements, supporter source categorization, and **storage reset** controls (`#518`, `#519`, `#495`).
- **Motion animations** — Smoother UI transitions via Motion (`#523`).

### GFN & session reliability

- **Session creation payload** — Aligns with official GFN endpoints to fix session start failures (`#529`).
- **serverInfo region fallback** — More resilient region selection when primary lookup fails (`#522`).
- **Persistent storage refactor** — Extracted GFN storage layer for clearer ownership and maintainability.

### Native streamer & streaming

- Fullscreen monitor placement fix (`#505`).
- Build/verification fixes for native streamer CI (`#527`).
- F10 fullscreen toggle no longer triggers unintended ESC (`#509`).
- German keyboard Z/Y swap fix by omitting physical scancodes from native keyboard input (`#502`).
- Controller mode button mapping regression fix (`#501`).

### Linux & platform

- Linux updater package support detection (`#504`).
- Linux NVIDIA codec diagnostics (`#506`).
- Electron fallback archive extraction on Linux via zip extractor (`#525`).
- Video acceleration probing and related test coverage.

### Tooling & docs

- Release workflow npm cache lockfile path fix (`#526`).
- Cursor Cloud setup notes in AGENTS.md (`#515`).
- OpenNOW-Mac repository documented for macOS users (`#499`).
- Dependency bumps (vite, form-data).

## Stats

- **26 commits** (excluding merge commits) since `main`
- **55 files changed**, ~6.4k insertions / ~2.8k deletions
- Version bump: **0.4.0 → 0.4.1**

## Test plan

- [ ] **Auth** — OAuth sign-in still works; QR login completes end-to-end and can be cancelled cleanly
- [ ] **Session start** — Launch a game; confirm session creation succeeds with updated payload
- [ ] **Settings** — Browse all settings tabs; verify storage reset, recording bitrate, appearance, and shortcut bindings save correctly
- [ ] **Streaming** — Fullscreen toggle (F10), controller input, and German keyboard layout in native streamer
- [ ] **Linux** — Updater detects supported packages; codec diagnostics display; dev install / fallback extraction
- [ ] **CI** — Release and auto-build workflows pass on merge
- [ ] `npm --prefix opennow-stable run typecheck`
- [ ] `npm --prefix opennow-stable test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming sessions can now automatically use a closer local region when available, improving connection routing.

* **Bug Fixes**
  * Improved native streamer version checks to prevent mismatches during setup.
  * Made GStreamer verification more reliable with better response parsing and clearer error handling.
  * Fixed streaming feature values so color depth and chroma format are reported consistently.
  * Improved session request handling for HDR and non-HDR cases, including more flexible feature data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->