### PR TITLE
fix(input): use physical key position for AZERTY/QWERTZ layouts on Linux

### DIFF
--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -299,9 +299,31 @@ const physicalOemVirtualKeyCodes = new Set([
   "Slash",
 ]);
 
+/**
+ * Layouts where ALL keys (letters, digits, OEM) should use physical position
+ * (event.code) instead of the platform keyCode.
+ *
+ * On Linux, browsers report event.keyCode based on the active OS keyboard layout
+ * rather than the physical key position. For AZERTY (fr-FR) and QWERTZ (de-DE),
+ * this means pressing the physical W key on an AZERTY board reports keyCode=90 (Z)
+ * instead of the physical position W. The GFN server already has the correct
+ * layout set via the session parameter, so we must send physical positions and
+ * let the server translate them — otherwise every letter key is misinterpreted.
+ */
+const physicalAllKeysLayouts = new Set<string>(["fr-FR", "de-DE", "fr-BE", "fr-CH"]);
+
 function shouldUsePhysicalOemVirtualKey(event: KeyLike, layout?: KeyboardLayout): boolean {
   if (!layout || layout === "en-US" || layout === "en-GB") {
     return false;
+  }
+  // For layouts where letters/digits differ from physical position, force
+  // physical code for ALL key types so the GFN server maps them correctly.
+  if (physicalAllKeysLayouts.has(layout)) {
+    const code = event.code;
+    // Letter keys: KeyA–KeyZ
+    if (code.startsWith("Key") && code.length === 4) return true;
+    // Digit keys: Digit0–Digit9
+    if (code.startsWith("Digit") && code.length === 6) return true;
   }
   return physicalOemVirtualKeyCodes.has(event.code);
 }


### PR DESCRIPTION
On Linux, browsers report event.keyCode based on the active OS keyboard layout rather than the physical key position. For AZERTY (fr-FR) and QWERTZ (de-DE), pressing the physical W key reports keyCode=90 (Z) instead of 87 (W), causing reversed controls on GFN which defaults to QWERTY.

This fix forces letter (KeyA-KeyZ) and digit (Digit0-Digit9) keys to use their physical position (event.code) for fr-FR, de-DE, fr-BE and fr-CH layouts. The GFN server already receives the correct layout via the session parameter and maps keys correctly once physical positions are sent.

Fixes AZERTY ZQSD not working as WASD in games.

## Description

<!-- Provide a brief description of the changes in this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling for several European layouts, making letter and number keys behave more consistently across layouts.
  * Better support for physical key mapping on affected keyboard layouts, reducing unexpected key behavior in some cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->