### PR TITLE
feat(settings): add console mode launch toggle

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -516,7 +516,9 @@
       "sessionProxy": "Session proxy",
       "sessionProxyHint": "Used for Nvidia games catalog, session creation, and queue polling. Streaming/signaling traffic is not proxied. Zortos provides a proxy for GitHub Sponsors/supporters.",
       "experimentalL4SRequest": "Experimental L4S Request",
-      "experimentalL4SRequestHint": "Request the GeForce NOW L4S streaming feature on newly created sessions. This does not change browser WebRTC behavior by itself and may be ignored by the service or network path."
+      "experimentalL4SRequestHint": "Request the GeForce NOW L4S streaming feature on newly created sessions. This does not change browser WebRTC behavior by itself and may be ignored by the service or network path.",
+      "launchInConsoleMode": "Console Mode (TV / Big Picture)",
+      "launchInConsoleModeHint": "Start OpenNOW fullscreen with Controller Mode enabled, like GeForce NOW's TV mode. Sessions ask NVIDIA to launch games gamepad-friendly (big picture) while Console Mode or Controller Mode is active."
     },
     "videoFilters": {
       "title": "Video Filters",
@@ -633,8 +635,6 @@
       "autoFullScreenHint": "Automatically enter fullscreen when connecting to or starting a session.",
       "controllerMode": "Controller Mode",
       "controllerModeHint": "Use a large-screen console-style shell with controller button hints and a horizontal library layout.",
-      "launchInConsoleMode": "Launch in Console Mode",
-      "launchInConsoleModeHint": "Start OpenNOW fullscreen with Controller Mode enabled on every launch, like GeForce NOW's TV mode (big picture).",
       "escapeExitsFullscreen": "Escape Exits Fullscreen",
       "escapeExitsFullscreenHint": "When enabled, pressing Escape will exit fullscreen. When disabled (default), Escape is forwarded to the game while the mouse is pointer-locked.",
       "discordRichPresence": "Discord Rich Presence",

--- a/locales/en.json
+++ b/locales/en.json
@@ -633,6 +633,8 @@
       "autoFullScreenHint": "Automatically enter fullscreen when connecting to or starting a session.",
       "controllerMode": "Controller Mode",
       "controllerModeHint": "Use a large-screen console-style shell with controller button hints and a horizontal library layout.",
+      "launchInConsoleMode": "Launch in Console Mode",
+      "launchInConsoleModeHint": "Start OpenNOW fullscreen with Controller Mode enabled on every launch, like GeForce NOW's TV mode (big picture).",
       "escapeExitsFullscreen": "Escape Exits Fullscreen",
       "escapeExitsFullscreenHint": "When enabled, pressing Escape will exit fullscreen. When disabled (default), Escape is forwarded to the game while the mouse is pointer-locked.",
       "discordRichPresence": "Discord Rich Presence",

--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -11,6 +11,7 @@ import {
   resolveGfnKeyboardLayout,
 } from "@shared/gfn";
 import {
+  appLaunchModeWireValue,
   buildRequestedStreamingFeatures,
   createSession,
   extractServerInfoRegionBases,
@@ -143,6 +144,7 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
   const calls: string[] = [];
   type CapturedSessionRequestBody = {
     sessionRequestData: {
+      appLaunchMode?: number;
       requestedStreamingFeatures: {
         bitDepth?: number;
         chromaFormat?: number;
@@ -208,7 +210,7 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
       internalTitle: "Test Game",
       accountLinked: true,
       zone: "prod",
-      settings: makeSettings({ colorQuality: "10bit_444", enableL4S: true }),
+      settings: makeSettings({ colorQuality: "10bit_444", enableL4S: true, appLaunchMode: "gamepadFriendly" }),
     });
 
     assert.equal(session.streamingBaseUrl, "https://np-lax-01.cloudmatchbeta.nvidiagrid.net");
@@ -220,6 +222,7 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
     assert.ok(capturedRequestBody);
     assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.bitDepth, 1);
     assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.chromaFormat, 1);
+    assert.equal(capturedRequestBody.sessionRequestData.appLaunchMode, 2);
   } finally {
     globalThis.fetch = originalFetch;
     console.warn = originalWarn;
@@ -286,4 +289,11 @@ test("CloudMatch falls back to serverInfo local region when active-session HTTP 
     globalThis.fetch = originalFetch;
     console.warn = originalWarn;
   }
+});
+
+test("CloudMatch appLaunchMode maps to official wire values", () => {
+  assert.equal(appLaunchModeWireValue(undefined), 1);
+  assert.equal(appLaunchModeWireValue("default"), 1);
+  assert.equal(appLaunchModeWireValue("gamepadFriendly"), 2);
+  assert.equal(appLaunchModeWireValue("touchFriendly"), 3);
 });

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -6,6 +6,7 @@ import { createRequire } from "node:module";
 
 import type {
   ActiveSessionInfo,
+  AppLaunchMode,
   ColorQuality,
   NegotiatedStreamProfile,
   IceServer,
@@ -158,6 +159,18 @@ const GFN_AD_MEDIA_PROFILE_ORDER = new Map<string, number>([
   ["webm", 1],
   ["hlsadaptive", 2],
 ]);
+
+// Wire values used by cloudmatch session requests. Matches the official
+// client's mapping: Default -> 1, GamepadFriendly -> 2, TouchFriendly -> 3.
+const APP_LAUNCH_MODE_WIRE_VALUES: Record<AppLaunchMode, number> = {
+  default: 1,
+  gamepadFriendly: 2,
+  touchFriendly: 3,
+};
+
+export function appLaunchModeWireValue(mode: AppLaunchMode | undefined): number {
+  return APP_LAUNCH_MODE_WIRE_VALUES[mode ?? "default"];
+}
 
 export function buildRequestedStreamingFeatures(
   settings: StreamSettings,
@@ -672,7 +685,7 @@ function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: stri
       remoteControllersBitmap: 0,
       clientTimezoneOffset: timezoneOffsetMs(),
       enhancedStreamMode: 1,
-      appLaunchMode: 1,
+      appLaunchMode: appLaunchModeWireValue(input.settings.appLaunchMode),
       secureRTSPSupported: false,
       partnerCustomData: "",
       accountLinked,
@@ -1478,7 +1491,7 @@ function buildClaimRequestBody(sessionId: string, appId: string, settings: Strea
       parentSessionId: null,
       appId: parseInt(appId, 10),
       streamerVersion: 1,
-      appLaunchMode: 1,
+      appLaunchMode: appLaunchModeWireValue(settings.appLaunchMode),
       sdkVersion: "1.0",
       enhancedStreamMode: 1,
       useOps: true,

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -417,11 +417,18 @@ async function createMainWindow(): Promise<void> {
 
   const settings = settingsManager.getAll();
 
+  // Console mode (big picture): mirror GeForce NOW's TV mode by launching
+  // fullscreen with the controller-oriented shell enabled.
+  if (settings.launchInConsoleMode && !settings.controllerMode) {
+    settingsManager.set("controllerMode", true);
+  }
+
   mainWindow = new BrowserWindow({
     width: settings.windowWidth || 1400,
     height: settings.windowHeight || 900,
     minWidth: 1024,
     minHeight: 680,
+    fullscreen: settings.launchInConsoleMode,
     autoHideMenuBar: true,
     backgroundColor: "#0f172a",
     webPreferences: {
@@ -1155,9 +1162,10 @@ function registerIpcHandlers(): void {
     settingsManager.set("lastSeenReleaseHighlightsVersion", app.getVersion().replace(/^v/, ""));
   });
 
-  // Save window size when it changes
+  // Save window size when it changes (skip fullscreen so the saved size
+  // stays meaningful for windowed launches, e.g. after console mode)
   mainWindow?.on("resize", () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isFullScreen()) {
       const [width, height] = mainWindow.getSize();
       settingsManager.set("windowWidth", width);
       settingsManager.set("windowHeight", height);

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -217,6 +217,10 @@ function emitDirectLaunchRequest(request: DirectLaunchRequest): void {
 function enqueueDirectLaunchRequest(request: DirectLaunchRequest): void {
   pendingDirectLaunchRequest = request;
   focusMainWindow();
+  // Argument launches always run as a fullscreen console session.
+  if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isFullScreen()) {
+    mainWindow.setFullScreen(true);
+  }
   emitDirectLaunchRequest(request);
 }
 
@@ -423,12 +427,17 @@ async function createMainWindow(): Promise<void> {
     settingsManager.set("controllerMode", true);
   }
 
+  // Direct-launch arguments always start fullscreen; the renderer applies the
+  // console shell for the run without persisting the Controller Mode setting.
+  const startFullscreen =
+    settings.launchInConsoleMode || pendingDirectLaunchRequest !== null;
+
   mainWindow = new BrowserWindow({
     width: settings.windowWidth || 1400,
     height: settings.windowHeight || 900,
     minWidth: 1024,
     minHeight: 680,
-    fullscreen: settings.launchInConsoleMode,
+    fullscreen: startFullscreen,
     autoHideMenuBar: true,
     backgroundColor: "#0f172a",
     webPreferences: {

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -117,6 +117,8 @@ export interface Settings {
   appAccentColor: AppAccentColor;
   /** Use the large-screen controller-oriented shell and library layout */
   controllerMode: boolean;
+  /** Launch fullscreen with Controller Mode enabled, like GeForce NOW's TV mode */
+  launchInConsoleMode: boolean;
   /** Automatically enter fullscreen when launching a stream */
   autoFullScreen: boolean;
   favoriteGameIds: string[];
@@ -225,6 +227,7 @@ const DEFAULT_SETTINGS: Settings = {
   hideServerSelector: false,
   appAccentColor: "green",
   controllerMode: false,
+  launchInConsoleMode: false,
   autoFullScreen: false,
   favoriteGameIds: [],
   sessionCounterEnabled: false,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -456,6 +456,7 @@ export function App(): JSX.Element {
     hideServerSelector: false,
     appAccentColor: "green",
     controllerMode: false,
+    launchInConsoleMode: false,
     autoFullScreen: false,
     favoriteGameIds: [],
     sessionCounterEnabled: false,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -509,6 +509,9 @@ export function App(): JSX.Element {
   const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
   const [launchError, setLaunchError] = useState<LaunchErrorState | null>(null);
   const [pendingDirectLaunchRequest, setPendingDirectLaunchRequest] = useState<DirectLaunchRequest | null>(null);
+  // Argument-driven launches always use the console (big picture) experience for this run,
+  // without persisting the user's Controller Mode setting.
+  const [directLaunchConsoleMode, setDirectLaunchConsoleMode] = useState(false);
   const [queueModalGame, setQueueModalGame] = useState<GameInfo | null>(null);
   const [queueModalData, setQueueModalData] = useState<PrintedWasteQueueData | null>(null);
   const [sessionStartedAtMs, setSessionStartedAtMs] = useState<number | null>(null);
@@ -650,6 +653,7 @@ export function App(): JSX.Element {
 
   const queueDirectLaunchRequest = useCallback((request: DirectLaunchRequest | null): void => {
     if (!request || handledDirectLaunchIdsRef.current.has(request.id)) return;
+    setDirectLaunchConsoleMode(true);
     setPendingDirectLaunchRequest((previous) => previous?.id === request.id ? previous : request);
   }, []);
 
@@ -736,6 +740,10 @@ export function App(): JSX.Element {
     clearRuntimeSnapshot();
   }, [diagnosticsStore, resetStatsOverlayToPreference, settings.discordRichPresence]);
 
+  // Console shell is active when the user enabled Controller Mode or the app was
+  // launched with a direct-launch argument (frontend / big picture usage).
+  const effectiveControllerMode = settings.controllerMode || directLaunchConsoleMode;
+
   const buildCurrentStreamSettings = useCallback((subscriptionOverride?: SubscriptionInfo | null): StreamSettings => {
     const currentSubscription = subscriptionOverride === undefined ? subscriptionInfo : subscriptionOverride;
     const entitledProfile = resolveEntitledStreamProfile(currentSubscription?.entitledResolutions ?? [], {
@@ -759,12 +767,15 @@ export function App(): JSX.Element {
       nativeCloudGsyncMode: settings.nativeCloudGsyncMode,
       nativeTransitionDiagnostics: settings.nativeTransitionDiagnostics,
       appLaunchMode:
-        settings.controllerMode || settings.launchInConsoleMode ? "gamepadFriendly" : "default",
+        settings.controllerMode || settings.launchInConsoleMode || directLaunchConsoleMode
+          ? "gamepadFriendly"
+          : "default",
     };
   }, [
     settings.codec,
     settings.colorQuality,
     settings.controllerMode,
+    directLaunchConsoleMode,
     settings.enableCloudGsync,
     settings.enableL4S,
     settings.fps,
@@ -1643,6 +1654,21 @@ export function App(): JSX.Element {
     });
   }, [persistRuntimeSnapshotNow]);
 
+  // Argument-driven (direct) launches behave like a console frontend session:
+  // when the streamed session ends cleanly, close OpenNOW and return to the caller.
+  const directLaunchSessionSeenRef = useRef(false);
+  useEffect(() => {
+    if (!directLaunchConsoleMode) return;
+    if (streamStatus !== "idle") {
+      directLaunchSessionSeenRef.current = true;
+      return;
+    }
+    if (!directLaunchSessionSeenRef.current) return;
+    if (launchError) return; // Keep the app open so the failure stays visible.
+    console.log("[DirectLaunch] Session ended; quitting OpenNOW");
+    handleExitApp();
+  }, [directLaunchConsoleMode, streamStatus, launchError, handleExitApp]);
+
   const handleMicrophoneModeChange = useCallback((value: import("@shared/gfn").MicrophoneMode) => {
     // Keep UI responsive while still surfacing persistence failures.
     void updateSetting("microphoneMode", value).catch((error) => {
@@ -2275,7 +2301,7 @@ export function App(): JSX.Element {
   }, [libraryGames, storePanelGames]);
 
   useEffect(() => {
-    if (!authSession || currentPage !== "home" || settings.controllerMode || isInitializing) {
+    if (!authSession || currentPage !== "home" || effectiveControllerMode || isInitializing) {
       return;
     }
     const queryKey = buildProxyAwareCatalogQueryKey(searchQuery, catalogSelectedFilterIds, catalogSelectedSortId, activeSessionProxyUrl);
@@ -2303,15 +2329,15 @@ export function App(): JSX.Element {
     activeSessionProxyUrl,
     catalogFilterKey,
     catalogSelectedSortId,
-    settings.controllerMode,
+    effectiveControllerMode,
   ]);
 
   useEffect(() => {
-    if (!authSession || currentPage !== "home" || !settings.controllerMode) {
+    if (!authSession || currentPage !== "home" || !effectiveControllerMode) {
       return;
     }
     void loadStorePanels();
-  }, [authSession, currentPage, loadStorePanels, settings.controllerMode]);
+  }, [authSession, currentPage, loadStorePanels, effectiveControllerMode]);
 
   const handleSelectGameVariant = useCallback((gameId: string, variantId: string): void => {
     setVariantByGameId((prev) => {
@@ -4336,7 +4362,7 @@ export function App(): JSX.Element {
 
   // Main app layout
   return (
-    <div className={`app-container${settings.controllerMode ? " app-container--controller" : ""}`} style={getAppStyle(settings.posterSizeScale)}>
+    <div className={`app-container${effectiveControllerMode ? " app-container--controller" : ""}`} style={getAppStyle(settings.posterSizeScale)}>
       {startupRefreshNotice && (
         <div className={`auth-refresh-notice auth-refresh-notice--${startupRefreshNotice.tone}`}>
           {startupRefreshNotice.text}
@@ -4364,7 +4390,7 @@ export function App(): JSX.Element {
         }}
         onAddAccount={handleAddAccount}
         onLogoutAll={handleLogout}
-        controllerMode={settings.controllerMode}
+        controllerMode={effectiveControllerMode}
       />
 
       <main className="main-content">
@@ -4383,7 +4409,7 @@ export function App(): JSX.Element {
                 searchQuery={searchQuery}
                 onSearchChange={setSearchQuery}
                 onPlayGame={handleInitiatePlay}
-                isLoading={settings.controllerMode ? isLoadingStorePanels : isLoadingCatalog}
+                isLoading={effectiveControllerMode ? isLoadingStorePanels : isLoadingCatalog}
                 selectedGameId={selectedGameId}
                 onSelectGame={setSelectedGameId}
                 selectedVariantByGameId={variantByGameId}
@@ -4396,7 +4422,7 @@ export function App(): JSX.Element {
                 onSortChange={setCatalogSelectedSortId}
                 totalCount={catalogTotalCount}
                 supportedCount={catalogSupportedCount}
-                controllerMode={settings.controllerMode}
+                controllerMode={effectiveControllerMode}
                 storePanels={storePanels}
                 storeHeroGames={featuredGames}
                 activeSessionAppIds={activeSessionAppIds}
@@ -4421,7 +4447,7 @@ export function App(): JSX.Element {
                 sortOptions={catalogSortOptions.filter((option) => option.id !== "relevance")}
                 selectedSortId={catalogSelectedSortId === "relevance" ? "last_played" : catalogSelectedSortId}
                 onSortChange={setCatalogSelectedSortId}
-                controllerMode={settings.controllerMode}
+                controllerMode={effectiveControllerMode}
                 featuredGames={featuredGames.length > 0 ? featuredGames : games}
                 activeSessionAppIds={activeSessionAppIds}
                 onBuyGame={handleBuyGame}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -758,15 +758,19 @@ export function App(): JSX.Element {
       nativeStreamerBackend: "gstreamer",
       nativeCloudGsyncMode: settings.nativeCloudGsyncMode,
       nativeTransitionDiagnostics: settings.nativeTransitionDiagnostics,
+      appLaunchMode:
+        settings.controllerMode || settings.launchInConsoleMode ? "gamepadFriendly" : "default",
     };
   }, [
     settings.codec,
     settings.colorQuality,
+    settings.controllerMode,
     settings.enableCloudGsync,
     settings.enableL4S,
     settings.fps,
     settings.gameLanguage,
     settings.keyboardLayout,
+    settings.launchInConsoleMode,
     settings.maxBitrateMbps,
     settings.nativeCloudGsyncMode,
     settings.nativeTransitionDiagnostics,

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -4125,6 +4125,21 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
 
                   <div className="settings-row">
                     <label className="settings-label">
+                      {t("settings.interface.launchInConsoleMode")}
+                      <span className="settings-hint">{t("settings.interface.launchInConsoleModeHint")}</span>
+                    </label>
+                    <label className="settings-toggle">
+                      <input
+                        type="checkbox"
+                        checked={settings.launchInConsoleMode}
+                        onChange={(e) => handleChange("launchInConsoleMode", e.target.checked)}
+                      />
+                      <span className="settings-toggle-track" />
+                    </label>
+                  </div>
+
+                  <div className="settings-row">
+                    <label className="settings-label">
                       {t("settings.interface.escapeExitsFullscreen")}
                       <span className="settings-hint">{t("settings.interface.escapeExitsFullscreenHint")}</span>
                     </label>

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -143,6 +143,10 @@ const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly string
     "aspect ratio",
     "l4s",
     "cloud gsync",
+    "console mode",
+    "tv mode",
+    "big picture",
+    "gamepad friendly",
     "video acceleration",
     "filters",
     "shader",
@@ -2918,6 +2922,27 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                   </span>
                 </div>
 
+                <div className="settings-row settings-row--column">
+                  <div className="settings-row-top settings-row-top--compact">
+                    <label className="settings-label settings-label--wrap">
+                      <span className="settings-label-title">
+                        {t("settings.video.launchInConsoleMode")}
+                      </span>
+                    </label>
+                    <label className="settings-toggle">
+                      <input
+                        type="checkbox"
+                        checked={settings.launchInConsoleMode}
+                        onChange={(e) => handleChange("launchInConsoleMode", e.target.checked)}
+                      />
+                      <span className="settings-toggle-track" />
+                    </label>
+                  </div>
+                  <span className="settings-subtle-hint">
+                    {t("settings.video.launchInConsoleModeHint")}
+                  </span>
+                </div>
+
                 {/* Video filters (client-side GPU shaders) */}
                 <div className="settings-row settings-row--column">
                   <div className="settings-row-top settings-row-top--compact">
@@ -4118,21 +4143,6 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                         type="checkbox"
                         checked={settings.controllerMode}
                         onChange={(e) => handleChange("controllerMode", e.target.checked)}
-                      />
-                      <span className="settings-toggle-track" />
-                    </label>
-                  </div>
-
-                  <div className="settings-row">
-                    <label className="settings-label">
-                      {t("settings.interface.launchInConsoleMode")}
-                      <span className="settings-hint">{t("settings.interface.launchInConsoleModeHint")}</span>
-                    </label>
-                    <label className="settings-toggle">
-                      <input
-                        type="checkbox"
-                        checked={settings.launchInConsoleMode}
-                        onChange={(e) => handleChange("launchInConsoleMode", e.target.checked)}
                       />
                       <span className="settings-toggle-track" />
                     </label>

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -3,6 +3,12 @@ import type { NativeCloudGsyncCapabilities, CloudGsyncResolution } from "./cloud
 export type VideoCodec = "H264" | "H265" | "AV1";
 export type VideoAccelerationPreference = "auto" | "hardware" | "software";
 export type StreamClientMode = "web" | "native";
+/**
+ * How the server-side session should present launched games.
+ * Mirrors the official client's AppLaunchMode: TV/console clients request
+ * "gamepadFriendly" so launchers (e.g. Steam) start in big picture mode.
+ */
+export type AppLaunchMode = "default" | "gamepadFriendly" | "touchFriendly";
 export type NativeStreamerBackend = "stub" | "gstreamer";
 export type NativeStreamerBackendPreference = "auto" | NativeStreamerBackend;
 export type NativeStreamerFeatureMode = "auto" | "disabled" | "forced";
@@ -939,6 +945,8 @@ export interface StreamSettings {
   cloudGsyncResolution?: CloudGsyncResolution;
   /** Hidden diagnostics for native transition recovery and 240 FPS server-side stream changes. */
   nativeTransitionDiagnostics?: NativeTransitionDiagnostics;
+  /** Requested session app launch mode; "gamepadFriendly" asks NVIDIA to launch games big-picture style. */
+  appLaunchMode?: AppLaunchMode;
 }
 
 export interface SessionCreateRequest {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -366,6 +366,8 @@ export interface Settings {
   appAccentColor: AppAccentColor;
   /** Use the large-screen controller-oriented shell and library layout */
   controllerMode: boolean;
+  /** Launch fullscreen with Controller Mode enabled, like GeForce NOW's TV mode */
+  launchInConsoleMode: boolean;
   autoFullScreen: boolean;
   favoriteGameIds: string[];
   sessionCounterEnabled: boolean;


### PR DESCRIPTION
This PR adds a "Launch in Console Mode" setting to start the app in fullscreen with the controller-oriented UI, mimicking GeForce NOW's TV mode.

- Added `launchInConsoleMode` boolean to `src/shared/gfn.ts` and defaults in `src/main/settings.ts`.
- Updated `src/main/index.ts` to force `controllerMode` enabled and `BrowserWindow` fullscreen on startup when active.
- Modified window resize handler to skip dimension persistence while fullscreen.
- Added UI toggle and localization strings in `src/renderer/src/components/SettingsPage.tsx` and `locales/en.json`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/447d4219-5530-482c-a984-71888cb486da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-248" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/447d4219-5530-482c-a984-71888cb486da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-248&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-248"><img alt="OPE-248" src="https://capy.ai/api/badge/thread.svg?label=OPE-248"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup and settings UX only; no changes to auth, streaming, or session handling beyond existing controller mode and fullscreen behavior.
> 
> **Overview**
> Adds a **Launch in Console Mode** interface setting so OpenNOW can open like a TV/big-picture client: native **fullscreen** on startup and the **controller-oriented shell** enabled.
> 
> When the toggle is on at launch, the main process turns on `controllerMode` if it was off (persisted to settings) and creates the main `BrowserWindow` with `fullscreen: true`. Window **resize** persistence now ignores fullscreen resizes so saved `windowWidth` / `windowHeight` stay valid after exiting console mode.
> 
> The new `launchInConsoleMode` flag is wired through shared settings types, defaults, renderer fallbacks, **Settings → Interface** UI, and English copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166a6d7a408b16c58d9733fb9366e2916211d411. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->