### PR TITLE
Fix native streamer clipboard, shortcuts, stats overlay, and anti-AFK

### DIFF
--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -104,6 +104,10 @@ pub(crate) enum NativeWindowInputEvent {
     Shortcut {
         action: NativeStreamerShortcutAction,
     },
+    ClipboardPaste,
+    InputCaptureChanged {
+        captured: bool,
+    },
     Key {
         pressed: bool,
         keycode: u16,
@@ -391,14 +395,24 @@ fn send_native_window_input_events(
         return;
     }
 
-    // Forward shortcuts immediately (before input readiness check)
-    // Shortcuts are local control and don't need the stream channel
+    // Forward shortcuts and host bridge events immediately (before input readiness check)
+    // These are local control events and don't need the stream channel
     let mut other_events = Vec::new();
     for event in events.iter().copied() {
         match event {
             NativeWindowInputEvent::Shortcut { action } => {
                 if let Some(sender) = event_sender.as_ref() {
                     let _ = sender.send(Event::Shortcut { action });
+                }
+            }
+            NativeWindowInputEvent::ClipboardPaste => {
+                if let Some(sender) = event_sender.as_ref() {
+                    let _ = sender.send(Event::ClipboardPaste);
+                }
+            }
+            NativeWindowInputEvent::InputCaptureChanged { captured } => {
+                if let Some(sender) = event_sender.as_ref() {
+                    let _ = sender.send(Event::InputCaptureChanged { captured });
                 }
             }
             _ => {
@@ -473,6 +487,18 @@ fn send_encoded_native_window_input_event(
         NativeWindowInputEvent::Shortcut { action } => {
             if let Some(sender) = event_sender.as_ref() {
                 let _ = sender.send(Event::Shortcut { action });
+            }
+            return;
+        }
+        NativeWindowInputEvent::ClipboardPaste => {
+            if let Some(sender) = event_sender.as_ref() {
+                let _ = sender.send(Event::ClipboardPaste);
+            }
+            return;
+        }
+        NativeWindowInputEvent::InputCaptureChanged { captured } => {
+            if let Some(sender) = event_sender.as_ref() {
+                let _ = sender.send(Event::InputCaptureChanged { captured });
             }
             return;
         }

--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -4,9 +4,9 @@ use crate::gstreamer_platform::win32_renderer_window;
 use crate::input::InputEncoder;
 #[cfg(target_os = "windows")]
 use crate::input::{
-    layout_mapped_keyboard_keycode, layout_mapped_keyboard_scancode, GamepadInput, KeyboardPayload,
-    MouseButtonPayload, MouseMovePayload, MouseWheelPayload, GAMEPAD_MAX_CONTROLLERS,
-    PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
+    combine_single_input_packets, layout_mapped_keyboard_keycode, layout_mapped_keyboard_scancode,
+    GamepadInput, KeyboardPayload, MouseButtonPayload, MouseMovePayload, MouseWheelPayload,
+    GAMEPAD_MAX_CONTROLLERS, PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
 };
 use crate::protocol::Event;
 #[cfg(target_os = "windows")]
@@ -313,34 +313,40 @@ impl NativeWindowInputBridge {
             );
 
             while !thread_stop.load(Ordering::SeqCst) {
-                match receiver.recv_timeout(NATIVE_INPUT_BRIDGE_POLL_INTERVAL) {
-                    Ok(event) => {
-                        pending_events.clear();
-                        pending_events.push(event);
-                        let mut disconnected = false;
-                        while pending_events.len() < NATIVE_INPUT_DRAIN_MAX_EVENTS {
-                            match receiver.try_recv() {
-                                Ok(event) => pending_events.push(event),
-                                Err(TryRecvError::Empty) => break,
-                                Err(TryRecvError::Disconnected) => {
-                                    disconnected = true;
-                                    break;
-                                }
-                            }
-                        }
-                        send_native_window_input_events(
-                            &input_thread_state,
-                            &input_thread_channels,
-                            &thread_sender,
-                            &pending_events,
-                        );
-                        if disconnected {
-                            break;
+                pending_events.clear();
+                loop {
+                    match receiver.try_recv() {
+                        Ok(event) => pending_events.push(event),
+                        Err(TryRecvError::Empty) => break,
+                        Err(TryRecvError::Disconnected) => return,
+                    }
+                    if pending_events.len() >= NATIVE_INPUT_DRAIN_MAX_EVENTS {
+                        break;
+                    }
+                }
+
+                if pending_events.is_empty() {
+                    match receiver.recv_timeout(NATIVE_INPUT_BRIDGE_POLL_INTERVAL) {
+                        Ok(event) => pending_events.push(event),
+                        Err(RecvTimeoutError::Timeout) => continue,
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+
+                    while pending_events.len() < NATIVE_INPUT_DRAIN_MAX_EVENTS {
+                        match receiver.try_recv() {
+                            Ok(event) => pending_events.push(event),
+                            Err(TryRecvError::Empty) => break,
+                            Err(TryRecvError::Disconnected) => break,
                         }
                     }
-                    Err(RecvTimeoutError::Timeout) => {}
-                    Err(RecvTimeoutError::Disconnected) => break,
                 }
+
+                send_native_window_input_events(
+                    &input_thread_state,
+                    &input_thread_channels,
+                    &thread_sender,
+                    &pending_events,
+                );
             }
         });
         let gamepad_thread = Some(spawn_native_gamepad_thread(
@@ -431,6 +437,26 @@ fn send_native_window_input_events(
     };
 
     let mut pending_mouse_move: Option<(i32, i32, u64)> = None;
+    let mut pending_reliable_singles: Vec<Vec<u8>> = Vec::new();
+
+    let mut flush_reliable_singles =
+        |input_channels: &GstreamerInputChannels, pending: &mut Vec<Vec<u8>>| {
+            if pending.is_empty() {
+                return;
+            }
+            match combine_single_input_packets(pending) {
+                Some(combined) => {
+                    pending.clear();
+                    let _ = input_channels.send_packet(&combined, false);
+                }
+                None => {
+                    for payload in pending.drain(..) {
+                        let _ = input_channels.send_packet(&payload, false);
+                    }
+                }
+            }
+        };
+
     for event in other_events.iter().copied() {
         if let NativeWindowInputEvent::MouseMove {
             dx,
@@ -446,9 +472,15 @@ fn send_native_window_input_events(
             continue;
         }
 
+        flush_reliable_singles(input_channels, &mut pending_reliable_singles);
         flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
-        send_encoded_native_window_input_event(&encoder, input_channels, event_sender, event);
+        if let Some(payload) =
+            encode_native_window_input_payload(&encoder, event_sender, event)
+        {
+            pending_reliable_singles.push(payload);
+        }
     }
+    flush_reliable_singles(input_channels, &mut pending_reliable_singles);
     flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
 }
 
@@ -477,30 +509,29 @@ fn flush_pending_mouse_move(
 }
 
 #[cfg(target_os = "windows")]
-fn send_encoded_native_window_input_event(
+fn encode_native_window_input_payload(
     encoder: &InputEncoder,
-    input_channels: &GstreamerInputChannels,
     event_sender: &Option<Sender<Event>>,
     event: NativeWindowInputEvent,
-) {
-    let (payload, partially_reliable) = match event {
+) -> Option<Vec<u8>> {
+    match event {
         NativeWindowInputEvent::Shortcut { action } => {
             if let Some(sender) = event_sender.as_ref() {
                 let _ = sender.send(Event::Shortcut { action });
             }
-            return;
+            None
         }
         NativeWindowInputEvent::ClipboardPaste => {
             if let Some(sender) = event_sender.as_ref() {
                 let _ = sender.send(Event::ClipboardPaste);
             }
-            return;
+            None
         }
         NativeWindowInputEvent::InputCaptureChanged { captured } => {
             if let Some(sender) = event_sender.as_ref() {
                 let _ = sender.send(Event::InputCaptureChanged { captured });
             }
-            return;
+            None
         }
         NativeWindowInputEvent::Key {
             pressed,
@@ -515,25 +546,21 @@ fn send_encoded_native_window_input_event(
                 modifiers,
                 timestamp_us,
             };
-            let bytes = if pressed {
+            Some(if pressed {
                 encoder.encode_key_down(payload)
             } else {
                 encoder.encode_key_up(payload)
-            };
-            (bytes, false)
+            })
         }
         NativeWindowInputEvent::MouseMove {
             dx,
             dy,
             timestamp_us,
-        } => (
-            encoder.encode_mouse_move(MouseMovePayload {
-                dx,
-                dy,
-                timestamp_us,
-            }),
-            true,
-        ),
+        } => Some(encoder.encode_mouse_move(MouseMovePayload {
+            dx,
+            dy,
+            timestamp_us,
+        })),
         NativeWindowInputEvent::MouseButton {
             pressed,
             button,
@@ -543,25 +570,38 @@ fn send_encoded_native_window_input_event(
                 button,
                 timestamp_us,
             };
-            let bytes = if pressed {
+            Some(if pressed {
                 encoder.encode_mouse_button_down(payload)
             } else {
                 encoder.encode_mouse_button_up(payload)
-            };
-            (bytes, false)
+            })
         }
         NativeWindowInputEvent::MouseWheel {
             delta,
             timestamp_us,
-        } => (
-            encoder.encode_mouse_wheel(MouseWheelPayload {
-                delta,
-                timestamp_us,
-            }),
-            false,
-        ),
+        } => Some(encoder.encode_mouse_wheel(MouseWheelPayload {
+            delta,
+            timestamp_us,
+        })),
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[allow(dead_code)]
+fn send_encoded_native_window_input_event(
+    encoder: &InputEncoder,
+    input_channels: &GstreamerInputChannels,
+    event_sender: &Option<Sender<Event>>,
+    event: NativeWindowInputEvent,
+) {
+    let Some(payload) = encode_native_window_input_payload(encoder, event_sender, event) else {
+        return;
     };
 
+    let partially_reliable = matches!(
+        event,
+        NativeWindowInputEvent::MouseMove { .. }
+    );
     let _ = input_channels.send_packet(&payload, partially_reliable);
 }
 

--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -4,8 +4,9 @@ use crate::gstreamer_platform::win32_renderer_window;
 use crate::input::InputEncoder;
 #[cfg(target_os = "windows")]
 use crate::input::{
-    combine_single_input_packets, layout_mapped_keyboard_keycode, layout_mapped_keyboard_scancode,
-    GamepadInput, KeyboardPayload, MouseButtonPayload, MouseMovePayload, MouseWheelPayload,
+    finalize_reliable_single_input_packets, layout_mapped_keyboard_keycode,
+    layout_mapped_keyboard_scancode, restamp_protocol_v3_outer_timestamp, GamepadInput,
+    KeyboardPayload, MouseButtonPayload, MouseMovePayload, MouseWheelPayload,
     GAMEPAD_MAX_CONTROLLERS, PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
 };
 use crate::protocol::Event;
@@ -128,6 +129,9 @@ pub(crate) enum NativeWindowInputEvent {
     MouseWheel {
         delta: i16,
         timestamp_us: u64,
+    },
+    LockKeysSync {
+        state: u8,
     },
 }
 
@@ -432,63 +436,84 @@ fn send_native_window_input_events(
         return;
     }
 
-    let Ok(encoder) = input_state.encoder.lock() else {
-        return;
-    };
-
     let mut pending_mouse_move: Option<(i32, i32, u64)> = None;
-    let mut pending_reliable_singles: Vec<Vec<u8>> = Vec::new();
+    let mut current_reliable_singles: Vec<Vec<u8>> = Vec::new();
+    let mut reliable_single_batches: Vec<Vec<Vec<u8>>> = Vec::new();
+    let mut pending_mouse_packets: Vec<Vec<u8>> = Vec::new();
 
-    let mut flush_reliable_singles =
-        |input_channels: &GstreamerInputChannels, pending: &mut Vec<Vec<u8>>| {
-            if pending.is_empty() {
-                return;
-            }
-            match combine_single_input_packets(pending) {
-                Some(combined) => {
-                    pending.clear();
-                    let _ = input_channels.send_packet(&combined, false);
-                }
-                None => {
-                    for payload in pending.drain(..) {
-                        let _ = input_channels.send_packet(&payload, false);
-                    }
-                }
-            }
+    {
+        let Ok(encoder) = input_state.encoder.lock() else {
+            return;
         };
 
-    for event in other_events.iter().copied() {
-        if let NativeWindowInputEvent::MouseMove {
-            dx,
-            dy,
-            timestamp_us,
-        } = event
-        {
-            let (pending_dx, pending_dy, pending_timestamp_us) =
-                pending_mouse_move.get_or_insert((0, 0, timestamp_us));
-            *pending_dx = pending_dx.saturating_add(i32::from(dx));
-            *pending_dy = pending_dy.saturating_add(i32::from(dy));
-            *pending_timestamp_us = timestamp_us;
-            continue;
+        let mut flush_current_reliable_singles = |singles: &mut Vec<Vec<u8>>,
+                                                   batches: &mut Vec<Vec<Vec<u8>>>| {
+            if singles.is_empty() {
+                return;
+            }
+            batches.push(std::mem::take(singles));
+        };
+
+        for event in other_events.iter().copied() {
+            if let NativeWindowInputEvent::MouseMove {
+                dx,
+                dy,
+                timestamp_us,
+            } = event
+            {
+                let (pending_dx, pending_dy, pending_timestamp_us) =
+                    pending_mouse_move.get_or_insert((0, 0, timestamp_us));
+                *pending_dx = pending_dx.saturating_add(i32::from(dx));
+                *pending_dy = pending_dy.saturating_add(i32::from(dy));
+                *pending_timestamp_us = timestamp_us;
+                continue;
+            }
+
+            flush_current_reliable_singles(
+                &mut current_reliable_singles,
+                &mut reliable_single_batches,
+            );
+            collect_pending_mouse_move_packets(
+                &encoder,
+                &mut pending_mouse_move,
+                &mut pending_mouse_packets,
+            );
+            if let Some(payload) =
+                encode_native_window_input_payload(&encoder, event_sender, event)
+            {
+                current_reliable_singles.push(payload);
+            }
         }
 
-        flush_reliable_singles(input_channels, &mut pending_reliable_singles);
-        flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
-        if let Some(payload) =
-            encode_native_window_input_payload(&encoder, event_sender, event)
-        {
-            pending_reliable_singles.push(payload);
+        flush_current_reliable_singles(
+            &mut current_reliable_singles,
+            &mut reliable_single_batches,
+        );
+        collect_pending_mouse_move_packets(
+            &encoder,
+            &mut pending_mouse_move,
+            &mut pending_mouse_packets,
+        );
+    }
+
+    let send_timestamp_us = native_input_timestamp_us();
+    for batch in reliable_single_batches {
+        for payload in finalize_reliable_single_input_packets(&batch, send_timestamp_us) {
+            let _ = input_channels.send_packet(&payload, false);
         }
     }
-    flush_reliable_singles(input_channels, &mut pending_reliable_singles);
-    flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
+
+    for mut payload in pending_mouse_packets {
+        restamp_protocol_v3_outer_timestamp(&mut payload, send_timestamp_us);
+        let _ = input_channels.send_packet(&payload, true);
+    }
 }
 
 #[cfg(target_os = "windows")]
-fn flush_pending_mouse_move(
+fn collect_pending_mouse_move_packets(
     encoder: &InputEncoder,
-    input_channels: &GstreamerInputChannels,
     pending_mouse_move: &mut Option<(i32, i32, u64)>,
+    pending_mouse_packets: &mut Vec<Vec<u8>>,
 ) {
     let Some((mut dx, mut dy, timestamp_us)) = pending_mouse_move.take() else {
         return;
@@ -497,12 +522,11 @@ fn flush_pending_mouse_move(
     while dx != 0 || dy != 0 {
         let chunk_dx = dx.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
         let chunk_dy = dy.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
-        let payload = encoder.encode_mouse_move(MouseMovePayload {
+        pending_mouse_packets.push(encoder.encode_mouse_move(MouseMovePayload {
             dx: chunk_dx,
             dy: chunk_dy,
             timestamp_us,
-        });
-        let _ = input_channels.send_packet(&payload, true);
+        }));
         dx = dx.saturating_sub(i32::from(chunk_dx));
         dy = dy.saturating_sub(i32::from(chunk_dy));
     }
@@ -583,6 +607,9 @@ fn encode_native_window_input_payload(
             delta,
             timestamp_us,
         })),
+        NativeWindowInputEvent::LockKeysSync { state } => {
+            Some(encoder.encode_lock_keys_sync(state))
+        }
     }
 }
 
@@ -744,9 +771,10 @@ fn send_native_gamepad_snapshot(
     let Ok(mut encoder) = input_state.encoder.lock() else {
         return;
     };
-    let payload = encoder.encode_gamepad_state(bitmap, input, use_partially_reliable);
+    let mut payload = encoder.encode_gamepad_state(bitmap, input, use_partially_reliable);
     drop(encoder);
 
+    restamp_protocol_v3_outer_timestamp(&mut payload, native_input_timestamp_us());
     let _ = input_channels.send_packet(&payload, use_partially_reliable);
 }
 

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -1080,7 +1080,7 @@ pub(crate) mod win32_renderer_window {
             if previous.is_some() {
                 return;
             }
-            let modifiers = current_modifier_flags(&keys);
+            let modifiers = keyboard_modifier_flags(keycode);
             if is_clipboard_paste_shortcut(keycode, modifiers) {
                 keys.insert(
                     scancode,
@@ -1115,15 +1115,12 @@ pub(crate) mod win32_renderer_window {
                     suppressed: false,
                 },
             );
-        } else {
-            let Some(previous) = keys.remove(&scancode) else {
-                return;
-            };
+        } else if let Some(previous) = keys.remove(&scancode) {
             if previous.suppressed {
                 return;
             }
         }
-        let modifiers = current_modifier_flags(&keys);
+        let modifiers = keyboard_modifier_flags(keycode);
         drop(keys);
 
         emit_input_event(NativeWindowInputEvent::Key {
@@ -1259,37 +1256,29 @@ pub(crate) mod win32_renderer_window {
         }
     }
 
-    unsafe fn current_modifier_flags(keys: &HashMap<u16, PressedKey>) -> u16 {
+    /// Per-key modifier byte matching official GFN `Cb()` / `xb()`.
+    /// Lock keys (Caps/Num/Scroll) sync separately via INPUT_LOCK_KEYS_SYNC, not here.
+    unsafe fn keyboard_modifier_flags(active_keycode: u16) -> u16 {
         let mut modifiers = 0u16;
-        if keys
-            .values()
-            .any(|key| matches!(key.keycode, VK_LSHIFT | VK_RSHIFT | VK_SHIFT))
+        if !matches!(active_keycode, VK_LSHIFT | VK_RSHIFT | VK_SHIFT)
+            && (is_key_down(VK_SHIFT) || is_key_down(VK_LSHIFT) || is_key_down(VK_RSHIFT))
         {
             modifiers |= 0x01;
         }
-        if keys
-            .values()
-            .any(|key| matches!(key.keycode, VK_LCONTROL | VK_RCONTROL | VK_CONTROL))
+        if !matches!(active_keycode, VK_LCONTROL | VK_RCONTROL | VK_CONTROL)
+            && (is_key_down(VK_CONTROL) || is_key_down(VK_LCONTROL) || is_key_down(VK_RCONTROL))
         {
             modifiers |= 0x02;
         }
-        if keys
-            .values()
-            .any(|key| matches!(key.keycode, VK_LMENU | VK_RMENU | VK_MENU))
+        if !matches!(active_keycode, VK_LMENU | VK_RMENU | VK_MENU)
+            && (is_key_down(VK_MENU) || is_key_down(VK_LMENU) || is_key_down(VK_RMENU))
         {
             modifiers |= 0x04;
         }
-        if keys
-            .values()
-            .any(|key| matches!(key.keycode, VK_LWIN | VK_RWIN))
+        if !matches!(active_keycode, VK_LWIN | VK_RWIN)
+            && (is_key_down(VK_LWIN) || is_key_down(VK_RWIN))
         {
             modifiers |= 0x08;
-        }
-        if (GetKeyState(VK_CAPITAL) & 0x0001) != 0 {
-            modifiers |= 0x10;
-        }
-        if (GetKeyState(VK_NUMLOCK) & 0x0001) != 0 {
-            modifiers |= 0x20;
         }
         modifiers
     }

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -195,6 +195,7 @@ pub(crate) mod win32_renderer_window {
     const RI_MOUSE_WHEEL: u16 = 0x0400;
     const VK_SHIFT: u16 = 0x10;
     const VK_ESCAPE: u16 = 0x1B;
+    const VK_V: u16 = 0x56;
     const VK_TAB: u16 = 0x09;
     const VK_CONTROL: u16 = 0x11;
     const VK_MENU: u16 = 0x12;
@@ -720,6 +721,7 @@ pub(crate) mod win32_renderer_window {
             ClipCursor(&rect);
         }
         hide_cursor();
+        emit_input_capture_changed(true);
 
         let slot = CAPTURED_HWND.get_or_init(|| Mutex::new(None));
         if let Ok(mut captured) = slot.lock() {
@@ -747,6 +749,7 @@ pub(crate) mod win32_renderer_window {
         ReleaseCapture();
         ClipCursor(null());
         show_cursor();
+        emit_input_capture_changed(false);
         unregister_raw_input_devices();
         SetWindowPos(
             hwnd,
@@ -1040,6 +1043,13 @@ pub(crate) mod win32_renderer_window {
         }
 
         let modifiers = current_legacy_modifier_flags();
+        if pressed && is_clipboard_paste_shortcut(keycode, modifiers) {
+            suppressed_keys.insert(key_id);
+            drop(suppressed_keys);
+            emit_clipboard_paste_request();
+            return true;
+        }
+
         let Some(action) = shortcut_action_for_keypress(keycode, scancode, modifiers) else {
             return false;
         };
@@ -1071,6 +1081,19 @@ pub(crate) mod win32_renderer_window {
                 return;
             }
             let modifiers = current_modifier_flags(&keys);
+            if is_clipboard_paste_shortcut(keycode, modifiers) {
+                keys.insert(
+                    scancode,
+                    PressedKey {
+                        keycode,
+                        scancode,
+                        suppressed: true,
+                    },
+                );
+                drop(keys);
+                emit_clipboard_paste_request();
+                return;
+            }
             if let Some(action) = shortcut_action_for_keypress(keycode, scancode, modifiers) {
                 keys.insert(
                     scancode,
@@ -1373,6 +1396,36 @@ pub(crate) mod win32_renderer_window {
             return;
         };
         let _ = sender.send(event);
+    }
+
+    fn is_clipboard_paste_shortcut(keycode: u16, modifiers: u16) -> bool {
+        keycode == VK_V
+            && ((modifiers & 0x02) != 0 || unsafe { is_ctrl_modifier_down() })
+            && (modifiers & 0x04) == 0
+    }
+
+    unsafe fn is_ctrl_modifier_down() -> bool {
+        is_key_down(VK_CONTROL) || is_key_down(VK_LCONTROL) || is_key_down(VK_RCONTROL)
+    }
+
+    fn emit_clipboard_paste_request() {
+        let Some(sender) = INPUT_EVENT_SENDER
+            .get()
+            .and_then(|sender| sender.lock().ok().and_then(|sender| sender.clone()))
+        else {
+            return;
+        };
+        let _ = sender.send(NativeWindowInputEvent::ClipboardPaste);
+    }
+
+    fn emit_input_capture_changed(captured: bool) {
+        let Some(sender) = INPUT_EVENT_SENDER
+            .get()
+            .and_then(|sender| sender.lock().ok().and_then(|sender| sender.clone()))
+        else {
+            return;
+        };
+        let _ = sender.send(NativeWindowInputEvent::InputCaptureChanged { captured });
     }
 
     fn clamp_i32_to_i16(value: i32) -> i16 {

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -201,6 +201,7 @@ pub(crate) mod win32_renderer_window {
     const VK_MENU: u16 = 0x12;
     const VK_CAPITAL: i32 = 0x14;
     const VK_NUMLOCK: i32 = 0x90;
+    const VK_SCROLL: i32 = 0x91;
     const VK_LSHIFT: u16 = 0xA0;
     const VK_RSHIFT: u16 = 0xA1;
     const VK_LCONTROL: u16 = 0xA2;
@@ -344,6 +345,7 @@ pub(crate) mod win32_renderer_window {
     static CAPTURED_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
     static PROTECTED_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
     static PRESSED_KEYS: OnceLock<Mutex<HashMap<u16, PressedKey>>> = OnceLock::new();
+    static LAST_LOCK_KEYS_STATE: OnceLock<Mutex<u8>> = OnceLock::new();
     static LEGACY_SUPPRESSED_KEYS: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
     static STARTED_AT: OnceLock<Instant> = OnceLock::new();
     static ESCAPE_HOLD_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
@@ -727,6 +729,7 @@ pub(crate) mod win32_renderer_window {
         if let Ok(mut captured) = slot.lock() {
             *captured = Some(hwnd as isize);
         }
+        sync_lock_keys_state(true);
     }
 
     unsafe fn release_input_capture(hwnd: Hwnd) {
@@ -1061,6 +1064,8 @@ pub(crate) mod win32_renderer_window {
     }
 
     unsafe fn handle_keyboard_state(keycode: u16, scancode: u16, pressed: bool) {
+        sync_lock_keys_state(false);
+
         let keys = PRESSED_KEYS.get_or_init(|| Mutex::new(HashMap::new()));
         let Ok(mut keys) = keys.lock() else {
             return;
@@ -1080,7 +1085,7 @@ pub(crate) mod win32_renderer_window {
             if previous.is_some() {
                 return;
             }
-            let modifiers = keyboard_modifier_flags(keycode);
+            let modifiers = pressed_key_modifier_flags(&keys, keycode);
             if is_clipboard_paste_shortcut(keycode, modifiers) {
                 keys.insert(
                     scancode,
@@ -1120,7 +1125,7 @@ pub(crate) mod win32_renderer_window {
                 return;
             }
         }
-        let modifiers = keyboard_modifier_flags(keycode);
+        let modifiers = pressed_key_modifier_flags(&keys, keycode);
         drop(keys);
 
         emit_input_event(NativeWindowInputEvent::Key {
@@ -1256,9 +1261,108 @@ pub(crate) mod win32_renderer_window {
         }
     }
 
-    /// Per-key modifier byte matching official GFN `Cb()` / `xb()`.
-    /// Lock keys (Caps/Num/Scroll) sync separately via INPUT_LOCK_KEYS_SYNC, not here.
+    /// Lock-key bitmask for INPUT_LOCK_KEYS_SYNC (official GFN iS() on desktop Windows).
+    unsafe fn lock_keys_sync_state() -> u8 {
+        let mut state = 0x10;
+        if (GetKeyState(VK_CAPITAL) & 0x0001) != 0 {
+            state |= 0x01;
+        }
+        state |= 0x20;
+        state |= 0x40;
+        if (GetKeyState(VK_NUMLOCK) & 0x0001) != 0 {
+            state |= 0x02;
+        }
+        if (GetKeyState(VK_SCROLL) & 0x0001) != 0 {
+            state |= 0x04;
+        }
+        state
+    }
+
+    unsafe fn sync_lock_keys_state(force: bool) {
+        let state = lock_keys_sync_state();
+        let slot = LAST_LOCK_KEYS_STATE.get_or_init(|| Mutex::new(0));
+        let Ok(mut last) = slot.lock() else {
+            return;
+        };
+        if !force && *last == state {
+            return;
+        }
+        *last = state;
+        drop(last);
+        emit_input_event(NativeWindowInputEvent::LockKeysSync { state });
+    }
+
+    /// Per-key modifier byte from tracked pressed keys (official GFN yS()/Cb()).
+    /// Lock keys sync separately via INPUT_LOCK_KEYS_SYNC, not here.
+    unsafe fn pressed_key_modifier_flags(keys: &HashMap<u16, PressedKey>, active_keycode: u16) -> u16 {
+        let mut modifiers = 0u16;
+        let mut shift_tracked = false;
+        let mut control_tracked = false;
+        let mut alt_tracked = false;
+        let mut win_tracked = false;
+
+        for key in keys.values() {
+            if key.keycode == active_keycode {
+                continue;
+            }
+            match key.keycode {
+                VK_LSHIFT | VK_RSHIFT | VK_SHIFT => {
+                    shift_tracked = true;
+                    modifiers |= 0x01;
+                }
+                VK_LCONTROL | VK_RCONTROL | VK_CONTROL => {
+                    control_tracked = true;
+                    modifiers |= 0x02;
+                }
+                VK_LMENU | VK_RMENU | VK_MENU => {
+                    alt_tracked = true;
+                    modifiers |= 0x04;
+                }
+                VK_LWIN | VK_RWIN => {
+                    win_tracked = true;
+                    modifiers |= 0x08;
+                }
+                _ => {}
+            }
+        }
+
+        if !matches!(active_keycode, VK_LSHIFT | VK_RSHIFT | VK_SHIFT)
+            && !shift_tracked
+            && (is_key_down(VK_SHIFT) || is_key_down(VK_LSHIFT) || is_key_down(VK_RSHIFT))
+        {
+            modifiers |= 0x01;
+        }
+        if !matches!(active_keycode, VK_LCONTROL | VK_RCONTROL | VK_CONTROL)
+            && !control_tracked
+            && (is_key_down(VK_CONTROL) || is_key_down(VK_LCONTROL) || is_key_down(VK_RCONTROL))
+        {
+            modifiers |= 0x02;
+        }
+        if !matches!(active_keycode, VK_LMENU | VK_RMENU | VK_MENU)
+            && !alt_tracked
+            && (is_key_down(VK_MENU) || is_key_down(VK_LMENU) || is_key_down(VK_RMENU))
+        {
+            modifiers |= 0x04;
+        }
+        if !matches!(active_keycode, VK_LWIN | VK_RWIN)
+            && !win_tracked
+            && (is_key_down(VK_LWIN) || is_key_down(VK_RWIN))
+        {
+            modifiers |= 0x08;
+        }
+
+        modifiers
+    }
+
+    /// Legacy fallback for shortcut matching before a key enters the pressed-key map.
     unsafe fn keyboard_modifier_flags(active_keycode: u16) -> u16 {
+        let keys = PRESSED_KEYS.get_or_init(|| Mutex::new(HashMap::new()));
+        if let Ok(keys) = keys.lock() {
+            if !keys.is_empty() {
+                return pressed_key_modifier_flags(&keys, active_keycode);
+            }
+        }
+
         let mut modifiers = 0u16;
         if !matches!(active_keycode, VK_LSHIFT | VK_RSHIFT | VK_SHIFT)
             && (is_key_down(VK_SHIFT) || is_key_down(VK_LSHIFT) || is_key_down(VK_RSHIFT))

--- a/native/opennow-streamer/src/input.rs
+++ b/native/opennow-streamer/src/input.rs
@@ -10,6 +10,7 @@ pub const INPUT_MOUSE_BUTTON_DOWN: u32 = 8;
 pub const INPUT_MOUSE_BUTTON_UP: u32 = 9;
 pub const INPUT_MOUSE_WHEEL: u32 = 10;
 pub const INPUT_GAMEPAD: u32 = 12;
+pub const INPUT_LOCK_KEYS_SYNC: u32 = 19;
 
 pub const GAMEPAD_MAX_CONTROLLERS: u8 = 4;
 pub const GAMEPAD_PACKET_SIZE: usize = 38;
@@ -116,6 +117,13 @@ impl InputEncoder {
         self.encode_keyboard(INPUT_KEY_UP, payload)
     }
 
+    pub fn encode_lock_keys_sync(&self, state: u8) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(5);
+        put_u32_le(&mut bytes, INPUT_LOCK_KEYS_SYNC);
+        bytes.push(state);
+        wrap_single_input(self.protocol_version, 0, &bytes)
+    }
+
     pub fn encode_mouse_move(&self, payload: MouseMovePayload) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(22);
         put_u32_le(&mut bytes, INPUT_MOUSE_REL);
@@ -195,30 +203,40 @@ impl InputEncoder {
     }
 }
 
+/// Rewrite the protocol v3 `[0x23][timestamp]` header to the send-time session clock.
+pub fn restamp_protocol_v3_outer_timestamp(packet: &mut [u8], timestamp_us: u64) -> bool {
+    if packet.len() < WRAPPER_VERSION_HEADER_BYTES || packet[0] != WRAPPER_VERSION_MARKER {
+        return false;
+    }
+
+    packet[1..WRAPPER_VERSION_HEADER_BYTES].copy_from_slice(&timestamp_us.to_be_bytes());
+    true
+}
+
 /// Coalesce protocol v3 single-input packets into one datachannel payload.
-/// Official GFN batches multiple `[0x22][body]` frames under one `[0x23][timestamp]` header.
+/// Official GFN batches multiple `[0x22][body]` frames under one `[0x23][timestamp]` header
+/// stamped with the send-time session clock (`ed()`), not per-event capture timestamps.
 /// Returns `None` when payloads cannot be safely coalesced (for example protocol v2).
-pub fn combine_single_input_packets(payloads: &[Vec<u8>]) -> Option<Vec<u8>> {
+pub fn combine_single_input_packets(
+    payloads: &[Vec<u8>],
+    send_timestamp_us: u64,
+) -> Option<Vec<u8>> {
     if payloads.is_empty() {
         return None;
     }
     if payloads.len() == 1 {
-        return Some(payloads[0].clone());
+        let mut packet = payloads[0].clone();
+        restamp_protocol_v3_outer_timestamp(&mut packet, send_timestamp_us);
+        return Some(packet);
     }
 
     let mut combined_bodies = Vec::new();
-    let mut timestamp_us = 0u64;
 
     for payload in payloads {
         if payload.len() >= WRAPPER_SINGLE_BODY_OFFSET
             && payload[0] == WRAPPER_VERSION_MARKER
             && payload[WRAPPER_VERSION_HEADER_BYTES] == WRAPPER_SINGLE_INPUT
         {
-            timestamp_us = timestamp_us.max(u64::from_be_bytes(
-                payload[1..WRAPPER_VERSION_HEADER_BYTES]
-                    .try_into()
-                    .unwrap_or([0; 8]),
-            ));
             combined_bodies.push(WRAPPER_SINGLE_INPUT);
             combined_bodies.extend_from_slice(&payload[WRAPPER_SINGLE_BODY_OFFSET..]);
             continue;
@@ -229,9 +247,32 @@ pub fn combine_single_input_packets(payloads: &[Vec<u8>]) -> Option<Vec<u8>> {
 
     let mut bytes = Vec::with_capacity(WRAPPER_VERSION_HEADER_BYTES + combined_bodies.len());
     bytes.push(WRAPPER_VERSION_MARKER);
-    bytes.extend_from_slice(&timestamp_us.to_be_bytes());
+    bytes.extend_from_slice(&send_timestamp_us.to_be_bytes());
     bytes.extend_from_slice(&combined_bodies);
     Some(bytes)
+}
+
+/// Finalize reliable keyboard/button packets for send, restamping v3 headers at send time.
+pub fn finalize_reliable_single_input_packets(
+    payloads: &[Vec<u8>],
+    send_timestamp_us: u64,
+) -> Vec<Vec<u8>> {
+    if payloads.is_empty() {
+        return Vec::new();
+    }
+
+    if let Some(combined) = combine_single_input_packets(payloads, send_timestamp_us) {
+        return vec![combined];
+    }
+
+    payloads
+        .iter()
+        .map(|payload| {
+            let mut packet = payload.clone();
+            restamp_protocol_v3_outer_timestamp(&mut packet, send_timestamp_us);
+            packet
+        })
+        .collect()
 }
 
 pub fn partially_reliable_hid_mask_for_input_type(input_type: u32) -> u32 {
@@ -496,7 +537,7 @@ mod combine_tests {
             timestamp_us: 20,
         });
 
-        let combined = combine_single_input_packets(&[first.clone(), second.clone()])
+        let combined = combine_single_input_packets(&[first.clone(), second.clone()], 20)
             .expect("v3 keyboard packets should combine");
 
         assert_eq!(combined[0], WRAPPER_VERSION_MARKER);
@@ -523,7 +564,33 @@ mod combine_tests {
             timestamp_us: 11,
         });
 
-        assert!(combine_single_input_packets(&[first, second]).is_none());
+        assert!(combine_single_input_packets(&[first, second], 11).is_none());
+    }
+
+    #[test]
+    fn restamps_single_v3_packet_at_send_time() {
+        let encoder = InputEncoder::new(3);
+        let mut packet = encoder.encode_key_down(KeyboardPayload {
+            keycode: 0x0041,
+            scancode: 0,
+            modifiers: 0,
+            timestamp_us: 10,
+        });
+
+        assert!(restamp_protocol_v3_outer_timestamp(&mut packet, 99));
+        assert_eq!(&packet[1..9], &99u64.to_be_bytes());
+    }
+
+    #[test]
+    fn encodes_lock_keys_sync_as_single_input() {
+        let encoder = InputEncoder::new(3);
+        let payload = encoder.encode_lock_keys_sync(0x73);
+
+        assert_eq!(payload.len(), 15);
+        assert_eq!(payload[0], WRAPPER_VERSION_MARKER);
+        assert_eq!(payload[9], WRAPPER_SINGLE_INPUT);
+        assert_eq!(&payload[10..14], &[0x13, 0, 0, 0]);
+        assert_eq!(payload[14], 0x73);
     }
 }
 

--- a/native/opennow-streamer/src/input.rs
+++ b/native/opennow-streamer/src/input.rs
@@ -20,6 +20,8 @@ const WRAPPER_LEGACY_INPUT: u8 = 0x21;
 const WRAPPER_SINGLE_INPUT: u8 = 0x22;
 const WRAPPER_PARTIALLY_RELIABLE_INPUT: u8 = 0x26;
 const WRAPPER_VERSION_MARKER: u8 = 0x23;
+const WRAPPER_VERSION_HEADER_BYTES: usize = 9;
+const WRAPPER_SINGLE_BODY_OFFSET: usize = WRAPPER_VERSION_HEADER_BYTES + 1;
 const GAMEPAD_PAYLOAD_SIZE: u16 = 26;
 const GAMEPAD_INNER_SIZE: u16 = 20;
 const GAMEPAD_RESERVED_MARKER: u16 = 85;
@@ -191,6 +193,45 @@ impl InputEncoder {
             .insert(controller_id, current.wrapping_add(1));
         current
     }
+}
+
+/// Coalesce protocol v3 single-input packets into one datachannel payload.
+/// Official GFN batches multiple `[0x22][body]` frames under one `[0x23][timestamp]` header.
+/// Returns `None` when payloads cannot be safely coalesced (for example protocol v2).
+pub fn combine_single_input_packets(payloads: &[Vec<u8>]) -> Option<Vec<u8>> {
+    if payloads.is_empty() {
+        return None;
+    }
+    if payloads.len() == 1 {
+        return Some(payloads[0].clone());
+    }
+
+    let mut combined_bodies = Vec::new();
+    let mut timestamp_us = 0u64;
+
+    for payload in payloads {
+        if payload.len() >= WRAPPER_SINGLE_BODY_OFFSET
+            && payload[0] == WRAPPER_VERSION_MARKER
+            && payload[WRAPPER_VERSION_HEADER_BYTES] == WRAPPER_SINGLE_INPUT
+        {
+            timestamp_us = timestamp_us.max(u64::from_be_bytes(
+                payload[1..WRAPPER_VERSION_HEADER_BYTES]
+                    .try_into()
+                    .unwrap_or([0; 8]),
+            ));
+            combined_bodies.push(WRAPPER_SINGLE_INPUT);
+            combined_bodies.extend_from_slice(&payload[WRAPPER_SINGLE_BODY_OFFSET..]);
+            continue;
+        }
+
+        return None;
+    }
+
+    let mut bytes = Vec::with_capacity(WRAPPER_VERSION_HEADER_BYTES + combined_bodies.len());
+    bytes.push(WRAPPER_VERSION_MARKER);
+    bytes.extend_from_slice(&timestamp_us.to_be_bytes());
+    bytes.extend_from_slice(&combined_bodies);
+    Some(bytes)
 }
 
 pub fn partially_reliable_hid_mask_for_input_type(input_type: u32) -> u32 {
@@ -433,6 +474,57 @@ fn put_u64_be(bytes: &mut Vec<u8>, value: u64) {
 
 fn put_u64_le(bytes: &mut Vec<u8>, value: u64) {
     bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+#[cfg(test)]
+mod combine_tests {
+    use super::*;
+
+    #[test]
+    fn combines_protocol_v3_single_input_packets() {
+        let encoder = InputEncoder::new(3);
+        let first = encoder.encode_key_down(KeyboardPayload {
+            keycode: 0x0041,
+            scancode: 0,
+            modifiers: 0,
+            timestamp_us: 10,
+        });
+        let second = encoder.encode_key_down(KeyboardPayload {
+            keycode: 0x0042,
+            scancode: 0,
+            modifiers: 0,
+            timestamp_us: 20,
+        });
+
+        let combined = combine_single_input_packets(&[first.clone(), second.clone()])
+            .expect("v3 keyboard packets should combine");
+
+        assert_eq!(combined[0], WRAPPER_VERSION_MARKER);
+        assert_eq!(&combined[1..9], &20u64.to_be_bytes());
+        assert_eq!(combined[9], WRAPPER_SINGLE_INPUT);
+        assert_eq!(&combined[10..14], &[0x03, 0, 0, 0]);
+        assert_eq!(combined[28], WRAPPER_SINGLE_INPUT);
+        assert_eq!(&combined[29..33], &[0x03, 0, 0, 0]);
+    }
+
+    #[test]
+    fn leaves_protocol_v2_packets_uncombined() {
+        let encoder = InputEncoder::new(2);
+        let first = encoder.encode_key_down(KeyboardPayload {
+            keycode: 0x0041,
+            scancode: 0,
+            modifiers: 0,
+            timestamp_us: 10,
+        });
+        let second = encoder.encode_key_up(KeyboardPayload {
+            keycode: 0x0041,
+            scancode: 0,
+            modifiers: 0,
+            timestamp_us: 11,
+        });
+
+        assert!(combine_single_input_packets(&[first, second]).is_none());
+    }
 }
 
 #[cfg(test)]

--- a/native/opennow-streamer/src/protocol.rs
+++ b/native/opennow-streamer/src/protocol.rs
@@ -526,6 +526,12 @@ pub enum Event {
     Shortcut {
         action: NativeStreamerShortcutAction,
     },
+    #[serde(rename = "clipboard-paste")]
+    ClipboardPaste,
+    #[serde(rename = "input-capture-changed")]
+    InputCaptureChanged {
+        captured: bool,
+    },
     #[serde(rename = "video-stall")]
     VideoStall(VideoStallEvent),
     #[serde(rename = "video-transition")]

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -1191,6 +1191,16 @@ export class NativeStreamerManager {
       return;
     }
 
+    if (message.type === "clipboard-paste") {
+      this.options.emit({ type: "native-clipboard-paste" });
+      return;
+    }
+
+    if (message.type === "input-capture-changed") {
+      this.options.emit({ type: "native-input-capture-changed", captured: message.captured });
+      return;
+    }
+
     if (message.type === "video-stall") {
       const formatAge = (value: number | undefined): string => value === undefined ? "n/a" : `${value}ms`;
       const stats = [

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -350,8 +350,8 @@ async function sendStreamClipboardPaste(
     const text = await readStreamClipboardText();
     if (text) {
       client.sendText(text);
-      return;
     }
+    return;
   } catch (error) {
     console.warn("Clipboard read failed, falling back to paste shortcut:", error);
   }

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -338,6 +338,27 @@ async function readStreamClipboardText(): Promise<string> {
   return window.openNow.readClipboardText();
 }
 
+async function sendStreamClipboardPaste(
+  client: GfnWebRtcClient | null,
+  isMac: boolean,
+): Promise<void> {
+  if (!client) {
+    return;
+  }
+
+  try {
+    const text = await readStreamClipboardText();
+    if (text) {
+      client.sendText(text);
+      return;
+    }
+  } catch (error) {
+    console.warn("Clipboard read failed, falling back to paste shortcut:", error);
+  }
+
+  client.sendPasteShortcut(isMac);
+}
+
 export function App(): JSX.Element {
   const { locale, t } = useTranslation();
 
@@ -459,6 +480,8 @@ export function App(): JSX.Element {
   const [showStatsOverlay, setShowStatsOverlay] = useState(false);
   const [antiAfkEnabled, setAntiAfkEnabled] = useState(false);
   const [antiAfkAckNonce, setAntiAfkAckNonce] = useState(0);
+  const [nativeInputCaptureActive, setNativeInputCaptureActive] = useState(false);
+  const [nativeInputBridgeReady, setNativeInputBridgeReady] = useState(false);
   const [exitPrompt, setExitPrompt] = useState<ExitPromptState>({ open: false, gameTitle: t("app.labels.game") });
   const [streamingGame, setStreamingGame] = useState<GameInfo | null>(null);
   const [streamingStore, setStreamingStore] = useState<string | null>(null);
@@ -1373,13 +1396,14 @@ export function App(): JSX.Element {
 
   useEffect(() => {
     if (!antiAfkEnabled || streamStatus !== "streaming") return;
+    if (nativeStreamingRef.current && !nativeInputBridgeReady) return;
 
     const interval = window.setInterval(() => {
       clientRef.current?.sendAntiAfkPulse();
     }, 240000); // 4 minutes
 
     return () => clearInterval(interval);
-  }, [antiAfkEnabled, streamStatus]);
+  }, [antiAfkEnabled, nativeInputBridgeReady, streamStatus]);
 
   // Periodically re-sync subscription playtime from backend while streaming.
   useEffect(() => {
@@ -2361,6 +2385,8 @@ export function App(): JSX.Element {
     setSession(claimed);
     sessionRef.current = claimed;
     nativeInputProtocolVersionRef.current = null;
+    setNativeInputBridgeReady(false);
+    setNativeInputCaptureActive(false);
     setQueuePosition(undefined);
     setLaunchError(null);
     setStreamStatus("connecting");
@@ -2814,12 +2840,19 @@ export function App(): JSX.Element {
         } else if (event.type === "native-input-ready") {
           console.log("[App] Native input protocol ready:", event.protocolVersion);
           nativeInputProtocolVersionRef.current = event.protocolVersion;
+          setNativeInputBridgeReady(true);
           clientRef.current?.setNativeInputProtocolVersion(event.protocolVersion);
           if (nativeStreamingRef.current || sessionRef.current) {
             activateNativeInputForCurrentSession(event.protocolVersion);
           }
         } else if (event.type === "native-shortcut") {
           handleStreamShortcutActionRef.current?.(event.action);
+        } else if (event.type === "native-clipboard-paste") {
+          if (settings.clipboardPaste && (!nativeStreamingRef.current || nativeInputBridgeReady)) {
+            void sendStreamClipboardPaste(clientRef.current, isMac);
+          }
+        } else if (event.type === "native-input-capture-changed") {
+          setNativeInputCaptureActive(event.captured);
         } else if (event.type === "native-stream-stats") {
           diagnosticsStore.set(mergeNativeStreamStats(
             diagnosticsStore.getSnapshot(),
@@ -2840,6 +2873,8 @@ export function App(): JSX.Element {
           console.warn("[App] Native streamer stopped:", reason);
           nativeStreamingRef.current = false;
           nativeInputProtocolVersionRef.current = null;
+          setNativeInputBridgeReady(false);
+          setNativeInputCaptureActive(false);
           clientRef.current?.dispose();
           clientRef.current = null;
           launchInFlightRef.current = false;
@@ -2999,7 +3034,7 @@ export function App(): JSX.Element {
     });
 
     return () => unsubscribe();
-  }, [attemptSessionRecovery, diagnosticsStore, handleExpectedNativeSessionClose, refreshNavbarActiveSession, resetLaunchRuntime, scheduleStableRecoveryReset, settings, streamMicLevel, streamVolume, t]);
+  }, [attemptSessionRecovery, diagnosticsStore, handleExpectedNativeSessionClose, nativeInputBridgeReady, refreshNavbarActiveSession, resetLaunchRuntime, scheduleStableRecoveryReset, settings, streamMicLevel, streamVolume, t]);
 
   // Play game handler
   const handlePlayGame = useCallback(async (game: GameInfo, options?: { bypassGuards?: boolean; streamingBaseUrl?: string; variantId?: string }) => {
@@ -3856,6 +3891,10 @@ export function App(): JSX.Element {
         setShowStatsOverlay((prev) => !prev);
         return;
       case "togglePointerLock":
+        if (nativeStreamingRef.current) {
+          // Native streamer toggles OS input capture locally in the renderer window.
+          return;
+        }
         {
           const targetVideo = videoRef.current;
           if (streamStatus === "streaming" && targetVideo) {
@@ -3938,20 +3977,7 @@ export function App(): JSX.Element {
 
         if (settings.clipboardPaste) {
           void (async () => {
-            const client = clientRef.current;
-            if (!client) return;
-
-            try {
-              const text = await readStreamClipboardText();
-              if (text) {
-                client.sendText(text);
-              }
-              return;
-            } catch (error) {
-              console.warn("Clipboard read failed, falling back to paste shortcut:", error);
-            }
-
-            client.sendPasteShortcut(isMac);
+            await sendStreamClipboardPaste(clientRef.current, isMac);
           })();
         }
         return;
@@ -4128,6 +4154,7 @@ export function App(): JSX.Element {
             diagnosticsStore={diagnosticsStore}
             showStats={showStatsOverlay}
             showNativeStats={settings.showNativeStreamerStats}
+            nativeInputCaptureActive={nativeInputCaptureActive}
             gstreamerEnabled={settings.streamClientMode === "native"}
             shortcuts={{
               toggleStats: formatShortcutForDisplay(settings.shortcutToggleStats, isMac),

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -26,6 +26,7 @@ interface StreamViewProps {
   diagnosticsStore: StreamDiagnosticsStore;
   showStats: boolean;
   showNativeStats?: boolean;
+  nativeInputCaptureActive?: boolean;
   gstreamerEnabled: boolean;
   shortcuts: {
     toggleStats: string;
@@ -397,6 +398,7 @@ export function StreamView({
   diagnosticsStore,
   showStats,
   showNativeStats = false,
+  nativeInputCaptureActive = false,
   gstreamerEnabled,
   shortcuts,
   serverRegion,
@@ -1200,7 +1202,7 @@ export function StreamView({
       updateSurface({
         deviceScaleFactor: dpr,
         visible,
-        showStats: showNativeStats,
+        showStats: showStats || showNativeStats,
         rect: visible
           ? {
               x: Math.round(rect.left * dpr),
@@ -1251,15 +1253,18 @@ export function StreamView({
         showStats: false,
       });
     };
-  }, [showNativeStats]);
+  }, [showNativeStats, showStats]);
 
   useEffect(() => {
     const handlePointerLockChange = () => {
-      setIsPointerLocked(document.pointerLockElement === localVideoRef.current);
+      setIsPointerLocked(
+        document.pointerLockElement === localVideoRef.current || nativeInputCaptureActive,
+      );
     };
+    handlePointerLockChange();
     document.addEventListener("pointerlockchange", handlePointerLockChange);
     return () => document.removeEventListener("pointerlockchange", handlePointerLockChange);
-  }, []);
+  }, [nativeInputCaptureActive]);
 
   useEffect(() => {
     // Show a transient HUD hint when pointer lock is acquired

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
@@ -24,6 +24,12 @@ import {
   INPUT_MOUSE_REL,
   INPUT_MOUSE_WHEEL,
   INPUT_TEXT,
+  finalizeReliableSingleInputPackets,
+  combineSingleInputPackets,
+  restampProtocolV3OuterTimestamp,
+  startInputSessionClock,
+  sendTimestampUs,
+  captureTimestampUs,
   InputEncoder,
   codeMap,
   isPartiallyReliableHidTransferEligible,
@@ -370,4 +376,64 @@ test("partially reliable HID helpers only mark mouse-relative input eligible", (
   assert.equal(isPartiallyReliableHidTransferEligible(INPUT_MOUSE_REL), true);
   assert.equal(isPartiallyReliableHidTransferEligible(INPUT_MOUSE_BUTTON_DOWN), false);
   assert.equal(isPartiallyReliableHidTransferEligible(INPUT_GAMEPAD), false);
+});
+
+test("uses session-relative capture and send timestamps", () => {
+  startInputSessionClock(1_000);
+  assert.equal(captureTimestampUs(1_010), 10_000n);
+  assert.equal(sendTimestampUs(1_025), 25_000n);
+});
+
+test("restamps protocol v3 outer header at send time", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(3);
+  const packet = encoder.encodeKeyDown({
+    keycode: 0x41,
+    scancode: 0,
+    modifiers: 0,
+    timestampUs: 7n,
+  });
+
+  startInputSessionClock(0);
+  assert.ok(restampProtocolV3OuterTimestamp(packet, 99n));
+  assert.equal(view(packet).getBigUint64(1, false), 99n);
+});
+
+test("combines multiple v3 keyboard packets under one outer header", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(3);
+  const down = encoder.encodeKeyDown({
+    keycode: 0x41,
+    scancode: 0,
+    modifiers: 0,
+    timestampUs: 1n,
+  });
+  const up = encoder.encodeKeyUp({
+    keycode: 0x41,
+    scancode: 0,
+    modifiers: 0,
+    timestampUs: 2n,
+  });
+
+  startInputSessionClock(0);
+  const combined = combineSingleInputPackets([down, up], 50n);
+  assert.ok(combined);
+  assert.equal(combined![0], 0x23);
+  assert.equal(view(combined!).getBigUint64(1, false), 50n);
+  assert.equal(combined![9], 0x22);
+  assert.equal(combined![28], 0x22);
+  assert.equal(view(combined!).getUint32(10, true), INPUT_KEY_DOWN);
+  assert.equal(view(combined!).getUint32(29, true), INPUT_KEY_UP);
+});
+
+test("finalizeReliableSingleInputPackets coalesces keyboard bursts", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(3);
+  const packets = finalizeReliableSingleInputPackets([
+    encoder.encodeKeyDown({ keycode: 0x41, scancode: 0, modifiers: 0, timestampUs: 1n }),
+    encoder.encodeKeyDown({ keycode: 0x42, scancode: 0, modifiers: 0, timestampUs: 2n }),
+  ], 77n);
+
+  assert.equal(packets.length, 1);
+  assert.equal(view(packets[0]).getBigUint64(1, false), 77n);
 });

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
@@ -167,7 +167,7 @@ test("uses German physical keys for synthetic text injection with de-DE layout",
   assert.deepEqual(mapTextCharToKeySpec("_", "de-DE"), { ...codeMap.Slash, shift: true });
 });
 
-test("modifierFlags matches official yS() (no lock keys in per-key byte)", () => {
+test("modifierFlags matches official Cb() including xb() shift bit", () => {
   const event = keyboardEvent({
     code: "KeyA",
     key: "a",
@@ -180,6 +180,16 @@ test("modifierFlags matches official yS() (no lock keys in per-key byte)", () =>
   });
 
   assert.equal(modifierFlags(event), 0x0f);
+});
+
+test("shiftModifierByte matches official xb() on Mac shifted punctuation", () => {
+  const event = keyboardEvent({
+    code: "Digit1",
+    key: "!",
+    keyCode: 49,
+    shiftKey: true,
+  });
+  assert.equal(modifierFlags(event, true), 0x01);
 });
 
 test("lockKeysStateFromEvent encodes caps/num/scroll for sync packet", () => {

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -1025,13 +1025,33 @@ function textInputChunkLength(bytes: Uint8Array, offset: number): number {
   return 0;
 }
 
-/** Per-key modifier byte (official GFN yS()). Lock keys sync separately via INPUT_LOCK_KEYS_SYNC. */
-export function modifierFlags(event: KeyboardEvent): number {
+function isMacKeyboardLayout(): boolean {
+  return typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+}
+
+/** Shift bit for per-key modifier byte (official GFN xb()). */
+export function shiftModifierByte(event: KeyboardEvent, isMacLayout: boolean = isMacKeyboardLayout()): number {
+  if (isMacLayout && event.key.length === 1) {
+    if ("!@#$%^&*()~_+{}|:\"<>?".includes(event.key)) {
+      return 1;
+    }
+    if ("1234567890`-=[]\\;',./".includes(event.key)) {
+      return 0;
+    }
+  }
+  if (event.shiftKey && !event.code.startsWith("Shift")) {
+    return 1;
+  }
+  return 0;
+}
+
+/** Per-key modifier byte (official GFN Cb(): ctrl/alt/meta + xb shift). */
+export function modifierFlags(event: KeyboardEvent, isMacLayout: boolean = isMacKeyboardLayout()): number {
   let flags = 0;
-  if (event.shiftKey && !event.code.startsWith("Shift")) flags |= 0x01;
   if (event.ctrlKey && !event.code.startsWith("Control")) flags |= 0x02;
   if (event.altKey && !event.code.startsWith("Alt")) flags |= 0x04;
   if (event.metaKey && !event.code.startsWith("Meta")) flags |= 0x08;
+  flags |= shiftModifierByte(event, isMacLayout);
   return flags;
 }
 

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -16,6 +16,110 @@ export const INPUT_TEXT = 23;
 const TEXT_INPUT_CHUNK_MAX_BYTES = 1016;
 const TEXT_INPUT_HEADER_BYTES = 5;
 
+export const WRAPPER_VERSION_MARKER = 0x23;
+export const WRAPPER_SINGLE_INPUT = 0x22;
+const WRAPPER_VERSION_HEADER_BYTES = 9;
+const WRAPPER_SINGLE_BODY_OFFSET = WRAPPER_VERSION_HEADER_BYTES + 1;
+
+let inputSessionStartedAtMs = 0;
+
+/** Reset session-relative input clock when the input handshake completes. */
+export function startInputSessionClock(nowMs: number = performance.now()): void {
+  inputSessionStartedAtMs = nowMs;
+}
+
+/** Session-relative capture timestamp for inner event payloads (official GFN Or()). */
+export function captureTimestampUs(sourceTimestampMs?: number): bigint {
+  const baseMs =
+    typeof sourceTimestampMs === "number" && Number.isFinite(sourceTimestampMs) && sourceTimestampMs >= 0
+      ? sourceTimestampMs - inputSessionStartedAtMs
+      : performance.now() - inputSessionStartedAtMs;
+  return BigInt(Math.max(0, Math.floor(baseMs * 1000)));
+}
+
+/** Send-time session clock for v3 outer headers (official GFN ed()). */
+export function sendTimestampUs(nowMs: number = performance.now()): bigint {
+  return captureTimestampUs(nowMs);
+}
+
+function writeSessionTimestamp(view: DataView, offset: number, timestampUs: bigint): void {
+  const clamped = timestampUs < 0n ? 0n : timestampUs;
+  const lo = Number(clamped & 0xFFFFFFFFn);
+  const hi = Number(clamped >> 32n);
+  view.setUint32(offset, hi, false);
+  view.setUint32(offset + 4, lo, false);
+}
+
+/** Rewrite the protocol v3 `[0x23][timestamp]` header to the send-time session clock. */
+export function restampProtocolV3OuterTimestamp(packet: Uint8Array, timestampUs: bigint): boolean {
+  if (packet.length < WRAPPER_VERSION_HEADER_BYTES || packet[0] !== WRAPPER_VERSION_MARKER) {
+    return false;
+  }
+  writeSessionTimestamp(new DataView(packet.buffer, packet.byteOffset, packet.byteLength), 1, timestampUs);
+  return true;
+}
+
+/**
+ * Coalesce protocol v3 single-input packets into one datachannel payload.
+ * Official GFN batches multiple `[0x22][body]` frames under one `[0x23][timestamp]`
+ * header stamped with the send-time session clock (`ed()`).
+ */
+export function combineSingleInputPackets(
+  payloads: readonly Uint8Array[],
+  sendTimestampUsValue: bigint,
+): Uint8Array | null {
+  if (payloads.length === 0) {
+    return null;
+  }
+  if (payloads.length === 1) {
+    const packet = payloads[0].slice();
+    restampProtocolV3OuterTimestamp(packet, sendTimestampUsValue);
+    return packet;
+  }
+
+  const combinedBodies: number[] = [];
+  for (const payload of payloads) {
+    if (
+      payload.length >= WRAPPER_SINGLE_BODY_OFFSET
+      && payload[0] === WRAPPER_VERSION_MARKER
+      && payload[WRAPPER_VERSION_HEADER_BYTES] === WRAPPER_SINGLE_INPUT
+    ) {
+      combinedBodies.push(WRAPPER_SINGLE_INPUT);
+      combinedBodies.push(...payload.subarray(WRAPPER_SINGLE_BODY_OFFSET));
+      continue;
+    }
+    return null;
+  }
+
+  const bytes = new Uint8Array(WRAPPER_VERSION_HEADER_BYTES + combinedBodies.length);
+  const view = new DataView(bytes.buffer);
+  bytes[0] = WRAPPER_VERSION_MARKER;
+  writeSessionTimestamp(view, 1, sendTimestampUsValue);
+  bytes.set(combinedBodies, WRAPPER_VERSION_HEADER_BYTES);
+  return bytes;
+}
+
+/** Finalize reliable keyboard/button packets, coalescing and restamping v3 headers at send time. */
+export function finalizeReliableSingleInputPackets(
+  payloads: readonly Uint8Array[],
+  sendTimestampUsValue: bigint,
+): Uint8Array[] {
+  if (payloads.length === 0) {
+    return [];
+  }
+
+  const combined = combineSingleInputPackets(payloads, sendTimestampUsValue);
+  if (combined) {
+    return [combined];
+  }
+
+  return payloads.map((payload) => {
+    const packet = payload.slice();
+    restampProtocolV3OuterTimestamp(packet, sendTimestampUsValue);
+    return packet;
+  });
+}
+
 // Mouse button constants (1-based for GFN protocol)
 // GFN uses: 1=Left, 2=Middle, 3=Right, 4=Back, 5=Forward
 export const MOUSE_LEFT = 1;
@@ -586,15 +690,11 @@ export function mapTextCharToKeySpec(char: string, layout?: KeyboardLayout): Tex
 }
 
 /**
- * Write an 8-byte big-endian timestamp (performance.now() * 1000 = microseconds)
- * into a DataView at the given offset. Matches official GFN client's _r() function.
+ * Write an 8-byte big-endian session-relative timestamp into a DataView.
+ * Outer v3 headers are restamped again at send time via restampProtocolV3OuterTimestamp().
  */
 function writeTimestamp(view: DataView, offset: number): void {
-  const tsUs = performance.now() * 1000;
-  const lo = Math.floor(tsUs) & 0xFFFFFFFF;
-  const hi = Math.floor(tsUs / 4294967296);
-  view.setUint32(offset, hi, false);     // high 32 bits, big-endian
-  view.setUint32(offset + 4, lo, false); // low 32 bits, big-endian
+  writeSessionTimestamp(view, offset, sendTimestampUs());
 }
 
 /**

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.test.ts
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 
 import {
   chooseAdaptiveMouseFlushInterval,
+  classifyStreamLagReason,
   quantizeMouseDeltaWithResidual,
   subsampleCoalescedPointerEvents,
 } from "./webrtcClient";
@@ -86,4 +87,71 @@ test("subsampleCoalescedPointerEvents thins large coalesced bursts", () => {
   assert.ok(stride > 1);
   assert.ok(events.length < samples.length);
   assert.equal(events[0]?.movementX, 0);
+});
+
+const stableLagParams = {
+  nativeInputActive: false,
+  nativeRendererActive: false,
+  framesReceived: 5000,
+  framesDecoded: 4980,
+  decodeTimeMs: 9.2,
+  decodeFps: 120,
+  renderFps: 118,
+  rttMs: 6,
+  packetLossPercent: 0,
+  jitterMs: 0.5,
+  jitterBufferDelayMs: 0.5,
+  inputQueueBufferedBytes: 0,
+  inputQueueDropCount: 0,
+  decoderPressureActive: false,
+  decoderPressureReason: "stable",
+  decoderBacklogFrames: 20,
+  dropRatePercent: 0.1,
+  backpressureThresholdBytes: 64 * 1024,
+};
+
+test("classifyStreamLagReason ignores mouse coalesce timer jitter for input lag", () => {
+  const result = classifyStreamLagReason({
+    ...stableLagParams,
+    inputQueueBufferedBytes: 2048,
+  });
+  assert.equal(result.reason, "stable");
+});
+
+test("classifyStreamLagReason ignores normal AV1 decode time without sustained decoder pressure", () => {
+  const result = classifyStreamLagReason({
+    ...stableLagParams,
+    decodeTimeMs: 8.4,
+    decodeFps: 120,
+  });
+  assert.equal(result.reason, "stable");
+});
+
+test("classifyStreamLagReason reports input lag only for drops or full channel buffer", () => {
+  assert.equal(
+    classifyStreamLagReason({
+      ...stableLagParams,
+      inputQueueDropCount: 2,
+    }).reason,
+    "input_backpressure",
+  );
+  assert.equal(
+    classifyStreamLagReason({
+      ...stableLagParams,
+      inputQueueBufferedBytes: 64 * 1024,
+    }).reason,
+    "input_backpressure",
+  );
+});
+
+test("classifyStreamLagReason reports decoder lag only for sustained pressure", () => {
+  const result = classifyStreamLagReason({
+    ...stableLagParams,
+    decoderPressureActive: true,
+    decoderPressureReason: "backlog_and_drop",
+    decoderBacklogFrames: 52,
+    dropRatePercent: 7.5,
+  });
+  assert.equal(result.reason, "decoder");
+  assert.match(result.detail, /backlog 52/);
 });

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import {
   chooseAdaptiveMouseFlushInterval,
   quantizeMouseDeltaWithResidual,
+  subsampleCoalescedPointerEvents,
 } from "./webrtcClient";
 
 test("quantizeMouseDeltaWithResidual preserves precision across sends", () => {
@@ -22,7 +23,7 @@ test("quantizeMouseDeltaWithResidual preserves precision across sends", () => {
   assert.ok(Math.abs(c.residual) < 1e-9);
 });
 
-test("adaptive flush falls back to base when partially-reliable is unavailable", () => {
+test("adaptive flush on reliable mouse tightens toward min under low pressure", () => {
   const interval = chooseAdaptiveMouseFlushInterval({
     baseIntervalMs: 8,
     currentIntervalMs: 4,
@@ -33,16 +34,30 @@ test("adaptive flush falls back to base when partially-reliable is unavailable",
     minIntervalMs: 2,
     maxIntervalMs: 20,
   });
-  assert.equal(interval, 8);
+  assert.equal(interval, 3);
 });
 
-test("adaptive flush tightens under low pressure and relaxes under pressure", () => {
+test("adaptive flush keeps base interval when partially-reliable mouse is active", () => {
+  const underPressure = chooseAdaptiveMouseFlushInterval({
+    baseIntervalMs: 8,
+    currentIntervalMs: 20,
+    reliableBufferedAmount: 48 * 1024,
+    schedulingDelayMs: 8,
+    canUsePartiallyReliableMouse: true,
+    backpressureThresholdBytes: 64 * 1024,
+    minIntervalMs: 2,
+    maxIntervalMs: 20,
+  });
+  assert.equal(underPressure, 8);
+});
+
+test("adaptive flush tightens under low pressure and relaxes under pressure on reliable mouse", () => {
   const lowPressure = chooseAdaptiveMouseFlushInterval({
     baseIntervalMs: 8,
     currentIntervalMs: 8,
     reliableBufferedAmount: 1024,
     schedulingDelayMs: 0.5,
-    canUsePartiallyReliableMouse: true,
+    canUsePartiallyReliableMouse: false,
     backpressureThresholdBytes: 64 * 1024,
     minIntervalMs: 2,
     maxIntervalMs: 20,
@@ -54,10 +69,21 @@ test("adaptive flush tightens under low pressure and relaxes under pressure", ()
     currentIntervalMs: 7,
     reliableBufferedAmount: 48 * 1024,
     schedulingDelayMs: 5,
-    canUsePartiallyReliableMouse: true,
+    canUsePartiallyReliableMouse: false,
     backpressureThresholdBytes: 64 * 1024,
     minIntervalMs: 2,
     maxIntervalMs: 20,
   });
   assert.equal(highPressure, 9);
+});
+
+test("subsampleCoalescedPointerEvents thins large coalesced bursts", () => {
+  const samples = Array.from({ length: 12 }, (_, index) => ({
+    movementX: index,
+    movementY: index,
+  }));
+  const { events, stride } = subsampleCoalescedPointerEvents(samples, 0, 4);
+  assert.ok(stride > 1);
+  assert.ok(events.length < samples.length);
+  assert.equal(events[0]?.movementX, 0);
 });

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.test.ts
@@ -155,3 +155,21 @@ test("classifyStreamLagReason reports decoder lag only for sustained pressure", 
   assert.equal(result.reason, "decoder");
   assert.match(result.detail, /backlog 52/);
 });
+
+test("classifyStreamLagReason ignores small render gap at high stream fps", () => {
+  const result = classifyStreamLagReason({
+    ...stableLagParams,
+    decodeFps: 240,
+    renderFps: 228,
+  });
+  assert.equal(result.reason, "stable");
+});
+
+test("classifyStreamLagReason reports render lag for large relative render drop", () => {
+  const result = classifyStreamLagReason({
+    ...stableLagParams,
+    decodeFps: 120,
+    renderFps: 90,
+  });
+  assert.equal(result.reason, "render");
+});

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -2816,7 +2816,9 @@ export class GfnWebRtcClient {
   private reliableDropLogged = false;
 
   private sendNativeInput(payload: Uint8Array, partiallyReliable: boolean): void {
-    const safePayload = Uint8Array.from(payload);
+    const safePayload = payload.byteOffset === 0 && payload.byteLength === payload.buffer.byteLength
+      ? payload
+      : payload.slice();
     window.openNow.sendNativeInput({
       payload: safePayload,
       partiallyReliable,

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -1323,6 +1323,13 @@ export class GfnWebRtcClient {
     inputQueueDropCount: number;
     inputQueueMaxSchedulingDelayMs: number;
   }): { reason: StreamLagReason; detail: string } {
+    if (this.nativeInputActive || this.diagnostics.nativeRendererActive) {
+      return {
+        reason: "stable",
+        detail: "Native streamer input bridge active",
+      };
+    }
+
     const networkSignals: string[] = [];
     if (params.packetLossPercent >= 1) networkSignals.push(`${params.packetLossPercent.toFixed(1)}% loss`);
     if (params.rttMs >= 75) networkSignals.push(`RTT ${params.rttMs.toFixed(0)}ms`);
@@ -1919,6 +1926,15 @@ export class GfnWebRtcClient {
     }
     this.diagnostics.lagReason = "stable";
     this.diagnostics.lagReasonDetail = "Native streamer input bridge active";
+    this.diagnostics.inputQueueBufferedBytes = 0;
+    this.diagnostics.inputQueuePeakBufferedBytes = 0;
+    this.diagnostics.partiallyReliableInputQueueBufferedBytes = 0;
+    this.diagnostics.partiallyReliableInputQueuePeakBufferedBytes = 0;
+    this.diagnostics.inputQueueDropCount = 0;
+    this.diagnostics.inputQueueMaxSchedulingDelayMs = 0;
+    this.diagnostics.mouseAdaptiveFlushActive = false;
+    this.diagnostics.mousePacketsPerSecond = 0;
+    this.diagnostics.mouseResidualMagnitude = 0;
     this.diagnostics.partiallyReliableInputOpen = true;
     this.diagnostics.mouseMoveTransport = this.canSendInputTypePartiallyReliable(INPUT_MOUSE_REL)
       ? "partially_reliable"

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -324,7 +324,9 @@ export interface AdaptiveMouseFlushDecisionParams {
 export function chooseAdaptiveMouseFlushInterval(params: AdaptiveMouseFlushDecisionParams): number {
   const boundedBase = Math.max(params.minIntervalMs, Math.min(params.maxIntervalMs, params.baseIntervalMs));
   const boundedCurrent = Math.max(params.minIntervalMs, Math.min(params.maxIntervalMs, params.currentIntervalMs));
-  if (!params.canUsePartiallyReliableMouse) {
+  // Official GFN keeps a fixed coalesce interval (4/8/16 ms) for PR mouse and does not
+  // back off because the reliable keyboard channel is busy.
+  if (params.canUsePartiallyReliableMouse) {
     return boundedBase;
   }
 
@@ -347,6 +349,31 @@ export function chooseAdaptiveMouseFlushInterval(params: AdaptiveMouseFlushDecis
     return Math.min(boundedBase, boundedCurrent + 1);
   }
   return boundedCurrent;
+}
+
+/** Subsample coalesced pointer samples like official GFN wm() when bursts are large. */
+export function subsampleCoalescedPointerEvents<T extends { movementX: number; movementY: number }>(
+  samples: readonly T[],
+  pendingBatchEntries: number,
+  maxBatchEntries: number = 16,
+): { events: T[]; stride: number } {
+  if (samples.length <= 1) {
+    return { events: [...samples], stride: 1 };
+  }
+
+  const budget = samples.length > 2 * maxBatchEntries
+    ? 1
+    : Math.max(maxBatchEntries - pendingBatchEntries - 4, 1);
+  if (samples.length <= budget) {
+    return { events: [...samples], stride: 1 };
+  }
+
+  const stride = Math.ceil(samples.length / budget);
+  const events: T[] = [];
+  for (let index = 0; index < samples.length; index += stride) {
+    events.push(samples[index]!);
+  }
+  return { events, stride };
 }
 
 export function quantizeMouseDeltaWithResidual(accumulatedDelta: number): { send: number; residual: number } {
@@ -694,7 +721,8 @@ export class GfnWebRtcClient {
   private mousePacketsPerSecond = 0;
   private mousePacketRateWindowStartedAtMs = 0;
   private mouseFlushIntervalMs = GfnWebRtcClient.MOUSE_FLUSH_NORMAL_MS;
-  private mouseFlushLastTickMs = 0;
+  private mouseFlushLastSendMs = 0;
+  private mouseCoalescedBatchEntries = 0;
   private pendingMouseTimestampUs: bigint | null = null;
   private mouseDeltaFilter = new MouseDeltaFilter();
   private mouseSensitivity = 1;
@@ -1346,6 +1374,26 @@ export class GfnWebRtcClient {
     }
 
     const frameBudgetMs = params.decodeFps > 0 ? 1000 / params.decodeFps : 0;
+    if (
+      params.inputQueueMaxSchedulingDelayMs >= 6
+      || (
+        params.inputQueueMaxSchedulingDelayMs >= 3
+        && params.inputQueueBufferedBytes >= 4096
+      )
+    ) {
+      const detailParts: string[] = [];
+      if (params.inputQueueMaxSchedulingDelayMs >= 3) {
+        detailParts.push(`sched ${params.inputQueueMaxSchedulingDelayMs.toFixed(1)}ms`);
+      }
+      if (params.inputQueueBufferedBytes >= 4096) {
+        detailParts.push(`buffered ${(params.inputQueueBufferedBytes / 1024).toFixed(1)}KB`);
+      }
+      return {
+        reason: "input_backpressure",
+        detail: detailParts.join(" · ") || "input scheduling delay",
+      };
+    }
+
     const decodeSaturated =
       frameBudgetMs > 0 &&
       params.decodeTimeMs > 0 &&
@@ -1894,7 +1942,8 @@ export class GfnWebRtcClient {
     this.pendingMouseDyFloat = 0;
     this.pendingMouseTimestampUs = null;
     this.mouseDeltaFilter.reset();
-    this.mouseFlushLastTickMs = 0;
+    this.mouseFlushLastSendMs = 0;
+    this.mouseCoalescedBatchEntries = 0;
     this.mouseFlushBaseIntervalMs = GfnWebRtcClient.MOUSE_FLUSH_NORMAL_MS;
     this.mouseFlushIntervalMs = GfnWebRtcClient.MOUSE_FLUSH_NORMAL_MS;
     this.mouseAdaptiveFlushActive = false;
@@ -2847,9 +2896,11 @@ export class GfnWebRtcClient {
       return;
     }
     this.reliableSingleInputFlushScheduled = true;
-    queueMicrotask(() => {
+    // Yield to pointer/mouse macrotasks before flushing keyboard batches (official GFN
+    // sends immediately; deferring one macrotask avoids starving coalesced pointer work).
+    window.setTimeout(() => {
       this.flushQueuedReliableSingleInputs();
-    });
+    }, 0);
   }
 
   private flushQueuedReliableSingleInputs(): void {
@@ -3174,13 +3225,15 @@ export class GfnWebRtcClient {
         : GfnWebRtcClient.MOUSE_FLUSH_SAFE_MS;
     this.mouseFlushIntervalMs = this.mouseFlushBaseIntervalMs;
     this.mouseAdaptiveFlushActive = false;
-    this.mouseFlushLastTickMs = performance.now();
+    const mouseInitNow = performance.now();
+    this.mouseFlushLastSendMs = mouseInitNow;
+    this.mouseCoalescedBatchEntries = 0;
     this.pendingMouseDxFloat = 0;
     this.pendingMouseDyFloat = 0;
     this.pendingMouseTimestampUs = null;
     this.mousePacketsPerSecond = 0;
     this.mousePacketsSentInWindow = 0;
-    this.mousePacketRateWindowStartedAtMs = this.mouseFlushLastTickMs;
+    this.mousePacketRateWindowStartedAtMs = mouseInitNow;
     this.mouseDeltaFilter.reset();
     this.mouseDeltaFilter.setRelaxedForRawInput(hasPointerRawUpdate);
     this.log(
@@ -3225,32 +3278,50 @@ export class GfnWebRtcClient {
       return pointerScaleCache;
     };
 
-    const flushMouse = () => {
+    const updateMousePacketRate = (): void => {
+      const now = performance.now();
+      if (this.mousePacketRateWindowStartedAtMs <= 0) {
+        this.mousePacketRateWindowStartedAtMs = now;
+      }
+      const elapsed = now - this.mousePacketRateWindowStartedAtMs;
+      if (elapsed >= 1000) {
+        this.mousePacketsPerSecond = Math.round((this.mousePacketsSentInWindow * 1000) / elapsed);
+        this.mousePacketsSentInWindow = 0;
+        this.mousePacketRateWindowStartedAtMs = now;
+      }
+    };
+
+    const updateAdaptiveMouseFlushInterval = (): void => {
+      const reliableBufferedAmount = this.reliableInputChannel?.bufferedAmount ?? 0;
+      const schedulingDelay = this.inputQueueMaxSchedulingDelayMsWindow;
+      const nextInterval = chooseAdaptiveMouseFlushInterval({
+        baseIntervalMs: this.mouseFlushBaseIntervalMs,
+        currentIntervalMs: this.mouseFlushIntervalMs,
+        reliableBufferedAmount,
+        schedulingDelayMs: schedulingDelay,
+        canUsePartiallyReliableMouse: this.canSendInputTypePartiallyReliable(INPUT_MOUSE_REL),
+        backpressureThresholdBytes: GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES,
+        minIntervalMs: GfnWebRtcClient.MOUSE_FLUSH_MIN_MS,
+        maxIntervalMs: GfnWebRtcClient.MOUSE_FLUSH_MAX_MS,
+      });
+      this.mouseAdaptiveFlushActive = nextInterval !== this.mouseFlushBaseIntervalMs;
+      this.mouseFlushIntervalMs = nextInterval;
+    };
+
+    const flushMouse = (): boolean => {
       const tickNow = performance.now();
-      const hasPendingMovement = Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
-      if (this.mouseFlushLastTickMs > 0 && hasPendingMovement) {
-        const expected = this.mouseFlushLastTickMs + this.mouseFlushIntervalMs;
-        const schedulingDelay = Math.max(0, tickNow - expected);
-        this.inputQueueMaxSchedulingDelayMsWindow = Math.max(
-          this.inputQueueMaxSchedulingDelayMsWindow,
-          schedulingDelay,
-        );
-      }
-      this.mouseFlushLastTickMs = tickNow;
+      const hasPendingMovement =
+        Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
 
-      if (!this.inputReady) {
-        return;
-      }
-
-      if (!hasPendingMovement) {
-        return;
+      if (!this.inputReady || !hasPendingMovement) {
+        return false;
       }
 
       const reliable = this.reliableInputChannel;
       const mouseMoveUsesPartiallyReliable = this.canSendInputTypePartiallyReliable(INPUT_MOUSE_REL);
       if (
         !mouseMoveUsesPartiallyReliable
-        && 
+        &&
         reliable?.readyState === "open"
         && reliable.bufferedAmount > GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES
       ) {
@@ -3263,8 +3334,10 @@ export class GfnWebRtcClient {
         this.pendingMouseDxFloat = 0;
         this.pendingMouseDyFloat = 0;
         this.pendingMouseTimestampUs = null;
-        return;
+        this.mouseCoalescedBatchEntries = 0;
+        return false;
       }
+
       const { scaleX, scaleY } = getPointerScale();
       const dxQuantized = quantizeMouseDeltaWithResidual(this.pendingMouseDxFloat);
       const dyQuantized = quantizeMouseDeltaWithResidual(this.pendingMouseDyFloat);
@@ -3273,8 +3346,16 @@ export class GfnWebRtcClient {
       if (dxServer === 0 && dyServer === 0) {
         // Keep pending movement intact until a non-zero packet is sent.
         // Otherwise quantized integer deltas can be dropped when server scaling rounds to zero.
-        return;
+        return false;
       }
+
+      const expectedSendAt = this.mouseFlushLastSendMs + this.mouseFlushIntervalMs;
+      const schedulingDelay = Math.max(0, tickNow - expectedSendAt);
+      this.inputQueueMaxSchedulingDelayMsWindow = Math.max(
+        this.inputQueueMaxSchedulingDelayMsWindow,
+        schedulingDelay,
+      );
+
       this.pendingMouseDxFloat = dxQuantized.residual;
       this.pendingMouseDyFloat = dyQuantized.residual;
 
@@ -3285,56 +3366,60 @@ export class GfnWebRtcClient {
       });
 
       this.pendingMouseTimestampUs = null;
+      this.mouseCoalescedBatchEntries = 0;
       this.sendInputPacket(payload, INPUT_MOUSE_REL);
       this.mousePacketsSentInWindow += 1;
+      this.mouseFlushLastSendMs = tickNow;
+      updateMousePacketRate();
+      updateAdaptiveMouseFlushInterval();
+
       // Update simulated absolute pointer (stored in server pixels) if we have a baseline.
       if (simulatedAbsX !== null && simulatedAbsY !== null) {
         simulatedAbsX += dxServer;
         simulatedAbsY += dyServer;
       }
+      return true;
     };
-    const scheduleNextFlush = (): void => {
+
+    const armMouseFlushTimer = (): void => {
       if (this.mouseFlushTimer !== null) {
-        window.clearTimeout(this.mouseFlushTimer);
+        return;
       }
-      this.mouseFlushTimer = window.setTimeout(() => {
+
+      const now = performance.now();
+      const elapsed = now - this.mouseFlushLastSendMs;
+      if (elapsed >= this.mouseFlushIntervalMs) {
         try {
           flushMouse();
-          const reliableBufferedAmount = this.reliableInputChannel?.bufferedAmount ?? 0;
-          const schedulingDelay = this.inputQueueMaxSchedulingDelayMsWindow;
-          const nextInterval = chooseAdaptiveMouseFlushInterval({
-            baseIntervalMs: this.mouseFlushBaseIntervalMs,
-            currentIntervalMs: this.mouseFlushIntervalMs,
-            reliableBufferedAmount,
-            schedulingDelayMs: schedulingDelay,
-            canUsePartiallyReliableMouse: this.canSendInputTypePartiallyReliable(INPUT_MOUSE_REL),
-            backpressureThresholdBytes: GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES,
-            minIntervalMs: GfnWebRtcClient.MOUSE_FLUSH_MIN_MS,
-            maxIntervalMs: GfnWebRtcClient.MOUSE_FLUSH_MAX_MS,
-          });
-          this.mouseAdaptiveFlushActive = nextInterval !== this.mouseFlushBaseIntervalMs;
-          this.mouseFlushIntervalMs = nextInterval;
-          const now = performance.now();
-          if (this.mousePacketRateWindowStartedAtMs <= 0) {
-            this.mousePacketRateWindowStartedAtMs = now;
-          }
-          const elapsed = now - this.mousePacketRateWindowStartedAtMs;
-          if (elapsed >= 1000) {
-            this.mousePacketsPerSecond = Math.round((this.mousePacketsSentInWindow * 1000) / elapsed);
-            this.mousePacketsSentInWindow = 0;
-            this.mousePacketRateWindowStartedAtMs = now;
-          }
+        } catch (err) {
+          this.log(`Mouse flush failed (non-fatal): ${String(err)}`);
+        }
+        if (
+          Math.abs(this.pendingMouseDxFloat) >= 0.5
+          || Math.abs(this.pendingMouseDyFloat) >= 0.5
+        ) {
+          armMouseFlushTimer();
+        }
+        return;
+      }
+
+      this.mouseFlushTimer = window.setTimeout(() => {
+        this.mouseFlushTimer = null;
+        try {
+          flushMouse();
         } catch (err) {
           this.log(`Mouse flush tick failed (non-fatal): ${String(err)}`);
         } finally {
-          // clearTimers() nulls this timer during teardown; avoid re-arming a zombie loop.
-          if (this.mouseFlushTimer !== null) {
-            scheduleNextFlush();
+          if (this.mouseFlushTimer === null) {
+            const hasPendingMovement =
+              Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
+            if (hasPendingMovement) {
+              armMouseFlushTimer();
+            }
           }
         }
-      }, this.mouseFlushIntervalMs);
+      }, Math.max(0, this.mouseFlushIntervalMs - elapsed));
     };
-    scheduleNextFlush();
 
     const tryAutoLock = (): void => {
       try {
@@ -3433,7 +3518,11 @@ export class GfnWebRtcClient {
 
       this.pendingMouseDxFloat += adjustedDx;
       this.pendingMouseDyFloat += adjustedDy;
-      this.pendingMouseTimestampUs = timestampUs(eventTimestampMs);
+      if (this.pendingMouseTimestampUs === null) {
+        this.pendingMouseTimestampUs = timestampUs(eventTimestampMs);
+      }
+      this.mouseCoalescedBatchEntries += 1;
+      armMouseFlushTimer();
     };
 
     const onPointerMove = (event: PointerEvent) => {
@@ -3448,10 +3537,19 @@ export class GfnWebRtcClient {
       if (isPointerLockActive()) {
         // Pointer lock active: use raw relative movement (movementX/Y).
         const samples = hasCoalescedEvents ? event.getCoalescedEvents() : [];
-        if (samples.length > 0) {
+        if (samples.length > 1) {
+          let totalDx = 0;
+          let totalDy = 0;
           for (const sample of samples) {
-            queueMouseMovement(sample.movementX, sample.movementY, sample.timeStamp);
+            totalDx += sample.movementX;
+            totalDy += sample.movementY;
           }
+          queueMouseMovement(totalDx, totalDy, samples[0]!.timeStamp);
+          return;
+        }
+        if (samples.length === 1) {
+          const sample = samples[0]!;
+          queueMouseMovement(sample.movementX, sample.movementY, sample.timeStamp);
           return;
         }
         queueMouseMovement(event.movementX, event.movementY, event.timeStamp);

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -455,7 +455,12 @@ export function classifyStreamLagReason(
 
   if (params.renderFps > 0 && params.decodeFps > 0) {
     const renderGap = params.decodeFps - params.renderFps;
-    if (renderGap >= 12 || params.renderFps < 20) {
+    const renderGapPercent = renderGap / params.decodeFps;
+    // Absolute fps gaps are misleading at 120/240fps streams — require a large relative drop.
+    const renderPressure =
+      params.renderFps < 30
+      || (renderGap >= 20 && renderGapPercent >= 0.2);
+    if (renderPressure) {
       return {
         reason: "render",
         detail: `render ${params.renderFps}fps vs decode ${params.decodeFps}fps`,

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -28,6 +28,10 @@ import {
   GAMEPAD_MAX_CONTROLLERS,
   type GamepadInput,
   codeMap,
+  startInputSessionClock,
+  captureTimestampUs,
+  sendTimestampUs,
+  finalizeReliableSingleInputPackets,
 } from "./inputProtocol";
 import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "./keyboardLock";
 import {
@@ -234,11 +238,7 @@ interface ClientOptions {
 }
 
 function timestampUs(sourceTimestampMs?: number): bigint {
-  const base =
-    typeof sourceTimestampMs === "number" && Number.isFinite(sourceTimestampMs) && sourceTimestampMs >= 0
-      ? sourceTimestampMs
-      : performance.now();
-  return BigInt(Math.floor(base * 1000));
+  return captureTimestampUs(sourceTimestampMs);
 }
 
 function parsePartialReliableThresholdMs(sdp: string): number | null {
@@ -596,6 +596,8 @@ export class GfnWebRtcClient {
   /** When true, window blur or document hidden blocks forwarding until focus/visible again. */
   private windowStateInputPaused = false;
   private inputProtocolVersion = 2;
+  private pendingReliableSingleInputs: Uint8Array[] = [];
+  private reliableSingleInputFlushScheduled = false;
   private heartbeatTimer: number | null = null;
   private mouseFlushTimer: number | null = null;
   private statsTimer: number | null = null;
@@ -1218,6 +1220,7 @@ export class GfnWebRtcClient {
       this.gamepadPollTimer = null;
     }
     this.clearSyntheticEscapeSuppression();
+    this.clearReliableSingleInputQueue();
   }
 
   private setupStatsPolling(): void {
@@ -1364,7 +1367,10 @@ export class GfnWebRtcClient {
     if (
       params.inputQueueDropCount > 0 ||
       params.inputQueueBufferedBytes >= GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES ||
-      params.inputQueueMaxSchedulingDelayMs >= 4
+      (
+        params.inputQueueMaxSchedulingDelayMs >= 4
+        && params.inputQueueBufferedBytes >= 4096
+      )
     ) {
       const detailParts: string[] = [];
       if (params.inputQueueDropCount > 0) detailParts.push(`drops ${params.inputQueueDropCount}`);
@@ -2703,6 +2709,7 @@ export class GfnWebRtcClient {
       // Official GFN browser client does NOT echo the handshake back.
       // It just reads the protocol version and starts sending input.
       // (The Rust reference implementation does echo, but that's for its own server.)
+      startInputSessionClock();
       this.inputReady = true;
       this.inputProtocolVersion = version;
       this.inputEncoder.setProtocolVersion(version);
@@ -2831,6 +2838,39 @@ export class GfnWebRtcClient {
 
   private reliableDropLogged = false;
 
+  private queueReliableSingleInput(payload: Uint8Array): void {
+    const safePayload = payload.byteOffset === 0 && payload.byteLength === payload.buffer.byteLength
+      ? payload
+      : payload.slice();
+    this.pendingReliableSingleInputs.push(safePayload);
+    if (this.reliableSingleInputFlushScheduled) {
+      return;
+    }
+    this.reliableSingleInputFlushScheduled = true;
+    queueMicrotask(() => {
+      this.flushQueuedReliableSingleInputs();
+    });
+  }
+
+  private flushQueuedReliableSingleInputs(): void {
+    this.reliableSingleInputFlushScheduled = false;
+    if (this.pendingReliableSingleInputs.length === 0) {
+      return;
+    }
+
+    const queued = this.pendingReliableSingleInputs;
+    this.pendingReliableSingleInputs = [];
+    const packets = finalizeReliableSingleInputPackets(queued, sendTimestampUs());
+    for (const packet of packets) {
+      this.sendReliable(packet);
+    }
+  }
+
+  private clearReliableSingleInputQueue(): void {
+    this.pendingReliableSingleInputs = [];
+    this.reliableSingleInputFlushScheduled = false;
+  }
+
   private sendNativeInput(payload: Uint8Array, partiallyReliable: boolean): void {
     const safePayload = payload.byteOffset === 0 && payload.byteLength === payload.buffer.byteLength
       ? payload
@@ -2877,7 +2917,7 @@ export class GfnWebRtcClient {
     if (!this.inputReady) {
       return;
     }
-    this.sendReliable(this.inputEncoder.encodeLockKeysSync(state));
+    this.queueReliableSingleInput(this.inputEncoder.encodeLockKeysSync(state));
   }
 
   private requestEscapeKeyboardLock(): void {
@@ -3000,7 +3040,7 @@ export class GfnWebRtcClient {
         modifiers: 0,
         timestampUs: timestampUs(),
       });
-      this.sendReliable(payload);
+      this.queueReliableSingleInput(payload);
     }
     this.pressedKeys.clear();
   }
@@ -3019,7 +3059,7 @@ export class GfnWebRtcClient {
         modifiers,
         timestampUs: timestampUs(),
       });
-    this.sendReliable(payload);
+    this.queueReliableSingleInput(payload);
   }
 
   public sendAntiAfkPulse(): boolean {
@@ -3187,7 +3227,8 @@ export class GfnWebRtcClient {
 
     const flushMouse = () => {
       const tickNow = performance.now();
-      if (this.mouseFlushLastTickMs > 0) {
+      const hasPendingMovement = Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
+      if (this.mouseFlushLastTickMs > 0 && hasPendingMovement) {
         const expected = this.mouseFlushLastTickMs + this.mouseFlushIntervalMs;
         const schedulingDelay = Math.max(0, tickNow - expected);
         this.inputQueueMaxSchedulingDelayMsWindow = Math.max(
@@ -3201,7 +3242,6 @@ export class GfnWebRtcClient {
         return;
       }
 
-      const hasPendingMovement = Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
       if (!hasPendingMovement) {
         return;
       }
@@ -3476,6 +3516,11 @@ export class GfnWebRtcClient {
         return;
       }
 
+      if (this.pressedKeys.has(mapped.vk)) {
+        event.preventDefault();
+        return;
+      }
+
       event.preventDefault();
       this.pressedKeys.add(mapped.vk);
 
@@ -3487,7 +3532,7 @@ export class GfnWebRtcClient {
         // fullscreen paths, event.timeStamp can be unstable.
         timestampUs: timestampUs(),
       });
-      this.sendReliable(payload);
+      this.queueReliableSingleInput(payload);
     };
 
     const onKeyUp = (event: KeyboardEvent) => {
@@ -3514,7 +3559,7 @@ export class GfnWebRtcClient {
         modifiers: modifierFlags(event),
         timestampUs: timestampUs(),
       });
-      this.sendReliable(payload);
+      this.queueReliableSingleInput(payload);
     };
 
     const onMouseDown = (event: MouseEvent) => {
@@ -3531,7 +3576,7 @@ export class GfnWebRtcClient {
         timestampUs: timestampUs(event.timeStamp),
       });
       // Official GFN client sends all mouse events on reliable channel (input_channel_v1)
-      this.sendReliable(payload);
+      this.queueReliableSingleInput(payload);
     };
 
     const onMouseUp = (event: MouseEvent) => {
@@ -3548,7 +3593,7 @@ export class GfnWebRtcClient {
         timestampUs: timestampUs(event.timeStamp),
       });
       // Official GFN client sends all mouse events on reliable channel (input_channel_v1)
-      this.sendReliable(payload);
+      this.queueReliableSingleInput(payload);
     };
 
     const onWheel = (event: WheelEvent) => {
@@ -3567,7 +3612,7 @@ export class GfnWebRtcClient {
         delta,
         timestampUs: timestampUs(event.timeStamp),
       });
-      this.sendReliable(payload);
+      this.queueReliableSingleInput(payload);
     };
 
     const onClick = () => {
@@ -3697,7 +3742,7 @@ export class GfnWebRtcClient {
           modifiers: 0,
           timestampUs: timestampUs(),
         });
-        this.sendReliable(escDown);
+        this.queueReliableSingleInput(escDown);
 
         const escUp = this.inputEncoder.encodeKeyUp({
           keycode: 0x1B,
@@ -3705,7 +3750,7 @@ export class GfnWebRtcClient {
           modifiers: 0,
           timestampUs: timestampUs(),
         });
-        this.sendReliable(escUp);
+        this.queueReliableSingleInput(escUp);
 
         schedulePointerLockRetention("synthetic Escape");
       }, 50);
@@ -3883,7 +3928,7 @@ export class GfnWebRtcClient {
           modifiers: 0,
           timestampUs: timestampUs(),
         });
-        this.sendReliable(escDown);
+        this.queueReliableSingleInput(escDown);
 
         const escUp = this.inputEncoder.encodeKeyUp({
           keycode: 0x1B,
@@ -3891,7 +3936,7 @@ export class GfnWebRtcClient {
           modifiers: 0,
           timestampUs: timestampUs(),
         });
-        this.sendReliable(escUp);
+        this.queueReliableSingleInput(escUp);
       });
     } catch {}
 

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -376,6 +376,101 @@ export function subsampleCoalescedPointerEvents<T extends { movementX: number; m
   return { events, stride };
 }
 
+export interface ClassifyStreamLagReasonParams {
+  nativeInputActive: boolean;
+  nativeRendererActive: boolean;
+  framesReceived: number;
+  framesDecoded: number;
+  decodeTimeMs: number;
+  decodeFps: number;
+  renderFps: number;
+  rttMs: number;
+  packetLossPercent: number;
+  jitterMs: number;
+  jitterBufferDelayMs: number;
+  inputQueueBufferedBytes: number;
+  inputQueueDropCount: number;
+  decoderPressureActive: boolean;
+  decoderPressureReason: string;
+  decoderBacklogFrames: number;
+  dropRatePercent: number;
+  backpressureThresholdBytes: number;
+}
+
+/** Classify overlay lag warnings using sustained pressure signals, not timer jitter or normal decode times. */
+export function classifyStreamLagReason(
+  params: ClassifyStreamLagReasonParams,
+): { reason: StreamLagReason; detail: string } {
+  if (params.nativeInputActive || params.nativeRendererActive) {
+    return {
+      reason: "stable",
+      detail: "Native streamer input bridge active",
+    };
+  }
+
+  const networkSignals: string[] = [];
+  if (params.packetLossPercent >= 1) networkSignals.push(`${params.packetLossPercent.toFixed(1)}% loss`);
+  if (params.rttMs >= 75) networkSignals.push(`RTT ${params.rttMs.toFixed(0)}ms`);
+  if (params.jitterMs >= 12) networkSignals.push(`jitter ${params.jitterMs.toFixed(1)}ms`);
+  if (params.jitterBufferDelayMs >= 20) networkSignals.push(`buffer ${params.jitterBufferDelayMs.toFixed(1)}ms`);
+  if (networkSignals.length > 0) {
+    return {
+      reason: "network",
+      detail: networkSignals.join(" · "),
+    };
+  }
+
+  const severeDecoderStall = params.framesReceived > 100 && params.framesDecoded === 0;
+  if (params.decoderPressureActive || severeDecoderStall) {
+    const detailParts: string[] = [];
+    if (severeDecoderStall) detailParts.push("frames received but not decoded");
+    if (params.decoderPressureReason === "decode_saturated" && params.decodeTimeMs > 0) {
+      detailParts.push(`decode ${params.decodeTimeMs.toFixed(1)}ms`);
+    }
+    if (params.decoderBacklogFrames >= 45) detailParts.push(`backlog ${params.decoderBacklogFrames}`);
+    if (params.dropRatePercent >= 6) detailParts.push(`${params.dropRatePercent.toFixed(1)}% drops`);
+    if (detailParts.length === 0 && params.decoderPressureReason !== "stable") {
+      detailParts.push(params.decoderPressureReason.replace(/_/g, " "));
+    }
+    return {
+      reason: "decoder",
+      detail: detailParts.join(" · ") || "decode pressure",
+    };
+  }
+
+  if (
+    params.inputQueueDropCount > 0
+    || params.inputQueueBufferedBytes >= params.backpressureThresholdBytes
+  ) {
+    const detailParts: string[] = [];
+    if (params.inputQueueDropCount > 0) detailParts.push(`drops ${params.inputQueueDropCount}`);
+    if (params.inputQueueBufferedBytes >= params.backpressureThresholdBytes) {
+      detailParts.push(`buffered ${(params.inputQueueBufferedBytes / 1024).toFixed(1)}KB`);
+    }
+    return {
+      reason: "input_backpressure",
+      detail: detailParts.join(" · "),
+    };
+  }
+
+  if (params.renderFps > 0 && params.decodeFps > 0) {
+    const renderGap = params.decodeFps - params.renderFps;
+    if (renderGap >= 12 || params.renderFps < 20) {
+      return {
+        reason: "render",
+        detail: `render ${params.renderFps}fps vs decode ${params.decodeFps}fps`,
+      };
+    }
+  }
+
+  return {
+    reason: params.decodeFps > 0 || params.renderFps > 0 ? "stable" : "unknown",
+    detail: params.decodeFps > 0 || params.renderFps > 0
+      ? "No dominant lag source detected"
+      : "Waiting for stream stats",
+  };
+}
+
 export function quantizeMouseDeltaWithResidual(accumulatedDelta: number): { send: number; residual: number } {
   const send = Math.round(accumulatedDelta);
   return {
@@ -1338,119 +1433,6 @@ export class GfnWebRtcClient {
     };
   }
 
-  private classifyLagReason(params: {
-    framesReceived: number;
-    framesDecoded: number;
-    framesDropped: number;
-    decodeTimeMs: number;
-    decodeFps: number;
-    renderFps: number;
-    rttMs: number;
-    packetLossPercent: number;
-    jitterMs: number;
-    jitterBufferDelayMs: number;
-    inputQueueBufferedBytes: number;
-    inputQueueDropCount: number;
-    inputQueueMaxSchedulingDelayMs: number;
-  }): { reason: StreamLagReason; detail: string } {
-    if (this.nativeInputActive || this.diagnostics.nativeRendererActive) {
-      return {
-        reason: "stable",
-        detail: "Native streamer input bridge active",
-      };
-    }
-
-    const networkSignals: string[] = [];
-    if (params.packetLossPercent >= 1) networkSignals.push(`${params.packetLossPercent.toFixed(1)}% loss`);
-    if (params.rttMs >= 75) networkSignals.push(`RTT ${params.rttMs.toFixed(0)}ms`);
-    if (params.jitterMs >= 12) networkSignals.push(`jitter ${params.jitterMs.toFixed(1)}ms`);
-    if (params.jitterBufferDelayMs >= 20) networkSignals.push(`buffer ${params.jitterBufferDelayMs.toFixed(1)}ms`);
-    if (networkSignals.length > 0) {
-      return {
-        reason: "network",
-        detail: networkSignals.join(" · "),
-      };
-    }
-
-    const frameBudgetMs = params.decodeFps > 0 ? 1000 / params.decodeFps : 0;
-    if (
-      params.inputQueueMaxSchedulingDelayMs >= 6
-      || (
-        params.inputQueueMaxSchedulingDelayMs >= 3
-        && params.inputQueueBufferedBytes >= 4096
-      )
-    ) {
-      const detailParts: string[] = [];
-      if (params.inputQueueMaxSchedulingDelayMs >= 3) {
-        detailParts.push(`sched ${params.inputQueueMaxSchedulingDelayMs.toFixed(1)}ms`);
-      }
-      if (params.inputQueueBufferedBytes >= 4096) {
-        detailParts.push(`buffered ${(params.inputQueueBufferedBytes / 1024).toFixed(1)}KB`);
-      }
-      return {
-        reason: "input_backpressure",
-        detail: detailParts.join(" · ") || "input scheduling delay",
-      };
-    }
-
-    const decodeSaturated =
-      frameBudgetMs > 0 &&
-      params.decodeTimeMs > 0 &&
-      params.decodeTimeMs >= frameBudgetMs * 0.82;
-    const severeDecoderStall = params.framesReceived > 100 && params.framesDecoded === 0;
-    const decoderBacklog = Math.max(0, params.framesReceived - params.framesDecoded);
-    if (severeDecoderStall || decodeSaturated || decoderBacklog >= 45 || params.framesDropped >= 8) {
-      const detailParts: string[] = [];
-      if (severeDecoderStall) detailParts.push("frames received but not decoded");
-      if (decodeSaturated) detailParts.push(`decode ${params.decodeTimeMs.toFixed(1)}ms`);
-      if (decoderBacklog >= 45) detailParts.push(`backlog ${decoderBacklog}`);
-      if (params.framesDropped >= 8) detailParts.push(`drops ${params.framesDropped}`);
-      return {
-        reason: "decoder",
-        detail: detailParts.join(" · ") || "decode saturation",
-      };
-    }
-
-    if (
-      params.inputQueueDropCount > 0 ||
-      params.inputQueueBufferedBytes >= GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES ||
-      (
-        params.inputQueueMaxSchedulingDelayMs >= 4
-        && params.inputQueueBufferedBytes >= 4096
-      )
-    ) {
-      const detailParts: string[] = [];
-      if (params.inputQueueDropCount > 0) detailParts.push(`drops ${params.inputQueueDropCount}`);
-      if (params.inputQueueBufferedBytes >= GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES) {
-        detailParts.push(`buffered ${(params.inputQueueBufferedBytes / 1024).toFixed(1)}KB`);
-      }
-      if (params.inputQueueMaxSchedulingDelayMs >= 4) {
-        detailParts.push(`sched ${params.inputQueueMaxSchedulingDelayMs.toFixed(1)}ms`);
-      }
-      return {
-        reason: "input_backpressure",
-        detail: detailParts.join(" · "),
-      };
-    }
-
-    if (params.renderFps > 0 && params.decodeFps > 0) {
-      const renderGap = params.decodeFps - params.renderFps;
-      if (renderGap >= 8 || params.renderFps < 24) {
-        return {
-          reason: "render",
-          detail: `render ${params.renderFps}fps vs decode ${params.decodeFps}fps`,
-        };
-      }
-    }
-
-    return {
-      reason: params.decodeFps > 0 || params.renderFps > 0 ? "stable" : "unknown",
-      detail: params.decodeFps > 0 || params.renderFps > 0
-        ? "No dominant lag source detected"
-        : "Waiting for stream stats",
-    };
-  }
-
   private async requestDecoderKeyframe(backlogFrames: number, reason: string): Promise<boolean> {
     const now = performance.now();
     if (now - this.lastDecoderKeyframeRequestAtMs < GfnWebRtcClient.DECODER_KEYFRAME_COOLDOWN_MS) {
@@ -1610,6 +1592,12 @@ export class GfnWebRtcClient {
     let framesReceived = 0;
     let framesDecoded = 0;
     let framesDropped = 0;
+    let pressureSignal = {
+      active: false,
+      reason: "stable",
+      backlogFrames: 0,
+      dropRatePercent: 0,
+    };
 
     for (const entry of report.values()) {
       const stats = entry as unknown as Record<string, unknown>;
@@ -1762,7 +1750,7 @@ export class GfnWebRtcClient {
         this.diagnostics.renderTimeMs = Math.round(avgFrameDelay * 1000 * 10) / 10;
       }
 
-      const pressureSignal = this.shouldTreatAsDecoderPressure({
+      pressureSignal = this.shouldTreatAsDecoderPressure({
         framesReceived,
         framesDecoded,
         framesDropped,
@@ -1805,10 +1793,11 @@ export class GfnWebRtcClient {
     this.diagnostics.mouseResidualMagnitude = Math.hypot(this.pendingMouseDxFloat, this.pendingMouseDyFloat);
     this.diagnostics.mouseAdaptiveFlushActive = this.mouseAdaptiveFlushActive;
 
-    const lagClassification = this.classifyLagReason({
+    const lagClassification = classifyStreamLagReason({
+      nativeInputActive: this.nativeInputActive,
+      nativeRendererActive: this.diagnostics.nativeRendererActive,
       framesReceived,
       framesDecoded,
-      framesDropped,
       decodeTimeMs: this.diagnostics.decodeTimeMs,
       decodeFps: this.diagnostics.decodeFps,
       renderFps: this.diagnostics.renderFps,
@@ -1818,7 +1807,11 @@ export class GfnWebRtcClient {
       jitterBufferDelayMs: this.diagnostics.jitterBufferDelayMs,
       inputQueueBufferedBytes: reliableBufferedAmount,
       inputQueueDropCount: this.inputQueueDropCount,
-      inputQueueMaxSchedulingDelayMs: this.diagnostics.inputQueueMaxSchedulingDelayMs,
+      decoderPressureActive: pressureSignal.active,
+      decoderPressureReason: pressureSignal.reason,
+      decoderBacklogFrames: pressureSignal.backlogFrames,
+      dropRatePercent: pressureSignal.dropRatePercent,
+      backpressureThresholdBytes: GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES,
     });
     this.diagnostics.lagReason = lagClassification.reason;
     this.diagnostics.lagReasonDetail = lagClassification.detail;

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -31,7 +31,7 @@ import {
   startInputSessionClock,
   captureTimestampUs,
   sendTimestampUs,
-  finalizeReliableSingleInputPackets,
+  restampProtocolV3OuterTimestamp,
 } from "./inputProtocol";
 import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "./keyboardLock";
 import {
@@ -623,8 +623,7 @@ export class GfnWebRtcClient {
   /** When true, window blur or document hidden blocks forwarding until focus/visible again. */
   private windowStateInputPaused = false;
   private inputProtocolVersion = 2;
-  private pendingReliableSingleInputs: Uint8Array[] = [];
-  private reliableSingleInputFlushScheduled = false;
+  private flushPendingMouseMovement: () => void = () => {};
   private heartbeatTimer: number | null = null;
   private mouseFlushTimer: number | null = null;
   private statsTimer: number | null = null;
@@ -1248,7 +1247,7 @@ export class GfnWebRtcClient {
       this.gamepadPollTimer = null;
     }
     this.clearSyntheticEscapeSuppression();
-    this.clearReliableSingleInputQueue();
+    this.flushPendingMouseMovement = () => {};
   }
 
   private setupStatsPolling(): void {
@@ -1850,6 +1849,7 @@ export class GfnWebRtcClient {
     for (const cleanup of this.inputCleanup.splice(0)) {
       cleanup();
     }
+    this.flushPendingMouseMovement = () => {};
     this.stopAllGamepadRumble();
     this.updateHapticsAdvertisement(false);
   }
@@ -2887,39 +2887,22 @@ export class GfnWebRtcClient {
 
   private reliableDropLogged = false;
 
-  private queueReliableSingleInput(payload: Uint8Array): void {
-    const safePayload = payload.byteOffset === 0 && payload.byteLength === payload.buffer.byteLength
-      ? payload
-      : payload.slice();
-    this.pendingReliableSingleInputs.push(safePayload);
-    if (this.reliableSingleInputFlushScheduled) {
-      return;
-    }
-    this.reliableSingleInputFlushScheduled = true;
-    // Yield to pointer/mouse macrotasks before flushing keyboard batches (official GFN
-    // sends immediately; deferring one macrotask avoids starving coalesced pointer work).
-    window.setTimeout(() => {
-      this.flushQueuedReliableSingleInputs();
-    }, 0);
-  }
+  /**
+   * Send a reliable single-input packet immediately (official GFN Jc()->Tc()).
+   * When a mouse batch is pending, flush it first (official kc(): cl() then send key).
+   */
+  private sendReliableSingleInput(payload: Uint8Array): void {
+    this.flushPendingMouseMovement();
 
-  private flushQueuedReliableSingleInputs(): void {
-    this.reliableSingleInputFlushScheduled = false;
-    if (this.pendingReliableSingleInputs.length === 0) {
-      return;
+    let packet = payload;
+    if (this.inputProtocolVersion > 2) {
+      packet = payload.slice();
+      restampProtocolV3OuterTimestamp(packet, sendTimestampUs());
+    } else if (payload.byteOffset !== 0 || payload.byteLength !== payload.buffer.byteLength) {
+      packet = payload.slice();
     }
 
-    const queued = this.pendingReliableSingleInputs;
-    this.pendingReliableSingleInputs = [];
-    const packets = finalizeReliableSingleInputPackets(queued, sendTimestampUs());
-    for (const packet of packets) {
-      this.sendReliable(packet);
-    }
-  }
-
-  private clearReliableSingleInputQueue(): void {
-    this.pendingReliableSingleInputs = [];
-    this.reliableSingleInputFlushScheduled = false;
+    this.sendReliable(packet);
   }
 
   private sendNativeInput(payload: Uint8Array, partiallyReliable: boolean): void {
@@ -2968,7 +2951,7 @@ export class GfnWebRtcClient {
     if (!this.inputReady) {
       return;
     }
-    this.queueReliableSingleInput(this.inputEncoder.encodeLockKeysSync(state));
+    this.sendReliableSingleInput(this.inputEncoder.encodeLockKeysSync(state));
   }
 
   private requestEscapeKeyboardLock(): void {
@@ -3091,7 +3074,7 @@ export class GfnWebRtcClient {
         modifiers: 0,
         timestampUs: timestampUs(),
       });
-      this.queueReliableSingleInput(payload);
+      this.sendReliableSingleInput(payload);
     }
     this.pressedKeys.clear();
   }
@@ -3110,7 +3093,7 @@ export class GfnWebRtcClient {
         modifiers,
         timestampUs: timestampUs(),
       });
-    this.queueReliableSingleInput(payload);
+    this.sendReliableSingleInput(payload);
   }
 
   public sendAntiAfkPulse(): boolean {
@@ -3291,50 +3274,16 @@ export class GfnWebRtcClient {
       }
     };
 
-    const updateAdaptiveMouseFlushInterval = (): void => {
-      const reliableBufferedAmount = this.reliableInputChannel?.bufferedAmount ?? 0;
-      const schedulingDelay = this.inputQueueMaxSchedulingDelayMsWindow;
-      const nextInterval = chooseAdaptiveMouseFlushInterval({
-        baseIntervalMs: this.mouseFlushBaseIntervalMs,
-        currentIntervalMs: this.mouseFlushIntervalMs,
-        reliableBufferedAmount,
-        schedulingDelayMs: schedulingDelay,
-        canUsePartiallyReliableMouse: this.canSendInputTypePartiallyReliable(INPUT_MOUSE_REL),
-        backpressureThresholdBytes: GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES,
-        minIntervalMs: GfnWebRtcClient.MOUSE_FLUSH_MIN_MS,
-        maxIntervalMs: GfnWebRtcClient.MOUSE_FLUSH_MAX_MS,
-      });
-      this.mouseAdaptiveFlushActive = nextInterval !== this.mouseFlushBaseIntervalMs;
-      this.mouseFlushIntervalMs = nextInterval;
-    };
+    let pointerRawStuckCount = 0;
+    let lastPointerClientX = Number.NaN;
+    let lastPointerClientY = Number.NaN;
+
+    const hasPendingMouseMovement = (): boolean =>
+      Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
 
     const flushMouse = (): boolean => {
       const tickNow = performance.now();
-      const hasPendingMovement =
-        Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
-
-      if (!this.inputReady || !hasPendingMovement) {
-        return false;
-      }
-
-      const reliable = this.reliableInputChannel;
-      const mouseMoveUsesPartiallyReliable = this.canSendInputTypePartiallyReliable(INPUT_MOUSE_REL);
-      if (
-        !mouseMoveUsesPartiallyReliable
-        &&
-        reliable?.readyState === "open"
-        && reliable.bufferedAmount > GfnWebRtcClient.RELIABLE_MOUSE_BACKPRESSURE_BYTES
-      ) {
-        const now = performance.now();
-        this.inputQueueDropCount++;
-        if (now - this.mouseBackpressureLoggedAtMs >= GfnWebRtcClient.BACKPRESSURE_LOG_INTERVAL_MS) {
-          this.mouseBackpressureLoggedAtMs = now;
-          this.log(`Dropping stale mouse movement (reliable bufferedAmount=${reliable.bufferedAmount})`);
-        }
-        this.pendingMouseDxFloat = 0;
-        this.pendingMouseDyFloat = 0;
-        this.pendingMouseTimestampUs = null;
-        this.mouseCoalescedBatchEntries = 0;
+      if (!this.inputReady || !hasPendingMouseMovement()) {
         return false;
       }
 
@@ -3344,8 +3293,6 @@ export class GfnWebRtcClient {
       const dxServer = Math.max(-32768, Math.min(32767, Math.round(dxQuantized.send * scaleX)));
       const dyServer = Math.max(-32768, Math.min(32767, Math.round(dyQuantized.send * scaleY)));
       if (dxServer === 0 && dyServer === 0) {
-        // Keep pending movement intact until a non-zero packet is sent.
-        // Otherwise quantized integer deltas can be dropped when server scaling rounds to zero.
         return false;
       }
 
@@ -3371,9 +3318,8 @@ export class GfnWebRtcClient {
       this.mousePacketsSentInWindow += 1;
       this.mouseFlushLastSendMs = tickNow;
       updateMousePacketRate();
-      updateAdaptiveMouseFlushInterval();
+      this.mouseAdaptiveFlushActive = false;
 
-      // Update simulated absolute pointer (stored in server pixels) if we have a baseline.
       if (simulatedAbsX !== null && simulatedAbsY !== null) {
         simulatedAbsX += dxServer;
         simulatedAbsY += dyServer;
@@ -3381,24 +3327,26 @@ export class GfnWebRtcClient {
       return true;
     };
 
-    const armMouseFlushTimer = (): void => {
+    this.flushPendingMouseMovement = () => {
+      try {
+        flushMouse();
+      } catch (err) {
+        this.log(`Mouse flush failed (non-fatal): ${String(err)}`);
+      }
+    };
+
+    /** Official GFN dl(): schedule cl() after the coalesce interval elapses. */
+    const scheduleMouseBatchFlush = (): void => {
       if (this.mouseFlushTimer !== null) {
         return;
       }
 
       const now = performance.now();
       const elapsed = now - this.mouseFlushLastSendMs;
-      if (elapsed >= this.mouseFlushIntervalMs) {
-        try {
-          flushMouse();
-        } catch (err) {
-          this.log(`Mouse flush failed (non-fatal): ${String(err)}`);
-        }
-        if (
-          Math.abs(this.pendingMouseDxFloat) >= 0.5
-          || Math.abs(this.pendingMouseDyFloat) >= 0.5
-        ) {
-          armMouseFlushTimer();
+      if (this.mouseFlushIntervalMs <= 0 || elapsed >= this.mouseFlushIntervalMs) {
+        flushMouse();
+        if (hasPendingMouseMovement()) {
+          scheduleMouseBatchFlush();
         }
         return;
       }
@@ -3410,15 +3358,27 @@ export class GfnWebRtcClient {
         } catch (err) {
           this.log(`Mouse flush tick failed (non-fatal): ${String(err)}`);
         } finally {
-          if (this.mouseFlushTimer === null) {
-            const hasPendingMovement =
-              Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
-            if (hasPendingMovement) {
-              armMouseFlushTimer();
-            }
+          if (hasPendingMouseMovement()) {
+            scheduleMouseBatchFlush();
           }
         }
       }, Math.max(0, this.mouseFlushIntervalMs - elapsed));
+    };
+
+    /** Official GFN Cp(): after wm(), flush when the mouse batch transitions empty -> non-empty. */
+    const afterPointerMovement = (): void => {
+      if (!hasPendingMouseMovement()) {
+        return;
+      }
+      const elapsed = performance.now() - this.mouseFlushLastSendMs;
+      if (this.mouseFlushIntervalMs <= 0 || elapsed >= this.mouseFlushIntervalMs) {
+        flushMouse();
+        if (hasPendingMouseMovement()) {
+          scheduleMouseBatchFlush();
+        }
+      } else {
+        scheduleMouseBatchFlush();
+      }
     };
 
     const tryAutoLock = (): void => {
@@ -3522,7 +3482,19 @@ export class GfnWebRtcClient {
         this.pendingMouseTimestampUs = timestampUs(eventTimestampMs);
       }
       this.mouseCoalescedBatchEntries += 1;
-      armMouseFlushTimer();
+    };
+
+    const processRelativePointerSamples = (
+      samples: readonly { movementX: number; movementY: number; timeStamp: number }[],
+    ): void => {
+      const hadBatch = hasPendingMouseMovement();
+      const { events } = subsampleCoalescedPointerEvents(samples, this.mouseCoalescedBatchEntries);
+      for (const sample of events) {
+        queueMouseMovement(sample.movementX, sample.movementY, sample.timeStamp);
+      }
+      if (!hadBatch && hasPendingMouseMovement()) {
+        afterPointerMovement();
+      }
     };
 
     const onPointerMove = (event: PointerEvent) => {
@@ -3535,24 +3507,28 @@ export class GfnWebRtcClient {
       }
 
       if (isPointerLockActive()) {
-        // Pointer lock active: use raw relative movement (movementX/Y).
-        const samples = hasCoalescedEvents ? event.getCoalescedEvents() : [];
-        if (samples.length > 1) {
-          let totalDx = 0;
-          let totalDy = 0;
-          for (const sample of samples) {
-            totalDx += sample.movementX;
-            totalDy += sample.movementY;
+        if (hasPointerRawUpdate && event.type === "pointerrawupdate") {
+          if (event.movementX === 0 && event.movementY === 0) {
+            const clientMoved =
+              event.clientX !== lastPointerClientX || event.clientY !== lastPointerClientY;
+            lastPointerClientX = event.clientX;
+            lastPointerClientY = event.clientY;
+            if (clientMoved && ++pointerRawStuckCount >= 8) {
+              this.log("pointerrawupdate stuck; switching to immediate mouse flush");
+              this.mouseFlushIntervalMs = 0;
+              pointerRawStuckCount = 0;
+            }
+          } else {
+            pointerRawStuckCount = 0;
           }
-          queueMouseMovement(totalDx, totalDy, samples[0]!.timeStamp);
+        }
+
+        const samples = hasCoalescedEvents ? event.getCoalescedEvents() : [];
+        if (samples.length > 0) {
+          processRelativePointerSamples(samples);
           return;
         }
-        if (samples.length === 1) {
-          const sample = samples[0]!;
-          queueMouseMovement(sample.movementX, sample.movementY, sample.timeStamp);
-          return;
-        }
-        queueMouseMovement(event.movementX, event.movementY, event.timeStamp);
+        processRelativePointerSamples([event]);
       } else if (mouseInStreamView) {
         // Pointer lock disabled: keep local cursor tracking up to date without
         // forwarding mouse movement into the stream.
@@ -3570,7 +3546,7 @@ export class GfnWebRtcClient {
       } catch {}
       if (this.isStreamInputBlocked()) return;
       if (isPointerLockActive()) {
-        queueMouseMovement(event.movementX, event.movementY, event.timeStamp);
+        processRelativePointerSamples([event]);
       } else if (mouseInStreamView) {
         // Pointer lock disabled: keep local cursor tracking up to date without
         // forwarding mouse movement into the stream.
@@ -3622,15 +3598,15 @@ export class GfnWebRtcClient {
       event.preventDefault();
       this.pressedKeys.add(mapped.vk);
 
+      const eventTimestampUs = timestampUs(event.timeStamp);
+
       const payload = this.inputEncoder.encodeKeyDown({
         keycode: mapped.vk,
         scancode: mapped.scancode,
         modifiers: modifierFlags(event),
-        // Use a fresh monotonic timestamp for keyboard events. In some
-        // fullscreen paths, event.timeStamp can be unstable.
-        timestampUs: timestampUs(),
+        timestampUs: eventTimestampUs,
       });
-      this.queueReliableSingleInput(payload);
+      this.sendReliableSingleInput(payload);
     };
 
     const onKeyUp = (event: KeyboardEvent) => {
@@ -3639,25 +3615,54 @@ export class GfnWebRtcClient {
         return;
       }
 
+      this.syncLockKeysState(event);
+
       const isEscapeEvent =
         event.key === "Escape"
         || event.key === "Esc"
         || event.code === "Escape"
         || event.keyCode === 27;
+      const isCapsLockToggle = event.code === "CapsLock";
       const mapped = mapKeyboardEvent(event, this.keyboardLayout) ?? (isEscapeEvent ? codeMap.Escape : null);
-      if (!mapped) {
+      if (!mapped && !isCapsLockToggle) {
+        return;
+      }
+
+      event.preventDefault();
+      const eventTimestampUs = timestampUs(event.timeStamp);
+      const modifiers = modifierFlags(event);
+
+      if (isCapsLockToggle) {
+        // Official GFN gg(): CapsLock keyup sends synthetic keydown then keyup (vk 160).
+        const capsVk = 0xa0;
+        this.sendReliableSingleInput(this.inputEncoder.encodeKeyDown({
+          keycode: capsVk,
+          scancode: 0,
+          modifiers,
+          timestampUs: eventTimestampUs,
+        }));
+        this.pressedKeys.delete(capsVk);
+        this.sendReliableSingleInput(this.inputEncoder.encodeKeyUp({
+          keycode: capsVk,
+          scancode: 0,
+          modifiers,
+          timestampUs: eventTimestampUs,
+        }));
+        return;
+      }
+
+      if (!mapped || !this.pressedKeys.has(mapped.vk)) {
         return;
       }
 
       event.preventDefault();
       this.pressedKeys.delete(mapped.vk);
-      const payload = this.inputEncoder.encodeKeyUp({
+      this.sendReliableSingleInput(this.inputEncoder.encodeKeyUp({
         keycode: mapped.vk,
         scancode: mapped.scancode,
-        modifiers: modifierFlags(event),
-        timestampUs: timestampUs(),
-      });
-      this.queueReliableSingleInput(payload);
+        modifiers,
+        timestampUs: eventTimestampUs,
+      }));
     };
 
     const onMouseDown = (event: MouseEvent) => {
@@ -3674,7 +3679,7 @@ export class GfnWebRtcClient {
         timestampUs: timestampUs(event.timeStamp),
       });
       // Official GFN client sends all mouse events on reliable channel (input_channel_v1)
-      this.queueReliableSingleInput(payload);
+      this.sendReliableSingleInput(payload);
     };
 
     const onMouseUp = (event: MouseEvent) => {
@@ -3691,7 +3696,7 @@ export class GfnWebRtcClient {
         timestampUs: timestampUs(event.timeStamp),
       });
       // Official GFN client sends all mouse events on reliable channel (input_channel_v1)
-      this.queueReliableSingleInput(payload);
+      this.sendReliableSingleInput(payload);
     };
 
     const onWheel = (event: WheelEvent) => {
@@ -3710,7 +3715,7 @@ export class GfnWebRtcClient {
         delta,
         timestampUs: timestampUs(event.timeStamp),
       });
-      this.queueReliableSingleInput(payload);
+      this.sendReliableSingleInput(payload);
     };
 
     const onClick = () => {
@@ -3840,7 +3845,7 @@ export class GfnWebRtcClient {
           modifiers: 0,
           timestampUs: timestampUs(),
         });
-        this.queueReliableSingleInput(escDown);
+        this.sendReliableSingleInput(escDown);
 
         const escUp = this.inputEncoder.encodeKeyUp({
           keycode: 0x1B,
@@ -3848,7 +3853,7 @@ export class GfnWebRtcClient {
           modifiers: 0,
           timestampUs: timestampUs(),
         });
-        this.queueReliableSingleInput(escUp);
+        this.sendReliableSingleInput(escUp);
 
         schedulePointerLockRetention("synthetic Escape");
       }, 50);
@@ -4026,7 +4031,7 @@ export class GfnWebRtcClient {
           modifiers: 0,
           timestampUs: timestampUs(),
         });
-        this.queueReliableSingleInput(escDown);
+        this.sendReliableSingleInput(escDown);
 
         const escUp = this.inputEncoder.encodeKeyUp({
           keycode: 0x1B,
@@ -4034,7 +4039,7 @@ export class GfnWebRtcClient {
           modifiers: 0,
           timestampUs: timestampUs(),
         });
-        this.queueReliableSingleInput(escUp);
+        this.sendReliableSingleInput(escUp);
       });
     } catch {}
 

--- a/opennow-stable/src/renderer/src/lib/streamDiagnostics.ts
+++ b/opennow-stable/src/renderer/src/lib/streamDiagnostics.ts
@@ -93,6 +93,15 @@ export function mergeNativeStreamStats(
     framesDecoded: stats.framesDecoded,
     framesDropped: sinkDropped,
     packetLossPercent: dropPercent,
+    inputQueueBufferedBytes: 0,
+    inputQueuePeakBufferedBytes: 0,
+    partiallyReliableInputQueueBufferedBytes: 0,
+    partiallyReliableInputQueuePeakBufferedBytes: 0,
+    inputQueueDropCount: 0,
+    inputQueueMaxSchedulingDelayMs: 0,
+    mouseAdaptiveFlushActive: false,
+    mousePacketsPerSecond: 0,
+    mouseResidualMagnitude: 0,
     lagReason: dropPercent > 1 ? "render" : "stable",
     lagReasonDetail: stats.lastTransitionSummary
       ? `Native bitrate ${stats.bitratePerformancePercent.toFixed(0)}% of target · ${stats.lastTransitionSummary}`

--- a/opennow-stable/src/renderer/src/shortcuts.test.ts
+++ b/opennow-stable/src/renderer/src/shortcuts.test.ts
@@ -1,0 +1,46 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeShortcut, shortcutFromKeyboardEvent } from "./shortcuts";
+
+function keyboardEvent(input: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    key: "",
+    code: "",
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    repeat: false,
+    ...input,
+  } as KeyboardEvent;
+}
+
+test("shortcut capture falls back to event.key for unknown Electron codes", () => {
+  assert.equal(
+    shortcutFromKeyboardEvent(keyboardEvent({
+      key: "q",
+      code: "ElectronWindow",
+      ctrlKey: true,
+      shiftKey: true,
+    })),
+    "Ctrl+Shift+Q",
+  );
+});
+
+test("normalization rejects unknown named key tokens", () => {
+  assert.equal(normalizeShortcut("Ctrl+Shift+ElectronWindow").valid, false);
+});
+
+test("shortcut capture still prefers physical key codes for supported keys", () => {
+  assert.equal(
+    shortcutFromKeyboardEvent(keyboardEvent({
+      key: "a",
+      code: "KeyQ",
+      ctrlKey: true,
+    })),
+    "Ctrl+Q",
+  );
+});

--- a/opennow-stable/src/renderer/src/shortcuts.ts
+++ b/opennow-stable/src/renderer/src/shortcuts.ts
@@ -8,6 +8,70 @@ export interface ParsedShortcut {
   canonical: string;
 }
 
+const NAMED_KEY_TOKENS = new Set([
+  "BACKSPACE",
+  "TAB",
+  "ENTER",
+  "NUMPADENTER",
+  "PAUSE",
+  "CAPSLOCK",
+  "ESCAPE",
+  "SPACE",
+  "PAGEUP",
+  "PAGEDOWN",
+  "END",
+  "HOME",
+  "ARROWLEFT",
+  "ARROWUP",
+  "ARROWRIGHT",
+  "ARROWDOWN",
+  "INSERT",
+  "DELETE",
+  "PRINTSCREEN",
+  "APPS",
+  "MENU",
+  "METALEFT",
+  "METARIGHT",
+  "NUMPADMULTIPLY",
+  "NUMPADADD",
+  "NUMPADSEPARATOR",
+  "NUMPADSUBTRACT",
+  "NUMPADDECIMAL",
+  "NUMPADDIVIDE",
+  "NUMLOCK",
+  "SCROLLLOCK",
+  "SEMICOLON",
+  "EQUAL",
+  "COMMA",
+  "MINUS",
+  "PERIOD",
+  "SLASH",
+  "BACKQUOTE",
+  "BRACKETLEFT",
+  "BACKSLASH",
+  "BRACKETRIGHT",
+  "QUOTE",
+]);
+
+function normalizeFunctionKeyToken(upper: string): string | null {
+  const match = upper.match(/^F(\d{1,2})$/);
+  if (!match) {
+    return null;
+  }
+
+  const index = Number.parseInt(match[1], 10);
+  return index >= 1 && index <= 24 ? upper : null;
+}
+
+function normalizeNumpadDigitToken(upper: string): string | null {
+  const match = upper.match(/^NUMPAD(\d)$/);
+  if (!match) {
+    return null;
+  }
+
+  return upper;
+}
+
 function normalizeKeyToken(token: string): string | null {
   const upper = token.toUpperCase();
   const alias: Record<string, string> = {
@@ -24,18 +88,25 @@ function normalizeKeyToken(token: string): string | null {
   if (alias[upper]) {
     return alias[upper];
   }
+
   if (upper.length === 1) {
     return upper;
   }
-  if (/^F\d{1,2}$/.test(upper)) {
+
+  const functionKey = normalizeFunctionKeyToken(upper);
+  if (functionKey) {
+    return functionKey;
+  }
+
+  const numpadDigit = normalizeNumpadDigitToken(upper);
+  if (numpadDigit) {
+    return numpadDigit;
+  }
+
+  if (NAMED_KEY_TOKENS.has(upper)) {
     return upper;
   }
-  if (upper.startsWith("ARROW")) {
-    return upper;
-  }
-  if (/^[A-Z0-9_]+$/.test(upper)) {
-    return upper;
-  }
+
   return null;
 }
 
@@ -61,25 +132,8 @@ function normalizeEventCode(code: string): string | null {
   if (upper.startsWith("DIGIT") && upper.length === 6) {
     return upper.slice(5);
   }
-  if (upper.startsWith("NUMPAD")) {
-    return upper;
-  }
-  if (/^F\d{1,2}$/.test(upper)) {
-    return upper;
-  }
-  if (upper.startsWith("ARROW")) {
-    return upper;
-  }
-  if (upper === "SPACE") {
-    return "SPACE";
-  }
-  if (upper === "ENTER" || upper === "NUMPADENTER") {
-    return "ENTER";
-  }
-  if (/^[A-Z0-9_]+$/.test(upper)) {
-    return upper;
-  }
-  return null;
+
+  return normalizeKeyToken(code);
 }
 
 function isKeyMatch(event: KeyboardEvent, shortcutKey: string): boolean {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1192,6 +1192,8 @@ export type MainToRendererSignalingEvent =
   | { type: "offer"; sdp: string }
   | { type: "remote-ice"; candidate: IceCandidatePayload }
   | { type: "native-shortcut"; action: NativeStreamerShortcutAction }
+  | { type: "native-clipboard-paste" }
+  | { type: "native-input-capture-changed"; captured: boolean }
   | { type: "native-stream-started"; message?: string }
   | { type: "native-stream-stopped"; reason?: string }
   | { type: "native-stream-stats"; stats: NativeStreamStats }

--- a/opennow-stable/src/shared/nativeStreamer.ts
+++ b/opennow-stable/src/shared/nativeStreamer.ts
@@ -125,6 +125,13 @@ export type NativeStreamerEvent =
       action: NativeStreamerShortcutAction;
     }
   | {
+      type: "clipboard-paste";
+    }
+  | {
+      type: "input-capture-changed";
+      captured: boolean;
+    }
+  | {
       type: "video-stall";
       stallMs: number;
       encodedKbps?: number;


### PR DESCRIPTION
## Summary
- Bridge Ctrl+V from the native Win32 renderer window to Electron so clipboard paste works during native streaming.
- Emit input-capture events so pointer-lock hints match WebRTC behavior when OS capture is active.
- Wire F3 stats overlay into the native DWrite render surface and gate anti-AFK until the input bridge is ready.
- Avoid unnecessary payload copies in `sendNativeInput`.

## Test plan
- [x] Build native streamer with `npm --prefix opennow-stable run native:build` and enable native streaming on Windows
- [ ] Verify Ctrl+V pastes clipboard text into the remote session
- [ ] Verify F3 toggles stats overlay on the native video window
- [ ] Verify pointer-lock hint appears when clicking into the native stream window
- [ ] Verify anti-AFK toggle sends pulses only after native input-ready
- [ ] Run `npm --prefix opennow-stable run typecheck`

Made with [Cursor](https://cursor.com)