### PR TITLE
Add GStreamer native cursor overlay

### DIFF
--- a/native/opennow-streamer/Cargo.lock
+++ b/native/opennow-streamer/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +42,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "cfg-expr"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +70,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +89,25 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "futures-channel"
@@ -343,6 +389,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +448,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muldiv"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +510,7 @@ dependencies = [
  "gstreamer-sdp",
  "gstreamer-video",
  "gstreamer-webrtc",
+ "image",
  "regex",
  "serde",
  "serde_json",
@@ -464,6 +544,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +564,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quote"
@@ -561,6 +660,12 @@ checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"

--- a/native/opennow-streamer/Cargo.toml
+++ b/native/opennow-streamer/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 [features]
 default = []
 gstreamer = [
+    "dep:image",
     "dep:gstreamer",
     "dep:gstreamer-sdp",
     "dep:gstreamer-video",
@@ -20,6 +21,7 @@ gstreamer = { version = "0.25.1", optional = true }
 gstreamer-sdp = { version = "0.25.0", optional = true }
 gstreamer-video = { version = "0.25.0", optional = true }
 gstreamer-webrtc = { version = "0.25.0", optional = true }
+image = { version = "0.25", default-features = false, features = ["ico", "png"], optional = true }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/native/opennow-streamer/src/backend.rs
+++ b/native/opennow-streamer/src/backend.rs
@@ -498,7 +498,9 @@ fn preferred_hevc_profile_id(color_quality: ColorQuality) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{ColorQuality, NativeStreamerShortcutBindings, SessionInfo, StreamSettings};
+    use crate::protocol::{
+        ColorQuality, NativeStreamerShortcutBindings, SessionInfo, StreamSettings,
+    };
 
     fn context(resolution: &str) -> NativeStreamerSessionContext {
         NativeStreamerSessionContext {
@@ -519,6 +521,9 @@ mod tests {
                 max_bitrate_mbps: 75,
                 codec: VideoCodec::H265,
                 color_quality: ColorQuality::TenBit420,
+                native_cursor_overlay: true,
+                mouse_sensitivity: 1.0,
+                mouse_acceleration: 1,
                 enable_cloud_gsync: false,
                 native_transition_diagnostics: None,
             },

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -6,10 +6,10 @@ use crate::gstreamer_config::{
     resolve_d3d_fullscreen_sink, resolve_present_max_fps, NATIVE_D3D_FULLSCREEN_ENV,
     NATIVE_PRESENT_MAX_FPS_ENV, PRESENT_LIMITER_AUTO_SENTINEL,
 };
-use crate::gstreamer_platform::{clear_native_shortcut_bindings, set_native_shortcut_bindings};
 use crate::gstreamer_pipeline::{
     current_platform_label, init_gstreamer, native_video_backend_capabilities, GstreamerPipeline,
 };
+use crate::gstreamer_platform::{clear_native_shortcut_bindings, set_native_shortcut_bindings};
 use crate::protocol::{
     missing_field, CommandEnvelope, Event, IceCandidatePayload, NativeRenderSurface,
     NativeStreamerCapabilities, NativeStreamerSessionContext, NativeVideoBackendCapability,
@@ -221,6 +221,8 @@ impl NativeStreamerBackend for GstreamerBackend {
             (prepared.gstreamer_ice_pwd_replacements > 0)
                 .then_some(&prepared.nvst_params.credentials),
             prepared.nvst_params.partial_reliable_threshold_ms,
+            context.settings.native_cursor_overlay,
+            &context,
         ) {
             Ok(answer_sdp) => munge_answer_sdp(&answer_sdp, prepared.nvst_params.max_bitrate_kbps),
             Err(message) => {
@@ -424,8 +426,8 @@ mod tests {
         caps_framerate_summary, sink_stats_summary, VideoStallAction, VideoStallTracker,
     };
     use crate::gstreamer_pipeline::{
-        configure_stats_overlay_element, effective_present_max_fps, format_video_chain_selection,
-        rtp_video_chain_definition, RtpVideoApi, RtpVideoChainRole,
+        configure_stats_overlay_element, default_rtp_video_api_priority, effective_present_max_fps,
+        format_video_chain_selection, rtp_video_chain_definition, RtpVideoApi, RtpVideoChainRole,
     };
     use crate::gstreamer_transitions::resolve_queue_mode;
     use crate::protocol::{NativeQueueMode, StreamSettings, VideoCodec};
@@ -812,6 +814,9 @@ mod tests {
             max_bitrate_mbps: 75,
             codec: VideoCodec::H265,
             color_quality: crate::protocol::ColorQuality::TenBit420,
+            native_cursor_overlay: true,
+            mouse_sensitivity: 1.0,
+            mouse_acceleration: 1,
             enable_cloud_gsync: false,
             native_transition_diagnostics: None,
         });
@@ -823,6 +828,9 @@ mod tests {
             max_bitrate_mbps: 75,
             codec: VideoCodec::H265,
             color_quality: crate::protocol::ColorQuality::TenBit420,
+            native_cursor_overlay: true,
+            mouse_sensitivity: 1.0,
+            mouse_acceleration: 1,
             enable_cloud_gsync: true,
             native_transition_diagnostics: None,
         });

--- a/native/opennow-streamer/src/gstreamer_cursor.rs
+++ b/native/opennow-streamer/src/gstreamer_cursor.rs
@@ -1,0 +1,377 @@
+use crate::gstreamer_backend::send_log;
+use crate::gstreamer_input::{channel_label, create_data_channel};
+use crate::gstreamer_platform::{apply_native_cursor_update, reset_native_cursor};
+use crate::protocol::Event;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use gstreamer as gst;
+use gstreamer_webrtc as gst_webrtc;
+use std::sync::mpsc::Sender;
+
+const CURSOR_CHANNEL_LABEL: &str = "cursor_channel";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NativeCursorPosition {
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeCursorImage {
+    pub(crate) mime_type: String,
+    pub(crate) bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NativeCursorUpdate {
+    Hidden,
+    Predefined {
+        cursor_id: u8,
+        position: Option<NativeCursorPosition>,
+    },
+    Custom {
+        cursor_id: u8,
+        hotspot_x: u8,
+        hotspot_y: u8,
+        image: Option<NativeCursorImage>,
+        position: Option<NativeCursorPosition>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GfnCursorChannelMessage {
+    Predefined {
+        cursor_id: u8,
+        position: Option<NativeCursorPosition>,
+    },
+    Custom {
+        cursor_id: u8,
+        hotspot_x: u8,
+        hotspot_y: u8,
+        mime_type: String,
+        image_base64: String,
+        position: Option<NativeCursorPosition>,
+    },
+}
+
+fn read_u16_le(bytes: &[u8], offset: usize) -> Option<u16> {
+    let low = *bytes.get(offset)?;
+    let high = *bytes.get(offset + 1)?;
+    Some(u16::from_le_bytes([low, high]))
+}
+
+fn parse_optional_cursor_position(
+    bytes: &[u8],
+    offset: usize,
+) -> (Option<NativeCursorPosition>, usize) {
+    if offset + 4 > bytes.len() {
+        return (None, offset);
+    }
+
+    let Some(x) = read_u16_le(bytes, offset) else {
+        return (None, offset);
+    };
+    let Some(y) = read_u16_le(bytes, offset + 2) else {
+        return (None, offset);
+    };
+    (Some(NativeCursorPosition { x, y }), offset + 4)
+}
+
+fn parse_gfn_cursor_channel_message(bytes: &[u8]) -> Option<GfnCursorChannelMessage> {
+    let message_type = *bytes.first()?;
+    if message_type != 0 && message_type != 1 {
+        return None;
+    }
+
+    let cursor_id = *bytes.get(1)?;
+    if bytes.len() < 5 {
+        return (message_type == 0).then_some(GfnCursorChannelMessage::Predefined {
+            cursor_id,
+            position: None,
+        });
+    }
+
+    let hotspot_x = bytes[2];
+    let hotspot_y = bytes[3];
+    let mime_type_len = bytes[4] as usize;
+    let mut offset = 5usize;
+    if offset + mime_type_len > bytes.len() {
+        return None;
+    }
+    let mime_type = if mime_type_len > 0 {
+        std::str::from_utf8(&bytes[offset..offset + mime_type_len])
+            .ok()?
+            .to_owned()
+    } else {
+        String::new()
+    };
+    offset += mime_type_len;
+
+    if offset + 2 > bytes.len() {
+        return (message_type == 0).then_some(GfnCursorChannelMessage::Predefined {
+            cursor_id,
+            position: None,
+        });
+    }
+
+    let image_len = read_u16_le(bytes, offset)? as usize;
+    offset += 2;
+    if offset + image_len > bytes.len() {
+        return None;
+    }
+    let image_base64 = if image_len > 0 {
+        std::str::from_utf8(&bytes[offset..offset + image_len])
+            .ok()?
+            .to_owned()
+    } else {
+        String::new()
+    };
+    offset += image_len;
+
+    let (position, _next_offset) = parse_optional_cursor_position(bytes, offset);
+    if message_type == 0 {
+        return Some(GfnCursorChannelMessage::Predefined {
+            cursor_id,
+            position,
+        });
+    }
+
+    Some(GfnCursorChannelMessage::Custom {
+        cursor_id,
+        hotspot_x,
+        hotspot_y,
+        mime_type,
+        image_base64,
+        position,
+    })
+}
+
+fn cursor_update_from_message(
+    message: GfnCursorChannelMessage,
+) -> Result<NativeCursorUpdate, String> {
+    match message {
+        GfnCursorChannelMessage::Predefined { cursor_id: 0, .. } => Ok(NativeCursorUpdate::Hidden),
+        GfnCursorChannelMessage::Predefined {
+            cursor_id,
+            position,
+        } => Ok(NativeCursorUpdate::Predefined {
+            cursor_id,
+            position,
+        }),
+        GfnCursorChannelMessage::Custom {
+            cursor_id,
+            hotspot_x,
+            hotspot_y,
+            mime_type,
+            image_base64,
+            position,
+        } => {
+            let image = if image_base64.is_empty() {
+                None
+            } else {
+                Some(NativeCursorImage {
+                    mime_type: if mime_type.is_empty() {
+                        "image/png".to_owned()
+                    } else {
+                        mime_type
+                    },
+                    bytes: BASE64_STANDARD
+                        .decode(image_base64.as_bytes())
+                        .map_err(|error| format!("Invalid cursor image base64: {error}"))?,
+                })
+            };
+            Ok(NativeCursorUpdate::Custom {
+                cursor_id,
+                hotspot_x,
+                hotspot_y,
+                image,
+                position,
+            })
+        }
+    }
+}
+
+pub(crate) fn create_cursor_data_channel(
+    webrtc: &gst::Element,
+    event_sender: Option<Sender<Event>>,
+) -> Result<gst_webrtc::WebRTCDataChannel, String> {
+    let channel = create_data_channel(webrtc, CURSOR_CHANNEL_LABEL, None)?;
+    connect_cursor_channel_callbacks(&channel, event_sender.clone());
+    send_log(
+        &event_sender,
+        "info",
+        "Created WebRTC cursor data channel (cursor_channel).".to_owned(),
+    );
+    Ok(channel)
+}
+
+fn connect_cursor_channel_callbacks(
+    channel: &gst_webrtc::WebRTCDataChannel,
+    event_sender: Option<Sender<Event>>,
+) {
+    channel.connect_on_open({
+        let event_sender = event_sender.clone();
+        move |channel| {
+            send_log(
+                &event_sender,
+                "info",
+                format!(
+                    "Cursor data channel open: label={}, id={}, ordered={}.",
+                    channel_label(channel),
+                    channel.id(),
+                    channel.is_ordered()
+                ),
+            );
+        }
+    });
+
+    channel.connect_on_close({
+        let event_sender = event_sender.clone();
+        move |_| {
+            reset_native_cursor();
+            send_log(
+                &event_sender,
+                "info",
+                "Cursor data channel closed.".to_owned(),
+            );
+        }
+    });
+
+    channel.connect_on_error({
+        let event_sender = event_sender.clone();
+        move |_, error| {
+            send_log(
+                &event_sender,
+                "warn",
+                format!("Cursor data channel error: {error}."),
+            );
+        }
+    });
+
+    channel.connect_on_message_data({
+        let event_sender = event_sender.clone();
+        move |_, data| {
+            let Some(data) = data else {
+                return;
+            };
+            handle_cursor_channel_message(data.as_ref(), event_sender.clone());
+        }
+    });
+
+    channel.connect_on_message_string(move |_, message| {
+        let Some(message) = message else {
+            return;
+        };
+        handle_cursor_channel_message(message.as_bytes(), event_sender.clone());
+    });
+}
+
+fn handle_cursor_channel_message(bytes: &[u8], event_sender: Option<Sender<Event>>) {
+    let Some(message) = parse_gfn_cursor_channel_message(bytes) else {
+        send_log(
+            &event_sender,
+            "debug",
+            format!("Cursor channel message ignored ({} bytes).", bytes.len()),
+        );
+        return;
+    };
+
+    match cursor_update_from_message(message).and_then(apply_native_cursor_update) {
+        Ok(true) => {}
+        Ok(false) => send_log(
+            &event_sender,
+            "debug",
+            "Cursor channel update did not change the native cursor.".to_owned(),
+        ),
+        Err(error) => send_log(
+            &event_sender,
+            "warn",
+            format!("Failed to apply cursor channel update: {error}."),
+        ),
+    }
+}
+
+pub(crate) fn disable_native_cursor_channel(event_sender: &Option<Sender<Event>>) {
+    reset_native_cursor();
+    send_log(
+        event_sender,
+        "info",
+        "Cursor channel disabled; using server-side cursor rendering.".to_owned(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn u16_le(value: u16) -> [u8; 2] {
+        value.to_le_bytes()
+    }
+
+    #[test]
+    fn parses_predefined_cursor_update_with_position() {
+        let bytes = [
+            0,
+            12,
+            0,
+            0,
+            0,
+            0,
+            0,
+            u16_le(32768)[0],
+            u16_le(32768)[1],
+            u16_le(65535)[0],
+            u16_le(65535)[1],
+        ];
+
+        assert_eq!(
+            parse_gfn_cursor_channel_message(&bytes),
+            Some(GfnCursorChannelMessage::Predefined {
+                cursor_id: 12,
+                position: Some(NativeCursorPosition { x: 32768, y: 65535 }),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_custom_cursor_metadata() {
+        let mime = b"image/png";
+        let image = b"AAAA";
+        let mut bytes = vec![1, 7, 3, 4, mime.len() as u8];
+        bytes.extend_from_slice(mime);
+        bytes.extend_from_slice(&(image.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(image);
+        bytes.extend_from_slice(&10u16.to_le_bytes());
+        bytes.extend_from_slice(&20u16.to_le_bytes());
+        bytes.extend_from_slice(&150u16.to_le_bytes());
+
+        assert_eq!(
+            parse_gfn_cursor_channel_message(&bytes),
+            Some(GfnCursorChannelMessage::Custom {
+                cursor_id: 7,
+                hotspot_x: 3,
+                hotspot_y: 4,
+                mime_type: "image/png".to_owned(),
+                image_base64: "AAAA".to_owned(),
+                position: Some(NativeCursorPosition { x: 10, y: 20 }),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_truncated_custom_image() {
+        let bytes = [1, 1, 0, 0, 0, 4, 0, b'A', b'A'];
+        assert_eq!(parse_gfn_cursor_channel_message(&bytes), None);
+    }
+
+    #[test]
+    fn converts_hidden_predefined_cursor_to_hidden_update() {
+        assert_eq!(
+            cursor_update_from_message(GfnCursorChannelMessage::Predefined {
+                cursor_id: 0,
+                position: Some(NativeCursorPosition { x: 1, y: 2 }),
+            })
+            .unwrap(),
+            NativeCursorUpdate::Hidden
+        );
+    }
+}

--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -175,8 +175,6 @@ impl NativeMouseSettings {
 #[cfg(target_os = "windows")]
 #[derive(Debug, Clone, Copy)]
 struct AdjustedMouseMove {
-    cursor_dx: f64,
-    cursor_dy: f64,
     send_dx: i16,
     send_dy: i16,
 }
@@ -204,21 +202,19 @@ impl NativeMouseAdjuster {
             return None;
         }
 
-        let mut cursor_dx = f64::from(dx) * self.settings.sensitivity;
-        let mut cursor_dy = f64::from(dy) * self.settings.sensitivity;
+        let mut adjusted_dx = f64::from(dx) * self.settings.sensitivity;
+        let mut adjusted_dy = f64::from(dy) * self.settings.sensitivity;
         if self.settings.acceleration_percent > 1 {
-            let speed = cursor_dx.hypot(cursor_dy);
+            let speed = adjusted_dx.hypot(adjusted_dy);
             let strength = f64::from(self.settings.acceleration_percent.saturating_sub(1)) / 149.0;
             let accel_factor = 1.0 + (0.6 * strength).min((speed / 50.0) * strength);
-            cursor_dx *= accel_factor;
-            cursor_dy *= accel_factor;
+            adjusted_dx *= accel_factor;
+            adjusted_dy *= accel_factor;
         }
 
         Some(AdjustedMouseMove {
-            cursor_dx,
-            cursor_dy,
-            send_dx: quantize_mouse_delta(cursor_dx, &mut self.residual_x),
-            send_dy: quantize_mouse_delta(cursor_dy, &mut self.residual_y),
+            send_dx: quantize_mouse_delta(adjusted_dx, &mut self.residual_x),
+            send_dy: quantize_mouse_delta(adjusted_dy, &mut self.residual_y),
         })
     }
 }
@@ -569,12 +565,6 @@ fn send_native_window_input_events(
                 let Some(adjusted) = mouse_adjuster.adjust(dx, dy) else {
                     continue;
                 };
-                unsafe {
-                    win32_renderer_window::move_native_cursor_by_delta(
-                        adjusted.cursor_dx,
-                        adjusted.cursor_dy,
-                    );
-                }
                 if adjusted.send_dx == 0 && adjusted.send_dy == 0 {
                     continue;
                 }
@@ -1271,7 +1261,6 @@ mod tests {
         let third = adjuster.adjust(1, 0).expect("third move");
         let fourth = adjuster.adjust(1, 0).expect("fourth move");
 
-        assert_eq!(first.cursor_dx, 0.25);
         assert_eq!(
             [first.send_dx, second.send_dx, third.send_dx, fourth.send_dx],
             [0, 1, 0, 0]
@@ -1286,7 +1275,6 @@ mod tests {
         });
 
         let adjusted = adjuster.adjust(50, 0).expect("accelerated move");
-        assert_eq!(adjusted.cursor_dx, 80.0);
         assert_eq!(adjusted.send_dx, 80);
     }
 }

--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -12,6 +12,8 @@ use crate::input::{
 use crate::protocol::Event;
 #[cfg(target_os = "windows")]
 use crate::protocol::NativeStreamerShortcutAction;
+#[cfg(target_os = "windows")]
+use crate::protocol::StreamSettings;
 use gst::glib;
 use gst::prelude::*;
 use gstreamer as gst;
@@ -41,6 +43,14 @@ const NATIVE_INPUT_DRAIN_MAX_EVENTS: usize = 512;
 const NATIVE_GAMEPAD_POLL_INTERVAL: Duration = Duration::from_millis(4);
 #[cfg(target_os = "windows")]
 const NATIVE_GAMEPAD_KEEPALIVE_INTERVAL: Duration = Duration::from_millis(100);
+#[cfg(target_os = "windows")]
+const MIN_MOUSE_SENSITIVITY: f64 = 0.01;
+#[cfg(target_os = "windows")]
+const MAX_MOUSE_SENSITIVITY: f64 = 4.0;
+#[cfg(target_os = "windows")]
+const MIN_MOUSE_ACCELERATION: u32 = 1;
+#[cfg(target_os = "windows")]
+const MAX_MOUSE_ACCELERATION: u32 = 150;
 
 #[cfg(target_os = "windows")]
 static NATIVE_INPUT_STARTED_AT: OnceLock<Instant> = OnceLock::new();
@@ -133,6 +143,97 @@ pub(crate) enum NativeWindowInputEvent {
     LockKeysSync {
         state: u8,
     },
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct NativeMouseSettings {
+    sensitivity: f64,
+    acceleration_percent: u32,
+}
+
+#[cfg(target_os = "windows")]
+impl NativeMouseSettings {
+    pub(crate) fn from_stream_settings(settings: &StreamSettings) -> Self {
+        let sensitivity = if settings.mouse_sensitivity.is_finite() {
+            settings
+                .mouse_sensitivity
+                .clamp(MIN_MOUSE_SENSITIVITY, MAX_MOUSE_SENSITIVITY)
+        } else {
+            1.0
+        };
+        let acceleration_percent = settings
+            .mouse_acceleration
+            .clamp(MIN_MOUSE_ACCELERATION, MAX_MOUSE_ACCELERATION);
+        Self {
+            sensitivity,
+            acceleration_percent,
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone, Copy)]
+struct AdjustedMouseMove {
+    cursor_dx: f64,
+    cursor_dy: f64,
+    send_dx: i16,
+    send_dy: i16,
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone, Copy)]
+struct NativeMouseAdjuster {
+    settings: NativeMouseSettings,
+    residual_x: f64,
+    residual_y: f64,
+}
+
+#[cfg(target_os = "windows")]
+impl NativeMouseAdjuster {
+    fn new(settings: NativeMouseSettings) -> Self {
+        Self {
+            settings,
+            residual_x: 0.0,
+            residual_y: 0.0,
+        }
+    }
+
+    fn adjust(&mut self, dx: i16, dy: i16) -> Option<AdjustedMouseMove> {
+        if dx == 0 && dy == 0 {
+            return None;
+        }
+
+        let mut cursor_dx = f64::from(dx) * self.settings.sensitivity;
+        let mut cursor_dy = f64::from(dy) * self.settings.sensitivity;
+        if self.settings.acceleration_percent > 1 {
+            let speed = cursor_dx.hypot(cursor_dy);
+            let strength = f64::from(self.settings.acceleration_percent.saturating_sub(1)) / 149.0;
+            let accel_factor = 1.0 + (0.6 * strength).min((speed / 50.0) * strength);
+            cursor_dx *= accel_factor;
+            cursor_dy *= accel_factor;
+        }
+
+        Some(AdjustedMouseMove {
+            cursor_dx,
+            cursor_dy,
+            send_dx: quantize_mouse_delta(cursor_dx, &mut self.residual_x),
+            send_dy: quantize_mouse_delta(cursor_dy, &mut self.residual_y),
+        })
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn quantize_mouse_delta(delta: f64, residual: &mut f64) -> i16 {
+    let accumulated = delta + *residual;
+    let rounded = accumulated.round();
+    let clamped = rounded.clamp(f64::from(i16::MIN), f64::from(i16::MAX));
+    *residual = if (rounded - clamped).abs() < f64::EPSILON {
+        accumulated - clamped
+    } else {
+        0.0
+    };
+    clamped as i16
 }
 
 #[cfg(target_os = "windows")]
@@ -297,6 +398,7 @@ impl NativeWindowInputBridge {
         input_state: GstreamerInputState,
         input_channels: GstreamerInputChannels,
         event_sender: Option<Sender<Event>>,
+        mouse_settings: NativeMouseSettings,
     ) -> Self {
         let (sender, receiver) = mpsc::channel::<NativeWindowInputEvent>();
         unsafe {
@@ -309,6 +411,7 @@ impl NativeWindowInputBridge {
         let input_thread_state = input_state.clone();
         let input_thread_channels = input_channels.clone();
         let input_thread = thread::spawn(move || {
+            let mut mouse_adjuster = NativeMouseAdjuster::new(mouse_settings);
             let mut pending_events = Vec::with_capacity(NATIVE_INPUT_DRAIN_MAX_EVENTS);
             send_log(
                 &thread_sender,
@@ -349,6 +452,7 @@ impl NativeWindowInputBridge {
                     &input_thread_state,
                     &input_thread_channels,
                     &thread_sender,
+                    &mut mouse_adjuster,
                     &pending_events,
                 );
             }
@@ -399,6 +503,7 @@ fn send_native_window_input_events(
     input_state: &GstreamerInputState,
     input_channels: &GstreamerInputChannels,
     event_sender: &Option<Sender<Event>>,
+    mouse_adjuster: &mut NativeMouseAdjuster,
     events: &[NativeWindowInputEvent],
 ) {
     if events.is_empty() {
@@ -446,13 +551,13 @@ fn send_native_window_input_events(
             return;
         };
 
-        let mut flush_current_reliable_singles = |singles: &mut Vec<Vec<u8>>,
-                                                   batches: &mut Vec<Vec<Vec<u8>>>| {
-            if singles.is_empty() {
-                return;
-            }
-            batches.push(std::mem::take(singles));
-        };
+        let flush_current_reliable_singles =
+            |singles: &mut Vec<Vec<u8>>, batches: &mut Vec<Vec<Vec<u8>>>| {
+                if singles.is_empty() {
+                    return;
+                }
+                batches.push(std::mem::take(singles));
+            };
 
         for event in other_events.iter().copied() {
             if let NativeWindowInputEvent::MouseMove {
@@ -461,10 +566,22 @@ fn send_native_window_input_events(
                 timestamp_us,
             } = event
             {
+                let Some(adjusted) = mouse_adjuster.adjust(dx, dy) else {
+                    continue;
+                };
+                unsafe {
+                    win32_renderer_window::move_native_cursor_by_delta(
+                        adjusted.cursor_dx,
+                        adjusted.cursor_dy,
+                    );
+                }
+                if adjusted.send_dx == 0 && adjusted.send_dy == 0 {
+                    continue;
+                }
                 let (pending_dx, pending_dy, pending_timestamp_us) =
                     pending_mouse_move.get_or_insert((0, 0, timestamp_us));
-                *pending_dx = pending_dx.saturating_add(i32::from(dx));
-                *pending_dy = pending_dy.saturating_add(i32::from(dy));
+                *pending_dx = pending_dx.saturating_add(i32::from(adjusted.send_dx));
+                *pending_dy = pending_dy.saturating_add(i32::from(adjusted.send_dy));
                 *pending_timestamp_us = timestamp_us;
                 continue;
             }
@@ -478,17 +595,13 @@ fn send_native_window_input_events(
                 &mut pending_mouse_move,
                 &mut pending_mouse_packets,
             );
-            if let Some(payload) =
-                encode_native_window_input_payload(&encoder, event_sender, event)
+            if let Some(payload) = encode_native_window_input_payload(&encoder, event_sender, event)
             {
                 current_reliable_singles.push(payload);
             }
         }
 
-        flush_current_reliable_singles(
-            &mut current_reliable_singles,
-            &mut reliable_single_batches,
-        );
+        flush_current_reliable_singles(&mut current_reliable_singles, &mut reliable_single_batches);
         collect_pending_mouse_move_packets(
             &encoder,
             &mut pending_mouse_move,
@@ -625,10 +738,7 @@ fn send_encoded_native_window_input_event(
         return;
     };
 
-    let partially_reliable = matches!(
-        event,
-        NativeWindowInputEvent::MouseMove { .. }
-    );
+    let partially_reliable = matches!(event, NativeWindowInputEvent::MouseMove { .. });
     let _ = input_channels.send_packet(&payload, partially_reliable);
 }
 
@@ -871,7 +981,7 @@ pub(crate) fn create_input_data_channels(
     })
 }
 
-fn create_data_channel(
+pub(crate) fn create_data_channel(
     webrtc: &gst::Element,
     label: &'static str,
     options: Option<gst::Structure>,
@@ -1143,4 +1253,40 @@ pub(crate) fn channel_label(channel: &gst_webrtc::WebRTCDataChannel) -> String {
         .label()
         .map(|label| label.to_string())
         .unwrap_or_else(|| "<unlabeled>".to_owned())
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_mouse_adjuster_applies_sensitivity_with_residuals() {
+        let mut adjuster = NativeMouseAdjuster::new(NativeMouseSettings {
+            sensitivity: 0.25,
+            acceleration_percent: 1,
+        });
+
+        let first = adjuster.adjust(1, 0).expect("first move");
+        let second = adjuster.adjust(1, 0).expect("second move");
+        let third = adjuster.adjust(1, 0).expect("third move");
+        let fourth = adjuster.adjust(1, 0).expect("fourth move");
+
+        assert_eq!(first.cursor_dx, 0.25);
+        assert_eq!(
+            [first.send_dx, second.send_dx, third.send_dx, fourth.send_dx],
+            [0, 1, 0, 0]
+        );
+    }
+
+    #[test]
+    fn native_mouse_adjuster_matches_renderer_acceleration_curve() {
+        let mut adjuster = NativeMouseAdjuster::new(NativeMouseSettings {
+            sensitivity: 1.0,
+            acceleration_percent: 150,
+        });
+
+        let adjusted = adjuster.adjust(50, 0).expect("accelerated move");
+        assert_eq!(adjusted.cursor_dx, 80.0);
+        assert_eq!(adjusted.send_dx, 80);
+    }
 }

--- a/native/opennow-streamer/src/gstreamer_pipeline.rs
+++ b/native/opennow-streamer/src/gstreamer_pipeline.rs
@@ -5,19 +5,20 @@ use crate::gstreamer_config::{
     NATIVE_PRESENT_MAX_FPS_ENV, NATIVE_VIDEO_API_ENV, NATIVE_VIDEO_BACKEND_ENV,
     PRESENT_LIMITER_AUTO_SENTINEL,
 };
-#[cfg(target_os = "windows")]
-use crate::gstreamer_input::NativeWindowInputBridge;
+use crate::gstreamer_cursor::{create_cursor_data_channel, disable_native_cursor_channel};
 use crate::gstreamer_input::{
     create_input_data_channels, wire_remote_data_channels, GstreamerInputChannels,
     GstreamerInputState,
 };
+#[cfg(target_os = "windows")]
+use crate::gstreamer_input::{NativeMouseSettings, NativeWindowInputBridge};
 use crate::gstreamer_liveness::{
     install_present_limiter, watch_audio_activity, watch_first_sink_buffer,
     watch_rtp_video_bitrate, watch_video_caps_transitions, watch_video_decoded_rate,
     watch_video_sink_caps_transitions, watch_video_sink_rate, VideoLivenessMonitor,
 };
 use crate::gstreamer_platform::{
-    apply_render_surface_to_video_sink, primary_display_refresh_hz,
+    apply_render_surface_to_video_sink, primary_display_refresh_hz, reset_native_cursor,
     start_external_renderer_window_guard, update_external_renderer_surface,
 };
 use crate::gstreamer_transitions::DEFAULT_VIDEO_QUEUE_DEPTH;
@@ -326,6 +327,7 @@ pub(crate) struct GstreamerPipeline {
     pub(crate) webrtc: gst::Element,
     input_state: GstreamerInputState,
     input_channels: Option<GstreamerInputChannels>,
+    cursor_channel: Option<gst_webrtc::WebRTCDataChannel>,
     #[cfg(target_os = "windows")]
     native_window_input_bridge: Option<NativeWindowInputBridge>,
     render_state: GstreamerRenderState,
@@ -385,6 +387,7 @@ impl GstreamerPipeline {
             webrtc,
             input_state,
             input_channels: None,
+            cursor_channel: None,
             #[cfg(target_os = "windows")]
             native_window_input_bridge: None,
             render_state,
@@ -426,6 +429,7 @@ impl GstreamerPipeline {
     fn ensure_input_data_channels(
         &mut self,
         partial_reliable_threshold_ms: u32,
+        context: &NativeStreamerSessionContext,
     ) -> Result<(), String> {
         if self.input_channels.is_some() {
             return Ok(());
@@ -440,12 +444,24 @@ impl GstreamerPipeline {
         )?;
         let _ = channels.labels();
         self.input_channels = Some(channels);
-        self.ensure_native_window_input_bridge();
+        self.ensure_native_window_input_bridge(context);
+        Ok(())
+    }
+
+    fn ensure_cursor_data_channel(&mut self) -> Result<(), String> {
+        if self.cursor_channel.is_some() {
+            return Ok(());
+        }
+
+        self.cursor_channel = Some(create_cursor_data_channel(
+            &self.webrtc,
+            self.event_sender.clone(),
+        )?);
         Ok(())
     }
 
     #[cfg(target_os = "windows")]
-    fn ensure_native_window_input_bridge(&mut self) {
+    fn ensure_native_window_input_bridge(&mut self, context: &NativeStreamerSessionContext) {
         if self.native_window_input_bridge.is_some() {
             return;
         }
@@ -457,11 +473,12 @@ impl GstreamerPipeline {
             self.input_state.clone(),
             input_channels,
             self.event_sender.clone(),
+            NativeMouseSettings::from_stream_settings(&context.settings),
         ));
     }
 
     #[cfg(not(target_os = "windows"))]
-    fn ensure_native_window_input_bridge(&mut self) {
+    fn ensure_native_window_input_bridge(&mut self, _context: &NativeStreamerSessionContext) {
         send_log(
             &self.event_sender,
             "warn",
@@ -477,6 +494,8 @@ impl GstreamerPipeline {
         offer_sdp: gst_sdp::SDPMessage,
         original_remote_credentials: Option<&IceCredentials>,
         partial_reliable_threshold_ms: u32,
+        native_cursor_overlay: bool,
+        context: &NativeStreamerSessionContext,
     ) -> Result<String, String> {
         let offer =
             gst_webrtc::WebRTCSessionDescription::new(gst_webrtc::WebRTCSDPType::Offer, offer_sdp);
@@ -490,7 +509,12 @@ impl GstreamerPipeline {
             self.original_remote_ice_credentials = Some(credentials.clone());
             self.try_restore_original_remote_ice_credentials("after remote description")?;
         }
-        self.ensure_input_data_channels(partial_reliable_threshold_ms)?;
+        self.ensure_input_data_channels(partial_reliable_threshold_ms, context)?;
+        if native_cursor_overlay {
+            self.ensure_cursor_data_channel()?;
+        } else {
+            disable_native_cursor_channel(&self.event_sender);
+        }
         let answer = self.create_answer()?;
         let answer_sdp = answer
             .sdp()
@@ -752,6 +776,7 @@ impl GstreamerPipeline {
 
     pub(crate) fn stop(mut self) -> Result<(), String> {
         self.video_liveness.set_stats_overlay_visible(false);
+        reset_native_cursor();
         self.render_state.stop_external_renderer_window_guard();
         #[cfg(target_os = "windows")]
         if let Some(mut bridge) = self.native_window_input_bridge.take() {

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -281,7 +281,6 @@ pub(crate) mod win32_renderer_window {
     const IDC_HAND: u16 = 32649;
     const IDC_APPSTARTING: u16 = 32650;
     const IDC_HELP: u16 = 32651;
-    const CURSOR_POSITION_MAX_F64: f64 = 65535.0;
     const MAX_CUSTOM_CURSOR_IMAGE_BYTES: usize = 2 * 1024 * 1024;
     const MAX_CUSTOM_CURSOR_DIMENSION: u32 = 512;
 
@@ -312,7 +311,6 @@ pub(crate) mod win32_renderer_window {
     struct NativeCursorRuntime {
         visible: bool,
         current: Option<CursorHandle>,
-        position: Option<(f64, f64)>,
         custom: HashMap<u8, CursorHandle>,
     }
 
@@ -433,7 +431,6 @@ pub(crate) mod win32_renderer_window {
             lparam: Lparam,
         ) -> Bool;
         fn GetMonitorInfoW(monitor: Hmonitor, info: *mut MonitorInfo) -> Bool;
-        fn GetCursorPos(point: *mut Point) -> Bool;
         fn GetRawInputData(
             raw_input: Hrawinput,
             command: Uint,
@@ -455,7 +452,6 @@ pub(crate) mod win32_renderer_window {
         fn ReleaseCapture() -> Bool;
         fn SetCapture(hwnd: Hwnd) -> Hwnd;
         fn SetCursor(cursor: Hcursor) -> Hcursor;
-        fn SetCursorPos(x: i32, y: i32) -> Bool;
         fn SetFocus(hwnd: Hwnd) -> Hwnd;
         fn SetForegroundWindow(hwnd: Hwnd) -> Bool;
         fn SetWindowLongPtrW(hwnd: Hwnd, index: i32, new_long: isize) -> isize;
@@ -532,20 +528,20 @@ pub(crate) mod win32_renderer_window {
 
             let was_visible = runtime.visible;
             let previous_cursor = runtime.current;
-            let (next_visible, next_cursor, position) = match update {
-                NativeCursorUpdate::Hidden => (false, None, None),
+            let (next_visible, next_cursor) = match update {
+                NativeCursorUpdate::Hidden => (false, None),
                 NativeCursorUpdate::Predefined {
                     cursor_id,
-                    position,
+                    position: _,
                 } => {
                     let handle = predefined_cursor_handle(cursor_id)
                         .ok_or_else(|| format!("Unknown predefined cursor id {cursor_id}."))?;
-                    (true, Some(handle), position)
+                    (true, Some(handle))
                 }
                 NativeCursorUpdate::Custom {
                     cursor_id,
                     image,
-                    position,
+                    position: _,
                     ..
                 } => {
                     let handle = if image.is_some() {
@@ -564,19 +560,11 @@ pub(crate) mod win32_renderer_window {
                             format!("Custom cursor id {cursor_id} was referenced before its image.")
                         })?
                     };
-                    (true, Some(handle), position)
+                    (true, Some(handle))
                 }
             };
             runtime.visible = next_visible;
             runtime.current = next_cursor;
-            if !was_visible && next_visible {
-                if let Some(position) = position {
-                    runtime.position = Some((f64::from(position.x), f64::from(position.y)));
-                } else if runtime.position.is_none() {
-                    runtime.position =
-                        Some((CURSOR_POSITION_MAX_F64 / 2.0, CURSOR_POSITION_MAX_F64 / 2.0));
-                }
-            }
             (
                 next_visible,
                 next_cursor,
@@ -589,7 +577,6 @@ pub(crate) mod win32_renderer_window {
         }
 
         apply_native_cursor_to_current_window();
-        sync_native_cursor_screen_position();
         request_native_cursor_refresh_for_current_window();
         Ok(changed && next_visible && next_cursor.is_some())
     }
@@ -603,7 +590,6 @@ pub(crate) mod win32_renderer_window {
             };
             runtime.visible = false;
             runtime.current = None;
-            runtime.position = None;
             runtime
                 .custom
                 .drain()
@@ -785,131 +771,6 @@ pub(crate) mod win32_renderer_window {
             hide_cursor();
         }
         SetCursor(null_mut());
-    }
-
-    unsafe fn sync_native_cursor_screen_position() {
-        if !native_cursor_visible() {
-            return;
-        }
-        let Some(hwnd) = captured_hwnd().or_else(protected_hwnd) else {
-            return;
-        };
-        let hwnd = hwnd as Hwnd;
-        let Some(rect) = target_renderer_rect().or_else(|| monitor_rect_for_window(hwnd)) else {
-            return;
-        };
-        let position = native_cursor_position_for_rect(hwnd, rect);
-        set_cursor_pos_for_normalized_position(rect, position);
-        apply_native_cursor_to_window(hwnd);
-    }
-
-    pub unsafe fn move_native_cursor_by_delta(dx: f64, dy: f64) {
-        if (!dx.is_finite() || !dy.is_finite())
-            || ((dx == 0.0 && dy == 0.0) || !native_cursor_visible())
-        {
-            return;
-        }
-        let Some(hwnd) = captured_hwnd() else {
-            return;
-        };
-        let hwnd = hwnd as Hwnd;
-        let Some(rect) = target_renderer_rect().or_else(|| monitor_rect_for_window(hwnd)) else {
-            return;
-        };
-        let width = f64::from(rect.right.saturating_sub(rect.left).max(1));
-        let height = f64::from(rect.bottom.saturating_sub(rect.top).max(1));
-        let mut position = native_cursor_position_for_rect(hwnd, rect);
-        position.0 = (position.0 + (dx / width) * CURSOR_POSITION_MAX_F64)
-            .clamp(0.0, CURSOR_POSITION_MAX_F64);
-        position.1 = (position.1 + (dy / height) * CURSOR_POSITION_MAX_F64)
-            .clamp(0.0, CURSOR_POSITION_MAX_F64);
-
-        let cursor_slot = NATIVE_CURSOR.get_or_init(|| Mutex::new(NativeCursorRuntime::default()));
-        if let Ok(mut runtime) = cursor_slot.lock() {
-            runtime.position = Some(position);
-        }
-        set_cursor_pos_for_normalized_position(rect, position);
-        apply_native_cursor_to_window(hwnd);
-    }
-
-    unsafe fn set_cursor_pos_for_normalized_position(rect: Rect, position: (f64, f64)) {
-        let width = f64::from(
-            rect.right
-                .saturating_sub(rect.left)
-                .saturating_sub(1)
-                .max(1),
-        );
-        let height = f64::from(
-            rect.bottom
-                .saturating_sub(rect.top)
-                .saturating_sub(1)
-                .max(1),
-        );
-        let x = f64::from(rect.left)
-            + (position.0.clamp(0.0, CURSOR_POSITION_MAX_F64) / CURSOR_POSITION_MAX_F64) * width;
-        let y = f64::from(rect.top)
-            + (position.1.clamp(0.0, CURSOR_POSITION_MAX_F64) / CURSOR_POSITION_MAX_F64) * height;
-        SetCursorPos(
-            (x.round() as i32).clamp(rect.left, rect.right.saturating_sub(1)),
-            (y.round() as i32).clamp(rect.top, rect.bottom.saturating_sub(1)),
-        );
-    }
-
-    unsafe fn native_cursor_position_for_rect(hwnd: Hwnd, rect: Rect) -> (f64, f64) {
-        if let Some(position) = NATIVE_CURSOR
-            .get()
-            .and_then(|cursor| cursor.lock().ok().and_then(|runtime| runtime.position))
-        {
-            return position;
-        }
-
-        let mut point = Point { x: 0, y: 0 };
-        let position = if GetCursorPos(&mut point) != 0 && point_in_rect(point, rect) {
-            normalized_position_from_screen_point(point, rect)
-        } else if let Some(monitor_rect) = monitor_rect_for_window(hwnd) {
-            let center = Point {
-                x: monitor_rect.left + monitor_rect.right.saturating_sub(monitor_rect.left) / 2,
-                y: monitor_rect.top + monitor_rect.bottom.saturating_sub(monitor_rect.top) / 2,
-            };
-            if point_in_rect(center, rect) {
-                normalized_position_from_screen_point(center, rect)
-            } else {
-                (CURSOR_POSITION_MAX_F64 / 2.0, CURSOR_POSITION_MAX_F64 / 2.0)
-            }
-        } else {
-            (CURSOR_POSITION_MAX_F64 / 2.0, CURSOR_POSITION_MAX_F64 / 2.0)
-        };
-
-        let cursor_slot = NATIVE_CURSOR.get_or_init(|| Mutex::new(NativeCursorRuntime::default()));
-        if let Ok(mut runtime) = cursor_slot.lock() {
-            runtime.position = Some(position);
-        }
-        position
-    }
-
-    fn normalized_position_from_screen_point(point: Point, rect: Rect) -> (f64, f64) {
-        let width = f64::from(
-            rect.right
-                .saturating_sub(rect.left)
-                .saturating_sub(1)
-                .max(1),
-        );
-        let height = f64::from(
-            rect.bottom
-                .saturating_sub(rect.top)
-                .saturating_sub(1)
-                .max(1),
-        );
-        (
-            (f64::from(point.x.saturating_sub(rect.left)) / width * CURSOR_POSITION_MAX_F64)
-                .clamp(0.0, CURSOR_POSITION_MAX_F64),
-            (f64::from(point.y.saturating_sub(rect.top)) / height * CURSOR_POSITION_MAX_F64)
-                .clamp(0.0, CURSOR_POSITION_MAX_F64),
-        )
-    }
-
-    fn point_in_rect(point: Point, rect: Rect) -> bool {
-        point.x >= rect.left && point.x < rect.right && point.y >= rect.top && point.y < rect.bottom
     }
 
     pub unsafe fn set_input_event_sender(sender: Option<Sender<NativeWindowInputEvent>>) {

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "windows")]
 use crate::gstreamer_backend::send_log;
+use crate::gstreamer_cursor::NativeCursorUpdate;
 #[cfg(target_os = "windows")]
 use crate::protocol::NativeRenderRect;
 use crate::protocol::{Event, NativeRenderSurface, NativeStreamerShortcutBindings};
@@ -118,6 +119,26 @@ pub(crate) fn clear_native_shortcut_bindings() {
 pub(crate) fn clear_native_shortcut_bindings() {}
 
 #[cfg(target_os = "windows")]
+pub(crate) fn apply_native_cursor_update(update: NativeCursorUpdate) -> Result<bool, String> {
+    unsafe { win32_renderer_window::apply_native_cursor_update(update) }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn apply_native_cursor_update(_update: NativeCursorUpdate) -> Result<bool, String> {
+    Ok(false)
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn reset_native_cursor() {
+    unsafe {
+        win32_renderer_window::reset_native_cursor();
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn reset_native_cursor() {}
+
+#[cfg(target_os = "windows")]
 pub(crate) fn update_external_renderer_surface(surface: &NativeRenderSurface) {
     let target = surface
         .window_handle
@@ -141,6 +162,7 @@ pub(crate) fn update_external_renderer_surface(_surface: &NativeRenderSurface) {
 
 #[cfg(target_os = "windows")]
 pub(crate) mod win32_renderer_window {
+    use crate::gstreamer_cursor::{NativeCursorImage, NativeCursorUpdate};
     use crate::gstreamer_input::NativeWindowInputEvent;
     use crate::protocol::NativeRenderRect;
     use crate::protocol::{NativeStreamerShortcutAction, NativeStreamerShortcutBindings};
@@ -156,6 +178,7 @@ pub(crate) mod win32_renderer_window {
 
     type Bool = i32;
     type Dword = u32;
+    type Hbitmap = *mut c_void;
     type Hcursor = *mut c_void;
     type Hmonitor = *mut c_void;
     type Hrawinput = *mut c_void;
@@ -246,6 +269,21 @@ pub(crate) mod win32_renderer_window {
     const SW_MINIMIZE: i32 = 6;
     const ESCAPE_SCANCODE: u16 = 0x0001;
     const ESCAPE_HOLD_TO_MINIMIZE: Duration = Duration::from_secs(5);
+    const IDC_ARROW: u16 = 32512;
+    const IDC_IBEAM: u16 = 32513;
+    const IDC_WAIT: u16 = 32514;
+    const IDC_CROSS: u16 = 32515;
+    const IDC_SIZENWSE: u16 = 32642;
+    const IDC_SIZENESW: u16 = 32643;
+    const IDC_SIZEWE: u16 = 32644;
+    const IDC_SIZENS: u16 = 32645;
+    const IDC_SIZEALL: u16 = 32646;
+    const IDC_HAND: u16 = 32649;
+    const IDC_APPSTARTING: u16 = 32650;
+    const IDC_HELP: u16 = 32651;
+    const CURSOR_POSITION_MAX_F64: f64 = 65535.0;
+    const MAX_CUSTOM_CURSOR_IMAGE_BYTES: usize = 2 * 1024 * 1024;
+    const MAX_CUSTOM_CURSOR_DIMENSION: u32 = 512;
 
     struct EnumState {
         process_id: u32,
@@ -262,6 +300,20 @@ pub(crate) mod win32_renderer_window {
     struct RenderTargetSurface {
         hwnd: isize,
         client_rect: Rect,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct CursorHandle {
+        hcursor: isize,
+        owned: bool,
+    }
+
+    #[derive(Default)]
+    struct NativeCursorRuntime {
+        visible: bool,
+        current: Option<CursorHandle>,
+        position: Option<(f64, f64)>,
+        custom: HashMap<u8, CursorHandle>,
     }
 
     #[repr(C)]
@@ -326,6 +378,15 @@ pub(crate) mod win32_renderer_window {
         extra_information: u32,
     }
 
+    #[repr(C)]
+    struct IconInfo {
+        f_icon: Bool,
+        x_hotspot: Dword,
+        y_hotspot: Dword,
+        hbm_mask: Hbitmap,
+        hbm_color: Hbitmap,
+    }
+
     #[derive(Clone, Copy)]
     struct PressedKey {
         keycode: u16,
@@ -353,6 +414,7 @@ pub(crate) mod win32_renderer_window {
     static ESCAPE_KEY_PRESS: OnceLock<Mutex<Option<EscapeKeyPress>>> = OnceLock::new();
     static SHORTCUT_MATCHER: OnceLock<Mutex<NativeShortcutMatcher>> = OnceLock::new();
     static RENDER_TARGET_SURFACE: OnceLock<Mutex<Option<RenderTargetSurface>>> = OnceLock::new();
+    static NATIVE_CURSOR: OnceLock<Mutex<NativeCursorRuntime>> = OnceLock::new();
 
     #[link(name = "user32")]
     unsafe extern "system" {
@@ -371,6 +433,7 @@ pub(crate) mod win32_renderer_window {
             lparam: Lparam,
         ) -> Bool;
         fn GetMonitorInfoW(monitor: Hmonitor, info: *mut MonitorInfo) -> Bool;
+        fn GetCursorPos(point: *mut Point) -> Bool;
         fn GetRawInputData(
             raw_input: Hrawinput,
             command: Uint,
@@ -385,11 +448,14 @@ pub(crate) mod win32_renderer_window {
         fn GetWindowThreadProcessId(hwnd: Hwnd, process_id: *mut u32) -> u32;
         fn IsIconic(hwnd: Hwnd) -> Bool;
         fn IsWindowVisible(hwnd: Hwnd) -> Bool;
+        fn LoadCursorW(instance: *mut c_void, cursor_name: *const u16) -> Hcursor;
         fn MonitorFromWindow(hwnd: Hwnd, flags: Dword) -> Hmonitor;
+        fn PostMessageW(hwnd: Hwnd, message: Uint, wparam: Wparam, lparam: Lparam) -> Bool;
         fn RegisterRawInputDevices(devices: *const RawInputDevice, count: u32, size: u32) -> Bool;
         fn ReleaseCapture() -> Bool;
         fn SetCapture(hwnd: Hwnd) -> Hwnd;
         fn SetCursor(cursor: Hcursor) -> Hcursor;
+        fn SetCursorPos(x: i32, y: i32) -> Bool;
         fn SetFocus(hwnd: Hwnd) -> Hwnd;
         fn SetForegroundWindow(hwnd: Hwnd) -> Bool;
         fn SetWindowLongPtrW(hwnd: Hwnd, index: i32, new_long: isize) -> isize;
@@ -404,6 +470,20 @@ pub(crate) mod win32_renderer_window {
         ) -> Bool;
         fn ShowWindow(hwnd: Hwnd, command: i32) -> Bool;
         fn ShowCursor(show: Bool) -> i32;
+        fn DestroyCursor(cursor: Hcursor) -> Bool;
+        fn CreateIconIndirect(icon_info: *mut IconInfo) -> Hcursor;
+    }
+
+    #[link(name = "gdi32")]
+    unsafe extern "system" {
+        fn CreateBitmap(
+            width: i32,
+            height: i32,
+            planes: u32,
+            bit_count: u32,
+            bits: *const c_void,
+        ) -> Hbitmap;
+        fn DeleteObject(object: *mut c_void) -> Bool;
     }
 
     #[link(name = "kernel32")]
@@ -425,6 +505,411 @@ pub(crate) mod win32_renderer_window {
         if let Ok(mut current) = slot.lock() {
             *current = target_surface;
         }
+    }
+
+    pub unsafe fn apply_native_cursor_update(update: NativeCursorUpdate) -> Result<bool, String> {
+        let prepared_custom = match &update {
+            NativeCursorUpdate::Custom {
+                cursor_id,
+                hotspot_x,
+                hotspot_y,
+                image: Some(image),
+                ..
+            } => Some((
+                *cursor_id,
+                create_custom_cursor(image, *hotspot_x, *hotspot_y)?,
+            )),
+            _ => None,
+        };
+
+        let mut old_custom = None;
+        let (next_visible, next_cursor, changed) = {
+            let cursor_slot =
+                NATIVE_CURSOR.get_or_init(|| Mutex::new(NativeCursorRuntime::default()));
+            let mut runtime = cursor_slot
+                .lock()
+                .map_err(|_| "Failed to acquire native cursor state.".to_owned())?;
+
+            let was_visible = runtime.visible;
+            let previous_cursor = runtime.current;
+            let (next_visible, next_cursor, position) = match update {
+                NativeCursorUpdate::Hidden => (false, None, None),
+                NativeCursorUpdate::Predefined {
+                    cursor_id,
+                    position,
+                } => {
+                    let handle = predefined_cursor_handle(cursor_id)
+                        .ok_or_else(|| format!("Unknown predefined cursor id {cursor_id}."))?;
+                    (true, Some(handle), position)
+                }
+                NativeCursorUpdate::Custom {
+                    cursor_id,
+                    image,
+                    position,
+                    ..
+                } => {
+                    let handle = if image.is_some() {
+                        let Some((prepared_cursor_id, handle)) = prepared_custom else {
+                            return Err("Custom cursor image was not prepared.".to_owned());
+                        };
+                        if prepared_cursor_id != cursor_id {
+                            return Err(
+                                "Prepared custom cursor id did not match update.".to_owned()
+                            );
+                        }
+                        old_custom = runtime.custom.insert(cursor_id, handle);
+                        handle
+                    } else {
+                        *runtime.custom.get(&cursor_id).ok_or_else(|| {
+                            format!("Custom cursor id {cursor_id} was referenced before its image.")
+                        })?
+                    };
+                    (true, Some(handle), position)
+                }
+            };
+            runtime.visible = next_visible;
+            runtime.current = next_cursor;
+            if !was_visible && next_visible {
+                if let Some(position) = position {
+                    runtime.position = Some((f64::from(position.x), f64::from(position.y)));
+                } else if runtime.position.is_none() {
+                    runtime.position =
+                        Some((CURSOR_POSITION_MAX_F64 / 2.0, CURSOR_POSITION_MAX_F64 / 2.0));
+                }
+            }
+            (
+                next_visible,
+                next_cursor,
+                was_visible != next_visible || previous_cursor != next_cursor,
+            )
+        };
+
+        if let Some(old_custom) = old_custom {
+            destroy_cursor_handle(old_custom);
+        }
+
+        apply_native_cursor_to_current_window();
+        sync_native_cursor_screen_position();
+        request_native_cursor_refresh_for_current_window();
+        Ok(changed && next_visible && next_cursor.is_some())
+    }
+
+    pub unsafe fn reset_native_cursor() {
+        let custom_handles = {
+            let cursor_slot =
+                NATIVE_CURSOR.get_or_init(|| Mutex::new(NativeCursorRuntime::default()));
+            let Ok(mut runtime) = cursor_slot.lock() else {
+                return;
+            };
+            runtime.visible = false;
+            runtime.current = None;
+            runtime.position = None;
+            runtime
+                .custom
+                .drain()
+                .map(|(_, handle)| handle)
+                .collect::<Vec<_>>()
+        };
+
+        for handle in custom_handles {
+            destroy_cursor_handle(handle);
+        }
+        apply_native_cursor_to_current_window();
+        request_native_cursor_refresh_for_current_window();
+    }
+
+    fn predefined_cursor_resource(cursor_id: u8) -> Option<u16> {
+        match cursor_id {
+            0 => None,
+            1 | 11 => Some(IDC_ARROW),
+            2 => Some(IDC_IBEAM),
+            3 => Some(IDC_WAIT),
+            4 => Some(IDC_CROSS),
+            5 => Some(IDC_APPSTARTING),
+            6 => Some(IDC_SIZENWSE),
+            7 => Some(IDC_SIZENESW),
+            8 => Some(IDC_SIZEWE),
+            9 => Some(IDC_SIZENS),
+            10 => Some(IDC_SIZEALL),
+            12 => Some(IDC_HAND),
+            13 => Some(IDC_HELP),
+            _ => Some(IDC_ARROW),
+        }
+    }
+
+    unsafe fn predefined_cursor_handle(cursor_id: u8) -> Option<CursorHandle> {
+        let resource = predefined_cursor_resource(cursor_id)?;
+        let cursor = LoadCursorW(null_mut(), resource_id(resource));
+        if cursor.is_null() {
+            return None;
+        }
+        Some(CursorHandle {
+            hcursor: cursor as isize,
+            owned: false,
+        })
+    }
+
+    fn resource_id(id: u16) -> *const u16 {
+        id as usize as *const u16
+    }
+
+    fn image_format_for_cursor(image: &NativeCursorImage) -> Option<image::ImageFormat> {
+        match image.mime_type.to_ascii_lowercase().as_str() {
+            "image/png" => Some(image::ImageFormat::Png),
+            "image/x-icon" | "image/vnd.microsoft.icon" | "image/ico" => {
+                Some(image::ImageFormat::Ico)
+            }
+            _ => image::guess_format(&image.bytes).ok(),
+        }
+    }
+
+    unsafe fn create_custom_cursor(
+        image: &NativeCursorImage,
+        hotspot_x: u8,
+        hotspot_y: u8,
+    ) -> Result<CursorHandle, String> {
+        if image.bytes.is_empty() {
+            return Err("Custom cursor image was empty.".to_owned());
+        }
+        if image.bytes.len() > MAX_CUSTOM_CURSOR_IMAGE_BYTES {
+            return Err(format!(
+                "Custom cursor image is too large ({} bytes).",
+                image.bytes.len()
+            ));
+        }
+
+        let decoded = match image_format_for_cursor(image) {
+            Some(format) => image::load_from_memory_with_format(&image.bytes, format)
+                .or_else(|_| image::load_from_memory(&image.bytes)),
+            None => image::load_from_memory(&image.bytes),
+        }
+        .map_err(|error| format!("Failed to decode custom cursor image: {error}"))?;
+        let rgba = decoded.to_rgba8();
+        let width = rgba.width();
+        let height = rgba.height();
+        if width == 0 || height == 0 {
+            return Err("Custom cursor image decoded to an empty bitmap.".to_owned());
+        }
+        if width > MAX_CUSTOM_CURSOR_DIMENSION || height > MAX_CUSTOM_CURSOR_DIMENSION {
+            return Err(format!(
+                "Custom cursor image dimensions are too large ({}x{}).",
+                width, height
+            ));
+        }
+
+        let mut bgra = Vec::with_capacity((width * height * 4) as usize);
+        for pixel in rgba.pixels() {
+            let [r, g, b, a] = pixel.0;
+            bgra.extend_from_slice(&[b, g, r, a]);
+        }
+
+        let width_i32 = width as i32;
+        let height_i32 = height as i32;
+        let color_bitmap =
+            CreateBitmap(width_i32, height_i32, 1, 32, bgra.as_ptr() as *const c_void);
+        if color_bitmap.is_null() {
+            return Err("CreateBitmap failed for custom cursor color bitmap.".to_owned());
+        }
+
+        let mask_stride = (((width + 15) / 16) * 2) as usize;
+        let mask = vec![0u8; mask_stride.saturating_mul(height as usize)];
+        let mask_bitmap = CreateBitmap(width_i32, height_i32, 1, 1, mask.as_ptr() as *const c_void);
+        if mask_bitmap.is_null() {
+            DeleteObject(color_bitmap as *mut c_void);
+            return Err("CreateBitmap failed for custom cursor mask bitmap.".to_owned());
+        }
+
+        let mut icon_info = IconInfo {
+            f_icon: 0,
+            x_hotspot: u32::from(hotspot_x).min(width.saturating_sub(1)),
+            y_hotspot: u32::from(hotspot_y).min(height.saturating_sub(1)),
+            hbm_mask: mask_bitmap,
+            hbm_color: color_bitmap,
+        };
+        let cursor = CreateIconIndirect(&mut icon_info);
+        DeleteObject(color_bitmap as *mut c_void);
+        DeleteObject(mask_bitmap as *mut c_void);
+
+        if cursor.is_null() {
+            return Err("CreateIconIndirect failed for custom cursor.".to_owned());
+        }
+        Ok(CursorHandle {
+            hcursor: cursor as isize,
+            owned: true,
+        })
+    }
+
+    unsafe fn destroy_cursor_handle(handle: CursorHandle) {
+        if handle.owned && handle.hcursor != 0 {
+            DestroyCursor(handle.hcursor as Hcursor);
+        }
+    }
+
+    fn current_native_cursor_handle() -> Option<CursorHandle> {
+        NATIVE_CURSOR.get().and_then(|cursor| {
+            cursor
+                .lock()
+                .ok()
+                .and_then(|runtime| (runtime.visible).then_some(()).and(runtime.current))
+        })
+    }
+
+    fn native_cursor_visible() -> bool {
+        current_native_cursor_handle().is_some()
+    }
+
+    unsafe fn apply_native_cursor_to_current_window() {
+        if let Some(hwnd) = captured_hwnd().or_else(protected_hwnd) {
+            apply_native_cursor_to_window(hwnd as Hwnd);
+        }
+    }
+
+    unsafe fn request_native_cursor_refresh_for_current_window() {
+        if let Some(hwnd) = captured_hwnd().or_else(protected_hwnd) {
+            let hwnd = hwnd as Hwnd;
+            PostMessageW(hwnd, WM_SETCURSOR, hwnd as Wparam, HTCLIENT as Lparam);
+        }
+    }
+
+    unsafe fn apply_native_cursor_to_window(hwnd: Hwnd) {
+        let captured = is_input_captured(hwnd);
+        if let Some(handle) = current_native_cursor_handle() {
+            if captured {
+                show_cursor();
+            }
+            SetCursor(handle.hcursor as Hcursor);
+            return;
+        }
+
+        if captured {
+            hide_cursor();
+        }
+        SetCursor(null_mut());
+    }
+
+    unsafe fn sync_native_cursor_screen_position() {
+        if !native_cursor_visible() {
+            return;
+        }
+        let Some(hwnd) = captured_hwnd().or_else(protected_hwnd) else {
+            return;
+        };
+        let hwnd = hwnd as Hwnd;
+        let Some(rect) = target_renderer_rect().or_else(|| monitor_rect_for_window(hwnd)) else {
+            return;
+        };
+        let position = native_cursor_position_for_rect(hwnd, rect);
+        set_cursor_pos_for_normalized_position(rect, position);
+        apply_native_cursor_to_window(hwnd);
+    }
+
+    pub unsafe fn move_native_cursor_by_delta(dx: f64, dy: f64) {
+        if (!dx.is_finite() || !dy.is_finite())
+            || ((dx == 0.0 && dy == 0.0) || !native_cursor_visible())
+        {
+            return;
+        }
+        let Some(hwnd) = captured_hwnd() else {
+            return;
+        };
+        let hwnd = hwnd as Hwnd;
+        let Some(rect) = target_renderer_rect().or_else(|| monitor_rect_for_window(hwnd)) else {
+            return;
+        };
+        let width = f64::from(rect.right.saturating_sub(rect.left).max(1));
+        let height = f64::from(rect.bottom.saturating_sub(rect.top).max(1));
+        let mut position = native_cursor_position_for_rect(hwnd, rect);
+        position.0 = (position.0 + (dx / width) * CURSOR_POSITION_MAX_F64)
+            .clamp(0.0, CURSOR_POSITION_MAX_F64);
+        position.1 = (position.1 + (dy / height) * CURSOR_POSITION_MAX_F64)
+            .clamp(0.0, CURSOR_POSITION_MAX_F64);
+
+        let cursor_slot = NATIVE_CURSOR.get_or_init(|| Mutex::new(NativeCursorRuntime::default()));
+        if let Ok(mut runtime) = cursor_slot.lock() {
+            runtime.position = Some(position);
+        }
+        set_cursor_pos_for_normalized_position(rect, position);
+        apply_native_cursor_to_window(hwnd);
+    }
+
+    unsafe fn set_cursor_pos_for_normalized_position(rect: Rect, position: (f64, f64)) {
+        let width = f64::from(
+            rect.right
+                .saturating_sub(rect.left)
+                .saturating_sub(1)
+                .max(1),
+        );
+        let height = f64::from(
+            rect.bottom
+                .saturating_sub(rect.top)
+                .saturating_sub(1)
+                .max(1),
+        );
+        let x = f64::from(rect.left)
+            + (position.0.clamp(0.0, CURSOR_POSITION_MAX_F64) / CURSOR_POSITION_MAX_F64) * width;
+        let y = f64::from(rect.top)
+            + (position.1.clamp(0.0, CURSOR_POSITION_MAX_F64) / CURSOR_POSITION_MAX_F64) * height;
+        SetCursorPos(
+            (x.round() as i32).clamp(rect.left, rect.right.saturating_sub(1)),
+            (y.round() as i32).clamp(rect.top, rect.bottom.saturating_sub(1)),
+        );
+    }
+
+    unsafe fn native_cursor_position_for_rect(hwnd: Hwnd, rect: Rect) -> (f64, f64) {
+        if let Some(position) = NATIVE_CURSOR
+            .get()
+            .and_then(|cursor| cursor.lock().ok().and_then(|runtime| runtime.position))
+        {
+            return position;
+        }
+
+        let mut point = Point { x: 0, y: 0 };
+        let position = if GetCursorPos(&mut point) != 0 && point_in_rect(point, rect) {
+            normalized_position_from_screen_point(point, rect)
+        } else if let Some(monitor_rect) = monitor_rect_for_window(hwnd) {
+            let center = Point {
+                x: monitor_rect.left + monitor_rect.right.saturating_sub(monitor_rect.left) / 2,
+                y: monitor_rect.top + monitor_rect.bottom.saturating_sub(monitor_rect.top) / 2,
+            };
+            if point_in_rect(center, rect) {
+                normalized_position_from_screen_point(center, rect)
+            } else {
+                (CURSOR_POSITION_MAX_F64 / 2.0, CURSOR_POSITION_MAX_F64 / 2.0)
+            }
+        } else {
+            (CURSOR_POSITION_MAX_F64 / 2.0, CURSOR_POSITION_MAX_F64 / 2.0)
+        };
+
+        let cursor_slot = NATIVE_CURSOR.get_or_init(|| Mutex::new(NativeCursorRuntime::default()));
+        if let Ok(mut runtime) = cursor_slot.lock() {
+            runtime.position = Some(position);
+        }
+        position
+    }
+
+    fn normalized_position_from_screen_point(point: Point, rect: Rect) -> (f64, f64) {
+        let width = f64::from(
+            rect.right
+                .saturating_sub(rect.left)
+                .saturating_sub(1)
+                .max(1),
+        );
+        let height = f64::from(
+            rect.bottom
+                .saturating_sub(rect.top)
+                .saturating_sub(1)
+                .max(1),
+        );
+        (
+            (f64::from(point.x.saturating_sub(rect.left)) / width * CURSOR_POSITION_MAX_F64)
+                .clamp(0.0, CURSOR_POSITION_MAX_F64),
+            (f64::from(point.y.saturating_sub(rect.top)) / height * CURSOR_POSITION_MAX_F64)
+                .clamp(0.0, CURSOR_POSITION_MAX_F64),
+        )
+    }
+
+    fn point_in_rect(point: Point, rect: Rect) -> bool {
+        point.x >= rect.left && point.x < rect.right && point.y >= rect.top && point.y < rect.bottom
     }
 
     pub unsafe fn set_input_event_sender(sender: Option<Sender<NativeWindowInputEvent>>) {
@@ -630,8 +1115,8 @@ pub(crate) mod win32_renderer_window {
             begin_input_capture(hwnd);
             return MA_ACTIVATE;
         }
-        if message == WM_SETCURSOR && is_input_captured(hwnd) {
-            SetCursor(null_mut());
+        if message == WM_SETCURSOR && (is_input_captured(hwnd) || native_cursor_visible()) {
+            apply_native_cursor_to_window(hwnd);
             return 1;
         }
         if message == WM_INPUT {
@@ -722,13 +1207,12 @@ pub(crate) mod win32_renderer_window {
         if let Some(rect) = target_renderer_rect().or_else(|| monitor_rect_for_window(hwnd)) {
             ClipCursor(&rect);
         }
-        hide_cursor();
-        emit_input_capture_changed(true);
-
         let slot = CAPTURED_HWND.get_or_init(|| Mutex::new(None));
         if let Ok(mut captured) = slot.lock() {
             *captured = Some(hwnd as isize);
         }
+        apply_native_cursor_to_window(hwnd);
+        emit_input_capture_changed(true);
         sync_lock_keys_state(true);
     }
 
@@ -1294,7 +1778,10 @@ pub(crate) mod win32_renderer_window {
 
     /// Per-key modifier byte from tracked pressed keys (official GFN yS()/Cb()).
     /// Lock keys sync separately via INPUT_LOCK_KEYS_SYNC, not here.
-    unsafe fn pressed_key_modifier_flags(keys: &HashMap<u16, PressedKey>, active_keycode: u16) -> u16 {
+    unsafe fn pressed_key_modifier_flags(
+        keys: &HashMap<u16, PressedKey>,
+        active_keycode: u16,
+    ) -> u16 {
         let mut modifiers = 0u16;
         let mut shift_tracked = false;
         let mut control_tracked = false;

--- a/native/opennow-streamer/src/main.rs
+++ b/native/opennow-streamer/src/main.rs
@@ -6,6 +6,8 @@ mod gstreamer_backend;
 #[cfg(feature = "gstreamer")]
 mod gstreamer_config;
 #[cfg(feature = "gstreamer")]
+mod gstreamer_cursor;
+#[cfg(feature = "gstreamer")]
 mod gstreamer_input;
 #[cfg(feature = "gstreamer")]
 mod gstreamer_liveness;
@@ -17,8 +19,8 @@ mod gstreamer_platform;
 mod gstreamer_transitions;
 mod input;
 mod protocol;
-mod shortcuts;
 mod sdp;
+mod shortcuts;
 
 use serde::Serialize;
 use serde_json::Value;

--- a/native/opennow-streamer/src/protocol.rs
+++ b/native/opennow-streamer/src/protocol.rs
@@ -72,12 +72,30 @@ pub struct StreamSettings {
     pub max_bitrate_mbps: u32,
     pub codec: VideoCodec,
     pub color_quality: ColorQuality,
+    #[serde(default = "default_native_cursor_overlay")]
+    pub native_cursor_overlay: bool,
+    #[serde(default = "default_mouse_sensitivity")]
+    pub mouse_sensitivity: f64,
+    #[serde(default = "default_mouse_acceleration")]
+    pub mouse_acceleration: u32,
     #[serde(default)]
     #[allow(dead_code)]
     pub enable_cloud_gsync: bool,
     #[cfg_attr(not(feature = "gstreamer"), allow(dead_code))]
     #[serde(default)]
     pub native_transition_diagnostics: Option<NativeTransitionDiagnosticsSettings>,
+}
+
+fn default_native_cursor_overlay() -> bool {
+    true
+}
+
+fn default_mouse_sensitivity() -> f64 {
+    1.0
+}
+
+fn default_mouse_acceleration() -> u32 {
+    1
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -529,9 +547,7 @@ pub enum Event {
     #[serde(rename = "clipboard-paste")]
     ClipboardPaste,
     #[serde(rename = "input-capture-changed")]
-    InputCaptureChanged {
-        captured: bool,
-    },
+    InputCaptureChanged { captured: bool },
     #[serde(rename = "video-stall")]
     VideoStall(VideoStallEvent),
     #[serde(rename = "video-transition")]

--- a/opennow-stable/src/main/signaling/signalingCoordinator.ts
+++ b/opennow-stable/src/main/signaling/signalingCoordinator.ts
@@ -216,7 +216,8 @@ export class SignalingCoordinator {
       key === "nativeStreamerExecutablePath" ||
       key === "nativeCloudGsyncMode" ||
       key === "nativeD3dFullscreenMode" ||
-      key === "nativeExternalRenderer"
+      key === "nativeExternalRenderer" ||
+      key === "nativeCursorOverlay"
     ) {
       this.stopNativeStreamer(
         key === "nativeStreamerBackend"
@@ -229,7 +230,9 @@ export class SignalingCoordinator {
                 ? "native D3D fullscreen mode changed"
                 : key === "nativeExternalRenderer"
                   ? "native external renderer setting changed"
-                  : "native streamer disabled",
+                  : key === "nativeCursorOverlay"
+                    ? "native cursor overlay setting changed"
+                    : "native streamer disabled",
       );
       this.resetNativeStreamerContext();
     }

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -735,6 +735,9 @@ export function App(): JSX.Element {
       nativeStreamerBackend: "gstreamer",
       nativeCloudGsyncMode: settings.nativeCloudGsyncMode,
       nativeTransitionDiagnostics: settings.nativeTransitionDiagnostics,
+      nativeCursorOverlay: settings.nativeCursorOverlay,
+      mouseSensitivity: settings.mouseSensitivity,
+      mouseAcceleration: settings.mouseAcceleration,
     };
   }, [
     settings.codec,
@@ -745,7 +748,10 @@ export function App(): JSX.Element {
     settings.gameLanguage,
     settings.keyboardLayout,
     settings.maxBitrateMbps,
+    settings.mouseAcceleration,
+    settings.mouseSensitivity,
     settings.nativeCloudGsyncMode,
+    settings.nativeCursorOverlay,
     settings.nativeTransitionDiagnostics,
     settings.resolution,
     settings.streamClientMode,

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -861,6 +861,12 @@ export interface StreamSettings {
   cloudGsyncResolution?: CloudGsyncResolution;
   /** Hidden diagnostics for native transition recovery and 240 FPS server-side stream changes. */
   nativeTransitionDiagnostics?: NativeTransitionDiagnostics;
+  /** Use the WebRTC cursor_channel cursor path instead of server-side cursor rendering. */
+  nativeCursorOverlay?: boolean;
+  /** Multiplier applied to relative mouse input before it is sent to the stream. */
+  mouseSensitivity?: number;
+  /** Optional software acceleration percentage for relative mouse input. */
+  mouseAcceleration?: number;
 }
 
 export interface SessionCreateRequest {


### PR DESCRIPTION
## Summary
- Add native GStreamer cursor_channel handling for predefined, hidden, and custom cursors.
- Apply native mouse sensitivity/acceleration consistently to both sent input and local cursor movement.
- Wire the Native Cursor Overlay setting into native streamer session restart/reset behavior and refresh Win32 cursor shape updates immediately.

## Tests
- npm --prefix opennow-stable run typecheck
- npm --prefix opennow-stable test
- cargo test --features gstreamer
- bundled win32-x64 native streamer hello verification with GStreamer runtime

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Win32 input capture, cursor rendering, and WebRTC data channels on the native streaming path; incorrect behavior could affect pointer feel or cursor display, but scope is mostly additive behind settings defaults.
> 
> **Overview**
> Adds **native cursor overlay** for the GStreamer streamer: when enabled, negotiation opens a WebRTC `cursor_channel`, parses GFN cursor messages (predefined, hidden, custom PNG/ICO), and drives Win32 cursor state including custom bitmap cursors via the optional `image` crate.
> 
> On Windows, **mouse sensitivity and acceleration** from stream settings are applied to relative moves before encoding—using the same curve for **local overlay cursor movement** and **packets sent to the server**, with sub-pixel residual quantization.
> 
> **Protocol and app wiring:** `StreamSettings` gains `nativeCursorOverlay`, `mouseSensitivity`, and `mouseAcceleration`; the Electron app passes them into native sessions and **restarts the native streamer** when `nativeCursorOverlay` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b95de5409839090c81b62165bae9932e796ea9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->