### PR TITLE
fix(cloudmatch): preserve session-stable appLaunchMode in resume

### DIFF
--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   appLaunchModeWireValue,
   buildRequestedStreamingFeatures,
+  claimSession,
   createSession,
   extractServerInfoRegionBases,
   getActiveSessions,
@@ -296,4 +297,81 @@ test("CloudMatch appLaunchMode maps to official wire values", () => {
   assert.equal(appLaunchModeWireValue("default"), 1);
   assert.equal(appLaunchModeWireValue("gamepadFriendly"), 2);
   assert.equal(appLaunchModeWireValue("touchFriendly"), 3);
+});
+
+test("CloudMatch claim keeps the session-stable appLaunchMode over live settings", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const originalLog = console.log;
+  console.warn = () => {};
+  console.log = () => {};
+
+  const claimBodies: Array<{ sessionRequestData: { appLaunchMode?: number } }> = [];
+
+  const readySessionResponse = JSON.stringify({
+    requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS" },
+    session: {
+      sessionId: "sess-1",
+      status: 3,
+      sessionControlInfo: { ip: "203.0.113.10" },
+      connectionInfo: [
+        { ip: "203.0.113.10", port: 443, usage: 14, resourcePath: "/nvst/" },
+        { ip: "203.0.113.10", port: 49006, usage: 2 },
+      ],
+      iceServerConfiguration: {
+        iceServers: [{ urls: "stun:127.0.0.1:19302" }],
+      },
+      sessionRequestData: {},
+    },
+  });
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    if (url.startsWith("https://203.0.113.10/v2/session/sess-1")) {
+      if (init?.method === "PUT") {
+        claimBodies.push(JSON.parse(String(init.body)));
+      }
+      return new Response(readySessionResponse, { status: 200 });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    // Session created as gamepad-friendly (wire 2) must stay gamepad-friendly on
+    // resume even if the live settings toggles now say "default".
+    await claimSession({
+      token: "token",
+      sessionId: "sess-1",
+      serverIp: "203.0.113.10",
+      appId: "1001",
+      appLaunchMode: 2,
+      settings: makeSettings(),
+    });
+
+    // Without a session-stable value the claim falls back to the settings-derived mode.
+    await claimSession({
+      token: "token",
+      sessionId: "sess-1",
+      serverIp: "203.0.113.10",
+      appId: "1001",
+      settings: makeSettings({ appLaunchMode: "gamepadFriendly" }),
+    });
+
+    await claimSession({
+      token: "token",
+      sessionId: "sess-1",
+      serverIp: "203.0.113.10",
+      appId: "1001",
+      settings: makeSettings(),
+    });
+
+    assert.equal(claimBodies.length, 3);
+    assert.equal(claimBodies[0].sessionRequestData.appLaunchMode, 2);
+    assert.equal(claimBodies[1].sessionRequestData.appLaunchMode, 2);
+    assert.equal(claimBodies[2].sessionRequestData.appLaunchMode, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+    console.log = originalLog;
+  }
 });

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -1402,6 +1402,14 @@ async function fetchActiveSessionsFromBase(
       // Extract appId from sessionRequestData
       const appId = s.sessionRequestData?.appId ? Number(s.sessionRequestData.appId) : 0;
 
+      // The server echoes the appLaunchMode the session was created with; keep it
+      // so claim/resume requests can stay session-stable.
+      const rawAppLaunchMode = s.sessionRequestData?.appLaunchMode;
+      const appLaunchMode =
+        typeof rawAppLaunchMode === "number" && Number.isFinite(rawAppLaunchMode)
+          ? rawAppLaunchMode
+          : undefined;
+
       // Prefer the real server IP from connectionInfo[usage=14] — this is the actual game server,
       // not the zone load balancer. sessionControlInfo.ip is the zone LB hostname and cannot
       // accept claim (PUT) requests, which causes HTTP 400.
@@ -1430,6 +1438,7 @@ async function fetchActiveSessionsFromBase(
       return {
         sessionId: s.sessionId,
         appId,
+        appLaunchMode,
         gpuType: s.gpuType,
         status: s.status,
         streamingBaseUrl: base,
@@ -1454,7 +1463,12 @@ function formatErrorForLog(error: unknown): string {
 /**
  * Build claim/resume request payload
  */
-function buildClaimRequestBody(sessionId: string, appId: string, settings: StreamSettings): unknown {
+function buildClaimRequestBody(
+  sessionId: string,
+  appId: string,
+  settings: StreamSettings,
+  sessionAppLaunchMode?: number,
+): unknown {
   // For RESUME claims, we must NOT attempt to renegotiate streaming parameters.
   // The session is already configured on the server side. Sending different fps, resolution,
   // codec, etc. causes HTTP 400 from the server because those parameters are immutable for
@@ -1491,7 +1505,9 @@ function buildClaimRequestBody(sessionId: string, appId: string, settings: Strea
       parentSessionId: null,
       appId: parseInt(appId, 10),
       streamerVersion: 1,
-      appLaunchMode: appLaunchModeWireValue(settings.appLaunchMode),
+      // Resume must not renegotiate session parameters: prefer the wire value the
+      // session was created with over whatever the UI toggles currently say.
+      appLaunchMode: sessionAppLaunchMode ?? appLaunchModeWireValue(settings.appLaunchMode),
       sdkVersion: "1.0",
       enhancedStreamMode: 1,
       useOps: true,
@@ -1613,7 +1629,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
   // Only send the RESUME claim PUT if the session is in a paused state (status 2 or 3).
   // For status=1 (still launching) we bypass the claim and fall through to the polling loop.
   if (preClaimStatus !== 1 && shouldSendResumeClaim) {
-    const payload = buildClaimRequestBody(input.sessionId, appId, settings);
+    const payload = buildClaimRequestBody(input.sessionId, appId, settings, input.appLaunchMode);
 
     const headers = buildGfnCloudMatchClaimHeaders({ token: input.token, clientId, deviceId });
 

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -172,6 +172,12 @@ export function appLaunchModeWireValue(mode: AppLaunchMode | undefined): number 
   return APP_LAUNCH_MODE_WIRE_VALUES[mode ?? "default"];
 }
 
+/** Wire appLaunchMode the server echoes back for an existing session, if present. */
+function echoedSessionAppLaunchMode(payload: CloudMatchResponse): number | undefined {
+  const raw = payload.session?.sessionRequestData?.appLaunchMode;
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
+}
+
 export function buildRequestedStreamingFeatures(
   settings: StreamSettings,
   bitDepth: number,
@@ -1049,6 +1055,8 @@ interface ToSessionInfoOptions {
   payload: CloudMatchResponse;
   clientId?: string;
   deviceId?: string;
+  /** Wire appLaunchMode sent with the request, used when the server does not echo it */
+  fallbackAppLaunchMode?: number;
 }
 
 async function toSessionInfo(options: ToSessionInfoOptions): Promise<SessionInfo> {
@@ -1105,6 +1113,7 @@ async function toSessionInfo(options: ToSessionInfoOptions): Promise<SessionInfo
     signalingServer: signaling.signalingServer,
     signalingUrl: signaling.signalingUrl,
     gpuType: payload.session.gpuType,
+    appLaunchMode: echoedSessionAppLaunchMode(payload) ?? options.fallbackAppLaunchMode,
     iceServers: await normalizeIceServers(payload),
     mediaConnectionInfo: signaling.mediaConnectionInfo,
     negotiatedStreamProfile,
@@ -1148,7 +1157,14 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
   }, input.proxyUrl);
 
   const { payload } = await readCloudMatchJson<CloudMatchResponse>(response);
-  return await toSessionInfo({ zone: input.zone, streamingBaseUrl: base, payload, clientId, deviceId });
+  return await toSessionInfo({
+    zone: input.zone,
+    streamingBaseUrl: base,
+    payload,
+    clientId,
+    deviceId,
+    fallbackAppLaunchMode: appLaunchModeWireValue(input.settings.appLaunchMode),
+  });
 }
 
 export async function pollSession(input: SessionPollRequest): Promise<SessionInfo> {
@@ -1709,6 +1725,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
         signalingServer: signaling.signalingServer,
         signalingUrl: signaling.signalingUrl,
         gpuType: sessionData.gpuType,
+        appLaunchMode: echoedSessionAppLaunchMode(pollApiResponse) ?? input.appLaunchMode,
         iceServers: await normalizeIceServers(pollApiResponse),
         mediaConnectionInfo: signaling.mediaConnectionInfo,
         negotiatedStreamProfile: negotiatedStreamProfile ?? extractNegotiatedStreamProfile(pollApiResponse),

--- a/opennow-stable/src/main/gfn/types.ts
+++ b/opennow-stable/src/main/gfn/types.ts
@@ -190,6 +190,7 @@ export interface SessionEntry {
   gpuType?: string;
   sessionRequestData?: {
     appId?: string;
+    appLaunchMode?: number;
     [key: string]: unknown;
   };
   sessionControlInfo?: {

--- a/opennow-stable/src/main/gfn/types.ts
+++ b/opennow-stable/src/main/gfn/types.ts
@@ -153,6 +153,7 @@ export interface CloudMatchResponse {
       }>;
     };
     sessionRequestData?: {
+      appLaunchMode?: number;
       clientRequestMonitorSettings?: Array<{
         widthInPixels?: number;
         heightInPixels?: number;

--- a/opennow-stable/src/main/ipc/sessionHandlers.ts
+++ b/opennow-stable/src/main/ipc/sessionHandlers.ts
@@ -97,6 +97,7 @@ export function registerSessionIpcHandlers(deps: SessionIpcHandlerDeps): void {
               sessionId: readyCandidate.sessionId,
               serverIp: readyCandidate.serverIp!,
               appId: resolvedPayload.appId,
+              appLaunchMode: readyCandidate.appLaunchMode,
               settings: resolvedPayload.settings,
             });
           }

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -927,6 +927,7 @@ export function App(): JSX.Element {
           signalingServer: session.signalingServer,
           signalingUrl: session.signalingUrl,
           appId: Number.isFinite(signalingRecoveryRef.current.appId ?? NaN) ? signalingRecoveryRef.current.appId ?? undefined : undefined,
+          appLaunchMode: session.appLaunchMode,
           clientId: session.clientId,
           deviceId: session.deviceId,
         }
@@ -937,6 +938,7 @@ export function App(): JSX.Element {
             streamingBaseUrl: navbarActiveSession.streamingBaseUrl,
             signalingUrl: navbarActiveSession.signalingUrl,
             appId: Number.isFinite(navbarActiveSession.appId) ? navbarActiveSession.appId : undefined,
+            appLaunchMode: navbarActiveSession.appLaunchMode,
           }
           : null,
     };
@@ -975,6 +977,7 @@ export function App(): JSX.Element {
           signalingServer: latestSession.signalingServer,
           signalingUrl: latestSession.signalingUrl,
           appId: Number.isFinite(signalingRecoveryRef.current.appId ?? NaN) ? signalingRecoveryRef.current.appId ?? undefined : undefined,
+          appLaunchMode: latestSession.appLaunchMode,
           clientId: latestSession.clientId,
           deviceId: latestSession.deviceId,
         }
@@ -985,6 +988,7 @@ export function App(): JSX.Element {
             streamingBaseUrl: latestNavbarSession.streamingBaseUrl,
             signalingUrl: latestNavbarSession.signalingUrl,
             appId: Number.isFinite(latestNavbarSession.appId) ? latestNavbarSession.appId : undefined,
+            appLaunchMode: latestNavbarSession.appLaunchMode,
           }
           : null,
     };
@@ -2628,6 +2632,7 @@ export function App(): JSX.Element {
                   Number.isFinite(persisted.appId ?? NaN)
                     ? (persisted.appId as number)
                     : (previousAppId ?? 0),
+                appLaunchMode: persisted.appLaunchMode,
                 status: 2,
                 serverIp: persisted.serverIp,
                 streamingBaseUrl: persisted.streamingBaseUrl,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -2510,6 +2510,7 @@ export function App(): JSX.Element {
           sessionId: existingSession.sessionId,
           ...resolveResumeIdentity(existingSession.sessionId),
           appId: resolveSessionClaimAppId(existingSession),
+          appLaunchMode: existingSession.appLaunchMode,
           settings: streamSettings,
         });
 
@@ -2662,6 +2663,7 @@ export function App(): JSX.Element {
             ...resolveResumeIdentity(candidate.sessionId),
             recoveryMode: true,
             appId: resolveSessionClaimAppId(candidate),
+            appLaunchMode: candidate.appLaunchMode,
             settings: recoveryStreamSettings,
           });
           if (!isRecoveryGenerationCurrent(recoveryGeneration)) {

--- a/opennow-stable/src/renderer/src/lib/queueAds.ts
+++ b/opennow-stable/src/renderer/src/lib/queueAds.ts
@@ -125,12 +125,15 @@ export function mergeAdState(
 }
 
 export function mergePolledSessionState(previous: SessionInfo, next: SessionInfo): SessionInfo {
+  // Poll responses may omit the echoed appLaunchMode; keep the session-stable value.
+  const appLaunchMode = next.appLaunchMode ?? previous.appLaunchMode;
   if (isSessionReadyForConnect(next.status)) {
-    return next;
+    return { ...next, appLaunchMode };
   }
 
   return {
     ...next,
+    appLaunchMode,
     adState: mergeAdState(previous.adState, next.adState),
     mediaConnectionInfo: next.mediaConnectionInfo ?? previous.mediaConnectionInfo,
   };

--- a/opennow-stable/src/renderer/src/lib/runtimeSnapshot.ts
+++ b/opennow-stable/src/renderer/src/lib/runtimeSnapshot.ts
@@ -18,6 +18,8 @@ export interface RuntimeSnapshot {
     signalingServer?: string;
     signalingUrl?: string;
     appId?: number;
+    /** Wire appLaunchMode the session was created with, for session-stable claims */
+    appLaunchMode?: number;
     clientId?: string;
     deviceId?: string;
   } | null;
@@ -61,6 +63,11 @@ export function loadRuntimeSnapshot(): RuntimeSnapshot | null {
             appId:
               typeof parsed.resumeContext.appId === "number" && Number.isFinite(parsed.resumeContext.appId)
                 ? parsed.resumeContext.appId
+                : undefined,
+            appLaunchMode:
+              typeof parsed.resumeContext.appLaunchMode === "number" &&
+                Number.isFinite(parsed.resumeContext.appLaunchMode)
+                ? parsed.resumeContext.appLaunchMode
                 : undefined,
             clientId:
               typeof parsed.resumeContext.clientId === "string"

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1132,6 +1132,8 @@ export interface SessionInfo {
 export interface ActiveSessionInfo {
   sessionId: string;
   appId: number;
+  /** Wire appLaunchMode the session was created with, as echoed by the server */
+  appLaunchMode?: number;
   gpuType?: string;
   status: number;
   streamingBaseUrl?: string;
@@ -1150,6 +1152,8 @@ export interface SessionClaimRequest {
   clientId?: string;
   deviceId?: string;
   appId?: string;
+  /** Session-stable wire appLaunchMode captured when the session was created */
+  appLaunchMode?: number;
   settings?: StreamSettings;
   /** True when claim is triggered by automatic reconnect recovery logic */
   recoveryMode?: boolean;

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1119,6 +1119,8 @@ export interface SessionInfo {
   signalingServer: string;
   signalingUrl: string;
   gpuType?: string;
+  /** Wire appLaunchMode the session runs with, kept session-stable for resumes */
+  appLaunchMode?: number;
   iceServers: IceServer[];
   mediaConnectionInfo?: MediaConnectionInfo;
   negotiatedStreamProfile?: NegotiatedStreamProfile;


### PR DESCRIPTION
| This PR fixes resume instability caused by renegotiating the immutable `appLaunchMode` parameter. Claim requests now send the wire value echoed by the server when the session was created, instead of the live UI `settings.appLaunchMode` toggle.

---

**Types & Data Flow**

- `opennow-stable/src/shared/gfn.ts` - Added `appLaunchMode?: number` to `ActiveSessionInfo` and `SessionClaimRequest`
- `opennow-stable/src/main/gfn/types.ts` - Typed `sessionRequestData.appLaunchMode` in `SessionEntry`

**CloudMatch Payloads**

- `opennow-stable/src/main/gfn/cloudmatch.ts` - `getActiveSessions` parses and returns `appLaunchMode` from the `/v2/session` list response
- `opennow-stable/src/main/gfn/cloudmatch.ts` - `buildClaimRequestBody` accepts an optional `sessionAppLaunchMode` overriding the default settings-derived value
- `opennow-stable/src/main/gfn/cloudmatch.ts` - `claimSession` threads `input.appLaunchMode` into `buildClaimRequestBody`

**Call Sites**

- `opennow-stable/src/renderer/src/App.tsx` - Pass `existingSession.appLaunchMode`/`candidate.appLaunchMode` to `claimSession` in resume and recovery paths
- `opennow-stable/src/main/ipc/sessionHandlers.ts` - Pass `readyCandidate.appLaunchMode` to `claimSession` in the create-session fallback path

**Tests**

- `opennow-stable/src/main/gfn/cloudmatch.test.ts` - Added regression test asserting claim payload uses session-stable `appLaunchMode` over live settings

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/447d4219-5530-482c-a984-71888cb486da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-248" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/447d4219-5530-482c-a984-71888cb486da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-248&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-248"><img alt="OPE-248" src="https://capy.ai/api/badge/thread.svg?label=OPE-248"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all session resume/claim paths for GFN CloudMatch; behavior change is narrow but session connectivity is user-critical if the echoed value is missing or wrong.
> 
> **Overview**
> **Resume/claim no longer renegotiates `appLaunchMode` from the live stream settings toggle**, which was causing CloudMatch resume failures when the UI mode differed from the session the server created.
> 
> Active-session listing now **captures the wire `appLaunchMode` echoed in `sessionRequestData`** and exposes it on `ActiveSessionInfo`. **Claim PUT payloads prefer that session-stable value** in `buildClaimRequestBody`, with a fallback to settings-derived wire values when it is missing. Renderer resume/recovery and main-process create-session claim paths **pass `appLaunchMode` through to `claimSession`**. A **regression test** asserts the claim body keeps the original mode even when current settings say default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38febbfe606882613bd41f17d9dc62ac66e930c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->