### PR TITLE
fix(android): unify ALS auth token and client config

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/GfnApi.kt
@@ -104,9 +104,9 @@ private const val TOTAL_STORAGE_SIZE_IN_GB = "TOTAL_STORAGE_SIZE_IN_GB"
 private const val USED_STORAGE_SIZE_IN_GB = "USED_STORAGE_SIZE_IN_GB"
 private const val STORAGE_METRO_REGION = "STORAGE_METRO_REGION"
 private const val STORAGE_METRO_REGION_NAME = "STORAGE_METRO_REGION_NAME"
-private const val ACCOUNT_LINKING_BASE_URL = "https://linking.nvidia.com/v1"
-private const val ACCOUNT_LINKING_CLIENT_ID = LCARS_CLIENT_ID
-private const val ACCOUNT_LINKING_REDIRECT_URL = "https://static-als.nvidia.com/result"
+private const val ACCOUNT_LINKING_BASE_URL = "https://als.geforcenow.com/v1"
+private const val ACCOUNT_LINKING_CLIENT_ID = "gfn-pc"
+private const val ACCOUNT_LINKING_REDIRECT_URL = "http://localhost:2259/"
 
 private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
 private val GRAPHQL_MEDIA_TYPE = "application/graphql".toMediaType()
@@ -1771,8 +1771,10 @@ class GfnAccountConnectorRepository(
 
     private fun accountLinkingHeaders(accessToken: String): Headers =
         Headers.Builder()
-            .add("Accept", "application/json")
+            .add("Accept", "application/json, text/plain, */*")
             .add("Authorization", bearerAuthorization(accessToken))
+            .add("Origin", GFN_PLAY_ORIGIN)
+            .add("Referer", GFN_PLAY_REFERER)
             .add("User-Agent", GFN_USER_AGENT)
             .build()
 
@@ -1795,7 +1797,12 @@ class GfnAccountConnectorRepository(
     }
 
     private fun accountLinkingPlatform(store: String): String =
-        normalizeGameStore(store).ifBlank { store }.uppercase(Locale.US)
+        when (val normalized = normalizeGameStore(store).ifBlank { store }.uppercase(Locale.US)) {
+            "UBISOFT", "UBISOFT_CONNECT" -> "UPLAY"
+            "BATTLE_NET", "BLIZZARD" -> "BATTLENET"
+            "EPIC_GAMES", "EPIC_GAMES_STORE" -> "EPIC"
+            else -> normalized
+        }
 
     private fun accountConnectorSortRank(store: String): Int =
         when (normalizeGameStore(store)) {


### PR DESCRIPTION
This PR updates Android's account-linking integration to use the correct ALS endpoint (`als.geforcenow.com`), client ID (`gfn-pc`), and redirect URI (`http://localhost:2259/`) matching the desktop implementation from PR #543. It also adds `Origin` and `Referer` headers and normalizes provider platform codes (e.g., Ubisoft→UPLAY, Battle.net→BATTLENET) to align with NVIDIA's expectations.

- Updated `ACCOUNT_LINKING_BASE_URL` from `linking.nvidia.com` to `als.geforcenow.com`
- Changed `ACCOUNT_LINKING_CLIENT_ID` to `gfn-pc` (was LCARS client)
- Changed redirect URI to localhost callback port 2259
- Added Origin and Referer headers to `accountLinkingHeaders`
- Updated `accountLinkingPlatform` to remap store codes to ALS identifiers

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/4705d841-b0f2-48e4-8c78-295f5cb5c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPEN-012" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/3a07dcb5-2214-4202-95f7-cce5c47ce6d3/thread/4705d841-b0f2-48e4-8c78-295f5cb5c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-012&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPEN-012"><img alt="OPEN-012" src="https://capy.ai/api/badge/thread.svg?label=OPEN-012"></picture></a>
<!-- capy-pr-badge:end -->