### PR TITLE
feat(discord): show queue state in rich presence

### DIFF
--- a/opennow-stable/src/main/discordPresence.test.ts
+++ b/opennow-stable/src/main/discordPresence.test.ts
@@ -6,16 +6,17 @@ import assert from "node:assert/strict";
 import {
   discordActivityFromSession,
   discordActivityKindForSession,
+  discordMonitorActivityDecision,
   isSameDiscordActivity,
 } from "./discordPresence";
 
 test("discordActivityKindForSession maps queued CloudMatch states without marking them streaming", () => {
   assert.equal(discordActivityKindForSession({ status: 1, seatSetupStep: 1, queuePosition: 42 }), "queued");
   assert.equal(discordActivityKindForSession({ status: 1, queuePosition: 2 }), "queued");
-  assert.equal(discordActivityKindForSession({ status: 1 }), "queued");
 });
 
 test("discordActivityKindForSession maps ready and streaming states distinctly", () => {
+  assert.equal(discordActivityKindForSession({ status: 1 }), "starting");
   assert.equal(discordActivityKindForSession({ status: 2 }), "starting");
   assert.equal(discordActivityKindForSession({ status: 3 }), "streaming");
   assert.equal(discordActivityKindForSession({ status: 4 }), null);
@@ -72,4 +73,56 @@ test("isSameDiscordActivity compares kind and queue position for the same app", 
     appId: "1001",
     queuePosition: 9,
   }), false);
+});
+
+test("discordMonitorActivityDecision does not downgrade active streaming presence", () => {
+  const startedAt = new Date("2026-01-01T00:00:00.000Z");
+  const decision = discordMonitorActivityDecision({
+    gameName: "Test Game",
+    kind: "streaming",
+    appId: "1001",
+    startTimestamp: startedAt,
+  }, {
+    sessionId: "s1",
+    appId: 1001,
+    status: 2,
+  });
+
+  assert.deepEqual(decision, { action: "none" });
+});
+
+test("discordMonitorActivityDecision preserves current game title on queue updates", () => {
+  const decision = discordMonitorActivityDecision({
+    gameName: "Human Game Title",
+    kind: "queued",
+    appId: "1001",
+    queuePosition: 12,
+  }, {
+    sessionId: "s1",
+    appId: 1001,
+    status: 1,
+    queuePosition: 11,
+  });
+
+  assert.equal(decision.action, "set");
+  if (decision.action === "set") {
+    assert.equal(decision.activity.gameName, "Human Game Title");
+    assert.equal(decision.activity.queuePosition, 11);
+  }
+});
+
+test("discordMonitorActivityDecision does not reset active streaming timer", () => {
+  const startedAt = new Date("2026-01-01T00:00:00.000Z");
+  const decision = discordMonitorActivityDecision({
+    gameName: "Test Game",
+    kind: "streaming",
+    appId: "1001",
+    startTimestamp: startedAt,
+  }, {
+    sessionId: "s1",
+    appId: 1001,
+    status: 3,
+  });
+
+  assert.deepEqual(decision, { action: "none" });
 });

--- a/opennow-stable/src/main/discordPresence.test.ts
+++ b/opennow-stable/src/main/discordPresence.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  discordActivityFromSession,
+  discordActivityKindForSession,
+  isSameDiscordActivity,
+} from "./discordPresence";
+
+test("discordActivityKindForSession maps queued CloudMatch states without marking them streaming", () => {
+  assert.equal(discordActivityKindForSession({ status: 1, seatSetupStep: 1, queuePosition: 42 }), "queued");
+  assert.equal(discordActivityKindForSession({ status: 1, queuePosition: 2 }), "queued");
+  assert.equal(discordActivityKindForSession({ status: 1 }), "queued");
+});
+
+test("discordActivityKindForSession maps ready and streaming states distinctly", () => {
+  assert.equal(discordActivityKindForSession({ status: 2 }), "starting");
+  assert.equal(discordActivityKindForSession({ status: 3 }), "streaming");
+  assert.equal(discordActivityKindForSession({ status: 4 }), null);
+});
+
+test("discordActivityFromSession includes queue position and only timestamps streaming", () => {
+  const queued = discordActivityFromSession({
+    sessionId: "s1",
+    appId: 1001,
+    status: 1,
+    queuePosition: 12,
+  }, "Test Game");
+
+  assert.deepEqual(queued, {
+    gameName: "Test Game",
+    kind: "queued",
+    appId: "1001",
+    queuePosition: 12,
+    startTimestampMs: undefined,
+  });
+
+  const streaming = discordActivityFromSession({
+    sessionId: "s1",
+    appId: 1001,
+    status: 3,
+  }, "Test Game");
+
+  assert.equal(streaming?.kind, "streaming");
+  assert.equal(streaming?.appId, "1001");
+  assert.equal(typeof streaming?.startTimestampMs, "number");
+});
+
+test("isSameDiscordActivity compares kind and queue position for the same app", () => {
+  assert.equal(isSameDiscordActivity({
+    gameName: "Game",
+    kind: "queued",
+    appId: "1001",
+    queuePosition: 10,
+  }, {
+    gameName: "1001",
+    kind: "queued",
+    appId: "1001",
+    queuePosition: 10,
+  }), true);
+
+  assert.equal(isSameDiscordActivity({
+    gameName: "Game",
+    kind: "queued",
+    appId: "1001",
+    queuePosition: 10,
+  }, {
+    gameName: "Game",
+    kind: "queued",
+    appId: "1001",
+    queuePosition: 9,
+  }), false);
+});

--- a/opennow-stable/src/main/discordPresence.ts
+++ b/opennow-stable/src/main/discordPresence.ts
@@ -6,14 +6,23 @@ export interface DiscordPresenceSessionState extends GfnSessionQueueState {
   appId?: number | string;
 }
 
+export type DiscordCurrentActivity = Omit<DiscordActivityUpdate, "startTimestampMs"> & {
+  startTimestamp?: Date;
+};
+
+export type DiscordMonitorActivityDecision =
+  | { action: "none" }
+  | { action: "clear" }
+  | { action: "set"; activity: DiscordActivityUpdate; startTimestamp?: Date };
+
 export function discordActivityKindForSession(session: DiscordPresenceSessionState): DiscordActivityKind | null {
   if (session.status === 3) {
     return "streaming";
   }
-  if (isGfnSessionInQueue(session) || session.status === 1) {
+  if (isGfnSessionInQueue(session)) {
     return "queued";
   }
-  if (session.status === 2) {
+  if (session.status === 1 || session.status === 2) {
     return "starting";
   }
   return null;
@@ -39,7 +48,7 @@ export function discordActivityFromSession(
 }
 
 export function isSameDiscordActivity(
-  current: DiscordActivityUpdate | null,
+  current: DiscordCurrentActivity | null,
   next: DiscordActivityUpdate,
 ): boolean {
   if (!current || current.kind !== next.kind || current.queuePosition !== next.queuePosition) {
@@ -49,4 +58,37 @@ export function isSameDiscordActivity(
     return current.appId === next.appId;
   }
   return current.gameName === next.gameName;
+}
+
+export function discordMonitorActivityDecision(
+  current: DiscordCurrentActivity | null,
+  activeSession: (ActiveSessionInfo & DiscordPresenceSessionState) | null,
+): DiscordMonitorActivityDecision {
+  if (!activeSession) {
+    return current ? { action: "clear" } : { action: "none" };
+  }
+
+  const sessionAppId = activeSession.appId.toString();
+  if (current?.kind === "streaming" && current.appId === sessionAppId) {
+    return { action: "none" };
+  }
+
+  const gameName = current?.appId === sessionAppId ? current.gameName : sessionAppId;
+  const nextActivity = discordActivityFromSession(activeSession, gameName);
+  if (!nextActivity) {
+    return current?.appId === sessionAppId ? { action: "clear" } : { action: "none" };
+  }
+
+  const startTimestamp =
+    nextActivity.kind === "streaming" && current?.kind === "streaming" && current.appId === sessionAppId
+      ? current.startTimestamp
+      : nextActivity.startTimestampMs
+        ? new Date(nextActivity.startTimestampMs)
+        : undefined;
+
+  if (isSameDiscordActivity(current, nextActivity)) {
+    return { action: "none" };
+  }
+
+  return { action: "set", activity: nextActivity, startTimestamp };
 }

--- a/opennow-stable/src/main/discordPresence.ts
+++ b/opennow-stable/src/main/discordPresence.ts
@@ -1,0 +1,52 @@
+import type { ActiveSessionInfo, GfnSessionQueueState, SessionInfo } from "@shared/gfn";
+import { isGfnSessionInQueue } from "@shared/gfn";
+import type { DiscordActivityKind, DiscordActivityUpdate } from "@shared/discord";
+
+export interface DiscordPresenceSessionState extends GfnSessionQueueState {
+  appId?: number | string;
+}
+
+export function discordActivityKindForSession(session: DiscordPresenceSessionState): DiscordActivityKind | null {
+  if (session.status === 3) {
+    return "streaming";
+  }
+  if (isGfnSessionInQueue(session) || session.status === 1) {
+    return "queued";
+  }
+  if (session.status === 2) {
+    return "starting";
+  }
+  return null;
+}
+
+export function discordActivityFromSession(
+  session: (SessionInfo | ActiveSessionInfo) & DiscordPresenceSessionState,
+  gameName: string,
+): DiscordActivityUpdate | null {
+  const kind = discordActivityKindForSession(session);
+  if (!kind) {
+    return null;
+  }
+
+  const appId = typeof session.appId === "number" ? session.appId.toString() : session.appId;
+  return {
+    gameName,
+    kind,
+    appId,
+    queuePosition: session.queuePosition,
+    startTimestampMs: kind === "streaming" ? Date.now() : undefined,
+  };
+}
+
+export function isSameDiscordActivity(
+  current: DiscordActivityUpdate | null,
+  next: DiscordActivityUpdate,
+): boolean {
+  if (!current || current.kind !== next.kind || current.queuePosition !== next.queuePosition) {
+    return false;
+  }
+  if (current.appId || next.appId) {
+    return current.appId === next.appId;
+  }
+  return current.gameName === next.gameName;
+}

--- a/opennow-stable/src/main/discordRpc.ts
+++ b/opennow-stable/src/main/discordRpc.ts
@@ -1,4 +1,5 @@
 import { Client } from "discord-rpc";
+import type { DiscordActivityUpdate } from "@shared/discord";
 
 /**
  * Discord Application ID for OpenNOW.
@@ -9,8 +10,12 @@ const DISCORD_CLIENT_ID = "1479944467112001669";
 
 let rpcClient: Client | null = null;
 let connected = false;
-let lastActivity: { gameName: string; startTimestamp: Date; appId?: string } | null = null;
-let pendingActivity: { gameName: string; startTimestamp: Date; appId?: string } | null = null;
+type DiscordRpcActivity = Omit<DiscordActivityUpdate, "startTimestampMs"> & {
+  startTimestamp?: Date;
+};
+
+let lastActivity: DiscordRpcActivity | null = null;
+let pendingActivity: DiscordRpcActivity | null = null;
 
 /**
  * Initialise and connect the Discord RPC client.
@@ -35,11 +40,11 @@ export async function connectDiscordRpc(): Promise<void> {
     console.log("[DiscordRPC] Connected.");
 
     if (pendingActivity) {
-      await setActivity(pendingActivity.gameName, pendingActivity.startTimestamp, pendingActivity.appId);
+      await setActivity(pendingActivity);
       // Consume reconnect replay so failed attempts are not reprocessed forever.
       pendingActivity = null;
     } else if (lastActivity) {
-      await setActivity(lastActivity.gameName, lastActivity.startTimestamp, lastActivity.appId);
+      await setActivity(lastActivity);
     } else {
       // Upon app start/connection, explicitly clear any stale status from previous runs
       await client.clearActivity().catch(() => {});
@@ -54,7 +59,7 @@ export async function connectDiscordRpc(): Promise<void> {
 /**
  * Get the currently active game name and start timestamp.
  */
-export function getCurrentActivity(): { gameName: string; startTimestamp: Date; appId?: string } | null {
+export function getCurrentActivity(): DiscordRpcActivity | null {
   return lastActivity;
 }
 
@@ -69,19 +74,33 @@ export function isDiscordRpcConnected(): boolean {
  * Update the Discord "Now Playing" activity to show the given game name and
  * how long the user has been playing.
  */
-export async function setActivity(gameName: string, startTimestamp: Date, appId?: string): Promise<void> {
-  pendingActivity = { gameName, startTimestamp, appId };
+function activityState(activity: DiscordRpcActivity): string {
+  switch (activity.kind) {
+    case "queued":
+      return activity.queuePosition ? `In queue (#${activity.queuePosition})` : "In queue";
+    case "starting":
+      return "Starting stream";
+    case "streaming":
+      return "Streaming via OpenNow";
+  }
+}
+
+export async function setActivity(activity: DiscordRpcActivity): Promise<void> {
+  pendingActivity = activity;
 
   if (!connected || !rpcClient) {
     return;
   }
 
   try {
-    await rpcClient.setActivity({
-      details: gameName,
-      state: "Streaming via OpenNow",
-      startTimestamp,
+    const rpcActivity = {
+      details: activity.gameName,
+      state: activityState(activity),
+      ...(activity.startTimestamp ? { startTimestamp: activity.startTimestamp } : {}),
       instance: false,
+    };
+    await rpcClient.setActivity({
+      ...rpcActivity,
     });
     lastActivity = pendingActivity;
     pendingActivity = null;

--- a/opennow-stable/src/main/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/gfn/cloudmatch.ts
@@ -981,13 +981,13 @@ function toOptionalString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function extractQueuePosition(payload: CloudMatchResponse): number | undefined {
-  const direct = toPositiveInt(payload.session.queuePosition);
+function extractSessionQueuePosition(session: CloudMatchResponse["session"] | GetSessionsResponse["sessions"][number]): number | undefined {
+  const direct = toPositiveInt(session.queuePosition);
   if (direct !== undefined) {
     return direct;
   }
 
-  const seatSetup = payload.session.seatSetupInfo;
+  const seatSetup = session.seatSetupInfo;
   if (seatSetup) {
     const nested = toPositiveInt(seatSetup.queuePosition);
     if (nested !== undefined) {
@@ -995,7 +995,7 @@ function extractQueuePosition(payload: CloudMatchResponse): number | undefined {
     }
   }
 
-  const nestedSessionProgress = payload.session.sessionProgress;
+  const nestedSessionProgress = session.sessionProgress;
   if (nestedSessionProgress) {
     const nested = toPositiveInt(nestedSessionProgress.queuePosition);
     if (nested !== undefined) {
@@ -1003,7 +1003,7 @@ function extractQueuePosition(payload: CloudMatchResponse): number | undefined {
     }
   }
 
-  const nestedProgressInfo = payload.session.progressInfo;
+  const nestedProgressInfo = session.progressInfo;
   if (nestedProgressInfo) {
     const nested = toPositiveInt(nestedProgressInfo.queuePosition);
     if (nested !== undefined) {
@@ -1014,12 +1014,20 @@ function extractQueuePosition(payload: CloudMatchResponse): number | undefined {
   return undefined;
 }
 
-function extractSeatSetupStep(payload: CloudMatchResponse): number | undefined {
-  const raw = payload.session.seatSetupInfo?.seatSetupStep;
+function extractQueuePosition(payload: CloudMatchResponse): number | undefined {
+  return extractSessionQueuePosition(payload.session);
+}
+
+function extractSessionSeatSetupStep(session: CloudMatchResponse["session"] | GetSessionsResponse["sessions"][number]): number | undefined {
+  const raw = session.seatSetupInfo?.seatSetupStep;
   if (typeof raw === "number" && Number.isFinite(raw)) {
     return Math.trunc(raw);
   }
   return undefined;
+}
+
+function extractSeatSetupStep(payload: CloudMatchResponse): number | undefined {
+  return extractSessionSeatSetupStep(payload.session);
 }
 
 function normalizeSessionAdInfo(ad: NonNullable<CloudMatchResponse["session"]["sessionAds"]>[number], index: number): SessionAdInfo | null {
@@ -1262,6 +1270,7 @@ interface ToSessionInfoOptions {
   payload: CloudMatchResponse;
   clientId?: string;
   deviceId?: string;
+  fallbackAppId?: string;
   /** Wire appLaunchMode sent with the request, used when the server does not echo it */
   fallbackAppLaunchMode?: number;
 }
@@ -1314,6 +1323,7 @@ async function toSessionInfo(options: ToSessionInfoOptions): Promise<SessionInfo
 
   return {
     sessionId: payload.session.sessionId,
+    appId: payload.session.sessionRequestData?.appId ?? options.fallbackAppId,
     status: payload.session.status,
     seatSetupStep,
     queuePosition,
@@ -1389,6 +1399,7 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
     payload,
     clientId,
     deviceId,
+    fallbackAppId: input.appId,
     fallbackAppLaunchMode: appLaunchModeWireValue(input.settings.appLaunchMode),
   });
 }
@@ -1688,6 +1699,8 @@ async function fetchActiveSessionsFromBase(
         enablePersistingInGameSettings,
         gpuType: s.gpuType,
         status: s.status,
+        queuePosition: extractSessionQueuePosition(s),
+        seatSetupStep: extractSessionSeatSetupStep(s),
         streamingBaseUrl: base,
         serverIp,
         signalingUrl,
@@ -1959,6 +1972,7 @@ export async function claimSession(input: SessionClaimRequest): Promise<SessionI
 
       return {
         sessionId: sessionData.sessionId,
+        appId: input.appId,
         status: sessionData.status,
         queuePosition,
         zone: "", // Zone not applicable for claimed sessions

--- a/opennow-stable/src/main/gfn/types.ts
+++ b/opennow-stable/src/main/gfn/types.ts
@@ -190,6 +190,17 @@ export interface CloudMatchResponse {
 export interface SessionEntry {
   sessionId: string;
   status: number;
+  queuePosition?: number;
+  seatSetupInfo?: {
+    seatSetupStep?: number;
+    queuePosition?: number;
+  };
+  sessionProgress?: {
+    queuePosition?: number;
+  };
+  progressInfo?: {
+    queuePosition?: number;
+  };
   gpuType?: string;
   sessionRequestData?: {
     appId?: string;

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -55,6 +55,11 @@ import {
   getCurrentActivity,
   isDiscordRpcConnected,
 } from "./discordRpc";
+import type { DiscordActivityUpdate } from "@shared/discord";
+import {
+  discordActivityFromSession,
+  isSameDiscordActivity,
+} from "./discordPresence";
 import {
   createAppUpdaterController,
   type AppUpdaterController,
@@ -386,11 +391,18 @@ class DiscordStatusMonitor {
 
       if (activeSession) {
         const sessionAppId = activeSession.appId.toString();
+        const nextActivity = discordActivityFromSession(activeSession, sessionAppId);
 
-        if (!currentActivity || currentActivity.appId !== sessionAppId) {
-          const title = sessionAppId;
-          const startTime = new Date();
-          void setActivity(title, startTime, sessionAppId);
+        if (nextActivity) {
+          if (!isSameDiscordActivity(currentActivity, nextActivity)) {
+            void setActivity({
+              ...nextActivity,
+              startTimestamp: nextActivity.startTimestampMs ? new Date(nextActivity.startTimestampMs) : undefined,
+            });
+          }
+        } else if (currentActivity?.appId === sessionAppId) {
+          console.log("[DiscordRPC] Monitor clearing non-streaming ready-session status.");
+          void clearActivity();
         }
       } else if (currentActivity) {
         console.log("[DiscordRPC] Monitor clearing stale status.");
@@ -836,6 +848,17 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(IPC_CHANNELS.DISCORD_CLEAR_ACTIVITY, async () => {
     void clearActivity();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.DISCORD_SET_ACTIVITY, async (_event, activity: DiscordActivityUpdate) => {
+    if (!settingsManager.get("discordRichPresence")) {
+      return;
+    }
+
+    void setActivity({
+      ...activity,
+      startTimestamp: activity.startTimestampMs ? new Date(activity.startTimestampMs) : undefined,
+    });
   });
 
   // Toggle fullscreen via IPC (for completeness)

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -57,8 +57,7 @@ import {
 } from "./discordRpc";
 import type { DiscordActivityUpdate } from "@shared/discord";
 import {
-  discordActivityFromSession,
-  isSameDiscordActivity,
+  discordMonitorActivityDecision,
 } from "./discordPresence";
 import {
   createAppUpdaterController,
@@ -388,23 +387,14 @@ class DiscordStatusMonitor {
         [1, 2, 3].includes(s.status),
       );
       const currentActivity = getCurrentActivity();
+      const decision = discordMonitorActivityDecision(currentActivity, activeSession ?? null);
 
-      if (activeSession) {
-        const sessionAppId = activeSession.appId.toString();
-        const nextActivity = discordActivityFromSession(activeSession, sessionAppId);
-
-        if (nextActivity) {
-          if (!isSameDiscordActivity(currentActivity, nextActivity)) {
-            void setActivity({
-              ...nextActivity,
-              startTimestamp: nextActivity.startTimestampMs ? new Date(nextActivity.startTimestampMs) : undefined,
-            });
-          }
-        } else if (currentActivity?.appId === sessionAppId) {
-          console.log("[DiscordRPC] Monitor clearing non-streaming ready-session status.");
-          void clearActivity();
-        }
-      } else if (currentActivity) {
+      if (decision.action === "set") {
+        void setActivity({
+          ...decision.activity,
+          startTimestamp: decision.startTimestamp,
+        });
+      } else if (decision.action === "clear") {
         console.log("[DiscordRPC] Monitor clearing stale status.");
         void clearActivity();
       }

--- a/opennow-stable/src/main/ipc/sessionHandlers.ts
+++ b/opennow-stable/src/main/ipc/sessionHandlers.ts
@@ -36,13 +36,15 @@ import {
   selectLaunchingSession,
   selectReadySessionToClaim,
 } from "../session/sessionSelection";
+import { discordActivityFromSession } from "../discordPresence";
+import type { DiscordActivityUpdate } from "@shared/discord";
 
 export interface SessionIpcHandlerDeps extends SessionConflictDialogDeps {
   ipcMain: IpcMain;
   authService: AuthService;
   settingsManager: SettingsManager;
   resolveJwt(token?: string): Promise<string>;
-  setActivity(gameName: string, startTimestamp: Date, appId?: string): Promise<void>;
+  setActivity(activity: Omit<DiscordActivityUpdate, "startTimestampMs"> & { startTimestamp?: Date }): Promise<void>;
   clearActivity(): Promise<void>;
 }
 
@@ -55,6 +57,19 @@ export function registerSessionIpcHandlers(deps: SessionIpcHandlerDeps): void {
     setActivity,
     clearActivity,
   } = deps;
+
+  const setLaunchPresence = (session: SessionInfo, gameName: string): void => {
+    const activity = discordActivityFromSession(session, gameName);
+    if (!settingsManager.get("discordRichPresence") || !activity) {
+      return;
+    }
+
+    void setActivity({
+      ...activity,
+      kind: activity.kind === "streaming" ? "starting" : activity.kind,
+      startTimestamp: undefined,
+    });
+  };
 
   ipcMain.handle(
     IPC_CHANNELS.CREATE_SESSION,
@@ -146,6 +161,7 @@ export function registerSessionIpcHandlers(deps: SessionIpcHandlerDeps): void {
               );
               return {
                 sessionId: launchingCandidate.sessionId,
+                appId: launchingCandidate.appId.toString(),
                 status: 1,
                 zone: resolvedPayload.zone,
                 streamingBaseUrl,
@@ -171,13 +187,7 @@ export function registerSessionIpcHandlers(deps: SessionIpcHandlerDeps): void {
       if (!forceNewSession) {
         const preChecked = await tryClaimExisting();
         if (preChecked) {
-          if (settingsManager.get("discordRichPresence")) {
-            void setActivity(
-              payload.internalTitle || payload.appId,
-              new Date(),
-              payload.appId,
-            );
-          }
+          setLaunchPresence(preChecked, payload.internalTitle || payload.appId);
           return preChecked;
         }
       }
@@ -196,13 +206,7 @@ export function registerSessionIpcHandlers(deps: SessionIpcHandlerDeps): void {
           token,
           streamingBaseUrl,
         });
-        if (settingsManager.get("discordRichPresence")) {
-          void setActivity(
-            payload.internalTitle || payload.appId,
-            new Date(),
-            payload.appId,
-          );
-        }
+        setLaunchPresence(sessionResult, payload.internalTitle || payload.appId);
         return sessionResult;
       } catch (error) {
         if (
@@ -215,13 +219,7 @@ export function registerSessionIpcHandlers(deps: SessionIpcHandlerDeps): void {
           );
           const fallback = await tryClaimExisting();
           if (fallback) {
-            if (settingsManager.get("discordRichPresence")) {
-              void setActivity(
-                payload.internalTitle || payload.appId,
-                new Date(),
-                payload.appId,
-              );
-            }
+            setLaunchPresence(fallback, payload.internalTitle || payload.appId);
             return fallback;
           }
         }

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -54,6 +54,7 @@ import type {
   GameAccountConnectionsResult,
   GameAccountOperationResult,
 } from "@shared/gfn";
+import type { DiscordActivityUpdate } from "@shared/discord";
 import { parseSerializedSessionErrorTransport } from "@shared/sessionError";
 
 const { contextBridge, ipcRenderer } = electron;
@@ -257,6 +258,8 @@ const api: OpenNowApi = {
   fetchPrintedWasteServerMapping: (): Promise<PrintedWasteServerMapping> =>
     ipcRenderer.invoke(IPC_CHANNELS.PRINTEDWASTE_SERVER_MAPPING_FETCH),
   getThanksData: (): Promise<ThankYouDataResult> => ipcRenderer.invoke(IPC_CHANNELS.COMMUNITY_GET_THANKS),
+  setDiscordActivity: (input: DiscordActivityUpdate): Promise<void> =>
+    ipcRenderer.invoke(IPC_CHANNELS.DISCORD_SET_ACTIVITY, input),
   clearDiscordActivity: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.DISCORD_CLEAR_ACTIVITY),
   getReleaseHighlights: (version?: string): Promise<import("@shared/gfn").ReleaseHighlightsPayload> =>
     ipcRenderer.invoke(IPC_CHANNELS.RELEASE_HIGHLIGHTS_GET, version),

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -698,6 +698,7 @@ export function App(): JSX.Element {
   /** Joins concurrent claim/resume calls for the same Cloud session id (single CloudMatch RESUME + signaling). */
   const claimResumePromisesRef = useRef<Map<string, Promise<void>>>(new Map());
   const launchAbortRef = useRef(false);
+  const discordStreamingActivitySessionRef = useRef<string | null>(null);
   const streamStatusRef = useRef<StreamStatus>(streamStatus);
   const nativeInputProtocolVersionRef = useRef<number | null>(null);
   const stableRecoveryResetTimerRef = useRef<number | null>(null);
@@ -784,6 +785,7 @@ export function App(): JSX.Element {
     hasConfirmedRemoteIceRef.current = false;
     latestIceConnectionStateRef.current = "new";
     pendingControlledDisconnectsRef.current = 0;
+    discordStreamingActivitySessionRef.current = null;
     signalingRecoveryRef.current.attemptCount = 0;
     signalingRecoveryRef.current.inFlight = null;
     signalingRecoveryRef.current.appId = null;
@@ -813,6 +815,26 @@ export function App(): JSX.Element {
     runtimeSnapshotRef.current = null;
     clearRuntimeSnapshot();
   }, [diagnosticsStore, resetStatsOverlayToPreference, settings.discordRichPresence]);
+
+  const markDiscordStreamStarted = useCallback((): void => {
+    if (!settings.discordRichPresence) {
+      return;
+    }
+
+    const activeSession = sessionRef.current;
+    if (!activeSession || discordStreamingActivitySessionRef.current === activeSession.sessionId) {
+      return;
+    }
+
+    const gameName = (streamingGameRef.current?.title || activeSession.appId || "Game").trim();
+    discordStreamingActivitySessionRef.current = activeSession.sessionId;
+    void window.openNow.setDiscordActivity({
+      gameName,
+      kind: "streaming",
+      appId: activeSession.appId,
+      startTimestampMs: Date.now(),
+    });
+  }, [settings.discordRichPresence]);
 
   // Console shell is active when the user enabled Controller Mode or the app was
   // launched with a direct-launch argument (frontend / big picture usage).
@@ -3038,6 +3060,7 @@ export function App(): JSX.Element {
       });
       setLaunchError(null);
       setStreamStatus("streaming");
+      markDiscordStreamStarted();
       scheduleStableRecoveryReset(activeSession.sessionId);
     };
 
@@ -3106,6 +3129,7 @@ export function App(): JSX.Element {
             });
             setLaunchError(null);
             setStreamStatus("streaming");
+            markDiscordStreamStarted();
             scheduleStableRecoveryReset(activeSession.sessionId);
             console.log(
               "[Stream] Offer applied; use [WebRTC] logs for ICE/video dimensions. signalingServer=%s media=%s",
@@ -3315,7 +3339,7 @@ export function App(): JSX.Element {
     });
 
     return () => unsubscribe();
-  }, [attemptSessionRecovery, diagnosticsStore, handleExpectedNativeSessionClose, nativeInputBridgeReady, refreshNavbarActiveSession, resetLaunchRuntime, scheduleStableRecoveryReset, settings, streamMicLevel, streamVolume, t]);
+  }, [attemptSessionRecovery, diagnosticsStore, handleExpectedNativeSessionClose, markDiscordStreamStarted, nativeInputBridgeReady, refreshNavbarActiveSession, resetLaunchRuntime, scheduleStableRecoveryReset, settings, streamMicLevel, streamVolume, t]);
 
   // Play game handler
   const handlePlayGame = useCallback(async (game: GameInfo, options?: { bypassGuards?: boolean; streamingBaseUrl?: string; variantId?: string }) => {

--- a/opennow-stable/src/renderer/src/lib/queueAds.ts
+++ b/opennow-stable/src/renderer/src/lib/queueAds.ts
@@ -127,12 +127,14 @@ export function mergeAdState(
 export function mergePolledSessionState(previous: SessionInfo, next: SessionInfo): SessionInfo {
   // Poll responses may omit the echoed appLaunchMode; keep the session-stable value.
   const appLaunchMode = next.appLaunchMode ?? previous.appLaunchMode;
+  const appId = next.appId ?? previous.appId;
   if (isSessionReadyForConnect(next.status)) {
-    return { ...next, appLaunchMode };
+    return { ...next, appId, appLaunchMode };
   }
 
   return {
     ...next,
+    appId,
     appLaunchMode,
     adState: mergeAdState(previous.adState, next.adState),
     mediaConnectionInfo: next.mediaConnectionInfo ?? previous.mediaConnectionInfo,

--- a/opennow-stable/src/renderer/src/lib/sessionState.ts
+++ b/opennow-stable/src/renderer/src/lib/sessionState.ts
@@ -1,4 +1,9 @@
-import type { GameInfo, SessionInfo } from "@shared/gfn";
+import {
+  isGfnSessionInQueue,
+  isSessionReadyForConnectStatus,
+  type GameInfo,
+  type SessionInfo,
+} from "@shared/gfn";
 
 import type { LaunchErrorState, StreamLoadingStatus, StreamStatus } from "./appTypes";
 
@@ -10,16 +15,11 @@ const GFN_USER_STORAGE_NOT_AVAILABLE_CODE = 3237093721;
 const GFN_STORAGE_NOT_AVAILABLE_CODE = 3237093722;
 
 export function isSessionReadyForConnect(status: number): boolean {
-  return status === 2 || status === 3;
+  return isSessionReadyForConnectStatus(status);
 }
 
 export function isSessionInQueue(session: SessionInfo): boolean {
-  // Official client treats seat setup step 1 as queue state even when queuePosition reaches 1.
-  // Fallback to queuePosition-based inference for payloads that do not expose seatSetupStep.
-  if (session.seatSetupStep === 1) {
-    return true;
-  }
-  return (session.queuePosition ?? 0) > 1;
+  return isGfnSessionInQueue(session);
 }
 
 export function isSessionLimitError(error: unknown): boolean {

--- a/opennow-stable/src/shared/discord.ts
+++ b/opennow-stable/src/shared/discord.ts
@@ -1,0 +1,9 @@
+export type DiscordActivityKind = "queued" | "starting" | "streaming";
+
+export interface DiscordActivityUpdate {
+  gameName: string;
+  kind: DiscordActivityKind;
+  appId?: string;
+  queuePosition?: number;
+  startTimestampMs?: number;
+}

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -1210,6 +1210,7 @@ export function getSessionAdDurationMs(ad: SessionAdInfo | undefined): number | 
 
 export interface SessionInfo {
   sessionId: string;
+  appId?: string;
   status: number;
   queuePosition?: number;
   seatSetupStep?: number;
@@ -1243,11 +1244,30 @@ export interface ActiveSessionInfo {
   enablePersistingInGameSettings?: boolean;
   gpuType?: string;
   status: number;
+  queuePosition?: number;
+  seatSetupStep?: number;
   streamingBaseUrl?: string;
   serverIp?: string;
   signalingUrl?: string;
   resolution?: string;
   fps?: number;
+}
+
+export interface GfnSessionQueueState {
+  status: number;
+  queuePosition?: number;
+  seatSetupStep?: number;
+}
+
+export function isSessionReadyForConnectStatus(status: number): boolean {
+  return status === 2 || status === 3;
+}
+
+export function isGfnSessionInQueue(session: GfnSessionQueueState): boolean {
+  if (session.seatSetupStep === 1) {
+    return true;
+  }
+  return (session.queuePosition ?? 0) > 1;
 }
 
 /** Request to claim/resume an existing session */
@@ -1633,6 +1653,8 @@ export interface OpenNowApi {
   /** Fetch PrintedWaste server mapping metadata (includes nuked status) */
   fetchPrintedWasteServerMapping(): Promise<PrintedWasteServerMapping>;
   getThanksData(): Promise<ThankYouDataResult>;
+  /** Set Discord rich presence activity */
+  setDiscordActivity(input: import("./discord").DiscordActivityUpdate): Promise<void>;
   /** Clear Discord rich presence activity */
   clearDiscordActivity(): Promise<void>;
 

--- a/opennow-stable/src/shared/ipc.ts
+++ b/opennow-stable/src/shared/ipc.ts
@@ -96,6 +96,7 @@ export const IPC_CHANNELS = {
   PRINTEDWASTE_QUEUE_FETCH: "printedwaste:queue-fetch",
   PRINTEDWASTE_SERVER_MAPPING_FETCH: "printedwaste:server-mapping-fetch",
   // Discord Rich Presence
+  DISCORD_SET_ACTIVITY: "discord:set-activity",
   DISCORD_CLEAR_ACTIVITY: "discord:clear-activity",
   // Release highlights (What's new)
   RELEASE_HIGHLIGHTS_GET: "release-highlights:get",


### PR DESCRIPTION
Introduces distinct Discord Rich Presence states for queued and launching sessions rather than showing "Streaming" immediately. Presence now maps GFN session status (`1` = queued, `2` = starting, `3` = streaming) to appropriate Discord states, includes queue position when available, and resets the elapsed timestamp only when the stream actually starts. Background session monitoring uses the same mapping. Adds unit tests for status-to-presence logic.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/80dcd188-fffb-424a-a43b-2003bb22db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-258" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/80dcd188-fffb-424a-a43b-2003bb22db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-258&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-258"><img alt="OPE-258" src="https://capy.ai/api/badge/thread.svg?label=OPE-258"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-focused Discord and session metadata changes with unit tests; no auth or payment paths touched.
> 
> **Overview**
> **Discord Rich Presence** now reflects GFN session lifecycle instead of showing “streaming” as soon as a session exists. New mapping turns status **1 → queued** (with optional queue position in the state line), **2 → starting**, and **3 → streaming**, and only attaches a **start timestamp** when playback actually begins.
> 
> Session create/resume sets presence via shared `discordPresence` helpers (launch paths downgrade status 3 to **starting** and omit the timer). The renderer calls **`setDiscordActivity`** when the stream goes live; the main-process monitor and **`setActivity`** API use the same shape and **`isSameDiscordActivity`** to avoid noisy RPC updates.
> 
> **CloudMatch** enriches **`SessionInfo` / active sessions** with **`appId`**, **`queuePosition`**, and **`seatSetupStep`** (including from list-session payloads), and queue detection is centralized in **`@shared/gfn`** for presence and UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac792367dfd1f29320b964fb707b4f7c7efb103c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->