### PR TITLE
fix(settings): gate resolution and FPS by subscription tier

### DIFF
--- a/opennow-stable/src/main/gfn/subscription.test.ts
+++ b/opennow-stable/src/main/gfn/subscription.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { fetchSubscription } from "./subscription";
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(payload), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
+  });
+}
+
+test("fetchSubscription exposes only entitled resolution and fps profiles", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async (input) => {
+    const url = new URL(String(input));
+    assert.equal(url.origin + url.pathname, "https://mes.geforcenow.com/v4/subscriptions");
+    assert.equal(url.searchParams.get("userId"), "user-1");
+    assert.equal(url.searchParams.get("vpcId"), "NP-AMS-08");
+
+    return jsonResponse({
+      membershipTier: "FREE",
+      subType: "LIMITED",
+      features: {
+        resolutions: [
+          {
+            widthInPixels: 1920,
+            heightInPixels: 1080,
+            framesPerSecond: 60,
+            isEntitled: true,
+          },
+          {
+            widthInPixels: 1920,
+            heightInPixels: 1080,
+            framesPerSecond: 240,
+            isEntitled: false,
+          },
+          {
+            widthInPixels: 3840,
+            heightInPixels: 2160,
+            framesPerSecond: 120,
+            isEntitled: false,
+          },
+        ],
+      },
+    });
+  }) as typeof fetch;
+
+  const subscription = await fetchSubscription("token", "user-1", "NP-AMS-08");
+
+  assert.deepEqual(subscription.entitledResolutions, [
+    { width: 1920, height: 1080, fps: 60 },
+  ]);
+});

--- a/opennow-stable/src/main/gfn/subscription.ts
+++ b/opennow-stable/src/main/gfn/subscription.ts
@@ -185,7 +185,9 @@ export async function fetchSubscription(
   const entitledResolutions: EntitledResolution[] = [];
   if (data.features?.resolutions) {
     for (const res of data.features.resolutions) {
-      // Include all resolutions (matching Rust implementation behavior)
+      if (!res.isEntitled) {
+        continue;
+      }
       entitledResolutions.push({
         width: res.widthInPixels,
         height: res.heightInPixels,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -33,6 +33,7 @@ import {
   getDefaultStreamPreferences,
   isGameInLibrary,
   isSessionAdsRequired,
+  resolveEntitledStreamProfile,
 } from "@shared/gfn";
 import { GfnWebRtcClient } from "./gfn/webrtcClient";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
@@ -686,21 +687,28 @@ export function App(): JSX.Element {
     clearRuntimeSnapshot();
   }, [diagnosticsStore, resetStatsOverlayToPreference, settings.discordRichPresence]);
 
-  const buildCurrentStreamSettings = useCallback((): StreamSettings => ({
-    resolution: settings.resolution,
-    fps: settings.fps,
-    maxBitrateMbps: settings.maxBitrateMbps,
-    codec: settings.codec,
-    colorQuality: settings.colorQuality,
-    keyboardLayout: settings.keyboardLayout,
-    gameLanguage: settings.gameLanguage,
-    enableL4S: settings.enableL4S,
-    enableCloudGsync: settings.enableCloudGsync,
-    clientMode: settings.streamClientMode,
-    nativeStreamerBackend: "gstreamer",
-    nativeCloudGsyncMode: settings.nativeCloudGsyncMode,
-    nativeTransitionDiagnostics: settings.nativeTransitionDiagnostics,
-  }), [
+  const buildCurrentStreamSettings = useCallback((): StreamSettings => {
+    const entitledProfile = resolveEntitledStreamProfile(subscriptionInfo?.entitledResolutions ?? [], {
+      resolution: settings.resolution,
+      fps: settings.fps,
+    });
+
+    return {
+      resolution: entitledProfile?.resolution ?? settings.resolution,
+      fps: entitledProfile?.fps ?? settings.fps,
+      maxBitrateMbps: settings.maxBitrateMbps,
+      codec: settings.codec,
+      colorQuality: settings.colorQuality,
+      keyboardLayout: settings.keyboardLayout,
+      gameLanguage: settings.gameLanguage,
+      enableL4S: settings.enableL4S,
+      enableCloudGsync: settings.enableCloudGsync,
+      clientMode: settings.streamClientMode,
+      nativeStreamerBackend: "gstreamer",
+      nativeCloudGsyncMode: settings.nativeCloudGsyncMode,
+      nativeTransitionDiagnostics: settings.nativeTransitionDiagnostics,
+    };
+  }, [
     settings.codec,
     settings.colorQuality,
     settings.enableCloudGsync,
@@ -713,6 +721,7 @@ export function App(): JSX.Element {
     settings.nativeTransitionDiagnostics,
     settings.resolution,
     settings.streamClientMode,
+    subscriptionInfo?.entitledResolutions,
   ]);
 
   const warmNativeStreamerForLaunch = useCallback((): void => {
@@ -1488,6 +1497,33 @@ export function App(): JSX.Element {
       }
     }
   }, [settingsLoaded]);
+
+  useEffect(() => {
+    if (!settingsLoaded || !subscriptionInfo) {
+      return;
+    }
+
+    const entitledProfile = resolveEntitledStreamProfile(subscriptionInfo.entitledResolutions, {
+      resolution: settings.resolution,
+      fps: settings.fps,
+    });
+    if (!entitledProfile) {
+      return;
+    }
+
+    if (entitledProfile.resolution !== settings.resolution) {
+      void updateSetting("resolution", entitledProfile.resolution);
+    }
+    if (entitledProfile.fps !== settings.fps) {
+      void updateSetting("fps", entitledProfile.fps);
+    }
+  }, [
+    settings.fps,
+    settings.resolution,
+    settingsLoaded,
+    subscriptionInfo,
+    updateSetting,
+  ]);
 
   const handleMouseSensitivityChange = useCallback((value: number) => {
     void updateSetting("mouseSensitivity", value);

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -31,6 +31,7 @@ import {
   NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
   colorQualityRequiresHevc,
   keyboardLayoutOptions,
+  resolveEntitledStreamProfile,
   USER_FACING_COLOR_QUALITY_OPTIONS,
   USER_FACING_VIDEO_CODEC_OPTIONS,
 } from "@shared/gfn";
@@ -562,10 +563,11 @@ function getFpsForResolution(entitled: EntitledResolution[], resolution: string)
   return [...new Set(fpsList)].sort((a, b) => a - b);
 }
 
-const ENTITLED_RESOLUTIONS_STORAGE_KEY = "opennow.entitled-resolutions.v1";
+const ENTITLED_RESOLUTIONS_STORAGE_KEY = "opennow.entitled-resolutions.v2";
 
 interface EntitledResolutionsCache {
   userId: string;
+  membershipTier: string;
   entitledResolutions: EntitledResolution[];
 }
 
@@ -579,6 +581,7 @@ function loadCachedEntitledResolutions(): EntitledResolutionsCache | null {
     }
     return {
       userId: parsed.userId,
+      membershipTier: typeof parsed.membershipTier === "string" ? parsed.membershipTier : "",
       entitledResolutions: parsed.entitledResolutions,
     };
   } catch {
@@ -916,7 +919,12 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
 
       const userId = session.user.userId;
       const cached = loadCachedEntitledResolutions();
-      if (cached && cached.userId === userId && !isCancelled()) {
+      if (
+        cached &&
+        cached.userId === userId &&
+        cached.membershipTier === session.user.membershipTier &&
+        !isCancelled()
+      ) {
         setEntitledResolutions(cached.entitledResolutions);
       }
 
@@ -929,6 +937,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
         setEntitledResolutions(sub.entitledResolutions);
         saveCachedEntitledResolutions({
           userId,
+          membershipTier: sub.membershipTier,
           entitledResolutions: sub.entitledResolutions,
         });
       }
@@ -1014,6 +1023,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   }, [t]);
 
   const hasDynamic = entitledResolutions.length > 0;
+  const useEntitledStreamOptions = hasDynamic || subscriptionInfo !== null;
 
   // Grouped resolution presets (dynamic)
   const resolutionGroups = useMemo(
@@ -1025,6 +1035,13 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   const dynamicFpsOptions = useMemo(
     () => (hasDynamic ? getFpsForResolution(entitledResolutions, settings.resolution) : []),
     [entitledResolutions, settings.resolution, hasDynamic]
+  );
+  const resolvedEntitledProfile = useMemo(
+    () => resolveEntitledStreamProfile(entitledResolutions, {
+      resolution: settings.resolution,
+      fps: settings.fps,
+    }),
+    [entitledResolutions, settings.fps, settings.resolution],
   );
   const posterSizePercent = Math.round(settings.posterSizeScale * 100);
   const updaterLastCheckedLabel = useMemo(() => formatUpdaterTimestamp(updaterState.lastCheckedAt), [updaterState.lastCheckedAt]);
@@ -1185,7 +1202,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   }, [gameAccountBusy, settings.sessionProxyEnabled, settings.sessionProxyUrl, t]);
 
   const selectedResolutionLabel = useMemo(() => {
-    if (hasDynamic) {
+    if (useEntitledStreamOptions) {
       for (const group of resolutionGroups) {
         const found = group.resolutions.find(r => r.value === settings.resolution);
         if (found) return found.label;
@@ -1194,7 +1211,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
     }
     const found = STATIC_RESOLUTION_PRESETS.find(r => r.value === settings.resolution);
     return found ? found.label : settings.resolution || "Select";
-  }, [settings.resolution, hasDynamic, resolutionGroups]);
+  }, [settings.resolution, useEntitledStreamOptions, resolutionGroups]);
 
   const handleChange = useCallback(
     <K extends keyof Settings>(key: K, value: Settings[K]) => {
@@ -1212,6 +1229,26 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
       handleChange("aspectRatio", aspectRatio);
     }
   }, [handleChange, settings.aspectRatio]);
+
+  useEffect(() => {
+    if (!useEntitledStreamOptions || !resolvedEntitledProfile) {
+      return;
+    }
+
+    if (resolvedEntitledProfile.resolution !== settings.resolution) {
+      handleResolutionChange(resolvedEntitledProfile.resolution);
+    }
+    if (resolvedEntitledProfile.fps !== settings.fps) {
+      handleChange("fps", resolvedEntitledProfile.fps);
+    }
+  }, [
+    handleChange,
+    handleResolutionChange,
+    resolvedEntitledProfile,
+    settings.fps,
+    settings.resolution,
+    useEntitledStreamOptions,
+  ]);
 
   const openNativeStreamerEnablePrompt = useCallback((): void => {
     if (nativeStreamerEnablePromptCloseTimerRef.current !== null) {
@@ -2728,7 +2765,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                     </button>
                     {resolutionDropdownOpen && (
                       <div className="settings-dropdown-menu settings-dropdown-menu--grouped">
-                        {(hasDynamic ? resolutionGroups : [{ category: "All", resolutions: STATIC_RESOLUTION_PRESETS.map(p => ({ ...p, width: 0, height: 0 })) }]).map(group => (
+                        {(useEntitledStreamOptions ? resolutionGroups : [{ category: "All", resolutions: STATIC_RESOLUTION_PRESETS.map(p => ({ ...p, width: 0, height: 0 })) }]).map(group => (
                           <div key={group.category} className="settings-dropdown-group">
                             <div className="settings-dropdown-group-label">{group.category}</div>
                             {group.resolutions.map(res => (
@@ -2756,7 +2793,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                     {t("settings.video.fps")}
                   </label>
                   <div className="settings-chip-row">
-                    {(hasDynamic ? dynamicFpsOptions.map((v) => ({ value: v })) : STATIC_FPS_PRESETS).map((preset) => (
+                    {(useEntitledStreamOptions ? dynamicFpsOptions.map((v) => ({ value: v })) : STATIC_FPS_PRESETS).map((preset) => (
                       <button
                         key={preset.value}
                         className={`settings-chip ${settings.fps === preset.value ? "active" : ""}`}

--- a/opennow-stable/src/shared/entitlements.test.ts
+++ b/opennow-stable/src/shared/entitlements.test.ts
@@ -1,0 +1,23 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveEntitledStreamProfile } from "./gfn";
+
+test("resolves requested stream settings to entitled resolution and fps profiles", () => {
+  const entitlements = [
+    { width: 1920, height: 1080, fps: 60 },
+    { width: 1280, height: 720, fps: 60 },
+  ];
+
+  assert.deepEqual(
+    resolveEntitledStreamProfile(entitlements, { resolution: "1920x1080", fps: 240 }),
+    { resolution: "1920x1080", fps: 60 },
+  );
+  assert.deepEqual(
+    resolveEntitledStreamProfile(entitlements, { resolution: "3840x2160", fps: 120 }),
+    { resolution: "1920x1080", fps: 60 },
+  );
+  assert.equal(resolveEntitledStreamProfile([], { resolution: "1920x1080", fps: 60 }), null);
+});

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -366,6 +366,78 @@ export interface EntitledResolution {
   fps: number;
 }
 
+export interface EntitledStreamProfile {
+  resolution: string;
+  fps: number;
+}
+
+function parseResolutionValue(resolution: string): { width: number; height: number } | null {
+  const [widthText, heightText] = resolution.split("x");
+  const width = Number.parseInt(widthText ?? "", 10);
+  const height = Number.parseInt(heightText ?? "", 10);
+  return Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0
+    ? { width, height }
+    : null;
+}
+
+function isValidEntitledResolution(resolution: EntitledResolution): boolean {
+  return Number.isFinite(resolution.width)
+    && resolution.width > 0
+    && Number.isFinite(resolution.height)
+    && resolution.height > 0
+    && Number.isFinite(resolution.fps)
+    && resolution.fps > 0;
+}
+
+function compareEntitledResolutionDescending(a: EntitledResolution, b: EntitledResolution): number {
+  const pixelDelta = b.width * b.height - a.width * a.height;
+  if (pixelDelta !== 0) return pixelDelta;
+  if (b.width !== a.width) return b.width - a.width;
+  if (b.height !== a.height) return b.height - a.height;
+  return b.fps - a.fps;
+}
+
+export function resolveEntitledStreamProfile(
+  entitledResolutions: readonly EntitledResolution[],
+  requested: EntitledStreamProfile,
+): EntitledStreamProfile | null {
+  const validEntitlements = entitledResolutions.filter(isValidEntitledResolution);
+  if (validEntitlements.length === 0) {
+    return null;
+  }
+
+  const requestedResolution = parseResolutionValue(requested.resolution);
+  const matchingResolutionEntries = requestedResolution
+    ? validEntitlements.filter(
+      (resolution) =>
+        resolution.width === requestedResolution.width &&
+        resolution.height === requestedResolution.height,
+    )
+    : [];
+  const fallbackResolution = [...validEntitlements].sort(compareEntitledResolutionDescending)[0];
+  const selectedResolutionEntries = matchingResolutionEntries.length > 0
+    ? matchingResolutionEntries
+    : validEntitlements.filter(
+      (resolution) =>
+        resolution.width === fallbackResolution.width &&
+        resolution.height === fallbackResolution.height,
+    );
+  const fpsOptions = [...new Set(selectedResolutionEntries.map((resolution) => Math.trunc(resolution.fps)))]
+    .sort((a, b) => a - b);
+  const requestedFps = Number.isFinite(requested.fps) && requested.fps > 0
+    ? Math.trunc(requested.fps)
+    : undefined;
+  const fps = requestedFps && fpsOptions.includes(requestedFps)
+    ? requestedFps
+    : [...fpsOptions].reverse().find((option) => requestedFps !== undefined && option <= requestedFps) ?? fpsOptions[0];
+  const selectedResolution = selectedResolutionEntries[0];
+
+  return {
+    resolution: `${selectedResolution.width}x${selectedResolution.height}`,
+    fps,
+  };
+}
+
 export interface StorageAddon {
   type: "PERMANENT_STORAGE";
   sizeGb?: number;


### PR DESCRIPTION
This PR filters available streaming options and automatically corrects user settings to match the user's entitled membership tier, preventing the selection of resolutions or FPS rates not supported by their subscription.

**Core Changes**

- **Subscription parsing** (`opennow-stable/src/main/gfn/subscription.ts`): Filter the `resolutions` list from the MES API to only include entries where `isEntitled` is true, ensuring the app only considers capabilities available to the user's tier.

- **Entitlement resolution** (`opennow-stable/src/shared/gfn.ts`): Add `resolveEntitledStreamProfile` helper to map requested resolution/FPS settings to the highest valid option available within the user's entitled list, matching official client fallback behavior.

- **Settings application** (`opennow-stable/src/renderer/src/App.tsx`): Call `resolveEntitledStreamProfile` when building stream settings for launch and when subscription info loads, automatically downgrading settings (e.g., 240 FPS -> 60 FPS) if they exceed entitlements.

- **Settings UI** (`opennow-stable/src/renderer/src/components/SettingsPage.tsx`): Update resolution and FPS dropdowns to populate options from the filtered `entitledResolutions` list. Correct the currently selected settings on mount/useEffect to match the entitlements.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/3b298c3c-2e29-4165-a421-afdf738f403c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-230" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/3b298c3c-2e29-4165-a421-afdf738f403c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-230&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-230"><img alt="OPE-230" src="https://capy.ai/api/badge/thread.svg?label=OPE-230"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect stream launch parameters and persisted user settings whenever subscription data loads; incorrect entitlement logic could downgrade quality or send invalid settings to GFN.
> 
> **Overview**
> Streaming resolution and FPS are now tied to **subscription entitlements** instead of treating every MES resolution as available.
> 
> **MES parsing** only keeps resolutions with `isEntitled: true`. A shared **`resolveEntitledStreamProfile`** helper maps requested resolution/FPS to the best allowed profile (same resolution with a lower FPS, or fallback to the highest entitled resolution).
> 
> **Runtime behavior**: `buildCurrentStreamSettings` and session create/claim/resume use the resolved profile so launches cannot exceed tier limits. **Settings** auto-correct stored resolution/FPS when subscription data loads, and the video UI uses entitled lists (with static presets only when subscription data is absent). Session cache for entitled resolutions is bumped to **v2** and keyed by **membership tier**.
> 
> Unit tests cover subscription filtering and profile resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb8a77ea187b17ddfbfaf6f9462960a6efc2c66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->