### PR TITLE
fix(android): unify ALS auth token selection

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
@@ -633,8 +633,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
 
     private suspend fun refreshAccountConnectors(session: AuthSession) {
         accountConnectorRefreshMutex.withLock {
-            val token = authRepository.restore(forceRefresh = false)?.tokens?.let { it.idToken ?: it.accessToken }
-                ?: (session.tokens.idToken ?: session.tokens.accessToken)
+            val token = accountConnectorAuthToken(session)
             _state.update { it.copy(loadingAccountConnectors = true) }
             runCatching { accountConnectorRepository.fetchConnectors(token) }
                 .onSuccess { connectors ->
@@ -650,7 +649,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
     fun connectAccountConnector(store: String, openUrl: (String) -> Unit) {
         val session = state.value.authSession ?: return
         viewModelScope.launch {
-            val token = authRepository.restore(forceRefresh = false)?.tokens?.accessToken ?: session.tokens.accessToken
+            val token = accountConnectorAuthToken(session)
             _state.update { it.copy(connectorActionStore = store, error = null) }
             runCatching { withTimeout(20_000L) { accountConnectorRepository.loginUrl(store, token) } }
                 .onSuccess { url ->
@@ -660,10 +659,16 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                 }
                 .onFailure { error ->
                     if (error is CancellationException) return@onFailure
-                    _state.update { it.copy(connectorActionStore = null, error = error.message ?: "Failed to start store connection") }
+                    val message = error.message ?: "Failed to start store connection"
+                    Toast.makeText(getApplication(), message, Toast.LENGTH_SHORT).show()
+                    _state.update { it.copy(connectorActionStore = null, error = message) }
                 }
         }
     }
+
+    private suspend fun accountConnectorAuthToken(session: AuthSession): String =
+        authRepository.restore(forceRefresh = false)?.tokens?.let { it.idToken ?: it.accessToken }
+            ?: (session.tokens.idToken ?: session.tokens.accessToken)
 
     private fun refreshAccountConnectorsAfterLinking() {
         viewModelScope.launch {
@@ -678,7 +683,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
     fun disconnectAccountConnector(store: String) {
         val session = state.value.authSession ?: return
         viewModelScope.launch {
-            val token = authRepository.restore(forceRefresh = false)?.tokens?.accessToken ?: session.tokens.accessToken
+            val token = accountConnectorAuthToken(session)
             _state.update { it.copy(connectorActionStore = store, error = null) }
             runCatching { accountConnectorRepository.disconnect(store, token) }
                 .onSuccess {
@@ -688,7 +693,9 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                 }
                 .onFailure { error ->
                     if (error is CancellationException) return@onFailure
-                    _state.update { it.copy(connectorActionStore = null, error = error.message ?: "Failed to disconnect store") }
+                    val message = error.message ?: "Failed to disconnect store"
+                    Toast.makeText(getApplication(), message, Toast.LENGTH_SHORT).show()
+                    _state.update { it.copy(connectorActionStore = null, error = message) }
                 }
         }
     }


### PR DESCRIPTION
This PR fixes the 401 Unauthorized error occurring when attempting to connect/disconnect game store accounts.

- **Unified token selection**: Created `accountConnectorAuthToken` to prefer `idToken` over `accessToken` for ALS requests, matching the successful `fetchConnectors` implementation.
- **Visible failure feedback**: Added `Toast` messages for connect/disconnect errors so users immediately see the failure state without navigating to the Home screen.

Related to [[pr:550](https://github.com/OpenCloudGaming/OpenNOW/pull/550)] and [[pr:553](https://github.com/OpenCloudGaming/OpenNOW/pull/553)].

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/4705d841-b0f2-48e4-8c78-295f5cb5c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPEN-012" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/4705d841-b0f2-48e4-8c78-295f5cb5c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-012&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-012"><img alt="OPEN-012" src="https://capy.ai/api/badge/thread.svg?label=OPEN-012"></picture></a>
<!-- capy-pr-badge:end -->