### PR TITLE
feat(settings): add gyroscope controls toggle

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -569,6 +569,8 @@
       "title": "Input",
       "mouseAndKeyboard": "Mouse and Keyboard",
       "clipboardPaste": "Clipboard Paste",
+      "gyroscopeControls": "Gyroscope Controls",
+      "gyroscopeControlsHint": "Expose controller motion sensors for gyro aiming when the input backend supports it.",
       "keyboardLayoutHint": "Controls how your physical keyboard is mapped inside the remote session. Separate from the in-game language setting.",
       "mouseSensitivity": "Mouse Sensitivity",
       "mouseSensitivityHint": "Multiplier applied to mouse movement (1.00 = default)",

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -68,6 +68,8 @@ export interface Settings {
   sessionProxyUrl: string;
   /** Enable clipboard paste into stream */
   clipboardPaste: boolean;
+  /** Enable experimental gyroscope controller input mapping */
+  enableGyroscopeControls: boolean;
   /** Mouse sensitivity multiplier */
   mouseSensitivity: number;
   /** Software mouse acceleration strength percentage (1-150) */
@@ -191,6 +193,7 @@ const DEFAULT_SETTINGS: Settings = {
   sessionProxyEnabled: false,
   sessionProxyUrl: "",
   clipboardPaste: false,
+  enableGyroscopeControls: false,
   mouseSensitivity: 1,
   mouseAcceleration: 1,
   shortcutToggleStats: "F3",

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -405,6 +405,7 @@ export function App(): JSX.Element {
     sessionProxyEnabled: false,
     sessionProxyUrl: "",
     clipboardPaste: false,
+    enableGyroscopeControls: false,
     mouseSensitivity: 1,
     mouseAcceleration: 1,
     shortcutToggleStats: DEFAULT_SHORTCUTS.shortcutToggleStats,

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -184,6 +184,11 @@ const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string
     "hotkey",
     "keybind",
     "controls",
+    "controller",
+    "gamepad",
+    "gyro",
+    "gyroscope",
+    "motion controls",
     "anti afk",
     "pointer lock",
     "recording",
@@ -3434,6 +3439,26 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                     />
                     <span className="settings-toggle-track" />
                   </label>
+                </div>
+
+                <div className="settings-row settings-row--column">
+                  <div className="settings-row-top settings-row-top--compact">
+                    <label className="settings-label settings-label--wrap">
+                      <span className="settings-label-title">
+                        {t("settings.input.gyroscopeControls")}
+                        <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span>
+                      </span>
+                    </label>
+                    <label className="settings-toggle">
+                      <input
+                        type="checkbox"
+                        checked={settings.enableGyroscopeControls}
+                        onChange={(e) => handleChange("enableGyroscopeControls", e.target.checked)}
+                      />
+                      <span className="settings-toggle-track" />
+                    </label>
+                  </div>
+                  <span className="settings-subtle-hint">{t("settings.input.gyroscopeControlsHint")}</span>
                 </div>
 
                 <div className="settings-row settings-row--top-aligned">

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -269,6 +269,8 @@ export interface Settings {
   sessionProxyEnabled: boolean;
   sessionProxyUrl: string;
   clipboardPaste: boolean;
+  /** Enable experimental gyroscope controller input mapping */
+  enableGyroscopeControls: boolean;
   mouseSensitivity: number;
   mouseAcceleration: number;
   shortcutToggleStats: string;


### PR DESCRIPTION
This PR adds an experimental toggle for gyroscope controller input mapping to address issue #226.

- Add `enableGyroscopeControls` boolean to shared and main `Settings` interfaces
- Render toggle in Input settings with Beta badge and explanatory hint
- index "gyro", "gyroscope", and "motion controls" for settings search
- Add English translation strings for the setting and hint

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/4073958b-e97b-4926-a2e1-b20bf70de975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-231" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/4073958b-e97b-4926-a2e1-b20bf70de975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-231&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-231"><img alt="OPE-231" src="https://capy.ai/api/badge/thread.svg?label=OPE-231"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings and UI-only change with default off; no stream or input pipeline behavior is modified in this diff.
> 
> **Overview**
> Adds an **experimental Gyroscope Controls** option under Input settings (Beta badge, hint text, English strings) so users can persist a preference for controller motion-sensor / gyro aiming when the input stack supports it.
> 
> Introduces `enableGyroscopeControls` on shared/main `Settings`, default **off**, with renderer defaults aligned and the Input settings search index extended for controller/gyro terms. **This PR does not add runtime wiring** from the flag into WebRTC or native input in the changed files—only storage and UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0383fd91dfe1311cca00bdb27e8673725ef804cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->