### PR TITLE
fix(settings): prevent toggle switches from shrinking

### DIFF
--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -5207,6 +5207,7 @@ button.game-card-store-chip.owned.active:hover {
 .settings-toggle {
   position: relative;
   display: inline-block;
+  flex: 0 0 44px;
   width: 44px;
   height: 24px;
   cursor: pointer;


### PR DESCRIPTION
The settings toggle switches render at reduced width when paired with long label text, compressing the toggle track (from 44px down to ~20px). This occurs because `.settings-toggle` lacks flex-basis constraints while positioned in `.settings-row` with `display: flex`. Added `flex: 0 0 44px` to prevent shrinking and maintain consistent 44px width across all toggles.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/6beef115-7eb3-4bbf-8846-bf3d91dc4fff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-223" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/6beef115-7eb3-4bbf-8846-bf3d91dc4fff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-223&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-223"><img alt="OPE-223" src="https://capy.ai/api/badge/thread.svg?label=OPE-223"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS flex constraint on settings toggles; no logic, data, or security impact.
> 
> **Overview**
> Fixes settings toggle switches **compressing** when a row has long label text beside them in flex layout.
> 
> Adds **`flex: 0 0 44px`** on **`.settings-toggle`** so the control keeps a fixed **44px** width and no longer shrinks (e.g. to ~20px) inside **`.settings-row`** flex rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9a28159f5e89b418e872b07d60b3af84fc4664. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->