### PR TITLE
feat(input): add macOS Steam Controller compatibility toggle

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -571,6 +571,8 @@
       "clipboardPaste": "Clipboard Paste",
       "gyroscopeControls": "Gyroscope Controls",
       "gyroscopeControlsHint": "Expose controller motion sensors for gyro aiming when the input backend supports it.",
+      "steamControllerCompatibilityMode": "Steam Controller Compatibility Mode",
+      "steamControllerCompatibilityModeHint": "macOS only. Restores Chromium's older HID gamepad path for Steam Controller, but may reduce Xbox controller compatibility. Applies after app restart.",
       "nativeCursorOverlay": "Native Cursor Overlay",
       "nativeCursorOverlayHint": "WebRTC only. Uses NVIDIA's cursor_channel for a local cursor overlay; turn this off to leave cursor rendering to the server-side stream.",
       "keyboardLayoutHint": "Controls how your physical keyboard is mapped inside the remote session. Separate from the in-game language setting.",

--- a/opennow-stable/src/main/chromiumCommandLine.test.ts
+++ b/opennow-stable/src/main/chromiumCommandLine.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildChromiumCommandLine,
+  MAC_STEAM_CONTROLLER_COMPATIBILITY_DISABLED_FEATURE,
+  normalizeBootstrapChromiumPreferences,
+} from "./chromiumCommandLine";
+
+test("normalizes bootstrap Chromium preferences", () => {
+  assert.deepEqual(
+    normalizeBootstrapChromiumPreferences({
+      decoderPreference: "hardware",
+      encoderPreference: "software",
+      steamControllerCompatibilityMode: true,
+    }),
+    {
+      decoderPreference: "hardware",
+      encoderPreference: "software",
+      steamControllerCompatibilityMode: true,
+    },
+  );
+
+  assert.deepEqual(
+    normalizeBootstrapChromiumPreferences({
+      decoderPreference: "invalid",
+      encoderPreference: false,
+      steamControllerCompatibilityMode: "true",
+    }),
+    {
+      decoderPreference: "auto",
+      encoderPreference: "auto",
+      steamControllerCompatibilityMode: false,
+    },
+  );
+});
+
+test("adds Steam Controller compatibility feature disable only on macOS when enabled", () => {
+  const preferences = normalizeBootstrapChromiumPreferences({
+    steamControllerCompatibilityMode: true,
+  });
+
+  assert.equal(
+    buildChromiumCommandLine(preferences, "darwin", "arm64").disableFeatures.includes(
+      MAC_STEAM_CONTROLLER_COMPATIBILITY_DISABLED_FEATURE,
+    ),
+    true,
+  );
+  assert.equal(
+    buildChromiumCommandLine(preferences, "linux", "x64").disableFeatures.includes(
+      MAC_STEAM_CONTROLLER_COMPATIBILITY_DISABLED_FEATURE,
+    ),
+    false,
+  );
+  assert.equal(
+    buildChromiumCommandLine(
+      { ...preferences, steamControllerCompatibilityMode: false },
+      "darwin",
+      "arm64",
+    ).disableFeatures.includes(MAC_STEAM_CONTROLLER_COMPATIBILITY_DISABLED_FEATURE),
+    false,
+  );
+});

--- a/opennow-stable/src/main/chromiumCommandLine.ts
+++ b/opennow-stable/src/main/chromiumCommandLine.ts
@@ -1,0 +1,56 @@
+import type { VideoAccelerationPreference } from "@shared/gfn";
+import {
+  buildVideoAccelerationCommandLine,
+  isAccelerationPreference,
+  type VideoAccelerationCommandLine,
+} from "./videoAcceleration";
+
+export const MAC_STEAM_CONTROLLER_COMPATIBILITY_DISABLED_FEATURE =
+  "XboxUseGameControllerDataFetcherMac";
+
+export interface BootstrapChromiumPreferences {
+  decoderPreference: VideoAccelerationPreference;
+  encoderPreference: VideoAccelerationPreference;
+  steamControllerCompatibilityMode: boolean;
+}
+
+export function normalizeBootstrapChromiumPreferences(raw: unknown): BootstrapChromiumPreferences {
+  const defaults: BootstrapChromiumPreferences = {
+    decoderPreference: "auto",
+    encoderPreference: "auto",
+    steamControllerCompatibilityMode: false,
+  };
+  if (!raw || typeof raw !== "object") {
+    return defaults;
+  }
+
+  const parsed = raw as Partial<BootstrapChromiumPreferences>;
+  return {
+    decoderPreference: isAccelerationPreference(parsed.decoderPreference)
+      ? parsed.decoderPreference
+      : defaults.decoderPreference,
+    encoderPreference: isAccelerationPreference(parsed.encoderPreference)
+      ? parsed.encoderPreference
+      : defaults.encoderPreference,
+    steamControllerCompatibilityMode: parsed.steamControllerCompatibilityMode === true,
+  };
+}
+
+export function buildChromiumCommandLine(
+  preferences: BootstrapChromiumPreferences,
+  platform: NodeJS.Platform,
+  arch: NodeJS.Architecture,
+): VideoAccelerationCommandLine {
+  const commandLine = buildVideoAccelerationCommandLine(preferences, platform, arch);
+  if (platform !== "darwin" || !preferences.steamControllerCompatibilityMode) {
+    return commandLine;
+  }
+
+  return {
+    ...commandLine,
+    disableFeatures: [
+      ...commandLine.disableFeatures,
+      MAC_STEAM_CONTROLLER_COMPATIBILITY_DISABLED_FEATURE,
+    ],
+  };
+}

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -78,10 +78,10 @@ import {
 } from "./services/printedWaste";
 import { pingRegions } from "./services/regionPing";
 import {
-  buildVideoAccelerationCommandLine,
-  isAccelerationPreference,
-  type BootstrapVideoPreferences,
-} from "./videoAcceleration";
+  buildChromiumCommandLine,
+  normalizeBootstrapChromiumPreferences,
+  type BootstrapChromiumPreferences,
+} from "./chromiumCommandLine";
 import {
   nextPointerLockEscapeCaptureUntilMs,
   shouldCaptureEscapeFullscreenInput,
@@ -92,51 +92,42 @@ import { getReleaseHighlightsPayload, shouldShowReleaseHighlights } from "./rele
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Configure Chromium video and WebRTC behavior before app.whenReady().
+// Configure Chromium video, WebRTC, and input behavior before app.whenReady().
 
-function loadBootstrapVideoPreferences(): BootstrapVideoPreferences {
-  const defaults: BootstrapVideoPreferences = {
-    decoderPreference: "auto",
-    encoderPreference: "auto",
-  };
+function loadBootstrapChromiumPreferences(): BootstrapChromiumPreferences {
   try {
     const settingsPath = join(app.getPath("userData"), "settings.json");
     if (!existsSync(settingsPath)) {
-      return defaults;
+      return normalizeBootstrapChromiumPreferences(null);
     }
-    const parsed = JSON.parse(
-      readFileSync(settingsPath, "utf-8"),
-    ) as Partial<BootstrapVideoPreferences>;
-    return {
-      decoderPreference: isAccelerationPreference(parsed.decoderPreference)
-        ? parsed.decoderPreference
-        : defaults.decoderPreference,
-      encoderPreference: isAccelerationPreference(parsed.encoderPreference)
-        ? parsed.encoderPreference
-        : defaults.encoderPreference,
-    };
+    return normalizeBootstrapChromiumPreferences(
+      JSON.parse(readFileSync(settingsPath, "utf-8")),
+    );
   } catch {
-    return defaults;
+    return normalizeBootstrapChromiumPreferences(null);
   }
 }
 
-const bootstrapVideoPrefs = loadBootstrapVideoPreferences();
+const bootstrapChromiumPrefs = loadBootstrapChromiumPreferences();
 console.log(
-  `[Main] Video acceleration preference: decode=${bootstrapVideoPrefs.decoderPreference}, encode=${bootstrapVideoPrefs.encoderPreference}`,
+  `[Main] Video acceleration preference: decode=${bootstrapChromiumPrefs.decoderPreference}, encode=${bootstrapChromiumPrefs.encoderPreference}`,
 );
 
-const videoAccelerationCommandLine = buildVideoAccelerationCommandLine(
-  bootstrapVideoPrefs,
+const chromiumCommandLine = buildChromiumCommandLine(
+  bootstrapChromiumPrefs,
   process.platform,
   process.arch,
 );
 
 app.commandLine.appendSwitch(
   "enable-features",
-  videoAccelerationCommandLine.enableFeatures.join(","),
+  chromiumCommandLine.enableFeatures.join(","),
 );
 
-app.commandLine.appendSwitch("disable-features", videoAccelerationCommandLine.disableFeatures.join(","));
+app.commandLine.appendSwitch(
+  "disable-features",
+  chromiumCommandLine.disableFeatures.join(","),
+);
 
 app.commandLine.appendSwitch(
   "force-fieldtrials",
@@ -146,7 +137,7 @@ app.commandLine.appendSwitch(
   ].join("/"),
 );
 
-for (const [name, value] of Object.entries(videoAccelerationCommandLine.switches)) {
+for (const [name, value] of Object.entries(chromiumCommandLine.switches)) {
   if (value === true) {
     app.commandLine.appendSwitch(name);
   } else {

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -70,6 +70,8 @@ export interface Settings {
   clipboardPaste: boolean;
   /** Enable experimental gyroscope controller input mapping */
   enableGyroscopeControls: boolean;
+  /** macOS-only workaround that restores Chromium's older HID path for Steam Controller compatibility */
+  steamControllerCompatibilityMode: boolean;
   /** Use the WebRTC cursor_channel overlay instead of leaving cursor rendering to the stream */
   nativeCursorOverlay: boolean;
   /** Mouse sensitivity multiplier */
@@ -198,6 +200,7 @@ const DEFAULT_SETTINGS: Settings = {
   sessionProxyUrl: "",
   clipboardPaste: false,
   enableGyroscopeControls: false,
+  steamControllerCompatibilityMode: false,
   nativeCursorOverlay: true,
   mouseSensitivity: 1,
   mouseAcceleration: 1,
@@ -352,6 +355,11 @@ export class SettingsManager {
     const recordingBitrate = normalizeRecordingBitrateMbps(settings.recordingBitrateMbps);
     if (settings.recordingBitrateMbps !== recordingBitrate) {
       settings.recordingBitrateMbps = recordingBitrate;
+      migrated = true;
+    }
+
+    if (typeof settings.steamControllerCompatibilityMode !== "boolean") {
+      settings.steamControllerCompatibilityMode = false;
       migrated = true;
     }
 

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -434,6 +434,7 @@ export function App(): JSX.Element {
     sessionProxyUrl: "",
     clipboardPaste: false,
     enableGyroscopeControls: false,
+    steamControllerCompatibilityMode: false,
     nativeCursorOverlay: true,
     mouseSensitivity: 1,
     mouseAcceleration: 1,

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -191,6 +191,13 @@ const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string
     "gamepad",
     "gyro",
     "gyroscope",
+    "steam",
+    "steam controller",
+    "xbox",
+    "compatibility",
+    "gamecontroller",
+    "hid",
+    "macos",
     "motion controls",
     "anti afk",
     "pointer lock",
@@ -3474,6 +3481,28 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                   </div>
                   <span className="settings-subtle-hint">{t("settings.input.gyroscopeControlsHint")}</span>
                 </div>
+
+                {isMac && (
+                  <div className="settings-row settings-row--column">
+                    <div className="settings-row-top settings-row-top--compact">
+                      <label className="settings-label settings-label--wrap">
+                        <span className="settings-label-title">
+                          {t("settings.input.steamControllerCompatibilityMode")}
+                          <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span>
+                        </span>
+                      </label>
+                      <label className="settings-toggle">
+                        <input
+                          type="checkbox"
+                          checked={settings.steamControllerCompatibilityMode}
+                          onChange={(e) => handleChange("steamControllerCompatibilityMode", e.target.checked)}
+                        />
+                        <span className="settings-toggle-track" />
+                      </label>
+                    </div>
+                    <span className="settings-subtle-hint">{t("settings.input.steamControllerCompatibilityModeHint")}</span>
+                  </div>
+                )}
 
                 <div className="settings-row settings-row--column">
                   <div className="settings-row-top settings-row-top--compact">

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -271,6 +271,8 @@ export interface Settings {
   clipboardPaste: boolean;
   /** Enable experimental gyroscope controller input mapping */
   enableGyroscopeControls: boolean;
+  /** macOS-only workaround that restores Chromium's older HID path for Steam Controller compatibility */
+  steamControllerCompatibilityMode: boolean;
   /** Use the WebRTC cursor_channel overlay instead of leaving cursor rendering to the stream. */
   nativeCursorOverlay: boolean;
   mouseSensitivity: number;


### PR DESCRIPTION
This PR adds an experimental macOS-only Input setting that restores Chromium's older HID gamepad path to fix Steam Controller recognition on Electron 42.3.3 (Chromium 135), which broke compatibility by enabling `kXboxUseGameControllerDataFetcherMac` by default. The setting is opt-in, defaults to off, applies after app restart, and includes a warning about potential Xbox controller compatibility trade-offs.

- Added `opennow-stable/src/main/chromiumCommandLine.ts` with `buildChromiumCommandLine` to conditionally append `XboxUseGameControllerDataFetcherMac` to `disable-features` on macOS when the setting is enabled.
- Added `steamControllerCompatibilityMode` to `Settings` interface in `opennow-stable/src/main/settings.ts` and `opennow-stable/src/shared/gfn.ts`, with normalization and migration to ensure boolean type.
- Updated `opennow-stable/src/main/index.ts` to use the new command-line builder and bootstrap preferences loader on startup.
- Added macOS-only toggle in Input settings in `opennow-stable/src/renderer/src/components/SettingsPage.tsx` with experimental badge and hint explaining the trade-offs.
- Added English localization strings for the new setting.
- Added unit tests for Chromium command-line building and preference normalization.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/927f8b88-babc-4e66-ab8a-deeac4825067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-245" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/927f8b88-babc-4e66-ab8a-deeac4825067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-245&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-245"><img alt="OPE-245" src="https://capy.ai/api/badge/thread.svg?label=OPE-245"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level gamepad discovery via Chromium flags at process start; opt-in and restart-bound, but wrong platform/state could affect Xbox vs Steam Controller behavior.
> 
> **Overview**
> Adds an **opt-in, macOS-only** Input setting **Steam Controller Compatibility Mode** (default off) that takes effect after restart.
> 
> Startup Chromium flags are built through a new `buildChromiumCommandLine` path: when the toggle is on on **darwin**, it appends **`XboxUseGameControllerDataFetcherMac`** to `disable-features` so Chromium uses the older HID gamepad path for Steam Controller, with UI copy warning this may hurt Xbox controller compatibility.
> 
> The setting is wired through shared types, `settings.json` defaults/migration, bootstrap preference loading in main, a macOS-only experimental toggle in Input settings (plus search keywords and English strings), and unit tests for normalization and platform-gated feature flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57319d1f0af88dab868ea6e8215958f62721e953. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->