### PR TITLE
feat(library): add filter UI for install, platform, controls, and activity

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -216,6 +216,10 @@
     },
     "filterOptions": {
       "installToPlay": "Install to Play",
+      "cloudLaunch": "Cloud Launch",
+      "keyboardMouse": "Keyboard & Mouse",
+      "controller": "Controller",
+      "touch": "Touch",
       "played": "Played",
       "neverPlayed": "Never Played"
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -186,7 +186,12 @@
     "searchPlaceholder": "Search your library...",
     "gameCount": "{{count}} game",
     "gameCount_plural": "{{count}} games",
+    "filteredGameCount": "{{shown}} of {{total}} games",
     "filter": "Filter",
+    "filters": "Filters",
+    "activeFilters": "Active filters",
+    "clearFilters": "Clear",
+    "removeFilter": "Remove {{filter}} filter",
     "allStores": "All Stores",
     "storeFilter": "Store Filter",
     "chooseStore": "Choose a Store",
@@ -203,6 +208,17 @@
     "nvidiaTech": "NVIDIA Tech: {{tech}}",
     "genres": "Genres: {{genres}}",
     "rating": "Rating: {{rating}}",
+    "filterGroups": {
+      "playType": "Play Type",
+      "platform": "Platform",
+      "controls": "Controls",
+      "activity": "Activity"
+    },
+    "filterOptions": {
+      "installToPlay": "Install to Play",
+      "played": "Played",
+      "neverPlayed": "Never Played"
+    },
     "lastPlayed": {
       "never": "Never played",
       "justNow": "Just now",
@@ -216,7 +232,9 @@
       "libraryEmpty": "Your library is empty",
       "ownedGamesAppearHere": "Games you own will appear here. Browse the catalog to find games.",
       "noGamesFound": "No games found",
-      "noGamesMatch": "No games match \"{{query}}\""
+      "noGamesMatch": "No games match \"{{query}}\"",
+      "noFilteredGames": "No games match those filters",
+      "tryAdjustingFilters": "Try clearing a filter or changing your search."
     }
   },
   "gameCard": {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -4442,6 +4442,7 @@ export function App(): JSX.Element {
             {mainPage === "library" && (
               <LibraryPage
                 games={filteredLibraryGames}
+                allGames={libraryGames}
                 searchQuery={searchQuery}
                 onSearchChange={setSearchQuery}
                 onPlayGame={handleInitiatePlay}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -4443,6 +4443,7 @@ export function App(): JSX.Element {
               <LibraryPage
                 games={filteredLibraryGames}
                 allGames={libraryGames}
+                playtimeData={playtime}
                 searchQuery={searchQuery}
                 onSearchChange={setSearchQuery}
                 onPlayGame={handleInitiatePlay}

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, m } from "motion/react";
 import type { CatalogSortOption, GameInfo } from "@shared/gfn";
 import { getStoreDisplayName, getStoreIconComponent, normalizeStoreKey } from "./GameCard";
 import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
+import type { PlaytimeData } from "../lib/gameCatalog";
 import { useTranslation } from "../i18n";
 import { formatCatalogLastPlayed } from "../utils/lastPlayedFormat";
 import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
@@ -43,6 +44,7 @@ interface LibraryFilterGroup {
 export interface LibraryPageProps {
   games: GameInfo[];
   allGames: GameInfo[];
+  playtimeData: PlaytimeData;
   searchQuery: string;
   onSearchChange: (query: string) => void;
   onPlayGame: (game: GameInfo) => void;
@@ -190,6 +192,15 @@ function gameRequiresInstallToPlay(game: GameInfo): boolean {
   return haystack.includes("install");
 }
 
+function getGamePlayTypeFilter(game: GameInfo, installToPlayLabel: string): LibraryFilterOption | null {
+  if (gameRequiresInstallToPlay(game)) {
+    return { id: "play:install-to-play", label: installToPlayLabel, count: 0 };
+  }
+  if (!game.playType?.trim()) return null;
+  const key = normalizeLibraryFilterValue(game.playType);
+  return key ? { id: `play:${key}`, label: formatLibraryPlayTypeLabel(game.playType), count: 0 } : null;
+}
+
 function getGameStoreFilters(game: GameInfo): Array<{ id: string; label: string }> {
   const stores = game.availableStores?.length ? game.availableStores : game.variants.map((variant) => variant.store);
   const seen = new Set<string>();
@@ -233,19 +244,23 @@ function mapLibraryFilterOptions(options: Map<string, LibraryFilterOption>): Lib
   return [...options.values()].sort((left, right) => left.label.localeCompare(right.label));
 }
 
-function getLibraryFilterGroups(games: GameInfo[], t: (key: string, values?: Record<string, string | number | boolean | null | undefined>) => string): LibraryFilterGroup[] {
+function gameHasLibraryActivity(game: GameInfo, playtimeData: PlaytimeData): boolean {
+  if (game.lastPlayed) return true;
+  const record = playtimeData[game.id];
+  if (!record) return false;
+  return Boolean(record.lastPlayedAt) || (record.totalSeconds ?? 0) > 0 || (record.sessionCount ?? 0) > 0;
+}
+
+function getLibraryFilterGroups(games: GameInfo[], playtimeData: PlaytimeData, t: (key: string, values?: Record<string, string | number | boolean | null | undefined>) => string): LibraryFilterGroup[] {
   const playTypeOptions = new Map<string, LibraryFilterOption>();
   const platformOptions = new Map<string, LibraryFilterOption>();
   const controlOptions = new Map<string, LibraryFilterOption>();
   const activityOptions = new Map<string, LibraryFilterOption>();
+  const installToPlayLabel = t("library.filterOptions.installToPlay");
 
   for (const game of games) {
-    if (gameRequiresInstallToPlay(game)) {
-      upsertLibraryFilterOption(playTypeOptions, "play:install-to-play", t("library.filterOptions.installToPlay"));
-    } else if (game.playType?.trim()) {
-      const key = normalizeLibraryFilterValue(game.playType);
-      if (key) upsertLibraryFilterOption(playTypeOptions, `play:${key}`, formatLibraryPlayTypeLabel(game.playType));
-    }
+    const playTypeOption = getGamePlayTypeFilter(game, installToPlayLabel);
+    if (playTypeOption) upsertLibraryFilterOption(playTypeOptions, playTypeOption.id, playTypeOption.label);
 
     for (const option of getGameStoreFilters(game)) {
       upsertLibraryFilterOption(platformOptions, option.id, option.label);
@@ -255,10 +270,11 @@ function getLibraryFilterGroups(games: GameInfo[], t: (key: string, values?: Rec
       upsertLibraryFilterOption(controlOptions, option.id, option.label);
     }
 
+    const hasActivity = gameHasLibraryActivity(game, playtimeData);
     upsertLibraryFilterOption(
       activityOptions,
-      game.lastPlayed ? "activity:played" : "activity:never-played",
-      game.lastPlayed ? t("library.filterOptions.played") : t("library.filterOptions.neverPlayed"),
+      hasActivity ? "activity:played" : "activity:never-played",
+      hasActivity ? t("library.filterOptions.played") : t("library.filterOptions.neverPlayed"),
     );
   }
 
@@ -275,13 +291,12 @@ function getLibraryFilterGroupId(filterId: string): string {
   return separatorIndex >= 0 ? filterId.slice(0, separatorIndex) : filterId;
 }
 
-function gameMatchesLibraryFilter(game: GameInfo, filterId: string): boolean {
+function gameMatchesLibraryFilter(game: GameInfo, filterId: string, playtimeData: PlaytimeData, installToPlayLabel: string): boolean {
   const [groupId, value] = filterId.split(":");
   if (!value) return true;
 
   if (groupId === "play") {
-    if (value === "install-to-play") return gameRequiresInstallToPlay(game);
-    return normalizeLibraryFilterValue(game.playType) === value;
+    return getGamePlayTypeFilter(game, installToPlayLabel)?.id === filterId;
   }
 
   if (groupId === "platform") {
@@ -293,13 +308,14 @@ function gameMatchesLibraryFilter(game: GameInfo, filterId: string): boolean {
   }
 
   if (groupId === "activity") {
-    return value === "played" ? Boolean(game.lastPlayed) : !game.lastPlayed;
+    const hasActivity = gameHasLibraryActivity(game, playtimeData);
+    return value === "played" ? hasActivity : !hasActivity;
   }
 
   return true;
 }
 
-function gameMatchesLibraryFilters(game: GameInfo, selectedFilterIds: string[]): boolean {
+function gameMatchesLibraryFilters(game: GameInfo, selectedFilterIds: string[], playtimeData: PlaytimeData, installToPlayLabel: string): boolean {
   if (selectedFilterIds.length === 0) return true;
   const selectedByGroup = new Map<string, string[]>();
   for (const filterId of selectedFilterIds) {
@@ -307,7 +323,7 @@ function gameMatchesLibraryFilters(game: GameInfo, selectedFilterIds: string[]):
     selectedByGroup.set(groupId, [...(selectedByGroup.get(groupId) ?? []), filterId]);
   }
   for (const groupFilterIds of selectedByGroup.values()) {
-    if (!groupFilterIds.some((filterId) => gameMatchesLibraryFilter(game, filterId))) return false;
+    if (!groupFilterIds.some((filterId) => gameMatchesLibraryFilter(game, filterId, playtimeData, installToPlayLabel))) return false;
   }
   return true;
 }
@@ -385,6 +401,7 @@ function ControllerGameCard({
 export const LibraryPage = memo(function LibraryPage({
   games,
   allGames,
+  playtimeData,
   searchQuery,
   onSearchChange,
   onPlayGame,
@@ -445,13 +462,15 @@ export const LibraryPage = memo(function LibraryPage({
     controllerSearchInputRef.current?.focus();
   }, [controllerMode, controllerSearchOpen]);
 
+  const installToPlayFilterLabel = t("library.filterOptions.installToPlay");
+  const librarySearchHasQuery = searchQuery.trim().length > 0;
   const libraryFilterGroups = useMemo(
-    () => getLibraryFilterGroups(allGames, t),
-    [allGames, t],
+    () => getLibraryFilterGroups(allGames, playtimeData, t),
+    [allGames, playtimeData, t],
   );
   const visibleLibraryGames = useMemo(
-    () => games.filter((game) => gameMatchesLibraryFilters(game, selectedLibraryFilterIds)),
-    [games, selectedLibraryFilterIds],
+    () => games.filter((game) => gameMatchesLibraryFilters(game, selectedLibraryFilterIds, playtimeData, installToPlayFilterLabel)),
+    [games, installToPlayFilterLabel, playtimeData, selectedLibraryFilterIds],
   );
   const activeLibraryFilterOptions = useMemo(
     () => selectedLibraryFilterIds
@@ -460,7 +479,7 @@ export const LibraryPage = memo(function LibraryPage({
     [libraryFilterGroups, selectedLibraryFilterIds],
   );
   const hasActiveLibraryFilters = activeLibraryFilterOptions.length > 0;
-  const libraryCountLabel = hasActiveLibraryFilters || searchQuery.trim()
+  const libraryCountLabel = hasActiveLibraryFilters || librarySearchHasQuery
     ? t("library.filteredGameCount", { shown: visibleLibraryGames.length, total: libraryCount, count: libraryCount })
     : t("library.gameCount", { count: libraryCount });
 
@@ -1170,10 +1189,12 @@ export const LibraryPage = memo(function LibraryPage({
         ) : visibleLibraryGames.length === 0 ? (
           <div className="library-empty-state">
             <Search className="library-empty-icon" size={44} />
-            <h3>{hasActiveLibraryFilters ? t("library.empty.noFilteredGames") : t("library.empty.noGamesFound")}</h3>
+            <h3>{hasActiveLibraryFilters && !librarySearchHasQuery ? t("library.empty.noFilteredGames") : t("library.empty.noGamesFound")}</h3>
             <p>
-              {hasActiveLibraryFilters
-                ? t("library.empty.tryAdjustingFilters")
+              {librarySearchHasQuery
+                ? t("library.empty.noGamesMatch", { query: searchQuery })
+                : hasActiveLibraryFilters
+                  ? t("library.empty.tryAdjustingFilters")
                 : t("library.empty.noGamesMatch", { query: searchQuery })}
             </p>
           </div>

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -41,6 +41,8 @@ interface LibraryFilterGroup {
   options: LibraryFilterOption[];
 }
 
+type LibraryTranslation = (key: string, values?: Record<string, string | number | boolean | null | undefined>) => string;
+
 export interface LibraryPageProps {
   games: GameInfo[];
   allGames: GameInfo[];
@@ -154,21 +156,6 @@ function formatLibraryFilterLabel(value: string): string {
     .replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
-function formatLibraryPlayTypeLabel(playType: string): string {
-  const normalized = normalizeLibraryFilterValue(playType);
-  if (normalized.includes("install")) return "Install to Play";
-  if (normalized.includes("instant") || normalized.includes("stream") || normalized.includes("cloud")) return "Cloud Launch";
-  return formatLibraryFilterLabel(playType);
-}
-
-function formatLibraryControlLabel(control: string): string {
-  const normalized = normalizeLibraryFilterValue(control);
-  if (normalized.includes("keyboard") || normalized.includes("mouse")) return "Keyboard & Mouse";
-  if (normalized.includes("gamepad") || normalized.includes("controller")) return "Controller";
-  if (normalized.includes("touch")) return "Touch";
-  return formatLibraryFilterLabel(control);
-}
-
 function getGameCatalogSkuText(game: GameInfo): string {
   const values = Object.values(game.catalogSkuStrings ?? {});
   const parts: string[] = [];
@@ -192,13 +179,19 @@ function gameRequiresInstallToPlay(game: GameInfo): boolean {
   return haystack.includes("install");
 }
 
-function getGamePlayTypeFilter(game: GameInfo, installToPlayLabel: string): LibraryFilterOption | null {
+function getGamePlayTypeFilter(game: GameInfo, t: LibraryTranslation): LibraryFilterOption | null {
   if (gameRequiresInstallToPlay(game)) {
-    return { id: "play:install-to-play", label: installToPlayLabel, count: 0 };
+    return { id: "play:install-to-play", label: t("library.filterOptions.installToPlay"), count: 0 };
   }
   if (!game.playType?.trim()) return null;
-  const key = normalizeLibraryFilterValue(game.playType);
-  return key ? { id: `play:${key}`, label: formatLibraryPlayTypeLabel(game.playType), count: 0 } : null;
+  const normalized = normalizeLibraryFilterValue(game.playType);
+  if (!normalized) return null;
+  if (normalized.includes("instant") || normalized.includes("stream") || normalized.includes("cloud")) {
+    return { id: "play:cloud-launch", label: t("library.filterOptions.cloudLaunch"), count: 0 };
+  }
+  const label = formatLibraryFilterLabel(game.playType);
+  const key = normalizeLibraryFilterValue(label);
+  return key ? { id: `play:${key}`, label, count: 0 } : null;
 }
 
 function getGameStoreFilters(game: GameInfo): Array<{ id: string; label: string }> {
@@ -215,7 +208,24 @@ function getGameStoreFilters(game: GameInfo): Array<{ id: string; label: string 
   return filters;
 }
 
-function getGameControlFilters(game: GameInfo): Array<{ id: string; label: string }> {
+function getControlFilter(control: string, t: LibraryTranslation): { id: string; label: string } | null {
+  const normalized = normalizeLibraryFilterValue(control);
+  if (!normalized) return null;
+  if (normalized.includes("keyboard") || normalized.includes("mouse")) {
+    return { id: "controls:keyboard-mouse", label: t("library.filterOptions.keyboardMouse") };
+  }
+  if (normalized.includes("gamepad") || normalized.includes("controller")) {
+    return { id: "controls:controller", label: t("library.filterOptions.controller") };
+  }
+  if (normalized.includes("touch")) {
+    return { id: "controls:touch", label: t("library.filterOptions.touch") };
+  }
+  const label = formatLibraryFilterLabel(control);
+  const key = normalizeLibraryFilterValue(label);
+  return key ? { id: `controls:${key}`, label } : null;
+}
+
+function getGameControlFilters(game: GameInfo, t: LibraryTranslation): Array<{ id: string; label: string }> {
   const controls = [
     ...(game.supportedControls ?? []),
     ...game.variants.flatMap((variant) => variant.supportedControls),
@@ -223,10 +233,10 @@ function getGameControlFilters(game: GameInfo): Array<{ id: string; label: strin
   const seen = new Set<string>();
   const filters: Array<{ id: string; label: string }> = [];
   for (const control of controls) {
-    const key = normalizeLibraryFilterValue(control);
-    if (!key || seen.has(key)) continue;
-    seen.add(key);
-    filters.push({ id: `controls:${key}`, label: formatLibraryControlLabel(control) });
+    const filter = getControlFilter(control, t);
+    if (!filter || seen.has(filter.id)) continue;
+    seen.add(filter.id);
+    filters.push(filter);
   }
   return filters;
 }
@@ -251,22 +261,21 @@ function gameHasLibraryActivity(game: GameInfo, playtimeData: PlaytimeData): boo
   return Boolean(record.lastPlayedAt) || (record.totalSeconds ?? 0) > 0 || (record.sessionCount ?? 0) > 0;
 }
 
-function getLibraryFilterGroups(games: GameInfo[], playtimeData: PlaytimeData, t: (key: string, values?: Record<string, string | number | boolean | null | undefined>) => string): LibraryFilterGroup[] {
+function getLibraryFilterGroups(games: GameInfo[], playtimeData: PlaytimeData, t: LibraryTranslation): LibraryFilterGroup[] {
   const playTypeOptions = new Map<string, LibraryFilterOption>();
   const platformOptions = new Map<string, LibraryFilterOption>();
   const controlOptions = new Map<string, LibraryFilterOption>();
   const activityOptions = new Map<string, LibraryFilterOption>();
-  const installToPlayLabel = t("library.filterOptions.installToPlay");
 
   for (const game of games) {
-    const playTypeOption = getGamePlayTypeFilter(game, installToPlayLabel);
+    const playTypeOption = getGamePlayTypeFilter(game, t);
     if (playTypeOption) upsertLibraryFilterOption(playTypeOptions, playTypeOption.id, playTypeOption.label);
 
     for (const option of getGameStoreFilters(game)) {
       upsertLibraryFilterOption(platformOptions, option.id, option.label);
     }
 
-    for (const option of getGameControlFilters(game)) {
+    for (const option of getGameControlFilters(game, t)) {
       upsertLibraryFilterOption(controlOptions, option.id, option.label);
     }
 
@@ -291,12 +300,12 @@ function getLibraryFilterGroupId(filterId: string): string {
   return separatorIndex >= 0 ? filterId.slice(0, separatorIndex) : filterId;
 }
 
-function gameMatchesLibraryFilter(game: GameInfo, filterId: string, playtimeData: PlaytimeData, installToPlayLabel: string): boolean {
+function gameMatchesLibraryFilter(game: GameInfo, filterId: string, playtimeData: PlaytimeData, t: LibraryTranslation): boolean {
   const [groupId, value] = filterId.split(":");
   if (!value) return true;
 
   if (groupId === "play") {
-    return getGamePlayTypeFilter(game, installToPlayLabel)?.id === filterId;
+    return getGamePlayTypeFilter(game, t)?.id === filterId;
   }
 
   if (groupId === "platform") {
@@ -304,7 +313,7 @@ function gameMatchesLibraryFilter(game: GameInfo, filterId: string, playtimeData
   }
 
   if (groupId === "controls") {
-    return getGameControlFilters(game).some((option) => option.id === filterId);
+    return getGameControlFilters(game, t).some((option) => option.id === filterId);
   }
 
   if (groupId === "activity") {
@@ -315,7 +324,7 @@ function gameMatchesLibraryFilter(game: GameInfo, filterId: string, playtimeData
   return true;
 }
 
-function gameMatchesLibraryFilters(game: GameInfo, selectedFilterIds: string[], playtimeData: PlaytimeData, installToPlayLabel: string): boolean {
+function gameMatchesLibraryFilters(game: GameInfo, selectedFilterIds: string[], playtimeData: PlaytimeData, t: LibraryTranslation): boolean {
   if (selectedFilterIds.length === 0) return true;
   const selectedByGroup = new Map<string, string[]>();
   for (const filterId of selectedFilterIds) {
@@ -323,7 +332,7 @@ function gameMatchesLibraryFilters(game: GameInfo, selectedFilterIds: string[], 
     selectedByGroup.set(groupId, [...(selectedByGroup.get(groupId) ?? []), filterId]);
   }
   for (const groupFilterIds of selectedByGroup.values()) {
-    if (!groupFilterIds.some((filterId) => gameMatchesLibraryFilter(game, filterId, playtimeData, installToPlayLabel))) return false;
+    if (!groupFilterIds.some((filterId) => gameMatchesLibraryFilter(game, filterId, playtimeData, t))) return false;
   }
   return true;
 }
@@ -462,15 +471,14 @@ export const LibraryPage = memo(function LibraryPage({
     controllerSearchInputRef.current?.focus();
   }, [controllerMode, controllerSearchOpen]);
 
-  const installToPlayFilterLabel = t("library.filterOptions.installToPlay");
   const librarySearchHasQuery = searchQuery.trim().length > 0;
   const libraryFilterGroups = useMemo(
     () => getLibraryFilterGroups(allGames, playtimeData, t),
     [allGames, playtimeData, t],
   );
   const visibleLibraryGames = useMemo(
-    () => games.filter((game) => gameMatchesLibraryFilters(game, selectedLibraryFilterIds, playtimeData, installToPlayFilterLabel)),
-    [games, installToPlayFilterLabel, playtimeData, selectedLibraryFilterIds],
+    () => games.filter((game) => gameMatchesLibraryFilters(game, selectedLibraryFilterIds, playtimeData, t)),
+    [games, playtimeData, selectedLibraryFilterIds, t],
   );
   const activeLibraryFilterOptions = useMemo(
     () => selectedLibraryFilterIds

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -1,9 +1,9 @@
-import { Library, Search, Clock, Gamepad2, Loader2, ArrowUpDown, MoreHorizontal, Menu } from "lucide-react";
+import { Library, Search, Clock, Gamepad2, Loader2, ArrowUpDown, MoreHorizontal, Menu, Filter, ChevronDown, X } from "lucide-react";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import { AnimatePresence, m } from "motion/react";
 import type { CatalogSortOption, GameInfo } from "@shared/gfn";
-import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
+import { getStoreDisplayName, getStoreIconComponent, normalizeStoreKey } from "./GameCard";
 import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
 import { useTranslation } from "../i18n";
 import { formatCatalogLastPlayed } from "../utils/lastPlayedFormat";
@@ -28,8 +28,21 @@ interface ControllerStoreFilterItem {
   title: string;
 }
 
+interface LibraryFilterOption {
+  id: string;
+  label: string;
+  count: number;
+}
+
+interface LibraryFilterGroup {
+  id: string;
+  label: string;
+  options: LibraryFilterOption[];
+}
+
 export interface LibraryPageProps {
   games: GameInfo[];
+  allGames: GameInfo[];
   searchQuery: string;
   onSearchChange: (query: string) => void;
   onPlayGame: (game: GameInfo) => void;
@@ -121,6 +134,192 @@ function gameMatchesStoreFilter(game: GameInfo, filterId: string): boolean {
   return game.variants.some((variant) => variant.store === store) || (game.availableStores ?? []).includes(store);
 }
 
+function normalizeLibraryFilterValue(value: string | undefined): string {
+  return (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function formatLibraryFilterLabel(value: string): string {
+  return value
+    .trim()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function formatLibraryPlayTypeLabel(playType: string): string {
+  const normalized = normalizeLibraryFilterValue(playType);
+  if (normalized.includes("install")) return "Install to Play";
+  if (normalized.includes("instant") || normalized.includes("stream") || normalized.includes("cloud")) return "Cloud Launch";
+  return formatLibraryFilterLabel(playType);
+}
+
+function formatLibraryControlLabel(control: string): string {
+  const normalized = normalizeLibraryFilterValue(control);
+  if (normalized.includes("keyboard") || normalized.includes("mouse")) return "Keyboard & Mouse";
+  if (normalized.includes("gamepad") || normalized.includes("controller")) return "Controller";
+  if (normalized.includes("touch")) return "Touch";
+  return formatLibraryFilterLabel(control);
+}
+
+function getGameCatalogSkuText(game: GameInfo): string {
+  const values = Object.values(game.catalogSkuStrings ?? {});
+  const parts: string[] = [];
+  for (const value of values) {
+    if (typeof value === "string") {
+      parts.push(value);
+    } else if (Array.isArray(value)) {
+      parts.push(...value.filter((item): item is string => typeof item === "string"));
+    }
+  }
+  return parts.join(" ");
+}
+
+function gameRequiresInstallToPlay(game: GameInfo): boolean {
+  const haystack = [
+    game.playType,
+    game.playabilityState,
+    ...(game.featureLabels ?? []),
+    getGameCatalogSkuText(game),
+  ].join(" ").toLowerCase();
+  return haystack.includes("install");
+}
+
+function getGameStoreFilters(game: GameInfo): Array<{ id: string; label: string }> {
+  const stores = game.availableStores?.length ? game.availableStores : game.variants.map((variant) => variant.store);
+  const seen = new Set<string>();
+  const filters: Array<{ id: string; label: string }> = [];
+  for (const store of stores) {
+    if (!store.trim()) continue;
+    const key = normalizeStoreKey(store);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    filters.push({ id: `platform:${key}`, label: getStoreDisplayName(store) });
+  }
+  return filters;
+}
+
+function getGameControlFilters(game: GameInfo): Array<{ id: string; label: string }> {
+  const controls = [
+    ...(game.supportedControls ?? []),
+    ...game.variants.flatMap((variant) => variant.supportedControls),
+  ];
+  const seen = new Set<string>();
+  const filters: Array<{ id: string; label: string }> = [];
+  for (const control of controls) {
+    const key = normalizeLibraryFilterValue(control);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    filters.push({ id: `controls:${key}`, label: formatLibraryControlLabel(control) });
+  }
+  return filters;
+}
+
+function upsertLibraryFilterOption(options: Map<string, LibraryFilterOption>, id: string, label: string): void {
+  const existing = options.get(id);
+  if (existing) {
+    existing.count += 1;
+    return;
+  }
+  options.set(id, { id, label, count: 1 });
+}
+
+function mapLibraryFilterOptions(options: Map<string, LibraryFilterOption>): LibraryFilterOption[] {
+  return [...options.values()].sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function getLibraryFilterGroups(games: GameInfo[], t: (key: string, values?: Record<string, string | number | boolean | null | undefined>) => string): LibraryFilterGroup[] {
+  const playTypeOptions = new Map<string, LibraryFilterOption>();
+  const platformOptions = new Map<string, LibraryFilterOption>();
+  const controlOptions = new Map<string, LibraryFilterOption>();
+  const activityOptions = new Map<string, LibraryFilterOption>();
+
+  for (const game of games) {
+    if (gameRequiresInstallToPlay(game)) {
+      upsertLibraryFilterOption(playTypeOptions, "play:install-to-play", t("library.filterOptions.installToPlay"));
+    } else if (game.playType?.trim()) {
+      const key = normalizeLibraryFilterValue(game.playType);
+      if (key) upsertLibraryFilterOption(playTypeOptions, `play:${key}`, formatLibraryPlayTypeLabel(game.playType));
+    }
+
+    for (const option of getGameStoreFilters(game)) {
+      upsertLibraryFilterOption(platformOptions, option.id, option.label);
+    }
+
+    for (const option of getGameControlFilters(game)) {
+      upsertLibraryFilterOption(controlOptions, option.id, option.label);
+    }
+
+    upsertLibraryFilterOption(
+      activityOptions,
+      game.lastPlayed ? "activity:played" : "activity:never-played",
+      game.lastPlayed ? t("library.filterOptions.played") : t("library.filterOptions.neverPlayed"),
+    );
+  }
+
+  return [
+    { id: "play", label: t("library.filterGroups.playType"), options: mapLibraryFilterOptions(playTypeOptions) },
+    { id: "platform", label: t("library.filterGroups.platform"), options: mapLibraryFilterOptions(platformOptions) },
+    { id: "controls", label: t("library.filterGroups.controls"), options: mapLibraryFilterOptions(controlOptions) },
+    { id: "activity", label: t("library.filterGroups.activity"), options: mapLibraryFilterOptions(activityOptions) },
+  ].filter((group) => group.options.length > 0);
+}
+
+function getLibraryFilterGroupId(filterId: string): string {
+  const separatorIndex = filterId.indexOf(":");
+  return separatorIndex >= 0 ? filterId.slice(0, separatorIndex) : filterId;
+}
+
+function gameMatchesLibraryFilter(game: GameInfo, filterId: string): boolean {
+  const [groupId, value] = filterId.split(":");
+  if (!value) return true;
+
+  if (groupId === "play") {
+    if (value === "install-to-play") return gameRequiresInstallToPlay(game);
+    return normalizeLibraryFilterValue(game.playType) === value;
+  }
+
+  if (groupId === "platform") {
+    return getGameStoreFilters(game).some((option) => option.id === filterId);
+  }
+
+  if (groupId === "controls") {
+    return getGameControlFilters(game).some((option) => option.id === filterId);
+  }
+
+  if (groupId === "activity") {
+    return value === "played" ? Boolean(game.lastPlayed) : !game.lastPlayed;
+  }
+
+  return true;
+}
+
+function gameMatchesLibraryFilters(game: GameInfo, selectedFilterIds: string[]): boolean {
+  if (selectedFilterIds.length === 0) return true;
+  const selectedByGroup = new Map<string, string[]>();
+  for (const filterId of selectedFilterIds) {
+    const groupId = getLibraryFilterGroupId(filterId);
+    selectedByGroup.set(groupId, [...(selectedByGroup.get(groupId) ?? []), filterId]);
+  }
+  for (const groupFilterIds of selectedByGroup.values()) {
+    if (!groupFilterIds.some((filterId) => gameMatchesLibraryFilter(game, filterId))) return false;
+  }
+  return true;
+}
+
+function getLibraryFilterOptionById(groups: LibraryFilterGroup[], id: string): LibraryFilterOption | undefined {
+  for (const group of groups) {
+    const option = group.options.find((candidate) => candidate.id === id);
+    if (option) return option;
+  }
+  return undefined;
+}
+
 function getControllerStoreFilterItems(games: GameInfo[], allStoresLabel: string): ControllerStoreFilterItem[] {
   const stores = new Set<string>();
   for (const game of games) {
@@ -185,6 +384,7 @@ function ControllerGameCard({
 
 export const LibraryPage = memo(function LibraryPage({
   games,
+  allGames,
   searchQuery,
   onSearchChange,
   onPlayGame,
@@ -216,6 +416,7 @@ export const LibraryPage = memo(function LibraryPage({
   const [controllerStoreFilterOpen, setControllerStoreFilterOpen] = useState(false);
   const [controllerSearchOpen, setControllerSearchOpen] = useState(false);
   const [focusedControllerStoreFilterIndex, setFocusedControllerStoreFilterIndex] = useState(0);
+  const [selectedLibraryFilterIds, setSelectedLibraryFilterIds] = useState<string[]>([]);
   const controllerSearchInputRef = useRef<HTMLInputElement | null>(null);
   const gamepadPreviousButtonsRef = useRef(0);
   const gamepadLastMoveAtRef = useRef(0);
@@ -243,6 +444,51 @@ export const LibraryPage = memo(function LibraryPage({
     if (!controllerMode || !controllerSearchOpen) return;
     controllerSearchInputRef.current?.focus();
   }, [controllerMode, controllerSearchOpen]);
+
+  const libraryFilterGroups = useMemo(
+    () => getLibraryFilterGroups(allGames, t),
+    [allGames, t],
+  );
+  const visibleLibraryGames = useMemo(
+    () => games.filter((game) => gameMatchesLibraryFilters(game, selectedLibraryFilterIds)),
+    [games, selectedLibraryFilterIds],
+  );
+  const activeLibraryFilterOptions = useMemo(
+    () => selectedLibraryFilterIds
+      .map((filterId) => getLibraryFilterOptionById(libraryFilterGroups, filterId))
+      .filter((option): option is LibraryFilterOption => Boolean(option)),
+    [libraryFilterGroups, selectedLibraryFilterIds],
+  );
+  const hasActiveLibraryFilters = activeLibraryFilterOptions.length > 0;
+  const libraryCountLabel = hasActiveLibraryFilters || searchQuery.trim()
+    ? t("library.filteredGameCount", { shown: visibleLibraryGames.length, total: libraryCount, count: libraryCount })
+    : t("library.gameCount", { count: libraryCount });
+
+  useEffect(() => {
+    const availableFilterIds = new Set(libraryFilterGroups.flatMap((group) => group.options.map((option) => option.id)));
+    setSelectedLibraryFilterIds((previous) => {
+      const next = previous.filter((filterId) => availableFilterIds.has(filterId));
+      return next.length === previous.length ? previous : next;
+    });
+  }, [libraryFilterGroups]);
+
+  useEffect(() => {
+    if (controllerMode || visibleLibraryGames.length === 0) return;
+    if (visibleLibraryGames.some((game) => game.id === selectedGameId)) return;
+    onSelectGame(visibleLibraryGames[0].id);
+  }, [controllerMode, onSelectGame, selectedGameId, visibleLibraryGames]);
+
+  const toggleLibraryFilter = (filterId: string): void => {
+    setSelectedLibraryFilterIds((previous) => (
+      previous.includes(filterId)
+        ? previous.filter((selectedFilterId) => selectedFilterId !== filterId)
+        : [...previous, filterId]
+    ));
+  };
+
+  const clearLibraryFilters = (): void => {
+    setSelectedLibraryFilterIds([]);
+  };
 
   const controllerStoreFilterItems = useMemo(
     () => getControllerStoreFilterItems(games, t("library.allStores")),
@@ -539,7 +785,7 @@ export const LibraryPage = memo(function LibraryPage({
   }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage]);
 
   const libraryGridItems = useMemo(
-    () => games.map((game) => (
+    () => visibleLibraryGames.map((game) => (
       <div key={game.id} className="library-game-wrapper">
         <GameCardListItem
           game={game}
@@ -555,7 +801,7 @@ export const LibraryPage = memo(function LibraryPage({
         )}
       </div>
     )),
-    [catalogActionsRef, games, selectedGameId, selectedVariantByGameId, t],
+    [catalogActionsRef, selectedGameId, selectedVariantByGameId, t, visibleLibraryGames],
   );
 
   if (controllerMode) {
@@ -829,6 +1075,43 @@ export const LibraryPage = memo(function LibraryPage({
           />
         </div>
 
+        {libraryFilterGroups.length > 0 && (
+          <details className="library-filter-dropdown">
+            <summary className="library-filter-dropdown-trigger">
+              <span className="library-filter-dropdown-label">
+                <Filter size={14} />
+                {t("library.filters")}
+              </span>
+              {selectedLibraryFilterIds.length > 0 && <span className="library-filter-dropdown-count">{selectedLibraryFilterIds.length}</span>}
+              <ChevronDown size={14} className="library-filter-dropdown-chevron" />
+            </summary>
+            <div className="library-filter-dropdown-menu">
+              {libraryFilterGroups.map((group) => (
+                <div key={group.id} className="library-filter-dropdown-group">
+                  <div className="library-filter-group-label">{group.label}</div>
+                  <div className="library-filter-chips">
+                    {group.options.map((option) => {
+                      const active = selectedLibraryFilterIds.includes(option.id);
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          className={`library-filter-chip ${active ? "active" : ""}`}
+                          onClick={() => toggleLibraryFilter(option.id)}
+                          aria-pressed={active}
+                        >
+                          <span>{option.label}</span>
+                          <span className="library-filter-chip-count">{option.count}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+
         <label className="library-sort">
           <ArrowUpDown size={14} />
           <select value={selectedSortId} onChange={(e) => onSortChange(e.target.value)}>
@@ -840,8 +1123,37 @@ export const LibraryPage = memo(function LibraryPage({
           </select>
         </label>
 
-        <span className="library-count">{t("library.gameCount", { count: libraryCount })}</span>
+        <span className="library-count">{libraryCountLabel}</span>
       </header>
+
+      <AnimatePresence initial={false}>
+        {activeLibraryFilterOptions.length > 0 && (
+          <m.div
+            className="library-active-filters"
+            initial={{ opacity: 0, y: -6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6 }}
+            transition={pageTransition}
+          >
+            <span className="library-active-filter-label">{t("library.activeFilters")}</span>
+            {activeLibraryFilterOptions.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                className="library-active-filter-chip"
+                onClick={() => toggleLibraryFilter(option.id)}
+                aria-label={t("library.removeFilter", { filter: option.label })}
+              >
+                <span>{option.label}</span>
+                <X size={12} />
+              </button>
+            ))}
+            <button type="button" className="library-clear-filters" onClick={clearLibraryFilters}>
+              {t("library.clearFilters")}
+            </button>
+          </m.div>
+        )}
+      </AnimatePresence>
 
       <div className="library-grid-area">
         {isLoading ? (
@@ -855,11 +1167,15 @@ export const LibraryPage = memo(function LibraryPage({
             <h3>{t("library.empty.libraryEmpty")}</h3>
             <p>{t("library.empty.ownedGamesAppearHere")}</p>
           </div>
-        ) : games.length === 0 ? (
+        ) : visibleLibraryGames.length === 0 ? (
           <div className="library-empty-state">
             <Search className="library-empty-icon" size={44} />
-            <h3>{t("library.empty.noGamesFound")}</h3>
-            <p>{t("library.empty.noGamesMatch", { query: searchQuery })}</p>
+            <h3>{hasActiveLibraryFilters ? t("library.empty.noFilteredGames") : t("library.empty.noGamesFound")}</h3>
+            <p>
+              {hasActiveLibraryFilters
+                ? t("library.empty.tryAdjustingFilters")
+                : t("library.empty.noGamesMatch", { query: searchQuery })}
+            </p>
           </div>
         ) : (
           <div className="game-grid">

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -2362,7 +2362,8 @@ body,
 
 .home-sort,
 .library-sort,
-.home-filter-dropdown-trigger {
+.home-filter-dropdown-trigger,
+.library-filter-dropdown-trigger {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -2379,7 +2380,8 @@ body,
 
 .home-sort:hover,
 .library-sort:hover,
-.home-filter-dropdown-trigger:hover {
+.home-filter-dropdown-trigger:hover,
+.library-filter-dropdown-trigger:hover {
   color: var(--ink-soft);
   border-color: rgba(255, 255, 255, 0.14);
   background: rgba(255, 255, 255, 0.03);
@@ -2387,7 +2389,8 @@ body,
 
 .home-sort:focus-within,
 .library-sort:focus-within,
-.home-filter-dropdown-trigger:focus-visible {
+.home-filter-dropdown-trigger:focus-visible,
+.library-filter-dropdown-trigger:focus-visible {
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-surface);
 }
@@ -2644,6 +2647,205 @@ body,
   font-weight: 500;
   white-space: nowrap;
   margin-left: auto;
+}
+
+.library-filter-dropdown {
+  position: relative;
+}
+
+.library-filter-dropdown[open] {
+  z-index: 6;
+}
+
+.library-filter-dropdown-trigger {
+  list-style: none;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.library-filter-dropdown-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.library-filter-dropdown-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.library-filter-dropdown-count {
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: var(--r-full);
+  background: var(--accent);
+  color: var(--accent-on);
+  font-size: 0.7rem;
+  line-height: 18px;
+  text-align: center;
+}
+
+.library-filter-dropdown-chevron {
+  transition: transform var(--t-fast);
+}
+
+.library-filter-dropdown[open] .library-filter-dropdown-chevron {
+  transform: rotate(180deg);
+}
+
+.library-filter-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(460px, calc(100vw - 48px));
+  max-height: min(560px, calc(100vh - 170px));
+  overflow-y: auto;
+  padding: 12px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--panel-border);
+  background:
+    radial-gradient(circle at 18% 0%, rgba(var(--accent-rgb), 0.12), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015)),
+    var(--card);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.42);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.library-filter-dropdown-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.library-filter-group-label {
+  color: var(--ink-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.library-filter-chips,
+.library-active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.library-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 29px;
+  padding: 5px 9px 5px 11px;
+  border-radius: var(--r-full);
+  border: 1px solid var(--panel-border);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--ink-soft);
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast), border-color var(--t-fast), transform var(--t-fast);
+}
+
+.library-filter-chip:hover {
+  color: var(--ink);
+  border-color: rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.library-filter-chip:active {
+  transform: scale(0.98);
+}
+
+.library-filter-chip.active {
+  border-color: rgba(var(--accent-rgb), 0.5);
+  background: var(--accent-surface-strong);
+  color: var(--accent);
+}
+
+.library-filter-chip-count {
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: var(--r-full);
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  line-height: 18px;
+  text-align: center;
+}
+
+.library-filter-chip.active .library-filter-chip-count {
+  background: rgba(var(--accent-rgb), 0.18);
+  color: var(--accent-hover);
+}
+
+.library-active-filters {
+  position: relative;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 10px 12px;
+  border-radius: var(--r-lg);
+  border: 1px solid rgba(var(--accent-rgb), 0.16);
+  background:
+    linear-gradient(90deg, rgba(var(--accent-rgb), 0.1), rgba(var(--accent-rgb), 0.02)),
+    rgba(255, 255, 255, 0.025);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+}
+
+.library-active-filter-label {
+  margin-right: 2px;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.library-active-filter-chip,
+.library-clear-filters {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 28px;
+  border: 1px solid rgba(var(--accent-rgb), 0.22);
+  border-radius: var(--r-full);
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 750;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast), border-color var(--t-fast);
+}
+
+.library-active-filter-chip {
+  padding: 0 9px 0 11px;
+  background: rgba(var(--accent-rgb), 0.1);
+  color: var(--accent-hover);
+}
+
+.library-active-filter-chip:hover {
+  border-color: rgba(var(--accent-rgb), 0.4);
+  background: rgba(var(--accent-rgb), 0.16);
+}
+
+.library-clear-filters {
+  margin-left: auto;
+  padding: 0 10px;
+  border-color: var(--panel-border);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--ink-muted);
+}
+
+.library-clear-filters:hover {
+  color: var(--ink-soft);
+  border-color: rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .library-grid-area {


### PR DESCRIPTION
This PR adds a filter dropdown to the library page allowing users to filter games by play type (Install to Play, Cloud Launch), platform (Steam, Epic, Xbox, etc.), controls (Keyboard & Mouse, Controller, Touch), and play activity (Played, Never Played).

- Added `LibraryFilterGroup` and `LibraryFilterOption` interfaces for filter structure
- Implemented filter generation from game metadata (`playType`, `availableStores`, `supportedControls`, `lastPlayed`)
- Added `visibleLibraryGames` memo to filter grid based on active filters
- Rendered filter dropdown with grouped chips and option counts
- Rendered active filter chips with clear buttons and animated transitions
- Updated empty states to show contextual messages when filtering
- Added translations for filter groups, options, and empty states
- Styled filter dropdown menu and chips to match app aesthetic

Changes:
- `locales/en.json`: Added `library.filterGroups`, `library.filterOptions`, `library.filters`, `library.activeFilters`, `library.clearFilters`, `library.removeFilter`, `library.filteredGameCount`, `library.empty.noFilteredGames`, `library.empty.tryAdjustingFilters`
- `opennow-stable/src/renderer/src/App.tsx`: Pass `allGames` prop to `LibraryPage` for filter generation
- `opennow-stable/src/renderer/src/components/LibraryPage.tsx`: Added filter UI, state management, and filtering logic
- `opennow-stable/src/renderer/src/styles.css`: Added `.library-filter-dropdown`, `.library-filter-chip`, `.library-active-filters` styles

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/0a6b9308-c0ed-453d-9ee9-83209e39b764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-251" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/0a6b9308-c0ed-453d-9ee9-83209e39b764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-251&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-251"><img alt="OPE-251" src="https://capy.ai/api/badge/thread.svg?label=OPE-251"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer-only library UI and client-side filtering; no auth, session, or backend changes.
> 
> **Overview**
> Adds **desktop library filtering** alongside search and sort: a **Filters** dropdown with grouped chips (play type, platform/store, controls, played vs never played), counts per option, and a removable **active filters** bar with clear-all.
> 
> Filter options are **derived from the full library** (`allGames` from `App`) while the grid uses **search/sort results** then applies filters with **OR within a group** and **AND across groups**. Selection resets when options disappear, selection follows the first visible game when the current pick is filtered out, and empty states distinguish **no matches for filters** vs search.
> 
> New **i18n** strings and **library-specific CSS** mirror the store filter dropdown pattern; **controller mode** is unchanged (existing Y-hold store filter only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06a78f8c4717fee526821e513ebf0cc67cf38d7f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->