### PR TITLE
fix: Steam Controller 2026 not recognized on Mac

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -131,7 +131,11 @@ app.commandLine.appendSwitch(
   videoAccelerationCommandLine.enableFeatures.join(","),
 );
 
-app.commandLine.appendSwitch("disable-features", videoAccelerationCommandLine.disableFeatures.join(","));
+const disableFeatures = [
+  ...videoAccelerationCommandLine.disableFeatures,
+  "XboxUseGameControllerDataFetcherMac",
+];
+app.commandLine.appendSwitch("disable-features", disableFeatures.join(","));
 
 app.commandLine.appendSwitch(
   "force-fieldtrials",


### PR DESCRIPTION
## Root Cause

The break was caused by an **Electron upgrade from 41 → 42** (Chromium 132 → 135).

In Chromium 135 enabled the feature flag `kXboxUseGameControllerDataFetcherMac` **by default**. This flag routes Xbox controllers through Apple's `GCController` framework on macOS. The Steam Controller's vendor ID (0x28DE) is similar enough to Xbox patterns that Chromium's mutual-exclusion logic blocks the Steam Controller from the raw HID gamepad data fetcher, while GCController doesn't know how to talk to it either.

The result: the controller is invisible to the Web Gamepad API on Chromium 135+.

## Investigation

- Tested upstream Electron 41 (works) vs 42 (broken)
- Tested pure Chromium 132 (works) vs 150 (broken)
- Confirmed Safari also doesn't work (uses GCController natively)
- Traced the Chromium regression to `device/gamepad/` changes in the Chromium commit `7707970` (April 2026)

# Description

Fix #582.

Disable `XboxUseGameControllerDataFetcherMac` via Chromium's `--disable-features` flag. This forces Chromium to use the original IOKit HID data fetcher path, which correctly handles the Steam Controller.

**Change:** Append `XboxUseGameControllerDataFetcherMac` to the existing `disable-features` command-line switch in the Electron main process.

