### PR TITLE
feat(android): add in-app store connector actions

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
@@ -104,6 +104,9 @@ private const val TOTAL_STORAGE_SIZE_IN_GB = "TOTAL_STORAGE_SIZE_IN_GB"
 private const val USED_STORAGE_SIZE_IN_GB = "USED_STORAGE_SIZE_IN_GB"
 private const val STORAGE_METRO_REGION = "STORAGE_METRO_REGION"
 private const val STORAGE_METRO_REGION_NAME = "STORAGE_METRO_REGION_NAME"
+private const val ACCOUNT_LINKING_BASE_URL = "https://linking.nvidia.com/v1"
+private const val ACCOUNT_LINKING_CLIENT_ID = LCARS_CLIENT_ID
+private const val ACCOUNT_LINKING_REDIRECT_URL = "https://static-als.nvidia.com/result"
 
 private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
 private val GRAPHQL_MEDIA_TYPE = "application/graphql".toMediaType()
@@ -1700,6 +1703,34 @@ class GfnAccountConnectorRepository(
             .orEmpty()
     }
 
+    suspend fun loginUrl(store: String, accessToken: String): String {
+        val url = "$ACCOUNT_LINKING_BASE_URL/login_url"
+            .toHttpUrl()
+            .newBuilder()
+            .addQueryParameter("platform", store)
+            .addQueryParameter("redirect_uri", ACCOUNT_LINKING_REDIRECT_URL)
+            .addQueryParameter("client_id", ACCOUNT_LINKING_CLIENT_ID)
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .headers(accountLinkingHeaders(accessToken))
+            .build()
+        val (code, text) = http.awaitText(request)
+        check(code in 200..299) { "Store connection failed ($code): ${text.take(240)}" }
+        return OpenNowJson.parseToJsonElement(text).jsonObject.string("login_url")
+            ?: error("Store connection did not return a login URL")
+    }
+
+    suspend fun disconnect(store: String, accessToken: String) {
+        val request = Request.Builder()
+            .url("$ACCOUNT_LINKING_BASE_URL/linking/${encoded(store)}")
+            .headers(accountLinkingHeaders(accessToken))
+            .delete()
+            .build()
+        val (code, text) = http.awaitText(request)
+        check(code in 200..299) { "Store disconnect failed ($code): ${text.take(240)}" }
+    }
+
     private suspend fun postGraphQl(query: String, variables: JsonObject, token: String): JsonObject {
         val body = buildJsonObject {
             put("query", query)
@@ -1714,6 +1745,13 @@ class GfnAccountConnectorRepository(
         check(code in 200..299) { "Account connectors failed ($code): ${text.take(400)}" }
         return OpenNowJson.parseToJsonElement(text).jsonObject
     }
+
+    private fun accountLinkingHeaders(accessToken: String): Headers =
+        Headers.Builder()
+            .add("Accept", "application/json")
+            .add("Authorization", bearerAuthorization(accessToken))
+            .add("User-Agent", GFN_USER_AGENT)
+            .build()
 }
 
 class PrintedWasteRepository(

--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowScreens.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowScreens.kt
@@ -3461,7 +3461,18 @@ private fun AccountSettingsPanel(state: OpenNowUiState, viewModel: OpenNowViewMo
         AccountConnectorsPanel(
             connectors = state.accountConnectors,
             loading = state.loadingAccountConnectors,
+            actionStore = state.connectorActionStore,
             onRefresh = viewModel::refreshAccountConnectors,
+            onConnect = { connector ->
+                viewModel.connectAccountConnector(connector.store) { url ->
+                    if (!openExternalUrl(context, url)) {
+                        Toast.makeText(context, "No browser available", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            },
+            onDisconnect = { connector ->
+                viewModel.disconnectAccountConnector(connector.store)
+            },
             openExternal = { url ->
                 if (!openExternalUrl(context, url)) {
                     Toast.makeText(context, "No browser available", Toast.LENGTH_SHORT).show()
@@ -3520,9 +3531,35 @@ private fun StorageAddonPanel(storageAddon: StorageAddon?, openExternal: (String
 private fun AccountConnectorsPanel(
     connectors: List<AccountConnector>,
     loading: Boolean,
+    actionStore: String?,
     onRefresh: () -> Unit,
+    onConnect: (AccountConnector) -> Unit,
+    onDisconnect: (AccountConnector) -> Unit,
     openExternal: (String) -> Unit,
 ) {
+    var disconnecting by remember { mutableStateOf<AccountConnector?>(null) }
+    disconnecting?.let { connector ->
+        AlertDialog(
+            onDismissRequest = { disconnecting = null },
+            title = { Text("Disconnect ${connector.label}?") },
+            text = { Text("This removes the linked ${connector.label} account from GeForce NOW. You can connect it again later.") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        disconnecting = null
+                        onDisconnect(connector)
+                    },
+                ) {
+                    Text("Disconnect")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { disconnecting = null }) {
+                    Text(stringResource(R.string.action_cancel))
+                }
+            },
+        )
+    }
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(14.dp),
@@ -3543,34 +3580,51 @@ private fun AccountConnectorsPanel(
                 )
             } else {
                 connectors.take(6).forEach { connector ->
-                    ConnectorRow(connector)
+                    ConnectorRow(
+                        connector = connector,
+                        busy = actionStore == connector.store,
+                        onConnect = { onConnect(connector) },
+                        onDisconnect = { disconnecting = connector },
+                    )
                 }
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-                Button(onClick = { openExternal(GFN_ACCOUNT_CONNECT_URL) }, modifier = Modifier.weight(1f)) {
-                    Text("Connect store", maxLines = 1, overflow = TextOverflow.Ellipsis)
-                }
-                OutlinedButton(onClick = { openExternal(GFN_ACCOUNT_MANAGEMENT_URL) }, modifier = Modifier.weight(1f)) {
-                    Text("Manage", maxLines = 1, overflow = TextOverflow.Ellipsis)
-                }
+            OutlinedButton(onClick = { openExternal(GFN_ACCOUNT_HELP_URL) }, modifier = Modifier.fillMaxWidth()) {
+                Text("Connection help", maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     }
 }
 
 @Composable
-private fun ConnectorRow(connector: AccountConnector) {
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+private fun ConnectorRow(
+    connector: AccountConnector,
+    busy: Boolean,
+    onConnect: () -> Unit,
+    onDisconnect: () -> Unit,
+) {
+    val actionEnabled = !busy && (connector.isLinked || connector.supported)
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = actionEnabled) {
+                if (connector.isLinked) onDisconnect() else onConnect()
+            },
+    ) {
         Column(Modifier.weight(1f)) {
             Text(connector.label, color = SettingsText, fontWeight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
             Text(connectorStatusText(connector), color = SettingsTextMuted, style = MaterialTheme.typography.bodySmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
-        Text(
-            if (connector.isLinked) "Linked" else "Not linked",
-            color = if (connector.isLinked) MaterialTheme.colorScheme.primary else SettingsTextMuted,
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = FontWeight.Bold,
-        )
+        if (connector.isLinked) {
+            OutlinedButton(onClick = onDisconnect, enabled = !busy, contentPadding = PaddingValues(horizontal = 10.dp, vertical = 6.dp)) {
+                Text(if (busy) "Removing..." else "Disconnect")
+            }
+        } else {
+            Button(onClick = onConnect, enabled = connector.supported && !busy, contentPadding = PaddingValues(horizontal = 10.dp, vertical = 6.dp)) {
+                Text(if (busy) "Opening..." else "Connect")
+            }
+        }
     }
 }
 
@@ -3587,8 +3641,7 @@ private fun AuthSession.toSavedAccount(): SavedAccount =
 private const val GFN_STORAGE_MANAGEMENT_URL = "https://gfn.link/cloudstorage"
 private const val GFN_STORAGE_RESET_URL = "https://gfn.link/resetstorage"
 private const val GFN_ADD_STORAGE_URL = "https://gfn.link/addstorage"
-private const val GFN_ACCOUNT_CONNECT_URL = "https://gfn.link/connect"
-private const val GFN_ACCOUNT_MANAGEMENT_URL = "https://gfn.link/account"
+private const val GFN_ACCOUNT_HELP_URL = "https://gfn.link/5399"
 
 private fun formatStorageGb(value: Double): String =
     if (value % 1.0 == 0.0) "${value.toInt()} GB" else "%.1f GB".format(Locale.US, value)

--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
@@ -56,6 +56,7 @@ data class OpenNowUiState(
     val subscriptionInfo: SubscriptionInfo? = null,
     val accountConnectors: List<AccountConnector> = emptyList(),
     val loadingAccountConnectors: Boolean = false,
+    val connectorActionStore: String? = null,
     val regions: List<StreamRegion> = emptyList(),
     val games: List<GameInfo> = emptyList(),
     val libraryGames: List<GameInfo> = emptyList(),
@@ -379,6 +380,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                     subscriptionInfo = null,
                     accountConnectors = emptyList(),
                     loadingAccountConnectors = false,
+                    connectorActionStore = null,
                     games = emptyList(),
                     libraryGames = emptyList(),
                     libraryFilterIds = emptyList(),
@@ -409,6 +411,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                     subscriptionInfo = null,
                     accountConnectors = emptyList(),
                     loadingAccountConnectors = false,
+                    connectorActionStore = null,
                     games = emptyList(),
                     libraryGames = emptyList(),
                     catalogResult = CatalogBrowseResult(emptyList()),
@@ -440,6 +443,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                 subscriptionInfo = null,
                 accountConnectors = emptyList(),
                 loadingAccountConnectors = false,
+                connectorActionStore = null,
                 games = emptyList(),
                 libraryGames = emptyList(),
                 libraryFilterIds = emptyList(),
@@ -631,6 +635,41 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                 .onFailure { error ->
                     if (error is CancellationException) return@onFailure
                     _state.update { it.copy(loadingAccountConnectors = false, error = error.message ?: "Failed to load account connections") }
+                }
+        }
+    }
+
+    fun connectAccountConnector(store: String, openUrl: (String) -> Unit) {
+        val session = state.value.authSession ?: return
+        viewModelScope.launch {
+            val token = authRepository.restore(forceRefresh = false)?.tokens?.accessToken ?: session.tokens.accessToken
+            _state.update { it.copy(connectorActionStore = store, error = null) }
+            runCatching { accountConnectorRepository.loginUrl(store, token) }
+                .onSuccess { url ->
+                    _state.update { it.copy(connectorActionStore = null) }
+                    openUrl(url)
+                }
+                .onFailure { error ->
+                    if (error is CancellationException) return@onFailure
+                    _state.update { it.copy(connectorActionStore = null, error = error.message ?: "Failed to start store connection") }
+                }
+        }
+    }
+
+    fun disconnectAccountConnector(store: String) {
+        val session = state.value.authSession ?: return
+        viewModelScope.launch {
+            val token = authRepository.restore(forceRefresh = false)?.tokens?.accessToken ?: session.tokens.accessToken
+            _state.update { it.copy(connectorActionStore = store, error = null) }
+            runCatching { accountConnectorRepository.disconnect(store, token) }
+                .onSuccess {
+                    Toast.makeText(getApplication(), "Store disconnected", Toast.LENGTH_SHORT).show()
+                    _state.update { it.copy(connectorActionStore = null) }
+                    refreshAccountConnectors()
+                }
+                .onFailure { error ->
+                    if (error is CancellationException) return@onFailure
+                    _state.update { it.copy(connectorActionStore = null, error = error.message ?: "Failed to disconnect store") }
                 }
         }
     }


### PR DESCRIPTION
This PR adds per-store connect and disconnect actions for game store account connectors in the Android native client.

- Add ALS API methods to request store connection URL and unlink stores via `GfnAccountConnectorRepository.loginUrl()` and `disconnect()`
- Track connector action state during connect/disconnect in `OpenNowUiState`
- Replace generic connect/manage buttons with per-store action buttons in `AccountConnectorsPanel`
- Add confirm dialog before disconnecting linked stores

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/afa5e577-c5e2-47f3-a750-26d72e2815f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPEN-011" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/afa5e577-c5e2-47f3-a750-26d72e2815f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-011&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-011"><img alt="OPEN-011" src="https://capy.ai/api/badge/thread.svg?label=OPEN-011"></picture></a>
<!-- capy-pr-badge:end -->