### PR TITLE
feat(stream): redesign Ctrl+G overlay with tabs and controller support

### DIFF
--- a/opennow-stable/src/renderer/src/components/SideBar.tsx
+++ b/opennow-stable/src/renderer/src/components/SideBar.tsx
@@ -1,18 +1,22 @@
-import type { JSX, ReactNode } from "react";
+import type { JSX, ReactNode, Ref } from "react";
 import { useTranslation } from "../i18n";
 
 interface SideBarProps {
   title?: string;
   children?: ReactNode;
+  footer?: ReactNode;
   className?: string;
   onClose?: () => void;
+  elementRef?: Ref<HTMLElement>;
 }
 
 export default function SideBar({
   title,
   children,
+  footer,
   className = "",
   onClose,
+  elementRef,
 }: SideBarProps): JSX.Element {
   const { t } = useTranslation();
   const classNames = ["sidebar", className].filter(Boolean).join(" ");
@@ -20,6 +24,7 @@ export default function SideBar({
 
   return (
     <aside
+      ref={elementRef}
       className={classNames}
       role="dialog"
       aria-label={sidebarTitle}
@@ -40,6 +45,7 @@ export default function SideBar({
       <div className="sidebar-body">
         {children}
       </div>
+      {footer && <div className="sidebar-footer">{footer}</div>}
     </aside>
   );
 }

--- a/opennow-stable/src/renderer/src/components/SideBar.tsx
+++ b/opennow-stable/src/renderer/src/components/SideBar.tsx
@@ -1,4 +1,5 @@
 import type { JSX, ReactNode, Ref } from "react";
+import { X } from "lucide-react";
 import { useTranslation } from "../i18n";
 
 interface SideBarProps {
@@ -27,6 +28,7 @@ export default function SideBar({
       ref={elementRef}
       className={classNames}
       role="dialog"
+      aria-modal="true"
       aria-label={sidebarTitle}
     >
       <div className="sidebar-header">
@@ -38,7 +40,8 @@ export default function SideBar({
             onClick={onClose}
             aria-label={t("sidebar.closeSettings")}
           >
-            ✕
+            <X size={16} aria-hidden="true" />
+            <span className="sidebar-close-hit-area" aria-hidden="true" />
           </button>
         )}
       </div>

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -475,6 +475,7 @@ export function StreamView({
   const sidebarGamepadLastMoveAtRef = useRef(0);
   const exitPromptGamepadFrameRef = useRef<number | null>(null);
   const exitPromptGamepadPreviousButtonsRef = useRef(0);
+  const suppressVideoFocusOnSidebarCloseRef = useRef(false);
   const screenshotApiAvailable =
     typeof window.openNow?.saveScreenshot === "function" &&
     typeof window.openNow?.listScreenshots === "function" &&
@@ -1362,6 +1363,10 @@ export function StreamView({
         } catch {}
       };
     }
+    if (suppressVideoFocusOnSidebarCloseRef.current) {
+      suppressVideoFocusOnSidebarCloseRef.current = false;
+      return undefined;
+    }
     // Sidebar just closed — restore focus to the video so clicks register
     // immediately. Without this, focus stays on the last sidebar element and
     // mousedown's preventDefault() blocks the browser from re-focusing on click.
@@ -1397,6 +1402,7 @@ export function StreamView({
   }, [onReleasePointerLock]);
 
   const handleSidebarExitSession = useCallback(() => {
+    suppressVideoFocusOnSidebarCloseRef.current = true;
     setShowSideBar(false);
     onEndSession();
   }, [onEndSession]);
@@ -1412,7 +1418,7 @@ export function StreamView({
   }, []);
 
   useEffect(() => {
-    if (!showSideBar) return;
+    if (!showSideBar || exitPrompt.open) return;
 
     const getMenuItems = (): HTMLElement[] => {
       const scope = selectedScreenshotId
@@ -1497,8 +1503,10 @@ export function StreamView({
     };
 
     const initialFocusTimer = window.setTimeout(() => {
-      const activeTab = sidebarRef.current?.querySelector<HTMLElement>(".sidebar-tab--active");
-      activeTab?.focus({ preventScroll: true });
+      const initialFocus = selectedScreenshotId
+        ? document.querySelector<HTMLElement>(".sv-shot-modal-btn:not(:disabled), .sv-shot-modal-close")
+        : sidebarRef.current?.querySelector<HTMLElement>(".sidebar-tab--active");
+      initialFocus?.focus({ preventScroll: true });
     }, 0);
     sidebarGamepadPreviousButtonsRef.current = readButtons();
     sidebarGamepadLastMoveAtRef.current = performance.now();
@@ -1513,7 +1521,7 @@ export function StreamView({
       sidebarGamepadPreviousButtonsRef.current = 0;
       sidebarGamepadLastMoveAtRef.current = 0;
     };
-  }, [selectAdjacentSidebarTab, selectedScreenshotId, showSideBar]);
+  }, [exitPrompt.open, selectAdjacentSidebarTab, selectedScreenshotId, showSideBar]);
 
   useEffect(() => {
     if (!exitPrompt.open) return;

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence } from "motion/react";
 import type { JSX } from "react";
-import { Maximize, Minimize, Loader2, LogOut, Clock3, AlertTriangle, Mic, MicOff, Camera, ChevronLeft, ChevronRight, Save, Trash2, X, Circle, Square, Video, FolderOpen } from "lucide-react";
+import { Maximize, Minimize, Loader2, LogOut, Clock3, AlertTriangle, Mic, MicOff, Camera, ChevronLeft, ChevronRight, Save, Trash2, X, Circle, Square, Video, FolderOpen, Gamepad2, Gauge, Images, Keyboard, MousePointer2, SlidersHorizontal } from "lucide-react";
 import SideBar from "./SideBar";
 import { SessionStartedSplash } from "./SessionStartedSplash";
 import { StreamStatsHud } from "./StreamStatsHud";
@@ -19,9 +19,13 @@ import { addStreamShortcutActionListener } from "../streamShortcutActions";
 import { useMicMeter } from "../hooks/useMicMeter";
 import { formatElapsed } from "../utils/timeFormat";
 import { useTranslation } from "../i18n";
+import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
 
 const ANTI_AFK_TOGGLE_ACK_MS = 5000;
+const CONTROLLER_MENU_REPEAT_MS = 180;
 const CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY = "View + Menu";
+const STREAM_MENU_TABS = ["session", "controls", "media", "shortcuts"] as const;
+type StreamMenuTab = (typeof STREAM_MENU_TABS)[number];
 
 interface StreamViewProps {
   videoRef: React.Ref<HTMLVideoElement>;
@@ -464,7 +468,13 @@ export function StreamView({
   const [selectedScreenshotId, setSelectedScreenshotId] = useState<string | null>(null);
   const [screenshotShortcutInput, setScreenshotShortcutInput] = useState(shortcuts.screenshot);
   const [screenshotShortcutError, setScreenshotShortcutError] = useState<string | null>(null);
-  const [activeSidebarTab, setActiveSidebarTab] = useState<"preferences" | "shortcuts">("preferences");
+  const [activeSidebarTab, setActiveSidebarTab] = useState<StreamMenuTab>("session");
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  const sidebarGamepadFrameRef = useRef<number | null>(null);
+  const sidebarGamepadPreviousButtonsRef = useRef(0);
+  const sidebarGamepadLastMoveAtRef = useRef(0);
+  const exitPromptGamepadFrameRef = useRef<number | null>(null);
+  const exitPromptGamepadPreviousButtonsRef = useRef(0);
   const screenshotApiAvailable =
     typeof window.openNow?.saveScreenshot === "function" &&
     typeof window.openNow?.listScreenshots === "function" &&
@@ -1391,6 +1401,170 @@ export function StreamView({
     onEndSession();
   }, [onEndSession]);
 
+  const selectAdjacentSidebarTab = useCallback((direction: -1 | 1) => {
+    setActiveSidebarTab((current) => {
+      const index = STREAM_MENU_TABS.indexOf(current);
+      return STREAM_MENU_TABS[(index + direction + STREAM_MENU_TABS.length) % STREAM_MENU_TABS.length];
+    });
+    window.requestAnimationFrame(() => {
+      sidebarRef.current?.querySelector<HTMLElement>(".sidebar-tab--active")?.focus({ preventScroll: true });
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!showSideBar) return;
+
+    const getMenuItems = (): HTMLElement[] => {
+      const scope = selectedScreenshotId
+        ? document.querySelector<HTMLElement>(".sv-shot-modal-card")
+        : sidebarRef.current;
+      if (!scope) return [];
+      return Array.from(scope.querySelectorAll<HTMLElement>(
+        "button:not(:disabled), input:not(:disabled):not([type='checkbox']), label.sidebar-mini-toggle, [tabindex='0']",
+      )).filter((element) => {
+        const style = window.getComputedStyle(element);
+        const isInactiveTab = element.getAttribute("role") === "tab" && element.getAttribute("aria-selected") !== "true";
+        return !isInactiveTab && style.display !== "none" && style.visibility !== "hidden";
+      });
+    };
+
+    const focusItem = (direction: -1 | 1): void => {
+      const items = getMenuItems();
+      if (items.length === 0) return;
+      const currentIndex = items.findIndex((item) => item === document.activeElement);
+      const nextIndex = currentIndex < 0
+        ? 0
+        : (currentIndex + direction + items.length) % items.length;
+      items[nextIndex]?.focus({ preventScroll: true });
+      items[nextIndex]?.scrollIntoView({ block: "nearest" });
+    };
+
+    const changeRange = (input: HTMLInputElement, direction: -1 | 1): void => {
+      const min = Number(input.min || 0);
+      const max = Number(input.max || 100);
+      const step = Number(input.step || 1);
+      const value = Math.max(min, Math.min(max, Number(input.value) + step * direction));
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(input, String(value));
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    };
+
+    const readButtons = (): number => {
+      const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
+      return readControllerGamepadButtons(pad);
+    };
+
+    const handleGamepadFrame = (): void => {
+      const buttons = readButtons();
+      let pressed = buttons & ~sidebarGamepadPreviousButtonsRef.current;
+      const moveMask = controllerButton.up | controllerButton.down | controllerButton.left | controllerButton.right;
+      const activeMoves = buttons & moveMask;
+      const now = performance.now();
+      if (pressed & moveMask) {
+        sidebarGamepadLastMoveAtRef.current = now;
+      } else if (activeMoves && now - sidebarGamepadLastMoveAtRef.current > CONTROLLER_MENU_REPEAT_MS) {
+        pressed |= activeMoves;
+        sidebarGamepadLastMoveAtRef.current = now;
+      }
+
+      const active = document.activeElement as HTMLElement | null;
+      const range = active instanceof HTMLInputElement && active.type === "range" ? active : null;
+      if (pressed & controllerButton.up) focusItem(-1);
+      if (pressed & controllerButton.down) focusItem(1);
+      if (pressed & controllerButton.left) {
+        if (range) changeRange(range, -1);
+        else if (active?.getAttribute("role") === "tab") selectAdjacentSidebarTab(-1);
+        else focusItem(-1);
+      }
+      if (pressed & controllerButton.right) {
+        if (range) changeRange(range, 1);
+        else if (active?.getAttribute("role") === "tab") selectAdjacentSidebarTab(1);
+        else focusItem(1);
+      }
+      if (pressed & controllerButton.leftShoulder) selectAdjacentSidebarTab(-1);
+      if (pressed & controllerButton.rightShoulder) selectAdjacentSidebarTab(1);
+      if (pressed & controllerButton.south) {
+        if (active && !range) active.click();
+      }
+      if (pressed & controllerButton.east) {
+        if (selectedScreenshotId) setSelectedScreenshotId(null);
+        else setShowSideBar(false);
+      }
+      if (pressed & controllerButton.menu) setShowSideBar(false);
+
+      sidebarGamepadPreviousButtonsRef.current = buttons;
+      sidebarGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+    };
+
+    const initialFocusTimer = window.setTimeout(() => {
+      const activeTab = sidebarRef.current?.querySelector<HTMLElement>(".sidebar-tab--active");
+      activeTab?.focus({ preventScroll: true });
+    }, 0);
+    sidebarGamepadPreviousButtonsRef.current = readButtons();
+    sidebarGamepadLastMoveAtRef.current = performance.now();
+    sidebarGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+
+    return () => {
+      window.clearTimeout(initialFocusTimer);
+      if (sidebarGamepadFrameRef.current !== null) {
+        window.cancelAnimationFrame(sidebarGamepadFrameRef.current);
+        sidebarGamepadFrameRef.current = null;
+      }
+      sidebarGamepadPreviousButtonsRef.current = 0;
+      sidebarGamepadLastMoveAtRef.current = 0;
+    };
+  }, [selectAdjacentSidebarTab, selectedScreenshotId, showSideBar]);
+
+  useEffect(() => {
+    if (!exitPrompt.open) return;
+
+    const focusExitButton = (confirm: boolean): void => {
+      document.querySelector<HTMLButtonElement>(
+        confirm ? ".sv-exit-btn-confirm" : ".sv-exit-btn-cancel",
+      )?.focus({ preventScroll: true });
+    };
+    const readButtons = (): number => {
+      const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
+      return readControllerGamepadButtons(pad);
+    };
+    const handleGamepadFrame = (): void => {
+      const buttons = readButtons();
+      const pressed = buttons & ~exitPromptGamepadPreviousButtonsRef.current;
+      if (pressed & (controllerButton.left | controllerButton.up)) focusExitButton(false);
+      if (pressed & (controllerButton.right | controllerButton.down)) focusExitButton(true);
+      if (pressed & controllerButton.south) {
+        const active = document.activeElement as HTMLElement | null;
+        if (active?.closest(".sv-exit-card")) active.click();
+      }
+      if (pressed & (controllerButton.east | controllerButton.menu)) onCancelExit();
+      exitPromptGamepadPreviousButtonsRef.current = buttons;
+      exitPromptGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+    };
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancelExit();
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        onConfirmExit();
+      }
+    };
+
+    const focusTimer = window.setTimeout(() => focusExitButton(false), 0);
+    exitPromptGamepadPreviousButtonsRef.current = readButtons();
+    exitPromptGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.clearTimeout(focusTimer);
+      window.removeEventListener("keydown", handleKeyDown, true);
+      if (exitPromptGamepadFrameRef.current !== null) {
+        window.cancelAnimationFrame(exitPromptGamepadFrameRef.current);
+        exitPromptGamepadFrameRef.current = null;
+      }
+      exitPromptGamepadPreviousButtonsRef.current = 0;
+    };
+  }, [exitPrompt.open, onCancelExit, onConfirmExit]);
+
   useEffect(() => {
     return addStreamShortcutActionListener((action) => {
       if (action === "toggleSidebar") {
@@ -1559,68 +1733,59 @@ export function StreamView({
             onMouseDown={(event) => event.stopPropagation()}
             onClick={() => setShowSideBar(false)}
           />
-          <SideBar title="Stream Control" className="sv-sidebar" onClose={() => setShowSideBar(false)}>
-            <section className="sidebar-session-card" aria-label="Current stream session">
-              <div className="sidebar-session-card-head">
-                <span className="sidebar-session-kicker">Now streaming</span>
-                <strong className="sidebar-session-title">{gameTitle}</strong>
-                {PlatformIcon && platformName && (
-                  <span className="sidebar-session-platform" title={platformName}>
-                    <span className="sidebar-session-platform-icon"><PlatformIcon /></span>
-                    <span>{platformName}</span>
-                  </span>
-                )}
-              </div>
-              <div className="sidebar-session-shortcuts" aria-label="Open this panel shortcuts">
-                <span className="sidebar-session-shortcut"><kbd>{sidebarToggleShortcutDisplay}</kbd><span>Keyboard</span></span>
-                <span className="sidebar-session-shortcut"><kbd>{CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY}</kbd><span>Controller</span></span>
-              </div>
-              <button
-                type="button"
-                className="sidebar-exit-session-button"
-                onClick={handleSidebarExitSession}
-              >
-                <LogOut size={15} />
-                <span>Exit session</span>
-              </button>
-            </section>
-            <div className="sidebar-stat-line" title="Total remaining playtime from subscription">
-              <span className="sidebar-stat-label">Remaining Playtime</span>
-              <RemainingPlaytimeIndicator subscriptionInfo={subscriptionInfo} startedAtMs={sessionStartedAtMs} active={isStreaming} className="settings-value-badge" />
-            </div>
-            {sessionTimeRemainingText !== null && (
-              <div className="sidebar-stat-line sidebar-stat-line--stacked" title={t("sidebar.sessionTimeRemainingTitle")}>
-                <span className="sidebar-stat-label">{t("sidebar.sessionTimeRemaining")}</span>
-                <div className="sidebar-session-time-controls">
-                  <span className="settings-value-badge sidebar-session-time-left">
-                    <Clock3 size={10} />
-                    <span>{sessionTimeRemainingText}</span>
-                  </span>
-                  <label
-                    className="sidebar-mini-toggle"
-                    title={t("sidebar.showSessionTimeRemainingInStatsOverlay")}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={showSessionTimeRemainingInStatsOverlay}
-                      aria-label={t("sidebar.showSessionTimeRemainingInStatsOverlay")}
-                      onChange={(event) => onShowSessionTimeRemainingInStatsOverlayChange(event.target.checked)}
-                    />
-                    <span className="sidebar-mini-toggle-track" />
-                    <span>{t("sidebar.statsOverlay")}</span>
-                  </label>
+          <SideBar
+            title="Quick menu"
+            className="sv-sidebar"
+            elementRef={sidebarRef}
+            onClose={() => setShowSideBar(false)}
+            footer={(
+              <>
+                <div className="sidebar-controller-hints" aria-hidden="true">
+                  <span><kbd>A</kbd> Select</span>
+                  <span><kbd>B</kbd> Back</span>
+                  <span><kbd>LB</kbd><kbd>RB</kbd> Pages</span>
                 </div>
-              </div>
+                <button
+                  type="button"
+                  className="sidebar-exit-session-button"
+                  onClick={handleSidebarExitSession}
+                >
+                  <LogOut size={17} />
+                  <span>End session</span>
+                </button>
+              </>
             )}
-            <div className="sidebar-tabs" role="tablist" aria-label="Sidebar sections">
+          >
+            <div className="sidebar-tabs" role="tablist" aria-label="Quick menu pages">
               <button
                 type="button"
                 role="tab"
-                aria-selected={activeSidebarTab === "preferences"}
-                className={`sidebar-tab${activeSidebarTab === "preferences" ? " sidebar-tab--active" : ""}`}
-                onClick={() => setActiveSidebarTab("preferences")}
+                aria-selected={activeSidebarTab === "session"}
+                className={`sidebar-tab${activeSidebarTab === "session" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveSidebarTab("session")}
               >
-                Preferences
+                <Gauge size={16} />
+                <span>Session</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeSidebarTab === "controls"}
+                className={`sidebar-tab${activeSidebarTab === "controls" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveSidebarTab("controls")}
+              >
+                <SlidersHorizontal size={16} />
+                <span>Controls</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeSidebarTab === "media"}
+                className={`sidebar-tab${activeSidebarTab === "media" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveSidebarTab("media")}
+              >
+                <Images size={16} />
+                <span>Media</span>
               </button>
               <button
                 type="button"
@@ -1629,13 +1794,95 @@ export function StreamView({
                 className={`sidebar-tab${activeSidebarTab === "shortcuts" ? " sidebar-tab--active" : ""}`}
                 onClick={() => setActiveSidebarTab("shortcuts")}
               >
-                Shortcuts
+                <Keyboard size={16} />
+                <span>Keys</span>
               </button>
             </div>
 
-            {activeSidebarTab === "preferences" && (
-              <>
-                <div className="sidebar-separator" aria-hidden="true" />
+            {activeSidebarTab === "session" && (
+              <div className="sidebar-page sidebar-page--session" role="tabpanel">
+                <section className="sidebar-session-card" aria-label="Current stream session">
+                  <div className="sidebar-session-card-head">
+                    <span className="sidebar-session-kicker">Now streaming</span>
+                    <strong className="sidebar-session-title">{gameTitle}</strong>
+                    {PlatformIcon && platformName && (
+                      <span className="sidebar-session-platform" title={platformName}>
+                        <span className="sidebar-session-platform-icon"><PlatformIcon /></span>
+                        <span>{platformName}</span>
+                      </span>
+                    )}
+                  </div>
+                </section>
+                <section className="sidebar-session-metrics" aria-label="Session time">
+                  <div className="sidebar-metric">
+                    <span>Total playtime left</span>
+                    <RemainingPlaytimeIndicator subscriptionInfo={subscriptionInfo} startedAtMs={sessionStartedAtMs} active={isStreaming} className="sidebar-metric-value" />
+                  </div>
+                  {sessionTimeRemainingText !== null && (
+                    <div className="sidebar-metric">
+                      <span>{t("sidebar.sessionTimeRemaining")}</span>
+                      <strong className="sidebar-metric-value">
+                        <Clock3 size={14} />
+                        {sessionTimeRemainingText}
+                      </strong>
+                    </div>
+                  )}
+                </section>
+                <section className="sidebar-section">
+                  <div className="sidebar-section-header">
+                    <span>Quick actions</span>
+                    <span className="sidebar-section-sub">The things you actually opened this menu for.</span>
+                  </div>
+                  <div className="sidebar-quick-actions">
+                    <button type="button" className="sidebar-action-card" onClick={handleFullscreenToggle}>
+                      {isFullscreen ? <Minimize size={20} /> : <Maximize size={20} />}
+                      <span>{isFullscreen ? "Windowed" : "Fullscreen"}</span>
+                    </button>
+                    <button type="button" className="sidebar-action-card" onClick={handlePointerLockToggle}>
+                      <MousePointer2 size={20} />
+                      <span>{isPointerLocked ? "Release mouse" : "Capture mouse"}</span>
+                    </button>
+                    {onToggleMicrophone && (
+                      <button type="button" className="sidebar-action-card" onClick={onToggleMicrophone}>
+                        <Mic size={20} />
+                        <span>Toggle mic</span>
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      className="sidebar-action-card"
+                      onClick={() => { void captureScreenshot(); }}
+                      disabled={isSavingScreenshot || !screenshotApiAvailable}
+                    >
+                      <Camera size={20} />
+                      <span>{isSavingScreenshot ? "Capturing" : "Screenshot"}</span>
+                    </button>
+                  </div>
+                </section>
+                {sessionTimeRemainingText !== null && (
+                  <label className="sidebar-setting-card sidebar-mini-toggle" tabIndex={0}>
+                    <span>
+                      <strong>Show time in stats</strong>
+                      <small>Keep session time visible in the performance overlay.</small>
+                    </span>
+                    <input
+                      type="checkbox"
+                      checked={showSessionTimeRemainingInStatsOverlay}
+                      aria-label={t("sidebar.showSessionTimeRemainingInStatsOverlay")}
+                      onChange={(event) => onShowSessionTimeRemainingInStatsOverlayChange(event.target.checked)}
+                    />
+                    <span className="sidebar-mini-toggle-track" />
+                  </label>
+                )}
+                <div className="sidebar-open-shortcuts">
+                  <span><kbd>{sidebarToggleShortcutDisplay}</kbd> Keyboard</span>
+                  <span><Gamepad2 size={14} /> {CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY}</span>
+                </div>
+              </div>
+            )}
+
+            {activeSidebarTab === "controls" && (
+              <div className="sidebar-page" role="tabpanel">
                 <section className="sidebar-section">
                   <div className="sidebar-section-header">
                     <span>Mouse Preferences</span>
@@ -1696,7 +1943,7 @@ export function StreamView({
                     <>
                       <div className="sidebar-row sidebar-row--aligned">
                         <span className="sidebar-label">Enable Filters</span>
-                        <label className="sidebar-mini-toggle" title="Enable GPU post-processing filters">
+                        <label className="sidebar-mini-toggle" title="Enable GPU post-processing filters" tabIndex={0}>
                           <input
                             type="checkbox"
                             checked={videoShader.enabled}
@@ -1801,14 +2048,18 @@ export function StreamView({
                     </div>
                   )}
                 </section>
-                <div className="sidebar-separator" aria-hidden="true" />
+              </div>
+            )}
+
+            {activeSidebarTab === "media" && (
+              <div className="sidebar-page" role="tabpanel">
                 <section className="sidebar-section">
                   <div className="sidebar-section-header">
                     <span>Gallery</span>
-                    <span className="sidebar-section-sub">ScreensShot key: {shortcuts.screenshot}</span>
+                    <span className="sidebar-section-sub">Screenshot key: {shortcuts.screenshot}</span>
                   </div>
                   <div className="sidebar-row sidebar-row--aligned">
-                    <span className="sidebar-label">ScreensShot</span>
+                    <span className="sidebar-label">Screenshots</span>
                     <button
                       type="button"
                       className="sidebar-button sidebar-screenshot-button"
@@ -1953,12 +2204,11 @@ export function StreamView({
                     </div>
                   )}
                 </section>
-              </>
+              </div>
             )}
 
             {activeSidebarTab === "shortcuts" && (
-              <>
-                <div className="sidebar-separator" aria-hidden="true" />
+              <div className="sidebar-page" role="tabpanel">
                 <section className="sidebar-section">
                   <div className="sidebar-section-header">
                     <span>Shortcut Bindings</span>
@@ -2060,7 +2310,7 @@ export function StreamView({
                     </span>
                   </div>
                 </section>
-              </>
+              </div>
             )}
           </SideBar>
         </>
@@ -2241,7 +2491,8 @@ export function StreamView({
               </button>
             </div>
             <div className="sv-exit-hint">
-              <kbd>Enter</kbd> confirm · <kbd>Esc</kbd> cancel
+              <span><kbd>Enter</kbd> confirm · <kbd>Esc</kbd> cancel</span>
+              <span><kbd>A</kbd> select · <kbd>B</kbd> cancel</span>
             </div>
           </div>
         </div>,

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1758,7 +1758,7 @@ export function StreamView({
                   className="sidebar-exit-session-button"
                   onClick={handleSidebarExitSession}
                 >
-                  <LogOut size={17} />
+                  <LogOut size={16} />
                   <span>End session</span>
                 </button>
               </>
@@ -1838,21 +1838,21 @@ export function StreamView({
                 </section>
                 <section className="sidebar-section">
                   <div className="sidebar-section-header">
-                    <span>Quick actions</span>
-                    <span className="sidebar-section-sub">The things you actually opened this menu for.</span>
+                    <span>Session controls</span>
+                    <span className="sidebar-section-sub">Manage the active stream.</span>
                   </div>
                   <div className="sidebar-quick-actions">
                     <button type="button" className="sidebar-action-card" onClick={handleFullscreenToggle}>
-                      {isFullscreen ? <Minimize size={20} /> : <Maximize size={20} />}
+                      {isFullscreen ? <Minimize size={16} /> : <Maximize size={16} />}
                       <span>{isFullscreen ? "Windowed" : "Fullscreen"}</span>
                     </button>
                     <button type="button" className="sidebar-action-card" onClick={handlePointerLockToggle}>
-                      <MousePointer2 size={20} />
+                      <MousePointer2 size={16} />
                       <span>{isPointerLocked ? "Release mouse" : "Capture mouse"}</span>
                     </button>
                     {onToggleMicrophone && (
                       <button type="button" className="sidebar-action-card" onClick={onToggleMicrophone}>
-                        <Mic size={20} />
+                        <Mic size={16} />
                         <span>Toggle mic</span>
                       </button>
                     )}
@@ -1862,7 +1862,7 @@ export function StreamView({
                       onClick={() => { void captureScreenshot(); }}
                       disabled={isSavingScreenshot || !screenshotApiAvailable}
                     >
-                      <Camera size={20} />
+                      <Camera size={16} />
                       <span>{isSavingScreenshot ? "Capturing" : "Screenshot"}</span>
                     </button>
                   </div>
@@ -1875,6 +1875,7 @@ export function StreamView({
                     </span>
                     <input
                       type="checkbox"
+                      name="show-session-time-in-stats"
                       checked={showSessionTimeRemainingInStatsOverlay}
                       aria-label={t("sidebar.showSessionTimeRemainingInStatsOverlay")}
                       onChange={(event) => onShowSessionTimeRemainingInStatsOverlayChange(event.target.checked)}
@@ -1894,7 +1895,7 @@ export function StreamView({
                 <section className="sidebar-section">
                   <div className="sidebar-section-header">
                     <span>Mouse Preferences</span>
-                    <span className="sidebar-section-sub">Fine-tune cursor movement</span>
+                    <span className="sidebar-section-sub">Fine-tune cursor movement.</span>
                   </div>
                   <div className="sidebar-row sidebar-row--column">
                     <div className="sidebar-row-top">
@@ -1903,6 +1904,8 @@ export function StreamView({
                     </div>
                     <input
                       type="range"
+                      name="mouse-sensitivity"
+                      aria-label="Mouse sensitivity"
                       className="settings-slider"
                       min={0.1}
                       max={4}
@@ -1924,6 +1927,8 @@ export function StreamView({
                     </div>
                     <input
                       type="range"
+                      name="mouse-acceleration"
+                      aria-label="Mouse accelerator"
                       className="settings-slider"
                       min={1}
                       max={150}
@@ -1943,7 +1948,7 @@ export function StreamView({
                 <section className="sidebar-section">
                   <div className="sidebar-section-header">
                     <span>Video Filters</span>
-                    <span className="sidebar-section-sub">GPU shaders applied to the stream</span>
+                    <span className="sidebar-section-sub">GPU shaders applied to the stream.</span>
                   </div>
                   {gstreamerEnabled ? (
                     <span className="sidebar-hint">Video filters are unavailable while the native streamer renders the video.</span>
@@ -1954,6 +1959,7 @@ export function StreamView({
                         <label className="sidebar-mini-toggle" title="Enable GPU post-processing filters" tabIndex={0}>
                           <input
                             type="checkbox"
+                            name="enable-video-filters"
                             checked={videoShader.enabled}
                             aria-label="Enable video filters"
                             onChange={(event) => onVideoShaderChange({ ...videoShader, enabled: event.target.checked })}
@@ -1978,6 +1984,8 @@ export function StreamView({
                               </div>
                               <input
                                 type="range"
+                                name={`video-filter-${control.key}`}
+                                aria-label={`${control.label} video filter`}
                                 className="settings-slider"
                                 min={control.min}
                                 max={control.max}
@@ -2016,7 +2024,7 @@ export function StreamView({
                 <section className="sidebar-section">
                   <div className="sidebar-section-header">
                     <span>Audio</span>
-                    <span className="sidebar-section-sub">Microphone handling</span>
+                    <span className="sidebar-section-sub">Configure microphone handling.</span>
                   </div>
                   <div className="sidebar-row sidebar-row--column">
                     <div className="sidebar-row-top">
@@ -2228,6 +2236,8 @@ export function StreamView({
                     </div>
                     <input
                       type="text"
+                      name="screenshot-shortcut"
+                      aria-label="Screenshot shortcut"
                       className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${screenshotShortcutError ? "error" : ""}`}
                       value={screenshotShortcutInput}
                       readOnly
@@ -2263,6 +2273,8 @@ export function StreamView({
                     </div>
                     <input
                       type="text"
+                      name="recording-shortcut"
+                      aria-label="Recording shortcut"
                       className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${recordingShortcutError ? "error" : ""}`}
                       value={recordingShortcutInput}
                       readOnly

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -8994,39 +8994,6 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--accent);
 }
 
-.sidebar-session-shortcuts {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 7px;
-  margin-top: 12px;
-}
-
-.sidebar-session-shortcut {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 7px 8px;
-  border-radius: 10px;
-  border: 1px solid color-mix(in srgb, var(--ink) 8%, transparent);
-  background: rgba(0, 0, 0, 0.22);
-  color: var(--ink-muted);
-  font-size: 0.67rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.sidebar-session-shortcut kbd {
-  color: var(--ink);
-  font-family: inherit;
-  font-size: 0.76rem;
-  font-weight: 800;
-  text-transform: none;
-  letter-spacing: 0;
-}
-
 .sidebar-exit-session-button {
   position: relative;
   width: 100%;
@@ -9061,40 +9028,6 @@ button.game-card-store-chip.owned.active:hover {
 .sidebar-exit-session-button:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--error-bg);
-}
-
-.sidebar-stat-line {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.sidebar-stat-line--stacked {
-  align-items: flex-start;
-}
-
-.sidebar-stat-label {
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--ink-soft);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.sidebar-session-time-controls {
-  display: flex;
-  align-items: flex-end;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-
-.sidebar-session-time-left {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-variant-numeric: tabular-nums;
 }
 
 .sidebar-mini-toggle {
@@ -9507,7 +9440,374 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sv-sidebar {
-  width: min(420px, calc(100vw - 28px));
+  width: min(500px, calc(100vw - 28px));
+  height: min(760px, calc(100vh - 28px));
+  background:
+    radial-gradient(circle at 8% -8%, rgba(119, 187, 255, 0.22), transparent 30%),
+    linear-gradient(155deg, rgba(20, 23, 30, 0.985), rgba(8, 10, 14, 0.98) 58%);
+  border-color: rgba(255, 255, 255, 0.13);
+  box-shadow:
+    0 32px 90px rgba(0, 0, 0, 0.68),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.sv-sidebar .sidebar-header {
+  padding: 17px 18px 14px;
+}
+
+.sv-sidebar .sidebar-header h3 {
+  font-size: 1.05rem;
+  font-weight: 750;
+  letter-spacing: -0.015em;
+}
+
+.sv-sidebar .sidebar-close {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 10px;
+}
+
+.sv-sidebar .sidebar-body {
+  gap: 16px;
+  padding: 14px 18px 18px;
+}
+
+.sidebar-footer {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 13px 18px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  background: rgba(5, 7, 10, 0.84);
+  box-shadow: 0 -16px 30px rgba(0, 0, 0, 0.2);
+}
+
+.sidebar-controller-hints {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.sidebar-controller-hints span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.sidebar-controller-hints kbd,
+.sidebar-open-shortcuts kbd {
+  min-width: 21px;
+  min-height: 21px;
+  display: inline-grid;
+  place-items: center;
+  padding: 2px 5px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-bottom-color: rgba(255, 255, 255, 0.28);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.65rem;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.35);
+}
+
+.sv-sidebar .sidebar-exit-session-button {
+  width: auto;
+  min-width: 142px;
+  min-height: 44px;
+  margin: 0;
+  padding: 0 16px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(255, 91, 91, 0.2), rgba(255, 70, 70, 0.12));
+}
+
+.sv-sidebar .sidebar-tabs {
+  position: sticky;
+  top: -14px;
+  z-index: 5;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+  margin: -14px -4px 0;
+  padding: 14px 4px 8px;
+  background: linear-gradient(180deg, rgba(14, 17, 22, 1) 72%, rgba(14, 17, 22, 0));
+}
+
+.sv-sidebar .sidebar-tab {
+  min-height: 52px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 7px 5px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.01em;
+}
+
+.sv-sidebar .sidebar-tab svg {
+  opacity: 0.82;
+}
+
+.sv-sidebar .sidebar-tab--active {
+  border-color: rgba(119, 187, 255, 0.66);
+  background:
+    linear-gradient(180deg, rgba(119, 187, 255, 0.18), rgba(119, 187, 255, 0.08));
+  color: #dff0ff;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.09);
+}
+
+.sidebar-page {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 0;
+  animation: sidebar-page-in 150ms ease-out both;
+}
+
+@keyframes sidebar-page-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.sidebar-page .sidebar-section {
+  gap: 12px;
+}
+
+.sidebar-page .sidebar-section + .sidebar-separator {
+  margin-top: -2px;
+}
+
+.sidebar-session-card {
+  min-height: 132px;
+  display: flex;
+  align-items: flex-end;
+  padding: 18px;
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 88% 12%, rgba(119, 187, 255, 0.26), transparent 36%),
+    linear-gradient(145deg, rgba(119, 187, 255, 0.15), rgba(255, 255, 255, 0.035) 48%, rgba(0, 0, 0, 0.16));
+}
+
+.sidebar-session-card::before {
+  inset: -22% -8% auto auto;
+  width: 190px;
+  height: 190px;
+  background: rgba(119, 187, 255, 0.08);
+}
+
+.sidebar-session-title {
+  max-width: 390px;
+  font-size: 1.35rem;
+  letter-spacing: -0.025em;
+}
+
+.sidebar-session-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.sidebar-metric {
+  min-width: 0;
+  min-height: 74px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 13px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 13px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.sidebar-metric-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--ink);
+  font-size: 0.95rem;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-transform: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.sidebar-quick-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.sidebar-action-card {
+  min-height: 62px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 0 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 13px;
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--ink-soft);
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 750;
+  text-align: left;
+  cursor: pointer;
+  transition: transform var(--t-fast), background var(--t-fast), border-color var(--t-fast), color var(--t-fast);
+}
+
+.sidebar-action-card svg {
+  flex: 0 0 auto;
+  color: var(--accent);
+}
+
+.sidebar-action-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(119, 187, 255, 0.48);
+  background: rgba(119, 187, 255, 0.1);
+  color: var(--ink);
+}
+
+.sidebar-setting-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 13px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 13px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.sidebar-setting-card > span:first-child {
+  min-width: 0;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.sidebar-setting-card strong {
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+}
+
+.sidebar-setting-card small {
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.sidebar-open-shortcuts {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.sidebar-open-shortcuts span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.sv-sidebar button:focus,
+.sv-sidebar input:focus,
+.sv-sidebar label:focus,
+.sv-sidebar [tabindex="0"]:focus {
+  outline: none;
+  border-color: #9bd1ff;
+  box-shadow:
+    0 0 0 3px rgba(119, 187, 255, 0.25),
+    0 8px 22px rgba(0, 0, 0, 0.2);
+}
+
+.sv-sidebar input[type="range"]:focus {
+  border-color: transparent;
+  box-shadow: none;
+  filter: drop-shadow(0 0 5px rgba(119, 187, 255, 0.7));
+}
+
+.sv-sidebar .sidebar-section-header > span:first-child {
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.sv-sidebar .sidebar-row--column {
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+@media (max-width: 560px) {
+  .sv-sidebar {
+    top: 8px;
+    left: 8px;
+    width: calc(100vw - 16px);
+    height: calc(100vh - 16px);
+    max-height: none;
+    border-radius: 18px;
+  }
+
+  .sidebar-controller-hints {
+    justify-content: center;
+  }
+
+  .sidebar-footer {
+    grid-template-columns: 1fr;
+  }
+
+  .sv-sidebar .sidebar-exit-session-button {
+    width: 100%;
+  }
+}
+
+@media (max-height: 560px) {
+  .sidebar-controller-hints {
+    display: none;
+  }
+
+  .sidebar-footer {
+    grid-template-columns: 1fr;
+    padding-block: 9px;
+  }
+
+  .sv-sidebar .sidebar-exit-session-button {
+    width: 100%;
+    min-height: 40px;
+  }
 }
 
 .sv-sidebar-backdrop {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -8853,13 +8853,11 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background:
-    radial-gradient(circle at 18% -12%, rgba(119, 187, 255, 0.18), transparent 34%),
-    linear-gradient(180deg, rgba(20, 22, 28, 0.98), rgba(8, 9, 12, 0.96));
-  border-radius: var(--r-xl);
+  background: #121417;
+  border-radius: 14px;
   border: 1px solid var(--panel-border);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 }
 
 .sidebar-header {
@@ -8880,20 +8878,41 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sidebar-close {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  display: inline-grid;
+  place-items: center;
   background: transparent;
-  border: none;
+  border: 1px solid transparent;
   color: var(--ink-muted);
-  font-size: 1.1rem;
-  line-height: 1;
   cursor: pointer;
-  padding: 6px;
-  border-radius: 6px;
-  transition: background var(--t-normal), color var(--t-normal);
+  padding: 0;
+  border-radius: 8px;
 }
 
 .sidebar-close:hover {
   background: var(--card-hover);
   color: var(--ink);
+}
+
+.sidebar-close svg {
+  flex-shrink: 0;
+}
+
+.sidebar-close-hit-area {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: max(100%, 48px);
+  height: max(100%, 48px);
+  transform: translate(-50%, -50%);
+}
+
+@media (pointer: fine) {
+  .sidebar-close-hit-area {
+    display: none;
+  }
 }
 
 .sidebar-body {
@@ -8905,7 +8924,7 @@ button.game-card-store-chip.owned.active:hover {
   overscroll-behavior: contain;
   padding: 12px 14px 14px;
   scrollbar-width: thin;
-  scrollbar-color: rgba(119, 187, 255, 0.36) transparent;
+  scrollbar-color: color-mix(in srgb, var(--accent) 34%, transparent) transparent;
 }
 
 .sidebar-body>* {
@@ -8918,7 +8937,7 @@ button.game-card-store-chip.owned.active:hover {
 
 .sidebar-body::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: rgba(119, 187, 255, 0.32);
+  background: color-mix(in srgb, var(--accent) 32%, transparent);
 }
 
 .sidebar-body::-webkit-scrollbar-track {
@@ -8926,26 +8945,13 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sidebar-session-card {
-  position: relative;
-  overflow: hidden;
-  padding: 13px;
-  border-radius: 15px;
-  border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--panel-border));
-  background:
-    linear-gradient(135deg, rgba(119, 187, 255, 0.16), color-mix(in srgb, var(--ink) 3.5%, transparent) 42%, rgba(255, 80, 80, 0.07)),
-    color-mix(in srgb, var(--ink) 3.5%, transparent);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--ink) 7%, transparent);
+  padding: 4px 0 18px;
+  border-bottom: 1px solid var(--panel-border);
+  background: transparent;
 }
 
 .sidebar-session-card::before {
-  content: "";
-  position: absolute;
-  inset: -38% -18% auto auto;
-  width: 140px;
-  height: 140px;
-  border-radius: 999px;
-  background: rgba(119, 187, 255, 0.12);
-  pointer-events: none;
+  content: none;
 }
 
 .sidebar-session-card-head {
@@ -8957,15 +8963,14 @@ button.game-card-store-chip.owned.active:hover {
 
 .sidebar-session-kicker {
   color: var(--accent);
-  font-size: 0.64rem;
-  font-weight: 800;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  font-size: 0.72rem;
+  font-weight: 650;
 }
 
 .sidebar-session-title {
   color: var(--ink);
-  font-size: 1.02rem;
+  font-size: 1.16rem;
+  font-weight: 600;
   line-height: 1.18;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -8978,10 +8983,10 @@ button.game-card-store-chip.owned.active:hover {
   gap: 6px;
   width: fit-content;
   max-width: 100%;
-  padding: 4px 8px;
-  border-radius: 999px;
-  border: 1px solid var(--panel-border);
-  background: rgba(0, 0, 0, 0.18);
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--ink-soft);
   font-size: 0.72rem;
   font-weight: 700;
@@ -8991,7 +8996,7 @@ button.game-card-store-chip.owned.active:hover {
   display: inline-flex;
   width: 14px;
   height: 14px;
-  color: var(--accent);
+  color: var(--ink-muted);
 }
 
 .sidebar-exit-session-button {
@@ -9003,34 +9008,29 @@ button.game-card-store-chip.owned.active:hover {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  border-radius: 11px;
-  border: 1px solid rgba(255, 105, 105, 0.34);
-  background: rgba(255, 80, 80, 0.12);
-  color: #ffd6d6;
+  border-radius: 8px;
+  border: 1px solid rgba(248, 113, 113, 0.26);
+  background: transparent;
+  color: #fca5a5;
   font: inherit;
   font-size: 0.84rem;
-  font-weight: 800;
+  font-weight: 650;
   cursor: pointer;
-  transition:
-    border-color var(--t-fast),
-    background var(--t-fast),
-    color var(--t-fast),
-    transform var(--t-fast);
 }
 
 .sidebar-exit-session-button:hover {
-  transform: translateY(-1px);
-  border-color: rgba(255, 105, 105, 0.7);
-  background: rgba(255, 80, 80, 0.2);
-  color: #fff;
+  border-color: rgba(248, 113, 113, 0.5);
+  background: rgba(248, 113, 113, 0.08);
+  color: #fecaca;
 }
 
 .sidebar-exit-session-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--error-bg);
+  outline: 2px solid var(--error);
+  outline-offset: 2px;
 }
 
 .sidebar-mini-toggle {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -9042,14 +9042,18 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sidebar-mini-toggle input {
-  display: none;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .sidebar-mini-toggle-track {
   position: relative;
   width: 28px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: var(--r-full);
   background: var(--chip);
   border: 1px solid var(--panel-border);
   transition: background var(--t-fast), border-color var(--t-fast);
@@ -9062,7 +9066,7 @@ button.game-card-store-chip.owned.active:hover {
   left: 2px;
   width: 10px;
   height: 10px;
-  border-radius: 999px;
+  border-radius: var(--r-full);
   background: var(--ink-muted);
   transition: transform var(--t-fast), background var(--t-fast);
 }
@@ -9077,6 +9081,11 @@ button.game-card-store-chip.owned.active:hover {
   background: var(--accent);
 }
 
+.sidebar-mini-toggle input:focus-visible + .sidebar-mini-toggle-track {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .sidebar-tabs {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -9085,24 +9094,23 @@ button.game-card-store-chip.owned.active:hover {
 
 .sidebar-tab {
   border-radius: 8px;
-  border: 1px solid var(--panel-border);
-  background: var(--card);
+  border: 1px solid transparent;
+  background: transparent;
   color: var(--ink-soft);
   font-size: 0.78rem;
   font-weight: 600;
   padding: 7px 10px;
   cursor: pointer;
-  transition: border-color var(--t-fast), background var(--t-fast), color var(--t-fast);
 }
 
 .sidebar-tab:hover {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--panel-border));
+  background: var(--card-hover);
   color: var(--ink);
 }
 
 .sidebar-tab--active {
-  border-color: var(--accent);
-  color: var(--accent);
+  border-color: var(--panel-border);
+  color: var(--ink);
   background: var(--accent-surface);
 }
 
@@ -9122,9 +9130,7 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 0.72rem;
   color: var(--ink-muted);
 }
 
@@ -9195,24 +9201,23 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sidebar-button {
-  border-radius: 4px;
+  min-height: 32px;
+  border-radius: 8px;
   border: 1px solid var(--panel-border);
   background: var(--card);
   color: var(--ink);
   font-size: 0.82rem;
-  font-weight: 600;
-  padding: 6px 12px;
+  font-weight: 650;
+  padding: 5px 10px;
   cursor: pointer;
-  transition: transform var(--t-normal), background var(--t-normal);
 }
 
 .sidebar-button:hover {
-  transform: translateY(-1px);
   background: var(--card-hover);
 }
 
 .sidebar-button:active {
-  transform: translateY(0);
+  background: var(--chip);
 }
 
 .sidebar-screenshot-button {
@@ -9228,7 +9233,7 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sidebar-chip {
-  border-radius: 999px;
+  border-radius: 8px;
   border: 1px solid var(--panel-border);
   background: var(--card);
   color: var(--ink);
@@ -9236,18 +9241,16 @@ button.game-card-store-chip.owned.active:hover {
   font-weight: 600;
   padding: 6px 12px;
   cursor: pointer;
-  transition: transform var(--t-normal), background var(--t-normal), border-color var(--t-normal), color var(--t-normal);
 }
 
 .sidebar-chip:hover {
-  transform: translateY(-1px);
   background: var(--card-hover);
 }
 
 .sidebar-chip--active {
-  border-color: var(--accent);
-  background: rgba(119, 187, 255, 0.12);
-  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+  background: var(--accent-surface);
+  color: var(--ink);
 }
 
 .sidebar-gallery-row {
@@ -9268,7 +9271,6 @@ button.game-card-store-chip.owned.active:hover {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: background var(--t-fast), border-color var(--t-fast), color var(--t-fast);
 }
 
 .sidebar-gallery-arrow:hover {
@@ -9296,11 +9298,9 @@ button.game-card-store-chip.owned.active:hover {
   background: #08090b;
   padding: 0;
   cursor: pointer;
-  transition: transform var(--t-fast), border-color var(--t-fast);
 }
 
 .sidebar-gallery-item:hover {
-  transform: translateY(-1px);
   border-color: var(--accent);
 }
 
@@ -9440,40 +9440,40 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sv-sidebar {
-  width: min(500px, calc(100vw - 28px));
-  height: min(760px, calc(100vh - 28px));
-  background:
-    radial-gradient(circle at 8% -8%, rgba(119, 187, 255, 0.22), transparent 30%),
-    linear-gradient(155deg, rgba(20, 23, 30, 0.985), rgba(8, 10, 14, 0.98) 58%);
-  border-color: rgba(255, 255, 255, 0.13);
-  box-shadow:
-    0 32px 90px rgba(0, 0, 0, 0.68),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --ink: #f4f4f5;
+  --ink-soft: #c3c7cc;
+  --ink-muted: #858c94;
+  --panel-border: rgba(255, 255, 255, 0.09);
+  --card: #191d21;
+  --card-hover: #20252a;
+  --chip: #24292e;
+  width: min(460px, calc(100vw - 28px));
+  height: min(720px, calc(100vh - 28px));
+  background: #121519;
+  border-color: rgba(255, 255, 255, 0.11);
+  color-scheme: dark;
 }
 
 .sv-sidebar .sidebar-header {
-  padding: 17px 18px 14px;
+  min-height: 58px;
+  padding: 13px 16px;
 }
 
 .sv-sidebar .sidebar-header h3 {
-  font-size: 1.05rem;
-  font-weight: 750;
-  letter-spacing: -0.015em;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .sv-sidebar .sidebar-close {
-  width: 36px;
-  height: 36px;
-  display: grid;
-  place-items: center;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: 10px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
 }
 
 .sv-sidebar .sidebar-body {
-  gap: 16px;
-  padding: 14px 18px 18px;
+  gap: 18px;
+  padding: 14px 16px 18px;
 }
 
 .sidebar-footer {
@@ -9482,10 +9482,9 @@ button.game-card-store-chip.owned.active:hover {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 14px;
-  padding: 13px 18px 16px;
-  border-top: 1px solid rgba(255, 255, 255, 0.09);
-  background: rgba(5, 7, 10, 0.84);
-  box-shadow: 0 -16px 30px rgba(0, 0, 0, 0.2);
+  padding: 12px 16px;
+  border-top: 1px solid var(--panel-border);
+  background: #101316;
 }
 
 .sidebar-controller-hints {
@@ -9512,23 +9511,21 @@ button.game-card-store-chip.owned.active:hover {
   place-items: center;
   padding: 2px 5px;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  border-bottom-color: rgba(255, 255, 255, 0.28);
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.07);
+  border-radius: 5px;
+  background: var(--card);
   color: var(--ink);
   font: inherit;
   font-size: 0.65rem;
-  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.35);
 }
 
 .sv-sidebar .sidebar-exit-session-button {
   width: auto;
-  min-width: 142px;
-  min-height: 44px;
+  min-width: 132px;
+  min-height: 36px;
   margin: 0;
-  padding: 0 16px;
-  border-radius: 12px;
-  background: linear-gradient(180deg, rgba(255, 91, 91, 0.2), rgba(255, 70, 70, 0.12));
+  padding: 0 12px 0 10px;
+  border-radius: 8px;
+  background: transparent;
 }
 
 .sv-sidebar .sidebar-tabs {
@@ -9536,38 +9533,34 @@ button.game-card-store-chip.owned.active:hover {
   top: -14px;
   z-index: 5;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 7px;
-  margin: -14px -4px 0;
-  padding: 14px 4px 8px;
-  background: linear-gradient(180deg, rgba(14, 17, 22, 1) 72%, rgba(14, 17, 22, 0));
+  gap: 2px;
+  margin: -14px 0 0;
+  padding: 14px 0 8px;
+  background: #121519;
 }
 
 .sv-sidebar .sidebar-tab {
-  min-height: 52px;
+  min-height: 38px;
   display: inline-flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 5px;
-  padding: 7px 5px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.035);
+  gap: 6px;
+  padding: 6px 7px;
+  border-radius: 8px;
+  background: transparent;
   color: var(--ink-muted);
-  font-size: 0.68rem;
-  font-weight: 750;
-  letter-spacing: 0.01em;
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
 .sv-sidebar .sidebar-tab svg {
-  opacity: 0.82;
+  flex-shrink: 0;
 }
 
 .sv-sidebar .sidebar-tab--active {
-  border-color: rgba(119, 187, 255, 0.66);
-  background:
-    linear-gradient(180deg, rgba(119, 187, 255, 0.18), rgba(119, 187, 255, 0.08));
-  color: #dff0ff;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.09);
+  border-color: var(--panel-border);
+  background: var(--card);
+  color: var(--ink);
 }
 
 .sidebar-page {
@@ -9575,7 +9568,7 @@ button.game-card-store-chip.owned.active:hover {
   flex-direction: column;
   gap: 18px;
   min-height: 0;
-  animation: sidebar-page-in 150ms ease-out both;
+  animation: sidebar-page-in 120ms ease-out both;
 }
 
 @keyframes sidebar-page-in {
@@ -9599,51 +9592,51 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sidebar-session-card {
-  min-height: 132px;
+  min-height: 0;
   display: flex;
-  align-items: flex-end;
-  padding: 18px;
-  border-radius: 18px;
-  background:
-    radial-gradient(circle at 88% 12%, rgba(119, 187, 255, 0.26), transparent 36%),
-    linear-gradient(145deg, rgba(119, 187, 255, 0.15), rgba(255, 255, 255, 0.035) 48%, rgba(0, 0, 0, 0.16));
+  align-items: flex-start;
+  padding: 4px 0 18px;
+  border-radius: 0;
+  background: transparent;
 }
 
 .sidebar-session-card::before {
-  inset: -22% -8% auto auto;
-  width: 190px;
-  height: 190px;
-  background: rgba(119, 187, 255, 0.08);
+  content: none;
 }
 
 .sidebar-session-title {
-  max-width: 390px;
-  font-size: 1.35rem;
-  letter-spacing: -0.025em;
+  max-width: 400px;
+  font-size: 1.3rem;
+  letter-spacing: -0.02em;
 }
 
 .sidebar-session-metrics {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
+  gap: 0;
+  border-bottom: 1px solid var(--panel-border);
 }
 
 .sidebar-metric {
   min-width: 0;
-  min-height: 74px;
+  min-height: 66px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 8px;
-  padding: 12px 13px;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 13px;
-  background: rgba(255, 255, 255, 0.035);
+  gap: 7px;
+  padding: 0 14px 16px 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--ink-muted);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.035em;
-  text-transform: uppercase;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.sidebar-metric + .sidebar-metric {
+  padding-right: 0;
+  padding-left: 14px;
+  border-left: 1px solid var(--panel-border);
 }
 
 .sidebar-metric-value {
@@ -9653,7 +9646,7 @@ button.game-card-store-chip.owned.active:hover {
   min-width: 0;
   color: var(--ink);
   font-size: 0.95rem;
-  font-weight: 750;
+  font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
   font-variant-numeric: tabular-nums;
@@ -9662,47 +9655,51 @@ button.game-card-store-chip.owned.active:hover {
 .sidebar-quick-actions {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 9px;
+  gap: 8px;
 }
 
 .sidebar-action-card {
-  min-height: 62px;
+  min-height: 38px;
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 0 14px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 13px;
-  background: rgba(255, 255, 255, 0.045);
+  gap: 8px;
+  padding: 0 10px 0 9px;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: transparent;
   color: var(--ink-soft);
   font: inherit;
   font-size: 0.8rem;
-  font-weight: 750;
+  font-weight: 600;
   text-align: left;
   cursor: pointer;
-  transition: transform var(--t-fast), background var(--t-fast), border-color var(--t-fast), color var(--t-fast);
 }
 
 .sidebar-action-card svg {
   flex: 0 0 auto;
-  color: var(--accent);
+  color: var(--ink-muted);
 }
 
 .sidebar-action-card:hover {
-  transform: translateY(-1px);
-  border-color: rgba(119, 187, 255, 0.48);
-  background: rgba(119, 187, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.16);
+  background: var(--card-hover);
   color: var(--ink);
+}
+
+.sidebar-action-card:hover svg {
+  color: var(--accent);
 }
 
 .sidebar-setting-card {
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 13px 14px;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 13px;
-  background: rgba(255, 255, 255, 0.035);
+  padding: 12px 0;
+  border: 0;
+  border-top: 1px solid var(--panel-border);
+  border-bottom: 1px solid var(--panel-border);
+  border-radius: 0;
+  background: transparent;
 }
 
 .sidebar-setting-card > span:first-child {
@@ -9716,6 +9713,7 @@ button.game-card-store-chip.owned.active:hover {
 .sidebar-setting-card strong {
   color: var(--ink-soft);
   font-size: 0.8rem;
+  font-weight: 600;
 }
 
 .sidebar-setting-card small {
@@ -9741,34 +9739,46 @@ button.game-card-store-chip.owned.active:hover {
   gap: 7px;
 }
 
-.sv-sidebar button:focus,
-.sv-sidebar input:focus,
-.sv-sidebar label:focus,
-.sv-sidebar [tabindex="0"]:focus {
-  outline: none;
-  border-color: #9bd1ff;
-  box-shadow:
-    0 0 0 3px rgba(119, 187, 255, 0.25),
-    0 8px 22px rgba(0, 0, 0, 0.2);
+.sv-sidebar button:focus-visible,
+.sv-sidebar input:focus-visible,
+.sv-sidebar label:focus-visible,
+.sv-sidebar [tabindex="0"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
-.sv-sidebar input[type="range"]:focus {
+.sv-sidebar input[type="range"]:focus-visible {
   border-color: transparent;
-  box-shadow: none;
-  filter: drop-shadow(0 0 5px rgba(119, 187, 255, 0.7));
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .sv-sidebar .sidebar-section-header > span:first-child {
   color: var(--ink-soft);
-  font-size: 0.75rem;
-  font-weight: 800;
+  font-size: 0.8rem;
+  font-weight: 600;
 }
 
 .sv-sidebar .sidebar-row--column {
   padding: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.075);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: #161a1e;
+}
+
+.sv-sidebar .settings-value-badge {
+  padding: 3px 7px;
+  border: 1px solid var(--panel-border);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.sv-sidebar .settings-slider::-webkit-slider-thumb:hover {
+  transform: none;
 }
 
 @media (max-width: 560px) {
@@ -9778,7 +9788,29 @@ button.game-card-store-chip.owned.active:hover {
     width: calc(100vw - 16px);
     height: calc(100vh - 16px);
     max-height: none;
-    border-radius: 18px;
+    border-radius: 12px;
+  }
+
+  .sv-sidebar .sidebar-body {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .sv-sidebar .sidebar-tab {
+    min-height: 42px;
+    font-size: 0.8rem;
+  }
+
+  .sidebar-label,
+  .sidebar-setting-card strong,
+  .sidebar-action-card {
+    font-size: 0.9rem;
+  }
+
+  .sidebar-hint,
+  .sidebar-setting-card small,
+  .sidebar-section-sub {
+    font-size: 0.78rem;
   }
 
   .sidebar-controller-hints {
@@ -9791,6 +9823,7 @@ button.game-card-store-chip.owned.active:hover {
 
   .sv-sidebar .sidebar-exit-session-button {
     width: 100%;
+    min-height: 38px;
   }
 }
 
@@ -9806,7 +9839,7 @@ button.game-card-store-chip.owned.active:hover {
 
   .sv-sidebar .sidebar-exit-session-button {
     width: 100%;
-    min-height: 40px;
+    min-height: 36px;
   }
 }
 


### PR DESCRIPTION
This PR redesigns the Ctrl+G in-stream quick menu around a four-tab controller-safe hierarchy, with the End session action always visible.

**UI Structure**
- Splits dense overlay into Session, Controls, Media, and Keys pages
- Relocates session metrics into a dedicated grid with clear time indicators
- Groups quick actions (fullscreen, mouse capture, mic toggle, screenshot) as large tappable cards
- Moves Exit Stream to a persistent footer that stays visible when the body scrolls

**Controller Navigation**
- Adds full gamepad navigation to the sidebar with dpad movement and button interaction
- Supports tab switching via shoulder buttons and adjacent navigation with left/right
- Handles range slider adjustment with dpad when focused
- Includes controller-specific exit confirmation dialog with D-pad navigation

**Visual Design**
- Modern gradients and glass-morphic effects throughout
- Blue accent color scheme with clear focus state for all interactive elements
- Improved contrast and tap targets for better usability
- Responsive adjustments for constrained viewports (<560px width or height)

**Changes to files**
- `opennow-stable/src/renderer/src/components/StreamView.tsx`: Rewrite of sidebar tab state, gamepad frame loop, and keyboard/exit handlers
- `opennow-stable/src/renderer/src/components/SideBar.tsx`: Added footer prop and element ref forwarding
- `opennow-stable/src/renderer/src/styles.css`: 370+ lines of new overlay styling, responsive breakpoints, and focus states

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c0ad3c5f-6584-45a2-a7ea-bc83a4fa3325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-265" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/c0ad3c5f-6584-45a2-a7ea-bc83a4fa3325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-265&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-265"><img alt="OPE-265" src="https://capy.ai/api/badge/thread.svg?label=OPE-265"></picture></a>
<!-- capy-pr-badge:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI refactor in the hot path for stream control and session exit, with new gamepad input loops that could conflict with game capture if edge cases are missed; no backend or auth changes.
> 
> **Overview**
> Redesigns the in-stream **Quick menu** (Ctrl+G) from a two-tab “preferences / shortcuts” panel into a four-tab layout—**Session**, **Controls**, **Media**, and **Keys**—with a sticky tab bar, larger action cards on Session, and **End session** moved to a persistent footer.
> 
> **`SideBar`** gains optional **`footer`** and **`elementRef`** so the stream overlay can anchor gamepad focus and pin controller hints plus exit outside the scrollable body.
> 
> **`StreamView`** wires a `requestAnimationFrame` gamepad loop while the menu is open: D-pad focus movement, shoulder buttons for tabs, range sliders on left/right, A/B/Menu for select/back, and the same pattern on the exit confirmation dialog (plus Enter/Esc). Session tab adds quick actions (fullscreen, pointer lock, mic, screenshot); controls/media/keys largely reuse existing settings but are split across pages.
> 
> **`styles.css`** adds overlay sizing, gradients, tab styling, metrics grid, focus rings, and responsive tweaks for small viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7611a168f8c00c5e6f245e0771fdcbeaa28eaf1f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->