### PR TITLE
docs(readme): update mobile info and add download badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@
     <img src="https://img.shields.io/github/v/tag/OpenCloudGaming/OpenNOW?style=for-the-badge&label=Download&color=brightgreen" alt="Download">
   </a>
   <a href="https://testflight.apple.com/join/u1XPJKH2">
-    <img src="https://img.shields.io/badge/TestFlight-Beta-blue.svg?style=for-the-badge&logo=apple" alt="TestFlight">
+    <img src="https://img.shields.io/badge/iOS-TestFlight-0A84FF?style=for-the-badge&logo=apple&logoColor=white" alt="Download OpenNOW on TestFlight">
+  </a>
+  <a href="https://github.com/OpenCloudGaming/OpenNOW-Android/releases">
+    <img src="https://img.shields.io/badge/Android-Download%20Build-3DDC84?style=for-the-badge&logo=android&logoColor=white" alt="Download Android build">
+  </a>
+  <a href="https://github.com/OpenCloudGaming/Opennow-homebrew">
+    <img src="https://img.shields.io/badge/Switch-Port%20Coming%20Soon-E60012?style=for-the-badge&logo=nintendoswitch&logoColor=white" alt="Switch port coming soon">
   </a>
   <a href="https://opennow.zortos.me">
     <img src="https://img.shields.io/badge/Docs-opennow.zortos.me-blue?style=for-the-badge" alt="Documentation">
@@ -56,11 +62,15 @@
 
 ## Overview
 
-OpenNOW is a community-built Electron app for playing GeForce NOW from an open-source desktop client. The active implementation lives in [`opennow-stable/`](opennow-stable), and an iOS SwiftUI prototype lives under [`ios/OpenNOWiOS/`](ios/OpenNOWiOS/).
+OpenNOW is a community-built Electron app for playing GeForce NOW from an open-source desktop client. The active desktop implementation lives in [`opennow-stable/`](opennow-stable).
 
 ## Downloads
 
-Grab the latest desktop build from [GitHub Releases](https://github.com/OpenCloudGaming/OpenNOW/releases). The iOS prototype is available through [TestFlight](https://testflight.apple.com/join/u1XPJKH2).
+Grab the latest desktop build from [GitHub Releases](https://github.com/OpenCloudGaming/OpenNOW/releases).
+
+- iOS beta: [join TestFlight](https://testflight.apple.com/join/u1XPJKH2). The SwiftUI prototype currently lives on the [`kief5555/ios` branch](https://github.com/OpenCloudGaming/OpenNOW/tree/kief5555/ios/ios/OpenNOWiOS) under `ios/OpenNOWiOS/`; that folder is not present on this branch.
+- Android build: [download from OpenNOW-Android](https://github.com/OpenCloudGaming/OpenNOW-Android/releases). iOS and Android are being migrated into their own repositories soon so this desktop repo can stay focused.
+- Nintendo Switch: a homebrew port is coming soon in [OpenCloudGaming/Opennow-homebrew](https://github.com/OpenCloudGaming/Opennow-homebrew), built on top of Moonlight.
 
 For macOS users looking for a more performant OpenNOW version, Jayian1890 maintains the separate [OpenNOW-Mac](https://github.com/OpenCloudGaming/OpenNOW-Mac) repository.
 
@@ -83,7 +93,6 @@ This repository intentionally does not carry duplicate long-form product, setup,
 .
 ├── opennow-stable/          Active Electron desktop client
 ├── native/opennow-streamer/ Native Rust streaming infrastructure
-├── ios/OpenNOWiOS/          Native iOS SwiftUI app prototype
 ├── locales/                 Crowdin-managed localization files
 ├── .github/                 Workflows, templates, and contributor metadata
 ├── AGENTS.md                Repository instructions for AI agents and contributors

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
   <a href="https://testflight.apple.com/join/u1XPJKH2">
     <img src="https://img.shields.io/badge/iOS-TestFlight-0A84FF?style=for-the-badge&logo=apple&logoColor=white" alt="Download OpenNOW on TestFlight">
   </a>
-  <a href="https://github.com/OpenCloudGaming/OpenNOW-Android/releases">
-    <img src="https://img.shields.io/badge/Android-Download%20Build-3DDC84?style=for-the-badge&logo=android&logoColor=white" alt="Download Android build">
+  <a href="https://discord.gg/8EJYaJcNfD">
+    <img src="https://img.shields.io/badge/Android-Discord%20Builds-3DDC84?style=for-the-badge&logo=android&logoColor=white" alt="Download Android builds from Discord">
   </a>
   <a href="https://github.com/OpenCloudGaming/Opennow-homebrew">
     <img src="https://img.shields.io/badge/Switch-Port%20Coming%20Soon-E60012?style=for-the-badge&logo=nintendoswitch&logoColor=white" alt="Switch port coming soon">
@@ -69,7 +69,7 @@ OpenNOW is a community-built Electron app for playing GeForce NOW from an open-s
 Grab the latest desktop build from [GitHub Releases](https://github.com/OpenCloudGaming/OpenNOW/releases).
 
 - iOS beta: [join TestFlight](https://testflight.apple.com/join/u1XPJKH2). The SwiftUI prototype currently lives on the [`kief5555/ios` branch](https://github.com/OpenCloudGaming/OpenNOW/tree/kief5555/ios/ios/OpenNOWiOS) under `ios/OpenNOWiOS/`; that folder is not present on this branch.
-- Android build: [download from OpenNOW-Android](https://github.com/OpenCloudGaming/OpenNOW-Android/releases). iOS and Android are being migrated into their own repositories soon so this desktop repo can stay focused.
+- Android builds: download current test builds from [Discord](https://discord.gg/8EJYaJcNfD). iOS and Android are being migrated into their own repositories soon so this desktop repo can stay focused.
 - Nintendo Switch: a homebrew port is coming soon in [OpenCloudGaming/Opennow-homebrew](https://github.com/OpenCloudGaming/Opennow-homebrew), built on top of Moonlight.
 
 For macOS users looking for a more performant OpenNOW version, Jayian1890 maintains the separate [OpenNOW-Mac](https://github.com/OpenCloudGaming/OpenNOW-Mac) repository.


### PR DESCRIPTION
This PR corrects outdated information regarding iOS and Android presence in this repository and adds badges linking to external mobile/homebrew projects.

- Removed stale `ios/OpenNOWiOS/` references from Overview and Repository Layout sections.
- Updated Downloads section to clarify the iOS SwiftUI prototype lives on the `kief5555/ios` branch, not the default branch.
- Added Downloads bullet linking to the dedicated `OpenNOW-Android` repository and the upcoming `Opennow-homebrew` (Switch) port.
- Added Android and Switch port badges to the header alongside the updated TestFlight badge.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/e46721fc-7a51-4ac6-8ddd-04677f451572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-243" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/e46721fc-7a51-4ac6-8ddd-04677f451572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-243&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-243"><img alt="OPE-243" src="https://capy.ai/api/badge/thread.svg?label=OPE-243"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, build, or security impact.
> 
> **Overview**
> Updates **README** so mobile and platform downloads match how the project is actually split across repos and branches.
> 
> The header gains **Android** and **Switch (coming soon)** badges and restyles the **TestFlight** badge; **Overview** and **Repository layout** no longer imply `ios/OpenNOWiOS/` exists on the default branch. **Downloads** now spells out iOS on the `kief5555/ios` branch, Android via **OpenNOW-Android**, and the upcoming Switch homebrew port, plus a note that mobile is moving out of this desktop repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea5e3602210d8576c533a83f451bcbf808a5ac97. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->