### PR TITLE
feat(gfn): add proxy support for games catalog requests

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -472,7 +472,7 @@
       "cpu": "CPU",
       "softwareCpu": "Software (CPU)",
       "sessionProxy": "Session proxy",
-      "sessionProxyHint": "Used only for Nvidia session creation and queue polling. Streaming/signaling traffic is not proxied. Zortos provides a proxy for GitHub Sponsors/supporters.",
+      "sessionProxyHint": "Used for Nvidia games catalog, session creation, and queue polling. Streaming/signaling traffic is not proxied. Zortos provides a proxy for GitHub Sponsors/supporters.",
       "experimentalL4SRequest": "Experimental L4S Request",
       "experimentalL4SRequestHint": "Request the GeForce NOW L4S streaming feature on newly created sessions. This does not change browser WebRTC behavior by itself and may be ignored by the service or network path."
     },

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -16,6 +16,8 @@ import {
   buildGfnGraphQlHeaders,
   buildGfnLcarsHeaders,
 } from "./clientHeaders";
+import { fetchWithOptionalProxy } from "./proxyFetch";
+import { sessionProxyCacheKeyPart } from "./proxyUrl";
 
 const GRAPHQL_URL = "https://games.geforce.com/graphql";
 const PANELS_QUERY_HASH = "f8e26265a5db5c20e1334a6872cf04b6e3970507697f6ae55a6ddefa5420daf0";
@@ -28,23 +30,35 @@ const MAX_CATALOG_PAGES = 3;
 const DEFAULT_SORT_ID = "relevance";
 const PUBLIC_GAMES_CACHE_KEY = "games:public:v2";
 
-function accountScopedGamesCacheKey(scope: string, accountId: string, providerStreamingBaseUrl?: string): string {
-  const digest = createHash("sha256")
+function addProxyCacheScope(hash: ReturnType<typeof createHash>, proxyUrl?: string): void {
+  const proxyCachePart = sessionProxyCacheKeyPart(proxyUrl);
+  if (proxyCachePart) {
+    hash.update("\0").update(proxyCachePart);
+  }
+}
+
+function publicGamesCacheKey(proxyUrl?: string): string {
+  const proxyCachePart = sessionProxyCacheKeyPart(proxyUrl);
+  return proxyCachePart ? `${PUBLIC_GAMES_CACHE_KEY}:${proxyCachePart}` : PUBLIC_GAMES_CACHE_KEY;
+}
+
+function accountScopedGamesCacheKey(scope: string, accountId: string, providerStreamingBaseUrl?: string, proxyUrl?: string): string {
+  const hash = createHash("sha256")
     .update(accountId)
     .update("\0")
-    .update(providerStreamingBaseUrl ?? "")
-    .digest("hex")
-    .slice(0, 16);
+    .update(providerStreamingBaseUrl ?? "");
+  addProxyCacheScope(hash, proxyUrl);
+  const digest = hash.digest("hex").slice(0, 16);
   return `games:${scope}:${digest}`;
 }
 
-function legacyTokenScopedGamesCacheKey(scope: string, token: string, providerStreamingBaseUrl?: string): string {
-  const digest = createHash("sha256")
+function legacyTokenScopedGamesCacheKey(scope: string, token: string, providerStreamingBaseUrl?: string, proxyUrl?: string): string {
+  const hash = createHash("sha256")
     .update(token)
     .update("\0")
-    .update(providerStreamingBaseUrl ?? "")
-    .digest("hex")
-    .slice(0, 16);
+    .update(providerStreamingBaseUrl ?? "");
+  addProxyCacheScope(hash, proxyUrl);
+  const digest = hash.digest("hex").slice(0, 16);
   return `games:${scope}:${digest}`;
 }
 
@@ -57,16 +71,17 @@ async function loadAccountScopedFromCache<T>(
   accountId: string | undefined,
   token: string,
   providerStreamingBaseUrl?: string,
+  proxyUrl?: string,
 ): Promise<Awaited<ReturnType<typeof cacheManager.loadFromCache<T>>>> {
   const resolvedAccountId = resolveAccountCacheId(accountId, token);
-  const primaryKey = accountScopedGamesCacheKey(scope, resolvedAccountId, providerStreamingBaseUrl);
+  const primaryKey = accountScopedGamesCacheKey(scope, resolvedAccountId, providerStreamingBaseUrl, proxyUrl);
   const cached = await cacheManager.loadFromCache<T>(primaryKey);
   if (cached) {
     return cached;
   }
 
   if (resolvedAccountId !== token) {
-    const legacyKey = legacyTokenScopedGamesCacheKey(scope, token, providerStreamingBaseUrl);
+    const legacyKey = legacyTokenScopedGamesCacheKey(scope, token, providerStreamingBaseUrl, proxyUrl);
     if (legacyKey !== primaryKey) {
       const legacy = await cacheManager.loadFromCache<T>(legacyKey);
       if (legacy) {
@@ -91,18 +106,18 @@ function catalogBrowseCacheKey(input: CatalogBrowseRequest, accountId: string): 
     .update(String(input.fetchCount ?? ""))
     .digest("hex")
     .slice(0, 12);
-  return `${accountScopedGamesCacheKey("catalog", accountId, input.providerStreamingBaseUrl)}:${queryDigest}`;
+  return `${accountScopedGamesCacheKey("catalog", accountId, input.providerStreamingBaseUrl, input.proxyUrl)}:${queryDigest}`;
 }
 
-export function getAccountGamesCacheKeys(accountId: string, providerStreamingBaseUrl?: string): {
+export function getAccountGamesCacheKeys(accountId: string, providerStreamingBaseUrl?: string, proxyUrl?: string): {
   main: string;
   library: string;
   public: string;
 } {
   return {
-    main: accountScopedGamesCacheKey("main", accountId, providerStreamingBaseUrl),
-    library: accountScopedGamesCacheKey("library", accountId, providerStreamingBaseUrl),
-    public: PUBLIC_GAMES_CACHE_KEY,
+    main: accountScopedGamesCacheKey("main", accountId, providerStreamingBaseUrl, proxyUrl),
+    library: accountScopedGamesCacheKey("library", accountId, providerStreamingBaseUrl, proxyUrl),
+    public: publicGamesCacheKey(proxyUrl),
   };
 }
 
@@ -278,12 +293,17 @@ function randomHuId(): string {
   return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
 }
 
-async function postGraphQl<T>(query: string, variables: Record<string, unknown>, token?: string): Promise<T> {
-  const response = await fetch(GRAPHQL_URL, {
+async function postGraphQl<T>(
+  query: string,
+  variables: Record<string, unknown>,
+  token?: string,
+  proxyUrl?: string,
+): Promise<T> {
+  const response = await fetchWithOptionalProxy(GRAPHQL_URL, {
     method: "POST",
     headers: buildGfnGraphQlHeaders(token),
     body: JSON.stringify({ query, variables }),
-  });
+  }, proxyUrl);
 
   if (!response.ok) {
     const text = await response.text();
@@ -293,7 +313,7 @@ async function postGraphQl<T>(query: string, variables: Record<string, unknown>,
   return (await response.json()) as T;
 }
 
-async function getVpcId(token: string, providerStreamingBaseUrl?: string): Promise<string> {
+async function getVpcId(token: string, providerStreamingBaseUrl?: string, proxyUrl?: string): Promise<string> {
   const defaultBase = "https://prod.cloudmatchbeta.nvidiagrid.net/";
   const allowedHosts = new Set([
     "prod.cloudmatchbeta.nvidiagrid.net",
@@ -314,7 +334,7 @@ async function getVpcId(token: string, providerStreamingBaseUrl?: string): Promi
 
   const serverInfoUrl = new URL("v2/serverInfo", validatedBaseUrl);
 
-  const response = await fetch(serverInfoUrl.toString(), {
+  const response = await fetchWithOptionalProxy(serverInfoUrl.toString(), {
     headers: buildGfnLcarsHeaders({
       token,
       clientType: "NATIVE",
@@ -322,7 +342,7 @@ async function getVpcId(token: string, providerStreamingBaseUrl?: string): Promi
       includeUserAgent: true,
       includeEmptyTokenAuthorization: true,
     }),
-  });
+  }, proxyUrl);
 
   if (!response.ok) {
     return "GFN-PC";
@@ -591,6 +611,7 @@ async function fetchAppMetaData(
   token: string,
   appIds: string[],
   vpcId: string,
+  proxyUrl?: string,
 ): Promise<AppMetaDataResponse> {
   const normalizedIds = [...new Set(appIds.map((id) => id.trim()).filter((id) => id.length > 0))];
   if (normalizedIds.length === 0) {
@@ -616,12 +637,12 @@ async function fetchAppMetaData(
     variables,
   });
 
-  const response = await fetch(`${GRAPHQL_URL}?${params.toString()}`, {
+  const response = await fetchWithOptionalProxy(`${GRAPHQL_URL}?${params.toString()}`, {
     headers: {
       ...buildGfnGraphQlHeaders(token),
       "Content-Type": "application/graphql",
     },
-  });
+  }, proxyUrl);
 
   if (!response.ok) {
     const text = await response.text();
@@ -631,7 +652,7 @@ async function fetchAppMetaData(
   return (await response.json()) as AppMetaDataResponse;
 }
 
-async function enrichGamesWithMetadata(token: string, vpcId: string, games: GameInfo[]): Promise<GameInfo[]> {
+async function enrichGamesWithMetadata(token: string, vpcId: string, games: GameInfo[], proxyUrl?: string): Promise<GameInfo[]> {
   const uuids = [...new Set(games.map((game) => game.uuid).filter((uuid): uuid is string => !!uuid))];
 
   if (uuids.length === 0) {
@@ -643,7 +664,7 @@ async function enrichGamesWithMetadata(token: string, vpcId: string, games: Game
 
   for (let index = 0; index < uuids.length; index += chunkSize) {
     const chunk = uuids.slice(index, index + chunkSize);
-    const payload = await fetchAppMetaData(token, chunk, vpcId);
+    const payload = await fetchAppMetaData(token, chunk, vpcId, proxyUrl);
     if (payload.errors?.length) {
       throw new Error(payload.errors.map((error) => error.message).join(", "));
     }
@@ -666,6 +687,7 @@ async function fetchPanels(
   panelNames: string[],
   vpcId: string,
   options?: { withLibraryTime?: boolean },
+  proxyUrl?: string,
 ): Promise<GraphQlResponse> {
   const variables = JSON.stringify({
     vpcId,
@@ -695,12 +717,12 @@ async function fetchPanels(
     variables,
   });
 
-  const response = await fetch(`${GRAPHQL_URL}?${params.toString()}`, {
+  const response = await fetchWithOptionalProxy(`${GRAPHQL_URL}?${params.toString()}`, {
     headers: {
       ...buildGfnGraphQlHeaders(token),
       "Content-Type": "application/graphql",
     },
-  });
+  }, proxyUrl);
 
   if (!response.ok) {
     const text = await response.text();
@@ -801,7 +823,7 @@ function parsePanelResults(payload: GraphQlResponse): GamePanelResult[] {
   return panels;
 }
 
-async function fetchFilterAndSortDefinitions(token?: string): Promise<CatalogDefinitions> {
+async function fetchFilterAndSortDefinitions(token?: string, proxyUrl?: string): Promise<CatalogDefinitions> {
   const query = `query GetFilterGroupAndSortOrderDefinitions($locale: String!) {
     filterGroupDefinitions(language: $locale) {
       id
@@ -819,7 +841,7 @@ async function fetchFilterAndSortDefinitions(token?: string): Promise<CatalogDef
     }
   }`;
 
-  const payload = await postGraphQl<FilterSortDefinitionsResponse>(query, { locale: DEFAULT_LOCALE }, token);
+  const payload = await postGraphQl<FilterSortDefinitionsResponse>(query, { locale: DEFAULT_LOCALE }, token, proxyUrl);
   if (payload.errors?.length) {
     throw new Error(payload.errors.map((error) => error.message).join(", "));
   }
@@ -885,8 +907,8 @@ async function browseCatalogUncached(input: CatalogBrowseRequest): Promise<Catal
     throw new Error("Catalog browsing requires an authenticated token");
   }
 
-  const vpcId = await getVpcId(token, input.providerStreamingBaseUrl);
-  const definitions = await fetchFilterAndSortDefinitions(token);
+  const vpcId = await getVpcId(token, input.providerStreamingBaseUrl, input.proxyUrl);
+  const definitions = await fetchFilterAndSortDefinitions(token, input.proxyUrl);
   const normalizedFilterIds = (input.filterIds ?? []).filter((id) => id in definitions.filterPayloadById);
   const selectedSort = definitions.sortOptions.find((option) => option.id === input.sortId)
     ?? definitions.sortOptions.find((option) => option.id === DEFAULT_SORT_ID)
@@ -1001,6 +1023,7 @@ ${appFields}
             filters,
           },
       token,
+      input.proxyUrl,
     );
 
     if (payload.errors?.length) {
@@ -1023,8 +1046,8 @@ ${appFields}
     cursor = endCursor;
   }
 
-  let games = dedupeGames(await enrichGamesWithMetadata(token, vpcId, collectedApps.map(appToGame)));
-  const publicGames = await fetchPublicGames();
+  let games = dedupeGames(await enrichGamesWithMetadata(token, vpcId, collectedApps.map(appToGame), input.proxyUrl));
+  const publicGames = await fetchPublicGames(input.proxyUrl);
   const gamesWithPublicVariants = appendPublicGameSearchMatches(
     mergePublicGameVariants(games, publicGames),
     publicGames,
@@ -1080,8 +1103,9 @@ export async function peekCachedLibraryGames(
   token: string,
   providerStreamingBaseUrl?: string,
   accountId?: string,
+  proxyUrl?: string,
 ): Promise<GameInfo[] | null> {
-  const cached = await loadAccountScopedFromCache<GameInfo[]>("library", accountId, token, providerStreamingBaseUrl);
+  const cached = await loadAccountScopedFromCache<GameInfo[]>("library", accountId, token, providerStreamingBaseUrl, proxyUrl);
   return cached?.data ?? null;
 }
 
@@ -1089,26 +1113,28 @@ export async function fetchLibraryGamesFromCache(
   token: string,
   providerStreamingBaseUrl?: string,
   accountId?: string,
+  proxyUrl?: string,
 ): Promise<GameInfo[] | null> {
-  const cached = await peekCachedLibraryGames(token, providerStreamingBaseUrl, accountId);
+  const cached = await peekCachedLibraryGames(token, providerStreamingBaseUrl, accountId, proxyUrl);
   if (!cached) {
     return null;
   }
-  return mergePublicGameVariants(cached, await fetchPublicGames());
+  return mergePublicGameVariants(cached, await fetchPublicGames(proxyUrl));
 }
 
 export async function fetchMainGames(
   token: string,
   providerStreamingBaseUrl?: string,
   accountId?: string,
+  proxyUrl?: string,
 ): Promise<GameInfo[]> {
-  const cached = await loadAccountScopedFromCache<GameInfo[]>("main", accountId, token, providerStreamingBaseUrl);
+  const cached = await loadAccountScopedFromCache<GameInfo[]>("main", accountId, token, providerStreamingBaseUrl, proxyUrl);
   if (cached) {
-    return mergePublicGameVariants(cached.data, await fetchPublicGames());
+    return mergePublicGameVariants(cached.data, await fetchPublicGames(proxyUrl));
   }
 
-  const games = await fetchMainGamesUncached(token, providerStreamingBaseUrl);
-  const cacheKey = accountScopedGamesCacheKey("main", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
+  const games = await fetchMainGamesUncached(token, providerStreamingBaseUrl, proxyUrl);
+  const cacheKey = accountScopedGamesCacheKey("main", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
   await cacheManager.saveToCache(cacheKey, games);
   return games;
 }
@@ -1117,14 +1143,15 @@ export async function fetchFeaturedGames(
   token: string,
   providerStreamingBaseUrl?: string,
   accountId?: string,
+  proxyUrl?: string,
 ): Promise<GameInfo[]> {
-  const cached = await loadAccountScopedFromCache<GameInfo[]>("featured", accountId, token, providerStreamingBaseUrl);
+  const cached = await loadAccountScopedFromCache<GameInfo[]>("featured", accountId, token, providerStreamingBaseUrl, proxyUrl);
   if (cached) return cached.data;
 
-  const vpcId = await getVpcId(token, providerStreamingBaseUrl);
-  const games = featuredGamesFromPanels(await fetchPanels(token, ["MARQUEE"], vpcId)).slice(0, 6);
+  const vpcId = await getVpcId(token, providerStreamingBaseUrl, proxyUrl);
+  const games = featuredGamesFromPanels(await fetchPanels(token, ["MARQUEE"], vpcId, undefined, proxyUrl)).slice(0, 6);
 
-  const cacheKey = accountScopedGamesCacheKey("featured", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
+  const cacheKey = accountScopedGamesCacheKey("featured", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
   await cacheManager.saveToCache(cacheKey, games);
   return games;
 }
@@ -1133,36 +1160,38 @@ export async function fetchStorePanels(
   token: string,
   providerStreamingBaseUrl?: string,
   accountId?: string,
+  proxyUrl?: string,
 ): Promise<GamePanelResult[]> {
-  const cached = await loadAccountScopedFromCache<GamePanelResult[]>("store-panels", accountId, token, providerStreamingBaseUrl);
+  const cached = await loadAccountScopedFromCache<GamePanelResult[]>("store-panels", accountId, token, providerStreamingBaseUrl, proxyUrl);
   if (cached) return cached.data;
 
-  const vpcId = await getVpcId(token, providerStreamingBaseUrl);
-  const panels = parsePanelResults(await fetchPanels(token, ["MAIN"], vpcId));
-  const cacheKey = accountScopedGamesCacheKey("store-panels", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
+  const vpcId = await getVpcId(token, providerStreamingBaseUrl, proxyUrl);
+  const panels = parsePanelResults(await fetchPanels(token, ["MAIN"], vpcId, undefined, proxyUrl));
+  const cacheKey = accountScopedGamesCacheKey("store-panels", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
   await cacheManager.saveToCache(cacheKey, panels);
   return panels;
 }
 
-async function fetchMainGamesUncached(token: string, providerStreamingBaseUrl?: string): Promise<GameInfo[]> {
-  const vpcId = await getVpcId(token, providerStreamingBaseUrl);
-  const payload = await fetchPanels(token, ["MAIN"], vpcId);
+async function fetchMainGamesUncached(token: string, providerStreamingBaseUrl?: string, proxyUrl?: string): Promise<GameInfo[]> {
+  const vpcId = await getVpcId(token, providerStreamingBaseUrl, proxyUrl);
+  const payload = await fetchPanels(token, ["MAIN"], vpcId, undefined, proxyUrl);
   const games = flattenPanels(payload);
-  return mergePublicGameVariants(await enrichGamesWithMetadata(token, vpcId, games), await fetchPublicGames());
+  return mergePublicGameVariants(await enrichGamesWithMetadata(token, vpcId, games, proxyUrl), await fetchPublicGames(proxyUrl));
 }
 
 export async function fetchLibraryGames(
   token: string,
   providerStreamingBaseUrl?: string,
   accountId?: string,
+  proxyUrl?: string,
 ): Promise<GameInfo[]> {
-  const cached = await loadAccountScopedFromCache<GameInfo[]>("library", accountId, token, providerStreamingBaseUrl);
+  const cached = await loadAccountScopedFromCache<GameInfo[]>("library", accountId, token, providerStreamingBaseUrl, proxyUrl);
   if (cached) {
-    return mergePublicGameVariants(cached.data, await fetchPublicGames());
+    return mergePublicGameVariants(cached.data, await fetchPublicGames(proxyUrl));
   }
 
-  const games = await fetchLibraryGamesUncached(token, providerStreamingBaseUrl);
-  const cacheKey = accountScopedGamesCacheKey("library", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl);
+  const games = await fetchLibraryGamesUncached(token, providerStreamingBaseUrl, proxyUrl);
+  const cacheKey = accountScopedGamesCacheKey("library", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
   await cacheManager.saveToCache(cacheKey, games);
   return games;
 }
@@ -1170,28 +1199,30 @@ export async function fetchLibraryGames(
 async function fetchLibraryGamesUncached(
   token: string,
   providerStreamingBaseUrl?: string,
+  proxyUrl?: string,
 ): Promise<GameInfo[]> {
-  const vpcId = await getVpcId(token, providerStreamingBaseUrl);
+  const vpcId = await getVpcId(token, providerStreamingBaseUrl, proxyUrl);
   let payload: GraphQlResponse;
 
   try {
-    payload = await fetchPanels(token, ["LIBRARY"], vpcId, { withLibraryTime: true });
+    payload = await fetchPanels(token, ["LIBRARY"], vpcId, { withLibraryTime: true }, proxyUrl);
   } catch {
-    payload = await fetchPanels(token, ["LIBRARY"], vpcId);
+    payload = await fetchPanels(token, ["LIBRARY"], vpcId, undefined, proxyUrl);
   }
 
   const games = flattenPanels(payload);
-  return mergePublicGameVariants(await enrichGamesWithMetadata(token, vpcId, games), await fetchPublicGames());
+  return mergePublicGameVariants(await enrichGamesWithMetadata(token, vpcId, games, proxyUrl), await fetchPublicGames(proxyUrl));
 }
 
-export async function fetchPublicGames(): Promise<GameInfo[]> {
-  const cached = await cacheManager.loadFromCache<GameInfo[]>(PUBLIC_GAMES_CACHE_KEY);
+export async function fetchPublicGames(proxyUrl?: string): Promise<GameInfo[]> {
+  const cacheKey = publicGamesCacheKey(proxyUrl);
+  const cached = await cacheManager.loadFromCache<GameInfo[]>(cacheKey);
   if (cached) {
     return cached.data;
   }
 
-  const games = await fetchPublicGamesUncached();
-  await cacheManager.saveToCache(PUBLIC_GAMES_CACHE_KEY, games);
+  const games = await fetchPublicGamesUncached(proxyUrl);
+  await cacheManager.saveToCache(cacheKey, games);
   return games;
 }
 
@@ -1199,13 +1230,14 @@ export async function resolveLaunchAppId(
   token: string,
   appIdOrUuid: string,
   providerStreamingBaseUrl?: string,
+  proxyUrl?: string,
 ): Promise<string | null> {
   if (isNumericId(appIdOrUuid)) {
     return appIdOrUuid;
   }
 
-  const vpcId = await getVpcId(token, providerStreamingBaseUrl);
-  const payload = await fetchAppMetaData(token, [appIdOrUuid], vpcId);
+  const vpcId = await getVpcId(token, providerStreamingBaseUrl, proxyUrl);
+  const payload = await fetchAppMetaData(token, [appIdOrUuid], vpcId, proxyUrl);
 
   if (payload.errors?.length) {
     throw new Error(payload.errors.map((error) => error.message).join(", "));
@@ -1223,10 +1255,10 @@ export async function resolveStoreUrl(
   token: string,
   appIdOrUuid: string,
   providerStreamingBaseUrl?: string,
-  options: { variantId?: string; store?: string } = {},
+  options: { variantId?: string; store?: string; proxyUrl?: string } = {},
 ): Promise<string | null> {
-  const vpcId = await getVpcId(token, providerStreamingBaseUrl);
-  const payload = await fetchAppMetaData(token, [appIdOrUuid], vpcId);
+  const vpcId = await getVpcId(token, providerStreamingBaseUrl, options.proxyUrl);
+  const payload = await fetchAppMetaData(token, [appIdOrUuid], vpcId, options.proxyUrl);
 
   if (payload.errors?.length) {
     throw new Error(payload.errors.map((error) => error.message).join(", "));

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -17,7 +17,7 @@ import {
   buildGfnLcarsHeaders,
 } from "./clientHeaders";
 import { fetchWithOptionalProxy } from "./proxyFetch";
-import { sessionProxyCacheKeyPart } from "./proxyUrl";
+import { sessionProxyCacheKeyPart, sessionProxyHasCredentials } from "./proxyUrl";
 
 const GRAPHQL_URL = "https://games.geforce.com/graphql";
 const PANELS_QUERY_HASH = "f8e26265a5db5c20e1334a6872cf04b6e3970507697f6ae55a6ddefa5420daf0";
@@ -40,6 +40,10 @@ function addProxyCacheScope(hash: ReturnType<typeof createHash>, proxyUrl?: stri
 function publicGamesCacheKey(proxyUrl?: string): string {
   const proxyCachePart = sessionProxyCacheKeyPart(proxyUrl);
   return proxyCachePart ? `${PUBLIC_GAMES_CACHE_KEY}:${proxyCachePart}` : PUBLIC_GAMES_CACHE_KEY;
+}
+
+function shouldBypassGamesCache(proxyUrl?: string): boolean {
+  return sessionProxyHasCredentials(proxyUrl);
 }
 
 function accountScopedGamesCacheKey(scope: string, accountId: string, providerStreamingBaseUrl?: string, proxyUrl?: string): string {
@@ -73,6 +77,10 @@ async function loadAccountScopedFromCache<T>(
   providerStreamingBaseUrl?: string,
   proxyUrl?: string,
 ): Promise<Awaited<ReturnType<typeof cacheManager.loadFromCache<T>>>> {
+  if (shouldBypassGamesCache(proxyUrl)) {
+    return null;
+  }
+
   const resolvedAccountId = resolveAccountCacheId(accountId, token);
   const primaryKey = accountScopedGamesCacheKey(scope, resolvedAccountId, providerStreamingBaseUrl, proxyUrl);
   const cached = await cacheManager.loadFromCache<T>(primaryKey);
@@ -1082,14 +1090,19 @@ export async function browseCatalog(input: CatalogBrowseRequest): Promise<Catalo
 
   const result = await browseCatalogUncached(input);
   const accountId = resolveAccountCacheId(input.userId, token);
-  const cacheKey = catalogBrowseCacheKey(input, accountId);
-  await cacheManager.saveToCache(cacheKey, result);
+  if (!shouldBypassGamesCache(input.proxyUrl)) {
+    const cacheKey = catalogBrowseCacheKey(input, accountId);
+    await cacheManager.saveToCache(cacheKey, result);
+  }
   return result;
 }
 
 export async function peekCachedBrowseCatalog(input: CatalogBrowseRequest): Promise<CatalogBrowseResult | null> {
   const token = input.token;
   if (!token) {
+    return null;
+  }
+  if (shouldBypassGamesCache(input.proxyUrl)) {
     return null;
   }
 
@@ -1134,8 +1147,10 @@ export async function fetchMainGames(
   }
 
   const games = await fetchMainGamesUncached(token, providerStreamingBaseUrl, proxyUrl);
-  const cacheKey = accountScopedGamesCacheKey("main", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
-  await cacheManager.saveToCache(cacheKey, games);
+  if (!shouldBypassGamesCache(proxyUrl)) {
+    const cacheKey = accountScopedGamesCacheKey("main", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
+    await cacheManager.saveToCache(cacheKey, games);
+  }
   return games;
 }
 
@@ -1151,8 +1166,10 @@ export async function fetchFeaturedGames(
   const vpcId = await getVpcId(token, providerStreamingBaseUrl, proxyUrl);
   const games = featuredGamesFromPanels(await fetchPanels(token, ["MARQUEE"], vpcId, undefined, proxyUrl)).slice(0, 6);
 
-  const cacheKey = accountScopedGamesCacheKey("featured", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
-  await cacheManager.saveToCache(cacheKey, games);
+  if (!shouldBypassGamesCache(proxyUrl)) {
+    const cacheKey = accountScopedGamesCacheKey("featured", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
+    await cacheManager.saveToCache(cacheKey, games);
+  }
   return games;
 }
 
@@ -1167,8 +1184,10 @@ export async function fetchStorePanels(
 
   const vpcId = await getVpcId(token, providerStreamingBaseUrl, proxyUrl);
   const panels = parsePanelResults(await fetchPanels(token, ["MAIN"], vpcId, undefined, proxyUrl));
-  const cacheKey = accountScopedGamesCacheKey("store-panels", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
-  await cacheManager.saveToCache(cacheKey, panels);
+  if (!shouldBypassGamesCache(proxyUrl)) {
+    const cacheKey = accountScopedGamesCacheKey("store-panels", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
+    await cacheManager.saveToCache(cacheKey, panels);
+  }
   return panels;
 }
 
@@ -1191,8 +1210,10 @@ export async function fetchLibraryGames(
   }
 
   const games = await fetchLibraryGamesUncached(token, providerStreamingBaseUrl, proxyUrl);
-  const cacheKey = accountScopedGamesCacheKey("library", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
-  await cacheManager.saveToCache(cacheKey, games);
+  if (!shouldBypassGamesCache(proxyUrl)) {
+    const cacheKey = accountScopedGamesCacheKey("library", resolveAccountCacheId(accountId, token), providerStreamingBaseUrl, proxyUrl);
+    await cacheManager.saveToCache(cacheKey, games);
+  }
   return games;
 }
 
@@ -1215,6 +1236,10 @@ async function fetchLibraryGamesUncached(
 }
 
 export async function fetchPublicGames(proxyUrl?: string): Promise<GameInfo[]> {
+  if (shouldBypassGamesCache(proxyUrl)) {
+    return fetchPublicGamesUncached(proxyUrl);
+  }
+
   const cacheKey = publicGamesCacheKey(proxyUrl);
   const cached = await cacheManager.loadFromCache<GameInfo[]>(cacheKey);
   if (cached) {

--- a/opennow-stable/src/main/gfn/paginatedApps.test.ts
+++ b/opennow-stable/src/main/gfn/paginatedApps.test.ts
@@ -61,3 +61,21 @@ test("fetchAllAppsPages fails instead of silently truncating at the page cap", a
     /exceeded 1 pages/,
   );
 });
+
+test("fetchAllAppsPages fails when a next page has no cursor", async () => {
+  await assert.rejects(
+    fetchAllAppsPages(
+      async () => ({
+        data: {
+          apps: {
+            numberReturned: 40,
+            pageInfo: { hasNextPage: true, endCursor: "", totalCount: 80 },
+            items: Array.from({ length: 40 }, (_, index) => index),
+          },
+        },
+      }),
+      { maxPages: 5 },
+    ),
+    /hasNextPage without endCursor/,
+  );
+});

--- a/opennow-stable/src/main/gfn/paginatedApps.ts
+++ b/opennow-stable/src/main/gfn/paginatedApps.ts
@@ -50,7 +50,11 @@ export async function fetchAllAppsPages<T>(
     endCursor = apps?.pageInfo?.endCursor ?? "";
     totalCount = apps?.pageInfo?.totalCount ?? totalCount;
 
-    if (!hasNextPage || !endCursor) {
+    if (hasNextPage && !endCursor) {
+      throw new Error("GFN apps pagination returned hasNextPage without endCursor");
+    }
+
+    if (!hasNextPage) {
       return {
         items,
         numberReturned,

--- a/opennow-stable/src/main/gfn/proxyFetch.test.ts
+++ b/opennow-stable/src/main/gfn/proxyFetch.test.ts
@@ -3,7 +3,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { normalizeSessionProxyUrl, sessionProxyCacheKeyPart, sessionProxyPartitionForUrl } from "./proxyUrl";
+import {
+  normalizeSessionProxyUrl,
+  sessionProxyCacheKeyPart,
+  sessionProxyHasCredentials,
+  sessionProxyPartitionForUrl,
+} from "./proxyUrl";
 
 test("normalizes scheme-less session proxy host:port values as http proxies", () => {
   assert.equal(normalizeSessionProxyUrl("localhost:8080"), "http://localhost:8080");
@@ -42,4 +47,10 @@ test("derives stable opaque proxy cache key parts", () => {
   assert.equal(withCredentials, explicit);
   assert.match(withCredentials ?? "", /^[0-9a-f]{16}$/);
   assert.ok(!withCredentials?.includes("secret"));
+});
+
+test("detects session proxy credentials without requiring them", () => {
+  assert.equal(sessionProxyHasCredentials("proxy.example.com:8080"), false);
+  assert.equal(sessionProxyHasCredentials("http://user@proxy.example.com:8080"), true);
+  assert.equal(sessionProxyHasCredentials("http://user:secret@proxy.example.com:8080"), true);
 });

--- a/opennow-stable/src/main/gfn/proxyFetch.test.ts
+++ b/opennow-stable/src/main/gfn/proxyFetch.test.ts
@@ -3,7 +3,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { normalizeSessionProxyUrl, sessionProxyPartitionForUrl } from "./proxyUrl";
+import { normalizeSessionProxyUrl, sessionProxyCacheKeyPart, sessionProxyPartitionForUrl } from "./proxyUrl";
 
 test("normalizes scheme-less session proxy host:port values as http proxies", () => {
   assert.equal(normalizeSessionProxyUrl("localhost:8080"), "http://localhost:8080");
@@ -30,4 +30,16 @@ test("derives stable opaque proxy session partitions", () => {
   assert.equal(withCredentials, sameProxy);
   assert.notEqual(withCredentials, differentProxy);
   assert.match(withCredentials, /^opennow:gfn-session-proxy:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+});
+
+test("derives stable opaque proxy cache key parts", () => {
+  const schemeLess = sessionProxyCacheKeyPart("proxy.example.com:8080");
+  const explicit = sessionProxyCacheKeyPart("http://proxy.example.com:8080");
+  const withCredentials = sessionProxyCacheKeyPart("http://user:secret@proxy.example.com:8080");
+
+  assert.equal(sessionProxyCacheKeyPart(), null);
+  assert.equal(schemeLess, explicit);
+  assert.notEqual(withCredentials, explicit);
+  assert.match(withCredentials ?? "", /^[0-9a-f]{16}$/);
+  assert.ok(!withCredentials?.includes("secret"));
 });

--- a/opennow-stable/src/main/gfn/proxyFetch.test.ts
+++ b/opennow-stable/src/main/gfn/proxyFetch.test.ts
@@ -39,7 +39,7 @@ test("derives stable opaque proxy cache key parts", () => {
 
   assert.equal(sessionProxyCacheKeyPart(), null);
   assert.equal(schemeLess, explicit);
-  assert.notEqual(withCredentials, explicit);
+  assert.equal(withCredentials, explicit);
   assert.match(withCredentials ?? "", /^[0-9a-f]{16}$/);
   assert.ok(!withCredentials?.includes("secret"));
 });

--- a/opennow-stable/src/main/gfn/proxyUrl.ts
+++ b/opennow-stable/src/main/gfn/proxyUrl.ts
@@ -18,7 +18,8 @@ export function sessionProxyPartitionForUrl(normalizedProxyUrl: string): string 
 export function sessionProxyCacheKeyPart(raw?: string): string | null {
   const normalizedProxyUrl = normalizeSessionProxyUrl(raw);
   if (!normalizedProxyUrl) return null;
-  return crypto.createHash("sha256").update(normalizedProxyUrl).digest("hex").slice(0, 16);
+  const parsed = new URL(normalizedProxyUrl);
+  return crypto.createHash("sha256").update(`${parsed.protocol}//${parsed.host}`).digest("hex").slice(0, 16);
 }
 
 export function normalizeSessionProxyUrl(raw?: string): string | null {

--- a/opennow-stable/src/main/gfn/proxyUrl.ts
+++ b/opennow-stable/src/main/gfn/proxyUrl.ts
@@ -22,6 +22,13 @@ export function sessionProxyCacheKeyPart(raw?: string): string | null {
   return crypto.createHash("sha256").update(`${parsed.protocol}//${parsed.host}`).digest("hex").slice(0, 16);
 }
 
+export function sessionProxyHasCredentials(raw?: string): boolean {
+  const normalizedProxyUrl = normalizeSessionProxyUrl(raw);
+  if (!normalizedProxyUrl) return false;
+  const parsed = new URL(normalizedProxyUrl);
+  return parsed.username.length > 0 || parsed.password.length > 0;
+}
+
 export function normalizeSessionProxyUrl(raw?: string): string | null {
   const trimmed = raw?.trim() ?? "";
   if (!trimmed) return null;

--- a/opennow-stable/src/main/gfn/proxyUrl.ts
+++ b/opennow-stable/src/main/gfn/proxyUrl.ts
@@ -15,6 +15,12 @@ export function sessionProxyPartitionForUrl(normalizedProxyUrl: string): string 
   return partition;
 }
 
+export function sessionProxyCacheKeyPart(raw?: string): string | null {
+  const normalizedProxyUrl = normalizeSessionProxyUrl(raw);
+  if (!normalizedProxyUrl) return null;
+  return crypto.createHash("sha256").update(normalizedProxyUrl).digest("hex").slice(0, 16);
+}
+
 export function normalizeSessionProxyUrl(raw?: string): string | null {
   const trimmed = raw?.trim() ?? "";
   if (!trimmed) return null;

--- a/opennow-stable/src/main/gfn/publicGames.ts
+++ b/opennow-stable/src/main/gfn/publicGames.ts
@@ -1,6 +1,7 @@
 import type { GameInfo, GameVariant } from "@shared/gfn";
 import { normalizeGameStore } from "@shared/gfn";
 import { GFN_USER_AGENT } from "./clientHeaders";
+import { fetchWithOptionalProxy } from "./proxyFetch";
 
 export interface RawPublicGame {
   id?: string | number;
@@ -184,14 +185,15 @@ export function appendPublicGameSearchMatches(
   return [...games, ...matches];
 }
 
-export async function fetchPublicGamesUncached(): Promise<GameInfo[]> {
-  const response = await fetch(
+export async function fetchPublicGamesUncached(proxyUrl?: string): Promise<GameInfo[]> {
+  const response = await fetchWithOptionalProxy(
     "https://static.nvidiagrid.net/supported-public-game-list/locales/gfnpc-en-US.json",
     {
       headers: {
         "User-Agent": GFN_USER_AGENT,
       },
     },
+    proxyUrl,
   );
 
   if (!response.ok) {

--- a/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
+++ b/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
@@ -32,7 +32,7 @@ import { fetchSubscription, fetchDynamicRegions } from "../gfn/subscription";
 import { fetchPersistentStorageLocations, resetPersistentStorage } from "../gfn/persistentStorage";
 
 interface RefreshSchedulerAuthContextUpdater {
-  updateAuthContext(token: string, userId: string, providerStreamingBaseUrl?: string): void;
+  updateAuthContext(token: string, userId: string, providerStreamingBaseUrl?: string, proxyUrl?: string): void;
 }
 
 async function resolveGamesFetchContext(
@@ -43,6 +43,7 @@ async function resolveGamesFetchContext(
   token: string;
   streamingBaseUrl: string;
   userId: string;
+  proxyUrl?: string;
 }> {
   let session = deps.authService.getSession();
   if (!session || options.networkRequired) {
@@ -57,8 +58,9 @@ async function resolveGamesFetchContext(
     payload?.providerStreamingBaseUrl ??
     deps.authService.getSelectedProvider().streamingServiceUrl;
   const userId = payload.userId ?? session.user.userId;
-  deps.refreshScheduler.updateAuthContext(token, userId, streamingBaseUrl);
-  return { token, streamingBaseUrl, userId };
+  const proxyUrl = payload.proxyUrl;
+  deps.refreshScheduler.updateAuthContext(token, userId, streamingBaseUrl, proxyUrl);
+  return { token, streamingBaseUrl, userId, proxyUrl };
 }
 
 function savedSessionTokens(
@@ -244,24 +246,24 @@ export function registerAccountCatalogIpcHandlers(
   ipcMain.handle(
     IPC_CHANNELS.GAMES_FETCH_MAIN,
     async (_event, payload: GamesFetchRequest) => {
-      const { token, streamingBaseUrl, userId } = await resolveGamesContext(payload);
-      return fetchMainGames(token, streamingBaseUrl, userId);
+      const { token, streamingBaseUrl, userId, proxyUrl } = await resolveGamesContext(payload);
+      return fetchMainGames(token, streamingBaseUrl, userId, proxyUrl);
     },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.GAMES_FETCH_FEATURED,
     async (_event, payload: GamesFetchRequest) => {
-      const { token, streamingBaseUrl, userId } = await resolveGamesContext(payload);
-      return fetchFeaturedGames(token, streamingBaseUrl, userId);
+      const { token, streamingBaseUrl, userId, proxyUrl } = await resolveGamesContext(payload);
+      return fetchFeaturedGames(token, streamingBaseUrl, userId, proxyUrl);
     },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.GAMES_FETCH_STORE_PANELS,
     async (_event, payload: GamesFetchRequest) => {
-      const { token, streamingBaseUrl, userId } = await resolveGamesContext(payload);
-      return fetchStorePanels(token, streamingBaseUrl, userId);
+      const { token, streamingBaseUrl, userId, proxyUrl } = await resolveGamesContext(payload);
+      return fetchStorePanels(token, streamingBaseUrl, userId, proxyUrl);
     },
   );
 
@@ -276,20 +278,20 @@ export function registerAccountCatalogIpcHandlers(
         const tokens = savedSessionTokens(savedSession);
         if (tokens) {
           const userId = payload.userId ?? tokens.userId;
-          const cachedLibrary = await fetchLibraryGamesFromCache(tokens.token, streamingBaseUrl, userId);
+          const cachedLibrary = await fetchLibraryGamesFromCache(tokens.token, streamingBaseUrl, userId, payload.proxyUrl);
           if (cachedLibrary) {
-            refreshScheduler.updateAuthContext(tokens.token, userId, streamingBaseUrl);
+            refreshScheduler.updateAuthContext(tokens.token, userId, streamingBaseUrl, payload.proxyUrl);
             return cachedLibrary;
           }
         }
       }
 
-      const { token, streamingBaseUrl: resolvedBaseUrl, userId } = await resolveGamesFetchContext(
+      const { token, streamingBaseUrl: resolvedBaseUrl, userId, proxyUrl } = await resolveGamesFetchContext(
         deps,
         payload,
         { networkRequired: true },
       );
-      return fetchLibraryGames(token, resolvedBaseUrl, userId);
+      return fetchLibraryGames(token, resolvedBaseUrl, userId, proxyUrl);
     },
   );
 
@@ -311,13 +313,13 @@ export function registerAccountCatalogIpcHandlers(
             providerStreamingBaseUrl: streamingBaseUrl,
           });
           if (cached) {
-            refreshScheduler.updateAuthContext(tokens.token, userId, streamingBaseUrl);
+            refreshScheduler.updateAuthContext(tokens.token, userId, streamingBaseUrl, payload.proxyUrl);
             return cached;
           }
         }
       }
 
-      const { token, streamingBaseUrl: resolvedBaseUrl, userId } = await resolveGamesFetchContext(
+      const { token, streamingBaseUrl: resolvedBaseUrl, userId, proxyUrl } = await resolveGamesFetchContext(
         deps,
         payload,
         { networkRequired: true },
@@ -327,6 +329,7 @@ export function registerAccountCatalogIpcHandlers(
         token,
         userId,
         providerStreamingBaseUrl: resolvedBaseUrl,
+        proxyUrl,
       });
     },
   );
@@ -342,7 +345,7 @@ export function registerAccountCatalogIpcHandlers(
       const streamingBaseUrl =
         payload?.providerStreamingBaseUrl ??
         authService.getSelectedProvider().streamingServiceUrl;
-      return resolveLaunchAppId(token, payload.appIdOrUuid, streamingBaseUrl);
+      return resolveLaunchAppId(token, payload.appIdOrUuid, streamingBaseUrl, payload.proxyUrl);
     },
   );
 
@@ -353,6 +356,7 @@ export function registerAccountCatalogIpcHandlers(
       return resolveStoreUrl(token, payload.appIdOrUuid, streamingBaseUrl, {
         variantId: payload.variantId,
         store: payload.store,
+        proxyUrl: payload.proxyUrl,
       });
     },
   );

--- a/opennow-stable/src/main/services/refreshScheduler.ts
+++ b/opennow-stable/src/main/services/refreshScheduler.ts
@@ -7,14 +7,15 @@ export interface RefreshAuthContext {
   token: string;
   userId: string;
   providerStreamingBaseUrl?: string;
+  proxyUrl?: string;
 }
 
 type FetchFunction<T> = (
   token: string,
   providerStreamingBaseUrl?: string,
-  accountId?: string,
+  proxyUrl?: string,
 ) => Promise<T>;
-type PublicFetchFunction = () => Promise<GameInfo[]>;
+type PublicFetchFunction = (proxyUrl?: string) => Promise<GameInfo[]>;
 
 class RefreshScheduler {
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
@@ -36,8 +37,8 @@ class RefreshScheduler {
     console.log(`[CACHE] RefreshScheduler initialized (interval: ${this.refreshIntervalMs / 60000} minutes)`);
   }
 
-  updateAuthContext(token: string, userId: string, providerStreamingBaseUrl?: string): void {
-    this.authContext = { token, userId, providerStreamingBaseUrl };
+  updateAuthContext(token: string, userId: string, providerStreamingBaseUrl?: string, proxyUrl?: string): void {
+    this.authContext = { token, userId, providerStreamingBaseUrl, proxyUrl };
     console.log(`[CACHE] Auth context updated for refresh scheduler`);
   }
 
@@ -87,8 +88,8 @@ class RefreshScheduler {
       return;
     }
 
-    const { token, userId, providerStreamingBaseUrl } = this.authContext;
-    const cacheKeys = getAccountGamesCacheKeys(userId, providerStreamingBaseUrl);
+    const { token, userId, providerStreamingBaseUrl, proxyUrl } = this.authContext;
+    const cacheKeys = getAccountGamesCacheKeys(userId, providerStreamingBaseUrl, proxyUrl);
     const force = options.force === true;
 
     const [mainNeedsRefresh, libraryNeedsRefresh, publicNeedsRefresh] = force
@@ -120,7 +121,7 @@ class RefreshScheduler {
 
       if (mainNeedsRefresh) {
         refreshTasks.push(
-          this.fetchMainGamesUncached(token, providerStreamingBaseUrl, userId)
+          this.fetchMainGamesUncached(token, providerStreamingBaseUrl, proxyUrl)
             .then(async (games) => {
               await cacheManager.saveToCache(cacheKeys.main, games);
             }),
@@ -129,7 +130,7 @@ class RefreshScheduler {
 
       if (libraryNeedsRefresh) {
         refreshTasks.push(
-          this.fetchLibraryGamesUncached(token, providerStreamingBaseUrl, userId)
+          this.fetchLibraryGamesUncached(token, providerStreamingBaseUrl, proxyUrl)
             .then(async (games) => {
               await cacheManager.saveToCache(cacheKeys.library, games);
             }),
@@ -138,7 +139,7 @@ class RefreshScheduler {
 
       if (publicNeedsRefresh) {
         refreshTasks.push(
-          this.fetchPublicGamesUncached()
+          this.fetchPublicGamesUncached(proxyUrl)
             .then(async (games) => {
               await cacheManager.saveToCache(cacheKeys.public, games);
             }),

--- a/opennow-stable/src/main/services/refreshScheduler.ts
+++ b/opennow-stable/src/main/services/refreshScheduler.ts
@@ -1,5 +1,6 @@
 import type { GameInfo } from "@shared/gfn";
 import { getAccountGamesCacheKeys } from "../gfn/games";
+import { sessionProxyHasCredentials } from "../gfn/proxyUrl";
 import { cacheEventBus } from "./cacheEventBus";
 import { cacheManager } from "./cacheManager";
 
@@ -89,6 +90,11 @@ class RefreshScheduler {
     }
 
     const { token, userId, providerStreamingBaseUrl, proxyUrl } = this.authContext;
+    if (sessionProxyHasCredentials(proxyUrl)) {
+      console.log("[CACHE] Credentialed proxy configured, skipping background game cache refresh");
+      return;
+    }
+
     const cacheKeys = getAccountGamesCacheKeys(userId, providerStreamingBaseUrl, proxyUrl);
     const force = options.force === true;
 

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -62,9 +62,9 @@ export interface Settings {
   colorQuality: ColorQuality;
   /** Preferred region URL (empty = auto) */
   region: string;
-  /** Enable the optional proxy for Nvidia session creation and queue polling */
+  /** Enable the optional proxy for Nvidia games catalog, session creation, and queue polling */
   sessionProxyEnabled: boolean;
-  /** Optional proxy used only for Nvidia session creation and queue polling */
+  /** Optional proxy used for Nvidia games catalog, session creation, and queue polling */
   sessionProxyUrl: string;
   /** Enable clipboard paste into stream */
   clipboardPaste: boolean;

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -123,6 +123,33 @@ function getAppStyle(posterSizeScale: number): AppStyle {
   };
 }
 
+function getEnabledSessionProxyUrl(settings: Pick<Settings, "sessionProxyEnabled" | "sessionProxyUrl">): string | undefined {
+  const proxyUrl = settings.sessionProxyEnabled ? settings.sessionProxyUrl.trim() : "";
+  return proxyUrl || undefined;
+}
+
+function getSessionProxyUiScope(proxyUrl: string | undefined): string {
+  if (!proxyUrl) return "direct";
+  const trimmed = proxyUrl.trim();
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+
+  try {
+    const parsed = new URL(candidate);
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return "proxy";
+  }
+}
+
+function buildProxyAwareCatalogQueryKey(
+  searchQuery: string,
+  filterIds: string[],
+  sortId: string,
+  proxyUrl: string | undefined,
+): string {
+  return `${buildCatalogQueryKey(searchQuery, filterIds, sortId)}|${getSessionProxyUiScope(proxyUrl)}`;
+}
+
 function normalizeDirectLaunchText(value: string | undefined): string {
   return value?.trim().replace(/\s+/g, " ").toLowerCase() ?? "";
 }
@@ -398,6 +425,10 @@ export function App(): JSX.Element {
     autoCheckForUpdates: true,
   });
   const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const activeSessionProxyUrl = useMemo(
+    () => getEnabledSessionProxyUrl(settings),
+    [settings.sessionProxyEnabled, settings.sessionProxyUrl],
+  );
   const [codecResults, setCodecResults] = useState<CodecTestResult[] | null>(() => loadStoredCodecResults());
   const [codecTesting, setCodecTesting] = useState(false);
   const [regions, setRegions] = useState<StreamRegion[]>([]);
@@ -1507,8 +1538,8 @@ export function App(): JSX.Element {
     });
   }, []);
 
-  const hydrateCatalogSnapshot = useCallback((session: AuthSession): string | null => {
-    const queryKey = buildCatalogQueryKey("", catalogSelectedFilterIds, catalogSelectedSortId);
+  const hydrateCatalogSnapshot = useCallback((session: AuthSession, proxyUrl: string | undefined = activeSessionProxyUrl): string | null => {
+    const queryKey = buildProxyAwareCatalogQueryKey("", catalogSelectedFilterIds, catalogSelectedSortId, proxyUrl);
     const snapshot = loadCatalogSnapshot(
       session.user.userId,
       session.provider.streamingServiceUrl,
@@ -1530,11 +1561,11 @@ export function App(): JSX.Element {
     applyVariantSelections([...snapshot.games, ...snapshot.libraryGames]);
     lastCatalogQueryRef.current = queryKey;
     return queryKey;
-  }, [applyVariantSelections, catalogSelectedFilterIds, catalogSelectedSortId]);
+  }, [activeSessionProxyUrl, applyVariantSelections, catalogSelectedFilterIds, catalogSelectedSortId]);
 
   const loadSessionRuntimeData = useCallback(async (
     session: AuthSession,
-    options?: { background?: boolean },
+    options?: { background?: boolean; proxyUrl?: string },
   ): Promise<void> => {
     const token = session.tokens.idToken ?? session.tokens.accessToken;
     const streamingBaseUrl = session.provider.streamingServiceUrl;
@@ -1542,7 +1573,8 @@ export function App(): JSX.Element {
     const loadId = ++runtimeDataLoadIdRef.current;
     const isCurrentLoad = (): boolean => runtimeDataLoadIdRef.current === loadId;
     const background = options?.background === true;
-    const catalogQueryKey = buildCatalogQueryKey("", catalogSelectedFilterIds, catalogSelectedSortId);
+    const proxyUrl = options?.proxyUrl ?? activeSessionProxyUrl;
+    const catalogQueryKey = buildProxyAwareCatalogQueryKey("", catalogSelectedFilterIds, catalogSelectedSortId, proxyUrl);
 
     if (!background) {
       lastCatalogQueryRef.current = null;
@@ -1575,6 +1607,7 @@ export function App(): JSX.Element {
       token,
       userId,
       providerStreamingBaseUrl: streamingBaseUrl,
+      proxyUrl,
       searchQuery: "",
       sortId: catalogSelectedSortId,
       filterIds: catalogSelectedFilterIds,
@@ -1602,6 +1635,7 @@ export function App(): JSX.Element {
       token,
       userId,
       providerStreamingBaseUrl: streamingBaseUrl,
+      proxyUrl,
     }).then((libGames) => {
       if (!isCurrentLoad()) return;
       latestLibraryGames = libGames;
@@ -1622,6 +1656,7 @@ export function App(): JSX.Element {
       token,
       userId,
       providerStreamingBaseUrl: streamingBaseUrl,
+      proxyUrl,
     }).then((featured) => {
       if (isCurrentLoad()) setFeaturedGames(featured);
     }).catch((error) => {
@@ -1629,6 +1664,7 @@ export function App(): JSX.Element {
       if (isCurrentLoad()) setFeaturedGames([]);
     });
   }, [
+    activeSessionProxyUrl,
     applyCatalogBrowseResult,
     applyVariantSelections,
     catalogSelectedFilterIds,
@@ -1648,6 +1684,7 @@ export function App(): JSX.Element {
         setSettings(loadedSettings);
         setShowStatsOverlay(loadedSettings.showStatsOnLaunch);
         setSettingsLoaded(true);
+        const loadedSessionProxyUrl = getEnabledSessionProxyUrl(loadedSettings);
 
         // Load providers and session (refresh only if token is near expiry)
         setStartupStatusMessage(t("auth.status.restoringSavedSession"));
@@ -1705,8 +1742,8 @@ export function App(): JSX.Element {
         setProviderIdpId(activeProviderId);
 
         if (persistedSession) {
-          const hydrated = hydrateCatalogSnapshot(persistedSession);
-          void loadSessionRuntimeData(persistedSession, { background: hydrated !== null });
+          const hydrated = hydrateCatalogSnapshot(persistedSession, loadedSessionProxyUrl);
+          void loadSessionRuntimeData(persistedSession, { background: hydrated !== null, proxyUrl: loadedSessionProxyUrl });
         } else {
           runtimeDataLoadIdRef.current += 1;
           resetStorePanels();
@@ -1982,6 +2019,7 @@ export function App(): JSX.Element {
       const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
       const userId = authSession?.user.userId;
       const baseUrl = effectiveStreamingBaseUrl;
+      const proxyUrl = activeSessionProxyUrl;
       if (!token || !userId) {
         return;
       }
@@ -1991,13 +2029,14 @@ export function App(): JSX.Element {
           token,
           userId,
           providerStreamingBaseUrl: baseUrl,
+          proxyUrl,
           searchQuery,
           sortId: catalogSelectedSortId,
           filterIds: catalogSelectedFilterIds,
         });
         applyCatalogBrowseResult(catalogResult);
         if (featuredGames.length === 0) {
-          void window.openNow.fetchFeaturedGames({ token, userId, providerStreamingBaseUrl: baseUrl }).then((featured) => {
+          void window.openNow.fetchFeaturedGames({ token, userId, providerStreamingBaseUrl: baseUrl, proxyUrl }).then((featured) => {
             if (featured.length > 0) setFeaturedGames(featured);
           }).catch((error) => {
             console.warn("Featured games refresh failed:", error);
@@ -2006,7 +2045,7 @@ export function App(): JSX.Element {
         return;
       }
 
-      const result = await window.openNow.fetchLibraryGames({ token, userId, providerStreamingBaseUrl: baseUrl });
+      const result = await window.openNow.fetchLibraryGames({ token, userId, providerStreamingBaseUrl: baseUrl, proxyUrl });
       setLibraryGames(result);
       setSelectedGameId((previous) => result.some((game) => game.id === previous) ? previous : (result[0]?.id ?? ""));
       applyVariantSelections(result);
@@ -2017,7 +2056,7 @@ export function App(): JSX.Element {
         setLoading(false);
       }
     }
-  }, [applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, featuredGames.length, searchQuery, catalogFilterKey, catalogSelectedSortId]);
+  }, [activeSessionProxyUrl, applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, featuredGames.length, searchQuery, catalogFilterKey, catalogSelectedSortId]);
 
   const loadStorePanels = useCallback(async () => {
     const session = authSession;
@@ -2026,7 +2065,7 @@ export function App(): JSX.Element {
     const token = session.tokens.idToken ?? session.tokens.accessToken;
     if (!token) return;
 
-    const contextKey = `${session.user.userId}\0${effectiveStreamingBaseUrl}`;
+    const contextKey = `${session.user.userId}\0${effectiveStreamingBaseUrl}\0${getSessionProxyUiScope(activeSessionProxyUrl)}`;
     if (storePanelsLoadedContextRef.current === contextKey) return;
 
     const loadId = ++storePanelsLoadIdRef.current;
@@ -2036,6 +2075,7 @@ export function App(): JSX.Element {
       const panels = await window.openNow.fetchStorePanels({
         token,
         providerStreamingBaseUrl: effectiveStreamingBaseUrl,
+        proxyUrl: activeSessionProxyUrl,
       });
       if (!isCurrentLoad()) return;
       const panelGames = flattenStorePanelGames(panels);
@@ -2057,7 +2097,7 @@ export function App(): JSX.Element {
     } finally {
       if (isCurrentLoad()) setIsLoadingStorePanels(false);
     }
-  }, [authSession, effectiveStreamingBaseUrl]);
+  }, [activeSessionProxyUrl, authSession, effectiveStreamingBaseUrl]);
 
   useEffect(() => {
     if (storePanelGames.length === 0 || libraryGames.length === 0) return;
@@ -2079,7 +2119,7 @@ export function App(): JSX.Element {
     if (!authSession || currentPage !== "home" || settings.controllerMode || isInitializing) {
       return;
     }
-    const queryKey = buildCatalogQueryKey(searchQuery, catalogSelectedFilterIds, catalogSelectedSortId);
+    const queryKey = buildProxyAwareCatalogQueryKey(searchQuery, catalogSelectedFilterIds, catalogSelectedSortId, activeSessionProxyUrl);
     if (lastCatalogQueryRef.current === queryKey && games.length > 0) {
       return;
     }
@@ -2096,6 +2136,7 @@ export function App(): JSX.Element {
     isInitializing,
     loadGames,
     searchQuery,
+    activeSessionProxyUrl,
     catalogFilterKey,
     catalogSelectedSortId,
     settings.controllerMode,
@@ -2931,6 +2972,7 @@ export function App(): JSX.Element {
           const resolved = await window.openNow.resolveLaunchAppId({
             token,
             providerStreamingBaseUrl: effectiveStreamingBaseUrl,
+            proxyUrl: activeSessionProxyUrl,
             appIdOrUuid: game.uuid ?? selectedVariantId,
           });
           if (resolved && isNumericId(resolved)) {
@@ -2997,7 +3039,7 @@ export function App(): JSX.Element {
         }
       }
 
-      const sessionProxyUrl = settings.sessionProxyEnabled ? settings.sessionProxyUrl.trim() : "";
+      const sessionProxyUrl = activeSessionProxyUrl;
 
       // Create new session
       const newSession = await window.openNow.createSession({
@@ -3007,7 +3049,7 @@ export function App(): JSX.Element {
         internalTitle: game.title,
         accountLinked: chooseAccountLinked(game, selectedVariant),
         existingSessionStrategy,
-        proxyUrl: sessionProxyUrl || undefined,
+        proxyUrl: sessionProxyUrl,
         zone: "prod",
         settings: buildCurrentStreamSettings(),
       });
@@ -3082,7 +3124,7 @@ export function App(): JSX.Element {
           sessionId: newSession.sessionId,
           clientId: newSession.clientId,
           deviceId: newSession.deviceId,
-          proxyUrl: sessionProxyUrl || undefined,
+          proxyUrl: sessionProxyUrl,
         });
 
         if (launchAbortRef.current) {
@@ -3150,7 +3192,9 @@ export function App(): JSX.Element {
     }
   }, [
     authSession,
+    activeSessionProxyUrl,
     allKnownGames,
+    buildCurrentStreamSettings,
     buildSignalingConnectRequest,
     claimAndConnectSession,
     effectiveStreamingBaseUrl,
@@ -3159,7 +3203,6 @@ export function App(): JSX.Element {
     resetLaunchRuntime,
     resetStatsOverlayToPreference,
     selectedProvider,
-    settings,
     streamStatus,
     t,
     variantByGameId,
@@ -3193,6 +3236,7 @@ export function App(): JSX.Element {
           const searchResult = await window.openNow.browseCatalog({
             token,
             providerStreamingBaseUrl: effectiveStreamingBaseUrl,
+            proxyUrl: activeSessionProxyUrl,
             searchQuery: request.title,
             sortId: "relevance",
             filterIds: [],
@@ -3250,6 +3294,7 @@ export function App(): JSX.Element {
     };
   }, [
     allKnownGames,
+    activeSessionProxyUrl,
     authSession,
     effectiveStreamingBaseUrl,
     handlePlayGame,
@@ -3366,6 +3411,7 @@ export function App(): JSX.Element {
     void window.openNow.resolveStoreUrl({
       token,
       providerStreamingBaseUrl: effectiveStreamingBaseUrl,
+      proxyUrl: activeSessionProxyUrl,
       appIdOrUuid: game.uuid ?? game.id,
       variantId: selectedVariant?.id ?? selectedVariantId,
       store: selectedVariant?.store,
@@ -3374,7 +3420,7 @@ export function App(): JSX.Element {
     }).catch((error) => {
       console.error("Failed to resolve Store URL:", error);
     });
-  }, [authSession, effectiveStreamingBaseUrl, handleOpenStoreUrl]);
+  }, [activeSessionProxyUrl, authSession, effectiveStreamingBaseUrl, handleOpenStoreUrl]);
 
   useEffect(() => {
     if (!logoutConfirmOpen && !removeAccountConfirmOpen) return;

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -141,6 +141,19 @@ function getSessionProxyUiScope(proxyUrl: string | undefined): string {
   }
 }
 
+function hasSessionProxyCredentials(proxyUrl: string | undefined): boolean {
+  if (!proxyUrl) return false;
+  const trimmed = proxyUrl.trim();
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+
+  try {
+    const parsed = new URL(candidate);
+    return parsed.username.length > 0 || parsed.password.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function buildProxyAwareCatalogQueryKey(
   searchQuery: string,
   filterIds: string[],
@@ -583,6 +596,7 @@ export function App(): JSX.Element {
   const storePanelsLoadIdRef = useRef(0);
   const runtimeDataLoadIdRef = useRef(0);
   const lastCatalogQueryRef = useRef<string | null>(null);
+  const lastCatalogProxyUrlRef = useRef<string | undefined>(undefined);
   const signalingRecoveryRef = useRef<SignalingRecoveryState>({
     attemptCount: 0,
     inFlight: null,
@@ -1522,7 +1536,13 @@ export function App(): JSX.Element {
     catalogResult: CatalogBrowseResult,
     library: GameInfo[],
     queryKey: string,
+    proxyUrl?: string,
   ): void => {
+    if (hasSessionProxyCredentials(proxyUrl)) {
+      clearCatalogSnapshot();
+      return;
+    }
+
     saveCatalogSnapshot({
       version: 1,
       userId: session.user.userId,
@@ -1539,6 +1559,11 @@ export function App(): JSX.Element {
   }, []);
 
   const hydrateCatalogSnapshot = useCallback((session: AuthSession, proxyUrl: string | undefined = activeSessionProxyUrl): string | null => {
+    if (hasSessionProxyCredentials(proxyUrl)) {
+      clearCatalogSnapshot();
+      return null;
+    }
+
     const queryKey = buildProxyAwareCatalogQueryKey("", catalogSelectedFilterIds, catalogSelectedSortId, proxyUrl);
     const snapshot = loadCatalogSnapshot(
       session.user.userId,
@@ -1560,6 +1585,7 @@ export function App(): JSX.Element {
     ));
     applyVariantSelections([...snapshot.games, ...snapshot.libraryGames]);
     lastCatalogQueryRef.current = queryKey;
+    lastCatalogProxyUrlRef.current = proxyUrl;
     return queryKey;
   }, [activeSessionProxyUrl, applyVariantSelections, catalogSelectedFilterIds, catalogSelectedSortId]);
 
@@ -1578,6 +1604,7 @@ export function App(): JSX.Element {
 
     if (!background) {
       lastCatalogQueryRef.current = null;
+      lastCatalogProxyUrlRef.current = proxyUrl;
       setIsLoadingCatalog(true);
       setIsLoadingLibrary(true);
     }
@@ -1616,8 +1643,9 @@ export function App(): JSX.Element {
       latestCatalogResult = catalogResult;
       applyCatalogBrowseResult(catalogResult);
       lastCatalogQueryRef.current = catalogQueryKey;
+      lastCatalogProxyUrlRef.current = proxyUrl;
       if (latestLibraryGames) {
-        persistCatalogSnapshot(session, catalogResult, latestLibraryGames, catalogQueryKey);
+        persistCatalogSnapshot(session, catalogResult, latestLibraryGames, catalogQueryKey, proxyUrl);
       }
     }).catch((error) => {
       console.error("Catalog load failed:", error);
@@ -1642,7 +1670,7 @@ export function App(): JSX.Element {
       setLibraryGames(libGames);
       applyVariantSelections(libGames);
       if (latestCatalogResult) {
-        persistCatalogSnapshot(session, latestCatalogResult, libGames, catalogQueryKey);
+        persistCatalogSnapshot(session, latestCatalogResult, libGames, catalogQueryKey, proxyUrl);
       }
     }).catch((error) => {
       console.error("Library load failed:", error);
@@ -2120,10 +2148,15 @@ export function App(): JSX.Element {
       return;
     }
     const queryKey = buildProxyAwareCatalogQueryKey(searchQuery, catalogSelectedFilterIds, catalogSelectedSortId, activeSessionProxyUrl);
-    if (lastCatalogQueryRef.current === queryKey && games.length > 0) {
+    if (
+      lastCatalogQueryRef.current === queryKey
+      && lastCatalogProxyUrlRef.current === activeSessionProxyUrl
+      && games.length > 0
+    ) {
       return;
     }
     lastCatalogQueryRef.current = queryKey;
+    lastCatalogProxyUrlRef.current = activeSessionProxyUrl;
 
     const handle = window.setTimeout(() => {
       void loadGames("main", { background: games.length > 0 });

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -514,6 +514,8 @@ export interface PingResult {
 export interface GamesFetchRequest {
   token?: string;
   providerStreamingBaseUrl?: string;
+  /** Optional proxy used for GFN games catalog/list requests. */
+  proxyUrl?: string;
   /** Stable account id used for on-disk cache scoping (avoids cache misses on token refresh). */
   userId?: string;
 }
@@ -536,12 +538,14 @@ export interface CatalogBrowseRequest extends GamesFetchRequest {
 export interface ResolveLaunchIdRequest {
   token?: string;
   providerStreamingBaseUrl?: string;
+  proxyUrl?: string;
   appIdOrUuid: string;
 }
 
 export interface ResolveStoreUrlRequest {
   token?: string;
   providerStreamingBaseUrl?: string;
+  proxyUrl?: string;
   appIdOrUuid: string;
   variantId?: string;
   store?: string;


### PR DESCRIPTION
This PR adds games list proxy support to the existing proxy pipeline, allowing users to bypass region-based content filtering on the GeForce NOW catalog. When a session proxy is enabled, all catalog GraphQL requests, public games list fetches, and store panel queries are routed through the configured proxy. Cache keys are scoped to the proxy configuration to prevent stale data when switching between direct and proxied requests.

**Proxy Pipeline**

- Add `sessionProxyCacheKeyPart` to generate stable cache key segments from proxy URLs
- Update `fetchWithOptionalProxy` to accept optional proxy URL parameter
- Wire proxy through public games uncached fetch in `publicGames.ts`

**Games Catalog**

- Add `proxyUrl` parameter to all catalog fetch functions (`fetchMainGames`, `fetchLibraryGames`, `fetchFeaturedGames`, `fetchStorePanels`, `browseCatalog`, `fetchPublicGames`)
- Update cache key generation functions to include proxy scope
- Pass proxy through GraphQL queries, panel requests, app metadata, and VPC ID lookups
- Update `getAccountGamesCacheKeys` to return proxy-scoped cache keys

**IPC and Refresh**

- Add `proxyUrl` to `GamesFetchRequest`, `CatalogBrowseRequest`, `ResolveLaunchIdRequest`, and `ResolveStoreUrlRequest` types
- Wire proxy through IPC handlers and context resolvers
- Update `RefreshScheduler` to include proxy in `RefreshAuthContext` and pass to uncached fetches

**Renderer**

- Add `getEnabledSessionProxyUrl` to resolve active proxy URL from settings
- Add `getSessionProxyUiScope` and `buildProxyAwareCatalogQueryKey` for proxy-aware cache keys
- Pass proxy URL through all catalog loads, featured games, store panels, and resolution requests
- Update store panels context key to include proxy scope

**Documentation**

- Update session proxy settings hint to reflect catalog proxy usage
- Add test for `sessionProxyCacheKeyPart` function

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/2c99f8a5-b11c-438a-87bc-358426741c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-224" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/2c99f8a5-b11c-438a-87bc-358426741c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-224&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-224"><img alt="OPE-224" src="https://capy.ai/api/badge/thread.svg?label=OPE-224"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches broad catalog fetch and caching paths; incorrect proxy scoping could show stale or wrong regional catalog data, though credentialed proxies intentionally bypass cache.
> 
> **Overview**
> Extends the optional **session proxy** so GeForce NOW **games catalog** traffic (not just session/queue) can go through the same proxy, helping users work around region-filtered storefront data. **Streaming/signaling stays direct**; settings copy is updated to say catalog is included.
> 
> **Main process:** Catalog GraphQL, `serverInfo`/VPC lookup, panels, metadata, public game list, and related paths now use `fetchWithOptionalProxy` with an optional `proxyUrl`. Game caches are **scoped by proxy host** (`sessionProxyCacheKeyPart`); **proxies with credentials skip disk cache** and **background refresh** is skipped for those configs.
> 
> **IPC/renderer:** `proxyUrl` is added to shared fetch/request types and threaded through catalog IPC handlers, refresh scheduler auth context, and the renderer (`activeSessionProxyUrl`) for browse/library/featured/store panels, launch/store resolution, and proxy-aware catalog snapshot/query keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7524ce8d74cb63fdc50ba872c3d568ac569cd9f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->