### PR TITLE
feat(ui): redesign sidebar overlay with exit session button and controller support

### DIFF
--- a/native/opennow-streamer/src/backend.rs
+++ b/native/opennow-streamer/src/backend.rs
@@ -18,6 +18,7 @@ pub trait NativeStreamerBackend {
     fn handle_offer(&mut self, command: CommandEnvelope) -> BackendReply;
     fn add_remote_ice(&mut self, command: CommandEnvelope) -> BackendReply;
     fn send_input(&mut self, command: CommandEnvelope) -> BackendReply;
+    fn set_input_paused(&mut self, command: CommandEnvelope) -> BackendReply;
     fn update_render_surface(&mut self, command: CommandEnvelope) -> BackendReply;
     fn update_bitrate_limit(&mut self, command: CommandEnvelope) -> BackendReply;
     fn update_shortcuts(&mut self, command: CommandEnvelope) -> BackendReply;
@@ -431,6 +432,14 @@ impl NativeStreamerBackend for StubBackend {
             let _ = packet.payload_bytes();
         }
         BackendReply::continue_without_response()
+    }
+
+    fn set_input_paused(&mut self, command: CommandEnvelope) -> BackendReply {
+        if command.paused.is_none() {
+            return BackendReply::response(missing_field(&command.id, "paused"));
+        }
+
+        BackendReply::response(Response::Ok { id: command.id })
     }
 
     fn update_render_surface(&mut self, command: CommandEnvelope) -> BackendReply {

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -343,6 +343,18 @@ impl NativeStreamerBackend for GstreamerBackend {
         BackendReply::continue_without_response()
     }
 
+    fn set_input_paused(&mut self, command: CommandEnvelope) -> BackendReply {
+        let Some(paused) = command.paused else {
+            return BackendReply::response(missing_field(&command.id, "paused"));
+        };
+
+        if let Some(pipeline) = self.pipeline.as_ref() {
+            pipeline.set_input_paused(paused);
+        }
+
+        BackendReply::response(Response::Ok { id: command.id })
+    }
+
     fn update_render_surface(&mut self, command: CommandEnvelope) -> BackendReply {
         let Some(surface) = command.surface else {
             return BackendReply::response(missing_field(&command.id, "surface"));

--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -49,6 +49,7 @@ static NATIVE_INPUT_STARTED_AT: OnceLock<Instant> = OnceLock::new();
 pub(crate) struct GstreamerInputState {
     encoder: Arc<Mutex<InputEncoder>>,
     pub(crate) ready: Arc<AtomicBool>,
+    pub(crate) paused: Arc<AtomicBool>,
     heartbeat_stop: Arc<AtomicBool>,
     heartbeat_thread: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
@@ -58,6 +59,7 @@ impl std::fmt::Debug for GstreamerInputState {
         formatter
             .debug_struct("GstreamerInputState")
             .field("ready", &self.ready.load(Ordering::SeqCst))
+            .field("paused", &self.paused.load(Ordering::SeqCst))
             .finish_non_exhaustive()
     }
 }
@@ -67,6 +69,7 @@ impl Default for GstreamerInputState {
         Self {
             encoder: Arc::new(Mutex::new(InputEncoder::default())),
             ready: Arc::new(AtomicBool::new(false)),
+            paused: Arc::new(AtomicBool::new(false)),
             heartbeat_stop: Arc::new(AtomicBool::new(false)),
             heartbeat_thread: Arc::new(Mutex::new(None)),
         }
@@ -76,6 +79,7 @@ impl Default for GstreamerInputState {
 impl GstreamerInputState {
     pub(crate) fn reset(&self) {
         self.ready.store(false, Ordering::SeqCst);
+        self.paused.store(false, Ordering::SeqCst);
         if let Ok(mut encoder) = self.encoder.lock() {
             encoder.set_protocol_version(2);
             encoder.reset_gamepad_sequences();
@@ -437,9 +441,15 @@ fn send_native_window_input_events(
         }
     }
 
-    // Only process non-shortcut events if input is ready
+    // Only process non-shortcut events if input is ready.
     if other_events.is_empty() || !input_state.ready.load(Ordering::SeqCst) {
         return;
+    }
+    if input_state.paused.load(Ordering::SeqCst) {
+        other_events.retain(is_native_input_release_event);
+        if other_events.is_empty() {
+            return;
+        }
     }
 
     let mut pending_mouse_move: Option<(i32, i32, u64)> = None;
@@ -519,6 +529,15 @@ fn send_native_window_input_events(
             }
         }
     }
+}
+
+#[cfg(target_os = "windows")]
+fn is_native_input_release_event(event: &NativeWindowInputEvent) -> bool {
+    matches!(
+        event,
+        NativeWindowInputEvent::Key { pressed: false, .. }
+            | NativeWindowInputEvent::MouseButton { pressed: false, .. }
+    )
 }
 
 #[cfg(target_os = "windows")]
@@ -673,6 +692,16 @@ impl NativeGamepadSnapshot {
             right_stick_y: snapshot.right_stick_y,
         }
     }
+
+    fn is_neutral(self) -> bool {
+        self.buttons == 0
+            && self.left_trigger == 0
+            && self.right_trigger == 0
+            && self.left_stick_x == 0
+            && self.left_stick_y == 0
+            && self.right_stick_x == 0
+            && self.right_stick_y == 0
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -700,22 +729,52 @@ fn spawn_native_gamepad_thread(
 
         let mut previous = [NativeGamepadSnapshot::default(); GAMEPAD_MAX_CONTROLLERS as usize];
         let mut last_sent = [Instant::now(); GAMEPAD_MAX_CONTROLLERS as usize];
+        let mut suppress_until_neutral = [false; GAMEPAD_MAX_CONTROLLERS as usize];
+        let mut was_paused = false;
 
         while !stop.load(Ordering::SeqCst) {
             if input_state.ready.load(Ordering::SeqCst) {
-                let mut snapshots =
-                    [NativeGamepadSnapshot::default(); GAMEPAD_MAX_CONTROLLERS as usize];
-                let mut bitmap = 0u16;
+                let (snapshots, bitmap) = poll_xinput_gamepads(xinput);
 
-                for controller_id in 0..GAMEPAD_MAX_CONTROLLERS as usize {
-                    if let Some(snapshot) = unsafe { xinput.get_state(controller_id as u32) } {
-                        snapshots[controller_id] = NativeGamepadSnapshot::from_xinput(snapshot);
-                        bitmap |= 1 << controller_id;
+                if input_state.paused.load(Ordering::SeqCst) {
+                    if !was_paused {
+                        send_neutral_gamepad_snapshots_for_pause(
+                            &input_state,
+                            &input_channels,
+                            &previous,
+                            &snapshots,
+                        );
+                    }
+                    previous = snapshots;
+                    for controller_id in 0..GAMEPAD_MAX_CONTROLLERS as usize {
+                        last_sent[controller_id] = Instant::now();
+                    }
+                    was_paused = true;
+                    thread::sleep(NATIVE_GAMEPAD_POLL_INTERVAL);
+                    continue;
+                }
+
+                if was_paused {
+                    for controller_id in 0..GAMEPAD_MAX_CONTROLLERS as usize {
+                        let snapshot = snapshots[controller_id];
+                        suppress_until_neutral[controller_id] =
+                            snapshot.connected && !snapshot.is_neutral();
+                        previous[controller_id] = snapshot;
+                        last_sent[controller_id] = Instant::now();
                     }
                 }
+                was_paused = false;
 
                 for controller_id in 0..GAMEPAD_MAX_CONTROLLERS as usize {
                     let snapshot = snapshots[controller_id];
+                    if suppress_until_neutral[controller_id] {
+                        previous[controller_id] = snapshot;
+                        last_sent[controller_id] = Instant::now();
+                        if !snapshot.connected || snapshot.is_neutral() {
+                            suppress_until_neutral[controller_id] = false;
+                        }
+                        continue;
+                    }
                     let state_changed = snapshot != previous[controller_id];
                     let keepalive_due = snapshot.connected
                         && last_sent[controller_id].elapsed() >= NATIVE_GAMEPAD_KEEPALIVE_INTERVAL;
@@ -748,11 +807,71 @@ fn spawn_native_gamepad_thread(
 
                     previous[controller_id] = snapshot;
                 }
+            } else {
+                was_paused = false;
             }
 
             thread::sleep(NATIVE_GAMEPAD_POLL_INTERVAL);
         }
     })
+}
+
+#[cfg(target_os = "windows")]
+fn poll_xinput_gamepads(
+    xinput: win32_xinput::XInput,
+) -> ([NativeGamepadSnapshot; GAMEPAD_MAX_CONTROLLERS as usize], u16) {
+    let mut snapshots = [NativeGamepadSnapshot::default(); GAMEPAD_MAX_CONTROLLERS as usize];
+    let mut bitmap = 0u16;
+
+    for controller_id in 0..GAMEPAD_MAX_CONTROLLERS as usize {
+        if let Some(snapshot) = unsafe { xinput.get_state(controller_id as u32) } {
+            snapshots[controller_id] = NativeGamepadSnapshot::from_xinput(snapshot);
+            bitmap |= 1 << controller_id;
+        }
+    }
+
+    (snapshots, bitmap)
+}
+
+#[cfg(target_os = "windows")]
+fn send_neutral_gamepad_snapshots_for_pause(
+    input_state: &GstreamerInputState,
+    input_channels: &GstreamerInputChannels,
+    previous: &[NativeGamepadSnapshot; GAMEPAD_MAX_CONTROLLERS as usize],
+    current: &[NativeGamepadSnapshot; GAMEPAD_MAX_CONTROLLERS as usize],
+) {
+    let bitmap = previous
+        .iter()
+        .zip(current.iter())
+        .enumerate()
+        .fold(0u16, |bitmap, (controller_id, (previous, current))| {
+            if previous.connected || current.connected {
+                bitmap | (1 << controller_id)
+            } else {
+                bitmap
+            }
+        });
+
+    if bitmap == 0 {
+        return;
+    }
+
+    for controller_id in 0..GAMEPAD_MAX_CONTROLLERS as usize {
+        if (bitmap & (1 << controller_id)) == 0 {
+            continue;
+        }
+
+        send_native_gamepad_snapshot(
+            input_state,
+            input_channels,
+            controller_id as u8,
+            bitmap,
+            NativeGamepadSnapshot {
+                connected: true,
+                ..NativeGamepadSnapshot::default()
+            },
+        );
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/native/opennow-streamer/src/gstreamer_pipeline.rs
+++ b/native/opennow-streamer/src/gstreamer_pipeline.rs
@@ -18,7 +18,8 @@ use crate::gstreamer_liveness::{
 };
 use crate::gstreamer_platform::{
     apply_render_surface_to_video_sink, primary_display_refresh_hz,
-    start_external_renderer_window_guard, update_external_renderer_surface,
+    release_native_input_capture, start_external_renderer_window_guard,
+    update_external_renderer_surface,
 };
 use crate::gstreamer_transitions::DEFAULT_VIDEO_QUEUE_DEPTH;
 use crate::protocol::{
@@ -733,7 +734,9 @@ impl GstreamerPipeline {
     }
 
     pub(crate) fn send_input_packet(&self, payload: &[u8], partially_reliable: bool) -> bool {
-        if !self.input_state.ready.load(Ordering::SeqCst) {
+        if !self.input_state.ready.load(Ordering::SeqCst)
+            || self.input_state.paused.load(Ordering::SeqCst)
+        {
             return false;
         }
 
@@ -742,6 +745,13 @@ impl GstreamerPipeline {
         };
 
         input_channels.send_packet(payload, partially_reliable)
+    }
+
+    pub(crate) fn set_input_paused(&self, paused: bool) {
+        self.input_state.paused.store(paused, Ordering::SeqCst);
+        if paused {
+            release_native_input_capture();
+        }
     }
 
     pub(crate) fn update_render_surface(&self, surface: NativeRenderSurface) {

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -118,6 +118,16 @@ pub(crate) fn clear_native_shortcut_bindings() {
 pub(crate) fn clear_native_shortcut_bindings() {}
 
 #[cfg(target_os = "windows")]
+pub(crate) fn release_native_input_capture() {
+    unsafe {
+        win32_renderer_window::release_current_input_capture();
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn release_native_input_capture() {}
+
+#[cfg(target_os = "windows")]
 pub(crate) fn update_external_renderer_surface(surface: &NativeRenderSurface) {
     let target = surface
         .window_handle

--- a/native/opennow-streamer/src/main.rs
+++ b/native/opennow-streamer/src/main.rs
@@ -95,6 +95,9 @@ fn handle_command(
         "input" => {
             return write_reply(backend.send_input(command));
         }
+        "input-paused" => {
+            return write_reply(backend.set_input_paused(command));
+        }
         "surface" => {
             return write_reply(backend.update_render_surface(command));
         }

--- a/native/opennow-streamer/src/protocol.rs
+++ b/native/opennow-streamer/src/protocol.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::borrow::Cow;
 
-pub const PROTOCOL_VERSION: u64 = 3;
+pub const PROTOCOL_VERSION: u64 = 4;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,6 +21,8 @@ pub struct CommandEnvelope {
     pub candidate: Option<IceCandidatePayload>,
     #[serde(default)]
     pub input: Option<NativeInputPacket>,
+    #[serde(default)]
+    pub paused: Option<bool>,
     #[serde(default)]
     pub surface: Option<NativeRenderSurface>,
     #[serde(default)]

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -748,6 +748,19 @@ export class NativeStreamerManager {
     });
   }
 
+  setInputPaused(paused: boolean): void {
+    if (!this.child || !this.activeSessionId) {
+      return;
+    }
+
+    void this.request({
+      type: "input-paused",
+      paused,
+    }, CONTROL_TIMEOUT_MS).catch((error) => {
+      console.warn("[NativeStreamer] Failed to update native input pause state:", error);
+    });
+  }
+
   updateShortcuts(shortcuts: NativeStreamerShortcutBindings): void {
     if (!this.child || !this.activeSessionId) {
       return;

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -248,6 +248,60 @@ const DEFAULT_SETTINGS: Settings = {
   videoShader: { ...DEFAULT_VIDEO_SHADER_SETTINGS },
 };
 
+const SHORTCUT_SETTING_KEYS = [
+  "shortcutToggleStats",
+  "shortcutTogglePointerLock",
+  "shortcutToggleFullscreen",
+  "shortcutStopStream",
+  "shortcutToggleAntiAfk",
+  "shortcutToggleMicrophone",
+  "shortcutScreenshot",
+  "shortcutToggleRecording",
+] as const satisfies readonly (keyof Settings)[];
+
+type ShortcutSettingKey = typeof SHORTCUT_SETTING_KEYS[number];
+
+const SIDEBAR_RESERVED_SHORTCUTS_NON_MAC = new Set(["CTRL+G", "CTRL+SHIFT+G"]);
+const SIDEBAR_RESERVED_SHORTCUTS_MAC = new Set(["META+G", "CMD+G", "COMMAND+G"]);
+const SIDEBAR_RESERVED_SHORTCUT_FALLBACKS: Record<ShortcutSettingKey, readonly string[]> = {
+  shortcutToggleStats: ["F3", "Ctrl+Shift+F3", "Ctrl+Alt+F3"],
+  shortcutTogglePointerLock: ["F8", "Ctrl+Shift+F8", "Ctrl+Alt+F8"],
+  shortcutToggleFullscreen: ["F10", "Ctrl+Shift+F10", "Ctrl+Alt+F10"],
+  shortcutStopStream: [defaultStopShortcut, "Ctrl+Alt+Q", "Ctrl+Alt+Shift+Q"],
+  shortcutToggleAntiAfk: [defaultAntiAfkShortcut, "Ctrl+Alt+K", "Ctrl+Alt+Shift+K"],
+  shortcutToggleMicrophone: [defaultMicShortcut, "Ctrl+Alt+M", "Ctrl+Alt+Shift+M"],
+  shortcutScreenshot: ["F11", "Ctrl+Shift+S", "Ctrl+Alt+S", "Ctrl+Shift+F11", "Ctrl+Alt+Shift+S"],
+  shortcutToggleRecording: ["F12", "Ctrl+Shift+R", "Ctrl+Alt+R", "Ctrl+Shift+F12", "Ctrl+Alt+Shift+R"],
+};
+
+function normalizeShortcutForComparison(value: string): string {
+  return value.replace(/\s+/g, "").toUpperCase();
+}
+
+function isSidebarReservedShortcut(value: string): boolean {
+  const normalized = normalizeShortcutForComparison(value);
+  const reserved = process.platform === "darwin"
+    ? SIDEBAR_RESERVED_SHORTCUTS_MAC
+    : SIDEBAR_RESERVED_SHORTCUTS_NON_MAC;
+  return reserved.has(normalized);
+}
+
+function isShortcutAvailable(
+  settings: Settings,
+  key: ShortcutSettingKey,
+  candidate: string,
+): boolean {
+  const normalizedCandidate = normalizeShortcutForComparison(candidate);
+  if (isSidebarReservedShortcut(candidate)) {
+    return false;
+  }
+
+  return SHORTCUT_SETTING_KEYS.every((otherKey) => (
+    otherKey === key ||
+    normalizeShortcutForComparison(settings[otherKey]) !== normalizedCandidate
+  ));
+}
+
 export class SettingsManager {
   private settings: Settings;
   private readonly settingsPath: string;
@@ -395,6 +449,18 @@ export class SettingsManager {
 
     if (LEGACY_ANTI_AFK_SHORTCUTS.has(antiAfkShortcut)) {
       settings.shortcutToggleAntiAfk = defaultAntiAfkShortcut;
+      migrated = true;
+    }
+
+    for (const key of SHORTCUT_SETTING_KEYS) {
+      if (!isSidebarReservedShortcut(settings[key])) {
+        continue;
+      }
+
+      const fallback = SIDEBAR_RESERVED_SHORTCUT_FALLBACKS[key].find((candidate) =>
+        isShortcutAvailable(settings, key, candidate),
+      ) ?? DEFAULT_SETTINGS[key];
+      settings[key] = fallback;
       migrated = true;
     }
 

--- a/opennow-stable/src/main/signaling/signalingCoordinator.ts
+++ b/opennow-stable/src/main/signaling/signalingCoordinator.ts
@@ -95,6 +95,17 @@ export class SignalingCoordinator {
     );
 
     ipcMain.on(
+      IPC_CHANNELS.NATIVE_INPUT_PAUSED,
+      (_event, paused: boolean) => {
+        if (!this.isNativeStreamerSelected() || !this.nativeStreamerContext) {
+          return;
+        }
+
+        this.nativeStreamerManager?.setInputPaused(paused === true);
+      },
+    );
+
+    ipcMain.on(
       IPC_CHANNELS.NATIVE_RENDER_SURFACE,
       (event, payload: NativeRenderSurfaceUpdate) => {
         if (!this.isNativeStreamerSelected()) {

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -144,6 +144,9 @@ const api: OpenNowApi = {
   sendNativeInput: (input: NativeInputPacket) => {
     ipcRenderer.send(IPC_CHANNELS.NATIVE_INPUT, input);
   },
+  setNativeInputPaused: (paused: boolean) => {
+    ipcRenderer.send(IPC_CHANNELS.NATIVE_INPUT_PAUSED, paused);
+  },
   updateNativeRenderSurface: (input: NativeRenderSurfaceUpdate) => {
     ipcRenderer.send(IPC_CHANNELS.NATIVE_RENDER_SURFACE, input);
   },

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1366,6 +1366,13 @@ export function App(): JSX.Element {
     }
   }, [requestPointerLockCapture]);
 
+  const setNativeInputPaused = useCallback((paused: boolean): void => {
+    if (!nativeStreamingRef.current && settings.streamClientMode !== "native") {
+      return;
+    }
+    window.openNow.setNativeInputPaused(paused);
+  }, [settings.streamClientMode]);
+
   const resolveExitPrompt = useCallback((confirmed: boolean) => {
     const resolver = exitPromptResolverRef.current;
     exitPromptResolverRef.current = null;
@@ -4333,6 +4340,7 @@ export function App(): JSX.Element {
             onReleasePointerLock={() => {
               void releasePointerLockIfNeeded();
             }}
+            onNativeInputPaused={setNativeInputPaused}
             allowEscapeToExitFullscreen={settings.allowEscapeToExitFullscreen}
             videoShader={settings.videoShader}
             onVideoShaderChange={handleVideoShaderChange}

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -2772,6 +2772,11 @@ export function App(): JSX.Element {
         onMicStateChange: (state) => {
           console.log(`[App] Mic state: ${state.state}${state.deviceLabel ? ` (${state.deviceLabel})` : ""}`);
         },
+        onControllerMetaPress: () => {
+          if (streamStatusRef.current === "streaming") {
+            dispatchStreamShortcutAction("toggleSidebar");
+          }
+        },
         onIceConnectionStateChange: (iceState) => {
           latestIceConnectionStateRef.current = iceState;
           if (iceDisconnectedRecoveryTimerRef.current !== null) {

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -430,7 +430,8 @@ const shortcutDefaults = {
 } as const;
 
 /** Canonical shortcut for toggling the stream sidebar (must match StreamView key handler). */
-const SIDEBAR_TOGGLE_SHORTCUT_RAW = isMac ? "Meta+G" : "Ctrl+Shift+G";
+const SIDEBAR_TOGGLE_SHORTCUT_RAW = isMac ? "Meta+G" : "Ctrl+G";
+const SIDEBAR_TOGGLE_SHORTCUT_ALIASES = isMac ? [SIDEBAR_TOGGLE_SHORTCUT_RAW] : [SIDEBAR_TOGGLE_SHORTCUT_RAW, "Ctrl+Shift+G"];
 const NATIVE_STREAMER_ENABLE_PROMPT_EXIT_MS = 160;
 
 type ShortcutSettingKey = keyof typeof shortcutDefaults;
@@ -442,8 +443,11 @@ function getShortcutConflictMessage(
   candidateCanonical: string,
   currentSettings: Settings,
 ): string | null {
-  const sidebarParsed = normalizeShortcut(SIDEBAR_TOGGLE_SHORTCUT_RAW);
-  if (sidebarParsed.valid && candidateCanonical === sidebarParsed.canonical) {
+  const sidebarShortcuts = SIDEBAR_TOGGLE_SHORTCUT_ALIASES
+    .map((value) => normalizeShortcut(value))
+    .filter((parsed) => parsed.valid)
+    .map((parsed) => parsed.canonical);
+  if (sidebarShortcuts.includes(candidateCanonical)) {
     return "Shortcut conflicts with the settings sidebar toggle.";
   }
   for (const key of SHORTCUT_SETTING_KEYS) {

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -21,6 +21,7 @@ import { formatElapsed } from "../utils/timeFormat";
 import { useTranslation } from "../i18n";
 
 const ANTI_AFK_TOGGLE_ACK_MS = 5000;
+const CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY = "View + Menu";
 
 interface StreamViewProps {
   videoRef: React.Ref<HTMLVideoElement>;
@@ -704,7 +705,7 @@ export function StreamView({
       shortcuts.toggleAntiAfk,
       shortcuts.toggleMicrophone,
       shortcuts.recording,
-      isMacClient ? "Meta+G" : "Ctrl+Shift+G",
+      ...(isMacClient ? ["Meta+G"] : ["Ctrl+G", "Ctrl+Shift+G"]),
     ]
       .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
       .map((value) => normalizeShortcut(value))
@@ -736,7 +737,7 @@ export function StreamView({
       shortcuts.toggleAntiAfk,
       shortcuts.toggleMicrophone,
       shortcuts.screenshot,
-      isMacClient ? "Meta+G" : "Ctrl+Shift+G",
+      ...(isMacClient ? ["Meta+G"] : ["Ctrl+G", "Ctrl+Shift+G"]),
     ]
       .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
       .map((value) => normalizeShortcut(value))
@@ -750,7 +751,7 @@ export function StreamView({
     return null;
   }, [isMacClient, shortcuts.screenshot, shortcuts.stopStream, shortcuts.toggleAntiAfk, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
 
-  const SIDEBAR_TOGGLE_RAW = isMacClient ? "Meta+G" : "Ctrl+Shift+G";
+  const SIDEBAR_TOGGLE_RAW = isMacClient ? "Meta+G" : "Ctrl+G";
   const sidebarToggleShortcutDisplay = formatShortcutForDisplay(SIDEBAR_TOGGLE_RAW, isMacClient);
 
   const applyScreenshotShortcutFromCapture = useCallback(
@@ -1334,7 +1335,11 @@ export function StreamView({
       }
       void refreshScreenshots();
       void refreshRecordings();
-      return;
+      return () => {
+        try {
+          delete (document.body.dataset as DOMStringMap).sidebarOpen;
+        } catch {}
+      };
     }
     // Sidebar just closed — restore focus to the video so clicks register
     // immediately. Without this, focus stays on the last sidebar element and
@@ -1370,8 +1375,17 @@ export function StreamView({
     });
   }, [onReleasePointerLock]);
 
+  const handleSidebarExitSession = useCallback(() => {
+    setShowSideBar(false);
+    onEndSession();
+  }, [onEndSession]);
+
   useEffect(() => {
     return addStreamShortcutActionListener((action) => {
+      if (action === "toggleSidebar") {
+        handleToggleSideBar();
+        return;
+      }
       if (action === "screenshot") {
         void captureScreenshot();
         return;
@@ -1380,7 +1394,7 @@ export function StreamView({
         void toggleRecording();
       }
     });
-  }, [captureScreenshot, toggleRecording]);
+  }, [captureScreenshot, handleToggleSideBar, toggleRecording]);
 
   useEffect(() => {
     const screenshotShortcut = normalizeShortcut(shortcuts.screenshot);
@@ -1432,10 +1446,14 @@ export function StreamView({
       if (isMacClient) {
         if (event.metaKey && !event.ctrlKey && !event.shiftKey && key === "g") {
           event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation();
           handleToggleSideBar();
         }
-      } else if (event.ctrlKey && event.shiftKey && !event.metaKey && key === "g") {
+      } else if (event.ctrlKey && !event.altKey && !event.metaKey && key === "g") {
         event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
         handleToggleSideBar();
       }
     };
@@ -1522,7 +1540,31 @@ export function StreamView({
             onMouseDown={(event) => event.stopPropagation()}
             onClick={() => setShowSideBar(false)}
           />
-          <SideBar title="Settings" className="sv-sidebar" onClose={() => setShowSideBar(false)}>
+          <SideBar title="Stream Control" className="sv-sidebar" onClose={() => setShowSideBar(false)}>
+            <section className="sidebar-session-card" aria-label="Current stream session">
+              <div className="sidebar-session-card-head">
+                <span className="sidebar-session-kicker">Now streaming</span>
+                <strong className="sidebar-session-title">{gameTitle}</strong>
+                {PlatformIcon && platformName && (
+                  <span className="sidebar-session-platform" title={platformName}>
+                    <span className="sidebar-session-platform-icon"><PlatformIcon /></span>
+                    <span>{platformName}</span>
+                  </span>
+                )}
+              </div>
+              <div className="sidebar-session-shortcuts" aria-label="Open this panel shortcuts">
+                <span className="sidebar-session-shortcut"><kbd>{sidebarToggleShortcutDisplay}</kbd><span>Keyboard</span></span>
+                <span className="sidebar-session-shortcut"><kbd>{CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY}</kbd><span>Controller</span></span>
+              </div>
+              <button
+                type="button"
+                className="sidebar-exit-session-button"
+                onClick={handleSidebarExitSession}
+              >
+                <LogOut size={15} />
+                <span>Exit session</span>
+              </button>
+            </section>
             <div className="sidebar-stat-line" title="Total remaining playtime from subscription">
               <span className="sidebar-stat-label">Remaining Playtime</span>
               <RemainingPlaytimeIndicator subscriptionInfo={subscriptionInfo} startedAtMs={sessionStartedAtMs} active={isStreaming} className="settings-value-badge" />
@@ -1993,7 +2035,10 @@ export function StreamView({
                   )}
                   <div className="sidebar-row sidebar-row--aligned">
                     <span className="sidebar-label">Toggle Sidebar</span>
-                    <span className="settings-value-badge">{sidebarToggleShortcutDisplay}</span>
+                    <span className="sidebar-shortcut-stack">
+                      <span className="settings-value-badge">{sidebarToggleShortcutDisplay}</span>
+                      <span className="settings-value-badge">{CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY}</span>
+                    </span>
                   </div>
                 </section>
               </>
@@ -2215,6 +2260,7 @@ export function StreamView({
           <div className="sv-hint"><kbd>{shortcuts.togglePointerLock}</kbd><span>Mouse lock</span></div>
           <div className="sv-hint"><kbd>{shortcuts.toggleFullscreen}</kbd><span>Full screen</span></div>
           <div className="sv-hint"><kbd>{shortcuts.stopStream}</kbd><span>Stop</span></div>
+          <div className="sv-hint"><kbd>{CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY}</kbd><span>Controller menu</span></div>
           {shortcuts.toggleMicrophone && <div className="sv-hint"><kbd>{shortcuts.toggleMicrophone}</kbd><span>Mic</span></div>}
         </div>
       )}

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -79,6 +79,7 @@ interface StreamViewProps {
   onMouseAccelerationChange: (value: number) => void;
   onRequestPointerLock?: () => void;
   onReleasePointerLock?: () => void;
+  onNativeInputPaused?: (paused: boolean) => void;
   microphoneMode: MicrophoneMode;
   onMicrophoneModeChange: (value: MicrophoneMode) => void;
   onScreenshotShortcutChange: (value: string) => void;
@@ -435,6 +436,7 @@ export function StreamView({
   onMouseAccelerationChange,
   onRequestPointerLock,
   onReleasePointerLock,
+  onNativeInputPaused,
   microphoneMode,
   onMicrophoneModeChange,
   onScreenshotShortcutChange,
@@ -1322,6 +1324,15 @@ export function StreamView({
   }, [isPointerLocked]);
 
   useEffect(() => {
+    onNativeInputPaused?.(showSideBar);
+    return () => {
+      if (showSideBar) {
+        onNativeInputPaused?.(false);
+      }
+    };
+  }, [onNativeInputPaused, showSideBar]);
+
+  useEffect(() => {
     if (showSideBar) {
       // Mark sidebar open so input auto-lock code can avoid re-requesting.
       try {
@@ -1411,6 +1422,14 @@ export function StreamView({
         return;
       }
 
+      const key = event.key.toLowerCase();
+      const isSidebarShortcut = isMacClient
+        ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && key === "g"
+        : event.ctrlKey && !event.altKey && !event.metaKey && key === "g";
+      if (isSidebarShortcut) {
+        return;
+      }
+
       if (isShortcutMatch(event, screenshotShortcut)) {
         event.preventDefault();
         event.stopPropagation();
@@ -1428,7 +1447,7 @@ export function StreamView({
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [captureScreenshot, shortcuts.screenshot, shortcuts.recording, toggleRecording]);
+  }, [captureScreenshot, isMacClient, shortcuts.screenshot, shortcuts.recording, toggleRecording]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.test.ts
@@ -6,9 +6,55 @@ import assert from "node:assert/strict";
 import {
   chooseAdaptiveMouseFlushInterval,
   classifyStreamLagReason,
+  evaluateControllerOverlayShortcutGate,
   quantizeMouseDeltaWithResidual,
   subsampleCoalescedPointerEvents,
 } from "./webrtcClient";
+
+function gamepadWithButtons(pressed: number[]): Pick<Gamepad, "buttons"> {
+  const pressedButtons = new Set(pressed);
+  return {
+    buttons: Array.from({ length: 17 }, (_, index) => {
+      const isPressed = pressedButtons.has(index);
+      return {
+        pressed: isPressed,
+        touched: isPressed,
+        value: isPressed ? 1 : 0,
+      };
+    }),
+  };
+}
+
+test("controller overlay gate preempts view/menu chord halves before stream forwarding", () => {
+  const viewOnly = evaluateControllerOverlayShortcutGate(gamepadWithButtons([8]), null, 1000, 120);
+  assert.equal(viewOnly.overlayPressed, false);
+  assert.equal(viewOnly.preemptInput, true);
+
+  const chord = evaluateControllerOverlayShortcutGate(gamepadWithButtons([8, 9]), viewOnly.nextState, 1050, 120);
+  assert.equal(chord.overlayPressed, true);
+  assert.equal(chord.preemptInput, true);
+});
+
+test("controller overlay gate lets standalone view/menu through after grace period", () => {
+  const viewOnly = evaluateControllerOverlayShortcutGate(gamepadWithButtons([8]), null, 1000, 120);
+  const standalone = evaluateControllerOverlayShortcutGate(gamepadWithButtons([8]), viewOnly.nextState, 1120, 120);
+  assert.equal(standalone.overlayPressed, false);
+  assert.equal(standalone.preemptInput, false);
+
+  const lateMenu = evaluateControllerOverlayShortcutGate(gamepadWithButtons([8, 9]), standalone.nextState, 1130, 120);
+  assert.equal(lateMenu.overlayPressed, false);
+  assert.equal(lateMenu.preemptInput, false);
+});
+
+test("controller overlay gate opens immediately for guide and simultaneous view/menu", () => {
+  const guide = evaluateControllerOverlayShortcutGate(gamepadWithButtons([16]), null, 1000, 120);
+  assert.equal(guide.overlayPressed, true);
+  assert.equal(guide.preemptInput, true);
+
+  const chord = evaluateControllerOverlayShortcutGate(gamepadWithButtons([8, 9]), null, 1000, 120);
+  assert.equal(chord.overlayPressed, true);
+  assert.equal(chord.preemptInput, true);
+});
 
 test("quantizeMouseDeltaWithResidual preserves precision across sends", () => {
   const a = quantizeMouseDeltaWithResidual(0.4);

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -263,11 +263,78 @@ function isPressedGamepadButton(button: GamepadButton | undefined): boolean {
   return Boolean(button?.pressed || (button?.value ?? 0) > 0.5);
 }
 
-function isControllerOverlayShortcutPressed(gamepad: Gamepad): boolean {
+type ControllerOverlayChordHalf = "view" | "menu";
+
+export interface ControllerOverlayChordState {
+  pendingHalf: ControllerOverlayChordHalf;
+  pendingSinceMs: number;
+  disqualified: boolean;
+}
+
+export interface ControllerOverlayShortcutGate {
+  overlayPressed: boolean;
+  preemptInput: boolean;
+  nextState: ControllerOverlayChordState | null;
+}
+
+const CONTROLLER_OVERLAY_CHORD_GRACE_MS = 120;
+
+export function evaluateControllerOverlayShortcutGate(
+  gamepad: Pick<Gamepad, "buttons">,
+  state: ControllerOverlayChordState | null,
+  nowMs: number,
+  graceMs: number = CONTROLLER_OVERLAY_CHORD_GRACE_MS,
+): ControllerOverlayShortcutGate {
   const guidePressed = isPressedGamepadButton(gamepad.buttons[16]);
   const viewPressed = isPressedGamepadButton(gamepad.buttons[8]);
   const menuPressed = isPressedGamepadButton(gamepad.buttons[9]);
-  return guidePressed || (viewPressed && menuPressed);
+  const pressedHalf: ControllerOverlayChordHalf | null = viewPressed === menuPressed
+    ? null
+    : viewPressed
+      ? "view"
+      : "menu";
+
+  if (guidePressed) {
+    return { overlayPressed: true, preemptInput: true, nextState: null };
+  }
+
+  if (viewPressed && menuPressed) {
+    if (state?.disqualified) {
+      return { overlayPressed: false, preemptInput: false, nextState: state };
+    }
+
+    return { overlayPressed: true, preemptInput: true, nextState: null };
+  }
+
+  if (!pressedHalf) {
+    return { overlayPressed: false, preemptInput: false, nextState: null };
+  }
+
+  if (state?.disqualified) {
+    return {
+      overlayPressed: false,
+      preemptInput: false,
+      nextState: state.pendingHalf === pressedHalf
+        ? state
+        : { pendingHalf: pressedHalf, pendingSinceMs: nowMs, disqualified: true },
+    };
+  }
+
+  if (!state || state.pendingHalf !== pressedHalf) {
+    return {
+      overlayPressed: false,
+      preemptInput: true,
+      nextState: { pendingHalf: pressedHalf, pendingSinceMs: nowMs, disqualified: false },
+    };
+  }
+
+  const disqualified = nowMs - state.pendingSinceMs >= graceMs;
+  const nextState = { ...state, disqualified };
+  return {
+    overlayPressed: false,
+    preemptInput: !disqualified,
+    nextState,
+  };
 }
 
 function timestampUs(sourceTimestampMs?: number): bigint {
@@ -842,6 +909,7 @@ export class GfnWebRtcClient {
   private renderFpsCounter = { frames: 0, lastUpdate: 0, fps: 0 };
   private connectedGamepads: Set<number> = new Set();
   private gamepadMetaPressed: Map<number, boolean> = new Map();
+  private gamepadOverlayChordStates: Map<number, ControllerOverlayChordState> = new Map();
   private lastEmittedDiagnostics: StreamDiagnostics | null = null;
   private previousGamepadStates: Map<number, GamepadInput> = new Map();
   private lastRumbleWeak: number[] = [0, 0, 0, 0];
@@ -2120,6 +2188,8 @@ export class GfnWebRtcClient {
     this.resetInputState();
     this.resetDiagnostics();
     this.connectedGamepads.clear();
+    this.gamepadMetaPressed.clear();
+    this.gamepadOverlayChordStates.clear();
     this.previousGamepadStates.clear();
     this.gamepadSendCount = 0;
     this.lastGamepadSendMs = 0;
@@ -2444,7 +2514,17 @@ export class GfnWebRtcClient {
       if (gamepad && gamepad.connected) {
         connectedCount++;
         this.updateGamepadBitmap(i, gamepad);
-        const overlayShortcutPressed = isControllerOverlayShortcutPressed(gamepad);
+        const overlayShortcutGate = evaluateControllerOverlayShortcutGate(
+          gamepad,
+          this.gamepadOverlayChordStates.get(i) ?? null,
+          nowMs,
+        );
+        if (overlayShortcutGate.nextState) {
+          this.gamepadOverlayChordStates.set(i, overlayShortcutGate.nextState);
+        } else {
+          this.gamepadOverlayChordStates.delete(i);
+        }
+        const overlayShortcutPressed = overlayShortcutGate.overlayPressed;
         const prevOverlayShortcutPressed = this.gamepadMetaPressed.get(i) ?? false;
         if (overlayShortcutPressed && !prevOverlayShortcutPressed) {
           try {
@@ -2468,7 +2548,7 @@ export class GfnWebRtcClient {
         // Read and encode gamepad state
         // Skip forwarding to the stream if input is blocked (dashboard open) or
         // the native renderer is handling controller input directly.
-        if (streamInputBlocked || this.nativeInputActive || overlayShortcutPressed) {
+        if (streamInputBlocked || this.nativeInputActive || overlayShortcutGate.preemptInput) {
           continue;
         }
         const gamepadInput = this.readGamepadState(gamepad, i);
@@ -2507,6 +2587,7 @@ export class GfnWebRtcClient {
         this.stopGamepadRumble(i, gamepad ?? undefined);
         this.connectedGamepads.delete(i);
         this.gamepadMetaPressed.delete(i);
+        this.gamepadOverlayChordStates.delete(i);
         this.previousGamepadStates.delete(i);
         this.clearGamepadBitmap(i);
         this.log(`Gamepad ${i} disconnected, bitmap now: 0x${this.gamepadBitmap.toString(16)}`);

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -255,8 +255,19 @@ interface ClientOptions {
   onMicStateChange?: (state: MicStateChange) => void;
   onIceConnectionStateChange?: (state: RTCIceConnectionState) => void;
   onPeerConnectionStateChange?: (state: RTCPeerConnectionState) => void;
-  /** Optional host callback for Meta/Home button edge presses (button 16). */
+  /** Optional host callback for controller overlay shortcut edge presses. */
   onControllerMetaPress?: (event: { controllerId: number; gamepad: Gamepad }) => void;
+}
+
+function isPressedGamepadButton(button: GamepadButton | undefined): boolean {
+  return Boolean(button?.pressed || (button?.value ?? 0) > 0.5);
+}
+
+function isControllerOverlayShortcutPressed(gamepad: Gamepad): boolean {
+  const guidePressed = isPressedGamepadButton(gamepad.buttons[16]);
+  const viewPressed = isPressedGamepadButton(gamepad.buttons[8]);
+  const menuPressed = isPressedGamepadButton(gamepad.buttons[9]);
+  return guidePressed || (viewPressed && menuPressed);
 }
 
 function timestampUs(sourceTimestampMs?: number): bigint {
@@ -2178,7 +2189,7 @@ export class GfnWebRtcClient {
     // state forwarding is suppressed inside pollGamepads() when nativeInputActive
     // is true so the native renderer remains the sole source for controller input.
     this.setupGamepadPolling();
-    this.log(`Native DX11 input forwarding active (protocol v${nativeProtocolVersion}); controller meta detection active, gamepad forwarding handled by native renderer.`);
+    this.log(`Native DX11 input forwarding active (protocol v${nativeProtocolVersion}); controller overlay shortcut detection active, gamepad forwarding handled by native renderer.`);
   }
 
   public setNativeInputProtocolVersion(protocolVersion: number): void {
@@ -2374,7 +2385,8 @@ export class GfnWebRtcClient {
   }
 
   private isStreamInputBlocked(): boolean {
-    return this.inputPaused || this.windowStateInputPaused;
+    const sidebarOpen = typeof document !== "undefined" && document.body?.dataset?.sidebarOpen === "1";
+    return this.inputPaused || this.windowStateInputPaused || sidebarOpen;
   }
 
   private getGamepadPollIntervalMs(): number {
@@ -2389,7 +2401,7 @@ export class GfnWebRtcClient {
     // Poll at reduced rate while input is paused (dashboard open) — fast enough
     // to catch the Meta button release and next press, but not burning CPU at
     // the full 4 ms stream-input rate.
-    return this.inputPaused ? 16 : 4;
+    return this.isStreamInputBlocked() ? 16 : 4;
   }
 
   private shouldPollGamepads(): boolean {
@@ -2432,16 +2444,16 @@ export class GfnWebRtcClient {
       if (gamepad && gamepad.connected) {
         connectedCount++;
         this.updateGamepadBitmap(i, gamepad);
-        const metaPressed = Boolean(gamepad.buttons[16]?.pressed);
-        const prevMetaPressed = this.gamepadMetaPressed.get(i) ?? false;
-        if (metaPressed && !prevMetaPressed) {
+        const overlayShortcutPressed = isControllerOverlayShortcutPressed(gamepad);
+        const prevOverlayShortcutPressed = this.gamepadMetaPressed.get(i) ?? false;
+        if (overlayShortcutPressed && !prevOverlayShortcutPressed) {
           try {
             this.options.onControllerMetaPress?.({ controllerId: i, gamepad });
           } catch {
             // Host callbacks must never break stream input polling.
           }
         }
-        this.gamepadMetaPressed.set(i, metaPressed);
+        this.gamepadMetaPressed.set(i, overlayShortcutPressed);
 
         // Track connected gamepads and update bitmap
         if (!this.connectedGamepads.has(i)) {
@@ -2456,7 +2468,7 @@ export class GfnWebRtcClient {
         // Read and encode gamepad state
         // Skip forwarding to the stream if input is blocked (dashboard open) or
         // the native renderer is handling controller input directly.
-        if (streamInputBlocked || this.nativeInputActive) {
+        if (streamInputBlocked || this.nativeInputActive || overlayShortcutPressed) {
           continue;
         }
         const gamepadInput = this.readGamepadState(gamepad, i);

--- a/opennow-stable/src/renderer/src/streamShortcutActions.ts
+++ b/opennow-stable/src/renderer/src/streamShortcutActions.ts
@@ -2,17 +2,19 @@ import type { NativeStreamerShortcutAction } from "@shared/gfn";
 
 const STREAM_SHORTCUT_ACTION_EVENT = "opennow:stream-shortcut-action";
 
-export function dispatchStreamShortcutAction(action: NativeStreamerShortcutAction): void {
-  window.dispatchEvent(new CustomEvent<NativeStreamerShortcutAction>(STREAM_SHORTCUT_ACTION_EVENT, {
+export type StreamShortcutAction = NativeStreamerShortcutAction | "toggleSidebar";
+
+export function dispatchStreamShortcutAction(action: StreamShortcutAction): void {
+  window.dispatchEvent(new CustomEvent<StreamShortcutAction>(STREAM_SHORTCUT_ACTION_EVENT, {
     detail: action,
   }));
 }
 
 export function addStreamShortcutActionListener(
-  listener: (action: NativeStreamerShortcutAction) => void,
+  listener: (action: StreamShortcutAction) => void,
 ): () => void {
   const handler: EventListener = (event) => {
-    listener((event as CustomEvent<NativeStreamerShortcutAction>).detail);
+    listener((event as CustomEvent<StreamShortcutAction>).detail);
   };
 
   window.addEventListener(STREAM_SHORTCUT_ACTION_EVENT, handler);

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -8504,20 +8504,29 @@ button.game-card-store-chip.owned.active:hover {
   top: 14px;
   left: 14px;
   z-index: 1002;
-  width: min(340px, 92vw);
-  padding: 14px;
-  background: rgba(10, 10, 12, 0.96);
+  width: min(380px, calc(100vw - 28px));
+  max-height: calc(100vh - 28px);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% -12%, rgba(119, 187, 255, 0.18), transparent 34%),
+    linear-gradient(180deg, rgba(20, 22, 28, 0.98), rgba(8, 9, 12, 0.96));
   border-radius: var(--r-xl);
   border: 1px solid var(--panel-border);
   box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(14px);
 }
 
 .sidebar-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 8px;
+  flex: 0 0 auto;
+  margin-bottom: 0;
+  padding: 14px 14px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
 }
 
 .sidebar-header h3 {
@@ -8548,10 +8557,167 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 12px 14px 14px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(119, 187, 255, 0.36) transparent;
 }
 
 .sidebar-body>* {
   min-width: 0;
+}
+
+.sidebar-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.sidebar-body::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(119, 187, 255, 0.32);
+}
+
+.sidebar-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar-session-card {
+  position: relative;
+  overflow: hidden;
+  padding: 13px;
+  border-radius: 15px;
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--panel-border));
+  background:
+    linear-gradient(135deg, rgba(119, 187, 255, 0.16), rgba(255, 255, 255, 0.035) 42%, rgba(255, 80, 80, 0.07)),
+    rgba(255, 255, 255, 0.035);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.07);
+}
+
+.sidebar-session-card::before {
+  content: "";
+  position: absolute;
+  inset: -38% -18% auto auto;
+  width: 140px;
+  height: 140px;
+  border-radius: 999px;
+  background: rgba(119, 187, 255, 0.12);
+  pointer-events: none;
+}
+
+.sidebar-session-card-head {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar-session-kicker {
+  color: var(--accent);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.sidebar-session-title {
+  color: var(--ink);
+  font-size: 1.02rem;
+  line-height: 1.18;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-session-platform {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.sidebar-session-platform-icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  color: var(--accent);
+}
+
+.sidebar-session-shortcuts {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 12px;
+}
+
+.sidebar-session-shortcut {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 7px 8px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--ink-muted);
+  font-size: 0.67rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.sidebar-session-shortcut kbd {
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.sidebar-exit-session-button {
+  position: relative;
+  width: 100%;
+  min-height: 38px;
+  margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 11px;
+  border: 1px solid rgba(255, 105, 105, 0.34);
+  background: rgba(255, 80, 80, 0.12);
+  color: #ffd6d6;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    border-color var(--t-fast),
+    background var(--t-fast),
+    color var(--t-fast),
+    transform var(--t-fast);
+}
+
+.sidebar-exit-session-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 105, 105, 0.7);
+  background: rgba(255, 80, 80, 0.2);
+  color: #fff;
+}
+
+.sidebar-exit-session-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--error-bg);
 }
 
 .sidebar-stat-line {
@@ -8741,6 +8907,14 @@ button.game-card-store-chip.owned.active:hover {
 
 .sidebar-shortcut-input {
   width: 100%;
+  min-width: 0;
+}
+
+.sidebar-shortcut-stack {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
   min-width: 0;
 }
 
@@ -8990,7 +9164,7 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sv-sidebar {
-  width: min(360px, 92vw);
+  width: min(420px, calc(100vw - 28px));
 }
 
 .sv-sidebar-backdrop {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1428,6 +1428,7 @@ export interface OpenNowApi {
   sendAnswer(input: SendAnswerRequest): Promise<void>;
   sendIceCandidate(input: IceCandidatePayload): Promise<void>;
   sendNativeInput(input: NativeInputPacket): void;
+  setNativeInputPaused(paused: boolean): void;
   updateNativeRenderSurface(input: NativeRenderSurfaceUpdate): void;
   updateNativeShortcuts(shortcuts: NativeStreamerShortcutBindings): void;
   requestKeyframe(input: KeyframeRequest): Promise<void>;

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -40,6 +40,7 @@ export const IPC_CHANNELS = {
   SEND_ANSWER: "gfn:send-answer",
   SEND_ICE_CANDIDATE: "gfn:send-ice-candidate",
   NATIVE_INPUT: "gfn:native-input",
+  NATIVE_INPUT_PAUSED: "gfn:native-input-paused",
   NATIVE_RENDER_SURFACE: "gfn:native-render-surface",
   NATIVE_UPDATE_SHORTCUTS: "gfn:native-update-shortcuts",
   REQUEST_KEYFRAME: "gfn:request-keyframe",

--- a/opennow-stable/src/shared/nativeStreamer.ts
+++ b/opennow-stable/src/shared/nativeStreamer.ts
@@ -10,7 +10,7 @@ import type {
   SendAnswerRequest,
 } from "./gfn";
 
-export const NATIVE_STREAMER_PROTOCOL_VERSION = 3;
+export const NATIVE_STREAMER_PROTOCOL_VERSION = 4;
 
 export type { NativeStreamerBackend };
 
@@ -57,6 +57,11 @@ export type NativeStreamerCommand =
       id: string;
       type: "input";
       input: NativeStreamerInputPacket;
+    }
+  | {
+      id: string;
+      type: "input-paused";
+      paused: boolean;
     }
   | {
       id: string;


### PR DESCRIPTION
This PR redesigns the in-session Ctrl+G sidebar overlay to better fit the screen with an extended layout featuring a session info card, exit-session button, and streamlined vertical scrolling.

- Redesign sidebar layout with session card at top, scrollable body below, and visual gradient background
- Add "Exit session" button in the session card that closes sidebar and ends stream
- Implement 'View + Menu' controller combo to open the overlay (Guide button also works)
- Stream overlay is blocked from sending input to the game when sidebar is open
- Add controller shortcut hint to keyboard hints overlay when streaming
- Change keyboard shortcut from Ctrl+Shift+G to Ctrl+G (while accepting Ctrl+Shift+G as alias)
- Update SettingsPage to recognize both shortcuts as reserved to prevent conflicts
- Fix sidebar open state tracking with proper cleanup effect

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/13adce48-dbbe-43d3-8f09-1cec77a15b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-252" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/13adce48-dbbe-43d3-8f09-1cec77a15b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-252&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-252"><img alt="OPE-252" src="https://capy.ai/api/badge/thread.svg?label=OPE-252"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live stream input gating and gamepad shortcut detection; wrong edge cases could leak menu buttons to the game or block input unexpectedly, but scope is limited to overlay/sidebar behavior.
> 
> **Overview**
> Redesigns the in-session **Stream Control** overlay and expands how users open it from keyboard and gamepad.
> 
> **Shortcuts:** Windows/Linux sidebar toggle moves from **Ctrl+Shift+G** to **Ctrl+G**; **Ctrl+Shift+G** stays as an alias. Settings conflict checks treat both as reserved. Keyboard handling uses **stopPropagation** on the sidebar keys. A new **`toggleSidebar`** stream shortcut action wires controller callbacks and the shortcut bus.
> 
> **Controller:** Opening the panel is detected on **Guide** or **View + Menu** (not Guide alone on edge). That fires **`onControllerMetaPress`** → toggle sidebar while streaming. While the overlay shortcut is held or the sidebar is open (`document.body.dataset.sidebarOpen`), **gamepad input is not forwarded** to the stream.
> 
> **UI:** Sidebar is retitled, gets a session card (game, platform, keyboard/controller hints), **Exit session**, and scrollable styling. Hints show the controller menu combo.
> 
> **Fix:** Sidebar-open dataset is cleared in the effect cleanup when the sidebar closes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e62e4089161e253046860ec20fc030c9e01fae1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->