### PR TITLE
Redesign WebRTC stream HUD and fix signaling for reliable playback

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -307,7 +307,22 @@
     }
   },
   "stream": {
+    "sessionStarted": {
+      "kicker": "Ready",
+      "title": "Session started"
+    },
     "stats": {
+      "overlayLabel": "Stream statistics",
+      "expand": "Show detailed stats",
+      "collapse": "Hide detailed stats",
+      "live": "Live",
+      "sync": "Sync",
+      "network": "RTT",
+      "bitrateShort": "Bit",
+      "bitratePerformance": "Actual receive bitrate compared with the negotiated target",
+      "showAdvanced": "Advanced diagnostics",
+      "hideAdvanced": "Hide advanced diagnostics",
+      "waitingForVideo": "Waiting for game video…",
       "connecting": "Connecting...",
       "network": "Network",
       "decode": "Decode",

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -459,7 +459,7 @@ function resolveMediaConnectionInfo(
   connections: Array<{ ip?: string; port: number; usage: number; protocol?: number; resourcePath?: string }>,
   serverIp: string,
   options?: { logMissing?: boolean },
-): { ip: string; port: number } | undefined {
+): { ip: string; port: number; usage: number } | undefined {
   // Helper: extract IP from a connection entry
   const extractIp = (conn: { ip?: string; resourcePath?: string }): string | null => {
     // Try direct IP field
@@ -500,7 +500,7 @@ function resolveMediaConnectionInfo(
     const ip = extractIp(primary);
     const port = extractPort(primary);
     console.log(`[CloudMatch] resolveMediaConnectionInfo: usage=2 candidate: ip=${ip}, port=${port}`);
-    if (ip && port > 0) return { ip, port };
+    if (ip && port > 0) return { ip, port, usage: primary.usage };
   }
 
   // Priority 2: usage=17 (Alternative media path)
@@ -509,7 +509,7 @@ function resolveMediaConnectionInfo(
     const ip = extractIp(alt);
     const port = extractPort(alt);
     console.log(`[CloudMatch] resolveMediaConnectionInfo: usage=17 candidate: ip=${ip}, port=${port}`);
-    if (ip && port > 0) return { ip, port };
+    if (ip && port > 0) return { ip, port, usage: alt.usage };
   }
 
   // Priority 3: usage=14 with highest port (Alliance fallback)
@@ -521,7 +521,7 @@ function resolveMediaConnectionInfo(
     const ip = extractIp(conn) ?? serverIp;
     const port = extractPort(conn);
     console.log(`[CloudMatch] resolveMediaConnectionInfo: usage=14 candidate: ip=${ip}, port=${port} (serverIp fallback=${serverIp})`);
-    if (ip && port > 0) return { ip, port };
+    if (ip && port > 0) return { ip, port, usage: conn.usage };
   }
 
   if (options?.logMissing ?? true) {

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -226,27 +226,10 @@ interface AppResolution {
   preferredVariantId?: string;
   selectedVariantIndex: number;
   lastPlayed?: string;
-  const defaultBase = "https://prod.cloudmatchbeta.nvidiagrid.net/";
-  const allowedHosts = new Set([
-    "prod.cloudmatchbeta.nvidiagrid.net",
-    "img.nvidiagrid.net",
-  ]);
+  isInLibrary: boolean;
+}
 
-  let validatedBaseUrl: URL;
-  try {
-    const candidate = new URL((providerStreamingBaseUrl?.trim() || defaultBase));
-    if (candidate.protocol !== "https:" || !allowedHosts.has(candidate.hostname)) {
-      validatedBaseUrl = new URL(defaultBase);
-    } else {
-      validatedBaseUrl = candidate;
-    }
-  } catch {
-    validatedBaseUrl = new URL(defaultBase);
-  }
-
-  const serverInfoUrl = new URL("v2/serverInfo", validatedBaseUrl);
-
-  const response = await fetch(serverInfoUrl.toString(), {
+interface CatalogDefinitions {
   filterGroups: CatalogFilterGroup[];
   sortOptions: CatalogSortOption[];
   filterPayloadById: Record<string, unknown>;
@@ -311,10 +294,27 @@ async function postGraphQl<T>(query: string, variables: Record<string, unknown>,
 }
 
 async function getVpcId(token: string, providerStreamingBaseUrl?: string): Promise<string> {
-  const base = providerStreamingBaseUrl?.trim() || "https://prod.cloudmatchbeta.nvidiagrid.net/";
-  const normalizedBase = base.endsWith("/") ? base : `${base}/`;
+  const defaultBase = "https://prod.cloudmatchbeta.nvidiagrid.net/";
+  const allowedHosts = new Set([
+    "prod.cloudmatchbeta.nvidiagrid.net",
+    "img.nvidiagrid.net",
+  ]);
 
-  const response = await fetch(`${normalizedBase}v2/serverInfo`, {
+  let validatedBaseUrl: URL;
+  try {
+    const candidate = new URL(providerStreamingBaseUrl?.trim() || defaultBase);
+    if (candidate.protocol !== "https:" || !allowedHosts.has(candidate.hostname)) {
+      validatedBaseUrl = new URL(defaultBase);
+    } else {
+      validatedBaseUrl = candidate;
+    }
+  } catch {
+    validatedBaseUrl = new URL(defaultBase);
+  }
+
+  const serverInfoUrl = new URL("v2/serverInfo", validatedBaseUrl);
+
+  const response = await fetch(serverInfoUrl.toString(), {
     headers: buildGfnLcarsHeaders({
       token,
       clientType: "NATIVE",

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -226,10 +226,27 @@ interface AppResolution {
   preferredVariantId?: string;
   selectedVariantIndex: number;
   lastPlayed?: string;
-  isInLibrary: boolean;
-}
+  const defaultBase = "https://prod.cloudmatchbeta.nvidiagrid.net/";
+  const allowedHosts = new Set([
+    "prod.cloudmatchbeta.nvidiagrid.net",
+    "img.nvidiagrid.net",
+  ]);
 
-interface CatalogDefinitions {
+  let validatedBaseUrl: URL;
+  try {
+    const candidate = new URL((providerStreamingBaseUrl?.trim() || defaultBase));
+    if (candidate.protocol !== "https:" || !allowedHosts.has(candidate.hostname)) {
+      validatedBaseUrl = new URL(defaultBase);
+    } else {
+      validatedBaseUrl = candidate;
+    }
+  } catch {
+    validatedBaseUrl = new URL(defaultBase);
+  }
+
+  const serverInfoUrl = new URL("v2/serverInfo", validatedBaseUrl);
+
+  const response = await fetch(serverInfoUrl.toString(), {
   filterGroups: CatalogFilterGroup[];
   sortOptions: CatalogSortOption[];
   filterPayloadById: Record<string, unknown>;

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -28,7 +28,17 @@ const MAX_CATALOG_PAGES = 3;
 const DEFAULT_SORT_ID = "relevance";
 const PUBLIC_GAMES_CACHE_KEY = "games:public:v2";
 
-function accountScopedGamesCacheKey(scope: string, token: string, providerStreamingBaseUrl?: string): string {
+function accountScopedGamesCacheKey(scope: string, accountId: string, providerStreamingBaseUrl?: string): string {
+  const digest = createHash("sha256")
+    .update(accountId)
+    .update("\0")
+    .update(providerStreamingBaseUrl ?? "")
+    .digest("hex")
+    .slice(0, 16);
+  return `games:${scope}:${digest}`;
+}
+
+function legacyTokenScopedGamesCacheKey(scope: string, token: string, providerStreamingBaseUrl?: string): string {
   const digest = createHash("sha256")
     .update(token)
     .update("\0")
@@ -36,6 +46,64 @@ function accountScopedGamesCacheKey(scope: string, token: string, providerStream
     .digest("hex")
     .slice(0, 16);
   return `games:${scope}:${digest}`;
+}
+
+function resolveAccountCacheId(accountId: string | undefined, token: string): string {
+  return accountId?.trim() || token;
+}
+
+async function loadAccountScopedFromCache<T>(
+  scope: string,
+  accountId: string | undefined,
+  token: string,
+  providerStreamingBaseUrl?: string,
+): Promise<Awaited<ReturnType<typeof cacheManager.loadFromCache<T>>>> {
+  const resolvedAccountId = resolveAccountCacheId(accountId, token);
+  const primaryKey = accountScopedGamesCacheKey(scope, resolvedAccountId, providerStreamingBaseUrl);
+  const cached = await cacheManager.loadFromCache<T>(primaryKey);
+  if (cached) {
+    return cached;
+  }
+
+  if (resolvedAccountId !== token) {
+    const legacyKey = legacyTokenScopedGamesCacheKey(scope, token, providerStreamingBaseUrl);
+    if (legacyKey !== primaryKey) {
+      const legacy = await cacheManager.loadFromCache<T>(legacyKey);
+      if (legacy) {
+        void cacheManager.saveToCache(primaryKey, legacy.data);
+        void cacheManager.invalidateCache(legacyKey);
+        return legacy;
+      }
+    }
+  }
+
+  return null;
+}
+
+function catalogBrowseCacheKey(input: CatalogBrowseRequest, accountId: string): string {
+  const queryDigest = createHash("sha256")
+    .update(input.searchQuery?.trim() ?? "")
+    .update("\0")
+    .update(input.sortId ?? "")
+    .update("\0")
+    .update((input.filterIds ?? []).join(","))
+    .update("\0")
+    .update(String(input.fetchCount ?? ""))
+    .digest("hex")
+    .slice(0, 12);
+  return `${accountScopedGamesCacheKey("catalog", accountId, input.providerStreamingBaseUrl)}:${queryDigest}`;
+}
+
+export function getAccountGamesCacheKeys(accountId: string, providerStreamingBaseUrl?: string): {
+  main: string;
+  library: string;
+  public: string;
+} {
+  return {
+    main: accountScopedGamesCacheKey("main", accountId, providerStreamingBaseUrl),
+    library: accountScopedGamesCacheKey("library", accountId, providerStreamingBaseUrl),
+    public: PUBLIC_GAMES_CACHE_KEY,
+  };
 }
 
 interface GraphQlResponse {
@@ -962,40 +1030,99 @@ ${appFields}
 }
 
 export async function browseCatalog(input: CatalogBrowseRequest): Promise<CatalogBrowseResult> {
-  return browseCatalogUncached(input);
+  const token = input.token;
+  if (!token) {
+    throw new Error("Catalog browsing requires an authenticated token");
+  }
+
+  const cached = await peekCachedBrowseCatalog(input);
+  if (cached) {
+    return cached;
+  }
+
+  const result = await browseCatalogUncached(input);
+  const accountId = resolveAccountCacheId(input.userId, token);
+  const cacheKey = catalogBrowseCacheKey(input, accountId);
+  await cacheManager.saveToCache(cacheKey, result);
+  return result;
 }
 
-export async function fetchMainGames(token: string, providerStreamingBaseUrl?: string): Promise<GameInfo[]> {
-  const cacheKey = accountScopedGamesCacheKey("main", token, providerStreamingBaseUrl);
-  const cached = await cacheManager.loadFromCache<GameInfo[]>(cacheKey);
+export async function peekCachedBrowseCatalog(input: CatalogBrowseRequest): Promise<CatalogBrowseResult | null> {
+  const token = input.token;
+  if (!token) {
+    return null;
+  }
+
+  const accountId = resolveAccountCacheId(input.userId, token);
+  const cacheKey = catalogBrowseCacheKey(input, accountId);
+  const cached = await cacheManager.loadFromCache<CatalogBrowseResult>(cacheKey);
+  return cached?.data ?? null;
+}
+
+export async function peekCachedLibraryGames(
+  token: string,
+  providerStreamingBaseUrl?: string,
+  accountId?: string,
+): Promise<GameInfo[] | null> {
+  const cached = await loadAccountScopedFromCache<GameInfo[]>("library", accountId, token, providerStreamingBaseUrl);
+  return cached?.data ?? null;
+}
+
+export async function fetchLibraryGamesFromCache(
+  token: string,
+  providerStreamingBaseUrl?: string,
+  accountId?: string,
+): Promise<GameInfo[] | null> {
+  const cached = await peekCachedLibraryGames(token, providerStreamingBaseUrl, accountId);
+  if (!cached) {
+    return null;
+  }
+  return mergePublicGameVariants(cached, await fetchPublicGames());
+}
+
+export async function fetchMainGames(
+  token: string,
+  providerStreamingBaseUrl?: string,
+  accountId?: string,
+): Promise<GameInfo[]> {
+  const cached = await loadAccountScopedFromCache<GameInfo[]>("main", accountId, token, providerStreamingBaseUrl);
   if (cached) {
     return mergePublicGameVariants(cached.data, await fetchPublicGames());
   }
 
   const games = await fetchMainGamesUncached(token, providerStreamingBaseUrl);
+  const cacheKey = accountScopedGamesCacheKey("main", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
   await cacheManager.saveToCache(cacheKey, games);
   return games;
 }
 
-export async function fetchFeaturedGames(token: string, providerStreamingBaseUrl?: string): Promise<GameInfo[]> {
-  const cacheKey = accountScopedGamesCacheKey("featured", token, providerStreamingBaseUrl);
-  const cached = await cacheManager.loadFromCache<GameInfo[]>(cacheKey);
+export async function fetchFeaturedGames(
+  token: string,
+  providerStreamingBaseUrl?: string,
+  accountId?: string,
+): Promise<GameInfo[]> {
+  const cached = await loadAccountScopedFromCache<GameInfo[]>("featured", accountId, token, providerStreamingBaseUrl);
   if (cached) return cached.data;
 
   const vpcId = await getVpcId(token, providerStreamingBaseUrl);
   const games = featuredGamesFromPanels(await fetchPanels(token, ["MARQUEE"], vpcId)).slice(0, 6);
 
+  const cacheKey = accountScopedGamesCacheKey("featured", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
   await cacheManager.saveToCache(cacheKey, games);
   return games;
 }
 
-export async function fetchStorePanels(token: string, providerStreamingBaseUrl?: string): Promise<GamePanelResult[]> {
-  const cacheKey = accountScopedGamesCacheKey("store-panels", token, providerStreamingBaseUrl);
-  const cached = await cacheManager.loadFromCache<GamePanelResult[]>(cacheKey);
+export async function fetchStorePanels(
+  token: string,
+  providerStreamingBaseUrl?: string,
+  accountId?: string,
+): Promise<GamePanelResult[]> {
+  const cached = await loadAccountScopedFromCache<GamePanelResult[]>("store-panels", accountId, token, providerStreamingBaseUrl);
   if (cached) return cached.data;
 
   const vpcId = await getVpcId(token, providerStreamingBaseUrl);
   const panels = parsePanelResults(await fetchPanels(token, ["MAIN"], vpcId));
+  const cacheKey = accountScopedGamesCacheKey("store-panels", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
   await cacheManager.saveToCache(cacheKey, panels);
   return panels;
 }
@@ -1010,14 +1137,15 @@ async function fetchMainGamesUncached(token: string, providerStreamingBaseUrl?: 
 export async function fetchLibraryGames(
   token: string,
   providerStreamingBaseUrl?: string,
+  accountId?: string,
 ): Promise<GameInfo[]> {
-  const cacheKey = accountScopedGamesCacheKey("library", token, providerStreamingBaseUrl);
-  const cached = await cacheManager.loadFromCache<GameInfo[]>(cacheKey);
+  const cached = await loadAccountScopedFromCache<GameInfo[]>("library", accountId, token, providerStreamingBaseUrl);
   if (cached) {
     return mergePublicGameVariants(cached.data, await fetchPublicGames());
   }
 
   const games = await fetchLibraryGamesUncached(token, providerStreamingBaseUrl);
+  const cacheKey = accountScopedGamesCacheKey("library", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
   await cacheManager.saveToCache(cacheKey, games);
   return games;
 }

--- a/opennow-stable/src/main/gfn/signaling.ts
+++ b/opennow-stable/src/main/gfn/signaling.ts
@@ -16,6 +16,7 @@ interface SignalingMessage {
   ackid?: number;
   ack?: number;
   hb?: number;
+  error?: string;
   peer_info?: {
     id: number;
     name?: string;
@@ -217,6 +218,12 @@ export class GfnSignalingClient {
       return;
     }
 
+    if (parsed.error === "peerRemoved") {
+      console.log("[Signaling] Received peerRemoved signaling error");
+      this.emit({ type: "disconnected", reason: "peerRemoved" });
+      return;
+    }
+
     if (!parsed.peer_msg?.msg) {
       return;
     }
@@ -226,9 +233,16 @@ export class GfnSignalingClient {
       console.log(`[Signaling] Remote peer id: ${this.remotePeerId}`);
     }
 
+    const peerMessage = parsed.peer_msg.msg.trim();
+    if (peerMessage === "BYE") {
+      console.log("[Signaling] Received BYE peer message");
+      this.emit({ type: "disconnected", reason: "BYE" });
+      return;
+    }
+
     let peerPayload: Record<string, unknown>;
     try {
-      peerPayload = JSON.parse(parsed.peer_msg.msg) as Record<string, unknown>;
+      peerPayload = JSON.parse(peerMessage) as Record<string, unknown>;
     } catch {
       this.emit({ type: "log", message: "Received non-JSON peer payload" });
       return;
@@ -242,7 +256,13 @@ export class GfnSignalingClient {
     }
 
     if (typeof peerPayload.candidate === "string") {
-      console.log(`[Signaling] Received remote ICE candidate: ${peerPayload.candidate}`);
+      const sdpMLineIndex =
+        typeof peerPayload.sdpMLineIndex === "number" || peerPayload.sdpMLineIndex === null
+          ? peerPayload.sdpMLineIndex
+          : 0;
+      console.log(
+        `[Signaling] Received remote ICE candidate: ${peerPayload.candidate} (sdpMLineIndex=${sdpMLineIndex})`,
+      );
       this.emit({
         type: "remote-ice",
         candidate: {
@@ -251,9 +271,10 @@ export class GfnSignalingClient {
             typeof peerPayload.sdpMid === "string" || peerPayload.sdpMid === null
               ? peerPayload.sdpMid
               : undefined,
-          sdpMLineIndex:
-            typeof peerPayload.sdpMLineIndex === "number" || peerPayload.sdpMLineIndex === null
-              ? peerPayload.sdpMLineIndex
+          sdpMLineIndex,
+          usernameFragment:
+            typeof peerPayload.usernameFragment === "string" || peerPayload.usernameFragment === null
+              ? peerPayload.usernameFragment
               : undefined,
         },
       });
@@ -304,6 +325,7 @@ export class GfnSignalingClient {
           candidate: candidate.candidate,
           sdpMid: candidate.sdpMid,
           sdpMLineIndex: candidate.sdpMLineIndex,
+          usernameFragment: candidate.usernameFragment,
         }),
       },
       ackid: this.nextAckId(),

--- a/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
+++ b/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
@@ -23,6 +23,8 @@ import {
   fetchMainGames,
   fetchPublicGames,
   fetchStorePanels,
+  peekCachedBrowseCatalog,
+  fetchLibraryGamesFromCache,
   resolveLaunchAppId,
   resolveStoreUrl,
 } from "../gfn/games";
@@ -30,7 +32,43 @@ import { fetchSubscription, fetchDynamicRegions } from "../gfn/subscription";
 import { fetchPersistentStorageLocations, resetPersistentStorage } from "../gfn/persistentStorage";
 
 interface RefreshSchedulerAuthContextUpdater {
-  updateAuthContext(token: string, providerStreamingBaseUrl?: string): void;
+  updateAuthContext(token: string, userId: string, providerStreamingBaseUrl?: string): void;
+}
+
+async function resolveGamesFetchContext(
+  deps: Pick<AccountCatalogIpcHandlerDeps, "authService" | "refreshScheduler" | "resolveJwt">,
+  payload: GamesFetchRequest | CatalogBrowseRequest = {},
+  options: { networkRequired?: boolean } = {},
+): Promise<{
+  token: string;
+  streamingBaseUrl: string;
+  userId: string;
+}> {
+  let session = deps.authService.getSession();
+  if (!session || options.networkRequired) {
+    session = await deps.authService.ensureValidSession();
+  }
+  if (!session) {
+    throw new Error("No authenticated session available");
+  }
+
+  const token = await deps.resolveJwt(payload?.token);
+  const streamingBaseUrl =
+    payload?.providerStreamingBaseUrl ??
+    deps.authService.getSelectedProvider().streamingServiceUrl;
+  const userId = payload.userId ?? session.user.userId;
+  deps.refreshScheduler.updateAuthContext(token, userId, streamingBaseUrl);
+  return { token, streamingBaseUrl, userId };
+}
+
+function savedSessionTokens(
+  session: NonNullable<ReturnType<AuthService["getSession"]>>,
+): { token: string; userId: string } | null {
+  const token = session.tokens.idToken ?? session.tokens.accessToken;
+  if (!token) {
+    return null;
+  }
+  return { token, userId: session.user.userId };
 }
 
 function sessionTokenCandidates(
@@ -57,6 +95,9 @@ export function registerAccountCatalogIpcHandlers(
   deps: AccountCatalogIpcHandlerDeps,
 ): void {
   const { ipcMain, authService, refreshScheduler, resolveJwt } = deps;
+
+  const resolveGamesContext = (payload: GamesFetchRequest | CatalogBrowseRequest = {}) =>
+    resolveGamesFetchContext(deps, payload);
 
   ipcMain.handle(
     IPC_CHANNELS.AUTH_GET_SESSION,
@@ -203,63 +244,89 @@ export function registerAccountCatalogIpcHandlers(
   ipcMain.handle(
     IPC_CHANNELS.GAMES_FETCH_MAIN,
     async (_event, payload: GamesFetchRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-      return fetchMainGames(token, streamingBaseUrl);
+      const { token, streamingBaseUrl, userId } = await resolveGamesContext(payload);
+      return fetchMainGames(token, streamingBaseUrl, userId);
     },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.GAMES_FETCH_FEATURED,
     async (_event, payload: GamesFetchRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-      return fetchFeaturedGames(token, streamingBaseUrl);
+      const { token, streamingBaseUrl, userId } = await resolveGamesContext(payload);
+      return fetchFeaturedGames(token, streamingBaseUrl, userId);
     },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.GAMES_FETCH_STORE_PANELS,
     async (_event, payload: GamesFetchRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-      return fetchStorePanels(token, streamingBaseUrl);
+      const { token, streamingBaseUrl, userId } = await resolveGamesContext(payload);
+      return fetchStorePanels(token, streamingBaseUrl, userId);
     },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.GAMES_FETCH_LIBRARY,
     async (_event, payload: GamesFetchRequest) => {
-      const token = await resolveJwt(payload?.token);
+      const savedSession = authService.getSession();
       const streamingBaseUrl =
         payload?.providerStreamingBaseUrl ??
         authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
-      return fetchLibraryGames(token, streamingBaseUrl);
+      if (savedSession) {
+        const tokens = savedSessionTokens(savedSession);
+        if (tokens) {
+          const userId = payload.userId ?? tokens.userId;
+          const cachedLibrary = await fetchLibraryGamesFromCache(tokens.token, streamingBaseUrl, userId);
+          if (cachedLibrary) {
+            refreshScheduler.updateAuthContext(tokens.token, userId, streamingBaseUrl);
+            return cachedLibrary;
+          }
+        }
+      }
+
+      const { token, streamingBaseUrl: resolvedBaseUrl, userId } = await resolveGamesFetchContext(
+        deps,
+        payload,
+        { networkRequired: true },
+      );
+      return fetchLibraryGames(token, resolvedBaseUrl, userId);
     },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.GAMES_BROWSE_CATALOG,
     async (_event, payload: CatalogBrowseRequest) => {
-      const token = await resolveJwt(payload?.token);
+      const savedSession = authService.getSession();
       const streamingBaseUrl =
         payload?.providerStreamingBaseUrl ??
         authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+      if (savedSession) {
+        const tokens = savedSessionTokens(savedSession);
+        if (tokens) {
+          const userId = payload.userId ?? tokens.userId;
+          const cached = await peekCachedBrowseCatalog({
+            ...payload,
+            token: tokens.token,
+            userId,
+            providerStreamingBaseUrl: streamingBaseUrl,
+          });
+          if (cached) {
+            refreshScheduler.updateAuthContext(tokens.token, userId, streamingBaseUrl);
+            return cached;
+          }
+        }
+      }
+
+      const { token, streamingBaseUrl: resolvedBaseUrl, userId } = await resolveGamesFetchContext(
+        deps,
+        payload,
+        { networkRequired: true },
+      );
       return browseCatalog({
         ...payload,
         token,
-        providerStreamingBaseUrl: streamingBaseUrl,
+        userId,
+        providerStreamingBaseUrl: resolvedBaseUrl,
       });
     },
   );
@@ -282,11 +349,7 @@ export function registerAccountCatalogIpcHandlers(
   ipcMain.handle(
     IPC_CHANNELS.GAMES_RESOLVE_STORE_URL,
     async (_event, payload: ResolveStoreUrlRequest) => {
-      const token = await resolveJwt(payload?.token);
-      const streamingBaseUrl =
-        payload?.providerStreamingBaseUrl ??
-        authService.getSelectedProvider().streamingServiceUrl;
-      refreshScheduler.updateAuthContext(token, streamingBaseUrl);
+      const { token, streamingBaseUrl } = await resolveGamesContext(payload);
       return resolveStoreUrl(token, payload.appIdOrUuid, streamingBaseUrl, {
         variantId: payload.variantId,
         store: payload.store,

--- a/opennow-stable/src/main/services/cacheManager.ts
+++ b/opennow-stable/src/main/services/cacheManager.ts
@@ -67,13 +67,14 @@ class CacheManager {
       }
 
       const now = Date.now();
-      if (now > parsed.metadata.expiresAt) {
-        console.log(`[CACHE] Cache expired: ${key} (expired ${Math.round((now - parsed.metadata.expiresAt) / 1000)}s ago)`);
-        return null;
-      }
-
       const ageSeconds = Math.round((now - parsed.metadata.timestamp) / 1000);
-      console.log(`[CACHE] Cache hit: ${key} (age: ${ageSeconds}s)`);
+      if (now > parsed.metadata.expiresAt) {
+        console.log(
+          `[CACHE] Cache hit (stale): ${key} (age: ${ageSeconds}s, expired ${Math.round((now - parsed.metadata.expiresAt) / 1000)}s ago)`,
+        );
+      } else {
+        console.log(`[CACHE] Cache hit: ${key} (age: ${ageSeconds}s)`);
+      }
       return parsed;
     } catch (error) {
       console.error(`[CACHE] Error reading cache file: ${key}`, error);
@@ -165,6 +166,28 @@ class CacheManager {
   isExpired(timestamp: number): boolean {
     const ageMs = Date.now() - timestamp;
     return ageMs > CACHE_TTL_MS;
+  }
+
+  async isStaleOrMissing(key: string): Promise<boolean> {
+    if (!this.initialized) {
+      return true;
+    }
+
+    const filePath = this.getCacheFilePath(key);
+    if (!existsSync(filePath)) {
+      return true;
+    }
+
+    try {
+      const content = await readFile(filePath, "utf-8");
+      const parsed = JSON.parse(content) as CachedData<unknown>;
+      if (!parsed.metadata || typeof parsed.metadata.expiresAt !== "number") {
+        return true;
+      }
+      return Date.now() > parsed.metadata.expiresAt;
+    } catch {
+      return true;
+    }
   }
 
   getCacheTtlMs(): number {

--- a/opennow-stable/src/main/services/refreshScheduler.ts
+++ b/opennow-stable/src/main/services/refreshScheduler.ts
@@ -1,37 +1,43 @@
 import type { GameInfo } from "@shared/gfn";
+import { getAccountGamesCacheKeys } from "../gfn/games";
 import { cacheEventBus } from "./cacheEventBus";
 import { cacheManager } from "./cacheManager";
 
 export interface RefreshAuthContext {
   token: string;
+  userId: string;
   providerStreamingBaseUrl?: string;
 }
 
-type FetchFunction<T> = (token: string, providerStreamingBaseUrl?: string) => Promise<T>;
+type FetchFunction<T> = (
+  token: string,
+  providerStreamingBaseUrl?: string,
+  accountId?: string,
+) => Promise<T>;
 type PublicFetchFunction = () => Promise<GameInfo[]>;
 
 class RefreshScheduler {
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
   private isRefreshing: boolean = false;
   private authContext: RefreshAuthContext | null = null;
-  private fetchMainGames: FetchFunction<GameInfo[]> | null = null;
-  private fetchLibraryGames: FetchFunction<GameInfo[]> | null = null;
-  private fetchPublicGames: PublicFetchFunction | null = null;
+  private fetchMainGamesUncached: FetchFunction<GameInfo[]> | null = null;
+  private fetchLibraryGamesUncached: FetchFunction<GameInfo[]> | null = null;
+  private fetchPublicGamesUncached: PublicFetchFunction | null = null;
   private refreshIntervalMs: number = 12 * 60 * 60 * 1000;
 
   initialize(
-    fetchMainGames: FetchFunction<GameInfo[]>,
-    fetchLibraryGames: FetchFunction<GameInfo[]>,
-    fetchPublicGames: PublicFetchFunction,
+    fetchMainGamesUncached: FetchFunction<GameInfo[]>,
+    fetchLibraryGamesUncached: FetchFunction<GameInfo[]>,
+    fetchPublicGamesUncached: PublicFetchFunction,
   ): void {
-    this.fetchMainGames = fetchMainGames;
-    this.fetchLibraryGames = fetchLibraryGames;
-    this.fetchPublicGames = fetchPublicGames;
+    this.fetchMainGamesUncached = fetchMainGamesUncached;
+    this.fetchLibraryGamesUncached = fetchLibraryGamesUncached;
+    this.fetchPublicGamesUncached = fetchPublicGamesUncached;
     console.log(`[CACHE] RefreshScheduler initialized (interval: ${this.refreshIntervalMs / 60000} minutes)`);
   }
 
-  updateAuthContext(token: string, providerStreamingBaseUrl?: string): void {
-    this.authContext = { token, providerStreamingBaseUrl };
+  updateAuthContext(token: string, userId: string, providerStreamingBaseUrl?: string): void {
+    this.authContext = { token, userId, providerStreamingBaseUrl };
     console.log(`[CACHE] Auth context updated for refresh scheduler`);
   }
 
@@ -41,13 +47,13 @@ class RefreshScheduler {
       return;
     }
 
-    if (!this.fetchMainGames || !this.fetchLibraryGames || !this.fetchPublicGames) {
+    if (!this.fetchMainGamesUncached || !this.fetchLibraryGamesUncached || !this.fetchPublicGamesUncached) {
       console.error(`[CACHE] Cannot start RefreshScheduler: fetch functions not initialized`);
       return;
     }
 
     console.log(`[CACHE] Starting RefreshScheduler`);
-    this.performRefresh();
+    void this.performRefresh();
     this.refreshTimer = setInterval(() => {
       void this.performRefresh();
     }, this.refreshIntervalMs);
@@ -65,7 +71,7 @@ class RefreshScheduler {
     console.log(`[CACHE] RefreshScheduler stopped`);
   }
 
-  async performRefresh(): Promise<void> {
+  async performRefresh(options: { force?: boolean } = {}): Promise<void> {
     if (this.isRefreshing) {
       console.log(`[CACHE] Refresh already in progress, skipping`);
       return;
@@ -76,40 +82,82 @@ class RefreshScheduler {
       return;
     }
 
-    if (!this.fetchMainGames || !this.fetchLibraryGames || !this.fetchPublicGames) {
+    if (!this.fetchMainGamesUncached || !this.fetchLibraryGamesUncached || !this.fetchPublicGamesUncached) {
       console.error(`[CACHE] Fetch functions not available`);
+      return;
+    }
+
+    const { token, userId, providerStreamingBaseUrl } = this.authContext;
+    const cacheKeys = getAccountGamesCacheKeys(userId, providerStreamingBaseUrl);
+    const force = options.force === true;
+
+    const [mainNeedsRefresh, libraryNeedsRefresh, publicNeedsRefresh] = force
+      ? [true, true, true]
+      : await Promise.all([
+        cacheManager.isStaleOrMissing(cacheKeys.main),
+        cacheManager.isStaleOrMissing(cacheKeys.library),
+        cacheManager.isStaleOrMissing(cacheKeys.public),
+      ]);
+
+    if (!mainNeedsRefresh && !libraryNeedsRefresh && !publicNeedsRefresh) {
+      console.log("[CACHE] All game caches are fresh, skipping background refresh");
       return;
     }
 
     this.isRefreshing = true;
     const startTime = Date.now();
-    console.log(`[CACHE] Refresh cycle started`);
+    console.log("[CACHE] Refresh cycle started", {
+      main: mainNeedsRefresh,
+      library: libraryNeedsRefresh,
+      public: publicNeedsRefresh,
+      force,
+    });
 
     try {
       cacheEventBus.emit("cache:refresh-start");
 
-      const shouldRefreshLibrary = !(await cacheManager.loadFromCache<GameInfo[]>("games:library"));
-      if (!shouldRefreshLibrary) {
-        console.log("[CACHE] Skipping library refresh; cached library is still fresh");
+      const refreshTasks: Promise<void>[] = [];
+
+      if (mainNeedsRefresh) {
+        refreshTasks.push(
+          this.fetchMainGamesUncached(token, providerStreamingBaseUrl, userId)
+            .then(async (games) => {
+              await cacheManager.saveToCache(cacheKeys.main, games);
+            }),
+        );
       }
 
-      const refreshTasks: Promise<GameInfo[]>[] = [
-        this.fetchMainGames(this.authContext.token, this.authContext.providerStreamingBaseUrl),
-        shouldRefreshLibrary
-          ? this.fetchLibraryGames(this.authContext.token, this.authContext.providerStreamingBaseUrl)
-          : Promise.resolve([]),
-        this.fetchPublicGames(),
-      ];
+      if (libraryNeedsRefresh) {
+        refreshTasks.push(
+          this.fetchLibraryGamesUncached(token, providerStreamingBaseUrl, userId)
+            .then(async (games) => {
+              await cacheManager.saveToCache(cacheKeys.library, games);
+            }),
+        );
+      }
+
+      if (publicNeedsRefresh) {
+        refreshTasks.push(
+          this.fetchPublicGamesUncached()
+            .then(async (games) => {
+              await cacheManager.saveToCache(cacheKeys.public, games);
+            }),
+        );
+      }
 
       const results = await Promise.allSettled(refreshTasks);
 
       let hasErrors = false;
-      for (let i = 0; i < results.length; i++) {
-        const result = results[i];
-        const name = ["main", "library", "public"][i];
+      const taskNames: string[] = [];
+      if (mainNeedsRefresh) taskNames.push("main");
+      if (libraryNeedsRefresh) taskNames.push("library");
+      if (publicNeedsRefresh) taskNames.push("public");
 
+      for (let i = 0; i < results.length; i += 1) {
+        const result = results[i];
         if (result.status === "rejected") {
           hasErrors = true;
+          const name = taskNames[i] ?? "unknown";
           console.error(`[CACHE] Refresh failed for ${name} games:`, result.reason);
           cacheEventBus.emit("cache:refresh-error", {
             key: `games:${name}`,
@@ -137,7 +185,7 @@ class RefreshScheduler {
 
   async manualRefresh(): Promise<void> {
     console.log(`[CACHE] Manual refresh requested`);
-    await this.performRefresh();
+    await this.performRefresh({ force: true });
   }
 
   setRefreshInterval(intervalMs: number): void {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -225,7 +225,11 @@ const isMac = navigator.platform.toLowerCase().includes("mac");
 
 function isExpectedNativeSessionClose(reason: string): boolean {
   const normalized = reason.trim().toLowerCase();
-  return normalized === "socket closed" || normalized === "signaling disconnected: socket closed";
+  return normalized === "bye" ||
+    normalized === "peerremoved" ||
+    normalized === "peer removed" ||
+    normalized === "socket closed" ||
+    normalized === "signaling disconnected: socket closed";
 }
 
 function gameIdentityMatches(left: GameInfo, right: GameInfo): boolean {
@@ -2360,7 +2364,7 @@ export function App(): JSX.Element {
   ]);
 
   const handleExpectedNativeSessionClose = useCallback((reason: string): void => {
-    console.log("[Recovery] Treating native signaling close as ended session:", reason);
+    console.log("[Recovery] Treating signaling close as ended session:", reason);
     const activeGameId = streamingGameRef.current?.id;
     if (activeGameId) {
       endPlaytimeSession(activeGameId);
@@ -2636,6 +2640,10 @@ export function App(): JSX.Element {
             console.log("[Recovery] Ignoring signaling disconnect during app shutdown");
             return;
           }
+          if (streamStatusRef.current !== "idle" && isExpectedNativeSessionClose(event.reason)) {
+            handleExpectedNativeSessionClose(event.reason);
+            return;
+          }
           if (
             nativeStreamingRef.current
             && streamStatusRef.current === "streaming"
@@ -2646,6 +2654,7 @@ export function App(): JSX.Element {
           }
           const iceState = latestIceConnectionStateRef.current;
           if (
+            (hasConfirmedRemoteIceRef.current && iceState === "new") ||
             iceState === "connected" ||
             iceState === "completed" ||
             iceState === "checking"

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -94,6 +94,7 @@ import { Navbar } from "./components/Navbar";
 import { HomePage } from "./components/HomePage";
 import { LibraryPage } from "./components/LibraryPage";
 import { SettingsPage } from "./components/SettingsPage";
+import { SettingsModalHost } from "./components/SettingsModalHost";
 import { StreamLoading } from "./components/StreamLoading";
 import { StreamView } from "./components/StreamView";
 import { QueueServerSelectModal } from "./components/QueueServerSelectModal";
@@ -311,6 +312,7 @@ export function App(): JSX.Element {
   // Navigation
   const [currentPage, setCurrentPage] = useState<AppPage>("home");
   const [pageBeforeSettings, setPageBeforeSettings] = useState<AppPage>("home");
+  const [settingsMounted, setSettingsMounted] = useState(false);
   const [sessionFullscreen, setSessionFullscreenState] = useState(false);
 
   // Games State
@@ -3810,6 +3812,16 @@ export function App(): JSX.Element {
     setCurrentPage(pageBeforeSettings);
   }, [pageBeforeSettings]);
 
+  const handleSettingsExitComplete = useCallback((): void => {
+    setSettingsMounted(false);
+  }, []);
+
+  useEffect(() => {
+    if (currentPage === "settings") {
+      setSettingsMounted(true);
+    }
+  }, [currentPage]);
+
   const mainPage: AppPage = currentPage === "settings" ? pageBeforeSettings : currentPage;
 
   // Show login screen if not authenticated
@@ -4049,10 +4061,13 @@ export function App(): JSX.Element {
           </m.div>
         </AnimatePresence>
       </main>
-      <AnimatePresence initial={false}>
-        {currentPage === "settings" && (
+      <SettingsModalHost
+        open={currentPage === "settings"}
+        onClose={handleCloseSettings}
+        onExitComplete={handleSettingsExitComplete}
+      >
+        {settingsMounted && (
           <SettingsPage
-            key="settings"
             settings={settings}
             regions={regions}
             codecResults={codecResults}
@@ -4062,7 +4077,7 @@ export function App(): JSX.Element {
             onClose={handleCloseSettings}
           />
         )}
-      </AnimatePresence>
+      </SettingsModalHost>
       {logoutConfirmModal}
       {removeAccountConfirmModal}
       {queueModalGame && streamStatus === "idle" && (

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -4144,7 +4144,7 @@ export function App(): JSX.Element {
                 controllerMode={settings.controllerMode}
                 storePanels={storePanels}
                 storeHeroGames={featuredGames}
-                activeSessionAppIds={navbarActiveSession ? [navbarActiveSession.appId] : []}
+                activeSessionAppIds={activeSessionAppIds}
                 onBuyGame={handleBuyGame}
                 onPreviousControllerPage={() => navigateControllerPage(-1)}
                 onNextControllerPage={() => navigateControllerPage(1)}
@@ -4168,7 +4168,7 @@ export function App(): JSX.Element {
                 onSortChange={setCatalogSelectedSortId}
                 controllerMode={settings.controllerMode}
                 featuredGames={featuredGames.length > 0 ? featuredGames : games}
-                activeSessionAppIds={navbarActiveSession ? [navbarActiveSession.appId] : []}
+                activeSessionAppIds={activeSessionAppIds}
                 onBuyGame={handleBuyGame}
                 onPreviousControllerPage={() => navigateControllerPage(-1)}
                 onNextControllerPage={() => navigateControllerPage(1)}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -49,6 +49,12 @@ import type {
   StreamWarningState,
 } from "./lib/appTypes";
 import { loadCatalogPreferences, saveCatalogPreferences, VARIANT_SELECTION_LOCALSTORAGE_KEY } from "./lib/catalogPreferences";
+import {
+  buildCatalogQueryKey,
+  clearCatalogSnapshot,
+  loadCatalogSnapshot,
+  saveCatalogSnapshot,
+} from "./lib/catalogSnapshot";
 import { loadStoredCodecResults, saveStoredCodecResults, testCodecSupport, type CodecTestResult } from "./lib/codecDiagnostics";
 import {
   areStringArraysEqual,
@@ -545,6 +551,7 @@ export function App(): JSX.Element {
   const storePanelsLoadedContextRef = useRef("");
   const storePanelsLoadIdRef = useRef(0);
   const runtimeDataLoadIdRef = useRef(0);
+  const lastCatalogQueryRef = useRef<string | null>(null);
   const signalingRecoveryRef = useRef<SignalingRecoveryState>({
     attemptCount: 0,
     inFlight: null,
@@ -1479,14 +1486,69 @@ export function App(): JSX.Element {
     applyVariantSelections(catalogResult.games);
   }, [applyVariantSelections]);
 
-  const loadSessionRuntimeData = useCallback(async (session: AuthSession): Promise<void> => {
+  const persistCatalogSnapshot = useCallback((
+    session: AuthSession,
+    catalogResult: CatalogBrowseResult,
+    library: GameInfo[],
+    queryKey: string,
+  ): void => {
+    saveCatalogSnapshot({
+      version: 1,
+      userId: session.user.userId,
+      streamingBaseUrl: session.provider.streamingServiceUrl,
+      queryKey,
+      games: catalogResult.games,
+      libraryGames: library,
+      filterGroups: catalogResult.filterGroups,
+      sortOptions: catalogResult.sortOptions,
+      totalCount: catalogResult.totalCount,
+      supportedCount: catalogResult.numberSupported,
+      savedAt: Date.now(),
+    });
+  }, []);
+
+  const hydrateCatalogSnapshot = useCallback((session: AuthSession): string | null => {
+    const queryKey = buildCatalogQueryKey("", catalogSelectedFilterIds, catalogSelectedSortId);
+    const snapshot = loadCatalogSnapshot(
+      session.user.userId,
+      session.provider.streamingServiceUrl,
+      queryKey,
+    );
+    if (!snapshot) {
+      return null;
+    }
+
+    setGames(snapshot.games);
+    setLibraryGames(snapshot.libraryGames);
+    setCatalogFilterGroups(snapshot.filterGroups);
+    setCatalogSortOptions(snapshot.sortOptions);
+    setCatalogTotalCount(snapshot.totalCount);
+    setCatalogSupportedCount(snapshot.supportedCount);
+    setSelectedGameId((previous) => (
+      snapshot.games.some((game) => game.id === previous) ? previous : (snapshot.games[0]?.id ?? "")
+    ));
+    applyVariantSelections([...snapshot.games, ...snapshot.libraryGames]);
+    lastCatalogQueryRef.current = queryKey;
+    return queryKey;
+  }, [applyVariantSelections, catalogSelectedFilterIds, catalogSelectedSortId]);
+
+  const loadSessionRuntimeData = useCallback(async (
+    session: AuthSession,
+    options?: { background?: boolean },
+  ): Promise<void> => {
     const token = session.tokens.idToken ?? session.tokens.accessToken;
     const streamingBaseUrl = session.provider.streamingServiceUrl;
+    const userId = session.user.userId;
     const loadId = ++runtimeDataLoadIdRef.current;
     const isCurrentLoad = (): boolean => runtimeDataLoadIdRef.current === loadId;
+    const background = options?.background === true;
+    const catalogQueryKey = buildCatalogQueryKey("", catalogSelectedFilterIds, catalogSelectedSortId);
 
-    setIsLoadingCatalog(true);
-    setIsLoadingLibrary(true);
+    if (!background) {
+      lastCatalogQueryRef.current = null;
+      setIsLoadingCatalog(true);
+      setIsLoadingLibrary(true);
+    }
 
     void window.openNow.getRegions({ token }).then((discovered) => {
       if (isCurrentLoad()) setRegions(discovered);
@@ -1506,44 +1568,59 @@ export function App(): JSX.Element {
       if (isCurrentLoad()) setSubscriptionInfo(null);
     });
 
+    let latestCatalogResult: CatalogBrowseResult | null = null;
+    let latestLibraryGames: GameInfo[] | null = null;
+
     void window.openNow.browseCatalog({
       token,
+      userId,
       providerStreamingBaseUrl: streamingBaseUrl,
       searchQuery: "",
       sortId: catalogSelectedSortId,
       filterIds: catalogSelectedFilterIds,
     }).then((catalogResult) => {
       if (!isCurrentLoad()) return;
+      latestCatalogResult = catalogResult;
       applyCatalogBrowseResult(catalogResult);
+      lastCatalogQueryRef.current = catalogQueryKey;
+      if (latestLibraryGames) {
+        persistCatalogSnapshot(session, catalogResult, latestLibraryGames, catalogQueryKey);
+      }
     }).catch((error) => {
       console.error("Catalog load failed:", error);
-      if (!isCurrentLoad()) return;
+      if (!isCurrentLoad() || background) return;
       setGames([]);
       setCatalogFilterGroups([]);
       setCatalogSortOptions([]);
       setCatalogTotalCount(0);
       setCatalogSupportedCount(0);
     }).finally(() => {
-      if (isCurrentLoad()) setIsLoadingCatalog(false);
+      if (isCurrentLoad() && !background) setIsLoadingCatalog(false);
     });
 
     void window.openNow.fetchLibraryGames({
       token,
+      userId,
       providerStreamingBaseUrl: streamingBaseUrl,
     }).then((libGames) => {
       if (!isCurrentLoad()) return;
+      latestLibraryGames = libGames;
       setLibraryGames(libGames);
       applyVariantSelections(libGames);
+      if (latestCatalogResult) {
+        persistCatalogSnapshot(session, latestCatalogResult, libGames, catalogQueryKey);
+      }
     }).catch((error) => {
       console.error("Library load failed:", error);
-      if (!isCurrentLoad()) return;
+      if (!isCurrentLoad() || background) return;
       setLibraryGames([]);
     }).finally(() => {
-      if (isCurrentLoad()) setIsLoadingLibrary(false);
+      if (isCurrentLoad() && !background) setIsLoadingLibrary(false);
     });
 
     void window.openNow.fetchFeaturedGames({
       token,
+      userId,
       providerStreamingBaseUrl: streamingBaseUrl,
     }).then((featured) => {
       if (isCurrentLoad()) setFeaturedGames(featured);
@@ -1556,6 +1633,7 @@ export function App(): JSX.Element {
     applyVariantSelections,
     catalogSelectedFilterIds,
     catalogSelectedSortId,
+    persistCatalogSnapshot,
   ]);
 
   // Initialize app
@@ -1627,7 +1705,8 @@ export function App(): JSX.Element {
         setProviderIdpId(activeProviderId);
 
         if (persistedSession) {
-          await loadSessionRuntimeData(persistedSession);
+          const hydrated = hydrateCatalogSnapshot(persistedSession);
+          void loadSessionRuntimeData(persistedSession, { background: hydrated !== null });
         } else {
           runtimeDataLoadIdRef.current += 1;
           resetStorePanels();
@@ -1653,7 +1732,7 @@ export function App(): JSX.Element {
     };
 
     void initialize();
-  }, [loadSessionRuntimeData, resetStorePanels, t]);
+  }, [hydrateCatalogSnapshot, loadSessionRuntimeData, resetStorePanels, t]);
 
   // Login handler
   const handleLogin = useCallback(async () => {
@@ -1862,6 +1941,7 @@ export function App(): JSX.Element {
     setLogoutConfirmOpen(false);
     runtimeDataLoadIdRef.current += 1;
     resetStorePanels();
+    clearCatalogSnapshot();
     await window.openNow.logoutAll();
     setAuthSession(null);
     setSavedAccounts([]);
@@ -1890,19 +1970,26 @@ export function App(): JSX.Element {
   }, []);
 
   // Load games handler
-  const loadGames = useCallback(async (targetSource: "main" | "library") => {
+  const loadGames = useCallback(async (
+    targetSource: "main" | "library",
+    options?: { background?: boolean },
+  ) => {
     const setLoading = targetSource === "main" ? setIsLoadingCatalog : setIsLoadingLibrary;
-    setLoading(true);
+    if (!options?.background) {
+      setLoading(true);
+    }
     try {
       const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
+      const userId = authSession?.user.userId;
       const baseUrl = effectiveStreamingBaseUrl;
-      if (!token) {
+      if (!token || !userId) {
         return;
       }
 
       if (targetSource === "main") {
         const catalogResult = await window.openNow.browseCatalog({
           token,
+          userId,
           providerStreamingBaseUrl: baseUrl,
           searchQuery,
           sortId: catalogSelectedSortId,
@@ -1910,7 +1997,7 @@ export function App(): JSX.Element {
         });
         applyCatalogBrowseResult(catalogResult);
         if (featuredGames.length === 0) {
-          void window.openNow.fetchFeaturedGames({ token, providerStreamingBaseUrl: baseUrl }).then((featured) => {
+          void window.openNow.fetchFeaturedGames({ token, userId, providerStreamingBaseUrl: baseUrl }).then((featured) => {
             if (featured.length > 0) setFeaturedGames(featured);
           }).catch((error) => {
             console.warn("Featured games refresh failed:", error);
@@ -1919,16 +2006,18 @@ export function App(): JSX.Element {
         return;
       }
 
-      const result = await window.openNow.fetchLibraryGames({ token, providerStreamingBaseUrl: baseUrl });
+      const result = await window.openNow.fetchLibraryGames({ token, userId, providerStreamingBaseUrl: baseUrl });
       setLibraryGames(result);
       setSelectedGameId((previous) => result.some((game) => game.id === previous) ? previous : (result[0]?.id ?? ""));
       applyVariantSelections(result);
     } catch (error) {
       console.error("Failed to load games:", error);
     } finally {
-      setLoading(false);
+      if (!options?.background) {
+        setLoading(false);
+      }
     }
-  }, [applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, featuredGames, searchQuery, catalogFilterKey, catalogSelectedSortId]);
+  }, [applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, featuredGames.length, searchQuery, catalogFilterKey, catalogSelectedSortId]);
 
   const loadStorePanels = useCallback(async () => {
     const session = authSession;
@@ -1987,14 +2076,30 @@ export function App(): JSX.Element {
   }, [libraryGames, storePanelGames]);
 
   useEffect(() => {
-    if (!authSession || currentPage !== "home" || settings.controllerMode) {
+    if (!authSession || currentPage !== "home" || settings.controllerMode || isInitializing) {
       return;
     }
+    const queryKey = buildCatalogQueryKey(searchQuery, catalogSelectedFilterIds, catalogSelectedSortId);
+    if (lastCatalogQueryRef.current === queryKey && games.length > 0) {
+      return;
+    }
+    lastCatalogQueryRef.current = queryKey;
+
     const handle = window.setTimeout(() => {
-      void loadGames("main");
+      void loadGames("main", { background: games.length > 0 });
     }, searchQuery.trim() ? 220 : 0);
     return () => window.clearTimeout(handle);
-  }, [authSession, currentPage, loadGames, searchQuery, catalogFilterKey, catalogSelectedSortId, settings.controllerMode]);
+  }, [
+    authSession,
+    currentPage,
+    games.length,
+    isInitializing,
+    loadGames,
+    searchQuery,
+    catalogFilterKey,
+    catalogSelectedSortId,
+    settings.controllerMode,
+  ]);
 
   useEffect(() => {
     if (!authSession || currentPage !== "home" || !settings.controllerMode) {
@@ -2016,6 +2121,14 @@ export function App(): JSX.Element {
       }
       return next;
     });
+  }, []);
+
+  const handleToggleCatalogFilter = useCallback((filterId: string): void => {
+    setCatalogSelectedFilterIds((previous) => (
+      previous.includes(filterId)
+        ? previous.filter((value) => value !== filterId)
+        : [...previous, filterId]
+    ));
   }, []);
 
   const resolveSessionClaimAppId = useCallback((existingSession: ActiveSessionInfo): string => {
@@ -3778,6 +3891,11 @@ export function App(): JSX.Element {
     );
   }, [libraryGames, searchQuery, catalogSelectedSortId, playtime]);
 
+  const activeSessionAppIds = useMemo(
+    () => (navbarActiveSession ? [navbarActiveSession.appId] : []),
+    [navbarActiveSession?.appId],
+  );
+
   const activeSessionGameTitle = useMemo(() => {
     if (!navbarActiveSession) return null;
     const mappedTitle = gameTitleByAppId.get(navbarActiveSession.appId);
@@ -4017,9 +4135,7 @@ export function App(): JSX.Element {
                 onSelectGameVariant={handleSelectGameVariant}
                 filterGroups={catalogFilterGroups}
                 selectedFilterIds={catalogSelectedFilterIds}
-                onToggleFilter={(filterId) => {
-                  setCatalogSelectedFilterIds((previous) => previous.includes(filterId) ? previous.filter((value) => value !== filterId) : [...previous, filterId]);
-                }}
+                onToggleFilter={handleToggleCatalogFilter}
                 sortOptions={catalogSortOptions}
                 selectedSortId={catalogSelectedSortId}
                 onSortChange={setCatalogSelectedSortId}

--- a/opennow-stable/src/renderer/src/components/GameCard.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCard.tsx
@@ -1,5 +1,5 @@
 import { Play, Monitor } from "lucide-react";
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import type { JSX } from "react";
 import { normalizeGameStore } from "@shared/gfn";
 import type { GameInfo } from "@shared/gfn";
@@ -20,7 +20,6 @@ interface StoreOption {
   storeKey: string;
   variantId: string;
   displayName: string;
-  IconComponent: () => JSX.Element;
   isOwned: boolean;
   isActive: boolean;
 }
@@ -157,6 +156,23 @@ export function getStoreIconComponent(store: string): () => JSX.Element {
   return STORE_ICON_MAP[key] ?? DefaultStoreIcon;
 }
 
+const StoreBrandIcon = memo(function StoreBrandIcon({ store }: { store: string }): JSX.Element {
+  const key = normalizeStoreKey(store);
+  const IconComponent = STORE_ICON_MAP[key] ?? DefaultStoreIcon;
+  return <IconComponent />;
+});
+
+function gameCardPropsAreEqual(prev: GameCardProps, next: GameCardProps): boolean {
+  return (
+    prev.game === next.game
+    && prev.isSelected === next.isSelected
+    && prev.selectedVariantId === next.selectedVariantId
+    && prev.onPlay === next.onPlay
+    && prev.onSelect === next.onSelect
+    && prev.onSelectStore === next.onSelectStore
+  );
+}
+
 export const GameCard = memo(function GameCard({
   game,
   isSelected = false,
@@ -166,11 +182,13 @@ export const GameCard = memo(function GameCard({
   onSelectStore,
 }: GameCardProps): JSX.Element {
   const { t } = useTranslation();
-  const storeOptions: StoreOption[] = getGameCardStoreOptions(game, selectedVariantId).map((option) => ({
-    ...option,
-    displayName: getStoreDisplayName(option.store),
-    IconComponent: getStoreIconComponent(option.store),
-  }));
+  const storeOptions = useMemo(
+    () => getGameCardStoreOptions(game, selectedVariantId).map((option) => ({
+      ...option,
+      displayName: getStoreDisplayName(option.store),
+    })),
+    [game, selectedVariantId],
+  );
   const activeStoreOption = storeOptions.find((option) => option.isActive) ?? storeOptions[0];
 
   const [aspectPct, setAspectPct] = useState<number | undefined>(undefined);
@@ -279,14 +297,14 @@ export const GameCard = memo(function GameCard({
                       aria-label={t("gameCard.store", { store: store.displayName })}
                       aria-pressed={store.isActive}
                     >
-                      <store.IconComponent />
+                      <StoreBrandIcon store={store.store} />
                     </button>
                   );
                 }
 
                 return (
                   <span key={store.storeKey} className={className} title={title}>
-                    <store.IconComponent />
+                    <StoreBrandIcon store={store.store} />
                   </span>
                 );
               })}
@@ -299,4 +317,4 @@ export const GameCard = memo(function GameCard({
       </div>
     </div>
   );
-});
+}, gameCardPropsAreEqual);

--- a/opennow-stable/src/renderer/src/components/GameCard.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCard.tsx
@@ -15,15 +15,6 @@ interface GameCardProps {
   onSelectStore?: (variantId: string) => void;
 }
 
-interface StoreOption {
-  store: string;
-  storeKey: string;
-  variantId: string;
-  displayName: string;
-  isOwned: boolean;
-  isActive: boolean;
-}
-
 /* ── Official store brand icons (Simple Icons / MDI, viewBox 0 0 24 24) ── */
 
 function SteamIcon(): JSX.Element {

--- a/opennow-stable/src/renderer/src/components/GameCardListItem.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCardListItem.tsx
@@ -1,0 +1,64 @@
+import { memo, useCallback, useRef, type RefObject } from "react";
+import type { GameInfo } from "@shared/gfn";
+import { GameCard } from "./GameCard";
+
+export interface CatalogCardActions {
+  onPlayGame: (game: GameInfo) => void;
+  onSelectGame: (gameId: string) => void;
+  onSelectGameVariant: (gameId: string, variantId: string) => void;
+}
+
+export interface GameCardListItemProps {
+  game: GameInfo;
+  selectedVariantId?: string;
+  isSelected?: boolean;
+  actionsRef: RefObject<CatalogCardActions>;
+}
+
+function gameCardListItemPropsAreEqual(
+  prev: GameCardListItemProps,
+  next: GameCardListItemProps,
+): boolean {
+  return (
+    prev.game === next.game
+    && prev.selectedVariantId === next.selectedVariantId
+    && prev.isSelected === next.isSelected
+    && prev.actionsRef === next.actionsRef
+  );
+}
+
+export const GameCardListItem = memo(function GameCardListItem({
+  game,
+  selectedVariantId,
+  isSelected = false,
+  actionsRef,
+}: GameCardListItemProps) {
+  const handleSelect = useCallback(() => {
+    actionsRef.current?.onSelectGame(game.id);
+  }, [actionsRef, game.id]);
+
+  const handlePlay = useCallback(() => {
+    actionsRef.current?.onPlayGame(game);
+  }, [actionsRef, game]);
+
+  const handleSelectStore = useCallback((variantId: string) => {
+    actionsRef.current?.onSelectGameVariant(game.id, variantId);
+  }, [actionsRef, game.id]);
+
+  return (
+    <GameCard
+      game={game}
+      isSelected={isSelected}
+      selectedVariantId={selectedVariantId}
+      onSelect={handleSelect}
+      onPlay={handlePlay}
+      onSelectStore={handleSelectStore}
+    />
+  );
+}, gameCardListItemPropsAreEqual);
+
+export function useCatalogCardActionsRef(actions: CatalogCardActions): RefObject<CatalogCardActions> {
+  const actionsRef = useRef(actions);
+  actionsRef.current = actions;
+  return actionsRef;
+}

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -1,10 +1,11 @@
 import { Search, LayoutGrid, Loader2, ArrowUpDown, Filter, ChevronDown, Gamepad2, Menu } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import { AnimatePresence, m } from "motion/react";
 import { isOwnedLibraryStatus } from "@shared/gfn";
 import type { CatalogFilterGroup, CatalogSortOption, GameInfo, GamePanelResult, GameVariant } from "@shared/gfn";
 import { GameCard, getStoreDisplayName, getStoreIconComponent } from "./GameCard";
+import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
 import { useTranslation } from "../i18n";
 import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
 import { pageTransition, panelSpring } from "./MotionProvider";
@@ -229,7 +230,7 @@ function ControllerStoreTile({
   );
 }
 
-export function HomePage({
+export const HomePage = memo(function HomePage({
   games,
   searchQuery,
   onSearchChange,
@@ -256,6 +257,11 @@ export function HomePage({
   onNextControllerPage,
 }: HomePageProps): JSX.Element {
   const { t } = useTranslation();
+  const catalogActionsRef = useCatalogCardActionsRef({
+    onPlayGame,
+    onSelectGame,
+    onSelectGameVariant,
+  });
   const [controllerHeroIndex, setControllerHeroIndex] = useState(0);
   const [focusedRowIndex, setFocusedRowIndex] = useState(0);
   const [focusedColumnIndex, setFocusedColumnIndex] = useState(0);
@@ -487,6 +493,19 @@ export function HomePage({
       stopGamepadNavigation();
     };
   }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage]);
+
+  const gameGridItems = useMemo(
+    () => games.map((game) => (
+      <GameCardListItem
+        key={game.id}
+        game={game}
+        isSelected={game.id === selectedGameId}
+        selectedVariantId={selectedVariantByGameId[game.id]}
+        actionsRef={catalogActionsRef}
+      />
+    )),
+    [catalogActionsRef, games, selectedGameId, selectedVariantByGameId],
+  );
 
   if (controllerMode) {
     const showInitialLoading = isLoading && controllerSections.length === 0;
@@ -746,25 +765,11 @@ export function HomePage({
             </p>
           </div>
         ) : (
-          <m.div
-            className="game-grid"
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={pageTransition}
-          >
-            {games.map((game) => (
-              <GameCard
-                key={game.id}
-                game={game}
-                onSelect={() => onSelectGame(game.id)}
-                onPlay={() => onPlayGame(game)}
-                selectedVariantId={selectedVariantByGameId[game.id]}
-                onSelectStore={(variantId) => onSelectGameVariant(game.id, variantId)}
-              />
-            ))}
-          </m.div>
+          <div className="game-grid">
+            {gameGridItems}
+          </div>
         )}
       </div>
     </div>
   );
-}
+});

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 import { AnimatePresence, m } from "motion/react";
 import { isOwnedLibraryStatus } from "@shared/gfn";
 import type { CatalogFilterGroup, CatalogSortOption, GameInfo, GamePanelResult, GameVariant } from "@shared/gfn";
-import { GameCard, getStoreDisplayName, getStoreIconComponent } from "./GameCard";
+import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
 import { useTranslation } from "../i18n";
 import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
@@ -251,7 +251,7 @@ export const HomePage = memo(function HomePage({
   controllerMode = false,
   storePanels = [],
   storeHeroGames = [],
-  activeSessionAppIds = [],
+  activeSessionAppIds: _activeSessionAppIds = [],
   onBuyGame,
   onPreviousControllerPage,
   onNextControllerPage,

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import { AnimatePresence, m } from "motion/react";
 import type { CatalogSortOption, GameInfo } from "@shared/gfn";
-import { GameCard, getStoreDisplayName, getStoreIconComponent } from "./GameCard";
+import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
 import { useTranslation } from "../i18n";
 import { formatCatalogLastPlayed } from "../utils/lastPlayedFormat";

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -1,9 +1,10 @@
 import { Library, Search, Clock, Gamepad2, Loader2, ArrowUpDown, MoreHorizontal, Menu } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import { AnimatePresence, m } from "motion/react";
 import type { CatalogSortOption, GameInfo } from "@shared/gfn";
 import { GameCard, getStoreDisplayName, getStoreIconComponent } from "./GameCard";
+import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
 import { useTranslation } from "../i18n";
 import { formatCatalogLastPlayed } from "../utils/lastPlayedFormat";
 import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
@@ -182,7 +183,7 @@ function ControllerGameCard({
   );
 }
 
-export function LibraryPage({
+export const LibraryPage = memo(function LibraryPage({
   games,
   searchQuery,
   onSearchChange,
@@ -204,6 +205,11 @@ export function LibraryPage({
   onNextControllerPage,
 }: LibraryPageProps): JSX.Element {
   const { t } = useTranslation();
+  const catalogActionsRef = useCatalogCardActionsRef({
+    onPlayGame,
+    onSelectGame,
+    onSelectGameVariant,
+  });
   const [controllerHeroIndex, setControllerHeroIndex] = useState(0);
   const [detailsGame, setDetailsGame] = useState<GameInfo | null>(null);
   const [controllerStoreFilterId, setControllerStoreFilterId] = useState("library");
@@ -532,6 +538,26 @@ export function LibraryPage({
     };
   }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage]);
 
+  const libraryGridItems = useMemo(
+    () => games.map((game) => (
+      <div key={game.id} className="library-game-wrapper">
+        <GameCardListItem
+          game={game}
+          isSelected={game.id === selectedGameId}
+          selectedVariantId={selectedVariantByGameId[game.id]}
+          actionsRef={catalogActionsRef}
+        />
+        {game.lastPlayed && (
+          <div className="library-last-played">
+            <Clock size={12} />
+            <span>{formatCatalogLastPlayed(t, game.lastPlayed)}</span>
+          </div>
+        )}
+      </div>
+    )),
+    [catalogActionsRef, games, selectedGameId, selectedVariantByGameId, t],
+  );
+
   if (controllerMode) {
     const featuredGame = controllerFeaturedGames[controllerHeroIndex] ?? selectedControllerGame;
     const heroImageUrl = featuredGame ? getControllerHeroBackgroundCandidates(featuredGame)[0] : undefined;
@@ -836,33 +862,11 @@ export function LibraryPage({
             <p>{t("library.empty.noGamesMatch", { query: searchQuery })}</p>
           </div>
         ) : (
-          <m.div
-            className="game-grid"
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={pageTransition}
-          >
-            {games.map((game) => (
-              <div key={game.id} className="library-game-wrapper">
-                <GameCard
-                  game={game}
-                  isSelected={game.id === selectedGameId}
-                  onSelect={() => onSelectGame(game.id)}
-                  onPlay={() => onPlayGame(game)}
-                  selectedVariantId={selectedVariantByGameId[game.id]}
-                  onSelectStore={(variantId) => onSelectGameVariant(game.id, variantId)}
-                />
-                {game.lastPlayed && (
-                  <div className="library-last-played">
-                    <Clock size={12} />
-                    <span>{formatCatalogLastPlayed(t, game.lastPlayed)}</span>
-                  </div>
-                )}
-              </div>
-            ))}
-          </m.div>
+          <div className="game-grid">
+            {libraryGridItems}
+          </div>
         )}
       </div>
     </div>
   );
-}
+});

--- a/opennow-stable/src/renderer/src/components/MotionProvider.tsx
+++ b/opennow-stable/src/renderer/src/components/MotionProvider.tsx
@@ -8,6 +8,12 @@ export const pageTransition = {
   ease: smoothEase,
 } as const;
 
+/** Shared reveal timing for floating panels (stats HUD, settings modal, etc.). */
+export const surfaceRevealTransition = {
+  duration: 0.34,
+  ease: smoothEase,
+} as const;
+
 export const panelSpring = {
   type: "spring",
   stiffness: 420,

--- a/opennow-stable/src/renderer/src/components/SessionStartedSplash.tsx
+++ b/opennow-stable/src/renderer/src/components/SessionStartedSplash.tsx
@@ -1,10 +1,109 @@
 import { useEffect } from "react";
 import { AnimatePresence, m } from "motion/react";
+import { Check } from "lucide-react";
 import type { JSX } from "react";
 import { smoothEase } from "./MotionProvider";
 import { useTranslation } from "../i18n";
 
-const SPLASH_VISIBLE_MS = 2800;
+const SPLASH_VISIBLE_MS = 3000;
+
+const overlayVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.35, ease: smoothEase },
+  },
+  exit: {
+    opacity: 0,
+    transition: { duration: 0.55, ease: smoothEase, delay: 0.08 },
+  },
+} as const;
+
+const backdropVariants = {
+  hidden: { opacity: 0, scale: 1.04 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: 0.7, ease: smoothEase },
+  },
+  exit: {
+    opacity: 0,
+    scale: 1.08,
+    transition: { duration: 0.5, ease: smoothEase },
+  },
+} as const;
+
+const cardVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0.9,
+    y: 32,
+    filter: "blur(10px)",
+  },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: {
+      duration: 0.72,
+      ease: smoothEase,
+      delay: 0.06,
+    },
+  },
+  exit: {
+    opacity: 0,
+    scale: 1.05,
+    y: -18,
+    filter: "blur(6px)",
+    transition: { duration: 0.48, ease: smoothEase },
+  },
+} as const;
+
+const contentVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      delayChildren: 0.22,
+      staggerChildren: 0.09,
+    },
+  },
+  exit: {
+    opacity: 0,
+    transition: { duration: 0.2 },
+  },
+} as const;
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 16, filter: "blur(4px)" },
+  visible: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: 0.48, ease: smoothEase },
+  },
+} as const;
+
+const emblemVariants = {
+  hidden: { opacity: 0, scale: 0.55, rotate: -18 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    rotate: 0,
+    transition: {
+      type: "spring",
+      stiffness: 340,
+      damping: 22,
+      mass: 0.85,
+    },
+  },
+  exit: {
+    opacity: 0,
+    scale: 1.12,
+    transition: { duration: 0.3, ease: smoothEase },
+  },
+} as const;
 
 export interface SessionStartedSplashProps {
   visible: boolean;
@@ -28,38 +127,75 @@ export function SessionStartedSplash({
   }, [onFinished, visible]);
 
   return (
-    <AnimatePresence>
+    <AnimatePresence mode="wait">
       {visible && (
         <m.div
           className="sv-ready-splash"
           role="status"
           aria-live="polite"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.45, ease: smoothEase }}
+          variants={overlayVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
         >
           <m.div
             className="sv-ready-splash-backdrop"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.55, ease: smoothEase }}
-          />
+            variants={backdropVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+          >
+            <span className="sv-ready-splash-orb sv-ready-splash-orb--a" aria-hidden />
+            <span className="sv-ready-splash-orb sv-ready-splash-orb--b" aria-hidden />
+            <span className="sv-ready-splash-orb sv-ready-splash-orb--c" aria-hidden />
+          </m.div>
+
           <m.div
             className="sv-ready-splash-card"
-            initial={{ opacity: 0, scale: 0.92, y: 18 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 1.04, y: -10 }}
-            transition={{ duration: 0.55, ease: smoothEase }}
+            variants={cardVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
           >
-            <div className="sv-ready-splash-ring" aria-hidden>
-              <span className="sv-ready-splash-ring-core" />
-              <span className="sv-ready-splash-ring-pulse" />
-            </div>
-            <p className="sv-ready-splash-kicker">{t("stream.sessionStarted.kicker")}</p>
-            <h2 className="sv-ready-splash-title">{t("stream.sessionStarted.title")}</h2>
-            <p className="sv-ready-splash-game">{gameTitle}</p>
+            <span className="sv-ready-splash-card-glow" aria-hidden />
+            <span className="sv-ready-splash-card-shimmer" aria-hidden />
+
+            <m.div
+              className="sv-ready-splash-emblem"
+              variants={emblemVariants}
+              aria-hidden
+            >
+              <span className="sv-ready-splash-ring sv-ready-splash-ring--outer" />
+              <span className="sv-ready-splash-ring sv-ready-splash-ring--mid" />
+              <span className="sv-ready-splash-ring sv-ready-splash-ring--inner" />
+              <span className="sv-ready-splash-emblem-core">
+                <Check size={28} strokeWidth={2.5} />
+              </span>
+            </m.div>
+
+            <m.div
+              className="sv-ready-splash-copy"
+              variants={contentVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+            >
+              <m.p className="sv-ready-splash-kicker" variants={itemVariants}>
+                {t("stream.sessionStarted.kicker")}
+              </m.p>
+              <m.h2 className="sv-ready-splash-title" variants={itemVariants}>
+                {t("stream.sessionStarted.title")}
+              </m.h2>
+              <m.p className="sv-ready-splash-game" variants={itemVariants}>
+                {gameTitle}
+              </m.p>
+            </m.div>
+
+            <div
+              className="sv-ready-splash-progress"
+              aria-hidden
+              style={{ animationDuration: `${SPLASH_VISIBLE_MS}ms` }}
+            />
           </m.div>
         </m.div>
       )}

--- a/opennow-stable/src/renderer/src/components/SessionStartedSplash.tsx
+++ b/opennow-stable/src/renderer/src/components/SessionStartedSplash.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+import { AnimatePresence, m } from "motion/react";
+import type { JSX } from "react";
+import { smoothEase } from "./MotionProvider";
+import { useTranslation } from "../i18n";
+
+const SPLASH_VISIBLE_MS = 2800;
+
+export interface SessionStartedSplashProps {
+  visible: boolean;
+  gameTitle: string;
+  onFinished: () => void;
+}
+
+export function SessionStartedSplash({
+  visible,
+  gameTitle,
+  onFinished,
+}: SessionStartedSplashProps): JSX.Element | null {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!visible) {
+      return undefined;
+    }
+    const timer = window.setTimeout(onFinished, SPLASH_VISIBLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [onFinished, visible]);
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <m.div
+          className="sv-ready-splash"
+          role="status"
+          aria-live="polite"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.45, ease: smoothEase }}
+        >
+          <m.div
+            className="sv-ready-splash-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.55, ease: smoothEase }}
+          />
+          <m.div
+            className="sv-ready-splash-card"
+            initial={{ opacity: 0, scale: 0.92, y: 18 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 1.04, y: -10 }}
+            transition={{ duration: 0.55, ease: smoothEase }}
+          >
+            <div className="sv-ready-splash-ring" aria-hidden>
+              <span className="sv-ready-splash-ring-core" />
+              <span className="sv-ready-splash-ring-pulse" />
+            </div>
+            <p className="sv-ready-splash-kicker">{t("stream.sessionStarted.kicker")}</p>
+            <h2 className="sv-ready-splash-title">{t("stream.sessionStarted.title")}</h2>
+            <p className="sv-ready-splash-game">{gameTitle}</p>
+          </m.div>
+        </m.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/SettingsModalHost.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsModalHost.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState, type JSX, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, m } from "motion/react";
+import { smoothEase } from "./MotionProvider";
+import { useTranslation } from "../i18n";
+
+const overlayExitTransition = {
+  duration: 0.22,
+  ease: smoothEase,
+} as const;
+
+export interface SettingsModalHostProps {
+  open: boolean;
+  onClose: () => void;
+  onExitComplete?: () => void;
+  children: ReactNode;
+}
+
+export function SettingsModalHost({
+  open,
+  onClose,
+  onExitComplete,
+  children,
+}: SettingsModalHostProps): JSX.Element | null {
+  const { t } = useTranslation();
+  const [contentReady, setContentReady] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    setContentReady(false);
+    const frame = window.requestAnimationFrame(() => {
+      setContentReady(true);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [open]);
+
+  const handleExitComplete = (): void => {
+    setContentReady(false);
+    onExitComplete?.();
+  };
+
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <AnimatePresence initial={false} onExitComplete={handleExitComplete}>
+      {open ? (
+        <m.div
+          key="settings-modal"
+          className="animated-modal-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label={t("settings.title")}
+          initial={false}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={overlayExitTransition}
+        >
+          <button
+            type="button"
+            className="animated-modal-scrim"
+            onClick={onClose}
+            aria-label={t("app.actions.close")}
+          />
+
+          <div
+            className="animated-modal-panel settings-modal"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {contentReady ? children : (
+              <div className="settings-modal-placeholder" aria-hidden />
+            )}
+          </div>
+        </m.div>
+      ) : null}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1,8 +1,6 @@
 import { Globe, Check, Search, X, Loader, Zap, Mic, FileDown, Wifi, Trash2, Heart, Users, ExternalLink, Monitor, Keyboard, Download, RefreshCcw, Info, Cpu, AlertTriangle, MapPin, ScanLine, Gauge, Film, SlidersHorizontal, HardDrive } from "lucide-react";
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
-import { createPortal } from "react-dom";
 import type { JSX } from "react";
-import { m } from "motion/react";
 
 import type {
   Settings,
@@ -39,7 +37,6 @@ import { formatShortcutForDisplay, normalizeShortcut, shortcutFromKeyboardEvent 
 import { getCodecDecodeBadgeState, shouldShowLinuxHardwareCodecHint, type CodecTestResult } from "../lib/codecDiagnostics";
 import { getAccentColorOption, getAccentColorOptions } from "../lib/uiCustomization";
 import { useTranslation } from "../i18n";
-import { pageTransition, panelSpring } from "./MotionProvider";
 import {
   clearStoredRegionPingResults,
   loadStoredRegionPingResults,
@@ -2030,40 +2027,8 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
     };
   }, [nativeStreamerEnablePromptVisible, onClose]);
 
-  if (typeof document === "undefined") {
-    return <></>;
-  }
-
-  return createPortal(
-    <m.div
-      className="settings-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-label={t("settings.title")}
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={pageTransition}
-    >
-      <m.button
-        type="button"
-        className="settings-overlay-backdrop"
-        onClick={onClose}
-        aria-label={t("app.actions.close")}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={pageTransition}
-      />
-
-      <m.div
-        className="settings-modal"
-        onClick={(event) => event.stopPropagation()}
-        initial={{ opacity: 0, y: 18, scale: 0.985 }}
-        animate={{ opacity: 1, y: 0, scale: 1 }}
-        exit={{ opacity: 0, y: 10, scale: 0.99 }}
-        transition={panelSpring}
-      >
+  return (
+    <>
         <header className="settings-modal-header">
           <h1>{t("settings.title")}</h1>
           <div className="settings-modal-header-actions">
@@ -4062,7 +4027,6 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
         )}
       </div>
         </div>
-      </m.div>
 
       {nativeStreamerEnablePromptVisible && (
         <div
@@ -4131,7 +4095,6 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
           </div>
         </div>
       )}
-    </m.div>,
-    document.body,
+    </>
   );
 }

--- a/opennow-stable/src/renderer/src/components/StreamStatsHud.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamStatsHud.tsx
@@ -1,0 +1,364 @@
+import { useMemo, useState } from "react";
+import { AnimatePresence, m } from "motion/react";
+import { AlertTriangle, ChevronDown } from "lucide-react";
+import type { JSX } from "react";
+import type { StreamLagReason } from "../gfn/webrtcClient";
+import type { StreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
+import { useStreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
+import {
+  getBitratePerformanceColor,
+  getInputQueueColor,
+  getPacketLossColor,
+  getRttColor,
+  getTimingColor,
+} from "../utils/streamDiagnosticsFormat";
+import { panelSpring, smoothEase } from "./MotionProvider";
+import { useTranslation } from "../i18n";
+
+function getLagReasonLabel(reason: StreamLagReason): string {
+  switch (reason) {
+    case "network":
+      return "Network";
+    case "decoder":
+      return "Decode";
+    case "input_backpressure":
+      return "Input";
+    case "render":
+      return "Render";
+    case "stable":
+      return "Stable";
+    default:
+      return "Unknown";
+  }
+}
+
+function getLagReasonColor(reason: StreamLagReason): string {
+  switch (reason) {
+    case "network":
+    case "decoder":
+      return "var(--error)";
+    case "input_backpressure":
+    case "render":
+      return "var(--warning)";
+    case "stable":
+      return "var(--success)";
+    default:
+      return "var(--ink-muted)";
+  }
+}
+
+export interface StreamStatsHudProps {
+  diagnosticsStore: StreamDiagnosticsStore;
+  gstreamerEnabled: boolean;
+  serverRegion?: string;
+  sessionTimeRemainingText: string | null;
+  hintsVisible?: boolean;
+}
+
+export function StreamStatsHud({
+  diagnosticsStore,
+  gstreamerEnabled,
+  serverRegion,
+  sessionTimeRemainingText,
+  hintsVisible = false,
+}: StreamStatsHudProps): JSX.Element {
+  const { t } = useTranslation();
+  const stats = useStreamDiagnosticsStore(diagnosticsStore);
+  const [expanded, setExpanded] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const hasLiveBitrate = stats.bitrateKbps > 0;
+  const bitrateKbps = hasLiveBitrate ? stats.bitrateKbps : stats.targetBitrateKbps;
+  const bitrateMbps = bitrateKbps > 0 ? (bitrateKbps / 1000).toFixed(1) : "--";
+  const bitrateLabel = hasLiveBitrate
+    ? `${bitrateMbps} Mbps`
+    : stats.targetBitrateKbps > 0
+      ? `Target ${bitrateMbps} Mbps`
+      : "-- Mbps";
+  const bitratePerformancePercent =
+    stats.targetBitrateKbps > 0 && stats.bitrateKbps > 0
+      ? (stats.bitrateKbps / stats.targetBitrateKbps) * 100
+      : 0;
+  const bitratePerformanceText =
+    bitratePerformancePercent > 0 ? `${bitratePerformancePercent.toFixed(0)}%` : "--";
+  const bitratePerformanceColor = getBitratePerformanceColor(bitratePerformancePercent);
+  const hasResolution = stats.nativeRendererActive || stats.resolution !== "";
+  const displayFps = Math.max(stats.decodeFps, stats.renderFps);
+  const primaryText = hasResolution
+    ? `${stats.resolution || "Native renderer"}${displayFps > 0 ? ` · ${displayFps}fps` : ""}`
+    : t("stream.stats.connecting");
+  const hasCodec = Boolean(stats.codec && stats.codec !== "");
+  const regionLabel = stats.serverRegion || serverRegion || "";
+  const decodeColor = getTimingColor(stats.decodeTimeMs, 8, 16);
+  const renderColor = getTimingColor(stats.renderTimeMs, 12, 22);
+  const jitterBufferColor = getTimingColor(stats.jitterBufferDelayMs, 10, 24);
+  const lossColor = getPacketLossColor(stats.packetLossPercent);
+  const lossLabel = stats.nativeRendererActive ? "Drop" : "Loss";
+  const lossTitle = stats.nativeRendererActive
+    ? "Native renderer dropped frame percentage"
+    : t("stream.stats.packetLoss");
+  const dText = stats.decodeTimeMs > 0 ? `${stats.decodeTimeMs.toFixed(1)}ms` : "--";
+  const rText = stats.renderTimeMs > 0 ? `${stats.renderTimeMs.toFixed(1)}ms` : "--";
+  const jbText = stats.jitterBufferDelayMs > 0 ? `${stats.jitterBufferDelayMs.toFixed(1)}ms` : "--";
+  const inputLive = stats.inputReady && stats.connectionState === "connected";
+  const inputQueueColor = getInputQueueColor(stats.inputQueueBufferedBytes, stats.inputQueueDropCount);
+  const inputQueueText = `${(stats.inputQueueBufferedBytes / 1024).toFixed(1)}KB`;
+  const partiallyReliableQueueText = `${(stats.partiallyReliableInputQueueBufferedBytes / 1024).toFixed(1)}KB`;
+  const mouseResidualText = `${stats.mouseResidualMagnitude.toFixed(2)}px`;
+  const rttColor = getRttColor(stats.rttMs);
+  const rttText = stats.rttMs > 0 ? `${stats.rttMs.toFixed(0)}ms` : "--";
+  const hasLagIssue = stats.lagReason !== "stable" && stats.lagReason !== "unknown";
+  const hasPacketLoss = stats.packetLossPercent > 0;
+  const hasIssues = hasLagIssue || hasPacketLoss;
+
+  const advancedLines = useMemo(() => {
+    const lines: string[] = [];
+    lines.push(
+      `Input queue peak ${(stats.inputQueuePeakBufferedBytes / 1024).toFixed(1)}KB · PR peak ${(stats.partiallyReliableInputQueuePeakBufferedBytes / 1024).toFixed(1)}KB · drops ${stats.inputQueueDropCount} · sched ${stats.inputQueueMaxSchedulingDelayMs.toFixed(1)}ms · residual ${mouseResidualText}`,
+    );
+    lines.push(
+      gstreamerEnabled
+        ? `GStreamer enabled · ${stats.nativeRendererActive ? "in use" : "not active"}`
+        : "GStreamer disabled · Chromium WebRTC",
+    );
+    const hwLine = [stats.hardwareAcceleration, stats.colorCodec].filter(Boolean).join(" · ");
+    if (hwLine) lines.push(hwLine);
+    if (stats.decoderPressureActive || stats.decoderRecoveryAttempts > 0) {
+      lines.push(
+        `Decoder recovery ${stats.decoderPressureActive ? "active" : "idle"} · attempts ${stats.decoderRecoveryAttempts} · action ${stats.decoderRecoveryAction}`,
+      );
+    }
+    if (stats.nativeTransitionSummary || stats.nativeQueueMode || stats.nativeCapsFramerate) {
+      lines.push(
+        `Native transition ${stats.nativeTransitionSummary ?? "none"} · queue ${stats.nativeQueueMode ?? "unknown"} · caps ${stats.nativeCapsFramerate ?? "unknown"}${typeof stats.nativeRequestedFps === "number" ? ` · requested ${stats.nativeRequestedFps}fps` : ""}${typeof stats.nativeFramesPendingToPresent === "number" ? ` · pending ${stats.nativeFramesPendingToPresent}` : ""}${typeof stats.nativePartialFlushCount === "number" || typeof stats.nativeCompleteFlushCount === "number" ? ` · flush ${stats.nativePartialFlushCount ?? 0}/${stats.nativeCompleteFlushCount ?? 0}` : ""}`,
+      );
+    }
+    if (stats.nativeRequestedStreamingFeaturesSummary || stats.nativeFinalizedStreamingFeaturesSummary) {
+      lines.push(
+        `Stream features requested ${stats.nativeRequestedStreamingFeaturesSummary ?? "none"} · finalized ${stats.nativeFinalizedStreamingFeaturesSummary ?? "none"}`,
+      );
+    }
+    const gpuRegion = [stats.gpuType, regionLabel].filter(Boolean).join(" · ");
+    if (gpuRegion) lines.push(gpuRegion);
+    if (hasLagIssue) {
+      lines.push(`Lag source ${getLagReasonLabel(stats.lagReason).toLowerCase()} · ${stats.lagReasonDetail}`);
+    }
+    return lines;
+  }, [
+    gstreamerEnabled,
+    hasLagIssue,
+    mouseResidualText,
+    regionLabel,
+    stats,
+  ]);
+
+  return (
+    <m.aside
+      className={[
+        "sv-stats",
+        expanded ? "sv-stats--expanded" : "",
+        hasIssues ? "sv-stats--warn" : "",
+        hintsVisible ? "sv-stats--hints" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      initial={{ opacity: 0, x: -14, y: 10 }}
+      animate={{ opacity: 1, x: 0, y: 0 }}
+      exit={{ opacity: 0, x: -10, y: 6 }}
+      transition={{ duration: 0.34, ease: smoothEase }}
+      layout
+      aria-label={t("stream.stats.overlayLabel")}
+    >
+      <button
+        type="button"
+        className="sv-stats-toggle"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        title={expanded ? t("stream.stats.collapse") : t("stream.stats.expand")}
+      >
+        <div className="sv-stats-toggle-main">
+          <p className="sv-stats-primary">{primaryText}</p>
+          <div className="sv-stats-toggle-meta">
+            <span className="sv-stats-kpi">
+              <span className="sv-stats-kpi-label">{t("stream.stats.network")}</span>
+              <span className="sv-stats-kpi-val sv-stats-kpi-val--rtt" style={{ color: rttColor }}>
+                {rttText}
+              </span>
+            </span>
+            <span className="sv-stats-kpi-divider" aria-hidden />
+            <span className="sv-stats-kpi">
+              <span className="sv-stats-kpi-label">{t("stream.stats.bitrateShort")}</span>
+              <span className="sv-stats-kpi-val">{bitrateLabel}</span>
+            </span>
+          </div>
+        </div>
+
+        <div className="sv-stats-toggle-trail">
+          <span className={`sv-stats-live ${inputLive ? "is-live" : "is-pending"}`}>
+            {inputLive ? t("stream.stats.live") : t("stream.stats.sync")}
+          </span>
+          {hasIssues && (
+            <span className="sv-stats-alert-dot" aria-hidden>
+              <AlertTriangle size={11} />
+            </span>
+          )}
+          <m.span
+            className="sv-stats-chevron"
+            animate={{ rotate: expanded ? 180 : 0 }}
+            transition={{ duration: 0.22, ease: smoothEase }}
+            aria-hidden
+          >
+            <ChevronDown size={14} />
+          </m.span>
+        </div>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {hasIssues && !expanded && (
+          <m.div
+            key="warn-strip"
+            className="sv-stats-warn-strip"
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.24, ease: smoothEase }}
+          >
+            {hasPacketLoss && (
+              <span className="sv-stats-warn-pill">
+                {t("stream.stats.packetLossValue", { value: stats.packetLossPercent.toFixed(1) })}
+              </span>
+            )}
+            {hasLagIssue && (
+              <span className="sv-stats-warn-pill" title={stats.lagReasonDetail}>
+                {getLagReasonLabel(stats.lagReason)}
+              </span>
+            )}
+          </m.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <m.div
+            key="details"
+            className="sv-stats-details"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={panelSpring}
+          >
+            <div className="sv-stats-details-inner">
+              <div className="sv-stats-sub">
+                <span className="sv-stats-sub-left">
+                  {hasCodec ? stats.codec : "N/A"}
+                  {stats.isHdr && <span className="sv-stats-hdr">HDR</span>}
+                </span>
+                {sessionTimeRemainingText && (
+                  <span className="sv-stats-chip sv-stats-chip--time" title={t("sidebar.sessionTimeRemainingTitle")}>
+                    {t("stream.stats.timeRemainingShort")}{" "}
+                    <span className="sv-stats-chip-val">{sessionTimeRemainingText}</span>
+                  </span>
+                )}
+              </div>
+
+              <div className="sv-stats-metrics">
+                <span className="sv-stats-chip" title={t("stream.stats.roundTripLatency")}>
+                  RTT{" "}
+                  <span className="sv-stats-chip-val" style={{ color: rttColor }}>
+                    {rttText}
+                  </span>
+                </span>
+                <span className="sv-stats-chip" title={t("stream.stats.decodeTime")}>
+                  D <span className="sv-stats-chip-val" style={{ color: decodeColor }}>{dText}</span>
+                </span>
+                <span className="sv-stats-chip" title={t("stream.stats.renderTime")}>
+                  R <span className="sv-stats-chip-val" style={{ color: renderColor }}>{rText}</span>
+                </span>
+                <span className="sv-stats-chip" title={t("stream.stats.jitterBuffer")}>
+                  JB <span className="sv-stats-chip-val" style={{ color: jitterBufferColor }}>{jbText}</span>
+                </span>
+                <span className="sv-stats-chip" title={lossTitle}>
+                  {lossLabel}{" "}
+                  <span className="sv-stats-chip-val" style={{ color: lossColor }}>
+                    {stats.packetLossPercent.toFixed(2)}%
+                  </span>
+                </span>
+                <span className="sv-stats-chip" title={t("stream.stats.bitratePerformance")}>
+                  Bit{" "}
+                  <span className="sv-stats-chip-val" style={{ color: bitratePerformanceColor }}>
+                    {bitratePerformanceText}
+                  </span>
+                </span>
+                <span className="sv-stats-chip" title={t("stream.stats.inputQueuePressure")}>
+                  IQ{" "}
+                  <span className="sv-stats-chip-val" style={{ color: inputQueueColor }}>
+                    {inputQueueText}
+                  </span>
+                </span>
+                <span className="sv-stats-chip" title={t("stream.stats.inputChannelState")}>
+                  PR{" "}
+                  <span
+                    className="sv-stats-chip-val"
+                    style={{ color: stats.partiallyReliableInputOpen ? "var(--success)" : "var(--ink-muted)" }}
+                  >
+                    {stats.partiallyReliableInputOpen
+                      ? `${stats.mouseMoveTransport === "partially_reliable" ? "mouse" : "open"} · ${partiallyReliableQueueText}`
+                      : "off"}
+                  </span>
+                </span>
+                <span className="sv-stats-chip" title={t("stream.stats.mouseFlushCadence")}>
+                  MF{" "}
+                  <span
+                    className="sv-stats-chip-val"
+                    style={{ color: stats.mouseAdaptiveFlushActive ? "var(--warning)" : "var(--success)" }}
+                  >
+                    {stats.mouseFlushIntervalMs.toFixed(0)}ms · {stats.mousePacketsPerSecond}/s
+                  </span>
+                </span>
+                {hasLagIssue && (
+                  <span className="sv-stats-chip sv-stats-chip--warn" title={stats.lagReasonDetail}>
+                    Lag{" "}
+                    <span className="sv-stats-chip-val" style={{ color: getLagReasonColor(stats.lagReason) }}>
+                      {getLagReasonLabel(stats.lagReason)}
+                    </span>
+                  </span>
+                )}
+              </div>
+
+              {advancedLines.length > 0 && (
+                <div className="sv-stats-advanced">
+                  <button
+                    type="button"
+                    className="sv-stats-advanced-toggle"
+                    onClick={() => setAdvancedOpen((value) => !value)}
+                    aria-expanded={advancedOpen}
+                  >
+                    {advancedOpen ? t("stream.stats.hideAdvanced") : t("stream.stats.showAdvanced")}
+                  </button>
+                  <AnimatePresence initial={false}>
+                    {advancedOpen && (
+                      <m.div
+                        key="advanced"
+                        className="sv-stats-advanced-body"
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.26, ease: smoothEase }}
+                      >
+                        {advancedLines.map((line) => (
+                          <p key={line} className="sv-stats-foot">
+                            {line}
+                          </p>
+                        ))}
+                      </m.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              )}
+            </div>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </m.aside>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/StreamStatsHud.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamStatsHud.tsx
@@ -12,7 +12,7 @@ import {
   getRttColor,
   getTimingColor,
 } from "../utils/streamDiagnosticsFormat";
-import { panelSpring, smoothEase } from "./MotionProvider";
+import { panelSpring, smoothEase, surfaceRevealTransition } from "./MotionProvider";
 import { useTranslation } from "../i18n";
 
 function getLagReasonLabel(reason: StreamLagReason): string {
@@ -165,7 +165,7 @@ export function StreamStatsHud({
       initial={{ opacity: 0, x: -14, y: 10 }}
       animate={{ opacity: 1, x: 0, y: 0 }}
       exit={{ opacity: 0, x: -10, y: 6 }}
-      transition={{ duration: 0.34, ease: smoothEase }}
+      transition={surfaceRevealTransition}
       layout
       aria-label={t("stream.stats.overlayLabel")}
     >

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -380,7 +380,7 @@ function VideoFocusOnReady({
     if (!isConnecting && videoRef.current && shouldFocusVideo) {
       const timer = window.setTimeout(() => {
         if (videoRef.current && document.activeElement !== videoRef.current) {
-          videoRef.current.focus();
+          videoRef.current.focus({ preventScroll: true });
           console.log("[StreamView] Focused video element");
         }
       }, 100);
@@ -1308,7 +1308,7 @@ export function StreamView({
     // mousedown's preventDefault() blocks the browser from re-focusing on click.
     const timer = window.setTimeout(() => {
       if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
-        localVideoRef.current.focus();
+        localVideoRef.current.focus({ preventScroll: true });
       }
     }, 50);
     try {
@@ -1411,6 +1411,44 @@ export function StreamView({
     return () => window.removeEventListener("keydown", onKeyDown, true);
   }, [handleToggleSideBar, isMacClient]);
 
+  useEffect(() => {
+    const blurStreamFocusTarget = (): void => {
+      const active = document.activeElement;
+      if (active instanceof HTMLElement && active.closest(".sv")) {
+        active.blur();
+      }
+    };
+
+    const hideFocusRingOnAccessKey = (event: KeyboardEvent): void => {
+      if (event.key === "Alt" && !event.repeat) {
+        blurStreamFocusTarget();
+      }
+    };
+
+    const restoreStreamVideoFocus = (event: PointerEvent): void => {
+      if (showSideBar || isConnecting || exitPrompt.open) {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      if (target?.closest(".sv-sidebar, .sv-exit, .sv-shot-modal, button, a, input, textarea, select")) {
+        return;
+      }
+      const video = localVideoRef.current;
+      if (video && document.activeElement !== video) {
+        video.focus({ preventScroll: true });
+      }
+    };
+
+    window.addEventListener("blur", blurStreamFocusTarget);
+    window.addEventListener("keydown", hideFocusRingOnAccessKey, true);
+    window.addEventListener("pointerdown", restoreStreamVideoFocus, true);
+    return () => {
+      window.removeEventListener("blur", blurStreamFocusTarget);
+      window.removeEventListener("keydown", hideFocusRingOnAccessKey, true);
+      window.removeEventListener("pointerdown", restoreStreamVideoFocus, true);
+    };
+  }, [exitPrompt.open, isConnecting, showSideBar]);
+
   return (
     <div className={["sv", className].filter(Boolean).join(" ")}>
       <video
@@ -1418,11 +1456,11 @@ export function StreamView({
         autoPlay
         playsInline
         muted
-        tabIndex={0}
+        tabIndex={-1}
         className="sv-video"
         onClick={() => {
           if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
-            localVideoRef.current.focus();
+            localVideoRef.current.focus({ preventScroll: true });
           }
         }}
       />

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
+import { AnimatePresence } from "motion/react";
 import type { JSX } from "react";
 import { Maximize, Minimize, Loader2, LogOut, Clock3, AlertTriangle, Mic, MicOff, Camera, ChevronLeft, ChevronRight, Save, Trash2, X, Circle, Square, Video, FolderOpen } from "lucide-react";
 import SideBar from "./SideBar";
+import { SessionStartedSplash } from "./SessionStartedSplash";
+import { StreamStatsHud } from "./StreamStatsHud";
 import type { StreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
-import { useStreamDiagnosticsSelector, useStreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
-import type { StreamLagReason } from "../gfn/webrtcClient";
+import { useStreamDiagnosticsSelector } from "../utils/streamDiagnosticsStore";
 import type { MicState } from "../gfn/microphoneManager";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { RemainingPlaytimeIndicator, SessionElapsedIndicator } from "./ElapsedSessionIndicators";
@@ -13,13 +15,6 @@ import type { MicrophoneMode, ScreenshotEntry, RecordingEntry, SubscriptionInfo 
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
 import { addStreamShortcutActionListener } from "../streamShortcutActions";
 import { useMicMeter } from "../hooks/useMicMeter";
-import {
-  getBitratePerformanceColor,
-  getInputQueueColor,
-  getPacketLossColor,
-  getRttColor,
-  getTimingColor,
-} from "../utils/streamDiagnosticsFormat";
 import { formatElapsed } from "../utils/timeFormat";
 import { useTranslation } from "../i18n";
 
@@ -92,39 +87,6 @@ interface StreamViewProps {
 }
 
 
-function getLagReasonLabel(reason: StreamLagReason): string {
-  switch (reason) {
-    case "network":
-      return "Network";
-    case "decoder":
-      return "Decode";
-    case "input_backpressure":
-      return "Input";
-    case "render":
-      return "Render";
-    case "stable":
-      return "Stable";
-    default:
-      return "Unknown";
-  }
-}
-
-function getLagReasonColor(reason: StreamLagReason): string {
-  switch (reason) {
-    case "network":
-    case "decoder":
-      return "var(--error)";
-    case "input_backpressure":
-    case "render":
-      return "var(--warning)";
-    case "stable":
-      return "var(--success)";
-    default:
-      return "var(--ink-muted)";
-  }
-}
-
-
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -162,171 +124,6 @@ function isMicBadgeStateEqual(prev: MicBadgeState, next: MicBadgeState): boolean
     prev.connectedGamepads === next.connectedGamepads &&
     prev.micState === next.micState &&
     prev.micEnabled === next.micEnabled
-  );
-}
-
-function StreamStatsHud({
-  diagnosticsStore,
-  gstreamerEnabled,
-  serverRegion,
-  sessionTimeRemainingText,
-}: {
-  diagnosticsStore: StreamDiagnosticsStore;
-  gstreamerEnabled: boolean;
-  serverRegion?: string;
-  sessionTimeRemainingText: string | null;
-}): JSX.Element {
-  const { t } = useTranslation();
-  const stats = useStreamDiagnosticsStore(diagnosticsStore);
-  const hasLiveBitrate = stats.bitrateKbps > 0;
-  const bitrateKbps = hasLiveBitrate ? stats.bitrateKbps : stats.targetBitrateKbps;
-  const bitrateMbps = bitrateKbps > 0 ? (bitrateKbps / 1000).toFixed(1) : "--";
-  const bitrateLabel = hasLiveBitrate
-    ? `${bitrateMbps} Mbps`
-    : stats.targetBitrateKbps > 0
-      ? `Target ${bitrateMbps} Mbps`
-      : "-- Mbps";
-  const bitratePerformancePercent = stats.targetBitrateKbps > 0 && stats.bitrateKbps > 0
-    ? (stats.bitrateKbps / stats.targetBitrateKbps) * 100
-    : 0;
-  const bitratePerformanceText = bitratePerformancePercent > 0
-    ? `${bitratePerformancePercent.toFixed(0)}%`
-    : "--";
-  const bitratePerformanceColor = getBitratePerformanceColor(bitratePerformancePercent);
-  const hasResolution = stats.nativeRendererActive || stats.resolution !== "";
-  const displayFps = Math.max(stats.decodeFps, stats.renderFps);
-  const primaryText = hasResolution
-    ? `${stats.resolution || "Native renderer"}${displayFps > 0 ? ` · ${displayFps}fps` : ""}`
-    : "";
-  const hasCodec = stats.codec && stats.codec !== "";
-  const regionLabel = stats.serverRegion || serverRegion || "";
-  const decodeColor = getTimingColor(stats.decodeTimeMs, 8, 16);
-  const renderColor = getTimingColor(stats.renderTimeMs, 12, 22);
-  const jitterBufferColor = getTimingColor(stats.jitterBufferDelayMs, 10, 24);
-  const lossColor = getPacketLossColor(stats.packetLossPercent);
-  const lossLabel = stats.nativeRendererActive ? "Drop" : "Loss";
-  const lossTitle = stats.nativeRendererActive ? "Native renderer dropped frame percentage" : "Packet loss percentage";
-  const dText = stats.decodeTimeMs > 0 ? `${stats.decodeTimeMs.toFixed(1)}ms` : "--";
-  const rText = stats.renderTimeMs > 0 ? `${stats.renderTimeMs.toFixed(1)}ms` : "--";
-  const jbText = stats.jitterBufferDelayMs > 0 ? `${stats.jitterBufferDelayMs.toFixed(1)}ms` : "--";
-  const inputLive = stats.inputReady && stats.connectionState === "connected";
-  const inputQueueColor = getInputQueueColor(stats.inputQueueBufferedBytes, stats.inputQueueDropCount);
-  const inputQueueText = `${(stats.inputQueueBufferedBytes / 1024).toFixed(1)}KB`;
-  const partiallyReliableQueueText = `${(stats.partiallyReliableInputQueueBufferedBytes / 1024).toFixed(1)}KB`;
-  const mouseResidualText = `${stats.mouseResidualMagnitude.toFixed(2)}px`;
-  const gstreamerStatusText = gstreamerEnabled
-    ? `GStreamer enabled · ${stats.nativeRendererActive ? "in use" : "not active"}`
-    : "GStreamer disabled · Chromium WebRTC";
-
-  return (
-    <div className="sv-stats">
-      <div className="sv-stats-head">
-        {hasResolution ? (
-          <span className="sv-stats-primary">{primaryText}</span>
-        ) : (
-          <span className="sv-stats-primary sv-stats-wait">Connecting...</span>
-        )}
-        <span className={`sv-stats-live ${inputLive ? "is-live" : "is-pending"}`}>
-          {inputLive ? "Live" : "Sync"}
-        </span>
-      </div>
-
-      <div className="sv-stats-sub">
-        <span className="sv-stats-sub-left">
-          {hasCodec ? stats.codec : "N/A"}
-          {stats.isHdr && <span className="sv-stats-hdr">HDR</span>}
-        </span>
-        <span className="sv-stats-sub-right">{bitrateLabel}</span>
-      </div>
-
-      <div className="sv-stats-metrics">
-        <span className="sv-stats-chip" title="Round-trip network latency">
-          RTT <span className="sv-stats-chip-val" style={{ color: getRttColor(stats.rttMs) }}>{stats.rttMs > 0 ? `${stats.rttMs.toFixed(0)}ms` : "--"}</span>
-        </span>
-        {sessionTimeRemainingText && (
-          <span className="sv-stats-chip sv-stats-chip--time" title={t("sidebar.sessionTimeRemainingTitle")}>
-            {t("stream.stats.timeRemainingShort")} <span className="sv-stats-chip-val">{sessionTimeRemainingText}</span>
-          </span>
-        )}
-        <span className="sv-stats-chip" title="D = decode time">
-          D <span className="sv-stats-chip-val" style={{ color: decodeColor }}>{dText}</span>
-        </span>
-        <span className="sv-stats-chip" title="R = render time">
-          R <span className="sv-stats-chip-val" style={{ color: renderColor }}>{rText}</span>
-        </span>
-        <span className="sv-stats-chip" title="JB = jitter buffer delay">
-          JB <span className="sv-stats-chip-val" style={{ color: jitterBufferColor }}>{jbText}</span>
-        </span>
-        <span className="sv-stats-chip" title={lossTitle}>
-          {lossLabel} <span className="sv-stats-chip-val" style={{ color: lossColor }}>{stats.packetLossPercent.toFixed(2)}%</span>
-        </span>
-        <span className="sv-stats-chip" title="Actual receive bitrate compared with the negotiated target">
-          Bit <span className="sv-stats-chip-val" style={{ color: bitratePerformanceColor }}>{bitratePerformanceText}</span>
-        </span>
-        <span className="sv-stats-chip" title="Input queue pressure (buffered bytes and delayed flush)">
-          IQ <span className="sv-stats-chip-val" style={{ color: inputQueueColor }}>{inputQueueText}</span>
-        </span>
-        <span className="sv-stats-chip" title="Partially reliable input channel state and queued bytes">
-          PR <span className="sv-stats-chip-val" style={{ color: stats.partiallyReliableInputOpen ? "var(--success)" : "var(--ink-muted)" }}>
-            {stats.partiallyReliableInputOpen ? `${stats.mouseMoveTransport === "partially_reliable" ? "mouse" : "open"} · ${partiallyReliableQueueText}` : "off"}
-          </span>
-        </span>
-        <span className="sv-stats-chip" title="Mouse flush cadence and packet rate">
-          MF <span className="sv-stats-chip-val" style={{ color: stats.mouseAdaptiveFlushActive ? "var(--warning)" : "var(--success)" }}>
-            {stats.mouseFlushIntervalMs.toFixed(0)}ms · {stats.mousePacketsPerSecond}/s
-          </span>
-        </span>
-        {stats.lagReason !== "stable" && stats.lagReason !== "unknown" && (
-          <span className="sv-stats-chip" title={stats.lagReasonDetail}>
-            Lag <span className="sv-stats-chip-val" style={{ color: getLagReasonColor(stats.lagReason) }}>{getLagReasonLabel(stats.lagReason)}</span>
-          </span>
-        )}
-      </div>
-
-      <div className="sv-stats-foot">
-        Input queue peak {(stats.inputQueuePeakBufferedBytes / 1024).toFixed(1)}KB · PR peak {(stats.partiallyReliableInputQueuePeakBufferedBytes / 1024).toFixed(1)}KB · drops {stats.inputQueueDropCount} · sched {stats.inputQueueMaxSchedulingDelayMs.toFixed(1)}ms · residual {mouseResidualText}
-      </div>
-
-      <div className="sv-stats-foot">
-        {gstreamerStatusText}
-      </div>
-
-      {(stats.hardwareAcceleration || stats.colorCodec) && (
-        <div className="sv-stats-foot">
-          {[stats.hardwareAcceleration, stats.colorCodec].filter(Boolean).join(" · ")}
-        </div>
-      )}
-
-      {(stats.decoderPressureActive || stats.decoderRecoveryAttempts > 0) && (
-        <div className="sv-stats-foot">
-          Decoder recovery {stats.decoderPressureActive ? "active" : "idle"} · attempts {stats.decoderRecoveryAttempts} · action {stats.decoderRecoveryAction}
-        </div>
-      )}
-
-      {(stats.nativeTransitionSummary || stats.nativeQueueMode || stats.nativeCapsFramerate) && (
-        <div className="sv-stats-foot">
-          Native transition {stats.nativeTransitionSummary ?? "none"} · queue {stats.nativeQueueMode ?? "unknown"} · caps {stats.nativeCapsFramerate ?? "unknown"}{typeof stats.nativeRequestedFps === "number" ? ` · requested ${stats.nativeRequestedFps}fps` : ""}{typeof stats.nativeFramesPendingToPresent === "number" ? ` · pending ${stats.nativeFramesPendingToPresent}` : ""}{typeof stats.nativePartialFlushCount === "number" || typeof stats.nativeCompleteFlushCount === "number" ? ` · flush ${stats.nativePartialFlushCount ?? 0}/${stats.nativeCompleteFlushCount ?? 0}` : ""}
-        </div>
-      )}
-
-      {(stats.nativeRequestedStreamingFeaturesSummary || stats.nativeFinalizedStreamingFeaturesSummary) && (
-        <div className="sv-stats-foot">
-          Stream features requested {stats.nativeRequestedStreamingFeaturesSummary ?? "none"} · finalized {stats.nativeFinalizedStreamingFeaturesSummary ?? "none"}
-        </div>
-      )}
-
-      {(stats.gpuType || regionLabel) && (
-        <div className="sv-stats-foot">
-          {[stats.gpuType, regionLabel].filter(Boolean).join(" · ")}
-        </div>
-      )}
-
-      {stats.lagReason !== "stable" && stats.lagReason !== "unknown" && (
-        <div className="sv-stats-foot">
-          Lag source {getLagReasonLabel(stats.lagReason).toLowerCase()} · {stats.lagReasonDetail}
-        </div>
-      )}
-    </div>
   );
 }
 
@@ -484,23 +281,64 @@ function StreamTitleBar({
   );
 }
 
+function hasVisibleStreamVideo(stats: {
+  nativeRendererActive: boolean;
+  framesDecoded: number;
+  resolution: string;
+}): boolean {
+  if (stats.nativeRendererActive) {
+    return true;
+  }
+  return stats.framesDecoded > 0;
+}
+
 function StreamEmptyState({
   diagnosticsStore,
 }: {
   diagnosticsStore: StreamDiagnosticsStore;
 }): JSX.Element | null {
-  const hasResolution = useStreamDiagnosticsSelector(
+  const hasVisibleVideo = useStreamDiagnosticsSelector(
     diagnosticsStore,
-    (stats) => stats.nativeRendererActive || stats.resolution !== "",
+    (stats) => hasVisibleStreamVideo(stats),
   );
 
-  if (hasResolution) {
+  if (hasVisibleVideo) {
     return null;
   }
 
   return (
     <div className="sv-empty">
       <div className="sv-empty-grad" />
+    </div>
+  );
+}
+
+function StreamWaitingForVideo({
+  diagnosticsStore,
+  isConnecting,
+}: {
+  diagnosticsStore: StreamDiagnosticsStore;
+  isConnecting: boolean;
+}): JSX.Element | null {
+  const { t } = useTranslation();
+  const waitingForFirstFrame = useStreamDiagnosticsSelector(
+    diagnosticsStore,
+    (stats) => {
+      if (stats.nativeRendererActive || stats.framesDecoded > 0) {
+        return false;
+      }
+      return stats.connectionState === "connected" || stats.resolution !== "";
+    },
+  );
+
+  if (isConnecting || !waitingForFirstFrame) {
+    return null;
+  }
+
+  return (
+    <div className="sv-warm" role="status" aria-live="polite">
+      <Loader2 className="sv-warm-spin" size={34} />
+      <p className="sv-warm-text">{t("stream.stats.waitingForVideo")}</p>
     </div>
   );
 }
@@ -625,7 +463,61 @@ export function StreamView({
     diagnosticsStore,
     (stats) => stats.nativeRendererActive,
   );
-  const showStatsHud = showStats && !nativeRendererActive && !isConnecting;
+  const localVideoRef = useRef<HTMLVideoElement | null>(null);
+  const streamHasVideo = useStreamDiagnosticsSelector(
+    diagnosticsStore,
+    (stats) => hasVisibleStreamVideo(stats),
+  );
+  const [videoElementHasFrame, setVideoElementHasFrame] = useState(false);
+
+  useEffect(() => {
+    if (isConnecting) {
+      setVideoElementHasFrame(false);
+      return undefined;
+    }
+
+    const video = localVideoRef.current;
+    if (!video) {
+      return undefined;
+    }
+
+    const syncVideoFrame = (): void => {
+      setVideoElementHasFrame(video.videoWidth > 0 && video.videoHeight > 0);
+    };
+
+    syncVideoFrame();
+    video.addEventListener("loadeddata", syncVideoFrame);
+    video.addEventListener("playing", syncVideoFrame);
+    video.addEventListener("resize", syncVideoFrame);
+
+    return () => {
+      video.removeEventListener("loadeddata", syncVideoFrame);
+      video.removeEventListener("playing", syncVideoFrame);
+      video.removeEventListener("resize", syncVideoFrame);
+    };
+  }, [isConnecting]);
+
+  const streamVideoReady = streamHasVideo || videoElementHasFrame;
+  const [sessionReadySplashVisible, setSessionReadySplashVisible] = useState(false);
+  const sessionReadySplashShownRef = useRef(false);
+  const showStatsHud = showStats && !nativeRendererActive && !isConnecting && !sessionReadySplashVisible;
+
+  useEffect(() => {
+    if (isConnecting) {
+      sessionReadySplashShownRef.current = false;
+      setSessionReadySplashVisible(false);
+      return;
+    }
+    if (nativeRendererActive || !streamVideoReady || sessionReadySplashShownRef.current) {
+      return;
+    }
+    sessionReadySplashShownRef.current = true;
+    setSessionReadySplashVisible(true);
+  }, [isConnecting, nativeRendererActive, streamVideoReady]);
+
+  const handleSessionReadySplashFinished = useCallback(() => {
+    setSessionReadySplashVisible(false);
+  }, []);
 
   // Recording state
   const [isRecording, setIsRecording] = useState(false);
@@ -760,8 +652,6 @@ export function StreamView({
   const PlatformIcon = platformStore ? getStoreIconComponent(platformStore) : null;
   const isMacClient = navigator.platform?.toLowerCase().includes("mac") || navigator.userAgent.includes("Macintosh");
 
-  // Local ref for video element to manage focus
-  const localVideoRef = useRef<HTMLVideoElement | null>(null);
   // Local ref for audio element (game audio stream)
   const localAudioRef = useRef<HTMLAudioElement | null>(null);
   // AudioContext used during an active recording (torn down on stop/error)
@@ -2021,6 +1911,7 @@ export function StreamView({
 
       {/* Gradient background when no video */}
       <StreamEmptyState diagnosticsStore={diagnosticsStore} />
+      <StreamWaitingForVideo diagnosticsStore={diagnosticsStore} isConnecting={isConnecting} />
 
       {/* Connecting overlay */}
       {isConnecting && (
@@ -2071,15 +1962,24 @@ export function StreamView({
         </div>
       )}
 
-      {/* Stats HUD (top-right) */}
-      {(showStatsHud || showStats) && !isConnecting && (
-        <StreamStatsHud
-          diagnosticsStore={diagnosticsStore}
-          gstreamerEnabled={gstreamerEnabled}
-          serverRegion={serverRegion}
-          sessionTimeRemainingText={showSessionTimeRemainingInStats ? sessionTimeRemainingText : null}
-        />
-      )}
+      <SessionStartedSplash
+        visible={sessionReadySplashVisible && !isConnecting}
+        gameTitle={gameTitle}
+        onFinished={handleSessionReadySplashFinished}
+      />
+
+      <AnimatePresence>
+        {showStatsHud && (
+          <StreamStatsHud
+            key="stream-stats-hud"
+            diagnosticsStore={diagnosticsStore}
+            gstreamerEnabled={gstreamerEnabled}
+            serverRegion={serverRegion}
+            sessionTimeRemainingText={showSessionTimeRemainingInStats ? sessionTimeRemainingText : null}
+            hintsVisible={showHints}
+          />
+        )}
+      </AnimatePresence>
 
       {/* Microphone toggle button */}
       <MicrophoneIndicator

--- a/opennow-stable/src/renderer/src/gfn/sdp.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.test.ts
@@ -12,7 +12,7 @@ import {
   rewriteH265TierFlag,
 } from "./sdp";
 
-test("fixServerIp replaces 0.0.0.0 connection and candidate IPs from GFN dashed hostnames", () => {
+test("fixServerIp replaces 0.0.0.0 candidate IPs without changing connection lines", () => {
   const sdp = [
     "v=0",
     "c=IN IP4 0.0.0.0",
@@ -22,7 +22,7 @@ test("fixServerIp replaces 0.0.0.0 connection and candidate IPs from GFN dashed 
 
   const fixed = fixServerIp(sdp, "161-248-11-132.bpc.geforcenow.nvidiagrid.net");
 
-  assert.match(fixed, /c=IN IP4 161\.248\.11\.132/);
+  assert.match(fixed, /c=IN IP4 0\.0\.0\.0/);
   assert.match(fixed, /a=candidate:1 1 udp 2130706431 161\.248\.11\.132 47998 typ host/);
   assert.match(fixed, /a=candidate:2 1 tcp 1 192\.168\.1\.5 9 typ host/);
   assert.equal(fixServerIp(sdp, "unparseable.example.com"), sdp);

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -40,10 +40,12 @@ export function extractPublicIp(hostOrIp: string): string | null {
 }
 
 /**
- * Fix 0.0.0.0 in the server's SDP offer with the actual server IP.
- * Matches Rust's fix_server_ip() — replaces "c=IN IP4 0.0.0.0" with real IP.
- * Also fixes a=candidate: lines that contain 0.0.0.0 as the candidate IP,
- * since Chrome's WebRTC stack treats those as unreachable and ICE fails.
+ * Fix 0.0.0.0 ICE candidate addresses with the actual server IP.
+ *
+ * The official GFN web client leaves c=IN IP4 0.0.0.0 lines intact and only
+ * rewrites a=candidate lines when an explicit WebRTC media endpoint is present.
+ * Rewriting every c= line to an RTSPS/session host can make DTLS close before
+ * media tracks arrive.
  */
 export function fixServerIp(sdp: string, serverIp: string): string {
   const ip = extractPublicIp(serverIp);
@@ -51,14 +53,8 @@ export function fixServerIp(sdp: string, serverIp: string): string {
     console.log(`[SDP] fixServerIp: could not extract IP from "${serverIp}"`);
     return sdp;
   }
-  // 1. Fix connection lines: c=IN IP4 0.0.0.0
-  const cCount = (sdp.match(/c=IN IP4 0\.0\.0\.0/g) ?? []).length;
-  let fixed = sdp.replace(/c=IN IP4 0\.0\.0\.0/g, `c=IN IP4 ${ip}`);
-  console.log(`[SDP] fixServerIp: replaced ${cCount} c= lines with ${ip}`);
-
-  // 2. Fix ICE candidate lines: a=candidate:... 0.0.0.0 ...
-  //    Format: a=candidate:<foundation> <component> <protocol> <priority> <ip> <port> typ <type>
-  const candidateCount = (fixed.match(/(a=candidate:\S+\s+\d+\s+\w+\s+\d+\s+)0\.0\.0\.0(\s+)/g) ?? []).length;
+  let fixed = sdp;
+  const candidateCount = (sdp.match(/(a=candidate:\S+\s+\d+\s+\w+\s+\d+\s+)0\.0\.0\.0(\s+)/g) ?? []).length;
   if (candidateCount > 0) {
     fixed = fixed.replace(
       /(a=candidate:\S+\s+\d+\s+\w+\s+\d+\s+)0\.0\.0\.0(\s+)/g,
@@ -471,7 +467,8 @@ export function buildNvstSdp(params: NvstParams): string {
   const is120Fps = params.fps === 120;
   const is240Fps = params.fps >= 240;
   const isAv1 = params.codec === "AV1";
-  const bitDepth = params.colorQuality.startsWith("10bit") ? 10 : 8;
+  const supportsHighBitDepth = params.codec === "H265" || params.codec === "AV1";
+  const bitDepth = supportsHighBitDepth && params.colorQuality.startsWith("10bit") ? 10 : 8;
   const hidDeviceMask = params.hidDeviceMask ?? PARTIALLY_RELIABLE_HID_DEVICE_MASK_ALL;
   const enablePartiallyReliableTransferGamepad = params.enablePartiallyReliableTransferGamepad
     ?? PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL;

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -34,8 +34,6 @@ import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "./keyboardLock";
 import {
   buildNvstSdp,
   extractIceCredentials,
-  extractIceUfragFromOffer,
-  extractPublicIp,
   fixServerIp,
   mungeAnswerSdp,
   preferCodec,
@@ -4215,6 +4213,14 @@ export class GfnWebRtcClient {
     this.installInputCapture(this.options.videoElement);
     this.setupStatsPolling();
 
+    let answerSent = false;
+    const queuedLocalIce: IceCandidatePayload[] = [];
+    const sendLocalIce = (candidate: IceCandidatePayload): void => {
+      window.openNow.sendIceCandidate(candidate).catch((error) => {
+        this.log(`Failed to send local ICE candidate: ${String(error)}`);
+      });
+    };
+
     pc.onicecandidate = (event) => {
       if (!event.candidate) {
         this.log("ICE gathering complete (null candidate)");
@@ -4231,9 +4237,12 @@ export class GfnWebRtcClient {
         sdpMLineIndex: payload.sdpMLineIndex,
         usernameFragment: payload.usernameFragment,
       };
-      window.openNow.sendIceCandidate(candidate).catch((error) => {
-        this.log(`Failed to send local ICE candidate: ${String(error)}`);
-      });
+      if (!answerSent) {
+        queuedLocalIce.push(candidate);
+        this.log("Queued local ICE candidate until answer is sent");
+        return;
+      }
+      sendLocalIce(candidate);
     };
 
     pc.onconnectionstatechange = () => {
@@ -4299,7 +4308,11 @@ export class GfnWebRtcClient {
 
     // 1. Fix 0.0.0.0 in server's SDP offer with real server IP
     //    The GFN server sends c=IN IP4 0.0.0.0; replace with actual IP
-    const serverIpForSdp = session.mediaConnectionInfo?.ip || session.serverIp || "";
+    const webRtcMediaConnection =
+      session.mediaConnectionInfo?.usage === 2 || session.mediaConnectionInfo?.usage === 17
+        ? session.mediaConnectionInfo
+        : undefined;
+    const serverIpForSdp = webRtcMediaConnection?.ip ?? "";
     let processedOffer = offerSdp;
     if (serverIpForSdp) {
       processedOffer = fixServerIp(processedOffer, serverIpForSdp);
@@ -4309,11 +4322,11 @@ export class GfnWebRtcClient {
       if (remaining > 0) {
         this.log(`Warning: ${remaining} occurrences of 0.0.0.0 still remain in SDP after fix`);
       }
+    } else if (session.mediaConnectionInfo) {
+      this.log(
+        `Skipping SDP ICE rewrite for mediaConnectionInfo usage=${session.mediaConnectionInfo.usage ?? "unknown"} (${session.mediaConnectionInfo.ip}:${session.mediaConnectionInfo.port})`,
+      );
     }
-
-    // 2. Extract server's ice-ufrag BEFORE any modifications (needed for manual candidate injection)
-    const serverIceUfrag = extractIceUfragFromOffer(processedOffer);
-    this.log(`Server ICE ufrag: "${serverIceUfrag}"`);
 
     const preferredHevcProfileId = hevcPreferredProfileId(settings.colorQuality);
 
@@ -4399,10 +4412,13 @@ export class GfnWebRtcClient {
     }
 
     await pc.setLocalDescription(answer);
-    this.log("Local description set, waiting for ICE gathering...");
+    this.log("Local description set; sending answer before ICE gathering completes");
 
-    const finalSdp = await this.waitForIceGathering(pc, 5000);
-    this.log(`ICE gathering done, final SDP length: ${finalSdp.length} chars`);
+    const finalSdp = pc.localDescription?.sdp ?? answer.sdp;
+    if (!finalSdp) {
+      throw new Error("Missing local SDP after setLocalDescription");
+    }
+    this.log(`Immediate local SDP length: ${finalSdp.length} chars`);
 
     // Debug negotiated video codec/fmtp lines from local answer SDP
     {
@@ -4463,55 +4479,31 @@ export class GfnWebRtcClient {
       nvstSdp,
     });
     this.log("Sent SDP answer and nvstSdp");
-
-    // 5. Inject manual ICE candidate from mediaConnectionInfo AFTER answer is sent
-    //    (matches Rust reference ordering — full SDP exchange completes first)
-    //    GFN servers use ice-lite and may not trickle candidates via signaling.
-    //    The actual media endpoint comes from the session's connectionInfo array.
-    if (session.mediaConnectionInfo) {
-      const mci = session.mediaConnectionInfo;
-      const rawIp = extractPublicIp(mci.ip);
-      if (rawIp && mci.port > 0) {
-        const candidateStr = `candidate:1 1 udp 2130706431 ${rawIp} ${mci.port} typ host`;
-        this.log(`Injecting manual ICE candidate: ${rawIp}:${mci.port}`);
-
-        // Try sdpMid "0" first, then "1", "2", "3" (matching Rust fallback)
-        const mids = ["0", "1", "2", "3"];
-        let injected = false;
-        for (const mid of mids) {
-          try {
-            await pc.addIceCandidate({
-              candidate: candidateStr,
-              sdpMid: mid,
-              sdpMLineIndex: parseInt(mid, 10),
-              usernameFragment: serverIceUfrag || undefined,
-            });
-            this.log(`Manual ICE candidate injected (sdpMid=${mid})`);
-            injected = true;
-            break;
-          } catch (error) {
-            this.log(`Manual ICE candidate failed for sdpMid=${mid}: ${String(error)}`);
-          }
-        }
-        if (!injected) {
-          this.log("Warning: Could not inject manual ICE candidate on any sdpMid");
-        }
-      } else {
-        this.log(`Warning: mediaConnectionInfo present but no valid IP (ip=${mci.ip}, port=${mci.port})`);
+    answerSent = true;
+    if (queuedLocalIce.length > 0) {
+      this.log(`Flushing ${queuedLocalIce.length} queued local ICE candidates after answer`);
+      for (const candidate of queuedLocalIce.splice(0)) {
+        sendLocalIce(candidate);
       }
-    } else {
-      this.log("No mediaConnectionInfo available — relying on trickle ICE only");
     }
+
+    // Recent GFN browser runtimes rely on the server-provided trickled ICE
+    // candidate. Injecting mediaConnectionInfo as a higher-priority fallback can
+    // make Chromium pick an RTSPS endpoint that connects but never delivers frames.
+    this.log("Waiting for server-provided ICE candidates");
 
     this.log("=== handleOffer COMPLETE — waiting for ICE connectivity and tracks ===");
   }
 
   async addRemoteCandidate(candidate: IceCandidatePayload): Promise<void> {
-    this.log(`Remote ICE candidate received: ${candidate.candidate} (sdpMid=${candidate.sdpMid})`);
+    const sdpMLineIndex = candidate.sdpMLineIndex ?? (candidate.sdpMid == null ? 0 : undefined);
+    this.log(
+      `Remote ICE candidate received: ${candidate.candidate} (sdpMid=${candidate.sdpMid}, sdpMLineIndex=${sdpMLineIndex})`,
+    );
     const init: RTCIceCandidateInit = {
       candidate: candidate.candidate,
       sdpMid: candidate.sdpMid ?? undefined,
-      sdpMLineIndex: candidate.sdpMLineIndex ?? undefined,
+      sdpMLineIndex,
       usernameFragment: candidate.usernameFragment ?? undefined,
     };
 

--- a/opennow-stable/src/renderer/src/lib/catalogSnapshot.ts
+++ b/opennow-stable/src/renderer/src/lib/catalogSnapshot.ts
@@ -1,0 +1,80 @@
+import type { CatalogBrowseResult, CatalogFilterGroup, CatalogSortOption, GameInfo } from "@shared/gfn";
+
+const CATALOG_SNAPSHOT_KEY = "opennow.catalogSnapshot.v1";
+
+export interface CatalogSnapshot {
+  version: 1;
+  userId: string;
+  streamingBaseUrl: string;
+  queryKey: string;
+  games: GameInfo[];
+  libraryGames: GameInfo[];
+  filterGroups: CatalogFilterGroup[];
+  sortOptions: CatalogSortOption[];
+  totalCount: number;
+  supportedCount: number;
+  savedAt: number;
+}
+
+export function buildCatalogQueryKey(
+  searchQuery: string,
+  filterIds: string[],
+  sortId: string,
+): string {
+  return `${searchQuery.trim()}|${filterIds.join("|")}|${sortId}`;
+}
+
+export function loadCatalogSnapshot(
+  userId: string,
+  streamingBaseUrl: string,
+  queryKey: string,
+): CatalogSnapshot | null {
+  try {
+    const raw = localStorage.getItem(CATALOG_SNAPSHOT_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<CatalogSnapshot>;
+    if (
+      parsed.version !== 1
+      || parsed.userId !== userId
+      || parsed.streamingBaseUrl !== streamingBaseUrl
+      || parsed.queryKey !== queryKey
+      || !Array.isArray(parsed.games)
+      || parsed.games.length === 0
+    ) {
+      return null;
+    }
+
+    return {
+      version: 1,
+      userId: parsed.userId,
+      streamingBaseUrl: parsed.streamingBaseUrl,
+      queryKey: parsed.queryKey,
+      games: parsed.games,
+      libraryGames: Array.isArray(parsed.libraryGames) ? parsed.libraryGames : [],
+      filterGroups: Array.isArray(parsed.filterGroups) ? parsed.filterGroups : [],
+      sortOptions: Array.isArray(parsed.sortOptions) ? parsed.sortOptions : [],
+      totalCount: typeof parsed.totalCount === "number" ? parsed.totalCount : parsed.games.length,
+      supportedCount: typeof parsed.supportedCount === "number" ? parsed.supportedCount : parsed.games.length,
+      savedAt: typeof parsed.savedAt === "number" ? parsed.savedAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveCatalogSnapshot(snapshot: CatalogSnapshot): void {
+  try {
+    localStorage.setItem(CATALOG_SNAPSHOT_KEY, JSON.stringify(snapshot));
+  } catch (error) {
+    console.warn("Failed to persist catalog snapshot:", error);
+  }
+}
+
+export function clearCatalogSnapshot(): void {
+  try {
+    localStorage.removeItem(CATALOG_SNAPSHOT_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/opennow-stable/src/renderer/src/lib/catalogSnapshot.ts
+++ b/opennow-stable/src/renderer/src/lib/catalogSnapshot.ts
@@ -1,4 +1,4 @@
-import type { CatalogBrowseResult, CatalogFilterGroup, CatalogSortOption, GameInfo } from "@shared/gfn";
+import type { CatalogFilterGroup, CatalogSortOption, GameInfo } from "@shared/gfn";
 
 const CATALOG_SNAPSHOT_KEY = "opennow.catalogSnapshot.v1";
 

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -6391,46 +6391,169 @@ button.game-card-store-chip.owned.active:hover {
   z-index: 1001;
   display: flex;
   flex-direction: column;
-  gap: 5px;
-  padding: 8px 10px;
-  background: rgba(10, 10, 12, 0.9);
+  gap: 0;
+  min-width: 220px;
+  max-width: min(92vw, 340px);
+  font-variant-numeric: tabular-nums;
   border: 1px solid var(--panel-border);
   border-radius: var(--r-md);
-  font-size: 0.7rem;
-  min-width: 260px;
-  max-width: 380px;
-  font-variant-numeric: tabular-nums;
-  backdrop-filter: blur(4px);
+  background: rgba(10, 10, 12, 0.9);
+  backdrop-filter: blur(6px);
+  overflow: hidden;
+  transition: bottom 420ms var(--ease), border-color 320ms var(--ease), box-shadow 320ms var(--ease);
 }
 
-.sv-stats-head {
+.sv-stats--hints {
+  bottom: 118px;
+}
+
+.sv-stats--warn {
+  border-color: color-mix(in srgb, var(--warning) 35%, var(--panel-border));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--warning) 12%, transparent);
+}
+
+.sv-stats--expanded {
+  max-width: min(92vw, 380px);
+}
+
+.sv-stats-toggle {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 8px;
-  font-weight: 700;
-  color: var(--ink);
-  font-size: 0.75rem;
-  line-height: 1.1;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sv-stats-toggle:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent-surface);
+}
+
+.sv-stats-toggle-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
 }
 
 .sv-stats-primary {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.sv-stats-wait {
+.sv-stats-toggle-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.sv-stats-kpi {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+}
+
+.sv-stats-kpi-label {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--ink-muted);
-  font-style: italic;
-  font-weight: 500;
+}
+
+.sv-stats-kpi-val {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--ink-soft);
+  transition: color 320ms var(--ease);
+}
+
+.sv-stats-kpi-val--rtt {
+  color: var(--ink-soft);
+}
+
+.sv-stats-kpi-divider {
+  width: 1px;
+  height: 12px;
+  background: color-mix(in srgb, var(--ink-muted) 35%, transparent);
+  flex-shrink: 0;
+}
+
+.sv-stats-toggle-trail {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.sv-stats-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-muted);
+}
+
+.sv-stats-alert-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--warning);
+  animation: sv-stats-pulse 1.6s ease-in-out infinite;
+}
+
+.sv-stats-warn-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0 10px 8px;
+  overflow: hidden;
+}
+
+.sv-stats-warn-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--warning) 45%, var(--panel-border));
+  background: color-mix(in srgb, var(--warning) 10%, transparent);
+  color: var(--warning);
+  font-size: 0.62rem;
+  font-weight: 700;
+}
+
+.sv-stats-details {
+  overflow: hidden;
+}
+
+.sv-stats-details-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 10px 10px;
+  border-top: 1px solid color-mix(in srgb, var(--ink-muted) 18%, transparent);
 }
 
 .sv-stats-live {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 40px;
+  min-width: 36px;
   padding: 1px 7px;
   border-radius: 999px;
   font-size: 0.62rem;
@@ -6438,6 +6561,7 @@ button.game-card-store-chip.owned.active:hover {
   border: 1px solid var(--panel-border);
   color: var(--ink-soft);
   background: rgba(255, 255, 255, 0.03);
+  transition: color 320ms var(--ease), border-color 320ms var(--ease), background 320ms var(--ease);
 }
 
 .sv-stats-live.is-live {
@@ -6465,11 +6589,7 @@ button.game-card-store-chip.owned.active:hover {
   align-items: center;
   gap: 6px;
   color: var(--ink-soft);
-}
-
-.sv-stats-sub-right {
-  color: var(--ink);
-  font-weight: 600;
+  font-size: 0.68rem;
 }
 
 .sv-stats-hdr {
@@ -6501,9 +6621,15 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--ink-muted);
 }
 
+.sv-stats-chip--warn {
+  border-color: color-mix(in srgb, var(--warning) 40%, var(--panel-border));
+  background: color-mix(in srgb, var(--warning) 8%, transparent);
+}
+
 .sv-stats-chip-val {
   font-weight: 700;
   color: var(--ink-soft);
+  transition: color 320ms var(--ease);
 }
 
 .sv-stats-chip--time {
@@ -6516,12 +6642,178 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--accent);
 }
 
+.sv-stats-advanced {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sv-stats-advanced-toggle {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--ink-muted);
+  font: inherit;
+  font-size: 0.64rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color var(--t-fast);
+}
+
+.sv-stats-advanced-toggle:hover {
+  color: var(--ink-soft);
+}
+
+.sv-stats-advanced-toggle:focus-visible {
+  outline: none;
+  color: var(--accent);
+}
+
+.sv-stats-advanced-body {
+  overflow: hidden;
+}
+
 .sv-stats-foot {
+  margin: 0;
   font-size: 0.64rem;
   color: var(--ink-muted);
-  white-space: nowrap;
+  line-height: 1.35;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+@keyframes sv-stats-pulse {
+
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.55;
+    transform: scale(0.92);
+  }
+}
+
+/* Session ready splash */
+.sv-ready-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 1005;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.sv-ready-splash-backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(var(--accent-rgb), 0.2), transparent 55%),
+    linear-gradient(180deg, rgba(8, 9, 11, 0.38), rgba(8, 9, 11, 0.58));
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.sv-ready-splash-card {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  max-width: min(88vw, 420px);
+  padding: 28px 34px 30px;
+  text-align: center;
+}
+
+.sv-ready-splash-ring {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  margin-bottom: 4px;
+}
+
+.sv-ready-splash-ring-core,
+.sv-ready-splash-ring-pulse {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+}
+
+.sv-ready-splash-ring-core {
+  border: 2px solid color-mix(in srgb, var(--accent) 70%, transparent);
+  box-shadow: 0 0 24px rgba(var(--accent-rgb), 0.35);
+}
+
+.sv-ready-splash-ring-pulse {
+  border: 1px solid rgba(var(--accent-rgb), 0.45);
+  animation: sv-ready-ring 1.8s ease-out infinite;
+}
+
+.sv-ready-splash-kicker {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.sv-ready-splash-title {
+  margin: 0;
+  font-size: clamp(1.35rem, 4vw, 1.85rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  text-wrap: balance;
+}
+
+.sv-ready-splash-game {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  text-wrap: pretty;
+}
+
+@keyframes sv-ready-ring {
+  0% {
+    transform: scale(0.82);
+    opacity: 0.85;
+  }
+
+  100% {
+    transform: scale(1.45);
+    opacity: 0;
+  }
+}
+
+.sv-warm {
+  position: absolute;
+  inset: 0;
+  z-index: 12;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  pointer-events: none;
+  animation: fade-in 280ms var(--ease);
+}
+
+.sv-warm-spin {
+  color: var(--accent);
+  animation: spin 1s linear infinite;
+}
+
+.sv-warm-text {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--ink-soft);
 }
 
 .sv-afk {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3626,9 +3626,9 @@ button.game-card-store-chip.owned.active:hover {
 
 
 /* ======================================================
-   SETTINGS PAGE — modal preferences panel
+   ANIMATED MODAL — shared Motion overlay shell
    ====================================================== */
-.settings-overlay {
+.animated-modal-overlay {
   position: fixed;
   inset: 0;
   z-index: 3100;
@@ -3638,14 +3638,28 @@ button.game-card-store-chip.owned.active:hover {
   padding: 28px 36px;
 }
 
-.settings-overlay-backdrop {
+.animated-modal-scrim {
   position: absolute;
   inset: 0;
   border: none;
-  background: rgba(6, 7, 9, 0.72);
+  padding: 0;
+  margin: 0;
+  background-color: rgba(6, 7, 9, 0.72);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   cursor: pointer;
+}
+
+.settings-modal-placeholder {
+  flex: 1;
+  min-height: 0;
+}
+
+.animated-modal-panel {
+  position: relative;
+  z-index: 1;
+  transform: translateZ(0);
+  backface-visibility: hidden;
 }
 
 .settings-modal {
@@ -3663,9 +3677,7 @@ button.game-card-store-chip.owned.active:hover {
     var(--shadow-lg),
     0 0 0 1px rgba(255, 255, 255, 0.03) inset;
   overflow: hidden;
-  transform: translate3d(0, 0, 0);
-  backface-visibility: hidden;
-  will-change: transform, opacity;
+  contain: layout style paint;
 }
 
 .settings-modal-header {
@@ -6124,6 +6136,11 @@ button.game-card-store-chip.owned.active:hover {
   transition: opacity 300ms ease;
 }
 
+.sv:focus,
+.sv:focus-within {
+  outline: none;
+}
+
 .sv--switching {
   opacity: 0;
   pointer-events: none;
@@ -6137,12 +6154,17 @@ button.game-card-store-chip.owned.active:hover {
   position: relative;
   z-index: 1;
   outline: none;
+  border: none;
+  box-shadow: none;
 }
 
 .sv-video:focus,
-.sv-video:focus-visible {
-  outline: none;
-  box-shadow: none;
+.sv-video:focus-visible,
+.sv-video:focus-within {
+  outline: none !important;
+  outline-offset: 0;
+  border: none;
+  box-shadow: none !important;
 }
 
 .sv-empty {
@@ -6705,17 +6727,57 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 24px;
   pointer-events: none;
 }
 
 .sv-ready-splash-backdrop {
   position: absolute;
   inset: 0;
+  overflow: hidden;
   background:
-    radial-gradient(circle at 50% 42%, rgba(var(--accent-rgb), 0.2), transparent 55%),
-    linear-gradient(180deg, rgba(8, 9, 11, 0.38), rgba(8, 9, 11, 0.58));
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+    radial-gradient(circle at 50% 38%, rgba(var(--accent-rgb), 0.16), transparent 52%),
+    radial-gradient(circle at 50% 100%, rgba(0, 0, 0, 0.45), transparent 58%),
+    linear-gradient(180deg, rgba(6, 7, 9, 0.42), rgba(6, 7, 9, 0.72));
+  backdrop-filter: blur(6px) saturate(1.15);
+  -webkit-backdrop-filter: blur(6px) saturate(1.15);
+  animation: sv-ready-backdrop-breathe 3.2s ease-in-out infinite;
+}
+
+.sv-ready-splash-orb {
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(28px);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.sv-ready-splash-orb--a {
+  width: 220px;
+  height: 220px;
+  top: 18%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(var(--accent-rgb), 0.28);
+  animation: sv-ready-orb-drift-a 4.8s ease-in-out infinite;
+}
+
+.sv-ready-splash-orb--b {
+  width: 140px;
+  height: 140px;
+  bottom: 16%;
+  left: 22%;
+  background: rgba(var(--accent-rgb), 0.14);
+  animation: sv-ready-orb-drift-b 5.6s ease-in-out infinite;
+}
+
+.sv-ready-splash-orb--c {
+  width: 120px;
+  height: 120px;
+  top: 28%;
+  right: 18%;
+  background: rgba(96, 165, 250, 0.12);
+  animation: sv-ready-orb-drift-c 6.2s ease-in-out infinite;
 }
 
 .sv-ready-splash-card {
@@ -6724,70 +6786,223 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  max-width: min(88vw, 420px);
-  padding: 28px 34px 30px;
+  gap: 14px;
+  width: min(100%, 440px);
+  padding: 30px 34px 26px;
   text-align: center;
+  border-radius: var(--r-xl);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--panel-border));
+  background:
+    linear-gradient(165deg, rgba(18, 19, 22, 0.94), rgba(10, 10, 12, 0.88));
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset,
+    0 24px 70px rgba(0, 0, 0, 0.55),
+    0 0 48px rgba(var(--accent-rgb), 0.12);
+  overflow: hidden;
+}
+
+.sv-ready-splash-card-glow {
+  position: absolute;
+  inset: -40% -20% auto;
+  height: 62%;
+  background: radial-gradient(circle at 50% 100%, rgba(var(--accent-rgb), 0.22), transparent 68%);
+  pointer-events: none;
+}
+
+.sv-ready-splash-card-shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 42%,
+    rgba(255, 255, 255, 0.07) 50%,
+    transparent 58%
+  );
+  transform: translateX(-120%);
+  animation: sv-ready-shimmer 1.1s var(--ease) 0.85s forwards;
+  pointer-events: none;
+}
+
+.sv-ready-splash-emblem {
+  position: relative;
+  width: 84px;
+  height: 84px;
+  margin-bottom: 2px;
 }
 
 .sv-ready-splash-ring {
-  position: relative;
-  width: 72px;
-  height: 72px;
-  margin-bottom: 4px;
-}
-
-.sv-ready-splash-ring-core,
-.sv-ready-splash-ring-pulse {
   position: absolute;
   inset: 0;
   border-radius: 999px;
+  border: 1px solid rgba(var(--accent-rgb), 0.35);
 }
 
-.sv-ready-splash-ring-core {
-  border: 2px solid color-mix(in srgb, var(--accent) 70%, transparent);
-  box-shadow: 0 0 24px rgba(var(--accent-rgb), 0.35);
+.sv-ready-splash-ring--outer {
+  animation: sv-ready-ring 2.4s ease-out infinite;
 }
 
-.sv-ready-splash-ring-pulse {
-  border: 1px solid rgba(var(--accent-rgb), 0.45);
-  animation: sv-ready-ring 1.8s ease-out infinite;
+.sv-ready-splash-ring--mid {
+  animation: sv-ready-ring 2.4s ease-out 0.55s infinite;
+}
+
+.sv-ready-splash-ring--inner {
+  animation: sv-ready-ring 2.4s ease-out 1.1s infinite;
+}
+
+.sv-ready-splash-emblem-core {
+  position: absolute;
+  inset: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  color: var(--accent-on);
+  background:
+    radial-gradient(circle at 30% 24%, rgba(255, 255, 255, 0.22), transparent 42%),
+    linear-gradient(145deg, var(--accent-hover), var(--accent-press));
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.12) inset,
+    0 10px 28px rgba(var(--accent-rgb), 0.35);
+  animation: sv-ready-emblem-pop 0.65s var(--ease) 0.18s both;
+}
+
+.sv-ready-splash-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
 }
 
 .sv-ready-splash-kicker {
   margin: 0;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
   color: var(--accent);
 }
 
 .sv-ready-splash-title {
   margin: 0;
-  font-size: clamp(1.35rem, 4vw, 1.85rem);
+  max-width: 24ch;
+  font-size: clamp(1.45rem, 4.2vw, 2rem);
   font-weight: 600;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
   color: var(--ink);
   text-wrap: balance;
 }
 
 .sv-ready-splash-game {
   margin: 0;
-  font-size: 0.92rem;
+  max-width: 40ch;
+  font-size: 0.95rem;
   color: var(--ink-soft);
   text-wrap: pretty;
 }
 
+.sv-ready-splash-progress {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 3px;
+  transform-origin: left center;
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+  box-shadow: 0 0 14px rgba(var(--accent-rgb), 0.45);
+  animation-name: sv-ready-progress;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
+@keyframes sv-ready-backdrop-breathe {
+  0%,
+  100% {
+    filter: brightness(1);
+  }
+
+  50% {
+    filter: brightness(1.08);
+  }
+}
+
+@keyframes sv-ready-orb-drift-a {
+  0%,
+  100% {
+    transform: translateX(-50%) translateY(0);
+  }
+
+  50% {
+    transform: translateX(-46%) translateY(12px);
+  }
+}
+
+@keyframes sv-ready-orb-drift-b {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+
+  50% {
+    transform: translate(18px, -10px);
+  }
+}
+
+@keyframes sv-ready-orb-drift-c {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+
+  50% {
+    transform: translate(-14px, 16px);
+  }
+}
+
 @keyframes sv-ready-ring {
   0% {
-    transform: scale(0.82);
-    opacity: 0.85;
+    transform: scale(0.76);
+    opacity: 0.75;
   }
 
   100% {
-    transform: scale(1.45);
+    transform: scale(1.55);
     opacity: 0;
+  }
+}
+
+@keyframes sv-ready-emblem-pop {
+  0% {
+    transform: scale(0.72);
+    opacity: 0;
+  }
+
+  65% {
+    transform: scale(1.06);
+    opacity: 1;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes sv-ready-shimmer {
+  0% {
+    transform: translateX(-120%);
+  }
+
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+@keyframes sv-ready-progress {
+  from {
+    transform: scaleX(1);
+  }
+
+  to {
+    transform: scaleX(0);
   }
 }
 
@@ -7112,6 +7327,12 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--accent);
 }
 
+.sv-fs:focus,
+.sv-fs:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
 /* End session button */
 .sv-end {
   position: fixed;
@@ -7137,6 +7358,12 @@ button.game-card-store-chip.owned.active:hover {
   background: rgba(180, 30, 30, 0.9);
   border-color: var(--error);
   color: #fff;
+}
+
+.sv-end:focus,
+.sv-end:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 /* Keyboard hints */
@@ -8690,6 +8917,10 @@ button.game-card-store-chip.owned.active:hover {
     animation-name: spin !important;
     animation-duration: 1s !important;
     animation-iteration-count: infinite !important;
+  }
+
+  .animated-modal-scrim {
+    background-color: rgba(6, 7, 9, 0.72);
   }
 }
 

--- a/opennow-stable/src/shared/gfn.test.ts
+++ b/opennow-stable/src/shared/gfn.test.ts
@@ -14,6 +14,8 @@ import {
   isOwnedLibraryStatus,
   isOwnedVariant,
   NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+  getDefaultStreamPreferences,
+  normalizeStreamPreferences,
   normalizeStreamClientModeForPlatform,
 } from "./gfn";
 
@@ -176,6 +178,26 @@ test("normalizes native stream client mode to web on non-Windows platforms", () 
   assert.equal(normalizeStreamClientModeForPlatform("native", "darwin"), "web");
   assert.equal(normalizeStreamClientModeForPlatform("web", "linux"), "web");
   assert.equal(normalizeStreamClientModeForPlatform("native", "win32"), "native");
+});
+
+test("defaults H264 streaming to 8-bit SDR-compatible color quality", () => {
+  assert.deepEqual(getDefaultStreamPreferences(), {
+    codec: "H264",
+    colorQuality: "8bit_420",
+  });
+});
+
+test("normalizes H264 stream preferences away from high bit-depth modes", () => {
+  assert.deepEqual(normalizeStreamPreferences("H264", "10bit_420"), {
+    codec: "H264",
+    colorQuality: "8bit_420",
+    migrated: true,
+  });
+  assert.deepEqual(normalizeStreamPreferences("H265", "10bit_420"), {
+    codec: "H265",
+    colorQuality: "10bit_420",
+    migrated: false,
+  });
 });
 
 test("uses the exact Windows-only unsupported native streamer status message", () => {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -115,11 +115,12 @@ export function normalizeStreamPreferences(codec: VideoCodec, colorQuality: Colo
   const normalizedColorQuality = USER_FACING_COLOR_QUALITY_OPTIONS.includes(colorQuality)
     ? colorQuality
     : USER_FACING_COLOR_QUALITY_OPTIONS[0];
+  const codecCompatibleColorQuality = normalizedCodec === "H264" ? "8bit_420" : normalizedColorQuality;
 
   return {
     codec: normalizedCodec,
-    colorQuality: normalizedColorQuality,
-    migrated: normalizedCodec !== codec || normalizedColorQuality !== colorQuality,
+    colorQuality: codecCompatibleColorQuality,
+    migrated: normalizedCodec !== codec || codecCompatibleColorQuality !== colorQuality,
   };
 }
 
@@ -318,7 +319,7 @@ export interface Settings {
 
 export const DEFAULT_STREAM_PREFERENCES: Readonly<Pick<Settings, "codec" | "colorQuality">> = Object.freeze({
   codec: "H264",
-  colorQuality: "10bit_420",
+  colorQuality: "8bit_420",
 });
 
 export function getDefaultStreamPreferences(): Pick<Settings, "codec" | "colorQuality"> {
@@ -795,6 +796,7 @@ export interface IceServer {
 export interface MediaConnectionInfo {
   ip: string;
   port: number;
+  usage?: number;
 }
 
 /** Server-negotiated stream profile received from CloudMatch after session ready */

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -514,6 +514,8 @@ export interface PingResult {
 export interface GamesFetchRequest {
   token?: string;
   providerStreamingBaseUrl?: string;
+  /** Stable account id used for on-disk cache scoping (avoids cache misses on token refresh). */
+  userId?: string;
 }
 
 export interface DirectLaunchRequest {


### PR DESCRIPTION
## Summary

- Redesign the WebRTC stats overlay with a collapsible left-side HUD, animated session-started splash, and waiting-for-video state instead of snapping straight into the feed.
- Align WebRTC signaling with the official GFN client: send SDP answers before ICE gathering completes, stop manual mediaConnectionInfo ICE injection, filter SDP rewrites to usage 2/17, and default H264 to 8-bit color depth.
- Treat BYE and peerRemoved signaling closes as expected session exits so ending a game no longer shows "Session Connection Lost".

## Test plan

- [x] `npm --prefix opennow-stable run typecheck`
- [x] Targeted tests for `gfn`, `sdp`, and related stream preference normalization
- [x] Launch a WebRTC session and confirm video frames appear (no black screen)
- [x] Verify stats HUD expands/collapses and session-started splash appears after first decoded frame
- [x] Exit a game/session and confirm clean return to library without recovery error UI
- [x] Confirm nvstSdp advertises `video.bitDepth:8` for H264

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebRTC signaling teardown, ICE handling, and session recovery paths alongside broad catalog cache/IPC behavior; regressions could affect playback stability or stale/wrong catalog data across accounts.
> 
> **Overview**
> Improves **WebRTC session UX and teardown**: new stream copy for a session-started moment and a collapsible stats HUD (live/sync/RTT/bitrate, advanced diagnostics, waiting-for-video). **Signaling** now treats `peerRemoved` and peer `BYE` as normal disconnects, forwards ICE `usernameFragment`, and **cloud match** media resolution includes the chosen connection **usage** alongside IP/port.
> 
> **Catalog and games data** shift to **account-scoped disk cache** (with legacy token-key migration), **stale-tolerant reads**, query-keyed browse cache, and IPC paths that serve **cached library/catalog** before forcing network refresh. The background **refresh scheduler** refreshes only stale/missing main/library/public keys and tracks **userId** in auth context.
> 
> **Renderer** hydrates/persists a **catalog snapshot** on startup, reloads in the background, avoids redundant catalog fetches, clears snapshot on logout, and hosts **settings in a modal**. **Recovery** treats `BYE` / `peerRemoved` (and related ICE edge cases) as expected session end. **Game cards** get tighter memoization via a shared store icon component and a **`GameCardListItem`** wrapper for stable list callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f33e85853532037069ce10f91ad4fa8c8b635610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->