### PR TITLE
fix(android): correct storage filter and connector state

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
@@ -1506,7 +1506,7 @@ class GfnSubscriptionRepository(
         val subscription = data.obj("subscription") ?: data
         val storageAddon = subscription.arr("addons")
             ?.mapNotNull { it.asObject() }
-            ?.firstOrNull { it.string("type") == STORAGE_ADDON_TYPE }
+            ?.firstOrNull(::isActivePersistentStorageAddon)
             ?.let(::parseStorageAddon)
         return SubscriptionInfo(
             membershipTier = data.string("membershipTier") ?: "FREE",
@@ -1546,6 +1546,11 @@ class GfnSubscriptionRepository(
             autoPayEnabled = addon.boolean("autoPayEnabled"),
         )
     }
+
+    private fun isActivePersistentStorageAddon(addon: JsonObject): Boolean =
+        addon.string("type") == STORAGE_ADDON_TYPE &&
+            addon.string("subType") == "PERMANENT_STORAGE" &&
+            addon.string("status") == "OK"
 }
 
 class GfnAccountConnectorRepository(

--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
@@ -376,6 +376,9 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                     authSession = nextSession,
                     selectedProvider = nextSession?.provider ?: it.selectedProvider,
                     savedAccounts = authStore.state.value.sessions.map { saved -> saved.toSavedAccount() },
+                    subscriptionInfo = null,
+                    accountConnectors = emptyList(),
+                    loadingAccountConnectors = false,
                     games = emptyList(),
                     libraryGames = emptyList(),
                     libraryFilterIds = emptyList(),
@@ -618,7 +621,8 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
     fun refreshAccountConnectors() {
         val session = state.value.authSession ?: return
         viewModelScope.launch {
-            val token = authRepository.restore(forceRefresh = false)?.tokens?.accessToken ?: session.tokens.accessToken
+            val token = authRepository.restore(forceRefresh = false)?.tokens?.let { it.idToken ?: it.accessToken }
+                ?: (session.tokens.idToken ?: session.tokens.accessToken)
             _state.update { it.copy(loadingAccountConnectors = true) }
             runCatching { accountConnectorRepository.fetchConnectors(token) }
                 .onSuccess { connectors ->


### PR DESCRIPTION
This PR fixes three medium-severity issues found in the merged storage/connectors implementation:

- Filter storage add-ons by `subType=PERMANENT_STORAGE` and `status=OK` before parsing to prevent inactive or non-permanent entries from being displayed.
- Clear `accountConnectors` and `loadingAccountConnectors` in the `logout()` state update to prevent stale connector data from persisting after sign-out.
- Align manual `refreshAccountConnectors()` token selection with `refreshAfterAuth()` by preferring `idToken` over `accessToken` to avoid failures when endpoints expect ID tokens.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/afa5e577-c5e2-47f3-a750-26d72e2815f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPEN-011" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/afa5e577-c5e2-47f3-a750-26d72e2815f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-011&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-011"><img alt="OPEN-011" src="https://capy.ai/api/badge/thread.svg?label=OPEN-011"></picture></a>
<!-- capy-pr-badge:end -->