### PR TITLE
fix(library): fetch full library via paginated apps query

### DIFF
--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -30,6 +30,7 @@ const LIBRARY_FETCH_COUNT = 200;
 const MAX_LIBRARY_PAGES = 25;
 const DEFAULT_SORT_ID = "relevance";
 const DEFAULT_LIBRARY_SORT = "variants.gfn.library.lastPlayedDate:DESC,computedValues.libraryAddedDate:DESC,sortName:ASC";
+const LIBRARY_GAMES_CACHE_SCOPE = "library:v2";
 const PUBLIC_GAMES_CACHE_KEY = "games:public:v2";
 const LIBRARY_APPS_FILTER = {
   variants: {
@@ -116,7 +117,7 @@ export function getAccountGamesCacheKeys(accountId: string, providerStreamingBas
 } {
   return {
     main: accountScopedGamesCacheKey("main", accountId, providerStreamingBaseUrl),
-    library: accountScopedGamesCacheKey("library", accountId, providerStreamingBaseUrl),
+    library: accountScopedGamesCacheKey(LIBRARY_GAMES_CACHE_SCOPE, accountId, providerStreamingBaseUrl),
     public: PUBLIC_GAMES_CACHE_KEY,
   };
 }
@@ -1111,7 +1112,7 @@ export async function peekCachedLibraryGames(
   providerStreamingBaseUrl?: string,
   accountId?: string,
 ): Promise<GameInfo[] | null> {
-  const cached = await loadAccountScopedFromCache<GameInfo[]>("library", accountId, token, providerStreamingBaseUrl);
+  const cached = await loadAccountScopedFromCache<GameInfo[]>(LIBRARY_GAMES_CACHE_SCOPE, accountId, token, providerStreamingBaseUrl);
   return cached?.data ?? null;
 }
 
@@ -1186,13 +1187,13 @@ export async function fetchLibraryGames(
   providerStreamingBaseUrl?: string,
   accountId?: string,
 ): Promise<GameInfo[]> {
-  const cached = await loadAccountScopedFromCache<GameInfo[]>("library", accountId, token, providerStreamingBaseUrl);
+  const cached = await loadAccountScopedFromCache<GameInfo[]>(LIBRARY_GAMES_CACHE_SCOPE, accountId, token, providerStreamingBaseUrl);
   if (cached) {
     return mergePublicGameVariants(cached.data, await fetchPublicGames());
   }
 
   const games = await fetchLibraryGamesUncached(token, providerStreamingBaseUrl);
-  const cacheKey = accountScopedGamesCacheKey("library", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
+  const cacheKey = accountScopedGamesCacheKey(LIBRARY_GAMES_CACHE_SCOPE, resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
   await cacheManager.saveToCache(cacheKey, games);
   return games;
 }

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -16,6 +16,7 @@ import {
   buildGfnGraphQlHeaders,
   buildGfnLcarsHeaders,
 } from "./clientHeaders";
+import { fetchAllAppsPages, type AppsPageResponse } from "./paginatedApps";
 
 const GRAPHQL_URL = "https://games.geforce.com/graphql";
 const PANELS_QUERY_HASH = "f8e26265a5db5c20e1334a6872cf04b6e3970507697f6ae55a6ddefa5420daf0";
@@ -25,8 +26,22 @@ const LIBRARY_WITH_TIME_QUERY_HASH = "039e8c0d553972975485fee56e59f2549d2fdb518e
 const DEFAULT_LOCALE = "en_US";
 const DEFAULT_CATALOG_FETCH_COUNT = 120;
 const MAX_CATALOG_PAGES = 3;
+const LIBRARY_FETCH_COUNT = 200;
+const MAX_LIBRARY_PAGES = 25;
 const DEFAULT_SORT_ID = "relevance";
+const DEFAULT_LIBRARY_SORT = "variants.gfn.library.lastPlayedDate:DESC,computedValues.libraryAddedDate:DESC,sortName:ASC";
 const PUBLIC_GAMES_CACHE_KEY = "games:public:v2";
+const LIBRARY_APPS_FILTER = {
+  variants: {
+    gfn: {
+      library: {
+        status: {
+          notEquals: "NOT_OWNED",
+        },
+      },
+    },
+  },
+} satisfies Record<string, unknown>;
 
 function accountScopedGamesCacheKey(scope: string, accountId: string, providerStreamingBaseUrl?: string): string {
   const digest = createHash("sha256")
@@ -160,6 +175,8 @@ interface AppsSearchResponse {
   };
   errors?: Array<{ message: string }>;
 }
+
+type AppsPage = AppsPageResponse<AppData>;
 
 interface GraphQlFilterGroup {
   id: string;
@@ -513,14 +530,27 @@ function appToGame(app: AppData): GameInfo {
 function mergeAppMetaIntoGame(game: GameInfo, app: AppData): GameInfo {
   const merged = appToGame(app);
   const selectedVariantId = game.variants[game.selectedVariantIndex]?.id;
+  const variants = merged.variants.map((variant) => {
+    const existing = game.variants.find((candidate) => candidate.id === variant.id);
+    return {
+      ...variant,
+      librarySelected: variant.librarySelected ?? existing?.librarySelected,
+      inLibrary: variant.inLibrary ?? existing?.inLibrary,
+      libraryStatus: variant.libraryStatus ?? existing?.libraryStatus,
+      lastPlayedDate: variant.lastPlayedDate ?? existing?.lastPlayedDate,
+    };
+  });
   const selectedVariantIndex = selectedVariantId
-    ? merged.variants.findIndex((variant) => variant.id === selectedVariantId)
+    ? variants.findIndex((variant) => variant.id === selectedVariantId)
     : -1;
 
   return {
     ...game,
     ...merged,
     id: game.id,
+    isInLibrary: merged.isInLibrary || game.isInLibrary,
+    lastPlayed: merged.lastPlayed ?? game.lastPlayed,
+    variants,
     selectedVariantIndex: selectedVariantIndex >= 0 ? selectedVariantIndex : merged.selectedVariantIndex,
   };
 }
@@ -1172,6 +1202,14 @@ async function fetchLibraryGamesUncached(
   providerStreamingBaseUrl?: string,
 ): Promise<GameInfo[]> {
   const vpcId = await getVpcId(token, providerStreamingBaseUrl);
+  try {
+    const apps = await fetchPaginatedLibraryApps(token, vpcId);
+    const games = dedupeGames(apps.map(appToGame));
+    return mergePublicGameVariants(await enrichGamesWithMetadata(token, vpcId, games), await fetchPublicGames());
+  } catch (error) {
+    console.warn("Paginated library query failed, falling back to library panel:", error);
+  }
+
   let payload: GraphQlResponse;
 
   try {
@@ -1182,6 +1220,74 @@ async function fetchLibraryGamesUncached(
 
   const games = flattenPanels(payload);
   return mergePublicGameVariants(await enrichGamesWithMetadata(token, vpcId, games), await fetchPublicGames());
+}
+
+async function fetchPaginatedLibraryApps(token: string, vpcId: string): Promise<AppData[]> {
+  const query = `query GetLibraryApps(
+    $vpcId: String!,
+    $locale: String!,
+    $sortString: String!,
+    $fetchCount: Int!,
+    $cursor: String!,
+    $filters: AppFilterFields!
+  ) {
+    apps(
+      vpcId: $vpcId,
+      language: $locale,
+      orderBy: $sortString,
+      first: $fetchCount,
+      after: $cursor,
+      filters: $filters
+    ) {
+      numberReturned
+      numberSupported
+      pageInfo { hasNextPage endCursor totalCount }
+      items {
+        id
+        title
+        images { KEY_ART KEY_IMAGE GAME_BOX_ART TV_BANNER HERO_IMAGE MARQUEE_HERO_IMAGE FEATURE_IMAGE GAME_LOGO SCREENSHOTS }
+        variants {
+          id
+          appStore
+          storeUrl
+          supportedControls
+          gfn {
+            status
+            library { status selected lastPlayedDate }
+          }
+        }
+        gfn {
+          playabilityState
+          minimumMembershipTierLabel
+          catalogSkuStrings {
+            SKU_BASED_TAG
+            SKU_BASED_PLAYABILITY_TEXT
+            SKU_BASED_UNPLAYABLE_DIALOG_HEADER
+            SKU_BASED_UNPLAYABLE_DIALOG_BODY_UPGRADE
+            SKU_BASED_UNPLAYABLE_DIALOG_BODY_UPGRADE_ECOMM_RESTRICTED
+          }
+        }
+        itemMetadata { campaignIds }
+      }
+    }
+  }`;
+
+  const result = await fetchAllAppsPages<AppData>(
+    (cursor) => postGraphQl<AppsPage>(
+      query,
+      {
+        vpcId,
+        locale: DEFAULT_LOCALE,
+        sortString: DEFAULT_LIBRARY_SORT,
+        fetchCount: LIBRARY_FETCH_COUNT,
+        cursor,
+        filters: LIBRARY_APPS_FILTER,
+      },
+      token,
+    ),
+    { maxPages: MAX_LIBRARY_PAGES },
+  );
+  return result.items;
 }
 
 export async function fetchPublicGames(): Promise<GameInfo[]> {

--- a/opennow-stable/src/main/gfn/paginatedApps.test.ts
+++ b/opennow-stable/src/main/gfn/paginatedApps.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { fetchAllAppsPages, type AppsPageResponse } from "./paginatedApps";
+
+test("fetchAllAppsPages follows cursors until every page is collected", async () => {
+  const cursors: string[] = [];
+  const pages: Record<string, AppsPageResponse<number>> = {
+    "": {
+      data: {
+        apps: {
+          numberReturned: 40,
+          numberSupported: 45,
+          pageInfo: { hasNextPage: true, endCursor: "page-2", totalCount: 45 },
+          items: Array.from({ length: 40 }, (_, index) => index),
+        },
+      },
+    },
+    "page-2": {
+      data: {
+        apps: {
+          numberReturned: 5,
+          numberSupported: 45,
+          pageInfo: { hasNextPage: false, endCursor: "", totalCount: 45 },
+          items: [40, 41, 42, 43, 44],
+        },
+      },
+    },
+  };
+
+  const result = await fetchAllAppsPages((cursor) => {
+    cursors.push(cursor);
+    return Promise.resolve(pages[cursor]);
+  }, { maxPages: 5 });
+
+  assert.deepEqual(cursors, ["", "page-2"]);
+  assert.equal(result.items.length, 45);
+  assert.deepEqual(result.items.slice(-5), [40, 41, 42, 43, 44]);
+  assert.equal(result.numberReturned, 45);
+  assert.equal(result.numberSupported, 45);
+  assert.equal(result.totalCount, 45);
+  assert.equal(result.hasNextPage, false);
+});
+
+test("fetchAllAppsPages fails instead of silently truncating at the page cap", async () => {
+  await assert.rejects(
+    fetchAllAppsPages(
+      async () => ({
+        data: {
+          apps: {
+            numberReturned: 40,
+            pageInfo: { hasNextPage: true, endCursor: "next", totalCount: 80 },
+            items: Array.from({ length: 40 }, (_, index) => index),
+          },
+        },
+      }),
+      { maxPages: 1 },
+    ),
+    /exceeded 1 pages/,
+  );
+});

--- a/opennow-stable/src/main/gfn/paginatedApps.ts
+++ b/opennow-stable/src/main/gfn/paginatedApps.ts
@@ -1,0 +1,68 @@
+export interface AppsPageResponse<T> {
+  data?: {
+    apps?: {
+      numberReturned?: number;
+      numberSupported?: number;
+      pageInfo?: {
+        hasNextPage?: boolean;
+        endCursor?: string;
+        totalCount?: number;
+      };
+      items?: T[];
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+export interface PaginatedAppsResult<T> {
+  items: T[];
+  numberReturned: number;
+  numberSupported: number;
+  totalCount: number;
+  hasNextPage: boolean;
+  endCursor?: string;
+}
+
+export async function fetchAllAppsPages<T>(
+  fetchPage: (cursor: string) => Promise<AppsPageResponse<T>>,
+  options: { maxPages: number },
+): Promise<PaginatedAppsResult<T>> {
+  const items: T[] = [];
+  let cursor = "";
+  let numberReturned = 0;
+  let numberSupported = 0;
+  let totalCount = 0;
+  let hasNextPage = false;
+  let endCursor = "";
+
+  for (let page = 0; page < options.maxPages; page += 1) {
+    const payload = await fetchPage(cursor);
+    if (payload.errors?.length) {
+      throw new Error(payload.errors.map((error) => error.message).join(", "));
+    }
+
+    const apps = payload.data?.apps;
+    const pageItems = apps?.items ?? [];
+    items.push(...pageItems);
+    numberReturned += apps?.numberReturned ?? pageItems.length;
+    numberSupported = apps?.numberSupported ?? numberSupported;
+    hasNextPage = apps?.pageInfo?.hasNextPage ?? false;
+    endCursor = apps?.pageInfo?.endCursor ?? "";
+    totalCount = apps?.pageInfo?.totalCount ?? totalCount;
+
+    if (!hasNextPage || !endCursor) {
+      return {
+        items,
+        numberReturned,
+        numberSupported,
+        totalCount,
+        hasNextPage: false,
+        endCursor: endCursor || undefined,
+      };
+    }
+
+    cursor = endCursor;
+  }
+
+  throw new Error(`GFN apps pagination exceeded ${options.maxPages} pages`);
+}


### PR DESCRIPTION
This PR adds cursor-based pagination to the library fetch to resolve the 40-game limit reported in #532.
- Adds `paginatedApps.ts` with `fetchAllAppsPages` helper to traverse `hasNextPage` cursors.
- Implements `fetchPaginatedLibraryApps` using the official `apps` query filtered by `library.status != "NOT_OWNED"`.
- Fetches 200 items per page for up to 25 pages to support full libraries.
- Falls back to existing panel query if pagination fails.
- Preserves `isInLibrary` and `lastPlayed` flags during metadata enrichment.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/5402752d-17b8-47ab-a63e-e53b7838ec30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-222" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/5402752d-17b8-47ab-a63e-e53b7838ec30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-222&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-222"><img alt="OPE-222" src="https://capy.ai/api/badge/thread.svg?label=OPE-222"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core library loading and GraphQL behavior; fallback limits user impact, but very large libraries could still fail at the 25-page cap.
> 
> **Overview**
> **Fixes the ~40-game library cap** by loading the user library through the GFN `apps` GraphQL query with cursor pagination instead of relying only on the LIBRARY panel.
> 
> A new **`fetchAllAppsPages`** helper walks `hasNextPage` / `endCursor` (200 items per page, up to 25 pages) and **throws** if the page limit is hit so results are not silently truncated. Library fetch filters to owned titles (`library.status != NOT_OWNED`) and uses the existing last-played sort order.
> 
> **`fetchLibraryGamesUncached`** tries this path first, then **falls back** to the panel query on failure. **`mergeAppMetaIntoGame`** now keeps library flags (`isInLibrary`, `lastPlayed`, per-variant library fields) when metadata enrichment overwrites app data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7acab460d340c9779a3e24ba8fd65e2ac8ba74a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->