### PR TITLE
fix(webrtc): preserve input on cursor hide

### DIFF
--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -3529,19 +3529,17 @@ export class GfnWebRtcClient {
       const batchTimestampUs = this.pendingMouseTimestampUs ?? timestampUs();
       let sentAny = false;
 
-      if (this.pendingMouseAbs !== null) {
-        const abs = this.pendingMouseAbs;
-        this.pendingMouseAbs = null;
-        const payload = this.inputEncoder.encodeMouseAbsolute({
-          ...abs,
-          timestampUs: batchTimestampUs,
-        });
-        this.sendInputPacket(payload, INPUT_MOUSE_ABS);
-        this.mousePacketsSentInWindow += 1;
-        markServerCursorAt(abs);
-        sentAny = true;
-      }
-
+      // Compute the relative part first (without consuming it) so a mixed
+      // abs+rel pair can be detected up front. The partially reliable channel
+      // is unordered, so a dependent pair must travel on the ordered reliable
+      // channel or the relative delta could arrive before the absolute pin
+      // and be overwritten by it.
+      let relPart: {
+        dxServer: number;
+        dyServer: number;
+        residualX: number;
+        residualY: number;
+      } | null = null;
       if (
         Math.abs(this.pendingMouseDxFloat) >= 0.5
         || Math.abs(this.pendingMouseDyFloat) >= 0.5
@@ -3552,23 +3550,54 @@ export class GfnWebRtcClient {
         const dxServer = Math.max(-32768, Math.min(32767, Math.round(dxQuantized.send * scaleX)));
         const dyServer = Math.max(-32768, Math.min(32767, Math.round(dyQuantized.send * scaleY)));
         if (dxServer !== 0 || dyServer !== 0) {
-          this.pendingMouseDxFloat = dxQuantized.residual;
-          this.pendingMouseDyFloat = dyQuantized.residual;
-
-          const payload = this.inputEncoder.encodeMouseMove({
-            dx: dxServer,
-            dy: dyServer,
-            timestampUs: batchTimestampUs,
-          });
-          this.sendInputPacket(payload, INPUT_MOUSE_REL);
-          this.mousePacketsSentInWindow += 1;
-
-          if (simulatedAbsX !== null && simulatedAbsY !== null) {
-            simulatedAbsX += dxServer;
-            simulatedAbsY += dyServer;
-          }
-          sentAny = true;
+          relPart = {
+            dxServer,
+            dyServer,
+            residualX: dxQuantized.residual,
+            residualY: dyQuantized.residual,
+          };
         }
+      }
+      const mixedBatch = this.pendingMouseAbs !== null && relPart !== null;
+
+      if (this.pendingMouseAbs !== null) {
+        const abs = this.pendingMouseAbs;
+        this.pendingMouseAbs = null;
+        const payload = this.inputEncoder.encodeMouseAbsolute({
+          ...abs,
+          timestampUs: batchTimestampUs,
+        });
+        if (mixedBatch) {
+          this.sendReliable(payload);
+        } else {
+          this.sendInputPacket(payload, INPUT_MOUSE_ABS);
+        }
+        this.mousePacketsSentInWindow += 1;
+        markServerCursorAt(abs);
+        sentAny = true;
+      }
+
+      if (relPart !== null) {
+        this.pendingMouseDxFloat = relPart.residualX;
+        this.pendingMouseDyFloat = relPart.residualY;
+
+        const payload = this.inputEncoder.encodeMouseMove({
+          dx: relPart.dxServer,
+          dy: relPart.dyServer,
+          timestampUs: batchTimestampUs,
+        });
+        if (mixedBatch) {
+          this.sendReliable(payload);
+        } else {
+          this.sendInputPacket(payload, INPUT_MOUSE_REL);
+        }
+        this.mousePacketsSentInWindow += 1;
+
+        if (simulatedAbsX !== null && simulatedAbsY !== null) {
+          simulatedAbsX += relPart.dxServer;
+          simulatedAbsY += relPart.dyServer;
+        }
+        sentAny = true;
       }
 
       if (!sentAny) {

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -3521,72 +3521,70 @@ export class GfnWebRtcClient {
         return false;
       }
 
+      // A batch can hold both an absolute position (queued while the overlay
+      // cursor was visible) and relative deltas accumulated after the cursor
+      // was hidden mid-batch. Send the absolute packet first, then the
+      // relative deltas, preserving event order like the official client's
+      // mixed batch encoding — never discard queued relative movement.
+      const batchTimestampUs = this.pendingMouseTimestampUs ?? timestampUs();
+      let sentAny = false;
+
       if (this.pendingMouseAbs !== null) {
         const abs = this.pendingMouseAbs;
         this.pendingMouseAbs = null;
-        // Movement was already consumed by the overlay position; drop any
-        // stale relative residue so it cannot double-apply after this packet.
-        this.pendingMouseDxFloat = 0;
-        this.pendingMouseDyFloat = 0;
-
-        const expectedSendAt = this.mouseFlushLastSendMs + this.mouseFlushIntervalMs;
-        this.inputQueueMaxSchedulingDelayMsWindow = Math.max(
-          this.inputQueueMaxSchedulingDelayMsWindow,
-          Math.max(0, tickNow - expectedSendAt),
-        );
-
         const payload = this.inputEncoder.encodeMouseAbsolute({
           ...abs,
-          timestampUs: this.pendingMouseTimestampUs ?? timestampUs(),
+          timestampUs: batchTimestampUs,
         });
-        this.pendingMouseTimestampUs = null;
-        this.mouseCoalescedBatchEntries = 0;
         this.sendInputPacket(payload, INPUT_MOUSE_ABS);
         this.mousePacketsSentInWindow += 1;
-        this.mouseFlushLastSendMs = tickNow;
-        updateMousePacketRate();
-        this.mouseAdaptiveFlushActive = false;
         markServerCursorAt(abs);
-        return true;
+        sentAny = true;
       }
 
-      const { scaleX, scaleY } = getPointerScale();
-      const dxQuantized = quantizeMouseDeltaWithResidual(this.pendingMouseDxFloat);
-      const dyQuantized = quantizeMouseDeltaWithResidual(this.pendingMouseDyFloat);
-      const dxServer = Math.max(-32768, Math.min(32767, Math.round(dxQuantized.send * scaleX)));
-      const dyServer = Math.max(-32768, Math.min(32767, Math.round(dyQuantized.send * scaleY)));
-      if (dxServer === 0 && dyServer === 0) {
+      if (
+        Math.abs(this.pendingMouseDxFloat) >= 0.5
+        || Math.abs(this.pendingMouseDyFloat) >= 0.5
+      ) {
+        const { scaleX, scaleY } = getPointerScale();
+        const dxQuantized = quantizeMouseDeltaWithResidual(this.pendingMouseDxFloat);
+        const dyQuantized = quantizeMouseDeltaWithResidual(this.pendingMouseDyFloat);
+        const dxServer = Math.max(-32768, Math.min(32767, Math.round(dxQuantized.send * scaleX)));
+        const dyServer = Math.max(-32768, Math.min(32767, Math.round(dyQuantized.send * scaleY)));
+        if (dxServer !== 0 || dyServer !== 0) {
+          this.pendingMouseDxFloat = dxQuantized.residual;
+          this.pendingMouseDyFloat = dyQuantized.residual;
+
+          const payload = this.inputEncoder.encodeMouseMove({
+            dx: dxServer,
+            dy: dyServer,
+            timestampUs: batchTimestampUs,
+          });
+          this.sendInputPacket(payload, INPUT_MOUSE_REL);
+          this.mousePacketsSentInWindow += 1;
+
+          if (simulatedAbsX !== null && simulatedAbsY !== null) {
+            simulatedAbsX += dxServer;
+            simulatedAbsY += dyServer;
+          }
+          sentAny = true;
+        }
+      }
+
+      if (!sentAny) {
         return false;
       }
 
       const expectedSendAt = this.mouseFlushLastSendMs + this.mouseFlushIntervalMs;
-      const schedulingDelay = Math.max(0, tickNow - expectedSendAt);
       this.inputQueueMaxSchedulingDelayMsWindow = Math.max(
         this.inputQueueMaxSchedulingDelayMsWindow,
-        schedulingDelay,
+        Math.max(0, tickNow - expectedSendAt),
       );
-
-      this.pendingMouseDxFloat = dxQuantized.residual;
-      this.pendingMouseDyFloat = dyQuantized.residual;
-
-      const payload = this.inputEncoder.encodeMouseMove({
-        dx: dxServer,
-        dy: dyServer,
-        timestampUs: this.pendingMouseTimestampUs ?? timestampUs(),
-      });
-
       this.pendingMouseTimestampUs = null;
       this.mouseCoalescedBatchEntries = 0;
-      this.sendInputPacket(payload, INPUT_MOUSE_REL);
-      this.mousePacketsSentInWindow += 1;
       this.mouseFlushLastSendMs = tickNow;
       updateMousePacketRate();
       this.mouseAdaptiveFlushActive = false;
-
-      if (simulatedAbsX !== null && simulatedAbsY !== null) {
-        simulatedAbsX += dxServer;
-        simulatedAbsY += dyServer;
-      }
       return true;
     };
 
@@ -3765,6 +3763,10 @@ export class GfnWebRtcClient {
         const abs = this.cursorOverlay.getAbsolutePosition();
         if (abs) {
           this.pendingMouseAbs = abs;
+          // Drop any relative residue queued before the cursor became
+          // visible: the absolute packet pins the final position, and a
+          // stale delta sent afterwards would shift the server cursor off
+          // the overlay again.
           this.pendingMouseDxFloat = 0;
           this.pendingMouseDyFloat = 0;
           if (this.pendingMouseTimestampUs === null) {

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -3515,7 +3515,7 @@ export class GfnWebRtcClient {
       simulatedAbsY = Math.round((abs.y / abs.height) * serverHeight);
     };
 
-    const flushMouse = (): boolean => {
+    const flushMouse = (forceReliable = false): boolean => {
       const tickNow = performance.now();
       if (!this.inputReady || !hasPendingMouseMovement()) {
         return false;
@@ -3567,7 +3567,7 @@ export class GfnWebRtcClient {
           ...abs,
           timestampUs: batchTimestampUs,
         });
-        if (mixedBatch) {
+        if (mixedBatch || forceReliable) {
           this.sendReliable(payload);
         } else {
           this.sendInputPacket(payload, INPUT_MOUSE_ABS);
@@ -3586,7 +3586,7 @@ export class GfnWebRtcClient {
           dy: relPart.dyServer,
           timestampUs: batchTimestampUs,
         });
-        if (mixedBatch) {
+        if (mixedBatch || forceReliable) {
           this.sendReliable(payload);
         } else {
           this.sendInputPacket(payload, INPUT_MOUSE_REL);
@@ -3791,13 +3791,19 @@ export class GfnWebRtcClient {
       if (this.cursorOverlay?.isCursorVisible()) {
         const abs = this.cursorOverlay.getAbsolutePosition();
         if (abs) {
-          this.pendingMouseAbs = abs;
-          // Drop any relative residue queued before the cursor became
-          // visible: the absolute packet pins the final position, and a
-          // stale delta sent afterwards would shift the server cursor off
-          // the overlay again.
+          // Deliver raw-input deltas queued before the cursor became
+          // visible ahead of the absolute pin, in order, on the reliable
+          // channel — never after it, where they would shift the server
+          // cursor off the overlay.
+          if (
+            Math.abs(this.pendingMouseDxFloat) >= 0.5
+            || Math.abs(this.pendingMouseDyFloat) >= 0.5
+          ) {
+            flushMouse(true);
+          }
           this.pendingMouseDxFloat = 0;
           this.pendingMouseDyFloat = 0;
+          this.pendingMouseAbs = abs;
           if (this.pendingMouseTimestampUs === null) {
             this.pendingMouseTimestampUs = timestampUs(eventTimestampMs);
           }


### PR DESCRIPTION
This PR fixes a bug where raw mouse input was discarded immediately after the native cursor overlay hid. When the cursor transitioned from visible (absolute positioning) to hidden (relative positioning), the previous flush logic would send the pending absolute packet and clear the relative accumulators without sending them, causing the first movement input to be dropped.

**Changes:**

* Updated `flushMouse` in `opennow-stable/src/renderer/src/gfn/webrtcClient.ts` to support mixed batches: it now sends any pending absolute packet followed immediately by any pending relative packets within the same flush cycle, rather than zeroing out relative deltas.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c52b51d1-2064-4296-bb7a-1a7c911cc7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-247" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c52b51d1-2064-4296-bb7a-1a7c911cc7aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-247&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-247"><img alt="OPE-247" src="https://capy.ai/api/badge/thread.svg?label=OPE-247"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live mouse input encoding in the WebRTC client; incorrect batching could cause cursor drift or double movement, but scope is limited to flush/queue logic.
> 
> **Overview**
> Fixes dropped mouse movement when the native cursor overlay hides mid-batch and the client switches from **absolute** to **relative** packets.
> 
> **`flushMouse`** no longer clears pending relative deltas after sending an absolute packet or returns after only the absolute send. A single flush can emit **absolute first, then relative** in one cycle with a shared timestamp, matching official GFN mixed-batch ordering.
> 
> **`queueMouseMovement`** now zeros stale relative accumulators when the overlay cursor is **visible** and an absolute position is queued, so an absolute pin is not followed by obsolete relative deltas that would drift the server cursor off the overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0da4d861f004703df6d338eeecec2f8eba78da8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse input batching to correctly transmit mixed absolute cursor moves and relative deltas in the right order.
  * Added more reliable handling for edge cases where rapid input could previously result in dropped movements or leftover motion.
  * Enhanced overlay-visible cursor updates by ensuring any pending relative residue is flushed before applying the overlay-pinned absolute cursor position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->