### PR TITLE
feat(agent): add CLI direct launch support

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -706,6 +706,8 @@
   "errors": {
     "launchUnknown": "The game could not start. Please try again.",
     "launchFailedTitle": "Launch Failed",
+    "directLaunchNotFoundTitle": "Direct Launch Failed",
+    "directLaunchNotFoundDescription": "OpenNOW could not find a game matching \"{{value}}\". Use --launch-app-id for exact LaunchBox entries.",
     "duplicateSessionTitle": "Duplicate Session Detected",
     "duplicateSessionDescription": "Another session is already running on your account. Close it first or wait for it to timeout, then launch again.",
     "insufficientPlayabilityTitle": "Membership Upgrade Required",

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -34,6 +34,7 @@ import type {
   AppUpdaterState,
   SessionConflictChoice,
   Settings,
+  DirectLaunchRequest,
   PingResult,
   StreamRegion,
   MicrophonePermissionResult,
@@ -81,6 +82,7 @@ import {
   isAccelerationPreference,
   type BootstrapVideoPreferences,
 } from "./videoAcceleration";
+import { parseDirectLaunchArgs, type DirectLaunchArgs } from "@shared/directLaunch";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -181,9 +183,45 @@ let isShutdownRequested = false;
 let isShutdownCleanupComplete = false;
 let isUpdaterInstallQuitInProgress = false;
 let explicitShutdownFallbackTimer: NodeJS.Timeout | null = null;
+let directLaunchRequestSequence = 0;
+let pendingDirectLaunchRequest: DirectLaunchRequest | null = createDirectLaunchRequestFromArgv(process.argv);
 
 // Runtime pointer-lock state (updated by renderer)
 let isPointerLockActiveRuntime = false;
+
+function createDirectLaunchRequest(args: DirectLaunchArgs): DirectLaunchRequest {
+  return {
+    ...args,
+    id: `cli-${process.pid}-${Date.now()}-${++directLaunchRequestSequence}`,
+    source: "cli",
+    receivedAt: Date.now(),
+  };
+}
+
+function createDirectLaunchRequestFromArgv(argv: readonly string[]): DirectLaunchRequest | null {
+  const args = parseDirectLaunchArgs(argv);
+  return args ? createDirectLaunchRequest(args) : null;
+}
+
+function focusMainWindow(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore();
+  }
+  mainWindow.show();
+  mainWindow.focus();
+}
+
+function emitDirectLaunchRequest(request: DirectLaunchRequest): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  mainWindow.webContents.send(IPC_CHANNELS.DIRECT_LAUNCH_REQUEST, request);
+}
+
+function enqueueDirectLaunchRequest(request: DirectLaunchRequest): void {
+  pendingDirectLaunchRequest = request;
+  focusMainWindow();
+  emitDirectLaunchRequest(request);
+}
 
 function clearExplicitShutdownFallback(): void {
   if (explicitShutdownFallbackTimer) {
@@ -456,6 +494,9 @@ async function createMainWindow(): Promise<void> {
     await mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL);
   } else {
     await mainWindow.loadFile(join(__dirname, "../../dist/index.html"));
+  }
+  if (pendingDirectLaunchRequest) {
+    emitDirectLaunchRequest(pendingDirectLaunchRequest);
   }
 
   mainWindow.on("closed", () => {
@@ -821,6 +862,15 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(
+    IPC_CHANNELS.DIRECT_LAUNCH_GET_PENDING,
+    async (): Promise<DirectLaunchRequest | null> => {
+      const request = pendingDirectLaunchRequest;
+      pendingDirectLaunchRequest = null;
+      return request;
+    },
+  );
+
+  ipcMain.handle(
     IPC_CHANNELS.APP_UPDATER_GET_STATE,
     async (): Promise<AppUpdaterState> => {
       const buildInfo = getAppBuildInfo();
@@ -1093,6 +1143,22 @@ function registerIpcHandlers(): void {
   });
 }
 
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on("second-instance", (_event, argv) => {
+    const request = createDirectLaunchRequestFromArgv(argv);
+    if (request) {
+      enqueueDirectLaunchRequest(request);
+      return;
+    }
+    focusMainWindow();
+  });
+}
+
+if (gotSingleInstanceLock) {
 app.whenReady().then(async () => {
   // Initialize log capture first to capture all console output
   initLogCapture("main");
@@ -1211,6 +1277,7 @@ app.whenReady().then(async () => {
     }
   });
 });
+}
 
 app.on("window-all-closed", () => {
   requestAppShutdown({ reason: "window-all-closed" });

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -8,6 +8,7 @@ import type {
   AuthDeviceLoginStartRequest,
   AuthSession,
   AuthSessionRequest,
+  DirectLaunchRequest,
   GamesFetchRequest,
   CatalogBrowseRequest,
   ResolveLaunchIdRequest,
@@ -103,6 +104,18 @@ const api: OpenNowApi = {
     ipcRenderer.invoke(IPC_CHANNELS.GAMES_RESOLVE_LAUNCH_ID, input),
   resolveStoreUrl: (input: ResolveStoreUrlRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.GAMES_RESOLVE_STORE_URL, input),
+  getPendingDirectLaunchRequest: (): Promise<DirectLaunchRequest | null> =>
+    ipcRenderer.invoke(IPC_CHANNELS.DIRECT_LAUNCH_GET_PENDING),
+  onDirectLaunchRequest: (listener: (request: DirectLaunchRequest) => void) => {
+    const wrapped = (_event: Electron.IpcRendererEvent, payload: DirectLaunchRequest) => {
+      listener(payload);
+    };
+
+    ipcRenderer.on(IPC_CHANNELS.DIRECT_LAUNCH_REQUEST, wrapped);
+    return () => {
+      ipcRenderer.off(IPC_CHANNELS.DIRECT_LAUNCH_REQUEST, wrapped);
+    };
+  },
   createSession: (input: SessionCreateRequest) => invokeSessionChannel(IPC_CHANNELS.CREATE_SESSION, input),
   pollSession: (input: SessionPollRequest) => invokeSessionChannel(IPC_CHANNELS.POLL_SESSION, input),
   reportSessionAd: (input: SessionAdReportRequest) => invokeSessionChannel(IPC_CHANNELS.REPORT_SESSION_AD, input),

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -3044,7 +3044,15 @@ export function App(): JSX.Element {
     const request = pendingDirectLaunchRequest;
     if (!request || handledDirectLaunchIdsRef.current.has(request.id)) return;
     if (!authSession || isInitializing || isLoadingCatalog || isLoadingLibrary) return;
-    if (launchInFlightRef.current || streamStatus !== "idle" || navbarSessionActionInFlightRef.current) return;
+    if (
+      launchInFlightRef.current ||
+      streamStatus !== "idle" ||
+      isResumingNavbarSession ||
+      isTerminatingNavbarSession ||
+      navbarSessionActionInFlightRef.current
+    ) {
+      return;
+    }
     if (directLaunchAttemptIdRef.current === request.id) return;
 
     directLaunchAttemptIdRef.current = request.id;
@@ -3080,6 +3088,15 @@ export function App(): JSX.Element {
 
       if (cancelled) return;
 
+      if (
+        launchInFlightRef.current ||
+        streamStatusRef.current !== "idle" ||
+        navbarSessionActionInFlightRef.current
+      ) {
+        directLaunchAttemptIdRef.current = null;
+        return;
+      }
+
       handledDirectLaunchIdsRef.current.add(request.id);
       directLaunchAttemptIdRef.current = null;
       setPendingDirectLaunchRequest((previous) => previous?.id === request.id ? null : previous);
@@ -3113,6 +3130,8 @@ export function App(): JSX.Element {
     isInitializing,
     isLoadingCatalog,
     isLoadingLibrary,
+    isResumingNavbarSession,
+    isTerminatingNavbarSession,
     pendingDirectLaunchRequest,
     streamStatus,
     t,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import type {
   CatalogBrowseResult,
   CatalogFilterGroup,
   CatalogSortOption,
+  DirectLaunchRequest,
   ExistingSessionStrategy,
   GameInfo,
   GamePanelResult,
@@ -30,6 +31,7 @@ import {
   buildNativeStreamerSessionContext,
   DEFAULT_KEYBOARD_LAYOUT,
   getDefaultStreamPreferences,
+  isGameInLibrary,
   isSessionAdsRequired,
 } from "@shared/gfn";
 import { GfnWebRtcClient } from "./gfn/webrtcClient";
@@ -103,10 +105,90 @@ type AppStyle = CSSProperties & {
   "--game-poster-scale"?: string;
 };
 
+interface DirectLaunchTarget {
+  game: GameInfo;
+  variantId?: string;
+}
+
 function getAppStyle(posterSizeScale: number): AppStyle {
   return {
     "--game-poster-scale": String(posterSizeScale),
   };
+}
+
+function normalizeDirectLaunchText(value: string | undefined): string {
+  return value?.trim().replace(/\s+/g, " ").toLowerCase() ?? "";
+}
+
+function directLaunchOwnershipScore(game: GameInfo): number {
+  return game.isInLibrary || isGameInLibrary(game) ? 10 : 0;
+}
+
+function findDirectLaunchTargetByTitle(catalog: GameInfo[], title: string): DirectLaunchTarget | null {
+  const normalizedTitle = normalizeDirectLaunchText(title);
+  if (!normalizedTitle) return null;
+
+  let best: { target: DirectLaunchTarget; score: number } | null = null;
+  for (const game of catalog) {
+    const gameTitle = normalizeDirectLaunchText(game.title);
+    const shortName = normalizeDirectLaunchText(game.shortName);
+    let score = 0;
+    if (gameTitle === normalizedTitle) {
+      score = 100;
+    } else if (shortName && shortName === normalizedTitle) {
+      score = 95;
+    } else if (gameTitle.startsWith(normalizedTitle)) {
+      score = 80;
+    } else if (matchesGameSearch(game, title)) {
+      score = 60;
+    }
+
+    if (score === 0) continue;
+    score += directLaunchOwnershipScore(game);
+    if (!best || score > best.score) {
+      best = { target: { game }, score };
+    }
+  }
+
+  return best?.target ?? null;
+}
+
+function createSyntheticDirectLaunchGame(request: DirectLaunchRequest, appId: string): GameInfo {
+  const title = request.title?.trim() || `GFN App ${appId}`;
+  return {
+    id: `direct-launch-${appId}`,
+    launchAppId: appId,
+    title,
+    searchText: normalizeDirectLaunchText(title),
+    selectedVariantIndex: 0,
+    variants: [
+      {
+        id: appId,
+        store: "UNKNOWN",
+        supportedControls: [],
+      },
+    ],
+  };
+}
+
+function findDirectLaunchTarget(
+  request: DirectLaunchRequest,
+  catalog: GameInfo[],
+  variantByGameId: Record<string, string>,
+): DirectLaunchTarget | null {
+  const numericAppId = parseNumericId(request.appId);
+  if (numericAppId !== null) {
+    const matched = findSessionContextForAppId(catalog, variantByGameId, numericAppId);
+    if (matched) {
+      return { game: matched.game, variantId: matched.variant?.id };
+    }
+  }
+
+  if (request.title) {
+    return findDirectLaunchTargetByTitle(catalog, request.title);
+  }
+
+  return null;
 }
 
 function isNvidiaProvider(provider: LoginProvider | null | undefined): boolean {
@@ -327,6 +409,7 @@ export function App(): JSX.Element {
   const [removeAccountConfirmOpen, setRemoveAccountConfirmOpen] = useState(false);
   const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
   const [launchError, setLaunchError] = useState<LaunchErrorState | null>(null);
+  const [pendingDirectLaunchRequest, setPendingDirectLaunchRequest] = useState<DirectLaunchRequest | null>(null);
   const [queueModalGame, setQueueModalGame] = useState<GameInfo | null>(null);
   const [queueModalData, setQueueModalData] = useState<PrintedWasteQueueData | null>(null);
   const [sessionStartedAtMs, setSessionStartedAtMs] = useState<number | null>(null);
@@ -433,6 +516,8 @@ export function App(): JSX.Element {
   const hasInitializedRef = useRef(false);
   const regionsRequestRef = useRef(0);
   const launchInFlightRef = useRef(false);
+  const directLaunchAttemptIdRef = useRef<string | null>(null);
+  const handledDirectLaunchIdsRef = useRef<Set<string>>(new Set());
   const runtimeSnapshotRef = useRef<RuntimeSnapshot | null>(loadRuntimeSnapshot());
   /** Joins concurrent claim/resume calls for the same Cloud session id (single CloudMatch RESUME + signaling). */
   const claimResumePromisesRef = useRef<Map<string, Promise<void>>>(new Map());
@@ -461,6 +546,21 @@ export function App(): JSX.Element {
   });
   const exitPromptResolverRef = useRef<((confirmed: boolean) => void) | null>(null);
 
+
+  const queueDirectLaunchRequest = useCallback((request: DirectLaunchRequest | null): void => {
+    if (!request || handledDirectLaunchIdsRef.current.has(request.id)) return;
+    setPendingDirectLaunchRequest((previous) => previous?.id === request.id ? previous : request);
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = window.openNow.onDirectLaunchRequest(queueDirectLaunchRequest);
+    void window.openNow.getPendingDirectLaunchRequest()
+      .then(queueDirectLaunchRequest)
+      .catch((error) => {
+        console.warn("Failed to read pending direct launch request:", error);
+      });
+    return unsubscribe;
+  }, [queueDirectLaunchRequest]);
 
   const resetStorePanels = useCallback((): void => {
     storePanelsLoadIdRef.current += 1;
@@ -2636,7 +2736,7 @@ export function App(): JSX.Element {
   }, [attemptSessionRecovery, diagnosticsStore, handleExpectedNativeSessionClose, refreshNavbarActiveSession, resetLaunchRuntime, scheduleStableRecoveryReset, settings, streamMicLevel, streamVolume, t]);
 
   // Play game handler
-  const handlePlayGame = useCallback(async (game: GameInfo, options?: { bypassGuards?: boolean; streamingBaseUrl?: string }) => {
+  const handlePlayGame = useCallback(async (game: GameInfo, options?: { bypassGuards?: boolean; streamingBaseUrl?: string; variantId?: string }) => {
     if (!selectedProvider) return;
 
     console.log("handlePlayGame entry", {
@@ -2655,7 +2755,7 @@ export function App(): JSX.Element {
       return;
     }
 
-    const selectedVariantId = variantByGameId[game.id] ?? defaultVariantId(game);
+    const selectedVariantId = options?.variantId ?? variantByGameId[game.id] ?? defaultVariantId(game);
     const selectedVariant = getSelectedVariant(game, selectedVariantId);
     const epicOwnershipError = getEpicOwnershipLaunchError(selectedVariant);
     if (epicOwnershipError) {
@@ -2938,6 +3038,85 @@ export function App(): JSX.Element {
     t,
     variantByGameId,
     warmNativeStreamerForLaunch,
+  ]);
+
+  useEffect(() => {
+    const request = pendingDirectLaunchRequest;
+    if (!request || handledDirectLaunchIdsRef.current.has(request.id)) return;
+    if (!authSession || isInitializing || isLoadingCatalog || isLoadingLibrary) return;
+    if (launchInFlightRef.current || streamStatus !== "idle" || navbarSessionActionInFlightRef.current) return;
+    if (directLaunchAttemptIdRef.current === request.id) return;
+
+    directLaunchAttemptIdRef.current = request.id;
+    let cancelled = false;
+
+    const launch = async (): Promise<void> => {
+      let target = findDirectLaunchTarget(request, allKnownGames, variantByGameId);
+      const token = authSession.tokens.idToken ?? authSession.tokens.accessToken;
+
+      if (!target && request.title && token) {
+        try {
+          const searchResult = await window.openNow.browseCatalog({
+            token,
+            providerStreamingBaseUrl: effectiveStreamingBaseUrl,
+            searchQuery: request.title,
+            sortId: "relevance",
+            filterIds: [],
+            fetchCount: 25,
+          });
+          target = findDirectLaunchTarget(request, searchResult.games, variantByGameId);
+        } catch (error) {
+          console.warn("Direct launch catalog search failed:", error);
+        }
+      }
+
+      const requestedAppId = request.appId && isNumericId(request.appId) ? request.appId : undefined;
+      if (!target && requestedAppId) {
+        target = {
+          game: createSyntheticDirectLaunchGame(request, requestedAppId),
+          variantId: requestedAppId,
+        };
+      }
+
+      if (cancelled) return;
+
+      handledDirectLaunchIdsRef.current.add(request.id);
+      directLaunchAttemptIdRef.current = null;
+      setPendingDirectLaunchRequest((previous) => previous?.id === request.id ? null : previous);
+
+      if (!target) {
+        const requestedName = request.title?.trim() || request.appId || t("app.labels.game");
+        setLaunchError({
+          stage: "queue",
+          title: t("errors.directLaunchNotFoundTitle"),
+          description: t("errors.directLaunchNotFoundDescription", { value: requestedName }),
+        });
+        return;
+      }
+
+      void handlePlayGame(target.game, { variantId: target.variantId });
+    };
+
+    void launch();
+
+    return () => {
+      cancelled = true;
+      if (directLaunchAttemptIdRef.current === request.id) {
+        directLaunchAttemptIdRef.current = null;
+      }
+    };
+  }, [
+    allKnownGames,
+    authSession,
+    effectiveStreamingBaseUrl,
+    handlePlayGame,
+    isInitializing,
+    isLoadingCatalog,
+    isLoadingLibrary,
+    pendingDirectLaunchRequest,
+    streamStatus,
+    t,
+    variantByGameId,
   ]);
 
   // Gate handler: shows queue server modal for FREE-tier users before launching

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -160,12 +160,14 @@ function createSyntheticDirectLaunchGame(request: DirectLaunchRequest, appId: st
     launchAppId: appId,
     title,
     searchText: normalizeDirectLaunchText(title),
+    isInLibrary: true,
     selectedVariantIndex: 0,
     variants: [
       {
         id: appId,
         store: "UNKNOWN",
         supportedControls: [],
+        libraryStatus: "IN_LIBRARY",
       },
     ],
   };

--- a/opennow-stable/src/shared/directLaunch.test.ts
+++ b/opennow-stable/src/shared/directLaunch.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDirectLaunchArgs } from "./directLaunch";
+
+test("parses launch app id from separate CLI argument", () => {
+  assert.deepEqual(
+    parseDirectLaunchArgs(["OpenNOW", "--launch-app-id", "12345"]),
+    { appId: "12345", title: undefined },
+  );
+});
+
+test("parses app id and title from inline CLI arguments", () => {
+  assert.deepEqual(
+    parseDirectLaunchArgs(["--launch-title=Fortnite", "--launch-app-id=98765"]),
+    { appId: "98765", title: "Fortnite" },
+  );
+});
+
+test("allows title fallback when no app id is present", () => {
+  assert.deepEqual(
+    parseDirectLaunchArgs(["--launch-game", "Cyberpunk 2077"]),
+    { appId: undefined, title: "Cyberpunk 2077" },
+  );
+});
+
+test("ignores invalid app ids unless a title fallback is available", () => {
+  assert.deepEqual(
+    parseDirectLaunchArgs(["--launch-app-id", "not-a-number", "--game", "Portal"]),
+    { appId: undefined, title: "Portal" },
+  );
+  assert.equal(parseDirectLaunchArgs(["--launch-app-id", "not-a-number"]), null);
+});

--- a/opennow-stable/src/shared/directLaunch.ts
+++ b/opennow-stable/src/shared/directLaunch.ts
@@ -1,0 +1,66 @@
+export interface DirectLaunchArgs {
+  appId?: string;
+  title?: string;
+}
+
+const APP_ID_FLAGS = new Set(["--launch-app-id", "--app-id"]);
+const TITLE_FLAGS = new Set(["--launch-title", "--launch-game", "--game-title", "--game"]);
+
+function normalizeFlagValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  if (
+    (trimmed.startsWith("\"") && trimmed.endsWith("\"")) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    const unquoted = trimmed.slice(1, -1).trim();
+    return unquoted || undefined;
+  }
+  return trimmed;
+}
+
+function readFlagValue(args: readonly string[], index: number, inlineValue?: string): string | undefined {
+  const normalizedInline = normalizeFlagValue(inlineValue);
+  if (normalizedInline) return normalizedInline;
+
+  const next = args[index + 1];
+  if (!next || next.startsWith("--")) return undefined;
+  return normalizeFlagValue(next);
+}
+
+function splitFlag(arg: string): { flag: string; inlineValue?: string } {
+  const separatorIndex = arg.indexOf("=");
+  if (separatorIndex === -1) {
+    return { flag: arg };
+  }
+  return {
+    flag: arg.slice(0, separatorIndex),
+    inlineValue: arg.slice(separatorIndex + 1),
+  };
+}
+
+export function parseDirectLaunchArgs(argv: readonly string[]): DirectLaunchArgs | null {
+  let appId: string | undefined;
+  let title: string | undefined;
+
+  for (let index = 0; index < argv.length; index++) {
+    const { flag, inlineValue } = splitFlag(argv[index] ?? "");
+    if (APP_ID_FLAGS.has(flag)) {
+      const value = readFlagValue(argv, index, inlineValue);
+      if (value && /^\d+$/.test(value)) {
+        appId = value;
+      }
+      continue;
+    }
+
+    if (TITLE_FLAGS.has(flag)) {
+      const value = readFlagValue(argv, index, inlineValue);
+      if (value) {
+        title = value;
+      }
+    }
+  }
+
+  if (!appId && !title) return null;
+  return { appId, title };
+}

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -515,6 +515,14 @@ export interface GamesFetchRequest {
   providerStreamingBaseUrl?: string;
 }
 
+export interface DirectLaunchRequest {
+  id: string;
+  source: "cli";
+  appId?: string;
+  title?: string;
+  receivedAt: number;
+}
+
 export interface CatalogBrowseRequest extends GamesFetchRequest {
   searchQuery?: string;
   sortId?: string;
@@ -1161,6 +1169,8 @@ export interface OpenNowApi {
   fetchPublicGames(): Promise<GameInfo[]>;
   resolveLaunchAppId(input: ResolveLaunchIdRequest): Promise<string | null>;
   resolveStoreUrl(input: ResolveStoreUrlRequest): Promise<string | null>;
+  getPendingDirectLaunchRequest(): Promise<DirectLaunchRequest | null>;
+  onDirectLaunchRequest(listener: (request: DirectLaunchRequest) => void): () => void;
   createSession(input: SessionCreateRequest): Promise<SessionInfo>;
   pollSession(input: SessionPollRequest): Promise<SessionInfo>;
   reportSessionAd(input: SessionAdReportRequest): Promise<SessionInfo>;

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -46,6 +46,8 @@ export const IPC_CHANNELS = {
   POINTER_LOCK_CHANGE: "window:pointer-lock-change",
   EXTERNAL_ESCAPE: "app:external-escape",
   OPEN_EXTERNAL_URL: "app:open-external-url",
+  DIRECT_LAUNCH_GET_PENDING: "app:direct-launch:get-pending",
+  DIRECT_LAUNCH_REQUEST: "app:direct-launch:request",
   CLIPBOARD_READ_TEXT: "clipboard:read-text",
   QUIT_APP: "app:quit",
   APP_UPDATER_GET_STATE: "app-updater:get-state",


### PR DESCRIPTION
This PR adds CLI-based direct game launch support so external tools like LaunchBox can start games by passing arguments when launching the OpenNOW executable. The implementation parses --launch-app-id/--app-id and --launch-title/--game-title flags, queues the request until the user is logged in and the catalog is loaded, then automatically initiates the stream.

**Main process**

- **opennow-stable/src/main/index.ts**: Add single-instance lock handling, parse argv at startup, register `second-instance` listener for subsequent launches, and emit queued requests to renderer via IPC

**Shared types and parsing**

- **opennow-stable/src/shared/gfn.ts**: Define `DirectLaunchRequest` for queueing and `OpenNowApi` methods
- **opennow-stable/src/shared/ipc.ts**: Add `DIRECT_LAUNCH_GET_PENDING` and `DIRECT_LAUNCH_REQUEST` channels
- **opennow-stable/src/shared/directLaunch.ts**: Implement argument parser supporting numeric app-ids and title fallback with inline/space-separated syntax
- **opennow-stable/src/shared/directLaunch.test.ts**: Add unit tests for parsing variants

**Preload bridge**

- **opennow-stable/src/preload/index.ts**: Expose `getPendingDirectLaunchRequest` and `onDirectLaunchRequest` to renderer

**Renderer**

- **opennow-stable/src/renderer/src/App.tsx**: Add request queue state, direct-launch target resolution (by appId or title), catalog search fallback, synthetic game creation for unknown numeric appIds, and auto-launch after login/catalog load with proper guards

**Localization**

- **locales/en.json**: Add error messages for direct-launch failures

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/bbc1723a-cd8c-46b1-bcd1-c72aaa8d867b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-219" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/bbc1723a-cd8c-46b1-bcd1-c72aaa8d867b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-219&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-219"><img alt="OPE-219" src="https://capy.ai/api/badge/thread.svg?label=OPE-219"></picture></a>
<!-- capy-pr-badge:end -->