### PR TITLE
feat(stream): replace session-started splash with minimal Connected badge

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -311,6 +311,9 @@
       "kicker": "Ready",
       "title": "Session started"
     },
+    "connectedBadge": {
+      "title": "Connected"
+    },
     "stats": {
       "overlayLabel": "Stream statistics",
       "expand": "Show detailed stats",

--- a/opennow-stable/src/renderer/src/components/SessionStartedSplash.tsx
+++ b/opennow-stable/src/renderer/src/components/SessionStartedSplash.tsx
@@ -5,40 +5,14 @@ import type { JSX } from "react";
 import { smoothEase } from "./MotionProvider";
 import { useTranslation } from "../i18n";
 
-const SPLASH_VISIBLE_MS = 3000;
+const CONNECTED_BADGE_VISIBLE_MS = 2400;
 
-const overlayVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { duration: 0.35, ease: smoothEase },
-  },
-  exit: {
-    opacity: 0,
-    transition: { duration: 0.55, ease: smoothEase, delay: 0.08 },
-  },
-} as const;
-
-const backdropVariants = {
-  hidden: { opacity: 0, scale: 1.04 },
-  visible: {
-    opacity: 1,
-    scale: 1,
-    transition: { duration: 0.7, ease: smoothEase },
-  },
-  exit: {
-    opacity: 0,
-    scale: 1.08,
-    transition: { duration: 0.5, ease: smoothEase },
-  },
-} as const;
-
-const cardVariants = {
+const badgeVariants = {
   hidden: {
     opacity: 0,
-    scale: 0.9,
-    y: 32,
-    filter: "blur(10px)",
+    scale: 0.88,
+    y: -28,
+    filter: "blur(8px)",
   },
   visible: {
     opacity: 1,
@@ -46,62 +20,16 @@ const cardVariants = {
     y: 0,
     filter: "blur(0px)",
     transition: {
-      duration: 0.72,
+      duration: 0.5,
       ease: smoothEase,
-      delay: 0.06,
     },
   },
   exit: {
     opacity: 0,
-    scale: 1.05,
-    y: -18,
+    scale: 0.96,
+    y: -20,
     filter: "blur(6px)",
-    transition: { duration: 0.48, ease: smoothEase },
-  },
-} as const;
-
-const contentVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      delayChildren: 0.22,
-      staggerChildren: 0.09,
-    },
-  },
-  exit: {
-    opacity: 0,
-    transition: { duration: 0.2 },
-  },
-} as const;
-
-const itemVariants = {
-  hidden: { opacity: 0, y: 16, filter: "blur(4px)" },
-  visible: {
-    opacity: 1,
-    y: 0,
-    filter: "blur(0px)",
-    transition: { duration: 0.48, ease: smoothEase },
-  },
-} as const;
-
-const emblemVariants = {
-  hidden: { opacity: 0, scale: 0.55, rotate: -18 },
-  visible: {
-    opacity: 1,
-    scale: 1,
-    rotate: 0,
-    transition: {
-      type: "spring",
-      stiffness: 340,
-      damping: 22,
-      mass: 0.85,
-    },
-  },
-  exit: {
-    opacity: 0,
-    scale: 1.12,
-    transition: { duration: 0.3, ease: smoothEase },
+    transition: { duration: 0.34, ease: smoothEase },
   },
 } as const;
 
@@ -113,7 +41,6 @@ export interface SessionStartedSplashProps {
 
 export function SessionStartedSplash({
   visible,
-  gameTitle,
   onFinished,
 }: SessionStartedSplashProps): JSX.Element | null {
   const { t } = useTranslation();
@@ -122,81 +49,28 @@ export function SessionStartedSplash({
     if (!visible) {
       return undefined;
     }
-    const timer = window.setTimeout(onFinished, SPLASH_VISIBLE_MS);
+    const timer = window.setTimeout(onFinished, CONNECTED_BADGE_VISIBLE_MS);
     return () => window.clearTimeout(timer);
   }, [onFinished, visible]);
 
   return (
-    <AnimatePresence mode="wait">
+    <AnimatePresence>
       {visible && (
         <m.div
           className="sv-ready-splash"
           role="status"
           aria-live="polite"
-          variants={overlayVariants}
+          variants={badgeVariants}
           initial="hidden"
           animate="visible"
           exit="exit"
         >
-          <m.div
-            className="sv-ready-splash-backdrop"
-            variants={backdropVariants}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-          >
-            <span className="sv-ready-splash-orb sv-ready-splash-orb--a" aria-hidden />
-            <span className="sv-ready-splash-orb sv-ready-splash-orb--b" aria-hidden />
-            <span className="sv-ready-splash-orb sv-ready-splash-orb--c" aria-hidden />
-          </m.div>
-
-          <m.div
-            className="sv-ready-splash-card"
-            variants={cardVariants}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-          >
-            <span className="sv-ready-splash-card-glow" aria-hidden />
-            <span className="sv-ready-splash-card-shimmer" aria-hidden />
-
-            <m.div
-              className="sv-ready-splash-emblem"
-              variants={emblemVariants}
-              aria-hidden
-            >
-              <span className="sv-ready-splash-ring sv-ready-splash-ring--outer" />
-              <span className="sv-ready-splash-ring sv-ready-splash-ring--mid" />
-              <span className="sv-ready-splash-ring sv-ready-splash-ring--inner" />
-              <span className="sv-ready-splash-emblem-core">
-                <Check size={28} strokeWidth={2.5} />
-              </span>
-            </m.div>
-
-            <m.div
-              className="sv-ready-splash-copy"
-              variants={contentVariants}
-              initial="hidden"
-              animate="visible"
-              exit="exit"
-            >
-              <m.p className="sv-ready-splash-kicker" variants={itemVariants}>
-                {t("stream.sessionStarted.kicker")}
-              </m.p>
-              <m.h2 className="sv-ready-splash-title" variants={itemVariants}>
-                {t("stream.sessionStarted.title")}
-              </m.h2>
-              <m.p className="sv-ready-splash-game" variants={itemVariants}>
-                {gameTitle}
-              </m.p>
-            </m.div>
-
-            <div
-              className="sv-ready-splash-progress"
-              aria-hidden
-              style={{ animationDuration: `${SPLASH_VISIBLE_MS}ms` }}
-            />
-          </m.div>
+          <span className="sv-ready-splash-card">
+            <span className="sv-ready-splash-emblem" aria-hidden>
+              <Check size={15} strokeWidth={3} />
+            </span>
+            <span className="sv-ready-splash-title">{t("stream.connectedBadge.title")}</span>
+          </span>
         </m.div>
       )}
     </AnimatePresence>

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -509,7 +509,7 @@ export function StreamView({
   const streamVideoReady = streamHasVideo || videoElementHasFrame;
   const [sessionReadySplashVisible, setSessionReadySplashVisible] = useState(false);
   const sessionReadySplashShownRef = useRef(false);
-  const showStatsHud = showStats && !nativeRendererActive && !isConnecting && !sessionReadySplashVisible;
+  const showStatsHud = showStats && !nativeRendererActive && !isConnecting;
 
   useEffect(() => {
     if (isConnecting) {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -6932,142 +6932,46 @@ button.game-card-store-chip.owned.active:hover {
   }
 }
 
-/* Session ready splash */
+/* Session ready badge */
 .sv-ready-splash {
   position: fixed;
-  inset: 0;
+  top: max(14px, env(safe-area-inset-top));
+  left: 0;
+  right: 0;
   z-index: 1005;
   display: flex;
-  align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: 0 16px;
   pointer-events: none;
-}
-
-.sv-ready-splash-backdrop {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  background:
-    radial-gradient(circle at 50% 38%, rgba(var(--accent-rgb), 0.16), transparent 52%),
-    radial-gradient(circle at 50% 100%, rgba(0, 0, 0, 0.45), transparent 58%),
-    linear-gradient(180deg, rgba(6, 7, 9, 0.42), rgba(6, 7, 9, 0.72));
-  backdrop-filter: blur(6px) saturate(1.15);
-  -webkit-backdrop-filter: blur(6px) saturate(1.15);
-  animation: sv-ready-backdrop-breathe 3.2s ease-in-out infinite;
-}
-
-.sv-ready-splash-orb {
-  position: absolute;
-  border-radius: 999px;
-  filter: blur(28px);
-  opacity: 0.55;
-  pointer-events: none;
-}
-
-.sv-ready-splash-orb--a {
-  width: 220px;
-  height: 220px;
-  top: 18%;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(var(--accent-rgb), 0.28);
-  animation: sv-ready-orb-drift-a 4.8s ease-in-out infinite;
-}
-
-.sv-ready-splash-orb--b {
-  width: 140px;
-  height: 140px;
-  bottom: 16%;
-  left: 22%;
-  background: rgba(var(--accent-rgb), 0.14);
-  animation: sv-ready-orb-drift-b 5.6s ease-in-out infinite;
-}
-
-.sv-ready-splash-orb--c {
-  width: 120px;
-  height: 120px;
-  top: 28%;
-  right: 18%;
-  background: rgba(96, 165, 250, 0.12);
-  animation: sv-ready-orb-drift-c 6.2s ease-in-out infinite;
 }
 
 .sv-ready-splash-card {
   position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
+  display: inline-flex;
   align-items: center;
-  gap: 14px;
-  width: min(100%, 440px);
-  padding: 30px 34px 26px;
-  text-align: center;
-  border-radius: var(--r-xl);
-  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--panel-border));
+  gap: 8px;
+  min-height: 38px;
+  padding: 8px 15px 8px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--accent-rgb), 0.35);
   background:
-    linear-gradient(165deg, rgba(18, 19, 22, 0.94), rgba(10, 10, 12, 0.88));
+    radial-gradient(circle at 28% 0%, rgba(255, 255, 255, 0.16), transparent 36%),
+    linear-gradient(180deg, rgba(18, 20, 23, 0.93), rgba(9, 10, 12, 0.88));
   box-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.03) inset,
-    0 24px 70px rgba(0, 0, 0, 0.55),
-    0 0 48px rgba(var(--accent-rgb), 0.12);
+    0 0 0 1px rgba(255, 255, 255, 0.05) inset,
+    0 10px 34px rgba(0, 0, 0, 0.38),
+    0 0 26px rgba(var(--accent-rgb), 0.14);
+  backdrop-filter: blur(14px) saturate(1.25);
+  -webkit-backdrop-filter: blur(14px) saturate(1.25);
   overflow: hidden;
 }
 
-.sv-ready-splash-card-glow {
-  position: absolute;
-  inset: -40% -20% auto;
-  height: 62%;
-  background: radial-gradient(circle at 50% 100%, rgba(var(--accent-rgb), 0.22), transparent 68%);
-  pointer-events: none;
-}
-
-.sv-ready-splash-card-shimmer {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    105deg,
-    transparent 42%,
-    rgba(255, 255, 255, 0.07) 50%,
-    transparent 58%
-  );
-  transform: translateX(-120%);
-  animation: sv-ready-shimmer 1.1s var(--ease) 0.85s forwards;
-  pointer-events: none;
-}
-
 .sv-ready-splash-emblem {
-  position: relative;
-  width: 84px;
-  height: 84px;
-  margin-bottom: 2px;
-}
-
-.sv-ready-splash-ring {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  border: 1px solid rgba(var(--accent-rgb), 0.35);
-}
-
-.sv-ready-splash-ring--outer {
-  animation: sv-ready-ring 2.4s ease-out infinite;
-}
-
-.sv-ready-splash-ring--mid {
-  animation: sv-ready-ring 2.4s ease-out 0.55s infinite;
-}
-
-.sv-ready-splash-ring--inner {
-  animation: sv-ready-ring 2.4s ease-out 1.1s infinite;
-}
-
-.sv-ready-splash-emblem-core {
-  position: absolute;
-  inset: 14px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 22px;
+  height: 22px;
   border-radius: 999px;
   color: var(--accent-on);
   background:
@@ -7075,148 +6979,14 @@ button.game-card-store-chip.owned.active:hover {
     linear-gradient(145deg, var(--accent-hover), var(--accent-press));
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.12) inset,
-    0 10px 28px rgba(var(--accent-rgb), 0.35);
-  animation: sv-ready-emblem-pop 0.65s var(--ease) 0.18s both;
-}
-
-.sv-ready-splash-copy {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-}
-
-.sv-ready-splash-kicker {
-  margin: 0;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  color: var(--accent);
+    0 6px 16px rgba(var(--accent-rgb), 0.32);
 }
 
 .sv-ready-splash-title {
-  margin: 0;
-  max-width: 24ch;
-  font-size: clamp(1.45rem, 4.2vw, 2rem);
-  font-weight: 600;
-  letter-spacing: -0.03em;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   color: var(--ink);
-  text-wrap: balance;
-}
-
-.sv-ready-splash-game {
-  margin: 0;
-  max-width: 40ch;
-  font-size: 0.95rem;
-  color: var(--ink-soft);
-  text-wrap: pretty;
-}
-
-.sv-ready-splash-progress {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 3px;
-  transform-origin: left center;
-  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
-  box-shadow: 0 0 14px rgba(var(--accent-rgb), 0.45);
-  animation-name: sv-ready-progress;
-  animation-timing-function: linear;
-  animation-fill-mode: forwards;
-}
-
-@keyframes sv-ready-backdrop-breathe {
-  0%,
-  100% {
-    filter: brightness(1);
-  }
-
-  50% {
-    filter: brightness(1.08);
-  }
-}
-
-@keyframes sv-ready-orb-drift-a {
-  0%,
-  100% {
-    transform: translateX(-50%) translateY(0);
-  }
-
-  50% {
-    transform: translateX(-46%) translateY(12px);
-  }
-}
-
-@keyframes sv-ready-orb-drift-b {
-  0%,
-  100% {
-    transform: translate(0, 0);
-  }
-
-  50% {
-    transform: translate(18px, -10px);
-  }
-}
-
-@keyframes sv-ready-orb-drift-c {
-  0%,
-  100% {
-    transform: translate(0, 0);
-  }
-
-  50% {
-    transform: translate(-14px, 16px);
-  }
-}
-
-@keyframes sv-ready-ring {
-  0% {
-    transform: scale(0.76);
-    opacity: 0.75;
-  }
-
-  100% {
-    transform: scale(1.55);
-    opacity: 0;
-  }
-}
-
-@keyframes sv-ready-emblem-pop {
-  0% {
-    transform: scale(0.72);
-    opacity: 0;
-  }
-
-  65% {
-    transform: scale(1.06);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-@keyframes sv-ready-shimmer {
-  0% {
-    transform: translateX(-120%);
-  }
-
-  100% {
-    transform: translateX(120%);
-  }
-}
-
-@keyframes sv-ready-progress {
-  from {
-    transform: scaleX(1);
-  }
-
-  to {
-    transform: scaleX(0);
-  }
 }
 
 .sv-warm {


### PR DESCRIPTION
This PR replaces the full-screen session-started splash screen with a compact, top-center "Connected" badge that briefly appears when streaming begins.

- Refactor `SessionStartedSplash` from full-screen card to minimal badge with checkmark icon
- Update badge to animate in from top-center and auto-dismiss after 2.4 seconds
- Remove backdrop, orbs, rings, shimmer effects, and progress bar from splash component
- Simplify motion variants from complex multi-part animations to single badge enter/exit
- Reduce visibility duration from 3s to 2.4s for quicker non-intrusive feedback
- Remove splash visibility check from stats HUD so overlay displays immediately
- Update locale text from "Session started" to "Connected" for brevity
- Update CSS comment from "Session ready splash" to "Session ready badge"

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/223cfb0a-6363-4c43-9cc3-6e68d1b9b963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-253" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/223cfb0a-6363-4c43-9cc3-6e68d1b9b963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-253&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-253"><img alt="OPE-253" src="https://capy.ai/api/badge/thread.svg?label=OPE-253"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only stream feedback and styling changes with no auth, session, or streaming protocol impact.
> 
> **Overview**
> Replaces the **full-screen “Session started” splash** (blurred backdrop, card, game title, progress bar) with a **small top-center pill** that shows a checkmark and **“Connected”** (`stream.connectedBadge.title`), auto-dismissed after **2.4s** (was 3s).
> 
> **`SessionStartedSplash`** is reduced to a single motion variant and no longer renders kicker, game name, or decorative layers; copy moves off the old `stream.sessionStarted` strings for the badge label.
> 
> **`StreamView`** stops gating the stats HUD on splash visibility, so stats can appear **while** the badge is still showing.
> 
> **CSS** repositions `.sv-ready-splash` to the safe-area top and restyles `.sv-ready-splash-card` as a compact chip, removing the large splash keyframes and orb/ring/shimmer rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8cf4ae919bcee0400b98810f141e51af7ee8c35. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->