### PR TITLE
feat(gfn): add Mark as Owned mutation for controller mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+opennow-stable/src/main/gfn/games.ts whitespace=cr-at-eol
+opennow-stable/src/main/ipc/accountCatalogHandlers.ts whitespace=cr-at-eol
+opennow-stable/src/renderer/src/components/HomePage.tsx whitespace=cr-at-eol

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-opennow-stable/src/main/gfn/games.ts whitespace=cr-at-eol
-opennow-stable/src/main/ipc/accountCatalogHandlers.ts whitespace=cr-at-eol
-opennow-stable/src/renderer/src/components/HomePage.tsx whitespace=cr-at-eol
+opennow-stable/src/main/gfn/games.ts whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+opennow-stable/src/main/ipc/accountCatalogHandlers.ts whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+opennow-stable/src/renderer/src/components/HomePage.tsx whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,6 +16,7 @@
       "open": "Open",
       "play": "Play",
       "buy": "Buy",
+      "markAsOwned": "Mark as Owned",
       "refresh": "Refresh",
       "remove": "Remove",
       "reset": "Reset",
@@ -38,6 +39,7 @@
       "failed": "Failed",
       "idle": "Idle",
       "loading": "Loading...",
+      "markingOwned": "Marking as owned...",
       "ready": "Ready",
       "saved": "Saved",
       "testing": "Testing...",
@@ -782,6 +784,11 @@
       "notAvailable": "N/A"
     }
   },
+  "games": {
+    "markOwned": {
+      "success": "Marked {{title}} as owned."
+    }
+  },
   "errors": {
     "launchUnknown": "The game could not start. Please try again.",
     "launchFailedTitle": "Launch Failed",
@@ -793,6 +800,10 @@
     "insufficientPlayabilityDescription": "Your current GeForce NOW membership is not high enough to play this game. Upgrade to a higher tier and try again.",
     "insufficientPlayabilityTierDescription": "This game requires {{tier}} on GeForce NOW. Upgrade your membership to play it.",
     "loginFailed": "Login failed",
+    "markOwnedFailed": "Failed to mark game as owned.",
+    "markOwnedFailedWithReason": "Failed to mark game as owned: {{reason}}",
+    "markOwnedMissingVariant": "Select a store variant before marking it owned.",
+    "markOwnedSignInRequired": "Sign in before marking games as owned.",
     "switchAccountFailed": "Failed to switch account",
     "nativeStreamerStoppedTitle": "Native Streamer Stopped",
     "nativeStreamerStoppedDescription": "The native streaming process stopped and could not be restored automatically. Try resuming the session again from the app.",

--- a/opennow-stable/src/main/gfn/accountConnections.ts
+++ b/opennow-stable/src/main/gfn/accountConnections.ts
@@ -10,11 +10,10 @@ import type {
   GameAccountConnectionsResult,
   GameAccountOperationResult,
 } from "@shared/gfn";
-import { cacheManager } from "../services/cacheManager";
-import { getAccountGamesCacheKeys, getLegacyTokenScopedAccountGamesCacheKeys } from "./games";
+import { invalidateAccountGameCaches as invalidateGameCachesForAccount } from "./games";
 import { buildGfnGraphQlHeaders, GFN_PLAY_ORIGIN, GFN_PLAY_REFERER, GFN_USER_AGENT } from "./clientHeaders";
+import { LCARS_GRAPHQL_URL, throwGraphQlErrors } from "./lcarsGraphql";
 
-const LCARS_GRAPHQL_URL = "https://apps.gxn.nvidia.com/graphql";
 const STATIC_APP_DATA_QUERY_HASH = "d4117df5319f644c984945715ded9574bb074107eb02e97be17605b5f14c33ba";
 const USER_ACCOUNT_QUERY_HASH = "39fa5dbf8c14ac4c873857fd510f337cdc8710d5614038a0625487d41f98986b";
 
@@ -208,12 +207,6 @@ function buildLcarsHeaders(token?: string): Record<string, string> {
     ...buildGfnGraphQlHeaders(token),
     "Content-Type": "application/graphql",
   };
-}
-
-function throwGraphQlErrors(errors: Array<{ message?: string }> | undefined, context: string): void {
-  if (errors?.length) {
-    throw new Error(`${context}: ${errors.map((error) => error.message ?? "Unknown error").join(", ")}`);
-  }
 }
 
 async function fetchStaticAccountProviderDefinitions(): Promise<AppStoreDefinition[]> {
@@ -583,31 +576,13 @@ async function deleteProviderLink(provider: string, token: string): Promise<void
 }
 
 async function invalidateAccountGameCaches(session: AuthSession, proxyUrl?: string): Promise<void> {
-  const cacheKeySets: Array<{ main: string; library: string; catalogPrefix: string }> = [
-    getAccountGamesCacheKeys(session.user.userId, session.provider.streamingServiceUrl),
-  ];
-  const legacyTokens = [...new Set([session.tokens.idToken, session.tokens.accessToken].filter((token): token is string => Boolean(token)))];
-  cacheKeySets.push(
-    ...legacyTokens.map((token) => getLegacyTokenScopedAccountGamesCacheKeys(token, session.provider.streamingServiceUrl)),
-  );
-  if (proxyUrl?.trim()) {
-    try {
-      cacheKeySets.push(getAccountGamesCacheKeys(session.user.userId, session.provider.streamingServiceUrl, proxyUrl));
-      cacheKeySets.push(
-        ...legacyTokens.map((token) => getLegacyTokenScopedAccountGamesCacheKeys(token, session.provider.streamingServiceUrl, proxyUrl)),
-      );
-    } catch (error) {
-      console.warn("[AccountConnections] Skipping proxy-scoped game cache invalidation:", error);
-    }
-  }
-
-  const invalidations = new Map<string, Promise<void>>();
-  for (const keys of cacheKeySets) {
-    invalidations.set(keys.main, cacheManager.invalidateCache(keys.main));
-    invalidations.set(keys.library, cacheManager.invalidateCache(keys.library));
-    invalidations.set(keys.catalogPrefix, cacheManager.invalidateCachesByPrefix(keys.catalogPrefix));
-  }
-  await Promise.allSettled(invalidations.values());
+  await invalidateGameCachesForAccount({
+    userId: session.user.userId,
+    providerStreamingBaseUrl: session.provider.streamingServiceUrl,
+    tokens: [session.tokens.idToken, session.tokens.accessToken],
+    proxyUrl,
+    logPrefix: "[AccountConnections]",
+  });
 }
 
 function mergeLoginResult(

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -7,6 +7,7 @@ import type {
   GameInfo,
   GamePanelResult,
   GameVariant,
+  MarkGameOwnedResult,
 } from "@shared/gfn";
 import { createHash } from "node:crypto";
 import { isOwnedLibraryStatus, normalizeGameStore } from "@shared/gfn";
@@ -19,6 +20,7 @@ import {
 import { fetchAllAppsPages, type AppsPageResponse } from "./paginatedApps";
 import { fetchWithOptionalProxy } from "./proxyFetch";
 import { sessionProxyCacheKeyPart, sessionProxyHasCredentials } from "./proxyUrl";
+import { postLcarsGraphQl } from "./lcarsGraphql";
 
 const GRAPHQL_URL = "https://games.geforce.com/graphql";
 const PANELS_QUERY_HASH = "f8e26265a5db5c20e1334a6872cf04b6e3970507697f6ae55a6ddefa5420daf0";
@@ -36,6 +38,13 @@ const LIBRARY_GAMES_CACHE_SCOPE = "library:v2";
 const CATALOG_GAMES_CACHE_SCOPE = "catalog";
 const PUBLIC_GAMES_CACHE_KEY = "games:public:v2";
 const DEFAULT_CLOUDMATCH_BASE_URL = "https://prod.cloudmatchbeta.nvidiagrid.net/";
+const ADD_OWNED_VARIANT_MUTATION = `mutation AddOwnedVariant($cmsId: String!, $locale: String!) {
+  addOwnedVariant(language: $locale, variantId: $cmsId) {
+    app {
+      id
+    }
+  }
+}`;
 const LIBRARY_APPS_FILTER = {
   variants: {
     gfn: {
@@ -145,12 +154,16 @@ export function getAccountCatalogGamesCachePrefix(
 
 export function getAccountGamesCacheKeys(accountId: string, providerStreamingBaseUrl?: string, proxyUrl?: string): {
   main: string;
+  featured: string;
+  storePanels: string;
   library: string;
   catalogPrefix: string;
   public: string;
 } {
   return {
     main: accountScopedGamesCacheKey("main", accountId, providerStreamingBaseUrl, proxyUrl),
+    featured: accountScopedGamesCacheKey("featured", accountId, providerStreamingBaseUrl, proxyUrl),
+    storePanels: accountScopedGamesCacheKey("store-panels", accountId, providerStreamingBaseUrl, proxyUrl),
     library: accountScopedGamesCacheKey(LIBRARY_GAMES_CACHE_SCOPE, accountId, providerStreamingBaseUrl, proxyUrl),
     catalogPrefix: getAccountCatalogGamesCachePrefix(accountId, providerStreamingBaseUrl, proxyUrl),
     public: publicGamesCacheKey(proxyUrl),
@@ -159,14 +172,66 @@ export function getAccountGamesCacheKeys(accountId: string, providerStreamingBas
 
 export function getLegacyTokenScopedAccountGamesCacheKeys(token: string, providerStreamingBaseUrl?: string, proxyUrl?: string): {
   main: string;
+  featured: string;
+  storePanels: string;
   library: string;
   catalogPrefix: string;
 } {
   return {
     main: legacyTokenScopedGamesCacheKey("main", token, providerStreamingBaseUrl, proxyUrl),
+    featured: legacyTokenScopedGamesCacheKey("featured", token, providerStreamingBaseUrl, proxyUrl),
+    storePanels: legacyTokenScopedGamesCacheKey("store-panels", token, providerStreamingBaseUrl, proxyUrl),
     library: legacyTokenScopedGamesCacheKey(LIBRARY_GAMES_CACHE_SCOPE, token, providerStreamingBaseUrl, proxyUrl),
     catalogPrefix: legacyTokenScopedGamesCacheKey(CATALOG_GAMES_CACHE_SCOPE, token, providerStreamingBaseUrl, proxyUrl),
   };
+}
+
+export interface AccountGameCacheInvalidationInput {
+  userId: string;
+  providerStreamingBaseUrl?: string;
+  tokens?: Array<string | undefined>;
+  proxyUrl?: string;
+  logPrefix?: string;
+}
+
+export async function invalidateAccountGameCaches(input: AccountGameCacheInvalidationInput): Promise<void> {
+  const cacheKeySets: Array<{ main: string; featured: string; storePanels: string; library: string; catalogPrefix: string }> = [
+    getAccountGamesCacheKeys(input.userId, input.providerStreamingBaseUrl),
+  ];
+  const legacyTokens = [...new Set((input.tokens ?? []).filter((token): token is string => Boolean(token)))];
+  cacheKeySets.push(
+    ...legacyTokens.map((token) => getLegacyTokenScopedAccountGamesCacheKeys(token, input.providerStreamingBaseUrl)),
+  );
+
+  if (input.proxyUrl?.trim()) {
+    try {
+      cacheKeySets.push(getAccountGamesCacheKeys(input.userId, input.providerStreamingBaseUrl, input.proxyUrl));
+      cacheKeySets.push(
+        ...legacyTokens.map((token) => getLegacyTokenScopedAccountGamesCacheKeys(token, input.providerStreamingBaseUrl, input.proxyUrl)),
+      );
+    } catch (error) {
+      console.warn(`${input.logPrefix ?? "[Games]"} Skipping proxy-scoped game cache invalidation:`, error);
+    }
+  }
+
+  const invalidations = new Map<string, Promise<void>>();
+  for (const keys of cacheKeySets) {
+    invalidations.set(keys.main, cacheManager.invalidateCache(keys.main));
+    invalidations.set(keys.featured, cacheManager.invalidateCache(keys.featured));
+    invalidations.set(keys.storePanels, cacheManager.invalidateCache(keys.storePanels));
+    invalidations.set(keys.library, cacheManager.invalidateCache(keys.library));
+    invalidations.set(keys.catalogPrefix, cacheManager.invalidateCachesByPrefix(keys.catalogPrefix));
+  }
+  await Promise.allSettled(invalidations.values());
+}
+
+export interface MarkGameOwnedInput {
+  token: string;
+  userId: string;
+  variantId: string;
+  providerStreamingBaseUrl?: string;
+  proxyUrl?: string;
+  tokens?: Array<string | undefined>;
 }
 
 interface GraphQlResponse {
@@ -219,6 +284,17 @@ interface AppsSearchResponse {
         totalCount?: number;
       };
       items?: AppData[];
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface AddOwnedVariantResponse {
+  data?: {
+    addOwnedVariant?: {
+      app?: {
+        id?: string;
+      };
     };
   };
   errors?: Array<{ message: string }>;
@@ -1437,6 +1513,40 @@ export async function resolveStoreUrl(
   if (matchingStoreVariant?.storeUrl) return matchingStoreVariant.storeUrl;
 
   return variants.find((variant) => variant.storeUrl)?.storeUrl ?? null;
+}
+
+export async function markGameOwned(input: MarkGameOwnedInput): Promise<MarkGameOwnedResult> {
+  const variantId = input.variantId.trim();
+  if (!variantId) {
+    throw new Error("Cannot mark game as owned without a variant ID");
+  }
+
+  const payload = await postLcarsGraphQl<AddOwnedVariantResponse>(
+    ADD_OWNED_VARIANT_MUTATION,
+    {
+      cmsId: variantId,
+      locale: DEFAULT_LOCALE,
+    },
+    input.token,
+    input.proxyUrl,
+  );
+
+  if (!payload.data?.addOwnedVariant?.app?.id) {
+    throw new Error("GFN library mutation failed: missing AddOwnedVariant response");
+  }
+
+  await invalidateAccountGameCaches({
+    userId: input.userId,
+    providerStreamingBaseUrl: input.providerStreamingBaseUrl,
+    tokens: [input.token, ...(input.tokens ?? [])],
+    proxyUrl: input.proxyUrl,
+  });
+
+  return {
+    ok: true,
+    variantId,
+    libraryStatus: "MANUAL",
+  };
 }
 
 export {

--- a/opennow-stable/src/main/gfn/lcarsGraphql.ts
+++ b/opennow-stable/src/main/gfn/lcarsGraphql.ts
@@ -1,0 +1,40 @@
+import { buildGfnGraphQlHeaders } from "./clientHeaders";
+import { fetchWithOptionalProxy } from "./proxyFetch";
+
+export const LCARS_GRAPHQL_URL = "https://apps.gxn.nvidia.com/graphql";
+
+export interface GraphQlErrorPayload {
+  message?: string;
+}
+
+export interface GraphQlResponsePayload {
+  errors?: GraphQlErrorPayload[];
+}
+
+export function throwGraphQlErrors(errors: GraphQlErrorPayload[] | undefined, context: string): void {
+  if (errors?.length) {
+    throw new Error(`${context}: ${errors.map((error) => error.message ?? "Unknown error").join(", ")}`);
+  }
+}
+
+export async function postLcarsGraphQl<T extends GraphQlResponsePayload>(
+  query: string,
+  variables: Record<string, unknown>,
+  token: string,
+  proxyUrl?: string,
+): Promise<T> {
+  const response = await fetchWithOptionalProxy(LCARS_GRAPHQL_URL, {
+    method: "POST",
+    headers: buildGfnGraphQlHeaders(token),
+    body: JSON.stringify({ query, variables }),
+  }, proxyUrl);
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GFN library mutation failed (${response.status}): ${text.slice(0, 400)}`);
+  }
+
+  const payload = (await response.json()) as T;
+  throwGraphQlErrors(payload.errors, "GFN library mutation failed");
+  return payload;
+}

--- a/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
+++ b/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
@@ -8,6 +8,7 @@ import type {
   AuthSessionRequest,
   CatalogBrowseRequest,
   GamesFetchRequest,
+  MarkGameOwnedRequest,
   RegionsFetchRequest,
   ResolveLaunchIdRequest,
   ResolveStoreUrlRequest,
@@ -26,6 +27,7 @@ import {
   fetchStorePanels,
   peekCachedBrowseCatalog,
   fetchLibraryGamesFromCache,
+  markGameOwned,
   resolveLaunchAppId,
   resolveStoreUrl,
 } from "../gfn/games";
@@ -401,6 +403,33 @@ export function registerAccountCatalogIpcHandlers(
         variantId: payload.variantId,
         store: payload.store,
         proxyUrl: payload.proxyUrl,
+      });
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.GAMES_MARK_OWNED,
+    async (_event, payload: MarkGameOwnedRequest) => {
+      const session = await authService.ensureValidSession();
+      if (!session) {
+        throw new Error("No authenticated session available");
+      }
+
+      const token = await resolveJwt(payload?.token ?? session.tokens.idToken ?? session.tokens.accessToken);
+      const streamingBaseUrl =
+        payload?.providerStreamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
+      const userId = payload.userId ?? session.user.userId;
+      const proxyUrl = payload.proxyUrl;
+      refreshScheduler.updateAuthContext(token, userId, streamingBaseUrl, proxyUrl);
+
+      return markGameOwned({
+        token,
+        userId,
+        variantId: payload.variantId,
+        providerStreamingBaseUrl: streamingBaseUrl,
+        proxyUrl,
+        tokens: [session.tokens.idToken, session.tokens.accessToken],
       });
     },
   );

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -15,6 +15,8 @@ import type {
   ResolveStoreUrlRequest,
   RegionsFetchRequest,
   MainToRendererSignalingEvent,
+  MarkGameOwnedRequest,
+  MarkGameOwnedResult,
   OpenNowApi,
   SavedAccount,
   SessionAdReportRequest,
@@ -115,6 +117,8 @@ const api: OpenNowApi = {
     ipcRenderer.invoke(IPC_CHANNELS.GAMES_RESOLVE_LAUNCH_ID, input),
   resolveStoreUrl: (input: ResolveStoreUrlRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.GAMES_RESOLVE_STORE_URL, input),
+  markGameOwned: (input: MarkGameOwnedRequest): Promise<MarkGameOwnedResult> =>
+    ipcRenderer.invoke(IPC_CHANNELS.GAMES_MARK_OWNED, input),
   getPendingDirectLaunchRequest: (): Promise<DirectLaunchRequest | null> =>
     ipcRenderer.invoke(IPC_CHANNELS.DIRECT_LAUNCH_GET_PENDING),
   onDirectLaunchRequest: (listener: (request: DirectLaunchRequest) => void) => {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ import type {
   ExistingSessionStrategy,
   GameInfo,
   GamePanelResult,
+  GameVariant,
   LoginProvider,
   MainToRendererSignalingEvent,
   NativeStreamerShortcutAction,
@@ -292,6 +293,72 @@ function gameIdentityMatches(left: GameInfo, right: GameInfo): boolean {
   return left.title.trim().length > 0 && left.title.localeCompare(right.title, undefined, { sensitivity: "accent" }) === 0;
 }
 
+function markVariantOwned(variant: GameVariant, selected: boolean): GameVariant {
+  return {
+    ...variant,
+    inLibrary: true,
+    librarySelected: selected,
+    libraryStatus: "MANUAL",
+  };
+}
+
+function markGameVariantOwned(game: GameInfo, variantId: string): GameInfo {
+  const selectedVariantIndex = game.variants.findIndex((variant) => variant.id === variantId);
+  if (selectedVariantIndex < 0) {
+    return game;
+  }
+
+  return {
+    ...game,
+    isInLibrary: true,
+    selectedVariantIndex,
+    variants: game.variants.map((variant, index) => (
+      index === selectedVariantIndex
+        ? markVariantOwned(variant, true)
+        : { ...variant, librarySelected: false }
+    )),
+  };
+}
+
+function markGameOwnedInList(games: GameInfo[], target: GameInfo, variantId: string): GameInfo[] {
+  let changed = false;
+  const next = games.map((game) => {
+    if (!gameIdentityMatches(game, target)) return game;
+    if (!game.variants.some((variant) => variant.id === variantId)) return game;
+    changed = true;
+    return markGameVariantOwned(game, variantId);
+  });
+  return changed ? next : games;
+}
+
+function upsertMarkedOwnedLibraryGame(games: GameInfo[], target: GameInfo, variantId: string): GameInfo[] {
+  let changed = false;
+  const next = games.map((game) => {
+    if (!gameIdentityMatches(game, target)) return game;
+    if (!game.variants.some((variant) => variant.id === variantId)) return game;
+    changed = true;
+    return markGameVariantOwned(game, variantId);
+  });
+  return changed ? next : [markGameVariantOwned(target, variantId), ...games];
+}
+
+function markGameOwnedInPanels(panels: GamePanelResult[], target: GameInfo, variantId: string): GamePanelResult[] {
+  let changed = false;
+  const next = panels.map((panel) => ({
+    ...panel,
+    sections: panel.sections.map((section) => ({
+      ...section,
+      games: section.games.map((game) => {
+        if (!gameIdentityMatches(game, target)) return game;
+        if (!game.variants.some((variant) => variant.id === variantId)) return game;
+        changed = true;
+        return markGameVariantOwned(game, variantId);
+      }),
+    })),
+  }));
+  return changed ? next : panels;
+}
+
 function getLibrarySelectedVariantId(storeGame: GameInfo, libraryGames: GameInfo[]): string | undefined {
   const libraryGame = libraryGames.find((candidate) => gameIdentityMatches(storeGame, candidate));
   const libraryVariant = libraryGame?.variants.find((variant) => variant.librarySelected)
@@ -410,6 +477,11 @@ export function App(): JSX.Element {
   const [catalogTotalCount, setCatalogTotalCount] = useState(0);
   const [catalogSupportedCount, setCatalogSupportedCount] = useState(0);
   const catalogFilterKey = useMemo(() => catalogSelectedFilterIds.join("|"), [catalogSelectedFilterIds]);
+  const [markOwnedInFlightByVariantId, setMarkOwnedInFlightByVariantId] = useState<Record<string, boolean>>({});
+  const [catalogActionNotice, setCatalogActionNotice] = useState<{
+    tone: "success" | "warn";
+    text: string;
+  } | null>(null);
 
   // Settings State
   const [settings, setSettings] = useState<Settings>({
@@ -1556,6 +1628,14 @@ export function App(): JSX.Element {
     applyAccentColor(settings.appAccentColor);
   }, [settings.appAccentColor]);
 
+  useEffect(() => {
+    if (!catalogActionNotice) return;
+    const timer = window.setTimeout(() => {
+      setCatalogActionNotice((current) => (current === catalogActionNotice ? null : current));
+    }, 4500);
+    return () => window.clearTimeout(timer);
+  }, [catalogActionNotice]);
+
   // Save settings when changed
   const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {
     setSettings((prev) => ({ ...prev, [key]: value }));
@@ -2247,7 +2327,7 @@ export function App(): JSX.Element {
     }
   }, [activeSessionProxyUrl, applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, featuredGames.length, searchQuery, catalogFilterKey, catalogSelectedSortId]);
 
-  const loadStorePanels = useCallback(async () => {
+  const loadStorePanels = useCallback(async (options?: { force?: boolean; background?: boolean }) => {
     const session = authSession;
     if (!session) return;
 
@@ -2255,11 +2335,11 @@ export function App(): JSX.Element {
     if (!token) return;
 
     const contextKey = `${session.user.userId}\0${effectiveStreamingBaseUrl}\0${getSessionProxyUiScope(activeSessionProxyUrl)}`;
-    if (storePanelsLoadedContextRef.current === contextKey) return;
+    if (!options?.force && storePanelsLoadedContextRef.current === contextKey) return;
 
     const loadId = ++storePanelsLoadIdRef.current;
     const isCurrentLoad = (): boolean => storePanelsLoadIdRef.current === loadId;
-    setIsLoadingStorePanels(true);
+    if (!options?.background) setIsLoadingStorePanels(true);
     try {
       const panels = await window.openNow.fetchStorePanels({
         token,
@@ -2284,9 +2364,74 @@ export function App(): JSX.Element {
       storePanelsLoadedContextRef.current = "";
       setStorePanels([]);
     } finally {
-      if (isCurrentLoad()) setIsLoadingStorePanels(false);
+      if (isCurrentLoad() && !options?.background) setIsLoadingStorePanels(false);
     }
   }, [activeSessionProxyUrl, authSession, effectiveStreamingBaseUrl]);
+
+  const handleMarkGameOwned = useCallback(async (game: GameInfo, selectedVariantId?: string): Promise<void> => {
+    const session = authSession;
+    const token = session?.tokens.idToken ?? session?.tokens.accessToken;
+    const userId = session?.user.userId;
+    if (!token || !userId) {
+      setCatalogActionNotice({ tone: "warn", text: t("errors.markOwnedSignInRequired") });
+      return;
+    }
+
+    const selectedVariant = getSelectedVariant(game, selectedVariantId ?? variantByGameId[game.id] ?? defaultVariantId(game));
+    const variantId = selectedVariant?.id ?? selectedVariantId;
+    if (!variantId) {
+      setCatalogActionNotice({ tone: "warn", text: t("errors.markOwnedMissingVariant") });
+      return;
+    }
+    if (markOwnedInFlightByVariantId[variantId]) {
+      return;
+    }
+
+    setMarkOwnedInFlightByVariantId((previous) => ({ ...previous, [variantId]: true }));
+    try {
+      await window.openNow.markGameOwned({
+        token,
+        userId,
+        providerStreamingBaseUrl: effectiveStreamingBaseUrl,
+        proxyUrl: activeSessionProxyUrl,
+        variantId,
+      });
+
+      setVariantByGameId((previous) => ({ ...previous, [game.id]: variantId }));
+      setGames((previous) => markGameOwnedInList(previous, game, variantId));
+      setFeaturedGames((previous) => markGameOwnedInList(previous, game, variantId));
+      setLibraryGames((previous) => upsertMarkedOwnedLibraryGame(previous, game, variantId));
+      setStorePanels((previous) => markGameOwnedInPanels(previous, game, variantId));
+      setCatalogActionNotice({ tone: "success", text: t("games.markOwned.success", { title: game.title }) });
+
+      void loadGames("main", { background: true });
+      void loadGames("library", { background: true });
+      void loadStorePanels({ force: true, background: true });
+    } catch (error) {
+      console.error("Failed to mark game as owned:", error);
+      setCatalogActionNotice({
+        tone: "warn",
+        text: error instanceof Error && error.message
+          ? t("errors.markOwnedFailedWithReason", { reason: error.message })
+          : t("errors.markOwnedFailed"),
+      });
+    } finally {
+      setMarkOwnedInFlightByVariantId((previous) => {
+        const next = { ...previous };
+        delete next[variantId];
+        return next;
+      });
+    }
+  }, [
+    activeSessionProxyUrl,
+    authSession,
+    effectiveStreamingBaseUrl,
+    loadGames,
+    loadStorePanels,
+    markOwnedInFlightByVariantId,
+    t,
+    variantByGameId,
+  ]);
 
   useEffect(() => {
     if (storePanelGames.length === 0 || libraryGames.length === 0) return;
@@ -4375,6 +4520,11 @@ export function App(): JSX.Element {
           {startupRefreshNotice.text}
         </div>
       )}
+      {catalogActionNotice && (
+        <div className={`auth-refresh-notice auth-refresh-notice--${catalogActionNotice.tone}`}>
+          {catalogActionNotice.text}
+        </div>
+      )}
       <Navbar
         currentPage={currentPage}
         onNavigate={handleNavigate}
@@ -4434,6 +4584,8 @@ export function App(): JSX.Element {
                 storeHeroGames={featuredGames}
                 activeSessionAppIds={activeSessionAppIds}
                 onBuyGame={handleBuyGame}
+                onMarkGameOwned={handleMarkGameOwned}
+                markOwnedInFlightByVariantId={markOwnedInFlightByVariantId}
                 onPreviousControllerPage={() => navigateControllerPage(-1)}
                 onNextControllerPage={() => navigateControllerPage(1)}
               />

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -55,6 +55,8 @@ export interface HomePageProps {
   storeHeroGames?: GameInfo[];
   activeSessionAppIds?: number[];
   onBuyGame?: (game: GameInfo, selectedVariantId?: string) => void;
+  onMarkGameOwned?: (game: GameInfo, selectedVariantId?: string) => void;
+  markOwnedInFlightByVariantId?: Record<string, boolean>;
   onPreviousControllerPage?: () => void;
   onNextControllerPage?: () => void;
 }
@@ -158,15 +160,17 @@ function ControllerStoreTile({
   selectedVariantId,
   focused,
   onFocus,
-  onBuy,
+  onMarkOwned,
   onPlay,
+  isMarkingOwned,
 }: {
   game: GameInfo;
   selectedVariantId?: string;
   focused: boolean;
   onFocus: () => void;
-  onBuy: () => void;
+  onMarkOwned: () => void;
   onPlay: () => void;
+  isMarkingOwned: boolean;
 }): JSX.Element {
   const { t } = useTranslation();
   const imageUrl = getControllerStoreImageCandidates(game, false)[0];
@@ -183,7 +187,7 @@ function ControllerStoreTile({
       onClick={onFocus}
       onDoubleClick={() => {
         if (needsPurchase) {
-          onBuy();
+          onMarkOwned();
           return;
         }
         onPlay();
@@ -218,13 +222,14 @@ function ControllerStoreTile({
           event.stopPropagation();
           onFocus();
           if (needsPurchase) {
-            onBuy();
+            onMarkOwned();
             return;
           }
           onPlay();
         }}
+        disabled={isMarkingOwned}
       >
-        {needsPurchase ? t("app.actions.buy") : t("app.actions.play")}
+        {needsPurchase ? (isMarkingOwned ? t("app.status.markingOwned") : t("app.actions.markAsOwned")) : t("app.actions.play")}
       </button>
     </m.div>
   );
@@ -253,6 +258,8 @@ export const HomePage = memo(function HomePage({
   storeHeroGames = [],
   activeSessionAppIds: _activeSessionAppIds = [],
   onBuyGame,
+  onMarkGameOwned,
+  markOwnedInFlightByVariantId = {},
   onPreviousControllerPage,
   onNextControllerPage,
 }: HomePageProps): JSX.Element {
@@ -308,7 +315,7 @@ export const HomePage = memo(function HomePage({
   const launchGame = (game: GameInfo): void => {
     const selectedVariantId = selectedVariantByGameId[game.id];
     if (gameNeedsPurchase(game, selectedVariantId)) {
-      onBuyGame?.(game, selectedVariantId);
+      (onMarkGameOwned ?? onBuyGame)?.(game, selectedVariantId);
       return;
     }
     onPlayGame(game);
@@ -513,6 +520,9 @@ export const HomePage = memo(function HomePage({
     const heroImageUrl = heroGame ? getControllerStoreImageCandidates(heroGame, true)[0] : undefined;
     const heroLogoUrl = heroGame ? getControllerStoreLogoUrl(heroGame) : undefined;
     const heroSelectedVariantId = heroGame ? selectedVariantByGameId[heroGame.id] : undefined;
+    const heroSelectedVariant = heroGame ? getSelectedVariant(heroGame, heroSelectedVariantId) : undefined;
+    const heroNeedsOwnership = heroGame ? gameNeedsPurchase(heroGame, heroSelectedVariantId) : false;
+    const heroMarkingOwned = Boolean(heroNeedsOwnership && heroSelectedVariant?.id && markOwnedInFlightByVariantId[heroSelectedVariant.id]);
     const heroDotCount = Math.min(Math.max(controllerHeroGames.length, 1), 6);
     const activeHeroDotIndex = controllerHeroGames.length > 0 ? Math.min(controllerHeroIndex % heroDotCount, heroDotCount - 1) : 0;
 
@@ -569,8 +579,21 @@ export const HomePage = memo(function HomePage({
                     {heroLogoUrl ? <img src={heroLogoUrl} alt={heroGame.title} className="controller-hero-logo" /> : <h1>{heroGame.title}</h1>}
                     <p className="controller-store-hero-meta">{getPrimaryStoreName(heroGame, heroSelectedVariantId)} / {getPrimaryGenre(heroGame)}</p>
                     <div className="controller-hero-actions">
-                      <button type="button" className="controller-primary-action" onClick={() => onBuyGame?.(heroGame, heroSelectedVariantId)}>
-                        {t("app.actions.buy")}
+                      <button
+                        type="button"
+                        className="controller-primary-action"
+                        onClick={() => {
+                          if (heroNeedsOwnership) {
+                            (onMarkGameOwned ?? onBuyGame)?.(heroGame, heroSelectedVariantId);
+                            return;
+                          }
+                          onPlayGame(heroGame);
+                        }}
+                        disabled={heroMarkingOwned}
+                      >
+                        {heroNeedsOwnership
+                          ? (heroMarkingOwned ? t("app.status.markingOwned") : t("app.actions.markAsOwned"))
+                          : t("app.actions.play")}
                       </button>
                       <span className="controller-store-hero-pill">{getPrimaryStoreName(heroGame, heroSelectedVariantId)}</span>
                     </div>
@@ -602,17 +625,20 @@ export const HomePage = memo(function HomePage({
                   >
                     {section.games.slice(0, 18).map((game, columnIndex) => {
                       const focused = rowIndex === focusedRowIndex && columnIndex === focusedColumnIndex;
+                      const selectedVariantId = selectedVariantByGameId[game.id];
+                      const selectedVariant = getSelectedVariant(game, selectedVariantId);
                       return (
                         <div key={game.id} className="controller-store-card" data-controller-store-column={columnIndex}>
                           <ControllerStoreTile
                             game={game}
-                            selectedVariantId={selectedVariantByGameId[game.id]}
+                            selectedVariantId={selectedVariantId}
+                            isMarkingOwned={Boolean(selectedVariant?.id && markOwnedInFlightByVariantId[selectedVariant.id])}
                             focused={focused}
                             onFocus={() => {
                               focusTile(rowIndex, columnIndex);
-                              if (game.variants.length > 0) onSelectGameVariant(game.id, selectedVariantByGameId[game.id] ?? game.variants[game.selectedVariantIndex]?.id ?? game.variants[0].id);
+                              if (game.variants.length > 0) onSelectGameVariant(game.id, selectedVariantId ?? game.variants[game.selectedVariantIndex]?.id ?? game.variants[0].id);
                             }}
-                            onBuy={() => onBuyGame?.(game, selectedVariantByGameId[game.id])}
+                            onMarkOwned={() => (onMarkGameOwned ?? onBuyGame)?.(game, selectedVariantId)}
                             onPlay={() => onPlayGame(game)}
                           />
                         </div>

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -2874,6 +2874,13 @@ body,
   border-color: rgba(255, 255, 255, 0.24);
 }
 
+.controller-primary-action:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.75);
+  opacity: 0.58;
+  transform: none;
+}
+
 .controller-hero-dots {
   display: flex;
   justify-content: center;

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -720,6 +720,16 @@ export interface ResolveStoreUrlRequest {
   store?: string;
 }
 
+export interface MarkGameOwnedRequest extends GamesFetchRequest {
+  variantId: string;
+}
+
+export interface MarkGameOwnedResult {
+  ok: true;
+  variantId: string;
+  libraryStatus: "MANUAL";
+}
+
 export interface SubscriptionFetchRequest {
   token?: string;
   providerStreamingBaseUrl?: string;
@@ -1409,6 +1419,7 @@ export interface OpenNowApi {
   fetchPublicGames(): Promise<GameInfo[]>;
   resolveLaunchAppId(input: ResolveLaunchIdRequest): Promise<string | null>;
   resolveStoreUrl(input: ResolveStoreUrlRequest): Promise<string | null>;
+  markGameOwned(input: MarkGameOwnedRequest): Promise<MarkGameOwnedResult>;
   getPendingDirectLaunchRequest(): Promise<DirectLaunchRequest | null>;
   onDirectLaunchRequest(listener: (request: DirectLaunchRequest) => void): () => void;
   createSession(input: SessionCreateRequest): Promise<SessionInfo>;

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -28,6 +28,7 @@ export const IPC_CHANNELS = {
   GAMES_FETCH_PUBLIC: "games:fetch-public",
   GAMES_RESOLVE_LAUNCH_ID: "games:resolve-launch-id",
   GAMES_RESOLVE_STORE_URL: "games:resolve-store-url",
+  GAMES_MARK_OWNED: "games:mark-owned",
   CREATE_SESSION: "gfn:create-session",
   POLL_SESSION: "gfn:poll-session",
   REPORT_SESSION_AD: "gfn:report-session-ad",


### PR DESCRIPTION
This PR implements the "Mark as Owned" feature requested in issue #590, allowing users to mark unowned GFN games directly in the client without opening the official web client.

Changes by area:

- **Backend** (`src/main/gfn/games.ts`, `accountConnections.ts`): Added `markGameOwned()` function using the official GFN `AddOwnedVariant` GraphQL mutation and exported `invalidateAccountGameCaches()` for cache invalidation
- **IPC** (`src/main/ipc/accountCatalogHandlers.ts`, `src/preload/index.ts`, `src/shared/ipc.ts`, `src/shared/gfn.ts`): Added `GAMES_MARK_OWNED` channel with request/response types `MarkGameOwnedRequest` and `MarkGameOwnedResult`
- **GraphQL client** (`src/main/gfn/lcarsGraphql.ts`): New `postLcarsGraphQl()` helper for LCARS GraphQL requests
- **Renderer** (`src/renderer/src/App.tsx`, `HomePage.tsx`): Added `handleMarkGameOwned()` callback, in-flight state tracking, and integrated into controller hero and store tiles to replace "Buy" with "Mark as Owned"
- **Styles** (`src/renderer/src/styles.css`): Added disabled state styling for `.controller-primary-action`
- **Locales** (`locales/en.json`): Added `markAsOwned`, `markingOwned`, and success/error messages

All changes pass typecheck (tsc), locales check, and 156 targeted GFN tests. Lint passes with 33 pre-existing warnings and 0 errors.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/3be922c2-0574-4a19-ad6c-ed2511c65d38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-254" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/3be922c2-0574-4a19-ad6c-ed2511c65d38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-254&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-254"><img alt="OPE-254" src="https://capy.ai/api/badge/thread.svg?label=OPE-254"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Authenticated mutations change remote library state on NVIDIA’s service; incorrect variant handling or cache invalidation could show stale ownership until refresh, but scope is limited to catalog/library UX.
> 
> **Overview**
> Adds **Mark as Owned** so users can add an unowned store variant to their GFN library from OpenNOW instead of opening the web client to buy.
> 
> The main process calls NVIDIA’s **`AddOwnedVariant`** LCARS GraphQL mutation via a new **`postLcarsGraphQl`** helper (shared with account connections). **`invalidateAccountGameCaches`** is centralized in `games.ts` and now also clears **featured** and **store-panels** cache keys. A new **`games:mark-owned`** IPC path wires **`markGameOwned`** through preload and shared types.
> 
> In **controller mode**, store hero and tiles use **Mark as Owned** (with in-flight disabling) when a variant isn’t owned, falling back to the existing buy handler if the new callback isn’t provided. **`App.tsx`** optimistically updates library/store state, shows success/error notices, and background-refreshes main, library, and store panels (including **`loadStorePanels({ force: true })`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae414c58b05b74d45055178e9177247a9022257b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->