### PR TITLE
Improve LCARS and CloudMatch parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ result
 .deriveddata/
 .deriveddata-device/
 .opencode
+vendor/

--- a/opennow-stable/src/main/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.test.ts
@@ -145,6 +145,7 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
   const calls: string[] = [];
   type CapturedSessionRequestBody = {
     sessionRequestData: {
+      networkTestSessionId?: string | null;
       appLaunchMode?: number;
       enablePersistingInGameSettings?: boolean;
       requestedStreamingFeatures: {
@@ -173,6 +174,17 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
           { key: "US West", value: "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/" },
           { key: "US East", value: "https://np-ash-01.cloudmatchbeta.nvidiagrid.net/" },
         ],
+      }), { status: 200 });
+    }
+
+    if (url === "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession") {
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
+        netTestSession: {
+          sessionId: "nettest-1",
+          connectionInfo: [{ ip: "127.0.0.1", port: 443, appLevelProtocol: 5 }],
+          netTestThresholds: {},
+        },
       }), { status: 200 });
     }
 
@@ -220,6 +232,7 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
     assert.equal(session.enablePersistingInGameSettings, false);
     assert.deepEqual(calls, [
       "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
+      "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession",
       expectedSessionUrl,
     ]);
     const capturedRequestBody = requestBody as CapturedSessionRequestBody | null;
@@ -228,9 +241,104 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
     assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.chromaFormat, 1);
     assert.equal(capturedRequestBody.sessionRequestData.appLaunchMode, 2);
     assert.equal(capturedRequestBody.sessionRequestData.enablePersistingInGameSettings, false);
+    assert.equal(capturedRequestBody.sessionRequestData.networkTestSessionId, "nettest-1");
   } finally {
     globalThis.fetch = originalFetch;
     console.warn = originalWarn;
+  }
+});
+
+test("CloudMatch retries transient serverInfo failures before creating a session", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const originalLog = console.log;
+  const calls: string[] = [];
+  const expectedSessionUrl = `https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?${new URLSearchParams({
+    keyboardLayout: resolveGfnKeyboardLayout(DEFAULT_KEYBOARD_LAYOUT, process.platform),
+    languageCode: "en_US",
+  }).toString()}`;
+
+  console.warn = () => {};
+  console.log = () => {};
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    calls.push(url);
+
+    if (url === "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo") {
+      if (calls.filter((entry) => entry === url).length === 1) {
+        return new Response("temporary", { status: 503 });
+      }
+
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
+        metaData: [
+          { key: "local-region", value: "US West" },
+          { key: "gfn-regions", value: "US West" },
+          { key: "US West", value: "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/" },
+        ],
+      }), { status: 200 });
+    }
+
+    if (url === "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession") {
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
+        netTestSession: {
+          sessionId: "nettest-retry",
+          connectionInfo: [{ ip: "127.0.0.1", port: 443, appLevelProtocol: 5 }],
+          netTestThresholds: {},
+        },
+      }), { status: 200 });
+    }
+
+    if (url === expectedSessionUrl) {
+      const body = JSON.parse(String(init?.body)) as {
+        sessionRequestData: {
+          requestedStreamingFeatures?: unknown;
+        };
+      };
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS" },
+        session: {
+          sessionId: "session-1",
+          status: 1,
+          seatSetupInfo: { seatSetupStep: 0 },
+          sessionControlInfo: { ip: "np-lax-01.cloudmatchbeta.nvidiagrid.net" },
+          connectionInfo: [],
+          iceServerConfiguration: {
+            iceServers: [{ urls: "stun:127.0.0.1:19302" }],
+          },
+          sessionRequestData: {
+            requestedStreamingFeatures: body.sessionRequestData.requestedStreamingFeatures,
+          },
+        },
+      }), { status: 200 });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const session = await createSession({
+      token: "token",
+      streamingBaseUrl: "https://prod.cloudmatchbeta.nvidiagrid.net/",
+      appId: "1001",
+      internalTitle: "Test Game",
+      accountLinked: true,
+      zone: "prod",
+      settings: makeSettings({ fps: 120 }),
+    });
+
+    assert.equal(session.streamingBaseUrl, "https://np-lax-01.cloudmatchbeta.nvidiagrid.net");
+    assert.deepEqual(calls, [
+      "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
+      "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
+      "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession",
+      expectedSessionUrl,
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+    console.log = originalLog;
   }
 });
 
@@ -252,6 +360,17 @@ test("CloudMatch only sends in-game settings persistence when user opt-in and ga
 
   globalThis.fetch = (async (input, init) => {
     const url = String(input);
+    if (url === "https://np-test.example.test/v2/nettestsession") {
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-TEST" },
+        netTestSession: {
+          sessionId: "nettest-persistence",
+          connectionInfo: [{ ip: "127.0.0.1", port: 443, appLevelProtocol: 5 }],
+          netTestThresholds: {},
+        },
+      }), { status: 200 });
+    }
+
     if (url !== expectedSessionUrl) {
       throw new Error(`Unexpected fetch: ${url}`);
     }

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -3,6 +3,7 @@ import dns from "node:dns";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createRequire } from "node:module";
+import { createHash } from "node:crypto";
 
 import type {
   ActiveSessionInfo,
@@ -47,8 +48,15 @@ import {
 const SESSION_MODIFY_ACTION_AD_UPDATE = 6;
 const READY_SESSION_STATUSES = new Set([2, 3]);
 const GFN_DEVICE_ID_FILENAME = "gfn-device-id.json";
+const CLOUDMATCH_REQUEST_TIMEOUT_MS = 30_000;
+const CLOUDMATCH_GET_RETRIES = 2;
+const CLOUDMATCH_RETRY_DELAYS_MS = [250, 750];
+const CLOUDMATCH_RETRY_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const NETWORK_TEST_SESSION_TIMEOUT_MS = 8_000;
+const NETWORK_TEST_SESSION_CACHE_TTL_MS = 30 * 60 * 1000;
 
 let cachedStableDeviceId: string | null = null;
+const networkTestSessionCache = new Map<string, { sessionId: string; expiresAt: number }>();
 const require = createRequire(import.meta.url);
 
 interface CloudMatchServerInfoResponse {
@@ -56,6 +64,83 @@ interface CloudMatchServerInfoResponse {
     key: string;
     value: string;
   }>;
+}
+
+interface NetworkTestSessionResponse {
+  requestStatus?: {
+    statusCode?: number;
+    statusDescription?: string;
+    serverId?: string;
+  };
+  netTestSession?: {
+    sessionId?: string;
+    connectionInfo?: Array<{
+      ip?: string;
+      port?: number;
+      appLevelProtocol?: number;
+    }>;
+    netTestThresholds?: {
+      recommendedBandwidthMBPS?: number;
+      requiredBandwidthMBPS?: number;
+      recommendedLatencyMS?: number;
+      requiredLatencyMS?: number;
+      recommendedPacketLossPct?: number;
+      requiredPacketLossPct?: number;
+    };
+    serverId?: string;
+  };
+}
+
+interface CloudMatchFetchOptions {
+  proxyUrl?: string;
+  timeoutMs?: number;
+  retries?: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchCloudMatch(
+  input: string,
+  init: RequestInit,
+  options: CloudMatchFetchOptions = {},
+): Promise<Response> {
+  const method = (init.method ?? "GET").toUpperCase();
+  const retries = options.retries ?? (method === "GET" ? CLOUDMATCH_GET_RETRIES : 0);
+  const timeoutMs = options.timeoutMs ?? CLOUDMATCH_REQUEST_TIMEOUT_MS;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetchWithOptionalProxy(input, {
+        ...init,
+        signal: controller.signal,
+      }, options.proxyUrl);
+      clearTimeout(timeout);
+
+      if (attempt < retries && CLOUDMATCH_RETRY_STATUSES.has(response.status)) {
+        await sleep(CLOUDMATCH_RETRY_DELAYS_MS[Math.min(attempt, CLOUDMATCH_RETRY_DELAYS_MS.length - 1)] ?? 0);
+        continue;
+      }
+
+      return response;
+    } catch (error) {
+      clearTimeout(timeout);
+      lastError = error;
+      if (attempt >= retries) {
+        throw error;
+      }
+
+      const retryDelay = CLOUDMATCH_RETRY_DELAYS_MS[Math.min(attempt, CLOUDMATCH_RETRY_DELAYS_MS.length - 1)];
+      await sleep(retryDelay ?? 0);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 function normalizeCloudMatchBaseUrl(url: string): string {
@@ -116,10 +201,10 @@ async function resolveCreateSessionBase(
   }
 
   try {
-    const response = await fetchWithOptionalProxy(`${base}/v2/serverInfo`, {
+    const response = await fetchCloudMatch(`${base}/v2/serverInfo`, {
       method: "GET",
       headers: buildGfnCloudMatchHeaders({ token, clientId, deviceId, includeOrigin: false }),
-    }, proxyUrl);
+    }, { proxyUrl });
     if (!response.ok) {
       return base;
     }
@@ -610,6 +695,114 @@ function parseResolution(input: string): { width: number; height: number } {
   return { width, height };
 }
 
+function networkTestSessionCacheKey(base: string, settings: StreamSettings, token: string, proxyUrl?: string): string {
+  const { width, height } = parseResolution(settings.resolution);
+  const identityHash = createHash("sha256")
+    .update(token)
+    .update("\0")
+    .update(proxyUrl ?? "")
+    .digest("hex")
+    .slice(0, 16);
+  return `${base}\0${width}x${height}@${settings.fps}\0${identityHash}`;
+}
+
+function getCachedNetworkTestSessionId(base: string, settings: StreamSettings, token: string, proxyUrl?: string): string | null {
+  const cacheKey = networkTestSessionCacheKey(base, settings, token, proxyUrl);
+  const cached = networkTestSessionCache.get(cacheKey);
+  if (!cached) {
+    return null;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    networkTestSessionCache.delete(cacheKey);
+    return null;
+  }
+
+  return cached.sessionId;
+}
+
+function cacheNetworkTestSessionId(
+  base: string,
+  settings: StreamSettings,
+  token: string,
+  sessionId: string,
+  proxyUrl?: string,
+): void {
+  networkTestSessionCache.set(networkTestSessionCacheKey(base, settings, token, proxyUrl), {
+    sessionId,
+    expiresAt: Date.now() + NETWORK_TEST_SESSION_CACHE_TTL_MS,
+  });
+}
+
+async function createNetworkTestSession(input: {
+  base: string;
+  token: string;
+  clientId: string;
+  deviceId: string;
+  settings: StreamSettings;
+  proxyUrl?: string;
+}): Promise<string | null> {
+  const cached = getCachedNetworkTestSessionId(input.base, input.settings, input.token, input.proxyUrl);
+  if (cached) {
+    return cached;
+  }
+
+  const { width, height } = parseResolution(input.settings.resolution);
+  const body = {
+    netTestRequestData: {
+      clientPlatformName: "windows",
+      netTestProfile: {
+        widthInPixels: width,
+        heightInPixels: height,
+        framesPerSecond: input.settings.fps,
+      },
+    },
+  };
+
+  try {
+    const response = await fetchCloudMatch(`${input.base}/v2/nettestsession`, {
+      method: "POST",
+      headers: buildGfnCloudMatchHeaders({
+        token: input.token,
+        clientId: input.clientId,
+        deviceId: input.deviceId,
+        includeOrigin: true,
+      }),
+      body: JSON.stringify(body),
+    }, {
+      proxyUrl: input.proxyUrl,
+      timeoutMs: NETWORK_TEST_SESSION_TIMEOUT_MS,
+      retries: 0,
+    });
+
+    if (!response.ok) {
+      console.warn(`[CloudMatch] nettestsession failed HTTP ${response.status}: ${(await response.text()).slice(0, 200)}`);
+      return null;
+    }
+
+    const payload = (await response.json()) as NetworkTestSessionResponse;
+    if (payload.requestStatus?.statusCode !== 1) {
+      console.warn(
+        `[CloudMatch] nettestsession API error: ${payload.requestStatus?.statusCode ?? "unknown"} ` +
+        `${payload.requestStatus?.statusDescription ?? ""}`.trim(),
+      );
+      return null;
+    }
+
+    const sessionId = payload.netTestSession?.sessionId?.trim();
+    if (!sessionId) {
+      console.warn("[CloudMatch] nettestsession response did not include a sessionId");
+      return null;
+    }
+
+    cacheNetworkTestSessionId(input.base, input.settings, input.token, sessionId, input.proxyUrl);
+    return sessionId;
+  } catch (error) {
+    console.warn(`[CloudMatch] nettestsession creation failed: ${formatErrorForLog(error)}`);
+    return null;
+  }
+}
+
 function timezoneOffsetMs(): number {
   return -new Date().getTimezoneOffset() * 60 * 1000;
 }
@@ -638,7 +831,11 @@ export function shouldEnableInGameSettingsPersistence(
   );
 }
 
-function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: string): CloudMatchRequest {
+function buildSessionRequestBody(
+  input: SessionCreateRequest,
+  deviceHashId: string,
+  networkTestSessionId: string | null = null,
+): CloudMatchRequest {
   const { width, height } = parseResolution(input.settings.resolution);
   const cq = input.settings.colorQuality;
   // IMPORTANT: hdrEnabled is a SEPARATE toggle from color quality.
@@ -656,7 +853,7 @@ function buildSessionRequestBody(input: SessionCreateRequest, deviceHashId: stri
       appId: input.appId,
       internalTitle: input.internalTitle || null,
       availableSupportedControllers: [],
-      networkTestSessionId: null,
+      networkTestSessionId,
       parentSessionId: null,
       clientIdentification: "GFN-PC",
       // Keep device identity stable across create -> reconnect/resume flows.
@@ -1152,13 +1349,6 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
   const clientId = crypto.randomUUID();
   const deviceId = getStableDeviceId();
 
-  const body = buildSessionRequestBody(input, deviceId);
-  console.log(
-    `[CloudMatch] createSession in-game settings persistence: user=${input.enablePersistingInGameSettings === true}, ` +
-    `gameSupport=${input.supportsInGameSettingsPersistence === true}, ` +
-    `sent=${body.sessionRequestData.enablePersistingInGameSettings}`,
-  );
-
   const requestedBase = resolveStreamingBaseUrl(input.zone, input.streamingBaseUrl);
   const base = await resolveCreateSessionBase(
     requestedBase,
@@ -1167,14 +1357,30 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
     deviceId,
     input.proxyUrl,
   );
+  const networkTestSessionId = await createNetworkTestSession({
+    base,
+    token: input.token,
+    clientId,
+    deviceId,
+    settings: input.settings,
+    proxyUrl: input.proxyUrl,
+  });
+  const body = buildSessionRequestBody(input, deviceId, networkTestSessionId);
+  console.log(
+    `[CloudMatch] createSession in-game settings persistence: user=${input.enablePersistingInGameSettings === true}, ` +
+    `gameSupport=${input.supportsInGameSettingsPersistence === true}, ` +
+    `sent=${body.sessionRequestData.enablePersistingInGameSettings}, ` +
+    `networkTestSessionId=${networkTestSessionId ?? "none"}`,
+  );
+
   const keyboardLayout = resolveGfnKeyboardLayout(input.settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);
   const languageCode = input.settings.gameLanguage ?? "en_US";
   const url = `${base}/v2/session?${new URLSearchParams({ keyboardLayout, languageCode }).toString()}`;
-  const response = await fetchWithOptionalProxy(url, {
+  const response = await fetchCloudMatch(url, {
     method: "POST",
     headers: buildGfnCloudMatchHeaders({ token: input.token, clientId, deviceId, includeOrigin: true }),
     body: JSON.stringify(body),
-  }, input.proxyUrl);
+  }, { proxyUrl: input.proxyUrl });
 
   const { payload } = await readCloudMatchJson<CloudMatchResponse>(response);
   return await toSessionInfo({
@@ -1202,10 +1408,10 @@ export async function pollSession(input: SessionPollRequest): Promise<SessionInf
   const url = `${base}/v2/session/${input.sessionId}`;
   // Polling should NOT include Origin/Referer headers (matches claimSession polling pattern)
   const headers = buildGfnCloudMatchHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
-  const response = await fetchWithOptionalProxy(url, {
+  const response = await fetchCloudMatch(url, {
     method: "GET",
     headers,
-  }, pollProxyUrl);
+  }, { proxyUrl: pollProxyUrl });
 
   const { payload } = await readCloudMatchJson<CloudMatchResponse>(response);
 
@@ -1231,7 +1437,7 @@ export async function pollSession(input: SessionPollRequest): Promise<SessionInf
     const directUrl = `${directBase}/v2/session/${input.sessionId}`;
     try {
       // The ready-session direct real-IP re-poll intentionally bypasses the session proxy.
-      const directResponse = await fetch(directUrl, {
+      const directResponse = await fetchCloudMatch(directUrl, {
         method: "GET",
         headers,
       });
@@ -1285,7 +1491,7 @@ export async function reportSessionAd(input: SessionAdReportRequest): Promise<Se
       `cancelReason=${input.cancelReason ?? "n/a"}, errorInfo=${input.errorInfo ?? "n/a"}`,
   );
 
-  const response = await fetch(url, {
+  const response = await fetchCloudMatch(url, {
     method: "PUT",
     // Official browser requests include Origin/Referer on cross-origin ad updates.
     headers: buildGfnCloudMatchHeaders({ token: input.token, clientId, deviceId, includeOrigin: true }),
@@ -1329,7 +1535,7 @@ export async function stopSession(input: SessionStopRequest): Promise<void> {
 
   const base = resolvePollStopBase(input.zone, input.streamingBaseUrl, input.serverIp);
   const url = `${base}/v2/session/${input.sessionId}`;
-  const response = await fetch(url, {
+  const response = await fetchCloudMatch(url, {
     method: "DELETE",
     headers: buildGfnCloudMatchHeaders({ token: input.token, clientId, deviceId, includeOrigin: false }),
   });
@@ -1378,7 +1584,7 @@ async function discoverActiveSessionFallbackBases(
   headers: Record<string, string>,
 ): Promise<string[]> {
   try {
-    const response = await fetch(`${base}/v2/serverInfo`, {
+    const response = await fetchCloudMatch(`${base}/v2/serverInfo`, {
       method: "GET",
       headers,
     });
@@ -1400,10 +1606,10 @@ async function fetchActiveSessionsFromBase(
 
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await fetchCloudMatch(url, {
       method: "GET",
       headers,
-    });
+    }, { retries: 0 });
   } catch (error) {
     console.warn(`[CloudMatch] getActiveSessions fetch failed for ${base}: ${formatErrorForLog(error)}`);
     return null;
@@ -1607,7 +1813,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
     console.log(`[CloudMatch] claimSession: pre-flight query ${prefetchUrl}`);
     const prefetchHeaders = buildGfnCloudMatchHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
     try {
-      const prefetchResp = await fetch(prefetchUrl, { method: "GET", headers: prefetchHeaders });
+      const prefetchResp = await fetchCloudMatch(prefetchUrl, { method: "GET", headers: prefetchHeaders });
       console.log(`[CloudMatch] claimSession: pre-flight response status=${prefetchResp.status}`);
       if (prefetchResp.ok) {
         const prefetchPayload = JSON.parse(await prefetchResp.text()) as CloudMatchResponse;
@@ -1637,7 +1843,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
   try {
     const validationUrl = `https://${effectiveServerIp}/v2/session/${input.sessionId}`;
     const validationHeaders = buildGfnCloudMatchHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
-    const validationResp = await fetch(validationUrl, { method: "GET", headers: validationHeaders });
+    const validationResp = await fetchCloudMatch(validationUrl, { method: "GET", headers: validationHeaders });
     if (validationResp.ok) {
       const validationText = await validationResp.text();
       const validationPayload = JSON.parse(validationText) as CloudMatchResponse;
@@ -1683,7 +1889,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
 
     console.log(`[CloudMatch] claimSession PUT ${claimUrl}`);
     console.log(`[CloudMatch] claimSession body: ${JSON.stringify(payload)}`);
-    const response = await fetch(claimUrl, {
+    const response = await fetchCloudMatch(claimUrl, {
       method: "PUT",
       headers,
       body: JSON.stringify(payload),
@@ -1712,7 +1918,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
 
     const pollHeaders = buildGfnCloudMatchHeaders({ token: input.token, clientId, deviceId, includeOrigin: false });
 
-    const pollResponse = await fetch(getUrl, {
+    const pollResponse = await fetchCloudMatch(getUrl, {
       method: "GET",
       headers: pollHeaders,
     });

--- a/opennow-stable/src/main/gfn/errorCodes.test.ts
+++ b/opennow-stable/src/main/gfn/errorCodes.test.ts
@@ -19,3 +19,15 @@ test("SessionError explains insufficient playability as a membership upgrade req
   assert.equal(error.isSessionConflict(), false);
 });
 
+test("SessionError maps CloudMatch status 91 to app streaming denied", () => {
+  const error = SessionError.fromResponse(200, JSON.stringify({
+    requestStatus: {
+      statusCode: 91,
+      statusDescription: "APP_NOT_ALLOWED_TO_STREAM",
+    },
+  }));
+
+  assert.equal(error.gfnErrorCode, GfnErrorCode.AppNotAllowedToStream);
+  assert.equal(error.title, "Streaming Not Allowed");
+  assert.match(error.message, /not allowed to stream/i);
+});

--- a/opennow-stable/src/main/gfn/errorCodes.ts
+++ b/opennow-stable/src/main/gfn/errorCodes.ts
@@ -114,6 +114,7 @@ export enum GfnErrorCode {
   InvalidTransportRequest = 3237093720, // statusCode 88
   UserStorageNotAvailable = 3237093721, // statusCode 89
   GfnStorageNotAvailable = 3237093722, // statusCode 90
+  AppNotAllowedToStream = 3237093723, // statusCode 91
   SessionServerErrorEnd = 3237093887,
 
   // Session setup cancelled
@@ -537,6 +538,13 @@ export const ERROR_MESSAGES: Map<number, ErrorMessageEntry> = new Map([
     {
       title: "Storage Error",
       description: "Service storage is not available.",
+    },
+  ],
+  [
+    3237093723,
+    {
+      title: "Streaming Not Allowed",
+      description: "This app is not allowed to stream on your current GeForce NOW account or region.",
     },
   ],
 

--- a/opennow-stable/src/main/gfn/games.ts
+++ b/opennow-stable/src/main/gfn/games.ts
@@ -21,13 +21,9 @@ import { fetchAllAppsPages, type AppsPageResponse } from "./paginatedApps";
 import { fetchWithOptionalProxy } from "./proxyFetch";
 import { sessionProxyCacheKeyPart, sessionProxyHasCredentials } from "./proxyUrl";
 import { supportsInGameSettingsPersistence } from "./gameFeatures";
-import { postLcarsGraphQl } from "./lcarsGraphql";
+import { fetchLcarsGraphQl, postLcarsMutation } from "./lcarsGraphql";
 
 const GRAPHQL_URL = "https://games.geforce.com/graphql";
-const PANELS_QUERY_HASH = "f8e26265a5db5c20e1334a6872cf04b6e3970507697f6ae55a6ddefa5420daf0";
-const MARQUEE_QUERY_HASH = "dd4bddfdef4707dfe340cc2040d6bb9c4c45f706976fca15b2ef33221c385d7f";
-const APP_METADATA_QUERY_HASH = "cf8b620dfd03617017ba7c858cee65197e1ace5180e41be194b39227227ced63";
-const LIBRARY_WITH_TIME_QUERY_HASH = "039e8c0d553972975485fee56e59f2549d2fdb518e247a42ab5022056a74406f";
 const DEFAULT_LOCALE = "en_US";
 const DEFAULT_CATALOG_FETCH_COUNT = 120;
 const MAX_CATALOG_PAGES = 3;
@@ -50,13 +46,6 @@ const GFN_FEATURE_FIELDS = `
                 values
               }
 `;
-const ADD_OWNED_VARIANT_MUTATION = `mutation AddOwnedVariant($cmsId: String!, $locale: String!) {
-  addOwnedVariant(language: $locale, variantId: $cmsId) {
-    app {
-      id
-    }
-  }
-}`;
 const LIBRARY_APPS_FILTER = {
   variants: {
     gfn: {
@@ -428,10 +417,6 @@ function isNumericId(value: string | undefined): value is string {
   return /^\d+$/.test(value);
 }
 
-function randomHuId(): string {
-  return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
-}
-
 async function postGraphQl<T>(
   query: string,
   variables: Record<string, unknown>,
@@ -776,38 +761,17 @@ async function fetchAppMetaData(
     return { data: { apps: { items: [] } } };
   }
 
-  const variables = JSON.stringify({
-    vpcId,
-    locale: DEFAULT_LOCALE,
-    appIds: normalizedIds,
-  });
-
-  const extensions = JSON.stringify({
-    persistedQuery: {
-      sha256Hash: APP_METADATA_QUERY_HASH,
+  return await fetchLcarsGraphQl<AppMetaDataResponse>(
+    "AppDataForAppId",
+    {
+      vpcId,
+      locale: DEFAULT_LOCALE,
+      appIds: normalizedIds,
     },
-  });
-
-  const params = new URLSearchParams({
-    requestType: "appMetaData",
-    extensions,
-    huId: randomHuId(),
-    variables,
-  });
-
-  const response = await fetchWithOptionalProxy(`${GRAPHQL_URL}?${params.toString()}`, {
-    headers: {
-      ...buildGfnGraphQlHeaders(token),
-      "Content-Type": "application/graphql",
-    },
-  }, proxyUrl);
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`App metadata failed (${response.status}): ${text.slice(0, 400)}`);
-  }
-
-  return (await response.json()) as AppMetaDataResponse;
+    token,
+    proxyUrl,
+    { context: "App metadata failed" },
+  );
 }
 
 async function enrichGamesWithMetadata(token: string, vpcId: string, games: GameInfo[], proxyUrl?: string): Promise<GameInfo[]> {
@@ -847,47 +811,23 @@ async function fetchPanels(
   options?: { withLibraryTime?: boolean },
   proxyUrl?: string,
 ): Promise<GraphQlResponse> {
-  const variables = JSON.stringify({
-    vpcId,
-    locale: DEFAULT_LOCALE,
-    panelNames,
-  });
-
-  const extensions = JSON.stringify({
-    persistedQuery: {
-      sha256Hash: panelNames.includes("MARQUEE")
-        ? MARQUEE_QUERY_HASH
-        : options?.withLibraryTime
-          ? LIBRARY_WITH_TIME_QUERY_HASH
-          : PANELS_QUERY_HASH,
-    },
-  });
-
-  const requestType = panelNames.includes("MARQUEE")
-    ? "panels/Marquee"
+  const queryName = panelNames.includes("MARQUEE")
+    ? "Marquee"
     : panelNames.includes("LIBRARY")
-      ? "panels/Library"
-      : "panels/MainV2";
-  const params = new URLSearchParams({
-    requestType,
-    extensions,
-    huId: randomHuId(),
-    variables,
-  });
+      ? options?.withLibraryTime === true ? "LibrarySectionWithTime" : "LibrarySection"
+      : "Main";
 
-  const response = await fetchWithOptionalProxy(`${GRAPHQL_URL}?${params.toString()}`, {
-    headers: {
-      ...buildGfnGraphQlHeaders(token),
-      "Content-Type": "application/graphql",
+  return await fetchLcarsGraphQl<GraphQlResponse>(
+    queryName,
+    {
+      vpcId,
+      locale: DEFAULT_LOCALE,
+      panelNames,
     },
-  }, proxyUrl);
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Games GraphQL failed (${response.status}): ${text.slice(0, 400)}`);
-  }
-
-  return (await response.json()) as GraphQlResponse;
+    token,
+    proxyUrl,
+    { context: "Games GraphQL failed" },
+  );
 }
 
 function panelTextMatchesFeatured(value: string | undefined): boolean {
@@ -982,24 +922,12 @@ function parsePanelResults(payload: GraphQlResponse): GamePanelResult[] {
 }
 
 async function fetchFilterAndSortDefinitions(token?: string, proxyUrl?: string): Promise<CatalogDefinitions> {
-  const query = `query GetFilterGroupAndSortOrderDefinitions($locale: String!) {
-    filterGroupDefinitions(language: $locale) {
-      id
-      label
-      filters {
-        id
-        label
-        filters
-      }
-    }
-    sortOrderDefinitions(language: $locale) {
-      id
-      label
-      orderBy
-    }
-  }`;
-
-  const payload = await postGraphQl<FilterSortDefinitionsResponse>(query, { locale: DEFAULT_LOCALE }, token, proxyUrl);
+  const payload = await fetchLcarsGraphQl<FilterSortDefinitionsResponse>(
+    "FilterGroupAndSortOrderDefinitions",
+    { locale: DEFAULT_LOCALE },
+    token,
+    proxyUrl,
+  );
   if (payload.errors?.length) {
     throw new Error(payload.errors.map((error) => error.message).join(", "));
   }
@@ -1163,28 +1091,33 @@ ${appFields}
   let cursor = "";
 
   for (let page = 0; page < MAX_CATALOG_PAGES; page += 1) {
-    const payload = await postGraphQl<AppsSearchResponse>(
-      query,
-      searchQuery.length > 0
-        ? {
-            vpcId,
-            locale: DEFAULT_LOCALE,
-            sortString: selectedSort.orderBy,
-            fetchCount,
-            cursor,
-            searchString: searchQuery,
-            filters,
-          }
-        : {
-            vpcId,
-            locale: DEFAULT_LOCALE,
-            sortString: selectedSort.orderBy,
-            fetchCount,
-            cursor,
-            filters,
-          },
+    const variables = searchQuery.length > 0
+      ? {
+          vpcId,
+          locale: DEFAULT_LOCALE,
+          sortString: selectedSort.orderBy,
+          fetchCount,
+          cursor,
+          searchString: searchQuery,
+          filters,
+        }
+      : {
+          vpcId,
+          locale: DEFAULT_LOCALE,
+          sortString: selectedSort.orderBy,
+          fetchCount,
+          cursor,
+          filters,
+        };
+    const payload = await fetchLcarsGraphQl<AppsSearchResponse>(
+      searchQuery.length > 0 ? "AppsWithSearch" : "AppsWithoutSearch",
+      variables,
       token,
       input.proxyUrl,
+      {
+        context: "GFN catalog query failed",
+        fallbackQuery: query,
+      },
     );
 
     if (payload.errors?.length) {
@@ -1544,8 +1477,8 @@ export async function markGameOwned(input: MarkGameOwnedInput): Promise<MarkGame
     throw new Error("Cannot mark game as owned without a variant ID");
   }
 
-  const payload = await postLcarsGraphQl<AddOwnedVariantResponse>(
-    ADD_OWNED_VARIANT_MUTATION,
+  const payload = await postLcarsMutation<AddOwnedVariantResponse>(
+    "AddOwnedVariant",
     {
       cmsId: variantId,
       locale: DEFAULT_LOCALE,

--- a/opennow-stable/src/main/gfn/lcarsGraphql.test.ts
+++ b/opennow-stable/src/main/gfn/lcarsGraphql.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { fetchLcarsGraphQl, postLcarsMutation } from "./lcarsGraphql";
+
+test("LCARS persisted queries retry HTTP 400 with the full query text", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    calls.push({ url, init });
+
+    if (calls.length === 1) {
+      return new Response("persisted query not found", { status: 400 });
+    }
+
+    return new Response(JSON.stringify({ data: { panels: [] } }), { status: 200 });
+  }) as typeof fetch;
+
+  const payload = await fetchLcarsGraphQl(
+    "Main",
+    { vpcId: "GFN-PC", locale: "en_US", panelNames: ["MAIN"] },
+    "token",
+  );
+
+  assert.deepEqual(payload, { data: { panels: [] } });
+  assert.equal(calls.length, 2);
+
+  const firstUrl = new URL(calls[0].url);
+  const firstExtensions = JSON.parse(firstUrl.searchParams.get("extensions") ?? "{}");
+  assert.equal(firstUrl.origin + firstUrl.pathname, "https://games.geforce.com/graphql");
+  assert.equal(firstUrl.searchParams.get("requestType"), "panels/MainV2");
+  assert.equal(firstUrl.searchParams.has("query"), false);
+  assert.equal(
+    firstExtensions.persistedQuery.sha256Hash,
+    "46ec15f267a056e7d5e46e629efa929529e5e7542a4850faece90b9f8fa5f810",
+  );
+
+  const secondUrl = new URL(calls[1].url);
+  assert.match(secondUrl.searchParams.get("query") ?? "", /query GetGameSection/);
+  assert.equal((calls[0].init?.headers as Record<string, string>)["Content-Type"], "application/graphql");
+  assert.equal((calls[0].init?.headers as Record<string, string>).Authorization, "GFNJWT token");
+});
+
+test("LCARS named mutations post the registered mutation query", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  let capturedBody = "";
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async (input, init) => {
+    capturedUrl = String(input);
+    capturedBody = String(init?.body);
+    return new Response(JSON.stringify({ data: { addOwnedVariant: { app: { id: "app-1" } } } }), { status: 200 });
+  }) as typeof fetch;
+
+  await postLcarsMutation(
+    "AddOwnedVariant",
+    { cmsId: "123", locale: "en_US" },
+    "token",
+  );
+
+  const body = JSON.parse(capturedBody) as { query?: string; variables?: Record<string, unknown> };
+  assert.equal(capturedUrl, "https://apps.gxn.nvidia.com/graphql");
+  assert.match(body.query ?? "", /mutation AddOwnedVariant/);
+  assert.deepEqual(body.variables, { cmsId: "123", locale: "en_US" });
+});

--- a/opennow-stable/src/main/gfn/lcarsGraphql.ts
+++ b/opennow-stable/src/main/gfn/lcarsGraphql.ts
@@ -2,6 +2,447 @@ import { buildGfnGraphQlHeaders } from "./clientHeaders";
 import { fetchWithOptionalProxy } from "./proxyFetch";
 
 export const LCARS_GRAPHQL_URL = "https://apps.gxn.nvidia.com/graphql";
+export const LCARS_CDN_GRAPHQL_URL = "https://games.geforce.com/graphql";
+
+export type LcarsQueryName =
+  | "Marquee"
+  | "Main"
+  | "LibrarySection"
+  | "LibrarySectionWithTime"
+  | "FilterGroupAndSortOrderDefinitions"
+  | "AppsWithSearch"
+  | "AppsWithoutSearch"
+  | "AppDataForAppId"
+  | "AddOwnedVariant";
+
+interface LcarsQueryDefinition {
+  requestType?: string;
+  sha256Hash?: string;
+  query?: string;
+}
+
+const GAME_SECTION_QUERY = `
+query GetGameSection($vpcId: String!, $locale: String!, $panelNames: [String]!) {
+  panels(vpcId: $vpcId, language: $locale, names: $panelNames) {
+    id
+    name
+    sections {
+      id
+      title
+      renderDirectives
+      seeMoreInfo {
+        filterTileId
+        title
+        filterIds
+        minTiles
+        sortOrderId
+      }
+      items {
+        __typename
+        ...filterFields
+        ...minimalGameFields
+        ...marketingFields
+      }
+    }
+  }
+}
+
+fragment filterFields on FilterItem {
+  id
+  title
+  image
+  filterIds
+  sortOrderId
+}
+
+fragment minimalGameFields on GameItem {
+  app {
+    id
+    images {
+      TV_BANNER
+      HERO_IMAGE
+    }
+    title
+    itemMetadata {
+      campaignIds
+    }
+    variants {
+      id
+      shortName
+      appStore
+      supportedControls
+      minimumSizeInBytes
+      gfn {
+        library {
+          status
+          selected
+          playStatus
+          installed
+          subscription
+        }
+        status
+        stateDetails {
+          ... on VariantGfnAutoPatchingMetadata {
+            subType
+            endTime
+          }
+          ... on VariantGfnManualPatchingMetadata {
+            subType
+            endTime
+          }
+          ... on VariantGfnMaintenanceMetadata {
+            subType
+          }
+        }
+      }
+    }
+    gfn {
+      playabilityState
+      minimumMembershipTierLabel
+      catalogSkuStrings {
+        SKU_BASED_TAG
+      }
+      playType
+    }
+  }
+}
+
+fragment marketingFields on MarketingItem {
+  id
+  title
+  subTitle
+  body
+  images {
+    MARQUEE_HERO_IMAGE
+    HERO_IMAGE
+  }
+  action {
+    uri
+    label
+    infoText
+  }
+  schedule {
+    startTime
+    endTime
+  }
+}`;
+
+const MARQUEE_QUERY = `
+query GetMarquee($vpcId: String!, $locale: String!, $panelNames: [String]!) {
+  panels(vpcId: $vpcId, language: $locale, names: $panelNames) {
+    id
+    name
+    sections {
+      id
+      title
+      items {
+        __typename
+        ...marketingFields
+        ...marqueeGameFields
+      }
+    }
+  }
+}
+
+fragment marketingFields on MarketingItem {
+  id
+  title
+  images {
+    MARQUEE_HERO_IMAGE
+    HERO_IMAGE
+  }
+  body
+  action {
+    uri
+    label
+    infoText
+  }
+  schedule {
+    startTime
+    endTime
+  }
+}
+
+fragment marqueeGameFields on GameItem {
+  app {
+    id
+    title
+    publisherName
+    contentRatings {
+      categoryKey
+      contentDescriptorKeys
+      interactiveElementKeys
+      type
+    }
+    marqueeScrimPrimaryRGB {
+      r
+      g
+      b
+    }
+    images {
+      GAME_LOGO
+      MARQUEE_HERO_IMAGE
+      HERO_IMAGE
+    }
+    itemMetadata {
+      campaignIds
+    }
+    variants {
+      id
+      appStore
+      supportedControls
+    }
+  }
+}`;
+
+const LIBRARY_SECTION_WITH_TIME_QUERY = `
+query GetGameSection($vpcId: String!, $locale: String!, $panelNames: [String]!) {
+  panels(vpcId: $vpcId, language: $locale, names: $panelNames) {
+    id
+    name
+    sections {
+      id
+      title
+      renderDirectives
+      seeMoreInfo {
+        filterTileId
+        title
+        filterIds
+        minTiles
+        sortOrderId
+      }
+      items {
+        __typename
+        ...filterFields
+        ...minimalGameFields
+      }
+    }
+  }
+}
+
+fragment filterFields on FilterItem {
+  id
+  title
+  image
+  filterIds
+  sortOrderId
+}
+
+fragment minimalGameFields on GameItem {
+  app {
+    id
+    images {
+      TV_BANNER
+      HERO_IMAGE
+      KEY_ART
+    }
+    title
+    itemMetadata {
+      campaignIds
+    }
+    variants {
+      id
+      shortName
+      appStore
+      publisherName
+      supportedControls
+      gfn {
+        library {
+          status
+          selected
+          playStatus
+          lastPlayedDate
+          subscription
+        }
+        status
+        stateDetails {
+          ... on VariantGfnAutoPatchingMetadata {
+            subType
+            endTime
+          }
+          ... on VariantGfnManualPatchingMetadata {
+            subType
+            endTime
+          }
+          ... on VariantGfnMaintenanceMetadata {
+            subType
+          }
+        }
+      }
+      contentRatings {
+        categoryKey
+        type
+      }
+    }
+    gfn {
+      playabilityState
+      minimumMembershipTierLabel
+      catalogSkuStrings {
+        SKU_BASED_TAG
+      }
+    }
+  }
+}`;
+
+const FILTER_GROUP_AND_SORT_QUERY = `query GetFilterGroupAndSortOrderDefinitions($locale: String!) {
+  filterGroupDefinitions(language: $locale) {
+    id
+    label
+    filters {
+      id
+      label
+      filters
+    }
+  }
+  sortOrderDefinitions(language: $locale) {
+    id
+    label
+    orderBy
+  }
+}`;
+
+const APP_DATA_FOR_APP_ID_QUERY = `
+query GetAppDataQueryForAppId($vpcId: String!, $locale: String!, $appIds: [String]!) {
+  apps(vpcId: $vpcId, language: $locale, appIds: $appIds) {
+    items {
+      contentRatings {
+        categoryKey
+        contentDescriptorKeys
+        interactiveElementKeys
+        type
+      }
+      developerName
+      id
+      genres
+      images {
+        GAME_BOX_ART
+        GAME_LOGO
+        HERO_IMAGE
+        SCREENSHOTS
+        TV_BANNER
+        KEY_ART
+      }
+      nvidiaTech {
+        PHOTO_MODE
+        FREESTYLE
+        HIGHLIGHTS
+      }
+      title
+      longDescription
+      shortDescription
+      maxLocalPlayers
+      maxOnlinePlayers
+      supportedControls
+      publisherName
+      itemMetadata {
+        campaignIds
+      }
+      variants {
+        appStore
+        id
+        shortName
+        supportedControls
+        storeUrl
+        publisherName
+        developerName
+        subscriptions
+        minimumSizeInBytes
+        cloudSaveSupported
+        gfn {
+          library {
+            installed
+            status
+            selected
+            playStatus
+            subscription
+            lastPlayedDate
+          }
+          status
+          features {
+            ...feature
+          }
+        }
+      }
+      gfn {
+        playabilityState
+        minimumMembershipTierLabel
+        catalogSkuStrings {
+          SKU_BASED_TAG
+          SKU_BASED_PLAYABILITY_TEXT
+          SKU_BASED_UNPLAYABLE_DIALOG_HEADER
+          SKU_BASED_UNPLAYABLE_DIALOG_BODY_UPGRADE
+          SKU_BASED_UNPLAYABLE_DIALOG_BODY_UPGRADE_ECOMM_RESTRICTED
+        }
+        playType
+      }
+    }
+  }
+}
+
+fragment feature on GfnSubscriptionFeature {
+  __typename
+  ... on GfnSubscriptionFeatureValue {
+    key
+    value
+  }
+  ... on GfnSubscriptionFeatureValueList {
+    key
+    values
+  }
+}`;
+
+const ADD_OWNED_VARIANT_MUTATION = `mutation AddOwnedVariant($cmsId: String!, $locale: String!) {
+  addOwnedVariant(language: $locale, variantId: $cmsId) {
+    app {
+      id
+    }
+  }
+}`;
+
+export const LCARS_QUERY_DEFINITIONS: Record<LcarsQueryName, LcarsQueryDefinition> = {
+  Marquee: {
+    requestType: "panels/Marquee",
+    sha256Hash: "dd4bddfdef4707dfe340cc2040d6bb9c4c45f706976fca15b2ef33221c385d7f",
+    query: MARQUEE_QUERY,
+  },
+  Main: {
+    requestType: "panels/MainV2",
+    sha256Hash: "46ec15f267a056e7d5e46e629efa929529e5e7542a4850faece90b9f8fa5f810",
+    query: GAME_SECTION_QUERY,
+  },
+  LibrarySection: {
+    requestType: "panels/Library",
+    sha256Hash: "46ec15f267a056e7d5e46e629efa929529e5e7542a4850faece90b9f8fa5f810",
+    query: GAME_SECTION_QUERY,
+  },
+  LibrarySectionWithTime: {
+    requestType: "panels/Library",
+    sha256Hash: "7f54d6bbbf3b1c09d0e5264dfa36f0f4aaf5e2678f2089f0cbf0d4dda18c3af9",
+    query: LIBRARY_SECTION_WITH_TIME_QUERY,
+  },
+  FilterGroupAndSortOrderDefinitions: {
+    requestType: "filterGroupAndSortOrderDefinitions",
+    sha256Hash: "ef725de5e93b093de1ac7418fed0ffb4f6ae2b9c14f743ab274a791521488eb9",
+    query: FILTER_GROUP_AND_SORT_QUERY,
+  },
+  AppsWithSearch: {
+    requestType: "apps",
+    sha256Hash: "ea1b5e417c95ceb5c7d6a65aa4613a417ed80b1a8d6a8c26b6953846da1fc513",
+  },
+  AppsWithoutSearch: {
+    requestType: "apps",
+    sha256Hash: "5ae1cfe2e04debdcd81279b5559313abab7d9cfa3ac9d9c048e969b3d445dcb9",
+  },
+  AppDataForAppId: {
+    requestType: "appMetaData",
+    sha256Hash: "cf8b620dfd03617017ba7c858cee65197e1ace5180e41be194b39227227ced63",
+    query: APP_DATA_FOR_APP_ID_QUERY,
+  },
+  AddOwnedVariant: {
+    sha256Hash: "02b373dd20366da6a7184c16a8a84505cc3d15e9f35788c0104c4d16456bcfaf",
+    query: ADD_OWNED_VARIANT_MUTATION,
+  },
+};
 
 export interface GraphQlErrorPayload {
   message?: string;
@@ -11,10 +452,79 @@ export interface GraphQlResponsePayload {
   errors?: GraphQlErrorPayload[];
 }
 
+interface FetchLcarsGraphQlOptions {
+  context?: string;
+  endpoint?: string;
+  fallbackQuery?: string;
+}
+
+function randomHuId(): string {
+  return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
+}
+
+function getLcarsQueryDefinition(queryName: LcarsQueryName): LcarsQueryDefinition {
+  return LCARS_QUERY_DEFINITIONS[queryName];
+}
+
+function buildPersistedQueryParams(
+  definition: LcarsQueryDefinition,
+  variables: Record<string, unknown>,
+): URLSearchParams {
+  const params = new URLSearchParams({
+    extensions: JSON.stringify({
+      persistedQuery: { sha256Hash: definition.sha256Hash },
+    }),
+    huId: randomHuId(),
+    variables: JSON.stringify(variables),
+  });
+
+  if (definition.requestType) {
+    params.set("requestType", definition.requestType);
+  }
+
+  return params;
+}
+
 export function throwGraphQlErrors(errors: GraphQlErrorPayload[] | undefined, context: string): void {
   if (errors?.length) {
     throw new Error(`${context}: ${errors.map((error) => error.message ?? "Unknown error").join(", ")}`);
   }
+}
+
+export async function fetchLcarsGraphQl<T extends GraphQlResponsePayload>(
+  queryName: LcarsQueryName,
+  variables: Record<string, unknown>,
+  token?: string,
+  proxyUrl?: string,
+  options: FetchLcarsGraphQlOptions = {},
+): Promise<T> {
+  const definition = getLcarsQueryDefinition(queryName);
+  if (!definition.sha256Hash) {
+    throw new Error(`LCARS query '${queryName}' does not define a persisted-query hash`);
+  }
+
+  const endpoint = options.endpoint ?? LCARS_CDN_GRAPHQL_URL;
+  const context = options.context ?? "GFN GraphQL failed";
+  const query = options.fallbackQuery ?? definition.query;
+  const params = buildPersistedQueryParams(definition, variables);
+  const headers = {
+    ...buildGfnGraphQlHeaders(token),
+    "Content-Type": "application/graphql",
+  };
+
+  let response = await fetchWithOptionalProxy(`${endpoint}?${params.toString()}`, { headers }, proxyUrl);
+
+  if (response.status === 400 && query) {
+    params.set("query", query);
+    response = await fetchWithOptionalProxy(`${endpoint}?${params.toString()}`, { headers }, proxyUrl);
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${context} (${response.status}): ${text.slice(0, 400)}`);
+  }
+
+  return (await response.json()) as T;
 }
 
 export async function postLcarsGraphQl<T extends GraphQlResponsePayload>(
@@ -37,4 +547,18 @@ export async function postLcarsGraphQl<T extends GraphQlResponsePayload>(
   const payload = (await response.json()) as T;
   throwGraphQlErrors(payload.errors, "GFN library mutation failed");
   return payload;
+}
+
+export async function postLcarsMutation<T extends GraphQlResponsePayload>(
+  queryName: LcarsQueryName,
+  variables: Record<string, unknown>,
+  token: string,
+  proxyUrl?: string,
+): Promise<T> {
+  const definition = getLcarsQueryDefinition(queryName);
+  if (!definition.query) {
+    throw new Error(`LCARS mutation '${queryName}' does not define a query`);
+  }
+
+  return postLcarsGraphQl<T>(definition.query, variables, token, proxyUrl);
 }


### PR DESCRIPTION
## Summary
- add LCARS persisted-query registry with vendor hashes and 400 full-query fallback
- wire game panels, metadata, catalog/filter calls, and AddOwnedVariant through shared LCARS helpers
- add CloudMatch status 91 mapping, request timeout/retry handling, and nettestsession creation/cache/threading

## Tests
- npm --prefix opennow-stable test -- --test-name-pattern lcars
- npm --prefix opennow-stable test -- --test-name-pattern CloudMatch
- npm --prefix opennow-stable test -- --test-name-pattern gfn
- npm --prefix opennow-stable run typecheck
- git diff --check