### PR TITLE
fix(gfn): resolve alliance VPC IDs and invalidate legacy caches

### DIFF
--- a/opennow-stable/src/main/gfn/accountConnections.ts
+++ b/opennow-stable/src/main/gfn/accountConnections.ts
@@ -11,7 +11,7 @@ import type {
   GameAccountOperationResult,
 } from "@shared/gfn";
 import { cacheManager } from "../services/cacheManager";
-import { getAccountGamesCacheKeys } from "./games";
+import { getAccountGamesCacheKeys, getLegacyTokenScopedAccountGamesCacheKeys } from "./games";
 import { buildGfnGraphQlHeaders, GFN_PLAY_ORIGIN, GFN_PLAY_REFERER, GFN_USER_AGENT } from "./clientHeaders";
 
 const LCARS_GRAPHQL_URL = "https://apps.gxn.nvidia.com/graphql";
@@ -583,10 +583,19 @@ async function deleteProviderLink(provider: string, token: string): Promise<void
 }
 
 async function invalidateAccountGameCaches(session: AuthSession, proxyUrl?: string): Promise<void> {
-  const cacheKeySets = [getAccountGamesCacheKeys(session.user.userId, session.provider.streamingServiceUrl)];
+  const cacheKeySets: Array<{ main: string; library: string; catalogPrefix: string }> = [
+    getAccountGamesCacheKeys(session.user.userId, session.provider.streamingServiceUrl),
+  ];
+  const legacyTokens = [...new Set([session.tokens.idToken, session.tokens.accessToken].filter((token): token is string => Boolean(token)))];
+  cacheKeySets.push(
+    ...legacyTokens.map((token) => getLegacyTokenScopedAccountGamesCacheKeys(token, session.provider.streamingServiceUrl)),
+  );
   if (proxyUrl?.trim()) {
     try {
       cacheKeySets.push(getAccountGamesCacheKeys(session.user.userId, session.provider.streamingServiceUrl, proxyUrl));
+      cacheKeySets.push(
+        ...legacyTokens.map((token) => getLegacyTokenScopedAccountGamesCacheKeys(token, session.provider.streamingServiceUrl, proxyUrl)),
+      );
     } catch (error) {
       console.warn("[AccountConnections] Skipping proxy-scoped game cache invalidation:", error);
     }

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -35,6 +35,7 @@ const DEFAULT_LIBRARY_SORT = "variants.gfn.library.lastPlayedDate:DESC,computedV
 const LIBRARY_GAMES_CACHE_SCOPE = "library:v2";
 const CATALOG_GAMES_CACHE_SCOPE = "catalog";
 const PUBLIC_GAMES_CACHE_KEY = "games:public:v2";
+const DEFAULT_CLOUDMATCH_BASE_URL = "https://prod.cloudmatchbeta.nvidiagrid.net/";
 const LIBRARY_APPS_FILTER = {
   variants: {
     gfn: {
@@ -153,6 +154,18 @@ export function getAccountGamesCacheKeys(accountId: string, providerStreamingBas
     library: accountScopedGamesCacheKey(LIBRARY_GAMES_CACHE_SCOPE, accountId, providerStreamingBaseUrl, proxyUrl),
     catalogPrefix: getAccountCatalogGamesCachePrefix(accountId, providerStreamingBaseUrl, proxyUrl),
     public: publicGamesCacheKey(proxyUrl),
+  };
+}
+
+export function getLegacyTokenScopedAccountGamesCacheKeys(token: string, providerStreamingBaseUrl?: string, proxyUrl?: string): {
+  main: string;
+  library: string;
+  catalogPrefix: string;
+} {
+  return {
+    main: legacyTokenScopedGamesCacheKey("main", token, providerStreamingBaseUrl, proxyUrl),
+    library: legacyTokenScopedGamesCacheKey(LIBRARY_GAMES_CACHE_SCOPE, token, providerStreamingBaseUrl, proxyUrl),
+    catalogPrefix: legacyTokenScopedGamesCacheKey(CATALOG_GAMES_CACHE_SCOPE, token, providerStreamingBaseUrl, proxyUrl),
   };
 }
 
@@ -351,22 +364,24 @@ async function postGraphQl<T>(
 }
 
 async function getVpcId(token: string, providerStreamingBaseUrl?: string, proxyUrl?: string): Promise<string> {
-  const defaultBase = "https://prod.cloudmatchbeta.nvidiagrid.net/";
-  const allowedHosts = new Set([
-    "prod.cloudmatchbeta.nvidiagrid.net",
-    "img.nvidiagrid.net",
-  ]);
-
   let validatedBaseUrl: URL;
   try {
-    const candidate = new URL(providerStreamingBaseUrl?.trim() || defaultBase);
-    if (candidate.protocol !== "https:" || !allowedHosts.has(candidate.hostname)) {
-      validatedBaseUrl = new URL(defaultBase);
+    const candidate = new URL(providerStreamingBaseUrl?.trim() || DEFAULT_CLOUDMATCH_BASE_URL);
+    const hostname = candidate.hostname.toLowerCase();
+    if (
+      candidate.protocol !== "https:" ||
+      (
+        hostname !== "prod.cloudmatchbeta.nvidiagrid.net" &&
+        hostname !== "img.nvidiagrid.net" &&
+        !hostname.endsWith(".geforcenow.nvidiagrid.net")
+      )
+    ) {
+      validatedBaseUrl = new URL(DEFAULT_CLOUDMATCH_BASE_URL);
     } else {
       validatedBaseUrl = candidate;
     }
   } catch {
-    validatedBaseUrl = new URL(defaultBase);
+    validatedBaseUrl = new URL(DEFAULT_CLOUDMATCH_BASE_URL);
   }
 
   const serverInfoUrl = new URL("v2/serverInfo", validatedBaseUrl);


### PR DESCRIPTION
This PR addresses remaining review comments from the dev-to-main merge.

*   **opennow-stable/src/main/gfn/games.ts**: Update `getVpcId` to accept alliance provider subdomains (e.g., `*.geforcenow.nvidiagrid.net`) so VPC lookups succeed for alliance accounts instead of falling back to the default NVIDIA host.
*   **opennow-stable/src/main/gfn/accountConnections.ts**: Ensure `invalidateAccountGameCaches` also deletes legacy token-scoped cache keys to prevent stale game data from migrating back into userId-scoped caches after account linking/unlinking/resync operations.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/42eb5d13-2c2c-433d-b145-05b236635d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-233" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/42eb5d13-2c2c-433d-b145-05b236635d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-233&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-233"><img alt="OPE-233" src="https://capy.ai/api/badge/thread.svg?label=OPE-233"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch authenticated GFN APIs, cache invalidation, and session/signaling paths; incorrect VPC or cache behavior could break alliance catalogs or show stale libraries, but scope is mostly additive with targeted fixes and tests on pagination/paywall/proxy helpers.
> 
> **Overview**
> Targets post–dev-to-main review fixes: **`getVpcId`** now treats alliance streaming hosts (`*.geforcenow.nvidiagrid.net`) as valid CloudMatch bases so VPC/server lookups work instead of silently using the default NVIDIA URL, and **game-account link/unlink/resync** clears both userId-scoped and **legacy token-scoped** game cache keys (plus catalog prefixes) so stale libraries cannot repopulate after cache migration.
> 
> The same diff also lands broader GFN work: a new **connected game accounts** flow (ALS OAuth callback server, GraphQL provider definitions, IPC), **proxy-aware** catalog/library fetching with account-scoped caching and paginated library queries, **subscription** resolution lists limited to entitled profiles, persistent-storage/paywall messaging for browser-only NVIDIA sessions, signaling handling for **`peerRemoved`/`BYE`** and ICE `usernameFragment`, **CLI direct launch** with single-instance forwarding, native streamer **position-based keyboard VK** mapping, and related UI copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bdea398254dd76dae82ac9b81d8cecce5eaebd3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->