### PR TITLE
fix(updater): disable verifyUpdateCodeSignature for unsigned macOS builds

### DIFF
--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -60,6 +60,7 @@
   "build": {
     "appId": "com.zortos.opennow.stable",
     "productName": "OpenNOW",
+    "afterSign": "scripts/after-sign-mac.mjs",
     "publish": [
       {
         "provider": "github",

--- a/opennow-stable/scripts/after-sign-mac.mjs
+++ b/opennow-stable/scripts/after-sign-mac.mjs
@@ -1,0 +1,18 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+export default async function afterSign({ appOutDir, packager }) {
+  if (process.platform !== "darwin") return;
+  if (process.env.CSC_IDENTITY_AUTO_DISCOVERY !== "false") return;
+
+  const appPath = join(appOutDir, `${packager.appInfo.productFilename}.app`);
+  const bundleId = packager.appInfo.id;
+
+  execFileSync("codesign", [
+    "--force",
+    "--deep",
+    "--sign", "-",
+    "--requirements", `designated => identifier "${bundleId}"`,
+    appPath,
+  ]);
+}


### PR DESCRIPTION
## Problem

Users on macOS who had v0.4.2 installed were unable to apply the v0.5.0 auto-update. After the update downloaded successfully, Squirrel.Mac rejected it at install time with:

```
WARN [main] Error: Code signature at URL file:///Users/.../Library/Caches/com.zortos.opennow.stable.ShipIt/update.DRVY1sH/OpenNOW.app/ did not pass validation: code failed to satisfy specified code requirement(s)
ERROR [main] Error: Code signature at URL file:///Users/.../Library/Caches/com.zortos.opennow.stable.ShipIt/update.DRVY1sH/OpenNOW.app/ did not pass validation: code failed to satisfy specified code requirement(s)
```

The UI showed: **"Downloaded update failed verification."**

## Root cause

The release CI sets `CSC_IDENTITY_AUTO_DISCOVERY: "false"`, producing macOS builds without a Developer ID certificate.

Squirrel.Mac validates each incoming update against the **installed app's designated requirement (DR)** — a code-signing constraint embedded in the running app at install time. If a previous build was signed with a Developer ID cert (or had a DR that requires one), any unsigned update will fail that check regardless of whether the download itself is intact.

The validation happens entirely in the native Squirrel.Mac binary via `SecStaticCodeCheckValidity`. There is no JavaScript-level override in `electron-updater` to skip it.

## What was tried first (and why it was wrong)

Adding `"verifyUpdateCodeSignature": false` to the `mac` build config in `package.json` — that option is Windows/NSIS-specific and does not exist in the macOS config schema. electron-builder validates platform configs with `additionalProperties: false`, so it would fail the build or be silently ignored depending on the version.

## Fix

Added an `afterSign` hook (`scripts/after-sign-mac.mjs`) that runs after electron-builder's signing step but before DMG/ZIP packaging.

When `CSC_IDENTITY_AUTO_DISCOVERY=false` (unsigned CI builds), the hook re-signs the app with:
- **Identity**: `-` (ad-hoc)
- **Designated requirement**: `identifier "com.zortos.opennow.stable"` — bundle ID only, no certificate anchor

This gives the installed app a stable, cert-independent DR. When Squirrel.Mac later validates an update, it checks the update against this DR. Since future unsigned builds also satisfy `identifier "com.zortos.opennow.stable"`, the validation passes.

When building with a real Developer ID cert (`dist:signed`, `CSC_IDENTITY_AUTO_DISCOVERY` not set to `"false"`), the hook is a no-op — the cert-based DR is preserved.

## Scope

- **v0.4.2 → v0.5.0 (users already affected)**: not fixable via auto-update. They must download the DMG from GitHub Releases manually. The update is already downloaded and failing verification on their machines.
- **v0.5.0 → next release**: auto-update will work correctly once the v0.5.0 build ships with this hook applied.