### PR TITLE
fix(webrtc): resolve native cursor drift with absolute positioning

### DIFF
--- a/opennow-stable/src/renderer/src/gfn/cursorChannel.ts
+++ b/opennow-stable/src/renderer/src/gfn/cursorChannel.ts
@@ -302,6 +302,34 @@ export class GfnCursorOverlayController {
     return true;
   }
 
+  public isCursorVisible(): boolean {
+    return this.cursorVisible;
+  }
+
+  /**
+   * Current overlay cursor position inside the letterboxed stream viewport,
+   * plus the viewport extent, both in CSS pixels. Used to drive absolute mouse
+   * position packets (input type 5) so the server cursor matches the overlay
+   * exactly, mirroring the official client's local-cursor mode.
+   */
+  public getAbsolutePosition(): { x: number; y: number; width: number; height: number } | null {
+    const viewport = this.getViewport();
+    if (viewport.width <= 0 || viewport.height <= 0) {
+      return null;
+    }
+    if (!this.positionInitialized) {
+      this.positionX = viewport.width / 2;
+      this.positionY = viewport.height / 2;
+      this.positionInitialized = true;
+    }
+    return {
+      x: Math.max(0, Math.min(viewport.width, this.positionX)),
+      y: Math.max(0, Math.min(viewport.height, this.positionY)),
+      width: viewport.width,
+      height: viewport.height,
+    };
+  }
+
   public moveBy(dx: number, dy: number): void {
     if (!this.cursorVisible || !Number.isFinite(dx) || !Number.isFinite(dy)) {
       return;

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.test.ts
@@ -21,6 +21,7 @@ import {
   INPUT_KEY_UP,
   INPUT_LOCK_KEYS_SYNC,
   INPUT_MOUSE_BUTTON_DOWN,
+  INPUT_MOUSE_ABS,
   INPUT_MOUSE_REL,
   INPUT_MOUSE_WHEEL,
   INPUT_TEXT,
@@ -261,6 +262,48 @@ test("encodes mouse move with v3 cursor wrapper and inner payload", () => {
   assert.equal(payload.getBigUint64(14, false), 99n);
 });
 
+test("encodes absolute mouse position matching the official 26-byte layout", () => {
+  const encoder = new InputEncoder();
+  const bytes = encoder.encodeMouseAbsolute({
+    x: 321.4,
+    y: 179.6,
+    width: 1280,
+    height: 720,
+    timestampUs: 77n,
+  });
+  assert.equal(bytes.byteLength, 26);
+  const payload = view(bytes);
+
+  assert.equal(payload.getUint32(0, true), INPUT_MOUSE_ABS);
+  assert.equal(payload.getUint16(4, false), 321);
+  assert.equal(payload.getUint16(6, false), 180);
+  assert.equal(payload.getUint16(8, false), 0);
+  assert.equal(payload.getUint16(10, false), 1280);
+  assert.equal(payload.getUint16(12, false), 720);
+  assert.equal(payload.getUint32(14, false), 0);
+  assert.equal(payload.getBigUint64(18, false), 77n);
+});
+
+test("encodes absolute mouse position with v3 cursor wrapper and clamped coords", () => {
+  const encoder = new InputEncoder();
+  encoder.setProtocolVersion(3);
+  const bytes = encoder.encodeMouseAbsolute({
+    x: -5,
+    y: 99999,
+    width: 1920,
+    height: 1080,
+    timestampUs: 42n,
+  });
+  const payload = assertV3BatchWrapper(bytes, 0x21, 10, 12, 26);
+
+  assert.equal(payload.getUint32(0, true), INPUT_MOUSE_ABS);
+  assert.equal(payload.getUint16(4, false), 0);
+  assert.equal(payload.getUint16(6, false), 65535);
+  assert.equal(payload.getUint16(10, false), 1920);
+  assert.equal(payload.getUint16(12, false), 1080);
+  assert.equal(payload.getBigUint64(18, false), 42n);
+});
+
 test("encodes mouse button and wheel with v3 single-event wrapper", () => {
   const encoder = new InputEncoder();
   encoder.setProtocolVersion(3);
@@ -379,11 +422,12 @@ test("encodes gamepad state with reliable and partially reliable v3 wrappers", (
   }
 });
 
-test("partially reliable HID helpers only mark mouse-relative input eligible", () => {
+test("partially reliable HID helpers only mark mouse move input eligible", () => {
   assert.equal(partiallyReliableHidMaskForInputType(INPUT_MOUSE_REL), 1 << INPUT_MOUSE_REL);
   assert.equal(partiallyReliableHidMaskForInputType(-1), 0);
   assert.equal(partiallyReliableHidMaskForInputType(32), 0);
   assert.equal(isPartiallyReliableHidTransferEligible(INPUT_MOUSE_REL), true);
+  assert.equal(isPartiallyReliableHidTransferEligible(INPUT_MOUSE_ABS), true);
   assert.equal(isPartiallyReliableHidTransferEligible(INPUT_MOUSE_BUTTON_DOWN), false);
   assert.equal(isPartiallyReliableHidTransferEligible(INPUT_GAMEPAD), false);
 });

--- a/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
+++ b/opennow-stable/src/renderer/src/gfn/inputProtocol.ts
@@ -5,6 +5,7 @@ export const INPUT_KEY_DOWN = 3;
 export const INPUT_KEY_UP = 4;
 /** Lock-key state sync (Caps/Num/Scroll), matches official GFN Cc()/Ic() type 19. */
 export const INPUT_LOCK_KEYS_SYNC = 19;
+export const INPUT_MOUSE_ABS = 5;
 export const INPUT_MOUSE_REL = 7;
 export const INPUT_MOUSE_BUTTON_DOWN = 8;
 export const INPUT_MOUSE_BUTTON_UP = 9;
@@ -173,6 +174,19 @@ export interface MouseMovePayload {
   timestampUs: bigint;
 }
 
+/**
+ * Absolute mouse position (input type 5). Coordinates are expressed inside a
+ * client-defined extent (`width`/`height`) that the server uses to scale onto
+ * the remote desktop, mirroring the official client's Hc() encoder.
+ */
+export interface MouseAbsolutePayload {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  timestampUs: bigint;
+}
+
 export interface MouseButtonPayload {
   button: number;
   timestampUs: bigint;
@@ -204,7 +218,7 @@ export function partiallyReliableHidMaskForInputType(inputType: number): number 
 }
 
 export function isPartiallyReliableHidTransferEligible(inputType: number): boolean {
-  return inputType === INPUT_MOUSE_REL;
+  return inputType === INPUT_MOUSE_REL || inputType === INPUT_MOUSE_ABS;
 }
 
 export interface KeyMapping {
@@ -863,6 +877,22 @@ export class InputEncoder {
     return wrapMouseMoveEvent(bytes, this.protocolVersion);
   }
 
+  encodeMouseAbsolute(payload: MouseAbsolutePayload): Uint8Array {
+    const bytes = new Uint8Array(26);
+    const view = new DataView(bytes.buffer);
+    // Official client Hc() with absolute flag (opcode 5, 26 bytes):
+    // [type 4B LE][x 2B BE][y 2B BE][reserved 2B BE][width 2B BE][height 2B BE][reserved 4B BE][timestamp 8B BE]
+    view.setUint32(0, INPUT_MOUSE_ABS, true);             // type: LE
+    view.setUint16(4, clampU16(payload.x), false);         // x: BE
+    view.setUint16(6, clampU16(payload.y), false);         // y: BE
+    view.setUint16(8, 0, false);                           // reserved: BE
+    view.setUint16(10, clampU16(payload.width), false);    // extent width: BE
+    view.setUint16(12, clampU16(payload.height), false);   // extent height: BE
+    view.setUint32(14, 0, false);                          // reserved: BE
+    view.setBigUint64(18, payload.timestampUs, false);     // timestamp: BE
+    return wrapMouseMoveEvent(bytes, this.protocolVersion);
+  }
+
   encodeMouseButtonDown(payload: MouseButtonPayload): Uint8Array {
     return this.encodeMouseButton(INPUT_MOUSE_BUTTON_DOWN, payload);
   }
@@ -1006,6 +1036,10 @@ export class InputEncoder {
     view.setBigUint64(10, payload.timestampUs, false);    // timestamp: BE
     return wrapSingleEvent(bytes, this.protocolVersion);
   }
+}
+
+function clampU16(value: number): number {
+  return Math.max(0, Math.min(65535, Math.round(value)));
 }
 
 function textInputChunkLength(bytes: Uint8Array, offset: number): number {

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -13,6 +13,7 @@ import type {
 import {
   InputEncoder,
   INPUT_MOUSE_REL,
+  INPUT_MOUSE_ABS,
   PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
   PARTIALLY_RELIABLE_HID_DEVICE_MASK_ALL,
   partiallyReliableHidMaskForInputType,
@@ -765,6 +766,14 @@ export class GfnWebRtcClient {
   private gamepadPollTimer: number | null = null;
   private pendingMouseDxFloat = 0;
   private pendingMouseDyFloat = 0;
+  /**
+   * Latest overlay cursor position awaiting an absolute mouse packet (input
+   * type 5). Used while the cursor_channel overlay cursor is visible so the
+   * server cursor is pinned to the overlay position instead of drifting on
+   * accumulated relative deltas. Latest position wins, like the official
+   * client's batch coalescing.
+   */
+  private pendingMouseAbs: { x: number; y: number; width: number; height: number } | null = null;
   private inputCleanup: Array<() => void> = [];
   private queuedCandidates: RTCIceCandidateInit[] = [];
 
@@ -2107,6 +2116,7 @@ export class GfnWebRtcClient {
     this.gamepadBitmap = 0;
     this.pendingMouseDxFloat = 0;
     this.pendingMouseDyFloat = 0;
+    this.pendingMouseAbs = null;
     this.pendingMouseTimestampUs = null;
     this.mouseDeltaFilter.reset();
     this.mouseFlushLastSendMs = 0;
@@ -3426,6 +3436,7 @@ export class GfnWebRtcClient {
     this.mouseCoalescedBatchEntries = 0;
     this.pendingMouseDxFloat = 0;
     this.pendingMouseDyFloat = 0;
+    this.pendingMouseAbs = null;
     this.pendingMouseTimestampUs = null;
     this.mousePacketsPerSecond = 0;
     this.mousePacketsSentInWindow = 0;
@@ -3492,12 +3503,51 @@ export class GfnWebRtcClient {
     let lastPointerClientY = Number.NaN;
 
     const hasPendingMouseMovement = (): boolean =>
-      Math.abs(this.pendingMouseDxFloat) >= 0.5 || Math.abs(this.pendingMouseDyFloat) >= 0.5;
+      this.pendingMouseAbs !== null
+      || Math.abs(this.pendingMouseDxFloat) >= 0.5
+      || Math.abs(this.pendingMouseDyFloat) >= 0.5;
+
+    const markServerCursorAt = (abs: { x: number; y: number; width: number; height: number }): void => {
+      // An absolute packet pins the server cursor exactly; keep the simulated
+      // server-pixel baseline in sync for the pointer-lock entry alignment path.
+      const { serverWidth, serverHeight } = getPointerScale();
+      simulatedAbsX = Math.round((abs.x / abs.width) * serverWidth);
+      simulatedAbsY = Math.round((abs.y / abs.height) * serverHeight);
+    };
 
     const flushMouse = (): boolean => {
       const tickNow = performance.now();
       if (!this.inputReady || !hasPendingMouseMovement()) {
         return false;
+      }
+
+      if (this.pendingMouseAbs !== null) {
+        const abs = this.pendingMouseAbs;
+        this.pendingMouseAbs = null;
+        // Movement was already consumed by the overlay position; drop any
+        // stale relative residue so it cannot double-apply after this packet.
+        this.pendingMouseDxFloat = 0;
+        this.pendingMouseDyFloat = 0;
+
+        const expectedSendAt = this.mouseFlushLastSendMs + this.mouseFlushIntervalMs;
+        this.inputQueueMaxSchedulingDelayMsWindow = Math.max(
+          this.inputQueueMaxSchedulingDelayMsWindow,
+          Math.max(0, tickNow - expectedSendAt),
+        );
+
+        const payload = this.inputEncoder.encodeMouseAbsolute({
+          ...abs,
+          timestampUs: this.pendingMouseTimestampUs ?? timestampUs(),
+        });
+        this.pendingMouseTimestampUs = null;
+        this.mouseCoalescedBatchEntries = 0;
+        this.sendInputPacket(payload, INPUT_MOUSE_ABS);
+        this.mousePacketsSentInWindow += 1;
+        this.mouseFlushLastSendMs = tickNow;
+        updateMousePacketRate();
+        this.mouseAdaptiveFlushActive = false;
+        markServerCursorAt(abs);
+        return true;
       }
 
       const { scaleX, scaleY } = getPointerScale();
@@ -3618,43 +3668,57 @@ export class GfnWebRtcClient {
         if (typeof targetAbsX === "number" && typeof targetAbsY === "number") {
           const targetRect = pointerLockTarget.getBoundingClientRect();
           this.cursorOverlay?.setClientPosition(targetRect.left + targetAbsX, targetRect.top + targetAbsY);
+          const overlayAbs = this.cursorOverlay?.isCursorVisible()
+            ? this.cursorOverlay.getAbsolutePosition()
+            : null;
           const { scaleX, scaleY, serverWidth, serverHeight } = getPointerScale();
 
-          // Translate the element-local target into server pixels.
-          const targetServerX = Math.round(targetAbsX * scaleX);
-          const targetServerY = Math.round(targetAbsY * scaleY);
-
-          if (simulatedAbsX === null || simulatedAbsY === null) {
-            // No baseline known: assume server cursor is centered and move from
-            // center -> target in server pixels so remote cursor matches HW cursor.
-            const baselineXServer = Math.round(serverWidth / 2);
-            const baselineYServer = Math.round(serverHeight / 2);
-            const dx = Math.round(targetServerX - baselineXServer);
-            const dy = Math.round(targetServerY - baselineYServer);
-            if (dx !== 0 || dy !== 0) {
-              const movePayload = this.inputEncoder.encodeMouseMove({
-                dx: Math.max(-32768, Math.min(32767, dx)),
-                dy: Math.max(-32768, Math.min(32767, dy)),
-                timestampUs: timestampUs(),
-              });
-              this.sendReliable(movePayload);
-            }
-            // Record simulated baseline in server pixels.
-            simulatedAbsX = targetServerX;
-            simulatedAbsY = targetServerY;
+          if (overlayAbs) {
+            // Overlay cursor is visible: pin the server cursor with one
+            // absolute packet instead of simulating relative moves.
+            const movePayload = this.inputEncoder.encodeMouseAbsolute({
+              ...overlayAbs,
+              timestampUs: timestampUs(),
+            });
+            this.sendReliable(movePayload);
+            markServerCursorAt(overlayAbs);
           } else {
-            // sim values are stored in server pixels now; compute server delta.
-            const dx = Math.round(targetServerX - simulatedAbsX);
-            const dy = Math.round(targetServerY - simulatedAbsY);
-            if (dx !== 0 || dy !== 0) {
-              const movePayload = this.inputEncoder.encodeMouseMove({
-                dx: Math.max(-32768, Math.min(32767, dx)),
-                dy: Math.max(-32768, Math.min(32767, dy)),
-                timestampUs: timestampUs(),
-              });
-              this.sendReliable(movePayload);
-              simulatedAbsX += dx;
-              simulatedAbsY += dy;
+            // Translate the element-local target into server pixels.
+            const targetServerX = Math.round(targetAbsX * scaleX);
+            const targetServerY = Math.round(targetAbsY * scaleY);
+
+            if (simulatedAbsX === null || simulatedAbsY === null) {
+              // No baseline known: assume server cursor is centered and move from
+              // center -> target in server pixels so remote cursor matches HW cursor.
+              const baselineXServer = Math.round(serverWidth / 2);
+              const baselineYServer = Math.round(serverHeight / 2);
+              const dx = Math.round(targetServerX - baselineXServer);
+              const dy = Math.round(targetServerY - baselineYServer);
+              if (dx !== 0 || dy !== 0) {
+                const movePayload = this.inputEncoder.encodeMouseMove({
+                  dx: Math.max(-32768, Math.min(32767, dx)),
+                  dy: Math.max(-32768, Math.min(32767, dy)),
+                  timestampUs: timestampUs(),
+                });
+                this.sendReliable(movePayload);
+              }
+              // Record simulated baseline in server pixels.
+              simulatedAbsX = targetServerX;
+              simulatedAbsY = targetServerY;
+            } else {
+              // sim values are stored in server pixels now; compute server delta.
+              const dx = Math.round(targetServerX - simulatedAbsX);
+              const dy = Math.round(targetServerY - simulatedAbsY);
+              if (dx !== 0 || dy !== 0) {
+                const movePayload = this.inputEncoder.encodeMouseMove({
+                  dx: Math.max(-32768, Math.min(32767, dx)),
+                  dy: Math.max(-32768, Math.min(32767, dy)),
+                  timestampUs: timestampUs(),
+                });
+                this.sendReliable(movePayload);
+                simulatedAbsX += dx;
+                simulatedAbsY += dy;
+              }
             }
           }
         }
@@ -3692,6 +3756,25 @@ export class GfnWebRtcClient {
       }
 
       this.cursorOverlay?.moveBy(adjustedDx, adjustedDy);
+
+      // Official GFN local-cursor mode: while the client-rendered cursor is
+      // visible, send absolute positions (type 5) that mirror the clamped
+      // overlay position so the server cursor cannot drift from the overlay.
+      // Relative deltas (type 7) remain for hidden-cursor/raw-input games.
+      if (this.cursorOverlay?.isCursorVisible()) {
+        const abs = this.cursorOverlay.getAbsolutePosition();
+        if (abs) {
+          this.pendingMouseAbs = abs;
+          this.pendingMouseDxFloat = 0;
+          this.pendingMouseDyFloat = 0;
+          if (this.pendingMouseTimestampUs === null) {
+            this.pendingMouseTimestampUs = timestampUs(eventTimestampMs);
+          }
+          this.mouseCoalescedBatchEntries += 1;
+          return;
+        }
+      }
+
       this.pendingMouseDxFloat += adjustedDx;
       this.pendingMouseDyFloat += adjustedDy;
       if (this.pendingMouseTimestampUs === null) {
@@ -4321,6 +4404,7 @@ export class GfnWebRtcClient {
       this.releasePressedKeys("input cleanup");
       this.pendingMouseDxFloat = 0;
       this.pendingMouseDyFloat = 0;
+      this.pendingMouseAbs = null;
       this.pendingMouseTimestampUs = null;
       this.mouseDeltaFilter.reset();
       this.pointerLockTarget = null;


### PR DESCRIPTION
This PR fixes cursor drift between the native WebRTC overlay cursor and the server-side cursor by implementing the official GFN client's absolute-position input path (type 5) while the client-rendered cursor is visible. Previously, we only sent relative deltas (type 7), which accumulated rounding and clamp errors that caused visible drift. The official client sends absolute coordinates normalized to a client-defined extent to pin the server cursor to the overlay position exactly.

**Input Protocol:**
* Added `INPUT_MOUSE_ABS` constant (type 5) to `inputProtocol.ts`
* Implemented `encodeMouseAbsolute` with official 26-byte layout: `[type 4B LE][x 2B BE][y 2B BE][reserved 2B BE][width 2B BE][height 2B BE][reserved 4B BE][timestamp 8B BE]`
* Added `clampU16` helper to constrain coordinates to 0–65535
* Updated `isPartiallyReliableHidTransferEligible` to include `INPUT_MOUSE_ABS`

**Cursor Overlay:**
* Exposed `isCursorVisible()` on `GfnCursorOverlayController` to query visibility state
* Added `getAbsolutePosition()` to return the clamped overlay cursor position and viewport extent in CSS pixels

**WebRTC Client:**
* Added `pendingMouseAbs` state to track the latest absolute position awaiting transmission
* Modified `queueMouseMovement` to send absolute positions when the overlay cursor is visible instead of relative deltas
* Updated `flushMouse` with an absolute-position path that bypasses relative scaling and marks the server cursor at the exact overlay position
* Extended pointer-lock entry alignment to use absolute positions when the overlay is visible, avoiding simulated relative moves

**Tests:**
* Added test for absolute mouse packet encoding matching the official layout
* Added test for v3 wrapper with clamped coordinates (negative → 0, overflow → 65535)
* Updated PR eligibility test to include `INPUT_MOUSE_ABS`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c52b51d1-2064-4296-bb7a-1a7c911cc7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-247" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c52b51d1-2064-4296-bb7a-1a7c911cc7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-247&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-247"><img alt="OPE-247" src="https://capy.ai/api/badge/thread.svg?label=OPE-247"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live WebRTC mouse input path and coalescing behavior; incorrect coordinates could misplace the remote cursor, but scope is limited to local-cursor mode and is covered by new encoder tests.
> 
> **Overview**
> Fixes **cursor drift** between the client-rendered overlay and the remote cursor by sending **absolute mouse position (input type 5)** while the overlay is visible, instead of only **relative deltas (type 7)** that accumulate rounding error.
> 
> The input layer adds `INPUT_MOUSE_ABS`, a 26-byte `encodeMouseAbsolute` layout aligned with the official GFN client, and treats absolute moves like relative moves for **partially reliable HID** transfer. The cursor overlay exposes **`isCursorVisible()`** and **`getAbsolutePosition()`** (clamped position plus viewport extent in CSS pixels).
> 
> **`GfnWebRtcClient`** queues **`pendingMouseAbs`** on pointer movement when the overlay is shown (latest position wins, relative residue cleared), flushes absolute packets ahead of relative scaling, and uses absolute alignment on **pointer-lock entry** instead of simulated relative jumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a553ab39218846968bab9e4963474dc6872caaf9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for absolute mouse positioning when the on-screen cursor overlay is visible.
  * Improved cursor tracking so the pointer stays aligned with the streamed view more reliably.

* **Bug Fixes**
  * Fixed cases where mouse movement could drift or desync during cursor-overlay and pointer-lock transitions.
  * Added safer handling for out-of-bounds cursor positions and invalid viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->