### PR TITLE
feat(clipboard): implement GFN paste protocol

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -342,9 +342,13 @@ async function readStreamClipboardText(): Promise<string> {
 
 async function sendStreamClipboardPaste(
   client: GfnWebRtcClient | null,
-  isMac: boolean,
 ): Promise<void> {
   if (!client) {
+    return;
+  }
+
+  const sentOfficialPaste = await client.pasteClipboardText();
+  if (sentOfficialPaste) {
     return;
   }
 
@@ -358,7 +362,7 @@ async function sendStreamClipboardPaste(
     console.warn("Clipboard read failed, falling back to paste shortcut:", error);
   }
 
-  client.sendPasteShortcut(isMac);
+  client.sendPasteShortcut(false);
 }
 
 export function App(): JSX.Element {
@@ -1556,6 +1560,13 @@ export function App(): JSX.Element {
         // ignore
       }
     }
+    if (key === "clipboardPaste") {
+      try {
+        (clientRef.current as any)?.setClipboardPasteEnabled?.(value as boolean);
+      } catch {
+        // ignore
+      }
+    }
     if (key === "maxBitrateMbps") {
       try {
         void (clientRef.current as any)?.setMaxBitrateKbps?.((value as number) * 1000);
@@ -2693,6 +2704,8 @@ export function App(): JSX.Element {
         mouseSensitivity: settings.mouseSensitivity,
         mouseAcceleration: settings.mouseAcceleration,
         keyboardLayout: settings.keyboardLayout,
+        clipboardPaste: settings.clipboardPaste,
+        readClipboardText: readStreamClipboardText,
         onLog: (line: string) => console.log(`[WebRTC] ${line}`),
         onStats: (stats) => diagnosticsStore.set(stats),
         onTimeWarning: (warning) => {
@@ -2865,7 +2878,7 @@ export function App(): JSX.Element {
           handleStreamShortcutActionRef.current?.(event.action);
         } else if (event.type === "native-clipboard-paste") {
           if (settings.clipboardPaste && (!nativeStreamingRef.current || nativeInputBridgeReady)) {
-            void sendStreamClipboardPaste(clientRef.current, isMac);
+            void sendStreamClipboardPaste(clientRef.current);
           }
         } else if (event.type === "native-input-capture-changed") {
           setNativeInputCaptureActive(event.captured);
@@ -3983,7 +3996,7 @@ export function App(): JSX.Element {
         return;
       }
 
-      const isPasteShortcut = e.key.toLowerCase() === "v" && !e.altKey && (isMac ? e.metaKey : e.ctrlKey);
+      const isPasteShortcut = e.key.toLowerCase() === "v" && !e.altKey && !e.shiftKey && (e.ctrlKey || (isMac && e.metaKey));
       if (streamStatus === "streaming" && isPasteShortcut) {
         // Always stop local/browser paste behavior while streaming.
         // If clipboard paste is enabled, send clipboard text into the stream.
@@ -3993,7 +4006,7 @@ export function App(): JSX.Element {
 
         if (settings.clipboardPaste) {
           void (async () => {
-            await sendStreamClipboardPaste(clientRef.current, isMac);
+            await sendStreamClipboardPaste(clientRef.current);
           })();
         }
         return;

--- a/opennow-stable/src/renderer/src/gfn/clipboardProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/clipboardProtocol.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildClipboardControlMessage,
+  clampClipboardText,
+  CLIPBOARD_CLIENT_DATA_RESPONSE,
+  CLIPBOARD_SERVER_DATA_REQUEST,
+  GFN_CLIPBOARD_MESSAGE_TYPE,
+  GFN_CLIPBOARD_SERVER_RECIPIENT,
+  isClipboardServerDataRequest,
+  parseClipboardControlMessage,
+} from "./clipboardProtocol";
+
+test("buildClipboardControlMessage matches official PASTE custom-message envelope", () => {
+  const message = buildClipboardControlMessage(CLIPBOARD_CLIENT_DATA_RESPONSE, {
+    text: "hello",
+    tracingData: {
+      requestId: "req-1",
+      traceId: "trace-1",
+      traceContext: [{ key: "k", value: "v" }],
+    },
+  });
+
+  const customMessage = JSON.parse(message.customMessage);
+  assert.equal(customMessage.messageType, "PASTE");
+  assert.equal(customMessage.messageRecipient, "UIPlugin");
+
+  const payload = JSON.parse(customMessage.data);
+  assert.equal(payload.messageType, "PASTE");
+  assert.equal(payload.pasteData.type, CLIPBOARD_CLIENT_DATA_RESPONSE);
+  assert.equal(payload.pasteData.data, "hello");
+  assert.equal(payload.tracingData.requestId, "req-1");
+  assert.equal(payload.tracingData.traceId, "trace-1");
+  assert.deepEqual(payload.tracingData.traceContext, [{ key: "k", value: "v" }]);
+});
+
+test("parseClipboardControlMessage detects official server data requests", () => {
+  const inner = {
+    messageType: GFN_CLIPBOARD_MESSAGE_TYPE,
+    pasteData: { type: CLIPBOARD_SERVER_DATA_REQUEST },
+    tracingData: { requestId: "req-2" },
+  };
+  const outer = {
+    customMessage: JSON.stringify({
+      messageType: GFN_CLIPBOARD_MESSAGE_TYPE,
+      messageRecipient: GFN_CLIPBOARD_SERVER_RECIPIENT,
+      data: JSON.stringify(inner),
+    }),
+  };
+
+  const payload = parseClipboardControlMessage(outer);
+  assert.equal(isClipboardServerDataRequest(payload), true);
+  assert.equal(payload?.tracingData?.requestId, "req-2");
+});
+
+test("clampClipboardText enforces UTF-8 byte limit", () => {
+  assert.equal(clampClipboardText("abc", 3), "abc");
+  assert.equal(clampClipboardText("é", 1), null);
+  assert.equal(clampClipboardText("", 10), null);
+});

--- a/opennow-stable/src/renderer/src/gfn/clipboardProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/clipboardProtocol.ts
@@ -1,0 +1,135 @@
+export const GFN_CLIPBOARD_MESSAGE_TYPE = "PASTE";
+export const GFN_CLIPBOARD_CLIENT_RECIPIENT = "UIPlugin";
+export const GFN_CLIPBOARD_SERVER_RECIPIENT = "GFN_CLIENT_UI";
+
+export const CLIPBOARD_CLIENT_ADDED_DATA = "CLIENT_ADDED_DATA";
+export const CLIPBOARD_CLIENT_REMOVED_DATA = "CLIENT_REMOVED_DATA";
+export const CLIPBOARD_CLIENT_DATA_RESPONSE = "CLIENT_DATA_RESPONSE";
+export const CLIPBOARD_SERVER_DATA_REQUEST = "SERVER_DATA_REQUEST";
+
+export type ClipboardPasteDataType =
+  | typeof CLIPBOARD_CLIENT_ADDED_DATA
+  | typeof CLIPBOARD_CLIENT_REMOVED_DATA
+  | typeof CLIPBOARD_CLIENT_DATA_RESPONSE
+  | typeof CLIPBOARD_SERVER_DATA_REQUEST;
+
+export interface ClipboardTraceContextEntry {
+  key: string;
+  value: string;
+}
+
+export interface ClipboardTracingData {
+  requestId?: string;
+  traceId?: string;
+  traceContext?: ClipboardTraceContextEntry[];
+}
+
+export interface ClipboardPastePayload {
+  messageType: typeof GFN_CLIPBOARD_MESSAGE_TYPE;
+  pasteData?: {
+    type?: ClipboardPasteDataType;
+    data?: string;
+  };
+  tracingData?: ClipboardTracingData;
+}
+
+export interface GfnCustomMessage {
+  messageType: string;
+  messageRecipient: string;
+  data?: string;
+}
+
+export interface GfnControlCustomMessageEnvelope {
+  customMessage: string;
+}
+
+const TRACE_ID_BYTES = 16;
+
+export function clipboardUtf8Size(text: string): number {
+  return new Blob([text]).size;
+}
+
+export function clampClipboardText(text: string, maxBytes: number): string | null {
+  if (!text || maxBytes <= 0 || clipboardUtf8Size(text) > maxBytes) {
+    return null;
+  }
+  return text;
+}
+
+export function createClipboardTraceId(): string {
+  const bytes = new Uint8Array(TRACE_ID_BYTES);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function buildClipboardControlMessage(
+  pasteType: ClipboardPasteDataType,
+  options: {
+    text?: string | null;
+    tracingData?: ClipboardTracingData;
+  } = {},
+): GfnControlCustomMessageEnvelope {
+  const pastePayload: ClipboardPastePayload = {
+    messageType: GFN_CLIPBOARD_MESSAGE_TYPE,
+    pasteData: { type: pasteType },
+    tracingData: {
+      traceId: options.tracingData?.traceId ?? createClipboardTraceId(),
+      traceContext: options.tracingData?.traceContext ?? [],
+      ...(options.tracingData?.requestId ? { requestId: options.tracingData.requestId } : {}),
+    },
+  };
+
+  if (pasteType === CLIPBOARD_CLIENT_DATA_RESPONSE && options.text) {
+    pastePayload.pasteData!.data = options.text;
+  }
+
+  const customMessage: GfnCustomMessage = {
+    messageType: GFN_CLIPBOARD_MESSAGE_TYPE,
+    messageRecipient: GFN_CLIPBOARD_CLIENT_RECIPIENT,
+    data: JSON.stringify(pastePayload),
+  };
+
+  return { customMessage: JSON.stringify(customMessage) };
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseClipboardControlMessage(value: unknown): ClipboardPastePayload | null {
+  const outer = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+  const customMessage = parseJsonObject(outer?.customMessage);
+  if (!customMessage) {
+    return null;
+  }
+
+  if (
+    customMessage.messageType !== GFN_CLIPBOARD_MESSAGE_TYPE
+    || customMessage.messageRecipient !== GFN_CLIPBOARD_SERVER_RECIPIENT
+  ) {
+    return null;
+  }
+
+  const payload = parseJsonObject(customMessage.data);
+  if (!payload || payload.messageType !== GFN_CLIPBOARD_MESSAGE_TYPE) {
+    return null;
+  }
+
+  return payload as unknown as ClipboardPastePayload;
+}
+
+export function isClipboardServerDataRequest(payload: ClipboardPastePayload | null): boolean {
+  return payload?.pasteData?.type === CLIPBOARD_SERVER_DATA_REQUEST;
+}

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -1071,7 +1071,12 @@ export class GfnWebRtcClient {
       return false;
     }
 
-    await this.refreshClipboardAvailability();
+    const available = await this.refreshClipboardAvailability();
+    if (!available) {
+      // Official GFN treats empty/oversized/unreadable clipboard data as a handled no-op.
+      // Do not synthesize Ctrl+V here, or the server can paste stale remote clipboard data.
+      return true;
+    }
     return this.sendPasteShortcut(false);
   }
 

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -36,6 +36,16 @@ import {
 import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "./keyboardLock";
 import { GfnCursorOverlayController } from "./cursorChannel";
 import {
+  buildClipboardControlMessage,
+  clampClipboardText,
+  CLIPBOARD_CLIENT_ADDED_DATA,
+  CLIPBOARD_CLIENT_DATA_RESPONSE,
+  CLIPBOARD_CLIENT_REMOVED_DATA,
+  isClipboardServerDataRequest,
+  parseClipboardControlMessage,
+  type ClipboardTracingData,
+} from "./clipboardProtocol";
+import {
   buildNvstSdp,
   extractIceCredentials,
   fixServerIp,
@@ -93,6 +103,8 @@ interface ConnectedRumbleGamepad {
   gamepad: Gamepad;
   api: GamepadRumbleApi | null;
 }
+
+const DEFAULT_CLIPBOARD_MAX_BYTES = 1024 * 1024;
 
 function hevcPreferredProfileId(colorQuality: ColorQuality): 1 | 2 {
   // 10-bit modes should prefer HEVC Main10 profile-id=2.
@@ -230,6 +242,12 @@ interface ClientOptions {
   mouseAcceleration?: number;
   /** Selected GFN keyboard layout for remote physical OEM key mapping. */
   keyboardLayout?: KeyboardLayout;
+  /** Enable official GFN clipboard custom-message paste support. */
+  clipboardPaste?: boolean;
+  /** Host clipboard reader used for server paste requests. */
+  readClipboardText?: () => Promise<string>;
+  /** Maximum UTF-8 clipboard bytes to advertise/send. */
+  clipboardMaxBytes?: number;
   onLog: (line: string) => void;
   onStats?: (stats: StreamDiagnostics) => void;
   onTimeWarning?: (warning: StreamTimeWarning) => void;
@@ -833,6 +851,9 @@ export class GfnWebRtcClient {
   private mouseAccelerationPercent = 1;
   private keyboardLayout?: KeyboardLayout;
   private autoFullScreenEnabled = true;
+  private clipboardPasteEnabled = false;
+  private clipboardMaxBytes = DEFAULT_CLIPBOARD_MAX_BYTES;
+  private lastAdvertisedClipboardAvailable: boolean | null = null;
 
   private partialReliableThresholdMs = GfnWebRtcClient.DEFAULT_PARTIAL_RELIABLE_THRESHOLD_MS;
   private riInputCapabilities: RiInputCapabilities = {
@@ -940,6 +961,8 @@ export class GfnWebRtcClient {
     this.mouseAccelerationPercent = Math.max(1, Math.min(150, Math.round(options.mouseAcceleration ?? 1)));
     this.keyboardLayout = options.keyboardLayout;
     this.autoFullScreenEnabled = options.autoFullScreen !== false;
+    this.clipboardPasteEnabled = Boolean(options.clipboardPaste);
+    this.clipboardMaxBytes = Math.max(0, Math.trunc(options.clipboardMaxBytes ?? DEFAULT_CLIPBOARD_MAX_BYTES));
 
     // Configure video element for lowest latency playback
     this.configureVideoElementForLowLatency(options.videoElement);
@@ -1015,6 +1038,78 @@ export class GfnWebRtcClient {
   public setAutoFullScreen(value: boolean): void {
     this.autoFullScreenEnabled = Boolean(value);
     this.log(`Auto fullscreen ${this.autoFullScreenEnabled ? "enabled" : "disabled"}`);
+  }
+
+  public setClipboardPasteEnabled(value: boolean): void {
+    const enabled = Boolean(value);
+    if (this.clipboardPasteEnabled === enabled) {
+      return;
+    }
+    this.clipboardPasteEnabled = enabled;
+    this.lastAdvertisedClipboardAvailable = null;
+    void this.refreshClipboardAvailability();
+  }
+
+  public async refreshClipboardAvailability(): Promise<boolean> {
+    if (this.controlChannel?.readyState !== "open") {
+      return false;
+    }
+
+    const text = this.clipboardPasteEnabled ? await this.readClipboardTextForPaste() : null;
+    const available = Boolean(text);
+    if (this.lastAdvertisedClipboardAvailable === available) {
+      return available;
+    }
+
+    this.sendClipboardControlMessage(available ? CLIPBOARD_CLIENT_ADDED_DATA : CLIPBOARD_CLIENT_REMOVED_DATA);
+    this.lastAdvertisedClipboardAvailable = available;
+    return available;
+  }
+
+  public async pasteClipboardText(): Promise<boolean> {
+    if (!this.inputReady || this.controlChannel?.readyState !== "open") {
+      return false;
+    }
+
+    await this.refreshClipboardAvailability();
+    return this.sendPasteShortcut(false);
+  }
+
+  private async readClipboardTextForPaste(): Promise<string | null> {
+    if (!this.clipboardPasteEnabled || !this.options.readClipboardText) {
+      return null;
+    }
+
+    try {
+      const text = await this.options.readClipboardText();
+      return clampClipboardText(text, this.clipboardMaxBytes);
+    } catch (error) {
+      this.log(`Clipboard read failed: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+  }
+
+  private sendClipboardControlMessage(
+    pasteType: typeof CLIPBOARD_CLIENT_ADDED_DATA | typeof CLIPBOARD_CLIENT_REMOVED_DATA | typeof CLIPBOARD_CLIENT_DATA_RESPONSE,
+    text?: string | null,
+    tracingData?: ClipboardTracingData,
+  ): boolean {
+    if (this.controlChannel?.readyState !== "open") {
+      return false;
+    }
+
+    this.controlChannel.send(JSON.stringify(buildClipboardControlMessage(pasteType, { text, tracingData })));
+    return true;
+  }
+
+  private async handleClipboardServerRequest(tracingData?: ClipboardTracingData): Promise<void> {
+    const text = await this.readClipboardTextForPaste();
+    this.sendClipboardControlMessage(
+      text ? CLIPBOARD_CLIENT_DATA_RESPONSE : CLIPBOARD_CLIENT_REMOVED_DATA,
+      text,
+      tracingData,
+    );
+    this.lastAdvertisedClipboardAvailable = Boolean(text);
   }
 
   public suppressNextSyntheticEscapeOnPointerLockLoss(durationMs = 1000): void {
@@ -2886,6 +2981,12 @@ export class GfnWebRtcClient {
       return;
     }
 
+    const clipboardPayload = parseClipboardControlMessage(parsed);
+    if (isClipboardServerDataRequest(clipboardPayload)) {
+      void this.handleClipboardServerRequest(clipboardPayload?.tracingData);
+      return;
+    }
+
     if (!parsed || typeof parsed !== "object" || !("timerNotification" in parsed)) {
       return;
     }
@@ -3950,6 +4051,7 @@ export class GfnWebRtcClient {
       lastAbsX = null;
       lastAbsY = null;
       focusPointerLockTarget();
+      void this.refreshClipboardAvailability();
       // Auto-lock: acquire pointer lock when the user switches back to the app.
       tryAutoLock();
     };
@@ -4464,6 +4566,11 @@ export class GfnWebRtcClient {
 
       this.controlChannel = channel;
       this.controlChannel.binaryType = "arraybuffer";
+      this.controlChannel.onopen = () => {
+        this.log("Control channel open");
+        this.lastAdvertisedClipboardAvailable = null;
+        void this.refreshClipboardAvailability();
+      };
       this.controlChannel.onmessage = (msgEvent) => {
         void this.onControlChannelMessage(msgEvent.data as string | Blob | ArrayBuffer);
       };
@@ -4471,11 +4578,15 @@ export class GfnWebRtcClient {
         this.log("Control channel closed");
         if (this.controlChannel === channel) {
           this.controlChannel = null;
+          this.lastAdvertisedClipboardAvailable = null;
         }
       };
       this.controlChannel.onerror = () => {
         this.log("Control channel error");
       };
+      if (channel.readyState === "open") {
+        this.controlChannel.onopen?.call(channel, new Event("open"));
+      }
     };
 
     pc.onicecandidateerror = (event: Event) => {


### PR DESCRIPTION
This PR implements official-style clipboard paste for OpenNOW using the GFN PASTE custom-message protocol over the data channel, with client-side availability advertisement and server request/response handling that mirrors the official JavaScript client's behavior.

- Added `src/renderer/src/gfn/clipboardProtocol.ts` implementing the GFN PASTE custom-message envelope, CLIENT_ADDED_DATA/CLIENT_REMOVED_DATA/CLIENT_DATA_RESPONSE and SERVER_DATA_REQUEST message types, trace ID generation, and UTF-8 byte size clamping.
- Added `src/renderer/src/gfn/clipboardProtocol.test.ts` with 3 test cases validating message construction and parsing.
- Integrated clipboard availability advertisement in `src/renderer/src/gfn/webrtcClient.ts` via `setClipboardPasteEnabled` and `refreshClipboardAvailability`, and server data request handling in `onControlChannelMessage`, with control channel open/close lifecycle hooks.
- Updated `src/renderer/src/App.tsx` to call `client.pasteClipboardText()` before falling back to `sendText`/`sendPasteShortcut`, and pass `clipboardPaste`/`readClipboardText` options to the client, with runtime setting changes propagated via `setClipboardPasteEnabled`.

### Verification
- npm test -- clipboardProtocol (3 tests pass, 148 total)
- npm run typecheck (no errors)
- npm run lint (0 errors, 35 pre-existing warnings unrelated to this change)

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/b8f70a6a-fb61-4721-a5e2-693d82fc6ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-242" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/b8f70a6a-fb61-4721-a5e2-693d82fc6ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-242&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-242"><img alt="OPE-242" src="https://capy.ai/api/badge/thread.svg?label=OPE-242"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming paste behavior and sends clipboard content over the control channel when enabled, though it remains behind the clipboardPaste setting with legacy fallbacks.
> 
> **Overview**
> Adds **official GFN clipboard paste** over the WebRTC `control_channel` using the **PASTE** custom-message protocol, so paste can follow the same request/response flow as the official client instead of only injecting text or simulating shortcuts.
> 
> A new **`clipboardProtocol`** module builds and parses the PASTE envelope (`CLIENT_ADDED_DATA` / `CLIENT_REMOVED_DATA` / `CLIENT_DATA_RESPONSE` / `SERVER_DATA_REQUEST`), generates trace IDs, and **clamps clipboard text by UTF-8 byte size** (with unit tests).
> 
> **`GfnWebRtcClient`** advertises clipboard availability when the control channel opens and on window focus, answers **server data requests** with host clipboard text, and exposes **`pasteClipboardText()`** (refresh availability then trigger paste). The **`clipboardPaste`** setting is passed in at connect and can be toggled live via **`setClipboardPasteEnabled`**.
> 
> **`App`** routes paste through **`client.pasteClipboardText()`** first, then falls back to **`sendText`** / **`sendPasteShortcut`**. Paste shortcut detection now ignores Shift and treats Ctrl/Cmd consistently; fallback paste shortcut always uses Ctrl.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba0fd1fc034f2bbc4df661568670175f99fd806. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->