### PR TITLE
fix(gfn): use SendUnicode for clipboard paste

### DIFF
--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
@@ -23,6 +23,7 @@ import {
   INPUT_MOUSE_BUTTON_DOWN,
   INPUT_MOUSE_REL,
   INPUT_MOUSE_WHEEL,
+  INPUT_TEXT,
   InputEncoder,
   codeMap,
   isPartiallyReliableHidTransferEligible,
@@ -265,6 +266,27 @@ test("encodes mouse button and wheel with v3 single-event wrapper", () => {
   assert.equal(wheelPayload.getInt16(4, false), 0);
   assert.equal(wheelPayload.getInt16(6, false), -120);
   assert.equal(wheelPayload.getBigUint64(14, false), 456n);
+});
+
+test("encodes unicode text input with official SendUnicode packet framing", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(3);
+  const [packet] = encoder.encodeTextInput("a🙂\nß");
+
+  assert.ok(packet);
+  assert.equal(packet[0], 0x22);
+  assert.equal(view(packet).getUint32(1, true), INPUT_TEXT);
+  assert.equal(new TextDecoder().decode(packet.subarray(5)), "a🙂\nß");
+});
+
+test("chunks unicode text input without splitting UTF-8 code points", () => {
+  const encoder = new InputEncoder();
+  const packets = encoder.encodeTextInput(`${"a".repeat(1015)}🙂b`);
+
+  assert.equal(packets.length, 2);
+  assert.equal(packets[0].byteLength, 5 + 1015);
+  assert.equal(new TextDecoder().decode(packets[0].subarray(5)), "a".repeat(1015));
+  assert.equal(new TextDecoder().decode(packets[1].subarray(5)), "🙂b");
 });
 
 test("maps Gamepad API button values to XInput flags without pressed", () => {

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -11,6 +11,10 @@ export const INPUT_MOUSE_BUTTON_UP = 9;
 export const INPUT_MOUSE_WHEEL = 10;
 export const INPUT_GAMEPAD = 12;
 export const INPUT_HAPTICS_ENABLED = 13;
+export const INPUT_TEXT = 23;
+
+const TEXT_INPUT_CHUNK_MAX_BYTES = 1016;
+const TEXT_INPUT_HEADER_BYTES = 5;
 
 // Mouse button constants (1-based for GFN protocol)
 // GFN uses: 1=Left, 2=Middle, 3=Right, 4=Back, 5=Forward
@@ -803,6 +807,28 @@ export class InputEncoder {
     return wrapSingleEvent(bytes, this.protocolVersion);
   }
 
+  encodeTextInput(text: string): Uint8Array[] {
+    const utf8 = new TextEncoder().encode(text);
+    const chunks: Uint8Array[] = [];
+
+    for (let offset = 0; offset < utf8.byteLength;) {
+      const chunkLength = textInputChunkLength(utf8, offset);
+      if (chunkLength <= 0) {
+        break;
+      }
+
+      const bytes = new Uint8Array(TEXT_INPUT_HEADER_BYTES + chunkLength);
+      const view = new DataView(bytes.buffer);
+      bytes[0] = 0x22;
+      view.setUint32(1, INPUT_TEXT, true);
+      bytes.set(utf8.subarray(offset, offset + chunkLength), TEXT_INPUT_HEADER_BYTES);
+      chunks.push(bytes);
+      offset += chunkLength;
+    }
+
+    return chunks;
+  }
+
   encodeGamepadState(payload: GamepadInput, bitmap: number, usePartiallyReliable: boolean): Uint8Array {
     const bytes = new Uint8Array(GAMEPAD_PACKET_SIZE);
     const view = new DataView(bytes.buffer);
@@ -895,6 +921,23 @@ export class InputEncoder {
     view.setBigUint64(10, payload.timestampUs, false);    // timestamp: BE
     return wrapSingleEvent(bytes, this.protocolVersion);
   }
+}
+
+function textInputChunkLength(bytes: Uint8Array, offset: number): number {
+  const remaining = bytes.byteLength - offset;
+  if (remaining <= TEXT_INPUT_CHUNK_MAX_BYTES) {
+    return remaining;
+  }
+
+  let end = offset + TEXT_INPUT_CHUNK_MAX_BYTES;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if ((bytes[end] & 0xc0) !== 0x80) {
+      return end - offset;
+    }
+    end--;
+  }
+
+  return 0;
 }
 
 /** Per-key modifier byte (official GFN yS()). Lock keys sync separately via INPUT_LOCK_KEYS_SYNC. */

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -28,7 +28,6 @@ import {
   GAMEPAD_MAX_CONTROLLERS,
   type GamepadInput,
   codeMap,
-  mapTextCharToKeySpec,
 } from "./inputProtocol";
 import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "./keyboardLock";
 import {
@@ -3036,30 +3035,12 @@ export class GfnWebRtcClient {
       return 0;
     }
 
-    let sent = 0;
-    const maxChars = 4096;
-    for (const char of text.slice(0, maxChars)) {
-      const key = mapTextCharToKeySpec(char, this.keyboardLayout);
-      if (!key) {
-        continue;
-      }
-
-      if (key.shift) {
-        this.sendKeyPacket(codeMap.ShiftLeft.vk, codeMap.ShiftLeft.scancode, 0x01, true);
-      }
-
-      const mods = key.shift ? 0x01 : 0;
-      this.sendKeyPacket(key.vk, key.scancode, mods, true);
-      this.sendKeyPacket(key.vk, key.scancode, mods, false);
-
-      if (key.shift) {
-        this.sendKeyPacket(codeMap.ShiftLeft.vk, codeMap.ShiftLeft.scancode, 0, false);
-      }
-
-      sent++;
+    const chunks = this.inputEncoder.encodeTextInput(text);
+    for (const chunk of chunks) {
+      this.sendReliable(chunk);
     }
 
-    return sent;
+    return Array.from(text).length;
   }
 
   private sendGamepad(payload: Uint8Array): void {


### PR DESCRIPTION
This PR fixes clipboard paste during streaming by using the official NVIDIA GFN SendUnicode protocol instead of synthesizing individual key events.

- Add `INPUT_TEXT` constant and text input encoding to `inputProtocol.ts`
- Implement UTF-8 text chunking that never splits multi-byte code points
- Replace character-by-character key synthesis in `webrtcClient.ts` with proper Unicode text packets
- Add tests verifying packet framing and UTF-8 splitting behavior

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/b1283afd-575d-42f5-b226-e7ea623fea59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-226" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/b1283afd-575d-42f5-b226-e7ea623fea59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-226&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-226"><img alt="OPE-226" src="https://capy.ai/api/badge/thread.svg?label=OPE-226"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the remote text-input path used for clipboard paste during active streams; behavior should improve for Unicode but depends on the server accepting SendUnicode packets correctly.
> 
> **Overview**
> **Clipboard and text injection during GFN streaming** now uses NVIDIA’s official **SendUnicode** path (`INPUT_TEXT` / type 23) instead of synthesizing per-character key down/up events from keyboard layout maps.
> 
> `InputEncoder.encodeTextInput` builds packets with the `0x22` sub-message marker, little-endian type 23, and UTF-8 payload, splitting long strings into **1016-byte chunks** that never cut a multi-byte code point. `GfnWebRtcClient.sendText` sends those chunks on the **reliable** input channel and no longer depends on `mapTextCharToKeySpec` for paste. Tests cover framing (including emoji/newlines) and chunk boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c09f119eba82e1f3dc2fedb08731beed0c93ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->