### PR TITLE
feat(android): add persistent storage and account connectors

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
@@ -98,6 +98,11 @@ private const val DEFAULT_CATALOG_FETCH_COUNT = 120
 private const val MAX_CATALOG_PAGES = 3
 private const val DEFAULT_SORT_ID = "relevance"
 private const val SESSION_MODIFY_ACTION_AD_UPDATE = 6
+private const val STORAGE_ADDON_TYPE = "STORAGE"
+private const val TOTAL_STORAGE_SIZE_IN_GB = "TOTAL_STORAGE_SIZE_IN_GB"
+private const val USED_STORAGE_SIZE_IN_GB = "USED_STORAGE_SIZE_IN_GB"
+private const val STORAGE_METRO_REGION = "STORAGE_METRO_REGION"
+private const val STORAGE_METRO_REGION_NAME = "STORAGE_METRO_REGION_NAME"
 
 private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
 private val GRAPHQL_MEDIA_TYPE = "application/graphql".toMediaType()
@@ -1498,6 +1503,11 @@ class GfnSubscriptionRepository(
                 fps = obj.int("framesPerSecond") ?: return@mapNotNull null,
             )
         }?.sortedWith(compareByDescending<EntitledResolution> { it.width }.thenByDescending { it.height }.thenByDescending { it.fps }).orEmpty()
+        val subscription = data.obj("subscription") ?: data
+        val storageAddon = subscription.arr("addons")
+            ?.mapNotNull { it.asObject() }
+            ?.firstOrNull { it.string("type") == STORAGE_ADDON_TYPE }
+            ?.let(::parseStorageAddon)
         return SubscriptionInfo(
             membershipTier = data.string("membershipTier") ?: "FREE",
             subscriptionType = data.string("type"),
@@ -1511,8 +1521,119 @@ class GfnSubscriptionRepository(
             state = data.obj("currentSubscriptionState")?.string("state"),
             isGamePlayAllowed = data.obj("currentSubscriptionState")?.boolean("isGamePlayAllowed"),
             isUnlimited = data.string("subType") == "UNLIMITED",
+            storageAddon = storageAddon,
             entitledResolutions = resolutions,
         )
+    }
+
+    private fun parseStorageAddon(addon: JsonObject): StorageAddon {
+        val attributes = addon.arr("attributes")
+            ?.mapNotNull { it.asObject() }
+            ?.associate { attribute ->
+                attribute.string("key").orEmpty() to attribute.string("textValue").orEmpty()
+            }
+            .orEmpty()
+        val total = attributes[TOTAL_STORAGE_SIZE_IN_GB]?.toDoubleOrNull()
+        val used = attributes[USED_STORAGE_SIZE_IN_GB]?.toDoubleOrNull()
+        return StorageAddon(
+            type = addon.string("type") ?: STORAGE_ADDON_TYPE,
+            sizeGb = total,
+            usedGb = used,
+            regionName = attributes[STORAGE_METRO_REGION_NAME],
+            regionCode = attributes[STORAGE_METRO_REGION],
+            status = addon.string("status"),
+            subType = addon.string("subType"),
+            autoPayEnabled = addon.boolean("autoPayEnabled"),
+        )
+    }
+}
+
+class GfnAccountConnectorRepository(
+    private val http: OkHttpClient = defaultHttpClient(),
+) {
+    suspend fun fetchConnectors(token: String): List<AccountConnector> {
+        val query = """
+            query GetAccountConnectors(${'$'}locale: String!, ${'$'}stringsKey: [String]!) {
+              appStoreDefinitions(language: ${'$'}locale) {
+                store
+                label
+                accountLinkingMetadata {
+                  isSupported
+                  isRequired
+                  label
+                }
+              }
+              userAccount {
+                storesData {
+                  store
+                  accountLinkingData {
+                    userDisplayName
+                    expiresIn
+                    userIdentifier
+                    accountSyncingData {
+                      totalNumberOfSyncedGfnGames
+                      syncState
+                      syncDate
+                    }
+                  }
+                }
+              }
+              clientStrings(language: ${'$'}locale, keys: ${'$'}stringsKey)
+            }
+        """.trimIndent()
+        val payload = postGraphQl(
+            query,
+            buildJsonObject {
+                put("locale", DEFAULT_LOCALE)
+                putJsonArray("stringsKey") {}
+            },
+            token,
+        ).checkGraphQlErrors("Account connectors")
+        val data = payload.obj("data") ?: return emptyList()
+        val userStores = data.obj("userAccount")?.arr("storesData")
+            ?.mapNotNull { it.asObject() }
+            ?.associateBy { normalizeGameStore(it.string("store").orEmpty()) }
+            .orEmpty()
+        return data.arr("appStoreDefinitions")
+            ?.mapNotNull { raw ->
+                val store = raw.asObject() ?: return@mapNotNull null
+                val storeId = store.string("store")?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                val metadata = store.obj("accountLinkingMetadata")
+                val supported = metadata?.boolean("isSupported") ?: false
+                val normalizedStoreId = normalizeGameStore(storeId)
+                if (!supported && normalizedStoreId !in userStores) return@mapNotNull null
+                val linked = userStores[normalizedStoreId]?.obj("accountLinkingData")
+                val sync = linked?.obj("accountSyncingData")
+                AccountConnector(
+                    store = storeId,
+                    label = metadata?.string("label") ?: store.string("label") ?: gameStoreDisplayName(storeId),
+                    supported = supported,
+                    required = metadata?.boolean("isRequired") ?: false,
+                    userDisplayName = linked?.string("userDisplayName"),
+                    userIdentifier = linked?.string("userIdentifier"),
+                    expiresInSeconds = linked?.long("expiresIn"),
+                    syncedGameCount = sync?.int("totalNumberOfSyncedGfnGames"),
+                    syncState = sync?.string("syncState"),
+                    syncDate = sync?.string("syncDate"),
+                )
+            }
+            ?.sortedWith(compareByDescending<AccountConnector> { it.isLinked }.thenBy { it.label.lowercase(Locale.US) })
+            .orEmpty()
+    }
+
+    private suspend fun postGraphQl(query: String, variables: JsonObject, token: String): JsonObject {
+        val body = buildJsonObject {
+            put("query", query)
+            put("variables", variables)
+        }.toString().toRequestBody(JSON_MEDIA_TYPE)
+        val request = Request.Builder()
+            .url(GAMES_GRAPHQL_URL)
+            .headers(desktopGraphQlHeaders(token))
+            .post(body)
+            .build()
+        val (code, text) = http.awaitText(request)
+        check(code in 200..299) { "Account connectors failed ($code): ${text.take(400)}" }
+        return OpenNowJson.parseToJsonElement(text).jsonObject
     }
 }
 

--- a/android/app/src/main/java/com/opencloudgaming/opennow/Models.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/Models.kt
@@ -427,6 +427,9 @@ data class StorageAddon(
     val usedGb: Double? = null,
     val regionName: String? = null,
     val regionCode: String? = null,
+    val status: String? = null,
+    val subType: String? = null,
+    val autoPayEnabled: Boolean? = null,
 )
 
 @Serializable
@@ -446,6 +449,23 @@ data class SubscriptionInfo(
     val storageAddon: StorageAddon? = null,
     val entitledResolutions: List<EntitledResolution> = emptyList(),
 )
+
+@Serializable
+data class AccountConnector(
+    val store: String,
+    val label: String,
+    val supported: Boolean = true,
+    val required: Boolean = false,
+    val userDisplayName: String? = null,
+    val userIdentifier: String? = null,
+    val expiresInSeconds: Long? = null,
+    val syncedGameCount: Int? = null,
+    val syncState: String? = null,
+    val syncDate: String? = null,
+)
+
+val AccountConnector.isLinked: Boolean
+    get() = !userDisplayName.isNullOrBlank() || !userIdentifier.isNullOrBlank()
 
 @Serializable
 data class GameVariant(

--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowScreens.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowScreens.kt
@@ -3321,6 +3321,7 @@ private fun formatUpdateBytes(bytes: Long): String {
 @Composable
 private fun AccountSettingsPanel(state: OpenNowUiState, viewModel: OpenNowViewModel) {
     val currentUserId = state.authSession?.user?.userId
+    val context = LocalContext.current
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         state.savedAccounts.ifEmpty {
             state.authSession?.toSavedAccount()?.let { listOf(it) } ?: emptyList()
@@ -3361,6 +3362,127 @@ private fun AccountSettingsPanel(state: OpenNowUiState, viewModel: OpenNowViewMo
             OutlinedButton(onClick = viewModel::logout, modifier = Modifier.weight(1f)) { Text("Sign out") }
         }
         OutlinedButton(onClick = viewModel::logoutAll, modifier = Modifier.fillMaxWidth()) { Text("Sign out all accounts") }
+        StorageAddonPanel(
+            storageAddon = state.subscriptionInfo?.storageAddon,
+            openExternal = { url ->
+                if (!openExternalUrl(context, url)) {
+                    Toast.makeText(context, "No browser available", Toast.LENGTH_SHORT).show()
+                }
+            },
+        )
+        AccountConnectorsPanel(
+            connectors = state.accountConnectors,
+            loading = state.loadingAccountConnectors,
+            onRefresh = viewModel::refreshAccountConnectors,
+            openExternal = { url ->
+                if (!openExternalUrl(context, url)) {
+                    Toast.makeText(context, "No browser available", Toast.LENGTH_SHORT).show()
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun StorageAddonPanel(storageAddon: StorageAddon?, openExternal: (String) -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.76f),
+    ) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Cloud storage", color = SettingsText, fontWeight = FontWeight.SemiBold)
+            if (storageAddon == null) {
+                Text("No persistent storage add-on is active for this account.", color = SettingsTextMuted, style = MaterialTheme.typography.bodySmall)
+                OutlinedButton(onClick = { openExternal(GFN_ADD_STORAGE_URL) }, modifier = Modifier.fillMaxWidth()) {
+                    Text("Add storage", maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+            } else {
+                val used = storageAddon.usedGb
+                val total = storageAddon.sizeGb
+                Text(
+                    listOfNotNull(
+                        total?.let { "Total ${formatStorageGb(it)}" },
+                        used?.let { "Used ${formatStorageGb(it)}" },
+                        if (used != null && total != null) "Available ${formatStorageGb((total - used).coerceAtLeast(0.0))}" else null,
+                    ).joinToString(" - "),
+                    color = SettingsTextMuted,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                storageAddon.regionName?.takeIf { it.isNotBlank() }?.let { region ->
+                    Text("Location: $region", color = SettingsTextMuted, style = MaterialTheme.typography.bodySmall)
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                    Button(onClick = { openExternal(GFN_STORAGE_MANAGEMENT_URL) }, modifier = Modifier.weight(1f)) {
+                        Text("Manage", maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                    OutlinedButton(onClick = { openExternal(GFN_STORAGE_RESET_URL) }, modifier = Modifier.weight(1f)) {
+                        Text("Reset", maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                }
+                OutlinedButton(onClick = { openExternal(GFN_STORAGE_MANAGEMENT_URL) }, modifier = Modifier.fillMaxWidth()) {
+                    Text("Change storage location", maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountConnectorsPanel(
+    connectors: List<AccountConnector>,
+    loading: Boolean,
+    onRefresh: () -> Unit,
+    openExternal: (String) -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.76f),
+    ) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Game store connections", color = SettingsText, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                TextButton(onClick = onRefresh, enabled = !loading) {
+                    Text(if (loading) "Refreshing..." else "Refresh")
+                }
+            }
+            if (connectors.isEmpty()) {
+                Text(
+                    if (loading) "Loading connected stores..." else "Connect Steam, Epic, Xbox, and other supported stores to sync your GeForce NOW library.",
+                    color = SettingsTextMuted,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            } else {
+                connectors.take(6).forEach { connector ->
+                    ConnectorRow(connector)
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                Button(onClick = { openExternal(GFN_ACCOUNT_CONNECT_URL) }, modifier = Modifier.weight(1f)) {
+                    Text("Connect store", maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+                OutlinedButton(onClick = { openExternal(GFN_ACCOUNT_MANAGEMENT_URL) }, modifier = Modifier.weight(1f)) {
+                    Text("Manage", maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConnectorRow(connector: AccountConnector) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.weight(1f)) {
+            Text(connector.label, color = SettingsText, fontWeight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(connectorStatusText(connector), color = SettingsTextMuted, style = MaterialTheme.typography.bodySmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
+        Text(
+            if (connector.isLinked) "Linked" else "Not linked",
+            color = if (connector.isLinked) MaterialTheme.colorScheme.primary else SettingsTextMuted,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
     }
 }
 
@@ -3373,6 +3495,28 @@ private fun AuthSession.toSavedAccount(): SavedAccount =
         membershipTier = user.membershipTier,
         providerCode = provider.code,
     )
+
+private const val GFN_STORAGE_MANAGEMENT_URL = "https://gfn.link/cloudstorage"
+private const val GFN_STORAGE_RESET_URL = "https://gfn.link/resetstorage"
+private const val GFN_ADD_STORAGE_URL = "https://gfn.link/addstorage"
+private const val GFN_ACCOUNT_CONNECT_URL = "https://gfn.link/connect"
+private const val GFN_ACCOUNT_MANAGEMENT_URL = "https://gfn.link/account"
+
+private fun formatStorageGb(value: Double): String =
+    if (value % 1.0 == 0.0) "${value.toInt()} GB" else "%.1f GB".format(Locale.US, value)
+
+private fun connectorStatusText(connector: AccountConnector): String {
+    if (!connector.isLinked) return if (connector.required) "Required for some games" else "Available to connect"
+    val identity = connector.userDisplayName?.takeIf { it.isNotBlank() }
+        ?: connector.userIdentifier?.takeIf { it.isNotBlank() }
+    val sync = when {
+        connector.syncedGameCount != null -> "${connector.syncedGameCount} synced games"
+        !connector.syncState.isNullOrBlank() -> connector.syncState.replace('_', ' ').lowercase(Locale.US)
+            .replaceFirstChar { it.titlecase(Locale.US) }
+        else -> null
+    }
+    return listOfNotNull(identity, sync).joinToString(" - ").ifBlank { "Connected" }
+}
 
 @Composable
 private fun CodecDiagnosticsPanel(report: RuntimeCodecReport?) {

--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
@@ -54,6 +54,8 @@ data class OpenNowUiState(
     val selectedProvider: LoginProvider = defaultProvider(),
     val savedAccounts: List<SavedAccount> = emptyList(),
     val subscriptionInfo: SubscriptionInfo? = null,
+    val accountConnectors: List<AccountConnector> = emptyList(),
+    val loadingAccountConnectors: Boolean = false,
     val regions: List<StreamRegion> = emptyList(),
     val games: List<GameInfo> = emptyList(),
     val libraryGames: List<GameInfo> = emptyList(),
@@ -100,6 +102,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
     private val catalogRepository = GfnCatalogRepository(http)
     private val catalogCacheStore = CatalogCacheStore(application)
     private val subscriptionRepository = GfnSubscriptionRepository(http)
+    private val accountConnectorRepository = GfnAccountConnectorRepository(http)
     private val printedWasteRepository = PrintedWasteRepository(http)
     private val sessionRepository = GfnSessionRepository(authStore, http)
     private val appUpdater = AndroidAppUpdater(application, http)
@@ -401,6 +404,8 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                     selectedProvider = session.provider,
                     savedAccounts = authStore.state.value.sessions.map { saved -> saved.toSavedAccount() },
                     subscriptionInfo = null,
+                    accountConnectors = emptyList(),
+                    loadingAccountConnectors = false,
                     games = emptyList(),
                     libraryGames = emptyList(),
                     catalogResult = CatalogBrowseResult(emptyList()),
@@ -429,6 +434,9 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
             it.copy(
                 authSession = null,
                 savedAccounts = emptyList(),
+                subscriptionInfo = null,
+                accountConnectors = emptyList(),
+                loadingAccountConnectors = false,
                 games = emptyList(),
                 libraryGames = emptyList(),
                 libraryFilterIds = emptyList(),
@@ -604,6 +612,22 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
         val session = state.value.authSession ?: return
         viewModelScope.launch {
             refreshAfterAuth(session)
+        }
+    }
+
+    fun refreshAccountConnectors() {
+        val session = state.value.authSession ?: return
+        viewModelScope.launch {
+            val token = authRepository.restore(forceRefresh = false)?.tokens?.accessToken ?: session.tokens.accessToken
+            _state.update { it.copy(loadingAccountConnectors = true) }
+            runCatching { accountConnectorRepository.fetchConnectors(token) }
+                .onSuccess { connectors ->
+                    _state.update { it.copy(accountConnectors = connectors, loadingAccountConnectors = false) }
+                }
+                .onFailure { error ->
+                    if (error is CancellationException) return@onFailure
+                    _state.update { it.copy(loadingAccountConnectors = false, error = error.message ?: "Failed to load account connections") }
+                }
         }
     }
 
@@ -1544,6 +1568,11 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
             }.getOrNull()
             _state.update { it.copy(subscriptionInfo = sub) }
         }
+        val accountConnectorsJob = viewModelScope.launch {
+            _state.update { it.copy(loadingAccountConnectors = true) }
+            val connectors = runCatching { accountConnectorRepository.fetchConnectors(token) }.getOrDefault(emptyList())
+            _state.update { it.copy(accountConnectors = connectors, loadingAccountConnectors = false) }
+        }
         val regionsJob = viewModelScope.launch {
             val regions = runCatching { fetchDynamicRegions(http, token, session.provider.streamingServiceUrl).first }.getOrDefault(emptyList())
             _state.update { it.copy(regions = regions) }
@@ -1584,6 +1613,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
             }
         }
         subscriptionJob.join()
+        accountConnectorsJob.join()
         regionsJob.join()
     }
 


### PR DESCRIPTION
This PR implements the missing account and storage management views for the Android client by connecting the existing subscription and new connector APIs to the settings UI.

*   Add `GfnAccountConnectorRepository` to fetch game store linking status and sync metadata via GraphQL.
*   Add `StorageAddon` parsing to `GfnSubscriptionRepository` to extract total/used GB and region name from subscription attributes.
*   Add `StorageAddonPanel` in settings to manage storage, reset data, or change region.
*   Add `AccountConnectorsPanel` in settings to view and refresh Steam/Epic/Xbox connection status.
*   Update `OpenNowUiState` to track connectors and their loading state.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/afa5e577-c5e2-47f3-a750-26d72e2815f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPEN-011" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/afa5e577-c5e2-47f3-a750-26d72e2815f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-011&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-011"><img alt="OPEN-011" src="https://capy.ai/api/badge/thread.svg?label=OPEN-011"></picture></a>
<!-- capy-pr-badge:end -->