### PR TITLE
fix(settings): correct toggle switch geometry

### DIFF
--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -5399,8 +5399,8 @@ button.game-card-store-chip.owned.active:hover {
 .settings-toggle {
   position: relative;
   display: inline-block;
-  flex: 0 0 44px;
-  width: 44px;
+  flex: 0 0 46px;
+  width: 46px;
   height: 24px;
   cursor: pointer;
 }
@@ -5415,17 +5415,19 @@ button.game-card-store-chip.owned.active:hover {
   position: absolute;
   inset: 0;
   background: rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  transition: background var(--t-normal);
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  transition: background var(--t-normal), box-shadow var(--t-normal);
 }
 
 .settings-toggle-track::before {
   content: "";
   position: absolute;
-  top: 3px;
-  left: 3px;
-  width: 18px;
-  height: 18px;
+  top: 4px;
+  left: 4px;
+  width: 16px;
+  height: 16px;
   background: #fff;
   border-radius: 50%;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
@@ -5434,10 +5436,13 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-toggle input:checked+.settings-toggle-track {
   background: var(--accent);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.18),
+    0 0 0 1px rgba(var(--accent-rgb), 0.12);
 }
 
 .settings-toggle input:checked+.settings-toggle-track::before {
-  transform: translateX(20px);
+  transform: translateX(22px);
 }
 
 /* Placeholder */


### PR DESCRIPTION
This PR refines the visual rendering of toggle switches in the settings interface.

- Increase toggle track width from `44px` to `46px`
- Update track `border-radius` to `999px` for pill shape
- Add `box-shadow` to track for inset border definition
- Reduce knob `::before` size to `16px` and adjust positioning
- Update checked state `transform` offset to `22px`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/848bca25-9469-46fe-b9d9-bf989ba821fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-229" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/848bca25-9469-46fe-b9d9-bf989ba821fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-229&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-229"><img alt="OPE-229" src="https://capy.ai/api/badge/thread.svg?label=OPE-229"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only styling for settings toggles; no logic, persistence, or API changes.
> 
> **Overview**
> **Settings toggle switches** get a CSS-only visual pass so track, knob, and checked travel line up more cleanly.
> 
> The control grows from **44px to 46px** wide, uses a **pill** track (`border-radius: 999px`) with an **inset border** via `box-shadow`, and adds **`overflow: hidden`** on the track. The knob shrinks to **16px** with **4px** inset padding, and the checked **`translateX`** moves from **20px to 22px**. The on state also picks up **accent-aligned** inset and outer glow on the track.
> 
> No markup or behavior changes—every `settings-toggle` in the settings UI picks this up automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e2eb4790096c187e6834343248040283f95589b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->