### PR TITLE
fix(settings): gate resolution and FPS by subscription tier

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -34,6 +34,7 @@ import {
   isGameInLibrary,
   isSessionAdsRequired,
   resolveEntitledStreamProfile,
+  SAFE_FALLBACK_STREAM_PROFILE,
 } from "@shared/gfn";
 import { GfnWebRtcClient } from "./gfn/webrtcClient";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
@@ -687,15 +688,17 @@ export function App(): JSX.Element {
     clearRuntimeSnapshot();
   }, [diagnosticsStore, resetStatsOverlayToPreference, settings.discordRichPresence]);
 
-  const buildCurrentStreamSettings = useCallback((): StreamSettings => {
-    const entitledProfile = resolveEntitledStreamProfile(subscriptionInfo?.entitledResolutions ?? [], {
+  const buildCurrentStreamSettings = useCallback((subscriptionOverride?: SubscriptionInfo | null): StreamSettings => {
+    const currentSubscription = subscriptionOverride === undefined ? subscriptionInfo : subscriptionOverride;
+    const entitledProfile = resolveEntitledStreamProfile(currentSubscription?.entitledResolutions ?? [], {
       resolution: settings.resolution,
       fps: settings.fps,
     });
+    const streamProfile = entitledProfile ?? SAFE_FALLBACK_STREAM_PROFILE;
 
     return {
-      resolution: entitledProfile?.resolution ?? settings.resolution,
-      fps: entitledProfile?.fps ?? settings.fps,
+      resolution: streamProfile.resolution,
+      fps: streamProfile.fps,
       maxBitrateMbps: settings.maxBitrateMbps,
       codec: settings.codec,
       colorQuality: settings.colorQuality,
@@ -969,6 +972,30 @@ export function App(): JSX.Element {
     }
     return selectedProvider?.streamingServiceUrl ?? "";
   }, [selectedProvider, settings.region]);
+
+  const resolveSubscriptionInfoForLaunch = useCallback(async (): Promise<SubscriptionInfo | null> => {
+    if (subscriptionInfo) {
+      return subscriptionInfo;
+    }
+
+    const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken;
+    if (!authSession || !token) {
+      return null;
+    }
+
+    try {
+      const subscription = await window.openNow.fetchSubscription({
+        token,
+        providerStreamingBaseUrl: effectiveStreamingBaseUrl,
+        userId: authSession.user.userId,
+      });
+      setSubscriptionInfo(subscription);
+      return subscription;
+    } catch (error) {
+      console.warn("Failed to resolve subscription before launch; using safe stream profile fallback:", error);
+      return null;
+    }
+  }, [authSession, effectiveStreamingBaseUrl, subscriptionInfo]);
 
   const {
     activeQueueAd,
@@ -1506,10 +1533,7 @@ export function App(): JSX.Element {
     const entitledProfile = resolveEntitledStreamProfile(subscriptionInfo.entitledResolutions, {
       resolution: settings.resolution,
       fps: settings.fps,
-    });
-    if (!entitledProfile) {
-      return;
-    }
+    }) ?? SAFE_FALLBACK_STREAM_PROFILE;
 
     if (entitledProfile.resolution !== settings.resolution) {
       void updateSetting("resolution", entitledProfile.resolution);
@@ -2378,6 +2402,8 @@ export function App(): JSX.Element {
           setStreamingStore(null);
         }
 
+        const launchSubscription = await resolveSubscriptionInfoForLaunch();
+        const streamSettings = buildCurrentStreamSettings(launchSubscription);
         const claimed = await window.openNow.claimSession({
           token,
           streamingBaseUrl: effectiveStreamingBaseUrl,
@@ -2385,7 +2411,7 @@ export function App(): JSX.Element {
           sessionId: existingSession.sessionId,
           ...resolveResumeIdentity(existingSession.sessionId),
           appId: resolveSessionClaimAppId(existingSession),
-          settings: buildCurrentStreamSettings(),
+          settings: streamSettings,
         });
 
         await applyClaimedSessionAndConnect(claimed);
@@ -2400,7 +2426,7 @@ export function App(): JSX.Element {
 
     claimResumePromisesRef.current.set(sid, resumePromiseHolder.promise);
     await resumePromiseHolder.promise;
-  }, [applyClaimedSessionAndConnect, authSession, buildCurrentStreamSettings, effectiveStreamingBaseUrl, findGameContextForSession, resolveResumeIdentity, resolveSessionClaimAppId, warmNativeStreamerForLaunch]);
+  }, [applyClaimedSessionAndConnect, authSession, buildCurrentStreamSettings, effectiveStreamingBaseUrl, findGameContextForSession, resolveResumeIdentity, resolveSessionClaimAppId, resolveSubscriptionInfoForLaunch, warmNativeStreamerForLaunch]);
 
   const attemptSessionRecovery = useCallback(async (reason: string): Promise<boolean> => {
     const recoveryState = signalingRecoveryRef.current;
@@ -2527,6 +2553,8 @@ export function App(): JSX.Element {
             throw new Error("The running session is missing a server address, so resume was not possible.");
           }
 
+          const recoverySubscription = await resolveSubscriptionInfoForLaunch();
+          const recoveryStreamSettings = buildCurrentStreamSettings(recoverySubscription);
           const claimed = await window.openNow.claimSession({
             token,
             streamingBaseUrl: effectiveStreamingBaseUrl,
@@ -2535,7 +2563,7 @@ export function App(): JSX.Element {
             ...resolveResumeIdentity(candidate.sessionId),
             recoveryMode: true,
             appId: resolveSessionClaimAppId(candidate),
-            settings: buildCurrentStreamSettings(),
+            settings: recoveryStreamSettings,
           });
           if (!isRecoveryGenerationCurrent(recoveryGeneration)) {
             console.log("[Recovery] Discarding claimed session due to stale recovery generation");
@@ -2586,6 +2614,7 @@ export function App(): JSX.Element {
     resolveResumeIdentity,
     resolveSessionClaimAppId,
     buildCurrentStreamSettings,
+    resolveSubscriptionInfoForLaunch,
   ]);
 
   const handleExpectedNativeSessionClose = useCallback((reason: string): void => {
@@ -3109,6 +3138,8 @@ export function App(): JSX.Element {
       }
 
       const sessionProxyUrl = activeSessionProxyUrl;
+      const launchSubscription = await resolveSubscriptionInfoForLaunch();
+      const streamSettings = buildCurrentStreamSettings(launchSubscription);
 
       // Create new session
       const newSession = await window.openNow.createSession({
@@ -3120,7 +3151,7 @@ export function App(): JSX.Element {
         existingSessionStrategy,
         proxyUrl: sessionProxyUrl,
         zone: "prod",
-        settings: buildCurrentStreamSettings(),
+        settings: streamSettings,
       });
 
       setSession(newSession);
@@ -3271,6 +3302,7 @@ export function App(): JSX.Element {
     resetSignalingRecoveryState,
     resetLaunchRuntime,
     resetStatsOverlayToPreference,
+    resolveSubscriptionInfoForLaunch,
     selectedProvider,
     streamStatus,
     t,

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -29,6 +29,7 @@ import {
   isNativeStreamerSupportedPlatform,
   NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
   colorQualityRequiresHevc,
+  getSafeFallbackEntitledResolutions,
   keyboardLayoutOptions,
   resolveEntitledStreamProfile,
   USER_FACING_COLOR_QUALITY_OPTIONS,
@@ -979,26 +980,33 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
     }
   }, [t]);
 
-  const hasDynamic = entitledResolutions.length > 0;
-  const useEntitledStreamOptions = hasDynamic || subscriptionInfo !== null;
+  const effectiveEntitledResolutions = useMemo(
+    () => entitledResolutions.length > 0
+      ? entitledResolutions
+      : subscriptionInfo
+        ? getSafeFallbackEntitledResolutions()
+        : [],
+    [entitledResolutions, subscriptionInfo],
+  );
+  const useEntitledStreamOptions = effectiveEntitledResolutions.length > 0;
 
   // Grouped resolution presets (dynamic)
   const resolutionGroups = useMemo(
-    () => (hasDynamic ? groupResolutions(entitledResolutions) : []),
-    [entitledResolutions, hasDynamic]
+    () => (useEntitledStreamOptions ? groupResolutions(effectiveEntitledResolutions) : []),
+    [effectiveEntitledResolutions, useEntitledStreamOptions]
   );
 
   // Dynamic FPS presets based on current resolution
   const dynamicFpsOptions = useMemo(
-    () => (hasDynamic ? getFpsForResolution(entitledResolutions, settings.resolution) : []),
-    [entitledResolutions, settings.resolution, hasDynamic]
+    () => (useEntitledStreamOptions ? getFpsForResolution(effectiveEntitledResolutions, settings.resolution) : []),
+    [effectiveEntitledResolutions, settings.resolution, useEntitledStreamOptions]
   );
   const resolvedEntitledProfile = useMemo(
-    () => resolveEntitledStreamProfile(entitledResolutions, {
+    () => resolveEntitledStreamProfile(effectiveEntitledResolutions, {
       resolution: settings.resolution,
       fps: settings.fps,
     }),
-    [entitledResolutions, settings.fps, settings.resolution],
+    [effectiveEntitledResolutions, settings.fps, settings.resolution],
   );
   const posterSizePercent = Math.round(settings.posterSizeScale * 100);
   const updaterLastCheckedLabel = useMemo(() => formatUpdaterTimestamp(updaterState.lastCheckedAt), [updaterState.lastCheckedAt]);

--- a/opennow-stable/src/shared/entitlements.test.ts
+++ b/opennow-stable/src/shared/entitlements.test.ts
@@ -3,7 +3,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveEntitledStreamProfile } from "./gfn";
+import {
+  getSafeFallbackEntitledResolutions,
+  resolveEntitledStreamProfile,
+  SAFE_FALLBACK_STREAM_PROFILE,
+} from "./gfn";
 
 test("resolves requested stream settings to entitled resolution and fps profiles", () => {
   const entitlements = [
@@ -20,4 +24,14 @@ test("resolves requested stream settings to entitled resolution and fps profiles
     { resolution: "1920x1080", fps: 60 },
   );
   assert.equal(resolveEntitledStreamProfile([], { resolution: "1920x1080", fps: 60 }), null);
+});
+
+test("safe fallback entitlements resolve oversized requests to 1080p60", () => {
+  assert.deepEqual(
+    resolveEntitledStreamProfile(
+      getSafeFallbackEntitledResolutions(),
+      { resolution: "3840x2160", fps: 240 },
+    ),
+    SAFE_FALLBACK_STREAM_PROFILE,
+  );
 });

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -371,6 +371,15 @@ export interface EntitledStreamProfile {
   fps: number;
 }
 
+export const SAFE_FALLBACK_STREAM_PROFILE: Readonly<EntitledStreamProfile> = Object.freeze({
+  resolution: "1920x1080",
+  fps: 60,
+});
+
+export function getSafeFallbackEntitledResolutions(): EntitledResolution[] {
+  return [{ width: 1920, height: 1080, fps: 60 }];
+}
+
 function parseResolutionValue(resolution: string): { width: number; height: number } | null {
   const [widthText, heightText] = resolution.split("x");
   const width = Number.parseInt(widthText ?? "", 10);


### PR DESCRIPTION
This PR resolves an issue where users on lower subscription tiers could select and attempt to stream with higher resolution/FPS settings that their membership does not support. It filters stream options based on MES entitlement data and prevents launching with non-entitled profiles.

- Filter MES subscription `features.resolutions` to only include entries where `isEntitled` is true, matching official client behavior.
- Gate the Settings UI resolution and FPS dropdowns to show only entitled options. If the MES response is empty, fall back to a safe static preset (1080p60) to prevent empty controls.
- Add a `resolveEntitledStreamProfile` helper that clamps user-requested settings to the closest entitled profile.
- Update `buildCurrentStreamSettings` to resolve against entitled profiles using a safe fallback (1080p60) if subscription data is unavailable.
- Add `resolveSubscriptionInfoForLaunch` to await subscription info before launch to avoid launching with non-entitled settings.
- Cache entitlement data in `sessionStorage` keyed by `userId` and `membershipTier` to stale the cache when the tier changes.

**Changes**
- `opennow-stable/src/main/gfn/subscription.ts`: Filter resolutions by entitlement status.
- `opennow-stable/src/shared/gfn.ts`: Add `EntitledStreamProfile`, `resolveEntitledStreamProfile`, and safe fallback constants.
- `opennow-stable/src/renderer/src/App.tsx`: Resolve subscription before launch, apply safe fallback profile, and auto-correct settings on tier change.
- `opennow-stable/src/renderer/src/components/SettingsPage.tsx`: Gate UI controls by entitled profiles and auto-correct current selection.
- Tests added for entitlement filtering and safe fallback profile resolution.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/3b298c3c-2e29-4165-a421-afdf738f403c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-230" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/3b298c3c-2e29-4165-a421-afdf738f403c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-230&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-230"><img alt="OPE-230" src="https://capy.ai/api/badge/thread.svg?label=OPE-230"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resolution/FPS sent on every session create, claim, and recovery path; incorrect entitlement handling could affect stream quality, though the fallback is intentionally conservative.
> 
> **Overview**
> Adds shared **1080p60** safe defaults (`SAFE_FALLBACK_STREAM_PROFILE`, `getSafeFallbackEntitledResolutions`) so resolution/FPS never fall through to raw user settings when entitlement data is empty or unresolved.
> 
> **Launch paths** now call `resolveSubscriptionInfoForLaunch` before create/claim/resume/recovery, then build session settings from entitled profiles with that fallback. `buildCurrentStreamSettings` accepts an optional subscription override for freshly fetched tier data.
> 
> **Settings** uses the same fallback list when subscription is loaded but entitled resolutions are empty, keeping resolution/FPS controls usable. The auto-correct effect clamps stored settings even when `resolveEntitledStreamProfile` would return null.
> 
> Tests cover oversized requests against the safe fallback entitlements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de44f8b7b78d06ff619feb7356f2dc400342220. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->