### PR TITLE
fix(game-card): dedupe store chips and surface status badges

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -248,7 +248,12 @@
     "playGame": "Play {{title}}",
     "store": "{{store}} store",
     "owned": "Owned",
-    "available": "Available"
+    "available": "Available",
+    "status": {
+      "maintenance": "Under maintenance",
+      "updating": "Updating",
+      "unavailable": "Unavailable"
+    }
   },
   "streamLoading": {
     "labels": {

--- a/opennow-stable/src/main/gfn/games.test.ts
+++ b/opennow-stable/src/main/gfn/games.test.ts
@@ -254,6 +254,40 @@ test("does not add Unknown public variants when catalog stores already exist", (
   assert.deepEqual(game?.availableStores, ["GAIJIN", "STEAM"]);
 });
 
+test("adds Unknown public variants when catalog only has a None placeholder store", () => {
+  const [game] = mergePublicGameVariants(
+    [
+      {
+        id: "launcher-only-game",
+        title: "Launcher Only Game",
+        selectedVariantIndex: 0,
+        variants: [{ id: "placeholder", store: "None", supportedControls: [] }],
+        availableStores: ["None"],
+      },
+    ],
+    [
+      publicGameToGameInfo({
+        id: 123456,
+        title: "Launcher Only Game",
+        steamUrl: "",
+        publisher: "Standalone Publisher",
+        store: "",
+        status: "AVAILABLE",
+      }),
+    ],
+  );
+
+  assert.deepEqual(
+    game?.variants.map((variant) => ({ id: variant.id, store: variant.store })),
+    [
+      { id: "placeholder", store: "None" },
+      { id: "123456", store: "Unknown" },
+    ],
+  );
+  assert.equal(game?.uuid, "123456");
+  assert.equal(game?.launchAppId, "123456");
+});
+
 test("appends public-only games that match catalog search", () => {
   const games = appendPublicGameSearchMatches(
     [

--- a/opennow-stable/src/main/gfn/games.test.ts
+++ b/opennow-stable/src/main/gfn/games.test.ts
@@ -218,6 +218,42 @@ test("does not duplicate primary catalog store variants from public data", () =>
   assert.deepEqual(game?.variants.map((variant) => variant.store), ["Steam"]);
 });
 
+test("does not add Unknown public variants when catalog stores already exist", () => {
+  const [game] = mergePublicGameVariants(
+    [
+      {
+        id: "war-thunder",
+        title: "War Thunder",
+        selectedVariantIndex: 0,
+        variants: [
+          { id: "10839111", store: "GAIJIN", supportedControls: [] },
+          { id: "100234911", store: "STEAM", supportedControls: [] },
+        ],
+        availableStores: ["GAIJIN", "STEAM"],
+      },
+    ],
+    [
+      publicGameToGameInfo({
+        id: 10839111,
+        title: "War Thunder",
+        steamUrl: "",
+        publisher: "Gaijin Entertainment",
+        store: "",
+        status: "AVAILABLE",
+      }),
+    ],
+  );
+
+  assert.deepEqual(
+    game?.variants.map((variant) => ({ id: variant.id, store: variant.store })),
+    [
+      { id: "10839111", store: "GAIJIN" },
+      { id: "100234911", store: "STEAM" },
+    ],
+  );
+  assert.deepEqual(game?.availableStores, ["GAIJIN", "STEAM"]);
+});
+
 test("appends public-only games that match catalog search", () => {
   const games = appendPublicGameSearchMatches(
     [

--- a/opennow-stable/src/main/gfn/publicGames.ts
+++ b/opennow-stable/src/main/gfn/publicGames.ts
@@ -14,14 +14,11 @@ export interface RawPublicGame {
 
 const PRIMARY_CATALOG_STORE_KEYS = new Set([
   "STEAM",
-  "EPIC",
   "EPIC_GAMES_STORE",
-  "EGS",
   "XBOX",
-  "XBOX_GAME_PASS",
-  "MICROSOFT",
-  "MICROSOFT_STORE",
 ]);
+
+const PUBLIC_PLACEHOLDER_STORE_KEYS = new Set(["UNKNOWN"]);
 
 export function inferPublicGameStore(item: RawPublicGame): string {
   const explicitStore = item.store?.trim();
@@ -95,9 +92,13 @@ function mergeSearchText(left?: string, right?: string): string | undefined {
 
 function getSupplementalPublicVariants(game: GameInfo, publicGame: GameInfo): GameVariant[] {
   const existingStores = new Set(game.variants.map((variant) => normalizeGameStore(variant.store)));
+  const hasCatalogStoreVariant = game.variants.some((variant) => variant.store.trim().length > 0);
 
   return publicGame.variants.filter((variant) => {
     const storeKey = normalizeGameStore(variant.store);
+    if (hasCatalogStoreVariant && PUBLIC_PLACEHOLDER_STORE_KEYS.has(storeKey)) {
+      return false;
+    }
     return !PRIMARY_CATALOG_STORE_KEYS.has(storeKey) && !existingStores.has(storeKey);
   });
 }

--- a/opennow-stable/src/main/gfn/publicGames.ts
+++ b/opennow-stable/src/main/gfn/publicGames.ts
@@ -92,7 +92,10 @@ function mergeSearchText(left?: string, right?: string): string | undefined {
 
 function getSupplementalPublicVariants(game: GameInfo, publicGame: GameInfo): GameVariant[] {
   const existingStores = new Set(game.variants.map((variant) => normalizeGameStore(variant.store)));
-  const hasCatalogStoreVariant = game.variants.some((variant) => variant.store.trim().length > 0);
+  const hasCatalogStoreVariant = game.variants.some((variant) => {
+    const storeKey = normalizeGameStore(variant.store);
+    return storeKey.length > 0 && storeKey !== "NONE";
+  });
 
   return publicGame.variants.filter((variant) => {
     const storeKey = normalizeGameStore(variant.store);

--- a/opennow-stable/src/renderer/src/components/GameCard.test.ts
+++ b/opennow-stable/src/renderer/src/components/GameCard.test.ts
@@ -76,7 +76,7 @@ test("keeps active and owned states separate for the selected store", () => {
     "epic",
   );
 
-  const epicOption = options.find((option) => option.storeKey === "EGS");
+  const epicOption = options.find((option) => option.storeKey === "EPIC_GAMES_STORE");
   const steamOption = options.find((option) => option.storeKey === "STEAM");
 
   assert.ok(epicOption);
@@ -85,6 +85,31 @@ test("keeps active and owned states separate for the selected store", () => {
   assert.equal(epicOption.isOwned, false);
   assert.equal(steamOption.isActive, false);
   assert.equal(steamOption.isOwned, true);
+});
+
+test("collapses store aliases that render as the same store", () => {
+  const options = getStoreOptions(
+    makeGame([
+      makeVariant({ id: "epic", store: "EPIC", libraryStatus: "NOT_OWNED" }),
+      makeVariant({ id: "egs", store: "EGS", libraryStatus: "PLATFORM_SYNC" }),
+      makeVariant({ id: "epic-games-store", store: "Epic Games Store", libraryStatus: "NOT_OWNED" }),
+      makeVariant({ id: "steam", store: "Steam", libraryStatus: "NOT_OWNED" }),
+    ]),
+    "epic-games-store",
+  );
+
+  assert.deepEqual(
+    options.map((option) => ({
+      storeKey: option.storeKey,
+      variantId: option.variantId,
+      isOwned: option.isOwned,
+      isActive: option.isActive,
+    })),
+    [
+      { storeKey: "EPIC_GAMES_STORE", variantId: "epic-games-store", isOwned: true, isActive: true },
+      { storeKey: "STEAM", variantId: "steam", isOwned: false, isActive: false },
+    ],
+  );
 });
 
 test("keeps unknown and third-party stores selectable for default icon fallback", () => {

--- a/opennow-stable/src/renderer/src/components/GameCard.test.ts
+++ b/opennow-stable/src/renderer/src/components/GameCard.test.ts
@@ -106,8 +106,30 @@ test("collapses store aliases that render as the same store", () => {
       isActive: option.isActive,
     })),
     [
-      { storeKey: "EPIC_GAMES_STORE", variantId: "epic-games-store", isOwned: true, isActive: true },
+      { storeKey: "EPIC_GAMES_STORE", variantId: "egs", isOwned: true, isActive: true },
       { storeKey: "STEAM", variantId: "steam", isOwned: false, isActive: false },
+    ],
+  );
+});
+
+test("prefers an owned alias variant id while preserving active chip state", () => {
+  const options = getStoreOptions(
+    makeGame([
+      makeVariant({ id: "selected-epic", store: "EPIC", libraryStatus: "NOT_OWNED" }),
+      makeVariant({ id: "owned-egs", store: "EGS", libraryStatus: "PLATFORM_SYNC" }),
+    ]),
+    "selected-epic",
+  );
+
+  assert.deepEqual(
+    options.map((option) => ({
+      storeKey: option.storeKey,
+      variantId: option.variantId,
+      isOwned: option.isOwned,
+      isActive: option.isActive,
+    })),
+    [
+      { storeKey: "EPIC_GAMES_STORE", variantId: "owned-egs", isOwned: true, isActive: true },
     ],
   );
 });

--- a/opennow-stable/src/renderer/src/components/GameCard.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCard.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useMemo, useState } from "react";
 import type { JSX } from "react";
 import { normalizeGameStore } from "@shared/gfn";
 import type { GameInfo } from "@shared/gfn";
+import { getActiveGameAvailabilityBadge } from "../lib/gameCardStatus";
 import { getStoreOptions as getGameCardStoreOptions } from "../lib/gameCardStores";
 import { useTranslation } from "../i18n";
 
@@ -86,43 +87,21 @@ function DefaultStoreIcon(): JSX.Element {
 const STORE_ICON_MAP: Record<string, () => JSX.Element> = {
   STEAM: SteamIcon,
   EPIC_GAMES_STORE: EpicIcon,
-  EPIC: EpicIcon,
-  EGS: EpicIcon,
   UPLAY: UbisoftIcon,
-  UBISOFT: UbisoftIcon,
-  UBISOFT_CONNECT: UbisoftIcon,
   EA_APP: EaIcon,
-  EA: EaIcon,
-  ORIGIN: EaIcon,
-  GOG_COM: GogIcon,
   GOG: GogIcon,
-  XBOX_GAME_PASS: XboxIcon,
   XBOX: XboxIcon,
-  MICROSOFT_STORE: XboxIcon,
-  MICROSOFT: XboxIcon,
   BATTLE_NET: BattleNetIcon,
-  BATTLENET: BattleNetIcon,
 };
 
 const STORE_DISPLAY_NAME: Record<string, string> = {
   STEAM: "Steam",
   EPIC_GAMES_STORE: "Epic",
-  EPIC: "Epic",
-  EGS: "Epic",
   UPLAY: "Ubisoft",
-  UBISOFT: "Ubisoft",
-  UBISOFT_CONNECT: "Ubisoft",
   EA_APP: "EA",
-  EA: "EA",
-  ORIGIN: "EA",
-  GOG_COM: "GOG",
   GOG: "GOG",
-  XBOX_GAME_PASS: "Xbox",
   XBOX: "Xbox",
-  MICROSOFT_STORE: "Xbox",
-  MICROSOFT: "Xbox",
   BATTLE_NET: "Battle.net",
-  BATTLENET: "Battle.net",
 };
 
 /** Normalize an appStore value to the uppercase key used by the icon/name maps. */
@@ -181,6 +160,10 @@ export const GameCard = memo(function GameCard({
     [game, selectedVariantId],
   );
   const activeStoreOption = storeOptions.find((option) => option.isActive) ?? storeOptions[0];
+  const availabilityBadge = useMemo(
+    () => getActiveGameAvailabilityBadge(game, selectedVariantId),
+    [game, selectedVariantId],
+  );
 
   const [aspectPct, setAspectPct] = useState<number | undefined>(undefined);
 
@@ -255,6 +238,11 @@ export const GameCard = memo(function GameCard({
         </div>
 
         <div className="game-card-info">
+          {availabilityBadge && (
+            <span className={`game-card-status-badge ${availabilityBadge.kind}`} title={availabilityBadge.status}>
+              {t(availabilityBadge.labelKey)}
+            </span>
+          )}
           {activeStoreOption && (
             <p className="game-card-platform" title={activeStoreOption.displayName}>
               {activeStoreOption.displayName}

--- a/opennow-stable/src/renderer/src/lib/gameCardStatus.test.ts
+++ b/opennow-stable/src/renderer/src/lib/gameCardStatus.test.ts
@@ -1,0 +1,71 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { GameInfo, GameVariant } from "@shared/gfn";
+import {
+  getActiveGameAvailabilityBadge,
+  getGameAvailabilityBadgeForStatus,
+} from "./gameCardStatus";
+
+function makeVariant(overrides: Partial<GameVariant> = {}): GameVariant {
+  return {
+    id: overrides.id ?? "variant-1",
+    store: overrides.store ?? "Steam",
+    supportedControls: overrides.supportedControls ?? [],
+    gfnStatus: overrides.gfnStatus,
+  };
+}
+
+function makeGame(variants: GameVariant[], selectedVariantIndex = 0): GameInfo {
+  return {
+    id: "game-1",
+    title: "Test Game",
+    selectedVariantIndex,
+    variants,
+  };
+}
+
+test("does not show a badge for available or missing GFN statuses", () => {
+  assert.equal(getGameAvailabilityBadgeForStatus(undefined), null);
+  assert.equal(getGameAvailabilityBadgeForStatus(""), null);
+  assert.equal(getGameAvailabilityBadgeForStatus("AVAILABLE"), null);
+  assert.equal(getGameAvailabilityBadgeForStatus(" available "), null);
+});
+
+test("maps maintenance statuses to the maintenance badge", () => {
+  assert.deepEqual(getGameAvailabilityBadgeForStatus("SERVER_MAINTENANCE"), {
+    kind: "maintenance",
+    labelKey: "gameCard.status.maintenance",
+    status: "SERVER_MAINTENANCE",
+  });
+  assert.equal(getGameAvailabilityBadgeForStatus("maintenance")?.kind, "maintenance");
+});
+
+test("maps patching and updating statuses to the updating badge", () => {
+  assert.deepEqual(getGameAvailabilityBadgeForStatus("PATCHING"), {
+    kind: "updating",
+    labelKey: "gameCard.status.updating",
+    status: "PATCHING",
+  });
+  assert.equal(getGameAvailabilityBadgeForStatus("manual update")?.kind, "updating");
+});
+
+test("maps unknown non-available statuses to the unavailable badge", () => {
+  assert.deepEqual(getGameAvailabilityBadgeForStatus("TEMPORARILY_DISABLED"), {
+    kind: "unavailable",
+    labelKey: "gameCard.status.unavailable",
+    status: "TEMPORARILY_DISABLED",
+  });
+});
+
+test("uses the selected active variant status for the card badge", () => {
+  const game = makeGame([
+    makeVariant({ id: "steam", store: "STEAM", gfnStatus: "AVAILABLE" }),
+    makeVariant({ id: "epic", store: "EPIC", gfnStatus: "PATCHING" }),
+  ]);
+
+  assert.equal(getActiveGameAvailabilityBadge(game), null);
+  assert.equal(getActiveGameAvailabilityBadge(game, "epic")?.kind, "updating");
+});

--- a/opennow-stable/src/renderer/src/lib/gameCardStatus.ts
+++ b/opennow-stable/src/renderer/src/lib/gameCardStatus.ts
@@ -1,0 +1,35 @@
+import type { GameInfo } from "@shared/gfn";
+import { getActiveGameVariant } from "./gameCardVariants";
+
+export type GameAvailabilityBadgeKind = "maintenance" | "updating" | "unavailable";
+
+export interface GameAvailabilityBadge {
+  kind: GameAvailabilityBadgeKind;
+  labelKey: string;
+  status: string;
+}
+
+function normalizeGfnStatus(status?: string): string {
+  return status?.trim().toUpperCase().replace(/[^A-Z0-9]+/g, "_") ?? "";
+}
+
+export function getGameAvailabilityBadgeForStatus(status?: string): GameAvailabilityBadge | null {
+  const normalizedStatus = normalizeGfnStatus(status);
+  if (!normalizedStatus || normalizedStatus === "AVAILABLE") {
+    return null;
+  }
+
+  if (normalizedStatus.includes("PATCH") || normalizedStatus.includes("UPDAT")) {
+    return { kind: "updating", labelKey: "gameCard.status.updating", status: normalizedStatus };
+  }
+
+  if (normalizedStatus.includes("MAINTENANCE")) {
+    return { kind: "maintenance", labelKey: "gameCard.status.maintenance", status: normalizedStatus };
+  }
+
+  return { kind: "unavailable", labelKey: "gameCard.status.unavailable", status: normalizedStatus };
+}
+
+export function getActiveGameAvailabilityBadge(game: GameInfo, selectedVariantId?: string): GameAvailabilityBadge | null {
+  return getGameAvailabilityBadgeForStatus(getActiveGameVariant(game, selectedVariantId)?.gfnStatus);
+}

--- a/opennow-stable/src/renderer/src/lib/gameCardStores.ts
+++ b/opennow-stable/src/renderer/src/lib/gameCardStores.ts
@@ -1,5 +1,6 @@
 import type { GameInfo, GameVariant } from "@shared/gfn";
 import { isOwnedVariant, normalizeGameStore } from "@shared/gfn";
+import { getResolvedSelectedVariantId } from "./gameCardVariants";
 
 export interface StoreOption {
   storeKey: string;
@@ -17,14 +18,6 @@ function normalizeStoreOptionKey(store: string): string | null {
 
   const key = normalizeGameStore(trimmed);
   return key === "NONE" ? null : key;
-}
-
-function getResolvedSelectedVariantId(game: GameInfo, selectedVariantId?: string): string | undefined {
-  if (selectedVariantId && game.variants.some((variant) => variant.id === selectedVariantId)) {
-    return selectedVariantId;
-  }
-
-  return game.variants[game.selectedVariantIndex]?.id ?? game.variants[0]?.id;
 }
 
 function getVariantForStore(variants: GameVariant[], activeVariantId?: string): GameVariant | undefined {

--- a/opennow-stable/src/renderer/src/lib/gameCardStores.ts
+++ b/opennow-stable/src/renderer/src/lib/gameCardStores.ts
@@ -21,11 +21,17 @@ function normalizeStoreOptionKey(store: string): string | null {
 }
 
 function getVariantForStore(variants: GameVariant[], activeVariantId?: string): GameVariant | undefined {
+  const ownedVariant = variants.find((variant) => isOwnedVariant(variant));
+
   if (activeVariantId) {
-    return variants.find((variant) => variant.id === activeVariantId) ?? variants[0];
+    const activeVariant = variants.find((variant) => variant.id === activeVariantId);
+    if (activeVariant && (isOwnedVariant(activeVariant) || !ownedVariant)) {
+      return activeVariant;
+    }
+    return ownedVariant ?? activeVariant ?? variants[0];
   }
 
-  return variants.find((variant) => isOwnedVariant(variant)) ?? variants[0];
+  return ownedVariant ?? variants[0];
 }
 
 export function getStoreOptions(game: GameInfo, selectedVariantId?: string): StoreOption[] {

--- a/opennow-stable/src/renderer/src/lib/gameCardVariants.ts
+++ b/opennow-stable/src/renderer/src/lib/gameCardVariants.ts
@@ -1,0 +1,14 @@
+import type { GameInfo, GameVariant } from "@shared/gfn";
+
+export function getResolvedSelectedVariantId(game: GameInfo, selectedVariantId?: string): string | undefined {
+  if (selectedVariantId && game.variants.some((variant) => variant.id === selectedVariantId)) {
+    return selectedVariantId;
+  }
+
+  return game.variants[game.selectedVariantIndex]?.id ?? game.variants[0]?.id;
+}
+
+export function getActiveGameVariant(game: GameInfo, selectedVariantId?: string): GameVariant | undefined {
+  const resolvedSelectedVariantId = getResolvedSelectedVariantId(game, selectedVariantId);
+  return game.variants.find((variant) => variant.id === resolvedSelectedVariantId) ?? game.variants[0];
+}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3735,6 +3735,43 @@ body,
   pointer-events: auto;
 }
 
+.game-card-status-badge {
+  align-self: flex-start;
+  max-width: 100%;
+  padding: 3px 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 18, 17, 0.72);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.66rem;
+  font-weight: 750;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.7);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+}
+
+.game-card-status-badge.maintenance {
+  color: #ffefc2;
+  background: color-mix(in srgb, var(--warning) 20%, rgba(15, 18, 17, 0.76));
+  border-color: color-mix(in srgb, var(--warning) 44%, transparent);
+}
+
+.game-card-status-badge.updating {
+  color: #d8f7ff;
+  background: color-mix(in srgb, var(--accent) 22%, rgba(15, 18, 17, 0.76));
+  border-color: color-mix(in srgb, var(--accent) 42%, transparent);
+}
+
+.game-card-status-badge.unavailable {
+  color: rgba(255, 255, 255, 0.84);
+  background: rgba(107, 114, 128, 0.34);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
 .game-card-title {
   margin: 0;
   font-size: 0.8rem;

--- a/opennow-stable/src/shared/gfn.test.ts
+++ b/opennow-stable/src/shared/gfn.test.ts
@@ -15,6 +15,7 @@ import {
   isOwnedVariant,
   NATIVE_STREAMER_WINDOWS_ONLY_MESSAGE,
   getDefaultStreamPreferences,
+  normalizeGameStore,
   normalizeStreamPreferences,
   normalizeStreamClientModeForPlatform,
 } from "./gfn";
@@ -92,6 +93,15 @@ test("matches Epic store aliases only", () => {
   assert.equal(isEpicStore("EPIC"), true);
   assert.equal(isEpicStore("EGS"), true);
   assert.equal(isEpicStore("Steam"), false);
+});
+
+test("normalizes equivalent store spellings to one canonical key", () => {
+  assert.equal(normalizeGameStore("Epic"), "EPIC_GAMES_STORE");
+  assert.equal(normalizeGameStore("EGS"), "EPIC_GAMES_STORE");
+  assert.equal(normalizeGameStore("GOG.com"), "GOG");
+  assert.equal(normalizeGameStore("Battle.net"), "BATTLE_NET");
+  assert.equal(normalizeGameStore("Gaijin.net"), "GAIJIN");
+  assert.equal(normalizeGameStore("Microsoft Store"), "XBOX");
 });
 
 test("buildNativeStreamerSessionContext forwards requested/finalized streaming features", () => {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -903,8 +903,29 @@ export interface GameVariant {
 
 export const OWNED_LIBRARY_STATUSES = ["MANUAL", "PLATFORM_SYNC", "IN_LIBRARY"] as const;
 
+const GAME_STORE_ALIASES: Record<string, string> = {
+  BATTLE_NET: "BATTLE_NET",
+  BATTLENET: "BATTLE_NET",
+  EA: "EA_APP",
+  EGS: "EPIC_GAMES_STORE",
+  EPIC: "EPIC_GAMES_STORE",
+  GAIJIN_NET: "GAIJIN",
+  GOG_COM: "GOG",
+  MICROSOFT: "XBOX",
+  MICROSOFT_STORE: "XBOX",
+  ORIGIN: "EA_APP",
+  UBISOFT: "UPLAY",
+  UBISOFT_CONNECT: "UPLAY",
+  XBOX_GAME_PASS: "XBOX",
+};
+
 export function normalizeGameStore(store: string): string {
-  return store.toUpperCase().replace(/[\s-]+/g, "_");
+  const key = store
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return GAME_STORE_ALIASES[key] ?? key;
 }
 
 export function isOwnedLibraryStatus(status?: string): boolean {
@@ -964,7 +985,7 @@ export function isGameInLibrary(game: Pick<GameInfo, "variants">): boolean {
 
 export function isEpicStore(store: string): boolean {
   const key = normalizeGameStore(store);
-  return key === "EPIC_GAMES_STORE" || key === "EPIC" || key === "EGS";
+  return key === "EPIC_GAMES_STORE";
 }
 
 export interface CatalogFilterOption {


### PR DESCRIPTION
Fixes duplicate store chips on game cards (e.g., War Thunder showing multiple identical fallback icons) by canonicalizing store aliases and preventing "Unknown" public variant merges when catalog stores exist. Surfaces GFN game availability status (SERVER_MAINTENANCE, PATCHING) as badges on game cards/list items with proper styling.

**Store deduplication**

* Add shared `GAME_STORE_ALIASES` to normalize equivalent store spellings (EPIC/EGS → EPIC_GAMES_STORE, BATTLENET → BATTLE_NET, EA/ORIGIN → EA_APP) — `src/shared/gfn.ts`
* Update `getSupplementalPublicVariants()` to skip adding "Unknown" public variants when the game already has catalog store variants — `src/main/gfn/publicGames.ts`
* Remove redundant alias keys from `STORE_ICON_MAP` and `STORE_DISPLAY_NAME` since normalization now handles them — `src/renderer/src/components/GameCard.tsx`

**Maintenance/patching status badges**

* Add `getActiveGameAvailabilityBadge()` to map GFN `gfnStatus` values to badge kinds (maintenance/updating/unavailable) — `src/renderer/src/lib/gameCardStatus.ts`
* Render status badge above the platform text on `GameCard.tsx` when the active variant status is non-AVAILABLE
* Add badge styles matching existing chip design language with `.game-card-status-badge.maintenance` and `.game-card-status-badge.updating` variants — `src/renderer/src/styles.css`
* Add locale strings `gameCard.status.maintenance`, `gameCard.status.updating`, `gameCard.status.unavailable` — `locales/en.json`

**Tests**

* `GameCard.test.ts`: test collapse of store aliases into single chip
* `GameCard.test.ts`: added test for War Thunder situation (no Unknown public variant when catalog stores exist)
* `gfn.test.ts`: added test for canonical store key normalization
* `gameCardStatus.test.ts`: added test for status → badge mapping

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/80dcd188-fffb-424a-a43b-2003bb22db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-258" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/80dcd188-fffb-424a-a43b-2003bb22db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-258&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-258"><img alt="OPE-258" src="https://capy.ai/api/badge/thread.svg?label=OPE-258"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and catalog-merge behavior only; changes are covered by unit tests and do not touch auth, sessions, or streaming.
> 
> **Overview**
> Fixes duplicate store chips on game cards by **canonicalizing store aliases** in shared `normalizeGameStore` (e.g. EPIC/EGS → `EPIC_GAMES_STORE`, EA/Origin → `EA_APP`) so `getStoreOptions` collapses variants into one chip per store. **GameCard** drops redundant icon/name map entries that aliases now cover.
> 
> **Public catalog merge** no longer appends **Unknown** supplemental variants when the title already has real catalog store variants (e.g. War Thunder with Gaijin + Steam).
> 
> **GFN availability** on the active variant’s `gfnStatus` is shown as a pill on the card (maintenance / updating / unavailable) via new `gameCardStatus` helpers, with English strings and `.game-card-status-badge` styles. Variant selection logic moves to shared `gameCardVariants`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bdf8bb30f3ce1e0a7dab3e5f06f4ca42a5b6aac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->