### PR TITLE
Add mouse fallback for controller bottom hints

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -4606,6 +4606,7 @@ export function App(): JSX.Element {
             gameTitle={streamingGame?.title ?? t("app.labels.game")}
             gameCover={streamingGame?.imageUrl}
             platformStore={streamingStore ?? undefined}
+            controllerMode={effectiveControllerMode}
             status={loadingStatus}
             queuePosition={queuePosition}
             adState={effectiveAdState}
@@ -4750,17 +4751,19 @@ export function App(): JSX.Element {
         onExitComplete={handleSettingsExitComplete}
       >
         {settingsMounted && (
-          <SettingsPage
-            settings={settings}
-            regions={regions}
-            codecResults={codecResults}
-            codecTesting={codecTesting}
-            onRunCodecTest={runCodecTest}
-            onSettingChange={updateSetting}
-            onClose={handleCloseSettings}
-            focusSection={settingsFocusSection}
-            onOpenWhatsNew={handleOpenWhatsNew}
-          />
+            <SettingsPage
+              settings={settings}
+              regions={regions}
+              codecResults={codecResults}
+              codecTesting={codecTesting}
+              onRunCodecTest={runCodecTest}
+              onSettingChange={updateSetting}
+              onClose={handleCloseSettings}
+              returnPageLabel={pageBeforeSettings === "home" ? t("navigation.home") : t("navigation.library")}
+              controllerMode={effectiveControllerMode}
+              focusSection={settingsFocusSection}
+              onOpenWhatsNew={handleOpenWhatsNew}
+            />
         )}
       </SettingsModalHost>
       {logoutConfirmModal}

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -462,6 +462,7 @@ export const HomePage = memo(function HomePage({
       if (pressed & controllerButton.leftShoulder) onPreviousControllerPage?.();
       if (pressed & controllerButton.rightShoulder) onNextControllerPage?.();
       if (pressed & controllerButton.menu) onNextControllerPage?.();
+      if (pressed & controllerButton.north) cycleControllerVariant();
       if (pressed & controllerButton.up) focusControllerTile(rowIndex - 1, columnIndex);
       if (pressed & controllerButton.down) focusControllerTile(rowIndex + 1, columnIndex);
       if (pressed & controllerButton.left) focusControllerTile(rowIndex, columnIndex - 1);
@@ -650,7 +651,7 @@ export const HomePage = memo(function HomePage({
               ))}
             </div>
 
-            <div className="controller-bottom-hints" aria-hidden="true">
+            <div className="controller-bottom-hints">
               <button type="button" className="controller-hint controller-hint--a" onClick={launchFocusedTile}>
                 <span className="controller-button controller-button--a">A</span>
                 <span>{t("app.actions.select")}</span>

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -461,7 +461,7 @@ export const HomePage = memo(function HomePage({
       if (pressed & controllerButton.west) setControllerSearchOpen(true);
       if (pressed & controllerButton.leftShoulder) onPreviousControllerPage?.();
       if (pressed & controllerButton.rightShoulder) onNextControllerPage?.();
-      if (pressed & controllerButton.menu) cycleControllerVariant();
+      if (pressed & controllerButton.menu) onNextControllerPage?.();
       if (pressed & controllerButton.up) focusControllerTile(rowIndex - 1, columnIndex);
       if (pressed & controllerButton.down) focusControllerTile(rowIndex + 1, columnIndex);
       if (pressed & controllerButton.left) focusControllerTile(rowIndex, columnIndex - 1);
@@ -655,7 +655,7 @@ export const HomePage = memo(function HomePage({
                 <span className="controller-button controller-button--a">A</span>
                 <span>{t("app.actions.select")}</span>
               </button>
-              <button type="button" className="controller-hint controller-hint--b" onClick={onPreviousControllerPage}>
+              <button type="button" className="controller-hint controller-hint--b" onClick={() => onPreviousControllerPage?.()}>
                 <span className="controller-button controller-button--b">B</span>
                 <span>{t("app.actions.back")}</span>
               </button>
@@ -667,7 +667,7 @@ export const HomePage = memo(function HomePage({
                 <span className="controller-button controller-button--x">X</span>
                 <span>{t("app.actions.search")}</span>
               </button>
-              <button type="button" className="controller-hint controller-hint--more" onClick={() => alert('More Options')}>
+              <button type="button" className="controller-hint controller-hint--more" onClick={() => onNextControllerPage?.()}>
                 <span className="controller-menu-button"><Menu size={22} /></span>
                 <span>{t("library.moreOptions")}</span>
               </button>
@@ -701,7 +701,11 @@ export const HomePage = memo(function HomePage({
                     placeholder={t("home.searchPlaceholder")}
                     className="controller-search-input"
                   />
-                  <p>{t("app.actions.back")}</p>
+                  <div className="controller-search-actions">
+                    <button type="button" className="controller-secondary-action" onClick={() => setControllerSearchOpen(false)}>
+                      {t("app.actions.back")}
+                    </button>
+                  </div>
                   </m.div>
                 </m.div>
               )}

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -651,10 +651,26 @@ export const HomePage = memo(function HomePage({
             </div>
 
             <div className="controller-bottom-hints" aria-hidden="true">
-              <div className="controller-hint"><span className="controller-button controller-button--a">A</span><span>{t("app.actions.select")}</span></div>
-              <div className="controller-hint"><span className="controller-button controller-button--b">B</span><span>{t("app.actions.back")}</span></div>
-              <div className="controller-hint"><span className="controller-button controller-button--x">X</span><span>{t("app.actions.search")}</span></div>
-              <div className="controller-hint controller-hint--more"><span className="controller-menu-button"><Menu size={22} /></span><span>{t("library.moreOptions")}</span></div>
+              <button type="button" className="controller-hint controller-hint--a" onClick={launchFocusedTile}>
+                <span className="controller-button controller-button--a">A</span>
+                <span>{t("app.actions.select")}</span>
+              </button>
+              <button type="button" className="controller-hint controller-hint--b" onClick={onPreviousControllerPage}>
+                <span className="controller-button controller-button--b">B</span>
+                <span>{t("app.actions.back")}</span>
+              </button>
+              <button type="button" className="controller-hint" onClick={cycleFocusedVariant}>
+                <span className="controller-button controller-button--y">Y</span>
+                <span>{t("library.filter")}</span>
+              </button>
+              <button type="button" className="controller-hint controller-hint--x" onClick={() => setControllerSearchOpen(true)}>
+                <span className="controller-button controller-button--x">X</span>
+                <span>{t("app.actions.search")}</span>
+              </button>
+              <button type="button" className="controller-hint controller-hint--more" onClick={() => alert('More Options')}>
+                <span className="controller-menu-button"><Menu size={22} /></span>
+                <span>{t("library.moreOptions")}</span>
+              </button>
             </div>
 
             <AnimatePresence initial={false}>

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -955,11 +955,26 @@ export const LibraryPage = memo(function LibraryPage({
             </section>
 
             <div className="controller-bottom-hints" aria-hidden="true">
-              <div className="controller-hint"><span className="controller-button controller-button--a">A</span><span>{t("app.actions.select")}</span></div>
-              <div className="controller-hint"><span className="controller-button controller-button--b">B</span><span>{t("app.actions.back")}</span></div>
-              <div className="controller-hint"><span className="controller-button controller-button--y">Y</span><span>{t("library.filter")}</span></div>
-              <div className="controller-hint"><span className="controller-button controller-button--x">X</span><span>{t("app.actions.search")}</span></div>
-              <div className="controller-hint controller-hint--more"><span className="controller-menu-button"><Menu size={22} /></span><span>{t("library.moreOptions")}</span></div>
+              <button type="button" className="controller-hint controller-hint--a" onClick={() => onPlayGame(selectedControllerGame ?? controllerGames[0])}>
+                <span className="controller-button controller-button--a">A</span>
+                <span>{t("app.actions.select")}</span>
+              </button>
+              <button type="button" className="controller-hint" onClick={() => setDetailsGame(null)}>
+                <span className="controller-button controller-button--b">B</span>
+                <span>{t("app.actions.back")}</span>
+              </button>
+              <button type="button" className="controller-hint" onClick={cycleSelectedVariant}>
+                <span className="controller-button controller-button--y">Y</span>
+                <span>{t("library.filter")}</span>
+              </button>
+              <button type="button" className="controller-hint controller-hint--x" onClick={() => setControllerSearchOpen(true)}>
+                <span className="controller-button controller-button--x">X</span>
+                <span>{t("app.actions.search")}</span>
+              </button>
+              <button type="button" className="controller-hint controller-hint--more" onClick={() => alert('More Options')}>
+                <span className="controller-menu-button"><Menu size={22} /></span>
+                <span>{t("library.moreOptions")}</span>
+              </button>
             </div>
 
             <AnimatePresence initial={false}>

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -959,11 +959,27 @@ export const LibraryPage = memo(function LibraryPage({
                 <span className="controller-button controller-button--a">A</span>
                 <span>{t("app.actions.select")}</span>
               </button>
-              <button type="button" className="controller-hint" onClick={() => setDetailsGame(null)}>
+              <button type="button" className="controller-hint controller-hint--b" onClick={() => {
+                if (detailsGame) {
+                  setDetailsGame(null);
+                } else if (controllerStoreFilterOpen) {
+                  setControllerStoreFilterOpen(false);
+                } else {
+                  onPreviousControllerPage?.();
+                }
+              }}>
                 <span className="controller-button controller-button--b">B</span>
                 <span>{t("app.actions.back")}</span>
               </button>
-              <button type="button" className="controller-hint" onClick={cycleSelectedVariant}>
+              <button type="button" className="controller-hint" onClick={() => {
+                const index = controllerStoreFilterItems.findIndex(item => item.id === controllerStoreFilterId);
+                const next = (index + 1) % controllerStoreFilterItems.length;
+                const item = controllerStoreFilterItems[next];
+                if (item) {
+                  setFocusedControllerStoreFilterIndex(next);
+                  setControllerStoreFilterId(item.id);
+                }
+              }}>
                 <span className="controller-button controller-button--y">Y</span>
                 <span>{t("library.filter")}</span>
               </button>
@@ -971,7 +987,9 @@ export const LibraryPage = memo(function LibraryPage({
                 <span className="controller-button controller-button--x">X</span>
                 <span>{t("app.actions.search")}</span>
               </button>
-              <button type="button" className="controller-hint controller-hint--more" onClick={() => alert('More Options')}>
+              <button type="button" className="controller-hint controller-hint--more" onClick={() => {
+                if (selectedControllerGame) setDetailsGame(selectedControllerGame);
+              }}>
                 <span className="controller-menu-button"><Menu size={22} /></span>
                 <span>{t("library.moreOptions")}</span>
               </button>
@@ -1048,7 +1066,11 @@ export const LibraryPage = memo(function LibraryPage({
                     placeholder={t("library.searchPlaceholder")}
                     className="controller-search-input"
                   />
-                  <p>{t("app.actions.back")}</p>
+                  <div className="controller-search-actions">
+                    <button type="button" className="controller-secondary-action" onClick={() => setControllerSearchOpen(false)}>
+                      {t("app.actions.back")}
+                    </button>
+                  </div>
                   </m.div>
                 </m.div>
               )}

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -42,6 +42,7 @@ import { formatShortcutForDisplay, normalizeShortcut, shortcutFromKeyboardEvent 
 import { getCodecDecodeBadgeState, shouldShowLinuxHardwareCodecHint, type CodecTestResult } from "../lib/codecDiagnostics";
 import { getAccentColorOption, getAccentColorOptions } from "../lib/uiCustomization";
 import { useTranslation } from "../i18n";
+import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
 import {
   clearStoredRegionPingResults,
   loadStoredRegionPingResults,
@@ -57,6 +58,8 @@ interface SettingsPageProps {
   onRunCodecTest: () => Promise<void>;
   onSettingChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
   onClose: () => void;
+  returnPageLabel: string;
+  controllerMode?: boolean;
   focusSection?: SettingsSectionId;
   /** Called when the user clicks "What's new" in the About section */
   onOpenWhatsNew?: () => void;
@@ -716,7 +719,19 @@ function saveCachedEntitledResolutions(cache: EntitledResolutionsCache): void {
 
 /* ── Component ────────────────────────────────────────────────────── */
 
-export function SettingsPage({ settings, regions, onSettingChange, codecResults, codecTesting, onRunCodecTest, onClose, focusSection, onOpenWhatsNew }: SettingsPageProps): JSX.Element {
+export function SettingsPage({
+  settings,
+  regions,
+  onSettingChange,
+  codecResults,
+  codecTesting,
+  onRunCodecTest,
+  onClose,
+  returnPageLabel,
+  controllerMode = false,
+  focusSection,
+  onOpenWhatsNew,
+}: SettingsPageProps): JSX.Element {
   const { locale, availableLocales, setLocale, t } = useTranslation();
   const [savedIndicator, setSavedIndicator] = useState(false);
   const [activeSection, setActiveSection] = useState<SettingsSectionId>("stream");
@@ -2412,6 +2427,33 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
     };
   }, [nativeStreamerEnablePromptVisible, onClose, zortosCommunityProxyPromptVisible]);
 
+  useEffect(() => {
+    if (!controllerMode) return;
+
+    let frameId: number | null = null;
+    const readButtons = (): number => {
+      const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
+      return readControllerGamepadButtons(pad);
+    };
+
+    const handleFrame = () => {
+      if (!nativeStreamerEnablePromptVisible && !zortosCommunityProxyPromptVisible) {
+        const buttons = readButtons();
+        if (buttons & controllerButton.west) {
+          onClose();
+        }
+      }
+      frameId = window.requestAnimationFrame(handleFrame);
+    };
+
+    frameId = window.requestAnimationFrame(handleFrame);
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [controllerMode, nativeStreamerEnablePromptVisible, onClose, zortosCommunityProxyPromptVisible]);
+
   return (
     <>
         <header className="settings-modal-header">
@@ -2469,6 +2511,14 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
               ))}
             </div>
           ))}
+        </div>
+        <div className="settings-sidebar-footer">
+          <span className="settings-footer-kicker">{t("settings.backTo")}</span>
+          <button type="button" className="settings-back-btn" onClick={onClose}>
+            <span className="controller-button controller-button--x">X</span>
+            <span>{t("app.actions.cancel")}</span>
+          </button>
+          <span className="settings-footer-destination">{returnPageLabel}</span>
         </div>
       </nav>
 
@@ -4680,7 +4730,8 @@ export function SettingsPage({ settings, regions, onSettingChange, codecResults,
           </>
         )}
       </div>
-        </div>
+
+      </div>
 
       {nativeStreamerEnablePromptVisible && (
         <div

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -2431,6 +2431,7 @@ export function SettingsPage({
     if (!controllerMode) return;
 
     let frameId: number | null = null;
+    let previousButtons = 0;
     const readButtons = (): number => {
       const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
       return readControllerGamepadButtons(pad);
@@ -2439,9 +2440,11 @@ export function SettingsPage({
     const handleFrame = () => {
       if (!nativeStreamerEnablePromptVisible && !zortosCommunityProxyPromptVisible) {
         const buttons = readButtons();
-        if (buttons & controllerButton.west) {
+        const pressed = buttons & ~previousButtons;
+        if (pressed & controllerButton.west) {
           onClose();
         }
+        previousButtons = buttons;
       }
       frameId = window.requestAnimationFrame(handleFrame);
     };
@@ -2515,7 +2518,11 @@ export function SettingsPage({
         <div className="settings-sidebar-footer">
           <span className="settings-footer-kicker">{t("settings.backTo")}</span>
           <button type="button" className="settings-back-btn" onClick={onClose}>
-            <span className="controller-button controller-button--x">X</span>
+            {controllerMode ? (
+              <span className="controller-button controller-button--x">X</span>
+            ) : (
+              <X size={18} />
+            )}
             <span>{t("app.actions.cancel")}</span>
           </button>
           <span className="settings-footer-destination">{returnPageLabel}</span>

--- a/opennow-stable/src/renderer/src/components/StreamLoading.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamLoading.tsx
@@ -1,4 +1,5 @@
 import { Loader2, Monitor, Cpu, Wifi, X, XCircle } from "lucide-react";
+import { useEffect } from "react";
 import type { JSX, Ref } from "react";
 import {
   getPreferredSessionAdMediaUrl,
@@ -13,6 +14,7 @@ import type { SessionAdInfo, SessionAdState } from "@shared/gfn";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { QueueAdPreview, type QueueAdPlaybackEvent, type QueueAdPreviewHandle } from "./QueueAdPreview";
 import { useTranslation } from "../i18n";
+import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
 
 type TranslateFunction = typeof import("../i18n").t;
 
@@ -20,6 +22,7 @@ export interface StreamLoadingProps {
   gameTitle: string;
   gameCover?: string;
   platformStore?: string;
+  controllerMode?: boolean;
   status: "queue" | "setup" | "starting" | "connecting";
   queuePosition?: number;
   estimatedWait?: string;
@@ -106,6 +109,7 @@ export function StreamLoading({
   gameTitle,
   gameCover,
   platformStore,
+  controllerMode = false,
   status,
   queuePosition,
   estimatedWait,
@@ -129,6 +133,49 @@ export function StreamLoading({
   const activeAdDurationMs = getSessionAdDurationMs(activeAd);
   const activeAdDurationSeconds = activeAdDurationMs ? Math.round(activeAdDurationMs / 1000) : undefined;
   const gracePeriodSeconds = getSessionAdGracePeriodSeconds(adState);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onCancel]);
+
+  useEffect(() => {
+    if (!controllerMode) return;
+
+    let frameId: number | null = null;
+    let previousButtons = 0;
+
+    const readButtons = (): number => {
+      const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
+      return readControllerGamepadButtons(pad);
+    };
+
+    const handleFrame = () => {
+      const buttons = readButtons();
+      const pressed = buttons & ~previousButtons;
+      if (pressed & controllerButton.west) {
+        onCancel();
+      }
+      previousButtons = buttons;
+      frameId = window.requestAnimationFrame(handleFrame);
+    };
+
+    frameId = window.requestAnimationFrame(handleFrame);
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [controllerMode, onCancel]);
 
   return (
     <div className={`sload${hasError ? " sload--error" : ""}`}>
@@ -238,7 +285,11 @@ export function StreamLoading({
             </button>
           )}
           <button className="sload-cancel" onClick={onCancel} aria-label={t("streamLoading.actions.cancelLoading")}>
-            <X size={16} />
+            {controllerMode && !hasError ? (
+              <span className="controller-button controller-button--x">X</span>
+            ) : (
+              <X size={16} />
+            )}
             <span>{hasError ? t("app.actions.close") : t("app.actions.cancel")}</span>
           </button>
         </div>

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -2069,8 +2069,7 @@ body,
 
 .controller-store-hero,
 .controller-store-sections,
-.controller-store-empty,
-.controller-store-page .controller-bottom-hints {
+.controller-store-empty {
   position: relative;
   z-index: 1;
 }
@@ -2131,6 +2130,7 @@ body,
   flex-direction: column;
   gap: clamp(24px, 3.1vh, 46px);
   margin-top: clamp(28px, 3.4vh, 58px);
+  margin-bottom: clamp(48px, 9vh, 114px);
 }
 
 .controller-store-section {
@@ -3573,9 +3573,8 @@ body,
   display: flex;
   align-items: center;
   gap: clamp(18px, 2.4vw, 74px);
-  pointer-events: none;
+  pointer-events: auto;
 }
-
 .controller-hint {
   display: inline-flex;
   align-items: center;
@@ -3584,6 +3583,20 @@ body,
   font-size: clamp(0.76rem, 0.68vw, 1.05rem);
   font-weight: 850;
   white-space: nowrap;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 6px 10px;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+}
+.controller-hint:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.24);
+}
+.controller-hint:active {
+  transform: scale(0.97);
+  background: rgba(255, 255, 255, 0.18);
 }
 
 .controller-hint--more {
@@ -3621,7 +3634,7 @@ body,
 .controller-search-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2190;
+  z-index: 1010;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3681,6 +3694,16 @@ body,
 
 .controller-search-input:focus {
   box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.2);
+}
+
+.controller-search-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 18px;
+}
+
+.controller-search-actions .controller-secondary-action {
+  min-width: 132px;
 }
 
 .controller-store-filter-options {
@@ -4556,6 +4579,30 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   gap: 14px;
+}
+
+.settings-sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 14px;
+  border-top: 1px solid var(--panel-border);
+}
+
+.settings-sidebar-footer .settings-footer-kicker {
+  color: var(--ink-muted);
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-footer-destination {
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.3;
 }
 
 .settings-nav-group {
@@ -6513,7 +6560,66 @@ button.game-card-store-chip.owned.active:hover {
 /* Footer */
 .settings-footer {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 22px 20px;
+  border-top: 1px solid var(--panel-border);
+  flex-shrink: 0;
+}
+
+.settings-footer-context {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.settings-footer-kicker {
+  color: var(--ink-muted);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-footer-context strong {
+  color: var(--ink);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.settings-back-btn {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 14px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-c));
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--panel-border-solid));
+  border-radius: var(--r-sm);
+  color: var(--ink);
+  font-size: 0.92rem;
+  font-weight: 700;
+  font-family: inherit;
+  cursor: pointer;
+  transition: transform var(--t-normal), background var(--t-normal), border-color var(--t-normal), color var(--t-normal);
+}
+
+.settings-back-btn svg {
+  flex-shrink: 0;
+}
+
+.settings-back-btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 12%, var(--card-hover));
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--panel-border-solid));
+}
+
+.settings-back-btn:active {
+  transform: translateY(0);
 }
 
 .settings-save-btn {

--- a/opennow-stable/src/renderer/src/utils/controllerGamepad.ts
+++ b/opennow-stable/src/renderer/src/utils/controllerGamepad.ts
@@ -14,17 +14,19 @@ export const controllerButton = {
 
 export function readControllerGamepadButtons(pad: Gamepad | undefined): number {
   if (!pad) return 0;
-  let buttons = 0;
-  if (pad.buttons[0]?.pressed) buttons |= controllerButton.south;
-  if (pad.buttons[1]?.pressed) buttons |= controllerButton.east;
-  if (pad.buttons[2]?.pressed) buttons |= controllerButton.west;
-  if (pad.buttons[3]?.pressed) buttons |= controllerButton.north;
-  if (pad.buttons[4]?.pressed) buttons |= controllerButton.leftShoulder;
-  if (pad.buttons[5]?.pressed) buttons |= controllerButton.rightShoulder;
-  if (pad.buttons[12]?.pressed || (pad.axes[1] ?? 0) < -0.65) buttons |= controllerButton.up;
-  if (pad.buttons[13]?.pressed || (pad.axes[1] ?? 0) > 0.65) buttons |= controllerButton.down;
-  if (pad.buttons[14]?.pressed || (pad.axes[0] ?? 0) < -0.65) buttons |= controllerButton.left;
-  if (pad.buttons[15]?.pressed || (pad.axes[0] ?? 0) > 0.65) buttons |= controllerButton.right;
-  if (pad.buttons[9]?.pressed || pad.buttons[16]?.pressed) buttons |= controllerButton.menu;
-  return buttons;
+  const buttons = pad.buttons ?? [];
+  const axes = pad.axes ?? [];
+  let result = 0;
+  if (buttons[0]?.pressed) result |= controllerButton.south;
+  if (buttons[1]?.pressed) result |= controllerButton.east;
+  if (buttons[2]?.pressed) result |= controllerButton.west;
+  if (buttons[3]?.pressed) result |= controllerButton.north;
+  if (buttons[4]?.pressed) result |= controllerButton.leftShoulder;
+  if (buttons[5]?.pressed) result |= controllerButton.rightShoulder;
+  if (buttons[12]?.pressed || (axes[1] ?? 0) < -0.65) result |= controllerButton.up;
+  if (buttons[13]?.pressed || (axes[1] ?? 0) > 0.65) result |= controllerButton.down;
+  if (buttons[14]?.pressed || (axes[0] ?? 0) < -0.65) result |= controllerButton.left;
+  if (buttons[15]?.pressed || (axes[0] ?? 0) > 0.65) result |= controllerButton.right;
+  if (buttons[9]?.pressed || buttons[16]?.pressed) result |= controllerButton.menu;
+  return result;
 }


### PR DESCRIPTION
Closes #620 
I have tested this locally on my linux machine with a controller and also clicking on the buttons presented. 
Basicly the reason I opened this was in big picture mode it was too tempting of a target to not be able to click the buttons with the mouse then pickup the controller to navigate the same way. 

ENJOY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved controller navigation across the home, search, settings, and loading screens.
  * Added controller-friendly actions for launching content, switching pages, opening search, and returning to previous screens.
  * Added clear back-navigation context and controller-styled controls in Settings.
  * Added controller support for canceling loading and closing Settings.

* **Bug Fixes**
  * Improved controller input handling when gamepad buttons or axes are unavailable.
  * Refined overlay layering, spacing, and interactive hint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->