### PR TITLE
fix(android): fix account linking and add Steam

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
@@ -1639,6 +1639,16 @@ class GfnAccountConnectorRepository(
               appStoreDefinitions(language: ${'$'}locale) {
                 store
                 label
+                sortOrder
+                features {
+                  __typename
+                  ... on AccountLinkingSso {
+                    supported
+                  }
+                  ... on AccountGamesSyncing {
+                    supported
+                  }
+                }
                 accountLinkingMetadata {
                   isSupported
                   isRequired
@@ -1676,12 +1686,18 @@ class GfnAccountConnectorRepository(
             ?.mapNotNull { it.asObject() }
             ?.associateBy { normalizeGameStore(it.string("store").orEmpty()) }
             .orEmpty()
-        return data.arr("appStoreDefinitions")
+        val connectors = data.arr("appStoreDefinitions")
             ?.mapNotNull { raw ->
                 val store = raw.asObject() ?: return@mapNotNull null
                 val storeId = store.string("store")?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                 val metadata = store.obj("accountLinkingMetadata")
-                val supported = metadata?.boolean("isSupported") ?: false
+                val featureSupported = store.arr("features")
+                    ?.mapNotNull { it.asObject() }
+                    ?.any { feature ->
+                        feature.boolean("supported") == true &&
+                            feature.string("__typename") in setOf("AccountLinkingSso", "AccountGamesSyncing")
+                    } == true
+                val supported = metadata?.boolean("isSupported") == true || featureSupported
                 val normalizedStoreId = normalizeGameStore(storeId)
                 if (!supported && normalizedStoreId !in userStores) return@mapNotNull null
                 val linked = userStores[normalizedStoreId]?.obj("accountLinkingData")
@@ -1699,15 +1715,21 @@ class GfnAccountConnectorRepository(
                     syncDate = sync?.string("syncDate"),
                 )
             }
-            ?.sortedWith(compareByDescending<AccountConnector> { it.isLinked }.thenBy { it.label.lowercase(Locale.US) })
             .orEmpty()
+            .ensureSteamConnector(userStores)
+        return connectors.sortedWith(
+            compareByDescending<AccountConnector> { it.isLinked }
+                .thenBy { accountConnectorSortRank(it.store) }
+                .thenBy { it.label.lowercase(Locale.US) },
+        )
     }
 
     suspend fun loginUrl(store: String, accessToken: String): String {
+        val platform = accountLinkingPlatform(store)
         val url = "$ACCOUNT_LINKING_BASE_URL/login_url"
             .toHttpUrl()
             .newBuilder()
-            .addQueryParameter("platform", store)
+            .addQueryParameter("platform", platform)
             .addQueryParameter("redirect_uri", ACCOUNT_LINKING_REDIRECT_URL)
             .addQueryParameter("client_id", ACCOUNT_LINKING_CLIENT_ID)
             .build()
@@ -1722,8 +1744,9 @@ class GfnAccountConnectorRepository(
     }
 
     suspend fun disconnect(store: String, accessToken: String) {
+        val platform = accountLinkingPlatform(store)
         val request = Request.Builder()
-            .url("$ACCOUNT_LINKING_BASE_URL/linking/${encoded(store)}")
+            .url("$ACCOUNT_LINKING_BASE_URL/linking/${encoded(platform)}")
             .headers(accountLinkingHeaders(accessToken))
             .delete()
             .build()
@@ -1752,6 +1775,36 @@ class GfnAccountConnectorRepository(
             .add("Authorization", bearerAuthorization(accessToken))
             .add("User-Agent", GFN_USER_AGENT)
             .build()
+
+    private fun List<AccountConnector>.ensureSteamConnector(userStores: Map<String, JsonObject>): List<AccountConnector> {
+        if (any { normalizeGameStore(it.store) == "STEAM" }) return this
+        val linked = userStores["STEAM"]?.obj("accountLinkingData")
+        val sync = linked?.obj("accountSyncingData")
+        return this + AccountConnector(
+            store = "STEAM",
+            label = "Steam",
+            supported = true,
+            required = false,
+            userDisplayName = linked?.string("userDisplayName"),
+            userIdentifier = linked?.string("userIdentifier"),
+            expiresInSeconds = linked?.long("expiresIn"),
+            syncedGameCount = sync?.int("totalNumberOfSyncedGfnGames"),
+            syncState = sync?.string("syncState"),
+            syncDate = sync?.string("syncDate"),
+        )
+    }
+
+    private fun accountLinkingPlatform(store: String): String =
+        normalizeGameStore(store).ifBlank { store }.uppercase(Locale.US)
+
+    private fun accountConnectorSortRank(store: String): Int =
+        when (normalizeGameStore(store)) {
+            "STEAM" -> 0
+            "EPIC", "EGS", "EPIC_GAMES_STORE" -> 1
+            "XBOX", "XBOX_GAME_PASS", "GAME_PASS" -> 2
+            "UBISOFT", "UBISOFT_CONNECT" -> 3
+            else -> 10
+        }
 }
 
 class PrintedWasteRepository(

--- a/android/app/src/main/java/com/opencloudgaming/opennow/Models.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/Models.kt
@@ -482,7 +482,12 @@ data class AccountConnector(
 )
 
 val AccountConnector.isLinked: Boolean
-    get() = !userDisplayName.isNullOrBlank() || !userIdentifier.isNullOrBlank()
+    get() = !userDisplayName.isNullOrBlank() ||
+        !userIdentifier.isNullOrBlank() ||
+        expiresInSeconds != null ||
+        syncedGameCount != null ||
+        !syncState.isNullOrBlank() ||
+        !syncDate.isNullOrBlank()
 
 @Serializable
 data class GameVariant(

--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
@@ -648,11 +648,21 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                 .onSuccess { url ->
                     _state.update { it.copy(connectorActionStore = null) }
                     openUrl(url)
+                    refreshAccountConnectorsAfterLinking()
                 }
                 .onFailure { error ->
                     if (error is CancellationException) return@onFailure
                     _state.update { it.copy(connectorActionStore = null, error = error.message ?: "Failed to start store connection") }
                 }
+        }
+    }
+
+    private fun refreshAccountConnectorsAfterLinking() {
+        viewModelScope.launch {
+            repeat(6) { attempt ->
+                delay(if (attempt == 0) 5_000L else 10_000L)
+                refreshAccountConnectors()
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes the Android native account linking flow by aligning API calls with the official web implementation and adds the missing Steam provider.

*   `android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt`: Updated `GetAccountConnectors` GraphQL query to fetch `features` and `sortOrder` fields. Added `ensureSteamConnector` helper to manually inject a Steam connector if omitted from definitions but present in user data. Added `accountLinkingPlatform` to normalize store IDs to uppercase (e.g. `STEAM`) for API compatibility. Implemented custom sorting to prioritize Steam, Epic, Xbox, and Ubisoft.
*   `android/app/src/main/java/com/opencloudgaming/opennow/Models.kt`: Expanded `AccountConnector.isLinked` logic to check sync metadata fields (`syncedGameCount`, `syncState`, `syncDate`) for more accurate link status detection.
*   `android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt`: Added `refreshAccountConnectorsAfterLinking` to poll the connector list after opening the OAuth login URL, ensuring the UI updates to reflect the linked state upon completion.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/4705d841-b0f2-48e4-8c78-295f5cb5c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPEN-012" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/4705d841-b0f2-48e4-8c78-295f5cb5c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-012&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-012"><img alt="OPEN-012" src="https://capy.ai/api/badge/thread.svg?label=OPEN-012"></picture></a>
<!-- capy-pr-badge:end -->