### PR TITLE
fix(webrtc): rewrite ICE candidates to CloudMatch media endpoint

### DIFF
--- a/native/opennow-streamer/src/backend.rs
+++ b/native/opennow-streamer/src/backend.rs
@@ -6,8 +6,9 @@ use crate::protocol::{
 };
 use crate::sdp::{
     duplicate_session_webrtc_attributes_to_media, extract_ice_credentials, fix_server_ip,
-    parse_resolution, prefer_codec, sanitize_ice_pwd_for_gstreamer,
-    summarize_media_transport_attributes, NvstParams, PreferCodecOptions,
+    parse_resolution, prefer_codec, rewrite_sdp_ice_candidate_endpoints,
+    sanitize_ice_pwd_for_gstreamer, summarize_media_transport_attributes, NvstParams,
+    PreferCodecOptions,
 };
 use std::env;
 use std::sync::mpsc::Sender;
@@ -116,6 +117,7 @@ pub struct PreparedNativeOffer {
     pub gstreamer_offer_sdp: String,
     pub gstreamer_ice_pwd_replacements: usize,
     pub gstreamer_framerate_adjusted: bool,
+    pub media_connection_ice_replacements: usize,
     pub nvst_params: NvstParams,
     pub media_connection_info: Option<MediaConnectionInfo>,
 }
@@ -147,10 +149,18 @@ pub fn prepare_native_offer(
         });
     };
 
-    let fixed_offer_sdp = duplicate_session_webrtc_attributes_to_media(&fix_server_ip(
-        offer_sdp,
-        &context.session.server_ip,
-    ));
+    let fixed_offer_sdp = fix_server_ip(offer_sdp, &context.session.server_ip);
+    let (fixed_offer_sdp, media_connection_ice_replacements) =
+        if let Some(media_connection_info) = web_rtc_media_connection_info(context) {
+            rewrite_sdp_ice_candidate_endpoints(
+                &fixed_offer_sdp,
+                &media_connection_info.ip,
+                media_connection_info.port,
+            )
+        } else {
+            (fixed_offer_sdp, 0)
+        };
+    let fixed_offer_sdp = duplicate_session_webrtc_attributes_to_media(&fixed_offer_sdp);
     let codec = resolve_native_codec(context.settings.codec);
     let fixed_offer_sdp = prefer_codec(
         &fixed_offer_sdp,
@@ -184,9 +194,24 @@ pub fn prepare_native_offer(
         gstreamer_offer_sdp,
         gstreamer_ice_pwd_replacements,
         gstreamer_framerate_adjusted,
+        media_connection_ice_replacements,
         nvst_params,
         media_connection_info: context.session.media_connection_info.clone(),
     })
+}
+
+pub(crate) fn web_rtc_media_connection_info(
+    context: &NativeStreamerSessionContext,
+) -> Option<&MediaConnectionInfo> {
+    let media_connection_info = context.session.media_connection_info.as_ref()?;
+    if matches!(media_connection_info.usage, Some(2 | 17))
+        && !media_connection_info.ip.trim().is_empty()
+        && media_connection_info.port > 0
+    {
+        Some(media_connection_info)
+    } else {
+        None
+    }
 }
 
 fn align_video_sdp_framerate_for_gstreamer(sdp: &str, fps: u32) -> (String, bool) {
@@ -288,10 +313,28 @@ pub fn prepared_offer_events(prepared: &PreparedNativeOffer) -> Vec<Event> {
         events.push(Event::Log {
             level: "debug",
             message: format!(
-                "GFN media connection hint {}:{}.",
-                media_connection_info.ip, media_connection_info.port
+                "GFN media connection hint {}:{} (usage={}).",
+                media_connection_info.ip,
+                media_connection_info.port,
+                media_connection_info
+                    .usage
+                    .map(|usage| usage.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned())
             ),
         });
+    }
+    if prepared.media_connection_ice_replacements > 0 {
+        if let Some(media_connection_info) = &prepared.media_connection_info {
+            events.push(Event::Log {
+                level: "info",
+                message: format!(
+                    "Rewrote {} remote ICE candidate endpoint(s) to GFN media connection hint {}:{}.",
+                    prepared.media_connection_ice_replacements,
+                    media_connection_info.ip,
+                    media_connection_info.port
+                ),
+            });
+        }
     }
     events.push(Event::Log {
         level: "debug",
@@ -508,6 +551,7 @@ mod tests {
                 media_connection_info: Some(MediaConnectionInfo {
                     ip: "10.0.0.7".to_owned(),
                     port: 49003,
+                    usage: Some(2),
                 }),
                 negotiated_stream_profile: None,
                 requested_streaming_features: None,
@@ -547,6 +591,58 @@ mod tests {
                 .map(|info| info.port),
             Some(49003),
         );
+    }
+
+    #[test]
+    fn prepares_offer_rewrites_server_ice_candidates_to_media_connection_info() {
+        let offer = [
+            "v=0",
+            "a=ice-ufrag:user",
+            "a=ice-pwd:pass",
+            "a=fingerprint:sha-256 AA:BB",
+            "m=audio 47998 UDP/TLS/RTP/SAVPF 111",
+            "a=candidate:1 1 udp 2122260223 203.0.113.10 47998 typ host",
+            "m=video 47998 UDP/TLS/RTP/SAVPF 96",
+            "a=candidate:2 1 udp 2122260223 203.0.113.10 47998 typ host",
+            "a=rtpmap:96 H265/90000",
+        ]
+        .join("\n");
+
+        let prepared = prepare_native_offer(&context("1920x1080"), &offer).expect("valid offer");
+
+        assert_eq!(prepared.media_connection_ice_replacements, 2);
+        assert!(prepared
+            .fixed_offer_sdp
+            .contains("a=candidate:1 1 udp 2122260223 10.0.0.7 49003 typ host"));
+        assert!(prepared
+            .fixed_offer_sdp
+            .contains("a=candidate:2 1 udp 2122260223 10.0.0.7 49003 typ host"));
+    }
+
+    #[test]
+    fn prepares_offer_skips_non_webrtc_media_connection_info() {
+        let mut context = context("1920x1080");
+        context
+            .session
+            .media_connection_info
+            .as_mut()
+            .expect("media connection")
+            .usage = Some(14);
+        let offer = [
+            "v=0",
+            "a=ice-ufrag:user",
+            "a=ice-pwd:pass",
+            "a=fingerprint:sha-256 AA:BB",
+            "a=candidate:1 1 udp 2122260223 203.0.113.10 47998 typ host",
+        ]
+        .join("\n");
+
+        let prepared = prepare_native_offer(&context, &offer).expect("valid offer");
+
+        assert_eq!(prepared.media_connection_ice_replacements, 0);
+        assert!(prepared
+            .fixed_offer_sdp
+            .contains("a=candidate:1 1 udp 2122260223 203.0.113.10 47998 typ host"));
     }
 
     #[test]

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -1,6 +1,7 @@
 use crate::backend::{
     normalize_bitrate_kbps, prepare_native_offer, prepared_offer_events,
     update_context_bitrate_limit, BackendReply, NativeStreamerBackend,
+    web_rtc_media_connection_info,
 };
 use crate::gstreamer_config::{
     resolve_d3d_fullscreen_sink, resolve_present_max_fps, NATIVE_D3D_FULLSCREEN_ENV,
@@ -15,7 +16,10 @@ use crate::protocol::{
     NativeStreamerCapabilities, NativeStreamerSessionContext, NativeVideoBackendCapability,
     Response, SendAnswerRequest, PROTOCOL_VERSION,
 };
-use crate::sdp::{build_nvst_sdp_for_answer, extract_negotiated_video_codec, munge_answer_sdp};
+use crate::sdp::{
+    build_nvst_sdp_for_answer, extract_negotiated_video_codec, munge_answer_sdp,
+    rewrite_ice_candidate_endpoint,
+};
 use std::sync::mpsc::Sender;
 
 pub(crate) fn send_log(event_sender: &Option<Sender<Event>>, level: &'static str, message: String) {
@@ -65,6 +69,36 @@ impl GstreamerBackend {
             }
         }
         events
+    }
+
+    fn rewrite_remote_ice_candidate(&self, candidate: IceCandidatePayload) -> IceCandidatePayload {
+        let Some(context) = self.active_context.as_ref() else {
+            return candidate;
+        };
+        let Some(media_connection_info) = web_rtc_media_connection_info(context) else {
+            return candidate;
+        };
+        let (rewritten, changed) = rewrite_ice_candidate_endpoint(
+            &candidate.candidate,
+            &media_connection_info.ip,
+            media_connection_info.port,
+        );
+        if changed {
+            send_log(
+                &self.event_sender,
+                "info",
+                format!(
+                    "Rewrote remote ICE candidate endpoint to GFN media connection hint {}:{}.",
+                    media_connection_info.ip, media_connection_info.port
+                ),
+            );
+            IceCandidatePayload {
+                candidate: rewritten,
+                ..candidate
+            }
+        } else {
+            candidate
+        }
     }
 }
 
@@ -304,6 +338,7 @@ impl NativeStreamerBackend for GstreamerBackend {
         let Some(candidate) = command.candidate else {
             return BackendReply::response(missing_field(&command.id, "candidate"));
         };
+        let candidate = self.rewrite_remote_ice_candidate(candidate);
 
         if self.remote_description_set {
             if let Some(pipeline) = self.pipeline.as_mut() {

--- a/native/opennow-streamer/src/protocol.rs
+++ b/native/opennow-streamer/src/protocol.rs
@@ -62,6 +62,8 @@ pub struct SessionInfo {
 pub struct MediaConnectionInfo {
     pub ip: String,
     pub port: u16,
+    #[serde(default)]
+    pub usage: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/native/opennow-streamer/src/sdp.rs
+++ b/native/opennow-streamer/src/sdp.rs
@@ -83,6 +83,57 @@ pub fn fix_server_ip(sdp: &str, server_ip: &str) -> String {
         .into_owned()
 }
 
+pub fn rewrite_ice_candidate_endpoint(
+    candidate: &str,
+    ip: &str,
+    port: u16,
+) -> (String, bool) {
+    let ip = ip.trim();
+    if ip.is_empty() || port == 0 {
+        return (candidate.to_owned(), false);
+    }
+
+    let mut parts: Vec<String> = candidate.split_whitespace().map(ToOwned::to_owned).collect();
+    if parts.len() < 6
+        || !(parts[0].starts_with("candidate:") || parts[0].starts_with("a=candidate:"))
+    {
+        return (candidate.to_owned(), false);
+    }
+
+    if parts[4] == ip && parts[5] == port.to_string() {
+        return (candidate.to_owned(), false);
+    }
+
+    parts[4] = ip.to_owned();
+    parts[5] = port.to_string();
+    let rewritten = parts.join(" ");
+    (rewritten, true)
+}
+
+pub fn rewrite_sdp_ice_candidate_endpoints(
+    sdp: &str,
+    ip: &str,
+    port: u16,
+) -> (String, usize) {
+    let ending = line_ending(sdp);
+    let mut replacements = 0usize;
+    let lines = split_lines_lossless(sdp)
+        .into_iter()
+        .map(|line| {
+            if !line.starts_with("a=candidate:") {
+                return line.to_owned();
+            }
+            let (rewritten, changed) = rewrite_ice_candidate_endpoint(line, ip, port);
+            if changed {
+                replacements += 1;
+            }
+            rewritten
+        })
+        .collect::<Vec<_>>();
+
+    (lines.join(ending), replacements)
+}
+
 pub fn duplicate_session_webrtc_attributes_to_media(sdp: &str) -> String {
     let ending = line_ending(sdp);
     let lines = split_lines_lossless(sdp);
@@ -841,6 +892,43 @@ mod tests {
         let fixed = fix_server_ip(offer, "80-250-97-40.cloudmatchbeta.nvidiagrid.net");
         assert!(fixed.contains("c=IN IP4 80.250.97.40"));
         assert!(fixed.contains("a=candidate:1 1 udp 1 80.250.97.40 49000 typ host"));
+    }
+
+    #[test]
+    fn rewrites_sdp_ice_candidate_endpoints() {
+        let offer = [
+            "v=0",
+            "c=IN IP4 0.0.0.0",
+            "a=candidate:1 1 udp 2122260223 203.0.113.10 47998 typ host",
+            "a=candidate:2 1 tcp 1518214911 203.0.113.10 9 typ host tcptype active",
+        ]
+        .join("\r\n");
+
+        let (rewritten, replacements) =
+            rewrite_sdp_ice_candidate_endpoints(&offer, "198.51.100.55", 18784);
+
+        assert_eq!(replacements, 2);
+        assert!(rewritten
+            .contains("a=candidate:1 1 udp 2122260223 198.51.100.55 18784 typ host"));
+        assert!(rewritten.contains(
+            "a=candidate:2 1 tcp 1518214911 198.51.100.55 18784 typ host tcptype active"
+        ));
+        assert!(rewritten.contains("c=IN IP4 0.0.0.0"));
+        assert!(rewritten.contains("\r\n"));
+    }
+
+    #[test]
+    fn rewrites_trickled_ice_candidate_endpoint() {
+        let candidate = "candidate:1 1 udp 2122260223 203.0.113.10 47998 typ host";
+
+        let (rewritten, changed) =
+            rewrite_ice_candidate_endpoint(candidate, "198.51.100.55", 18784);
+
+        assert!(changed);
+        assert_eq!(
+            rewritten,
+            "candidate:1 1 udp 2122260223 198.51.100.55 18784 typ host"
+        );
     }
 
     #[test]

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -10,6 +10,7 @@ import type {
   ColorQuality,
   NegotiatedStreamProfile,
   IceServer,
+  MediaConnectionInfo,
   StreamingFeatures,
   SessionAdAction,
   SessionAdInfo,
@@ -424,7 +425,7 @@ function resolveSignaling(response: CloudMatchResponse): {
   serverIp: string;
   signalingServer: string;
   signalingUrl: string;
-  mediaConnectionInfo?: { ip: string; port: number };
+  mediaConnectionInfo?: MediaConnectionInfo;
 } {
   const connections = response.session.connectionInfo ?? [];
   const signalingConnection =

--- a/opennow-stable/src/renderer/src/gfn/sdp.test.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.test.ts
@@ -8,8 +8,10 @@ import {
   fixServerIp,
   mungeAnswerSdp,
   preferCodec,
+  rewriteIceCandidateEndpoint,
   rewriteH265LevelIdByProfile,
   rewriteH265TierFlag,
+  rewriteSdpIceCandidateEndpoints,
 } from "./sdp";
 
 test("fixServerIp replaces 0.0.0.0 candidate IPs without changing connection lines", () => {
@@ -26,6 +28,43 @@ test("fixServerIp replaces 0.0.0.0 candidate IPs without changing connection lin
   assert.match(fixed, /a=candidate:1 1 udp 2130706431 161\.248\.11\.132 47998 typ host/);
   assert.match(fixed, /a=candidate:2 1 tcp 1 192\.168\.1\.5 9 typ host/);
   assert.equal(fixServerIp(sdp, "unparseable.example.com"), sdp);
+});
+
+test("rewriteSdpIceCandidateEndpoints points server candidates at WebRTC mediaConnectionInfo", () => {
+  const sdp = [
+    "v=0",
+    "c=IN IP4 0.0.0.0",
+    "a=candidate:1 1 udp 2122260223 203.0.113.10 47998 typ host",
+    "a=candidate:2 1 tcp 1518214911 203.0.113.10 9 typ host tcptype active",
+  ].join("\r\n");
+
+  const rewritten = rewriteSdpIceCandidateEndpoints(sdp, {
+    ip: "198.51.100.55",
+    port: 18784,
+    usage: 2,
+  });
+
+  assert.equal(rewritten.replacements, 2);
+  assert.match(rewritten.sdp, /a=candidate:1 1 udp 2122260223 198\.51\.100\.55 18784 typ host/);
+  assert.match(rewritten.sdp, /a=candidate:2 1 tcp 1518214911 198\.51\.100\.55 18784 typ host tcptype active/);
+  assert.match(rewritten.sdp, /c=IN IP4 0\.0\.0\.0/);
+  assert.match(rewritten.sdp, /\r\n/);
+});
+
+test("rewriteIceCandidateEndpoint skips non-WebRTC mediaConnectionInfo usages", () => {
+  const candidate = "candidate:1 1 udp 2122260223 203.0.113.10 47998 typ host";
+
+  assert.deepEqual(
+    rewriteIceCandidateEndpoint(candidate, { ip: "198.51.100.55", port: 18784, usage: 14 }),
+    { candidate, rewritten: false },
+  );
+  assert.deepEqual(
+    rewriteIceCandidateEndpoint(candidate, { ip: "198.51.100.55", port: 18784, usage: 17 }),
+    {
+      candidate: "candidate:1 1 udp 2122260223 198.51.100.55 18784 typ host",
+      rewritten: true,
+    },
+  );
 });
 
 test("preferCodec keeps selected video payloads and RTX apt payloads while leaving audio untouched", () => {

--- a/opennow-stable/src/renderer/src/gfn/sdp.ts
+++ b/opennow-stable/src/renderer/src/gfn/sdp.ts
@@ -1,4 +1,4 @@
-import type { ColorQuality, VideoCodec } from "@shared/gfn";
+import type { ColorQuality, MediaConnectionInfo, VideoCodec } from "@shared/gfn";
 import {
   PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
   PARTIALLY_RELIABLE_HID_DEVICE_MASK_ALL,
@@ -67,6 +67,77 @@ export function fixServerIp(sdp: string, serverIp: string): string {
   }
 
   return fixed;
+}
+
+function normalizeWebRtcMediaConnectionInfo(
+  mediaConnectionInfo: MediaConnectionInfo | null | undefined,
+): { ip: string; port: number } | null {
+  if (!mediaConnectionInfo) {
+    return null;
+  }
+  if (mediaConnectionInfo.usage !== 2 && mediaConnectionInfo.usage !== 17) {
+    return null;
+  }
+  const ip = mediaConnectionInfo.ip.trim();
+  const port = Math.round(mediaConnectionInfo.port);
+  if (!ip || !Number.isFinite(port) || port <= 0 || port > 65535) {
+    return null;
+  }
+  return { ip, port };
+}
+
+export function rewriteIceCandidateEndpoint(
+  candidate: string,
+  mediaConnectionInfo: MediaConnectionInfo | null | undefined,
+): { candidate: string; rewritten: boolean } {
+  const endpoint = normalizeWebRtcMediaConnectionInfo(mediaConnectionInfo);
+  if (!endpoint) {
+    return { candidate, rewritten: false };
+  }
+
+  const match = candidate.match(
+    /^(a=candidate:\S+\s+\d+\s+\S+\s+\d+\s+|candidate:\S+\s+\d+\s+\S+\s+\d+\s+)(\S+)(\s+)(\d+)(?=\s|$)/,
+  );
+  if (!match) {
+    return { candidate, rewritten: false };
+  }
+
+  const [, prefix = "", oldIp = "", separator = " ", oldPort = ""] = match;
+  if (oldIp === endpoint.ip && Number.parseInt(oldPort, 10) === endpoint.port) {
+    return { candidate, rewritten: false };
+  }
+
+  return {
+    candidate: candidate.replace(
+      match[0],
+      `${prefix}${endpoint.ip}${separator}${endpoint.port}`,
+    ),
+    rewritten: true,
+  };
+}
+
+export function rewriteSdpIceCandidateEndpoints(
+  sdp: string,
+  mediaConnectionInfo: MediaConnectionInfo | null | undefined,
+): { sdp: string; replacements: number } {
+  if (!normalizeWebRtcMediaConnectionInfo(mediaConnectionInfo)) {
+    return { sdp, replacements: 0 };
+  }
+
+  const lineEnding = sdp.includes("\r\n") ? "\r\n" : "\n";
+  let replacements = 0;
+  const rewritten = sdp.split(/\r?\n/).map((line) => {
+    if (!line.startsWith("a=candidate:")) {
+      return line;
+    }
+    const result = rewriteIceCandidateEndpoint(line, mediaConnectionInfo);
+    if (result.rewritten) {
+      replacements += 1;
+    }
+    return result.candidate;
+  });
+
+  return { sdp: rewritten.join(lineEnding), replacements };
 }
 
 /**

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -52,8 +52,10 @@ import {
   fixServerIp,
   mungeAnswerSdp,
   preferCodec,
+  rewriteIceCandidateEndpoint,
   rewriteH265LevelIdByProfile,
   rewriteH265TierFlag,
+  rewriteSdpIceCandidateEndpoints,
 } from "./sdp";
 import { MicrophoneManager, type MicState, type MicStateChange } from "./microphoneManager";
 
@@ -747,6 +749,7 @@ export class GfnWebRtcClient {
   private controlChannel: RTCDataChannel | null = null;
   private cursorOverlay: GfnCursorOverlayController | null = null;
   private nativeInputActive = false;
+  private remoteIceEndpoint: SessionInfo["mediaConnectionInfo"] | null = null;
   private audioContext: AudioContext | null = null;
   private audioSourceNode: MediaStreamAudioSourceNode | null = null;
   private audioGainNode: GainNode | null = null;
@@ -2089,6 +2092,8 @@ export class GfnWebRtcClient {
     this.detachInputCapture();
     this.closeDataChannels();
     this.cleanupAudioRouting();
+    this.remoteIceEndpoint = null;
+    this.queuedCandidates = [];
     if (this.pc) {
       this.pc.onicecandidate = null;
       this.pc.ontrack = null;
@@ -4650,6 +4655,7 @@ export class GfnWebRtcClient {
 
   async handleOffer(offerSdp: string, session: SessionInfo, settings: OfferSettings): Promise<void> {
     this.cleanupPeerConnection();
+    this.remoteIceEndpoint = session.mediaConnectionInfo ?? null;
     this.log("=== handleOffer START ===");
     this.log(`Session: id=${session.sessionId}, status=${session.status}, serverIp=${session.serverIp}`);
     this.log(`Signaling: server=${session.signalingServer}, url=${session.signalingUrl}`);
@@ -4814,21 +4820,28 @@ export class GfnWebRtcClient {
 
     // --- SDP Processing (matching Rust reference) ---
 
-    // 1. Fix 0.0.0.0 in server's SDP offer with real server IP
-    //    The GFN server sends c=IN IP4 0.0.0.0; replace with actual IP
+    // 1. Match the official client by pointing server ICE candidates at the
+    //    WebRTC media endpoint from CloudMatch when one is present.
     const webRtcMediaConnection =
       session.mediaConnectionInfo?.usage === 2 || session.mediaConnectionInfo?.usage === 17
         ? session.mediaConnectionInfo
         : undefined;
-    const serverIpForSdp = webRtcMediaConnection?.ip ?? "";
     let processedOffer = offerSdp;
-    if (serverIpForSdp) {
+    if (webRtcMediaConnection?.ip) {
+      const serverIpForSdp = webRtcMediaConnection.ip;
       processedOffer = fixServerIp(processedOffer, serverIpForSdp);
       this.log(`Fixed server IP in SDP offer: ${serverIpForSdp}`);
       // Log any remaining 0.0.0.0 references after fix
       const remaining = (processedOffer.match(/0\.0\.0\.0/g) ?? []).length;
       if (remaining > 0) {
         this.log(`Warning: ${remaining} occurrences of 0.0.0.0 still remain in SDP after fix`);
+      }
+      const rewritten = rewriteSdpIceCandidateEndpoints(processedOffer, webRtcMediaConnection);
+      if (rewritten.replacements > 0) {
+        processedOffer = rewritten.sdp;
+        this.log(
+          `Rewrote ${rewritten.replacements} server ICE candidate endpoint(s) to mediaConnectionInfo ${webRtcMediaConnection.ip}:${webRtcMediaConnection.port}`,
+        );
       }
     } else if (session.mediaConnectionInfo) {
       this.log(
@@ -4995,9 +5008,8 @@ export class GfnWebRtcClient {
       }
     }
 
-    // Recent GFN browser runtimes rely on the server-provided trickled ICE
-    // candidate. Injecting mediaConnectionInfo as a higher-priority fallback can
-    // make Chromium pick an RTSPS endpoint that connects but never delivers frames.
+    // Keep using server-provided trickled ICE; when CloudMatch gives a WebRTC
+    // media endpoint, remote candidate IP/port rewriting happens in addRemoteCandidate.
     this.log("Waiting for server-provided ICE candidates");
 
     this.log("=== handleOffer COMPLETE — waiting for ICE connectivity and tracks ===");
@@ -5005,11 +5017,17 @@ export class GfnWebRtcClient {
 
   async addRemoteCandidate(candidate: IceCandidatePayload): Promise<void> {
     const sdpMLineIndex = candidate.sdpMLineIndex ?? (candidate.sdpMid == null ? 0 : undefined);
+    const rewritten = rewriteIceCandidateEndpoint(candidate.candidate, this.remoteIceEndpoint);
+    if (rewritten.rewritten && this.remoteIceEndpoint) {
+      this.log(
+        `Rewrote remote ICE candidate endpoint to mediaConnectionInfo ${this.remoteIceEndpoint.ip}:${this.remoteIceEndpoint.port}`,
+      );
+    }
     this.log(
-      `Remote ICE candidate received: ${candidate.candidate} (sdpMid=${candidate.sdpMid}, sdpMLineIndex=${sdpMLineIndex})`,
+      `Remote ICE candidate received: ${rewritten.candidate} (sdpMid=${candidate.sdpMid}, sdpMLineIndex=${sdpMLineIndex})`,
     );
     const init: RTCIceCandidateInit = {
-      candidate: candidate.candidate,
+      candidate: rewritten.candidate,
       sdpMid: candidate.sdpMid ?? undefined,
       sdpMLineIndex,
       usernameFragment: candidate.usernameFragment ?? undefined,

--- a/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/gfn/webrtcClient.ts
@@ -2093,7 +2093,6 @@ export class GfnWebRtcClient {
     this.closeDataChannels();
     this.cleanupAudioRouting();
     this.remoteIceEndpoint = null;
-    this.queuedCandidates = [];
     if (this.pc) {
       this.pc.onicecandidate = null;
       this.pc.ontrack = null;
@@ -3102,8 +3101,30 @@ export class GfnWebRtcClient {
       if (!candidate) {
         continue;
       }
-      await this.pc.addIceCandidate(candidate);
+      await this.pc.addIceCandidate(this.rewriteRemoteIceCandidateInit(candidate));
     }
+  }
+
+  private rewriteRemoteIceCandidateInit(candidate: RTCIceCandidateInit): RTCIceCandidateInit {
+    if (!candidate.candidate) {
+      return candidate;
+    }
+
+    const rewritten = rewriteIceCandidateEndpoint(candidate.candidate, this.remoteIceEndpoint);
+    if (!rewritten.rewritten) {
+      return candidate;
+    }
+
+    if (this.remoteIceEndpoint) {
+      this.log(
+        `Rewrote remote ICE candidate endpoint to mediaConnectionInfo ${this.remoteIceEndpoint.ip}:${this.remoteIceEndpoint.port}`,
+      );
+    }
+
+    return {
+      ...candidate,
+      candidate: rewritten.candidate,
+    };
   }
 
   private reliableDropLogged = false;
@@ -5017,17 +5038,11 @@ export class GfnWebRtcClient {
 
   async addRemoteCandidate(candidate: IceCandidatePayload): Promise<void> {
     const sdpMLineIndex = candidate.sdpMLineIndex ?? (candidate.sdpMid == null ? 0 : undefined);
-    const rewritten = rewriteIceCandidateEndpoint(candidate.candidate, this.remoteIceEndpoint);
-    if (rewritten.rewritten && this.remoteIceEndpoint) {
-      this.log(
-        `Rewrote remote ICE candidate endpoint to mediaConnectionInfo ${this.remoteIceEndpoint.ip}:${this.remoteIceEndpoint.port}`,
-      );
-    }
     this.log(
-      `Remote ICE candidate received: ${rewritten.candidate} (sdpMid=${candidate.sdpMid}, sdpMLineIndex=${sdpMLineIndex})`,
+      `Remote ICE candidate received: ${candidate.candidate} (sdpMid=${candidate.sdpMid}, sdpMLineIndex=${sdpMLineIndex})`,
     );
     const init: RTCIceCandidateInit = {
-      candidate: rewritten.candidate,
+      candidate: candidate.candidate,
       sdpMid: candidate.sdpMid ?? undefined,
       sdpMLineIndex,
       usernameFragment: candidate.usernameFragment ?? undefined,
@@ -5038,7 +5053,7 @@ export class GfnWebRtcClient {
       return;
     }
 
-    await this.pc.addIceCandidate(init);
+    await this.pc.addIceCandidate(this.rewriteRemoteIceCandidateInit(init));
   }
 
   dispose(): void {


### PR DESCRIPTION
This PR fixes ICE negotiation failures on Alliance servers by rewriting server ICE candidate IP/port to the CloudMatch WebRTC media endpoint, matching official GFN behavior. When CloudMatch provides a WebRTC media connection (usage 2 or 17), candidates now point at that endpoint instead of the server's initial 0.0.0.0 or signaling host, avoiding DTSS/RTSPS fallback paths that never deliver frames.

### Changes

**TypeScript / renderer (OpenNOW stable):**
- Added `rewriteIceCandidateEndpoint` to rewrite single trickled candidates
- Added `rewriteSdpIceCandidateEndpoints` to rewrite all `a=candidate` lines in offer SDP
- Added `normalizeWebRtcMediaConnectionInfo` to validate usage (2 or 17) and port ranges
- Updated `webrtcClient.ts` to:
  - Store `remoteIceEndpoint` from session and clear on cleanup
  - Rewrite SDP ICE candidates in `handleOffer` when WebRTC media endpoint present
  - Rewrite trickled ICE candidates in `addRemoteCandidate` before adding to peer connection
- Fixed `cloudmatch.ts` return type to use `MediaConnectionInfo` instead of inline object
- Added 3 TS tests: SDP endpoint rewriting, candidate usage filtering

**Rust / native streamer:**
- Added `rewrite_sdp_ice_candidate_endpoints` to rewrite all candidate lines in SDP
- Added `rewrite_ice_candidate_endpoint` to rewrite single trickled candidates
- Added `web_rtc_media_connection_info` helper to validate usage and extract IP/port
- Updated `backend.rs` to:
  - Track `media_connection_ice_replacements` count in `PreparedNativeOffer`
  - Rewrite SDP candidates when preparing native offer
- Updated `gstreamer_backend.rs` to:
  - Rewrite trickled candidates in `send_answer` before passing to pipeline
- Added 2 Rust unit tests: offer preparation rewrites, non-WebRTC usage skip
- Updated `protocol.rs` to add missing `usage` field to `MediaConnectionInfo`

### Validation
- All 158 TS tests pass (including 3 new ICE rewrite tests)
- All 21 Rust SDP tests pass (including 2 new offer prep tests)
- `npm run typecheck` passes
- `npm run native:check` passes (pre-existing unused-field warnings excluded)

### Context
Evidence from user logs and official GFN browser confirms that when CloudMatch returns a WebRTC media endpoint (usage 2 or 17), the official client rewrites both the SDP offer's `a=candidate` lines and trickled remote candidates to point at that endpoint. This PR implements that behavior to fix Alliance server ICE negotiation.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/dbbbe11b-2ed4-4f98-bb6f-76cd7282afd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-250" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/dbbbe11b-2ed4-4f98-bb6f-76cd7282afd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-250&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-250"><img alt="OPE-250" src="https://capy.ai/api/badge/thread.svg?label=OPE-250"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ICE endpoint selection on the critical streaming connect path; incorrect usage gating or rewriting could break connectivity, but behavior is scoped to usage 2/17 and mirrors the official client.
> 
> **Overview**
> Aligns **browser and native** WebRTC ICE handling with official GFN when CloudMatch exposes a **WebRTC media endpoint** (`mediaConnectionInfo.usage` **2** or **17**).
> 
> **`MediaConnectionInfo`** now carries optional **`usage`**, and new SDP helpers rewrite every server **`a=candidate:`** line and each **trickled** remote candidate so IP/port point at that media hint instead of signaling or placeholder addresses. Rewrites run only for usage 2/17; signaling-only hints (e.g. usage 14) are left unchanged.
> 
> **Renderer:** `handleOffer` applies `fixServerIp` plus bulk SDP rewrites when appropriate; `addRemoteCandidate` rewrites trickled candidates via stored `remoteIceEndpoint`. **Native streamer:** `prepare_native_offer` rewrites offer SDP after `fix_server_ip`; GStreamer **`add_remote_ice`** rewrites before the pipeline. Logging reports replacement counts and usage.
> 
> **Tests** cover SDP/candidate rewriting and usage filtering on both TS and Rust paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e6522b69a2e31b13fbb4f474d9284291614359. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->