### PR TITLE
fix(locales): neutralize Linux codec hint

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -546,7 +546,7 @@
       "decode": "Decode",
       "encode": "Encode",
       "profiles": "Profiles:",
-      "linuxHardwareHint": "Linux AppImage diagnostics use Chromium's VA-API/WebRTC capability report. OpenNOW now enables NVIDIA VA-API flags on restart, but proprietary NVIDIA systems still need distro codecs plus libva-nvidia-driver/nvidia-vaapi-driver; if H.265 or GPU stays missing, check your distro's VA-API setup rather than installing more AppImage files."
+      "linuxHardwareHint": "Linux AppImage diagnostics use Chromium's WebRTC/MediaCapabilities report. Hardware decode depends on the Chromium build plus your distro GPU/video stack: x64 systems may need VA-API/NVIDIA VA-API drivers, while ARM V4L2 support depends on Chromium/Electron exposing that decoder."
     },
     "colorQuality": {
       "mostCompatible": "Most compatible",


### PR DESCRIPTION
This PR updates the Linux codec diagnostics hint to avoid architecture-specific assumptions. The previous wording implied NVIDIA VA-API flag enablement for all Linux clients, but Linux ARM web-client builds use `UseChromeOSDirectVideoDecoder` and do not enable NVIDIA VA-API flags. This misleads ARM users troubleshooting software-only decode. The new wording is architecture-neutral and correctly covers both x64 VA-API/NVIDIA VA-API needs and ARM V4L2 decoder dependencies.

- locales/en.json: Updated `linuxHardwareHint` text to remove NVIDIA-specific claims and generalize to x64 vs ARM Linux decode requirements

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/d69b4b6f-69e7-4103-935b-dbadcfe30760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-257" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/d69b4b6f-69e7-4103-935b-dbadcfe30760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-257&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-257"><img alt="OPE-257" src="https://capy.ai/api/badge/thread.svg?label=OPE-257"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English-only user-facing string change in settings; no runtime or codec logic touched.
> 
> **Overview**
> Updates the **Codec Diagnostics** `linuxHardwareHint` copy so Linux troubleshooting guidance no longer assumes NVIDIA VA-API flags or distro codec installs for every AppImage user.
> 
> The new text frames diagnostics around Chromium’s **WebRTC/MediaCapabilities** report and splits expectations by platform: **x64** may need VA-API or NVIDIA VA-API drivers, while **ARM** hardware decode depends on Chromium/Electron exposing V4L2 decoders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca42c2bf8b8f70e84795084b76faa66d32e7949. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->