### PR TITLE
fix(release): include latest-mac.yml in macOS release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
+              opennow-stable/dist-release/latest-mac.yml
           - label: macos-arm64
             os: blacksmith-6vcpu-macos-15
             builder_args: "--mac dmg zip --arm64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -571,16 +571,51 @@ jobs:
       - name: Merge macOS update feeds
         shell: bash
         run: |
-          x64_ver=$(awk '/^version:/{print $2; exit}' release-artifacts/latest-mac.yml)
-          arm64_ver=$(awk '/^version:/{print $2; exit}' release-artifacts/latest-mac-arm64.yml)
+          set -euo pipefail
+
+          x64_feed=release-artifacts/latest-mac.yml
+          arm64_feed=release-artifacts/latest-mac-arm64.yml
+
+          for feed in "$x64_feed" "$arm64_feed"; do
+            [ -s "$feed" ] || { echo "Missing macOS update feed: $feed" >&2; exit 1; }
+            grep -q '^files:' "$feed" || { echo "Missing files block in $feed" >&2; exit 1; }
+          done
+
+          x64_ver=$(awk '/^version:/{print $2; exit}' "$x64_feed")
+          arm64_ver=$(awk '/^version:/{print $2; exit}' "$arm64_feed")
+          [ -n "$x64_ver" ] && [ -n "$arm64_ver" ] || { echo "Missing macOS update feed version." >&2; exit 1; }
           [ "$x64_ver" != "$arm64_ver" ] && { echo "Version mismatch: x64=$x64_ver arm64=$arm64_ver" >&2; exit 1; }
           awk '
-            FNR==NR { if(/^files:/) { f=1; next } if(f && /^[^ ]/) f=0; if(f) arm64=arm64 $0"\n"; next }
-            /^path:/ { printf "%s", arm64 }
-            1
-          ' release-artifacts/latest-mac-arm64.yml release-artifacts/latest-mac.yml > /tmp/merged.yml
-          mv /tmp/merged.yml release-artifacts/latest-mac.yml
-          rm release-artifacts/latest-mac-arm64.yml
+            FNR == NR {
+              if (/^files:/) { in_arm64_files=1; next }
+              if (in_arm64_files && /^[^ ]/) in_arm64_files=0
+              if (in_arm64_files) arm64_files=arm64_files $0 "\n"
+              next
+            }
+            /^files:/ { in_x64_files=1; print; next }
+            in_x64_files && /^[^ ]/ && !inserted {
+              printf "%s", arm64_files
+              inserted=1
+              in_x64_files=0
+            }
+            { print }
+            END {
+              if (arm64_files == "") {
+                print "Missing arm64 files block entries." > "/dev/stderr"
+                exit 1
+              }
+              if (in_x64_files && !inserted) {
+                printf "%s", arm64_files
+                inserted=1
+              }
+              if (!inserted) {
+                print "Missing x64 files block insertion point." > "/dev/stderr"
+                exit 1
+              }
+            }
+          ' "$arm64_feed" "$x64_feed" > /tmp/merged.yml
+          mv /tmp/merged.yml "$x64_feed"
+          rm "$arm64_feed"
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,7 @@ jobs:
             bundle_gstreamer: "1"
             native_target: "x86_64-apple-darwin"
             native_platform_key: "darwin-x64"
+            arch: x64
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-x64.zip
@@ -192,9 +193,11 @@ jobs:
             bundle_gstreamer: "1"
             native_target: "aarch64-apple-darwin"
             native_platform_key: "darwin-arm64"
+            arch: arm64
             artifact_paths: |
               opennow-stable/dist-release/*.dmg
               opennow-stable/dist-release/*-arm64.zip
+              opennow-stable/dist-release/latest-mac-arm64.yml
           - label: linux-x64
             os: blacksmith-2vcpu-ubuntu-2404
             builder_args: "--linux AppImage deb --x64"
@@ -534,6 +537,11 @@ jobs:
       - name: Package installers
         run: npx electron-builder --publish never ${{ matrix.builder_args }}
 
+      - name: Rename macOS update feed
+        if: matrix.arch == 'arm64'
+        shell: bash
+        run: mv dist-release/latest-mac.yml dist-release/latest-mac-arm64.yml
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -559,6 +567,24 @@ jobs:
         with:
           path: release-artifacts
           merge-multiple: true
+
+      - name: Merge macOS update feeds
+        shell: bash
+        run: |
+          pip install pyyaml -q
+          python3 - <<'PYEOF'
+          import yaml, sys, os
+          base_path = 'release-artifacts/latest-mac.yml'
+          arm64_path = 'release-artifacts/latest-mac-arm64.yml'
+          with open(base_path) as f: base = yaml.safe_load(f)
+          with open(arm64_path) as f: arm64 = yaml.safe_load(f)
+          if base['version'] != arm64['version']:
+              print(f"Version mismatch: x64={base['version']} arm64={arm64['version']}", file=sys.stderr)
+              sys.exit(1)
+          base['files'] = (base.get('files') or []) + (arm64.get('files') or [])
+          with open(base_path, 'w') as f: yaml.dump(base, f, default_flow_style=False)
+          os.remove(arm64_path)
+          PYEOF
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -571,20 +571,16 @@ jobs:
       - name: Merge macOS update feeds
         shell: bash
         run: |
-          pip install pyyaml -q
-          python3 - <<'PYEOF'
-          import yaml, sys, os
-          base_path = 'release-artifacts/latest-mac.yml'
-          arm64_path = 'release-artifacts/latest-mac-arm64.yml'
-          with open(base_path) as f: base = yaml.safe_load(f)
-          with open(arm64_path) as f: arm64 = yaml.safe_load(f)
-          if base['version'] != arm64['version']:
-              print(f"Version mismatch: x64={base['version']} arm64={arm64['version']}", file=sys.stderr)
-              sys.exit(1)
-          base['files'] = (base.get('files') or []) + (arm64.get('files') or [])
-          with open(base_path, 'w') as f: yaml.dump(base, f, default_flow_style=False)
-          os.remove(arm64_path)
-          PYEOF
+          x64_ver=$(awk '/^version:/{print $2; exit}' release-artifacts/latest-mac.yml)
+          arm64_ver=$(awk '/^version:/{print $2; exit}' release-artifacts/latest-mac-arm64.yml)
+          [ "$x64_ver" != "$arm64_ver" ] && { echo "Version mismatch: x64=$x64_ver arm64=$arm64_ver" >&2; exit 1; }
+          awk '
+            FNR==NR { if(/^files:/) { f=1; next } if(f && /^[^ ]/) f=0; if(f) arm64=arm64 $0"\n"; next }
+            /^path:/ { printf "%s", arm64 }
+            1
+          ' release-artifacts/latest-mac-arm64.yml release-artifacts/latest-mac.yml > /tmp/merged.yml
+          mv /tmp/merged.yml release-artifacts/latest-mac.yml
+          rm release-artifacts/latest-mac-arm64.yml
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
`electron-updater` on macOS looks for `latest-mac.yml` in the GitHub release assets to check for updates. The file is generated by electron-builder during packaging but was never included in the `artifact_paths` for either macOS matrix entry, so it was never uploaded to the release.

Windows and Linux both had their equivalent yml files listed; macOS was simply missing it.

Adds `latest-mac.yml` to the `macos-x64` artifact paths (x64 only, mirroring the Windows pattern).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS releases now publish a single, merged “latest” update feed that combines Intel (x64) and Apple Silicon (arm64) metadata for consistent update information.
  * Release assets now include the correct combined macOS feed, ensuring the latest updates are reliably discoverable across architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->