### PR TITLE
fix(entitlements): expand ultrawide resolutions against 4K entitlements

### DIFF
--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -30,6 +30,7 @@ import {
   isNativeStreamerSupportedPlatform,
   NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
   colorQualityRequiresHevc,
+  expandEntitledStreamResolutions,
   getSafeFallbackEntitledResolutions,
   keyboardLayoutOptions,
   resolveEntitledStreamProfile,
@@ -1015,11 +1016,14 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
   }, [t]);
 
   const effectiveEntitledResolutions = useMemo(
-    () => entitledResolutions.length > 0
-      ? entitledResolutions
-      : subscriptionInfo
-        ? getSafeFallbackEntitledResolutions()
-        : [],
+    () => {
+      const baseResolutions = entitledResolutions.length > 0
+        ? entitledResolutions
+        : subscriptionInfo
+          ? getSafeFallbackEntitledResolutions()
+          : [];
+      return expandEntitledStreamResolutions(baseResolutions);
+    },
     [entitledResolutions, subscriptionInfo],
   );
   const useEntitledStreamOptions = effectiveEntitledResolutions.length > 0;

--- a/opennow-stable/src/shared/entitlements.test.ts
+++ b/opennow-stable/src/shared/entitlements.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  expandEntitledStreamResolutions,
   getSafeFallbackEntitledResolutions,
   resolveEntitledStreamProfile,
   SAFE_FALLBACK_STREAM_PROFILE,
@@ -33,5 +34,45 @@ test("safe fallback entitlements resolve oversized requests to 1080p60", () => {
       { resolution: "3840x2160", fps: 240 },
     ),
     SAFE_FALLBACK_STREAM_PROFILE,
+  );
+});
+
+test("derives official ultrawide modes covered by a larger entitlement", () => {
+  const entitlements = [
+    { width: 3840, height: 2160, fps: 120 },
+    { width: 2560, height: 1080, fps: 120 },
+  ];
+
+  assert.ok(
+    expandEntitledStreamResolutions(entitlements).some(
+      (resolution) =>
+        resolution.width === 3440 &&
+        resolution.height === 1440 &&
+        resolution.fps === 120,
+    ),
+  );
+  assert.deepEqual(
+    resolveEntitledStreamProfile(entitlements, { resolution: "3440x1440", fps: 120 }),
+    { resolution: "3440x1440", fps: 120 },
+  );
+});
+
+test("does not derive ultrawide modes larger than the entitlement envelope", () => {
+  const entitlements = [
+    { width: 2560, height: 1440, fps: 120 },
+    { width: 2560, height: 1080, fps: 120 },
+  ];
+
+  assert.equal(
+    expandEntitledStreamResolutions(entitlements).some(
+      (resolution) =>
+        resolution.width === 3440 &&
+        resolution.height === 1440,
+    ),
+    false,
+  );
+  assert.deepEqual(
+    resolveEntitledStreamProfile(entitlements, { resolution: "3440x1440", fps: 120 }),
+    { resolution: "2560x1440", fps: 120 },
   );
 });

--- a/opennow-stable/src/shared/entitlements.test.ts
+++ b/opennow-stable/src/shared/entitlements.test.ts
@@ -76,3 +76,29 @@ test("does not derive ultrawide modes larger than the entitlement envelope", () 
     { resolution: "2560x1440", fps: 120 },
   );
 });
+
+test("does not derive modes that exceed entitlement dimensions", () => {
+  const entitlements = [{ width: 1920, height: 1080, fps: 120 }];
+  const expanded = expandEntitledStreamResolutions(entitlements);
+
+  assert.equal(
+    expanded.some(
+      (resolution) =>
+        resolution.width === 1600 &&
+        resolution.height === 1200,
+    ),
+    false,
+  );
+  assert.equal(
+    expanded.some(
+      (resolution) =>
+        resolution.width === 1680 &&
+        resolution.height === 1050,
+    ),
+    true,
+  );
+  assert.deepEqual(
+    resolveEntitledStreamProfile(entitlements, { resolution: "1600x1200", fps: 120 }),
+    { resolution: "1920x1080", fps: 120 },
+  );
+});

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -486,7 +486,6 @@ const STREAM_MODE_PRESETS: ReadonlyArray<Readonly<{
   { width: 1280, height: 720, fps: [120, 60, 30] },
   { width: 1376, height: 640, fps: [120, 60, 30] },
   { width: 1024, height: 768, fps: [120, 60, 30] },
-  { width: 5120, height: 1440, fps: [120, 60, 30] },
 ]);
 
 export const SAFE_FALLBACK_STREAM_PROFILE: Readonly<EntitledStreamProfile> = Object.freeze({
@@ -538,10 +537,10 @@ function isModeCoveredByEntitlement(
   height: number,
   fps: number,
 ): boolean {
-  const pixelCount = width * height;
   return entitlements.some(
     (entitlement) =>
-      entitlement.width * entitlement.height >= pixelCount &&
+      entitlement.width >= width &&
+      entitlement.height >= height &&
       entitlement.fps >= fps,
   );
 }

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -459,6 +459,36 @@ export interface EntitledStreamProfile {
   fps: number;
 }
 
+const STREAM_MODE_PRESETS: ReadonlyArray<Readonly<{
+  width: number;
+  height: number;
+  fps: readonly number[];
+}>> = Object.freeze([
+  { width: 3840, height: 2160, fps: [120, 60, 30] },
+  { width: 3456, height: 2160, fps: [120, 60, 30] },
+  { width: 3840, height: 1600, fps: [120, 60, 30] },
+  { width: 3440, height: 1440, fps: [120, 60, 30] },
+  { width: 3840, height: 1080, fps: [120, 60, 30] },
+  { width: 2560, height: 1600, fps: [120, 60, 30] },
+  { width: 2560, height: 1440, fps: [120, 60, 30] },
+  { width: 2560, height: 1080, fps: [120, 60, 30] },
+  { width: 1920, height: 1200, fps: [240, 120, 60, 30] },
+  { width: 1920, height: 1080, fps: [240, 120, 60, 30] },
+  { width: 1600, height: 1200, fps: [120, 60, 30] },
+  { width: 1680, height: 1050, fps: [120, 60, 30] },
+  { width: 1600, height: 900, fps: [120, 60, 30] },
+  { width: 1280, height: 1024, fps: [120, 60, 30] },
+  { width: 1440, height: 900, fps: [120, 60, 30] },
+  { width: 1680, height: 720, fps: [120, 60, 30] },
+  { width: 1366, height: 768, fps: [120, 60, 30] },
+  { width: 1280, height: 800, fps: [120, 60, 30] },
+  { width: 1112, height: 834, fps: [120, 60, 30] },
+  { width: 1280, height: 720, fps: [120, 60, 30] },
+  { width: 1376, height: 640, fps: [120, 60, 30] },
+  { width: 1024, height: 768, fps: [120, 60, 30] },
+  { width: 5120, height: 1440, fps: [120, 60, 30] },
+]);
+
 export const SAFE_FALLBACK_STREAM_PROFILE: Readonly<EntitledStreamProfile> = Object.freeze({
   resolution: "1920x1080",
   fps: 60,
@@ -494,11 +524,63 @@ function compareEntitledResolutionDescending(a: EntitledResolution, b: EntitledR
   return b.fps - a.fps;
 }
 
+function normalizeEntitledResolution(resolution: EntitledResolution): EntitledResolution {
+  return {
+    width: Math.trunc(resolution.width),
+    height: Math.trunc(resolution.height),
+    fps: Math.trunc(resolution.fps),
+  };
+}
+
+function isModeCoveredByEntitlement(
+  entitlements: readonly EntitledResolution[],
+  width: number,
+  height: number,
+  fps: number,
+): boolean {
+  const pixelCount = width * height;
+  return entitlements.some(
+    (entitlement) =>
+      entitlement.width * entitlement.height >= pixelCount &&
+      entitlement.fps >= fps,
+  );
+}
+
+export function expandEntitledStreamResolutions(
+  entitledResolutions: readonly EntitledResolution[],
+): EntitledResolution[] {
+  const validEntitlements = entitledResolutions
+    .filter(isValidEntitledResolution)
+    .map(normalizeEntitledResolution);
+  const byKey = new Map<string, EntitledResolution>();
+
+  const addResolution = (resolution: EntitledResolution): void => {
+    byKey.set(
+      `${resolution.width}x${resolution.height}@${resolution.fps}`,
+      resolution,
+    );
+  };
+
+  for (const resolution of validEntitlements) {
+    addResolution(resolution);
+  }
+
+  for (const mode of STREAM_MODE_PRESETS) {
+    for (const fps of mode.fps) {
+      if (isModeCoveredByEntitlement(validEntitlements, mode.width, mode.height, fps)) {
+        addResolution({ width: mode.width, height: mode.height, fps });
+      }
+    }
+  }
+
+  return [...byKey.values()].sort(compareEntitledResolutionDescending);
+}
+
 export function resolveEntitledStreamProfile(
   entitledResolutions: readonly EntitledResolution[],
   requested: EntitledStreamProfile,
 ): EntitledStreamProfile | null {
-  const validEntitlements = entitledResolutions.filter(isValidEntitledResolution);
+  const validEntitlements = expandEntitledStreamResolutions(entitledResolutions);
   if (validEntitlements.length === 0) {
     return null;
   }


### PR DESCRIPTION
This PR expands entitled stream resolutions to include ultrawide modes (e.g., 3440x1440) when covered by a larger entitlement envelope, matching GeForce NOW's official client behavior.

- Added `expandEntitledStreamResolutions` in `opennow-stable/src/shared/gfn.ts` to derive ultrawide presets from entitlements using a predefined `STREAM_MODE_PRESETS` list
- Updated `resolveEntitledStreamProfile` to use the expanded resolution list
- Integrated expansion into `SettingsPage.tsx` resolution options
- Added tests for deriving ultrawide modes from 4K entitlements and rejecting modes larger than the entitlement envelope

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/38f54521-e96c-43fb-bc70-9ac815cdb944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-255" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/38f54521-e96c-43fb-bc70-9ac815cdb944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-255&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-255"><img alt="OPE-255" src="https://capy.ai/api/badge/thread.svg?label=OPE-255"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized entitlement/stream-settings logic with new unit tests; no auth or network changes, though incorrect envelope rules could show or clamp wrong resolutions.
> 
> **Overview**
> Adds **derived stream resolution modes** (including ultrawide presets like `3440x1440`) when a user’s subscription entitlements cover them by pixel count and FPS, aligning OpenNOW with official GeForce NOW behavior.
> 
> A new `expandEntitledStreamResolutions` helper merges API entitlements with a fixed `STREAM_MODE_PRESETS` list using an “envelope” rule (mode pixels ≤ entitlement pixels and mode FPS ≤ entitlement FPS). **`resolveEntitledStreamProfile`** now resolves requests against this expanded set, and **Settings** runs the same expansion before building resolution/FPS pickers.
> 
> Tests cover deriving ultrawide from 4K entitlements and **not** offering modes that exceed the entitlement envelope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f2cd0b3a5d1fb7291e1a86d14678777d739c09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->