### PR TITLE
Reflect name/UI changes in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,7 +47,7 @@ body:
       description: |
         Please export and attach your logs:
         1. Open Settings (gear icon)
-        2. Scroll to Troubleshooting section
+        2. Go to the "About" tab
         3. Click "Export Logs"
         4. Drag the exported .log file here or paste its contents
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions
-    url: https://github.com/zortos293/GFNClient/discussions
+    url: https://github.com/OpenCloudGaming/OpenNOW/discussions
     about: For general discussions, ideas, and community support
   - name: GeForce NOW Official
     url: https://www.nvidia.com/en-us/geforce-now/

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,5 +1,5 @@
 name: Question
-description: Ask a question about GFNClient
+description: Ask a question about OpenNOW
 labels: ["question"]
 body:
   - type: textarea


### PR DESCRIPTION
## Description

* Update the link in config.yml according to the new URL
* Change the guidance to exporting logs in bug_report.yml according to new UI
* Replace old "GFNClient" residual name with new 'OpenNOW" in question.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report template so the log collection steps now point users to the **About** tab.
  * Refreshed the question template text to use **OpenNOW** naming.
  * Updated the community/discussions link to the project’s current discussions page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->