### PR TITLE
fix(linux): enable native V4L2 streamer for ARM

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -543,7 +543,7 @@
       "decode": "Decode",
       "encode": "Encode",
       "profiles": "Profiles:",
-      "linuxHardwareHint": "Linux AppImage diagnostics use Chromium's VA-API/WebRTC capability report. OpenNOW now enables NVIDIA VA-API flags on restart, but proprietary NVIDIA systems still need distro codecs plus libva-nvidia-driver/nvidia-vaapi-driver; if H.265 or GPU stays missing, check your distro's VA-API setup rather than installing more AppImage files."
+      "linuxHardwareHint": "This web-client diagnostic uses Chromium's WebRTC/MediaCapabilities path. On Linux ARM, Chromium/Electron may not expose V4L2 decode; use Native Streamer with the GStreamer V4L2 backend and check Native Streamer > Video Path for the actual native decode path."
     },
     "colorQuality": {
       "mostCompatible": "Most compatible",
@@ -707,7 +707,7 @@
       "checkNativeStreamer": "Check native streamer",
       "gstreamerReady": "GStreamer Ready",
       "notReady": "Not Ready",
-      "statusDefaultHint": "OpenNOW will check the bundled GStreamer streamer when this tab opens.",
+      "statusDefaultHint": "OpenNOW will check the GStreamer native streamer when this tab opens.",
       "gstreamerRuntime": "GStreamer Runtime",
       "bundledPathDetected": "Bundled path detected",
       "runtimeDefaultHint": "Packaged Windows/macOS builds auto-detect a bundled runtime next to the native streamer. Linux uses distro packages.",
@@ -716,8 +716,8 @@
       "codecSupportUnknown": "Codec support unknown",
       "memoryPathUnknown": "Memory path unknown",
       "videoPathDefaultHint": "OpenNOW will show the active hardware decode path after GStreamer is detected.",
-      "directxBackend": "DirectX Backend",
-      "directxBackendHint": "Applies to the next native streamer process. Auto uses the fastest default path; choose DirectX 11 or DirectX 12 to force a specific Windows renderer.",
+      "directxBackend": "Native Video Backend",
+      "directxBackendHint": "Applies to the next native streamer process. Auto uses the fastest platform default; choose a backend to force DirectX on Windows or V4L2/VAAPI/Vulkan/software on Linux.",
       "framePacing": "Frame Pacing",
       "lowestLatency": "Lowest Latency",
       "smoothGsync": "Smooth G-Sync",

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -18,7 +18,8 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import {
   createUnsupportedNativeStreamerStatus,
   isNativeStreamerSupportedPlatform,
-  NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+  NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE,
+  normalizeNativeVideoBackendPreferenceForPlatform,
   nativeStreamerFeatureModeToEnvValue,
   type IceCandidatePayload,
   type KeyframeRequest,
@@ -603,7 +604,10 @@ export class NativeStreamerManager {
       const videoBackends = this.capabilities?.videoBackends ?? [];
       const activeVideoBackend = resolveActiveVideoBackend(
         videoBackends,
-        this.options.getVideoBackendPreference(),
+        normalizeNativeVideoBackendPreferenceForPlatform(
+          this.options.getVideoBackendPreference(),
+          process.platform,
+        ),
       );
       const codecSummary = summarizeCodecs(activeVideoBackend);
       const zeroCopySummary = summarizeZeroCopy(activeVideoBackend);
@@ -790,7 +794,7 @@ export class NativeStreamerManager {
 
   private async ensureProcess(): Promise<void> {
     if (!isNativeStreamerSupportedPlatform(process.platform)) {
-      throw new Error(NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE);
+      throw new Error(NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE);
     }
 
     if (this.child && this.capabilities) {
@@ -850,7 +854,10 @@ export class NativeStreamerManager {
   ): Promise<void> {
     console.log("[NativeStreamer] Starting:", executablePath);
     console.log("[NativeStreamer] Backend preference:", backendPreference);
-    const videoBackendPreference = this.options.getVideoBackendPreference();
+    const videoBackendPreference = normalizeNativeVideoBackendPreferenceForPlatform(
+      this.options.getVideoBackendPreference(),
+      process.platform,
+    );
     console.log("[NativeStreamer] Video backend preference:", videoBackendPreference);
 
     const childEnv: NodeJS.ProcessEnv = {

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_KEYBOARD_LAYOUT,
   DEFAULT_VIDEO_SHADER_SETTINGS,
   getDefaultStreamPreferences,
+  normalizeNativeVideoBackendPreferenceForPlatform,
   normalizeStreamClientModeForPlatform,
   normalizeStreamPreferences,
   normalizeVideoShaderSettings,
@@ -159,7 +160,15 @@ const LEGACY_STOP_SHORTCUTS = new Set(["META+SHIFT+Q", "CMD+SHIFT+Q"]);
 const LEGACY_ANTI_AFK_SHORTCUTS = new Set(["META+SHIFT+F10", "CMD+SHIFT+F10", "CTRL+SHIFT+F10"]);
 const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
 
-const NATIVE_VIDEO_BACKEND_PREFERENCES = new Set<NativeVideoBackendPreference>(["auto", "d3d11", "d3d12"]);
+const NATIVE_VIDEO_BACKEND_PREFERENCES = new Set<NativeVideoBackendPreference>([
+  "auto",
+  "d3d11",
+  "d3d12",
+  "vaapi",
+  "v4l2",
+  "vulkan",
+  "software",
+]);
 const APP_ACCENT_COLORS = new Set<AppAccentColor>(["green", "blue", "violet", "amber", "rose"]);
 
 function normalizeNativeVideoBackendPreference(raw: unknown): NativeVideoBackendPreference {
@@ -355,7 +364,10 @@ export class SettingsManager {
       settings.nativeExternalRenderer = true;
       migrated = true;
     }
-    const nativeVideoBackend = normalizeNativeVideoBackendPreference(settings.nativeVideoBackend);
+    const nativeVideoBackend = normalizeNativeVideoBackendPreferenceForPlatform(
+      normalizeNativeVideoBackendPreference(settings.nativeVideoBackend),
+      process.platform,
+    );
     if (settings.nativeVideoBackend !== nativeVideoBackend) {
       settings.nativeVideoBackend = nativeVideoBackend;
       migrated = true;

--- a/opennow-stable/src/main/videoAcceleration.test.ts
+++ b/opennow-stable/src/main/videoAcceleration.test.ts
@@ -31,3 +31,19 @@ test("does not enable Linux VA-API decoder flags when software decode is forced"
   assert.equal(commandLine.switches["disable-accelerated-video-decode"], true);
   assert.equal(commandLine.switches["disable-accelerated-video-encode"], true);
 });
+
+test("enables Linux ARM Chromium V4L2 decoder feature flags", () => {
+  const commandLine = buildVideoAccelerationCommandLine(
+    { decoderPreference: "hardware", encoderPreference: "auto" },
+    "linux",
+    "arm64",
+  );
+
+  assert.ok(commandLine.enableFeatures.includes("AcceleratedVideoDecoder"));
+  assert.ok(commandLine.enableFeatures.includes("AcceleratedVideoDecodeLinuxGL"));
+  assert.ok(commandLine.enableFeatures.includes("AcceleratedVideoDecodeLinuxZeroCopyGL"));
+  assert.ok(commandLine.enableFeatures.includes("UseChromeOSDirectVideoDecoder"));
+  assert.equal(commandLine.enableFeatures.includes("VaapiVideoDecoder"), false);
+  assert.equal(commandLine.disableFeatures.includes("UseChromeOSDirectVideoDecoder"), false);
+  assert.equal(commandLine.switches["enable-accelerated-video-decode"], true);
+});

--- a/opennow-stable/src/main/videoAcceleration.ts
+++ b/opennow-stable/src/main/videoAcceleration.ts
@@ -43,7 +43,12 @@ export function buildVideoAccelerationCommandLine(
   } else if (platform === "linux") {
     if (isLinuxArm) {
       if (preferences.decoderPreference !== "software") {
-        enableFeatures.push("UseChromeOSDirectVideoDecoder");
+        enableFeatures.push(
+          "AcceleratedVideoDecoder",
+          "AcceleratedVideoDecodeLinuxGL",
+          "AcceleratedVideoDecodeLinuxZeroCopyGL",
+          "UseChromeOSDirectVideoDecoder",
+        );
       }
     } else {
       if (preferences.decoderPreference !== "software") {

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -28,7 +28,7 @@ import {
   createUnsupportedNativeStreamerStatus,
   DEFAULT_VIDEO_SHADER_SETTINGS,
   isNativeStreamerSupportedPlatform,
-  NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+  NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE,
   colorQualityRequiresHevc,
   getSafeFallbackEntitledResolutions,
   keyboardLayoutOptions,
@@ -276,12 +276,6 @@ const allColorQualityOptions: { value: ColorQuality; label: string; description:
 
 const colorQualityOptions: { value: ColorQuality; label: string; description: string }[] = [...allColorQualityOptions];
 
-const nativeVideoBackendOptions: { value: NativeVideoBackendPreference; label: string; description: string }[] = [
-  { value: "auto", label: "Auto", description: "Pick the default native path for the session" },
-  { value: "d3d12", label: "DirectX 12", description: "Use the D3D12 decoder and renderer" },
-  { value: "d3d11", label: "DirectX 11", description: "Use the D3D11 decoder and renderer" },
-];
-
 const APP_LANGUAGE_LABELS: Record<string, string> = {
   en: "English",
   es: "Español",
@@ -415,8 +409,23 @@ const STATIC_FPS_PRESETS: FpsPreset[] = [
   { value: 360 },
 ];
 
+const platformDescriptor = `${navigator.platform} ${navigator.userAgent}`;
 const isMac = navigator.platform.toLowerCase().includes("mac");
-const isWindows = isNativeStreamerSupportedPlatform(`${navigator.platform} ${navigator.userAgent}`);
+const isLinux = platformDescriptor.toLowerCase().includes("linux");
+const isNativeStreamerSupported = isNativeStreamerSupportedPlatform(platformDescriptor);
+const nativeVideoBackendOptions: { value: NativeVideoBackendPreference; label: string; description: string }[] = isLinux
+  ? [
+    { value: "auto", label: "Auto", description: "Pick the default native path for the session" },
+    { value: "v4l2", label: "V4L2", description: "Use Linux V4L2 decoders for ARM and SBC hardware" },
+    { value: "vaapi", label: "VAAPI", description: "Use VA-API decoders for Intel/AMD Linux systems" },
+    { value: "vulkan", label: "Vulkan", description: "Use the Vulkan decode and render path when available" },
+    { value: "software", label: "Software", description: "Force GStreamer software decode" },
+  ]
+  : [
+    { value: "auto", label: "Auto", description: "Pick the default native path for the session" },
+    { value: "d3d12", label: "DirectX 12", description: "Use the D3D12 decoder and renderer" },
+    { value: "d3d11", label: "DirectX 11", description: "Use the D3D11 decoder and renderer" },
+  ];
 const shortcutExamples = "Examples: F3, Ctrl+Shift+Q, Ctrl+Shift+K";
 const shortcutDefaults = {
   shortcutToggleStats: "F3",
@@ -900,7 +909,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   }, []);
 
   const refreshNativeStreamerStatus = useCallback(async () => {
-    if (!isWindows) {
+    if (!isNativeStreamerSupported) {
       setNativeStreamerStatus(createUnsupportedNativeStreamerStatus());
       setNativeStreamerStatusLoading(false);
       return;
@@ -3174,7 +3183,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
               <h2>{t("settings.nativeStreamer.title")}</h2>
             </div>
             <div className="settings-rows">
-              {!isWindows ? (
+              {!isNativeStreamerSupported ? (
                 <div className="settings-row settings-row--column">
                   <div className="settings-row-top settings-row-top--compact">
                     <label className="settings-label settings-label--wrap">
@@ -3185,7 +3194,7 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
                     </label>
                   </div>
                   <span className="settings-input-hint">
-                    {NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE}
+                    {NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE}
                   </span>
                 </div>
               ) : (

--- a/opennow-stable/src/shared/gfn.test.ts
+++ b/opennow-stable/src/shared/gfn.test.ts
@@ -13,8 +13,9 @@ import {
   isNativeStreamerSupportedPlatform,
   isOwnedLibraryStatus,
   isOwnedVariant,
-  NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+  NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE,
   getDefaultStreamPreferences,
+  normalizeNativeVideoBackendPreferenceForPlatform,
   normalizeStreamPreferences,
   normalizeStreamClientModeForPlatform,
 } from "./gfn";
@@ -173,11 +174,19 @@ test("buildNativeStreamerSessionContext forwards requested/finalized streaming f
   assert.equal(context.shortcuts.toggleRecording, "F12");
 });
 
-test("normalizes native stream client mode to web on non-Windows platforms", () => {
-  assert.equal(normalizeStreamClientModeForPlatform("native", "linux"), "web");
+test("allows native stream client mode on Windows and Linux platforms", () => {
+  assert.equal(normalizeStreamClientModeForPlatform("native", "linux"), "native");
   assert.equal(normalizeStreamClientModeForPlatform("native", "darwin"), "web");
   assert.equal(normalizeStreamClientModeForPlatform("web", "linux"), "web");
   assert.equal(normalizeStreamClientModeForPlatform("native", "win32"), "native");
+});
+
+test("normalizes native video backend preferences for the current platform", () => {
+  assert.equal(normalizeNativeVideoBackendPreferenceForPlatform("v4l2", "linux"), "v4l2");
+  assert.equal(normalizeNativeVideoBackendPreferenceForPlatform("vaapi", "linux"), "vaapi");
+  assert.equal(normalizeNativeVideoBackendPreferenceForPlatform("d3d12", "linux"), "auto");
+  assert.equal(normalizeNativeVideoBackendPreferenceForPlatform("d3d12", "win32"), "d3d12");
+  assert.equal(normalizeNativeVideoBackendPreferenceForPlatform("v4l2", "win32"), "auto");
 });
 
 test("defaults H264 streaming to 8-bit SDR-compatible color quality", () => {
@@ -200,14 +209,15 @@ test("normalizes H264 stream preferences away from high bit-depth modes", () => 
   });
 });
 
-test("uses the exact Windows-only unsupported native streamer status message", () => {
+test("uses the unsupported native streamer status message on unsupported platforms", () => {
   assert.equal(isNativeStreamerSupportedPlatform("win32"), true);
-  assert.equal(isNativeStreamerSupportedPlatform("linux"), false);
+  assert.equal(isNativeStreamerSupportedPlatform("linux"), true);
+  assert.equal(isNativeStreamerSupportedPlatform("darwin"), false);
 
   const status = createUnsupportedNativeStreamerStatus();
   assert.equal(status.detected, false);
   assert.equal(status.gstreamerAvailable, false);
   assert.equal(status.supportsOfferAnswer, false);
-  assert.equal(status.message, NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE);
-  assert.equal(status.gstreamerRuntime.message, NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE);
+  assert.equal(status.message, NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE);
+  assert.equal(status.gstreamerRuntime.message, NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE);
 });

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -12,18 +12,59 @@ export type AppLaunchMode = "default" | "gamepadFriendly" | "touchFriendly";
 export type NativeStreamerBackend = "stub" | "gstreamer";
 export type NativeStreamerBackendPreference = "auto" | NativeStreamerBackend;
 export type NativeStreamerFeatureMode = "auto" | "disabled" | "forced";
-export type NativeVideoBackendPreference = "auto" | "d3d11" | "d3d12";
+export type NativeVideoBackendPreference =
+  | "auto"
+  | "d3d11"
+  | "d3d12"
+  | "vaapi"
+  | "v4l2"
+  | "vulkan"
+  | "software";
 export type NativeQueueMode = "auto" | "fixed" | "adaptive" | "vrr";
 
-export const NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE = "experimental feature: Windows only. Mac and Linux support is being worked on";
+export const NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE = "experimental feature: native streaming is supported on Windows and Linux. macOS support is being worked on";
+
+const WINDOWS_NATIVE_VIDEO_BACKENDS = new Set<NativeVideoBackendPreference>(["d3d11", "d3d12"]);
+const LINUX_NATIVE_VIDEO_BACKENDS = new Set<NativeVideoBackendPreference>(["vaapi", "v4l2", "vulkan", "software"]);
+
+function normalizePlatformLabel(platform: string): "windows" | "linux" | "macos" | "other" {
+  const normalized = platform.toLowerCase();
+  if (normalized === "win32" || normalized.startsWith("win") || normalized.includes("windows")) {
+    return "windows";
+  }
+  if (normalized === "linux" || normalized.includes("linux")) {
+    return "linux";
+  }
+  if (normalized === "darwin" || normalized.includes("mac")) {
+    return "macos";
+  }
+  return "other";
+}
 
 export function isNativeStreamerSupportedPlatform(platform: string): boolean {
-  const normalized = platform.toLowerCase();
-  return normalized === "win32" || normalized.startsWith("win") || normalized.includes("windows");
+  const normalized = normalizePlatformLabel(platform);
+  return normalized === "windows" || normalized === "linux";
 }
 
 export function normalizeStreamClientModeForPlatform(mode: StreamClientMode, platform: string): StreamClientMode {
   return mode === "native" && !isNativeStreamerSupportedPlatform(platform) ? "web" : mode;
+}
+
+export function normalizeNativeVideoBackendPreferenceForPlatform(
+  preference: NativeVideoBackendPreference,
+  platform: string,
+): NativeVideoBackendPreference {
+  if (preference === "auto") {
+    return "auto";
+  }
+  switch (normalizePlatformLabel(platform)) {
+    case "windows":
+      return WINDOWS_NATIVE_VIDEO_BACKENDS.has(preference) ? preference : "auto";
+    case "linux":
+      return LINUX_NATIVE_VIDEO_BACKENDS.has(preference) ? preference : "auto";
+    default:
+      return "auto";
+  }
 }
 
 export function nativeStreamerFeatureModeToEnvValue(mode: NativeStreamerFeatureMode): "auto" | "0" | "1" {
@@ -201,9 +242,9 @@ export function createUnsupportedNativeStreamerStatus(): NativeStreamerStatus {
     gstreamerRuntime: {
       source: "unknown",
       bundled: false,
-      message: NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+      message: NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE,
     },
-    message: NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
+    message: NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE,
   };
 }
 


### PR DESCRIPTION
This PR enables native GStreamer streaming on Linux and adds V4L2 backend support for Linux ARM64 devices.

- Extend native streamer platform support to Linux
- Add Linux-specific video backend options (V4L2, VAAPI, Vulkan, software)
- Add Linux ARM64 Chromium V4L2 decoder feature flags
- Update codec diagnostics hint to reference native streamer for V4L2 decode path

Resolves #578 by allowing Linux ARM systems to use the native GStreamer streamer with V4L2 decoders for hardware-accelerated video playback via /dev/video0 (meson-vdec), avoiding CPU-intensive software decode fallback.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/d69b4b6f-69e7-4103-935b-dbadcfe30760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-257" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/d69b4b6f-69e7-4103-935b-dbadcfe30760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-257&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-257"><img alt="OPE-257" src="https://capy.ai/api/badge/thread.svg?label=OPE-257"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches experimental native streaming, persisted video-backend settings, and platform-specific hardware decode paths; macOS behavior is unchanged but Linux ARM/x64 diverge in both Electron and GStreamer env configuration.
> 
> **Overview**
> **Enables native GStreamer streaming on Linux** alongside Windows, so `streamClientMode: native` is no longer forced back to web on Linux. Unsupported messaging and gating now treat **Windows and Linux** as supported and **macOS** as in progress.
> 
> **Expands `NativeVideoBackendPreference`** with Linux backends (`vaapi`, `v4l2`, `vulkan`, `software`) and **`normalizeNativeVideoBackendPreferenceForPlatform`**, which strips incompatible saved values (e.g. D3D on Linux) on load and when spawning the native streamer via `OPENNOW_NATIVE_VIDEO_BACKEND`.
> 
> **Settings UI** shows Linux backend choices (V4L2/VAAPI/Vulkan/software) vs DirectX on Windows, and renames the control to **Native Video Backend** with updated hints. **Codec diagnostics** copy now steers Linux ARM users toward native V4L2 instead of VA-API AppImage guidance.
> 
> **Web client decode on Linux ARM64** uses a dedicated Chromium feature set (`AcceleratedVideoDecoder`, Linux GL zero-copy, `UseChromeOSDirectVideoDecoder`) instead of the x64 VA-API path, with a new unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d2ce7be18fbc553de86839256c99c651409315. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->