### PR TITLE
fix(ci): update GStreamer, fix macOS signing, and target main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
       npm_config_audit: "false"
       npm_config_fund: "false"
       GSTREAMER_VERSION: "1.28.2"
-      GSTREAMER_WINDOWS_VERSION: "1.26.1"
+      GSTREAMER_WINDOWS_VERSION: "1.26.8"
       CARGO_NET_RETRY: "10"
       CARGO_HTTP_MULTIPLEXING: "false"
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
@@ -648,7 +648,7 @@ jobs:
           if [[ "$REF_TYPE" == "branch" ]]; then
             branch="$REF_NAME"
           else
-            branch="dev"
+            branch="main"
           fi
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 

--- a/opennow-stable/scripts/after-sign-mac.mjs
+++ b/opennow-stable/scripts/after-sign-mac.mjs
@@ -12,7 +12,7 @@ export default async function afterSign({ appOutDir, packager }) {
     "--force",
     "--deep",
     "--sign", "-",
-    "--requirements", `designated => identifier "${bundleId}"`,
+    "--requirements", `=designated => identifier "${bundleId}"`,
     appPath,
   ]);
 }


### PR DESCRIPTION
This PR fixes failing release CI jobs on Windows and macOS.

- Update `GSTREAMER_WINDOWS_VERSION` from 1.26.1 to 1.26.8 in `.github/workflows/release.yml` to resolve 404 errors during Windows GStreamer SDK download.
- Fix `codesign` requirement syntax in `opennow-stable/scripts/after-sign-mac.mjs` by prefixing with `=` to ensure valid requirement specification on macOS.
- Change fallback branch in `finalize-version-bump` job from `dev` to `main`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/7daa0f26-75bc-4bae-9575-040998c83663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-246" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/7daa0f26-75bc-4bae-9575-040998c83663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-246&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-246"><img alt="OPE-246" src="https://capy.ai/api/badge/thread.svg?label=OPE-246"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release workflow configuration and the macOS after-sign script; no application runtime or security-sensitive product logic is modified.
> 
> **Overview**
> **Unblocks failing release builds** on Windows and macOS by adjusting CI env and the ad-hoc macOS sign hook.
> 
> The release workflow bumps **`GSTREAMER_WINDOWS_VERSION`** from `1.26.1` to `1.26.8` so the Windows GStreamer MSI download URLs resolve instead of 404ing. In **`after-sign-mac.mjs`**, the `codesign --requirements` string is prefixed with `=` so the requirement expression is valid when CI uses ad-hoc signing (`CSC_IDENTITY_AUTO_DISCOVERY=false`). The **`finalize-version-bump`** job now falls back to **`main`** instead of **`dev`** when the release was triggered from a tag rather than a branch, so the post-release version commit targets the correct default branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a907d7b516d32194d2c67f264d4e46bc0292883. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the native Windows build to use a newer bundled media SDK version.
  * Improved release automation so branch selection falls back to the main branch when no branch context is available.
  * Adjusted macOS code-signing requirements formatting to better align with signing expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->