### PR TITLE
fix(input): prevent fullscreen exit on rapid Escape presses

### DIFF
--- a/opennow-stable/src/main/escapeFullscreenGuard.test.ts
+++ b/opennow-stable/src/main/escapeFullscreenGuard.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 import {
   isEscapeKeyDownInput,
+  nextPointerLockEscapeCaptureUntilMs,
+  POINTER_LOCK_ESCAPE_FULLSCREEN_GRACE_MS,
   shouldCaptureEscapeFullscreenInput,
 } from "./escapeFullscreenGuard";
 
@@ -64,4 +66,13 @@ test("shouldCaptureEscapeFullscreenInput allows Escape outside protected stream 
     pointerLockEscapeCaptureUntilMs: 1500,
     nowMs: 1000,
   }), false);
+});
+
+test("nextPointerLockEscapeCaptureUntilMs only arms grace for unsuppressed pointer-lock loss", () => {
+  assert.equal(nextPointerLockEscapeCaptureUntilMs(true, false, 1000), 0);
+  assert.equal(nextPointerLockEscapeCaptureUntilMs(false, true, 1000), 0);
+  assert.equal(
+    nextPointerLockEscapeCaptureUntilMs(false, false, 1000),
+    1000 + POINTER_LOCK_ESCAPE_FULLSCREEN_GRACE_MS,
+  );
 });

--- a/opennow-stable/src/main/escapeFullscreenGuard.test.ts
+++ b/opennow-stable/src/main/escapeFullscreenGuard.test.ts
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isEscapeKeyDownInput,
+  shouldCaptureEscapeFullscreenInput,
+} from "./escapeFullscreenGuard";
+
+test("isEscapeKeyDownInput recognizes Electron Escape keydown variants", () => {
+  assert.equal(isEscapeKeyDownInput({ type: "keyDown", key: "Escape" }), true);
+  assert.equal(isEscapeKeyDownInput({ type: "keyDown", key: "Esc" }), true);
+  assert.equal(isEscapeKeyDownInput({ type: "keyDown", code: "Escape" }), true);
+  assert.equal(isEscapeKeyDownInput({ type: "keyDown", keyCode: 27 }), true);
+  assert.equal(isEscapeKeyDownInput({ type: "keyUp", key: "Escape", keyCode: 27 }), false);
+  assert.equal(isEscapeKeyDownInput({ type: "keyDown", key: "Enter" }), false);
+});
+
+test("shouldCaptureEscapeFullscreenInput captures Escape while pointer locked", () => {
+  assert.equal(shouldCaptureEscapeFullscreenInput(
+    { type: "keyDown", key: "Escape" },
+    {
+      allowEscapeToExitFullscreen: false,
+      pointerLockActive: true,
+      windowFullscreen: false,
+      pointerLockEscapeCaptureUntilMs: 0,
+      nowMs: 100,
+    },
+  ), true);
+});
+
+test("shouldCaptureEscapeFullscreenInput captures rapid Escape presses during fullscreen pointer-lock loss", () => {
+  assert.equal(shouldCaptureEscapeFullscreenInput(
+    { type: "keyDown", key: "Escape" },
+    {
+      allowEscapeToExitFullscreen: false,
+      pointerLockActive: false,
+      windowFullscreen: true,
+      pointerLockEscapeCaptureUntilMs: 1500,
+      nowMs: 1000,
+    },
+  ), true);
+});
+
+test("shouldCaptureEscapeFullscreenInput allows Escape outside protected stream states", () => {
+  const input = { type: "keyDown", key: "Escape" };
+  assert.equal(shouldCaptureEscapeFullscreenInput(input, {
+    allowEscapeToExitFullscreen: true,
+    pointerLockActive: true,
+    windowFullscreen: true,
+    pointerLockEscapeCaptureUntilMs: 1500,
+    nowMs: 1000,
+  }), false);
+  assert.equal(shouldCaptureEscapeFullscreenInput(input, {
+    allowEscapeToExitFullscreen: false,
+    pointerLockActive: false,
+    windowFullscreen: true,
+    pointerLockEscapeCaptureUntilMs: 999,
+    nowMs: 1000,
+  }), false);
+  assert.equal(shouldCaptureEscapeFullscreenInput(input, {
+    allowEscapeToExitFullscreen: false,
+    pointerLockActive: false,
+    windowFullscreen: false,
+    pointerLockEscapeCaptureUntilMs: 1500,
+    nowMs: 1000,
+  }), false);
+});

--- a/opennow-stable/src/main/escapeFullscreenGuard.ts
+++ b/opennow-stable/src/main/escapeFullscreenGuard.ts
@@ -1,0 +1,40 @@
+export const POINTER_LOCK_ESCAPE_FULLSCREEN_GRACE_MS = 1000;
+
+export interface EscapeKeyInput {
+  type?: string;
+  key?: string;
+  code?: string;
+  keyCode?: number;
+}
+
+export interface EscapeFullscreenGuardState {
+  allowEscapeToExitFullscreen: boolean;
+  pointerLockActive: boolean;
+  windowFullscreen: boolean;
+  pointerLockEscapeCaptureUntilMs: number;
+  nowMs: number;
+}
+
+export function isEscapeKeyDownInput(input: EscapeKeyInput): boolean {
+  return input.type === "keyDown" && (
+    input.key === "Escape" ||
+    input.key === "Esc" ||
+    input.code === "Escape" ||
+    input.keyCode === 27
+  );
+}
+
+export function shouldCaptureEscapeFullscreenInput(
+  input: EscapeKeyInput,
+  state: EscapeFullscreenGuardState,
+): boolean {
+  if (!isEscapeKeyDownInput(input) || state.allowEscapeToExitFullscreen) {
+    return false;
+  }
+
+  if (state.pointerLockActive) {
+    return true;
+  }
+
+  return state.windowFullscreen && state.nowMs <= state.pointerLockEscapeCaptureUntilMs;
+}

--- a/opennow-stable/src/main/escapeFullscreenGuard.ts
+++ b/opennow-stable/src/main/escapeFullscreenGuard.ts
@@ -38,3 +38,15 @@ export function shouldCaptureEscapeFullscreenInput(
 
   return state.windowFullscreen && state.nowMs <= state.pointerLockEscapeCaptureUntilMs;
 }
+
+export function nextPointerLockEscapeCaptureUntilMs(
+  active: boolean,
+  suppressEscapeFullscreenGrace: boolean,
+  nowMs: number,
+): number {
+  if (active || suppressEscapeFullscreenGrace) {
+    return 0;
+  }
+
+  return nowMs + POINTER_LOCK_ESCAPE_FULLSCREEN_GRACE_MS;
+}

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -82,6 +82,10 @@ import {
   isAccelerationPreference,
   type BootstrapVideoPreferences,
 } from "./videoAcceleration";
+import {
+  POINTER_LOCK_ESCAPE_FULLSCREEN_GRACE_MS,
+  shouldCaptureEscapeFullscreenInput,
+} from "./escapeFullscreenGuard";
 import { parseDirectLaunchArgs, type DirectLaunchArgs } from "@shared/directLaunch";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -188,6 +192,7 @@ let pendingDirectLaunchRequest: DirectLaunchRequest | null = createDirectLaunchR
 
 // Runtime pointer-lock state (updated by renderer)
 let isPointerLockActiveRuntime = false;
+let pointerLockEscapeCaptureUntilMs = 0;
 
 function createDirectLaunchRequest(args: DirectLaunchArgs): DirectLaunchRequest {
   return {
@@ -466,20 +471,26 @@ async function createMainWindow(): Promise<void> {
   // Escape at the native level (before Chromium handles it).
   ipcMain.on(IPC_CHANNELS.POINTER_LOCK_CHANGE, (_ev, active: boolean) => {
     isPointerLockActiveRuntime = Boolean(active);
+    if (isPointerLockActiveRuntime) {
+      pointerLockEscapeCaptureUntilMs = 0;
+    } else {
+      pointerLockEscapeCaptureUntilMs = Date.now() + POINTER_LOCK_ESCAPE_FULLSCREEN_GRACE_MS;
+    }
   });
 
   // Intercept Escape early to avoid Chromium exiting fullscreen before the
-  // renderer can forward the key to the remote session. This is a best-effort
-  // interception and is gated by the user's `allowEscapeToExitFullscreen` setting.
+  // renderer can forward the key to the remote session. Keep a short fullscreen
+  // grace window after pointer lock drops so rapid repeated Escape presses cannot
+  // win the race before the renderer re-locks the pointer.
   mainWindow.webContents.on("before-input-event", (event, input) => {
     try {
-      if (
-        input.type === "keyDown" &&
-        input.key === "Escape" &&
-        isPointerLockActiveRuntime &&
-        settingsManager &&
-        !settingsManager.get("allowEscapeToExitFullscreen")
-      ) {
+      if (shouldCaptureEscapeFullscreenInput(input, {
+        allowEscapeToExitFullscreen: Boolean(settingsManager?.get("allowEscapeToExitFullscreen")),
+        pointerLockActive: isPointerLockActiveRuntime,
+        windowFullscreen: Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isFullScreen()),
+        pointerLockEscapeCaptureUntilMs,
+        nowMs: Date.now(),
+      })) {
         event.preventDefault();
         if (mainWindow && mainWindow.webContents) {
           mainWindow.webContents.send(IPC_CHANNELS.EXTERNAL_ESCAPE);
@@ -502,6 +513,8 @@ async function createMainWindow(): Promise<void> {
   mainWindow.on("closed", () => {
     mainWindow = null;
     rendererControlledFullscreen = false;
+    isPointerLockActiveRuntime = false;
+    pointerLockEscapeCaptureUntilMs = 0;
   });
 }
 

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -83,7 +83,7 @@ import {
   type BootstrapVideoPreferences,
 } from "./videoAcceleration";
 import {
-  POINTER_LOCK_ESCAPE_FULLSCREEN_GRACE_MS,
+  nextPointerLockEscapeCaptureUntilMs,
   shouldCaptureEscapeFullscreenInput,
 } from "./escapeFullscreenGuard";
 import { parseDirectLaunchArgs, type DirectLaunchArgs } from "@shared/directLaunch";
@@ -469,14 +469,17 @@ async function createMainWindow(): Promise<void> {
 
   // Track pointer-lock state from renderer; used to decide whether to swallow
   // Escape at the native level (before Chromium handles it).
-  ipcMain.on(IPC_CHANNELS.POINTER_LOCK_CHANGE, (_ev, active: boolean) => {
-    isPointerLockActiveRuntime = Boolean(active);
-    if (isPointerLockActiveRuntime) {
-      pointerLockEscapeCaptureUntilMs = 0;
-    } else {
-      pointerLockEscapeCaptureUntilMs = Date.now() + POINTER_LOCK_ESCAPE_FULLSCREEN_GRACE_MS;
-    }
-  });
+  ipcMain.on(
+    IPC_CHANNELS.POINTER_LOCK_CHANGE,
+    (_ev, active: boolean, suppressEscapeFullscreenGrace?: boolean) => {
+      isPointerLockActiveRuntime = Boolean(active);
+      pointerLockEscapeCaptureUntilMs = nextPointerLockEscapeCaptureUntilMs(
+        isPointerLockActiveRuntime,
+        Boolean(suppressEscapeFullscreenGrace),
+        Date.now(),
+      );
+    },
+  );
 
   // Intercept Escape early to avoid Chromium exiting fullscreen before the
   // renderer can forward the key to the remote session. Keep a short fullscreen

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -194,7 +194,9 @@ const api: OpenNowApi = {
   selectNativeStreamerExecutable: () => ipcRenderer.invoke(IPC_CHANNELS.SETTINGS_SELECT_NATIVE_STREAMER_EXECUTABLE),
   getNativeStreamerStatus: () => ipcRenderer.invoke(IPC_CHANNELS.NATIVE_STREAMER_STATUS),
   getNativeCloudGsyncCapabilities: () => ipcRenderer.invoke(IPC_CHANNELS.NATIVE_CLOUD_GSYNC_CAPABILITIES),
-  notifyPointerLockChange: (active: boolean) => ipcRenderer.send(IPC_CHANNELS.POINTER_LOCK_CHANGE, active),
+  notifyPointerLockChange: (active: boolean, suppressEscapeFullscreenGrace?: boolean) => {
+    ipcRenderer.send(IPC_CHANNELS.POINTER_LOCK_CHANGE, active, suppressEscapeFullscreenGrace);
+  },
   onExternalEscape: (listener: () => void) => {
     const wrapped = () => listener();
     ipcRenderer.on(IPC_CHANNELS.EXTERNAL_ESCAPE, wrapped);

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -3622,13 +3622,15 @@ export class GfnWebRtcClient {
         return;
       }
 
+      const suppressEscapeFullscreenGrace = this.suppressNextSyntheticEscape;
+
       // Pointer lock was lost — reset mirror state so tracking resumes from the
       // current cursor position rather than from a stale last-known position.
       lastAbsX = null;
       lastAbsY = null;
 
       try {
-        (window as any).openNow?.notifyPointerLockChange?.(false);
+        (window as any).openNow?.notifyPointerLockChange?.(false, suppressEscapeFullscreenGrace);
       } catch {}
 
       // Pointer lock was lost

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1335,8 +1335,8 @@ export interface OpenNowApi {
   setFullscreen(v: boolean): Promise<void>;
   toggleFullscreen(): Promise<void>;
   togglePointerLock(): Promise<void>;
-  /** Notify main process that pointer lock state changed (active = true/false) */
-  notifyPointerLockChange(active: boolean): void;
+  /** Notify main process that pointer lock state changed (active = true/false). */
+  notifyPointerLockChange(active: boolean, suppressEscapeFullscreenGrace?: boolean): void;
   /** Read plain text from the OS clipboard through Electron main process */
   readClipboardText(): Promise<string>;
   getSettings(): Promise<Settings>;


### PR DESCRIPTION
This PR fixes an issue where pressing Escape while streaming (Chromium/WebRTC mode) would unexpectedly exit fullscreen even when the "Allow Escape to exit fullscreen" setting was disabled. The bug was caused by a race condition where rapid Escape presses could occur after the browser released pointer lock but before the renderer re-acquired it, allowing Chromium's default fullscreen accelerator to trigger.

- Added a 1-second grace window in the main process (`escapeFullscreenGuard.ts`) to continue intercepting Escape key events immediately after pointer lock loss.
- Updated `POINTER_LOCK_CHANGE` handler to manage the grace window state and reset it on pointer lock acquisition.
- Refactored `before-input-event` logic in `index.ts` to use the new guard, checking pointer lock state, grace windows, and user settings.
- Added unit tests in `escapeFullscreenGuard.test.ts` verifying interception during pointer lock, during the grace window, and when the setting is enabled.
- Ensured guard state resets correctly when the main window closes.

This ensures Escape is consistently forwarded to the remote session during the transition period, honoring the user's preference to keep fullscreen active.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/90b3eab6-a657-4f59-a5f1-33fc23ea1771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-237" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/90b3eab6-a657-4f59-a5f1-33fc23ea1771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-237&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-237"><img alt="OPE-237" src="https://capy.ai/api/badge/thread.svg?label=OPE-237"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input/fullscreen behavior with unit tests; no auth, data, or network changes.
> 
> **Overview**
> Fixes a race where **Escape** could exit fullscreen during streaming when `allowEscapeToExitFullscreen` is off: after pointer lock drops, Chromium could handle Escape before the renderer re-locks.
> 
> A new **`escapeFullscreenGuard`** module centralizes when the main process should swallow Escape: while pointer lock is active, or for **1s** after lock loss while still fullscreen. Escape detection now covers Electron key variants (`Esc`, `code`, `keyCode` 27), not only `key === "Escape"`.
> 
> **`POINTER_LOCK_CHANGE`** arms or clears the grace deadline via `nextPointerLockEscapeCaptureUntilMs`; an optional **`suppressEscapeFullscreenGrace`** flag skips the grace window when lock was released intentionally (e.g. F8), wired from **`webrtcClient`** through preload/API types. Guard state resets when the main window closes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5ae47f8ef48e914369247beab0647389759550. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->