### PR TITLE
feat(renderer): polish queue shaders and Motion animations

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -261,11 +261,13 @@
     "labels": {
       "launchError": "Launch Error",
       "nowLoading": "Now Loading",
-      "adQueue": "Ad Queue"
+      "adQueue": "Ad Queue",
+      "launchProgress": "Game launch progress"
     },
     "steps": {
       "queue": "Queue",
       "setup": "Setup",
+      "connect": "Connect",
       "ready": "Ready"
     },
     "status": {
@@ -278,6 +280,28 @@
       "connectingToServer": "Connecting to server...",
       "settingUpStream": "Setting up stream...",
       "loading": "Loading..."
+    },
+    "detail": {
+      "queueMoving": "The live queue is moving. Your place is secured at #{{position}}.",
+      "findingCapacity": "Finding the best available cloud rig for this session.",
+      "rigReserved": "A gaming rig is reserved. Applying your session configuration now.",
+      "servicesStarting": "Starting game services and preparing the remote display.",
+      "mediaHandshake": "Negotiating the low-latency video and input channels."
+    },
+    "cozy": {
+      "queue": "Settle in. We'll keep your place and bring the game in when it's ready.",
+      "setup": "Your cloud rig is reserved and getting comfortable for you.",
+      "starting": "The game is starting on your cloud rig.",
+      "connecting": "The game is ready. Waiting for the first clear frame.",
+      "next": "Up next"
+    },
+    "telemetry": {
+      "queuePosition": "Queue position",
+      "calculating": "Calculating",
+      "cleared": "Cleared",
+      "elapsed": "Elapsed",
+      "session": "Session",
+      "protected": "Secured"
     },
     "ads": {
       "resumeToStayInQueue": "Resume ads to stay in queue.",

--- a/opennow-stable/bun.lock
+++ b/opennow-stable/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "opennow-stable",
       "dependencies": {
+        "@react-three/fiber": "^9.6.1",
         "discord-rpc": "^4.0.1",
         "electron-updater": "^6.8.3",
         "lucide-react": "^1.17.0",
@@ -12,6 +13,7 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "three": "^0.185.1",
         "ws": "^8.21.0",
       },
       "devDependencies": {
@@ -20,6 +22,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.185.1",
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^5.2.0",
         "cross-env": "^10.1.0",
@@ -71,6 +74,8 @@
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
@@ -78,6 +83,8 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@develar/schema-utils": ["@develar/schema-utils@2.6.5", "", { "dependencies": { "ajv": "^6.12.0", "ajv-keywords": "^3.4.1" } }, "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig=="],
+
+    "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 
@@ -217,6 +224,8 @@
 
     "@preact/signals-core": ["@preact/signals-core@1.14.1", "", {}, "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng=="],
 
+    "@react-three/fiber": ["@react-three/fiber@9.6.1", "", { "dependencies": { "@babel/runtime": "^7.17.8", "@types/webxr": "*", "base64-js": "^1.5.1", "buffer": "^6.0.3", "its-fine": "^2.0.0", "react-use-measure": "^2.1.7", "scheduler": "^0.27.0", "suspend-react": "^0.1.3", "use-sync-external-store": "^1.4.0", "zustand": "^5.0.3" }, "peerDependencies": { "expo": ">=43.0", "expo-asset": ">=8.4", "expo-file-system": ">=11.0", "expo-gl": ">=11.0", "react": ">=19 <19.3", "react-dom": ">=19 <19.3", "react-native": ">=0.78", "three": ">=0.156" }, "optionalPeers": ["expo", "expo-asset", "expo-file-system", "expo-gl", "react-dom", "react-native"] }, "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
@@ -277,6 +286,8 @@
 
     "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
 
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -313,9 +324,17 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/react-reconciler": ["@types/react-reconciler@0.28.9", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="],
+
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.185.1", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A=="],
+
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -391,7 +410,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": "cli.js" }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
@@ -571,6 +590,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "filelist": ["filelist@1.0.4", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q=="],
@@ -677,6 +698,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "its-fine": ["its-fine@2.0.0", "", { "dependencies": { "@types/react-reconciler": "^0.28.9" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng=="],
+
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": "bin/cli.js" }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
@@ -740,6 +763,8 @@
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
 
     "mime": ["mime@2.6.0", "", { "bin": "cli.js" }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
 
@@ -879,6 +904,8 @@
 
     "react-scan": ["react-scan@0.5.3", "", { "dependencies": { "@babel/core": "^7.26.0", "@babel/generator": "^7.26.2", "@babel/types": "^7.26.0", "@preact/signals": "^1.3.1", "@rollup/pluginutils": "^5.1.3", "@types/node": "^20.17.9", "bippy": "^0.5.30", "commander": "^14.0.0", "esbuild": "^0.25.0", "estree-walker": "^3.0.3", "picocolors": "^1.1.1", "preact": "^10.25.1", "prompts": "^2.4.2" }, "optionalDependencies": { "unplugin": "2.1.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "bin": { "react-scan": "bin/cli.js" } }, "sha512-qde9PupmUf0L3MU1H6bjmoukZNbCXdMyTEwP4Gh8RQ4rZPd2GGNBgEKWszwLm96E8k+sGtMpc0B9P0KyFDP6Bw=="],
 
+    "react-use-measure": ["react-use-measure@2.1.7", "", { "peerDependencies": { "react": ">=16.13", "react-dom": ">=16.13" }, "optionalPeers": ["react-dom"] }, "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="],
+
     "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": "cli.js" }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -969,11 +996,15 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "suspend-react": ["suspend-react@0.1.3", "", { "peerDependencies": { "react": ">=17.0" } }, "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ=="],
+
     "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "temp-file": ["temp-file@3.4.0", "", { "dependencies": { "async-exit-hook": "^2.0.1", "fs-extra": "^10.0.0" } }, "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg=="],
+
+    "three": ["three@0.185.1", "", {}, "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
@@ -1012,6 +1043,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "utf8-byte-length": ["utf8-byte-length@1.0.5", "", {}, "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="],
 
@@ -1058,6 +1091,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zip-stream": ["zip-stream@4.1.1", "", { "dependencies": { "archiver-utils": "^3.0.4", "compress-commons": "^4.1.2", "readable-stream": "^3.6.0" } }, "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ=="],
+
+    "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1107,6 +1142,8 @@
 
     "archiver-utils/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
     "cacache/fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
 
     "cacache/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": "dist/esm/bin.mjs" }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -1118,6 +1155,8 @@
     "config-file-ts/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": "dist/esm/bin.mjs" }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "config-file-ts/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "crc/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "dir-compare/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 

--- a/opennow-stable/package-lock.json
+++ b/opennow-stable/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.5.1",
       "hasInstallScript": true,
       "dependencies": {
+        "@react-three/fiber": "^9.6.1",
         "discord-rpc": "^4.0.1",
         "electron-updater": "^6.8.3",
         "lucide-react": "^1.17.0",
@@ -16,6 +17,7 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "three": "^0.185.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -24,6 +26,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.185.1",
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^5.2.0",
         "cross-env": "^10.1.0",
@@ -307,6 +310,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -372,6 +384,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
@@ -1660,6 +1679,78 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2073,6 +2164,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2252,7 +2350,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2268,6 +2365,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -2278,6 +2384,28 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -2285,6 +2413,12 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2687,7 +2821,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3453,7 +3586,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4244,6 +4376,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -4814,7 +4953,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4920,6 +5058,18 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     },
     "node_modules/jackspeak": {
       "version": "4.2.3",
@@ -5210,6 +5360,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "2.6.0",
@@ -6317,6 +6474,21 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -6854,6 +7026,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
@@ -6910,6 +7091,12 @@
       "bin": {
         "rimraf": "bin.js"
       }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
@@ -7634,6 +7821,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utf8-byte-length": {
@@ -8427,6 +8623,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -30,6 +30,7 @@
     "test": "node scripts/run-tests.mjs"
   },
   "dependencies": {
+    "@react-three/fiber": "^9.6.1",
     "discord-rpc": "^4.0.1",
     "electron-updater": "^6.8.3",
     "lucide-react": "^1.17.0",
@@ -37,6 +38,7 @@
     "qrcode": "^1.5.4",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "three": "^0.185.1",
     "ws": "^8.21.0"
   },
   "devDependencies": {
@@ -45,6 +47,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.185.1",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.2.0",
     "cross-env": "^10.1.0",

--- a/opennow-stable/scripts/ensure-electron-installed.mjs
+++ b/opennow-stable/scripts/ensure-electron-installed.mjs
@@ -118,11 +118,27 @@ if (!hasElectronBinary()) {
   rmSync(resolvedDistRoot, { recursive: true, force: true });
   mkdirSync(resolvedDistRoot, { recursive: true });
 
-  const electronRequire = createRequire(electronPackageJson);
-  const { extract } = await import(pathToFileURL(electronRequire.resolve("@electron-internal/extract-zip")).href);
-
   try {
-    await extract(zipPath, { dir: resolvedDistRoot });
+    if (platform === "win32") {
+      // Windows ships bsdtar, which extracts Electron's zip reliably even on
+      // newer Node releases where extract-zip@2 can leave its promise pending.
+      const extractResult = spawnSync("tar.exe", ["-xf", zipPath, "-C", resolvedDistRoot], {
+        stdio: "inherit",
+      });
+      if (extractResult.status !== 0) {
+        throw new Error(`Windows archive extraction failed with exit code ${extractResult.status ?? "unknown"}.`);
+      }
+    } else {
+      // Electron 42 publishes extract-zip as a regular dependency. Resolve it
+      // from Electron's package boundary so npm hoisting does not affect us.
+      const electronRequire = createRequire(electronPackageJson);
+      const extractZipModule = await import(pathToFileURL(electronRequire.resolve("extract-zip")).href);
+      const extract = extractZipModule.default ?? extractZipModule.extract;
+      if (typeof extract !== "function") {
+        throw new TypeError("Electron archive extractor did not expose a callable function.");
+      }
+      await extract(zipPath, { dir: resolvedDistRoot });
+    }
   } catch (error) {
     console.error("Failed to extract Electron archive:", error);
     process.exit(1);

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -198,7 +198,7 @@ function normalizeRecordingBitrateMbps(raw: unknown): number | null {
 const DEFAULT_SETTINGS: Settings = {
   resolution: "1920x1080",
   aspectRatio: "16:9",
-  posterSizeScale: 1,
+  posterSizeScale: 1.05,
   fps: 60,
   maxBitrateMbps: 75,
   recordingBitrateMbps: null,

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -52,7 +52,7 @@ import {
 } from "./hooks/useStreamSession";
 import { useQueueAdRuntime } from "./hooks/useQueueAdRuntime";
 import { usePlaytime } from "./utils/usePlaytime";
-import { createStreamDiagnosticsStore } from "./utils/streamDiagnosticsStore";
+import { createStreamDiagnosticsStore, useStreamDiagnosticsSelector } from "./utils/streamDiagnosticsStore";
 import type {
   LaunchErrorState,
   LocalSessionTimerWarningState,
@@ -95,6 +95,7 @@ import {
 import {
   isSessionInQueue,
   isSessionReadyForConnect,
+  isStreamVideoReady,
   streamStatusToLoadingStage,
   toLaunchErrorState,
   toLoadingStatus,
@@ -115,7 +116,8 @@ import { StreamLoading } from "./components/StreamLoading";
 import { StreamView } from "./components/StreamView";
 import { QueueServerSelectModal } from "./components/QueueServerSelectModal";
 import { ReleaseHighlightsModal } from "./components/ReleaseHighlightsModal";
-import { pageTransition } from "./components/MotionProvider";
+import { overlayMotion, pageTransition, standardEase } from "./components/MotionProvider";
+import { LazyShaderAtmosphere } from "./components/LazyShaderAtmosphere";
 
 const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
 
@@ -172,7 +174,7 @@ export function App(): JSX.Element {
   const [settings, setSettings] = useState<Settings>({
     resolution: "1920x1080",
     aspectRatio: "16:9",
-    posterSizeScale: 1,
+    posterSizeScale: 1.05,
     fps: 60,
     maxBitrateMbps: 75,
     recordingBitrateMbps: null,
@@ -246,6 +248,10 @@ export function App(): JSX.Element {
   const diagnosticsStoreRef = useRef<ReturnType<typeof createStreamDiagnosticsStore> | null>(null);
   const diagnosticsStore =
     diagnosticsStoreRef.current ?? (diagnosticsStoreRef.current = createStreamDiagnosticsStore(defaultDiagnostics()));
+  const diagnosticsVideoReady = useStreamDiagnosticsSelector(
+    diagnosticsStore,
+    (stats) => stats.nativeRendererActive || stats.framesDecoded > 0,
+  );
 
   // Stream State
   const [session, setSession] = useState<SessionInfo | null>(null);
@@ -327,12 +333,48 @@ export function App(): JSX.Element {
   // Refs
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [videoElementHasFrame, setVideoElementHasFrame] = useState(false);
+  const [streamRevealComplete, setStreamRevealComplete] = useState(false);
   const clientRef = useRef<GfnWebRtcClient | null>(null);
   const isStreamingRef = useRef(streamStatus === "streaming");
 
   useEffect(() => {
     isStreamingRef.current = streamStatus === "streaming";
   }, [streamStatus]);
+
+  useEffect(() => {
+    if (streamStatus !== "streaming") {
+      setVideoElementHasFrame(false);
+      setStreamRevealComplete(false);
+    }
+
+    if (streamStatus === "idle") return undefined;
+
+    const video = videoRef.current;
+    if (!video) return undefined;
+
+    const syncVideoFrame = (): void => {
+      setVideoElementHasFrame(video.videoWidth > 0 && video.videoHeight > 0);
+    };
+
+    syncVideoFrame();
+    video.addEventListener("loadeddata", syncVideoFrame);
+    video.addEventListener("playing", syncVideoFrame);
+    video.addEventListener("resize", syncVideoFrame);
+    return () => {
+      video.removeEventListener("loadeddata", syncVideoFrame);
+      video.removeEventListener("playing", syncVideoFrame);
+      video.removeEventListener("resize", syncVideoFrame);
+    };
+  }, [streamStatus]);
+
+  const streamVideoReady = isStreamVideoReady(streamStatus, diagnosticsVideoReady, videoElementHasFrame);
+
+  useEffect(() => {
+    if (streamStatus === "idle" || !streamVideoReady || streamRevealComplete) return undefined;
+    const timer = window.setTimeout(() => setStreamRevealComplete(true), 680);
+    return () => window.clearTimeout(timer);
+  }, [streamRevealComplete, streamStatus, streamVideoReady]);
 
   useEffect(() => {
     if (streamStatus === "streaming" && audioRef.current) {
@@ -3533,10 +3575,14 @@ export function App(): JSX.Element {
   const showLaunchOverlay = streamStatus !== "idle" || launchError !== null;
   const hasActiveStreamView = streamStatus !== "idle";
   const showLaunchErrorOverlay = launchError !== null;
-  const showDesktopLaunchLoading = showLaunchErrorOverlay || (streamStatus !== "idle" && streamStatus !== "streaming");
+  const showDesktopLaunchLoading = showLaunchErrorOverlay || (streamStatus !== "idle" && !streamRevealComplete);
   // Show stream lifecycle (waiting/connecting/streaming/failure)
   if (showLaunchOverlay) {
-    const loadingStatus = launchError ? launchError.stage : toLoadingStatus(streamStatus);
+    const loadingStatus = launchError
+      ? launchError.stage
+      : streamStatus === "streaming"
+        ? "connecting"
+        : toLoadingStatus(streamStatus);
     return (
       <>
         {hasActiveStreamView && (
@@ -3615,55 +3661,84 @@ export function App(): JSX.Element {
             onVideoShaderChange={handleVideoShaderChange}
           />
         )}
-        {showDesktopLaunchLoading && (
-          <StreamLoading
-            gameTitle={streamingGame?.title ?? t("app.labels.game")}
-            gameCover={streamingGame?.imageUrl}
-            platformStore={streamingStore ?? undefined}
-            status={loadingStatus}
-            queuePosition={queuePosition}
-            adState={effectiveAdState}
-            activeAd={activeQueueAd}
-            activeAdMediaUrl={activeQueueAdMediaUrl}
-            onAdPlaybackEvent={handleQueueAdPlaybackEvent}
-            adPreviewRef={queueAdPreviewRef}
-            error={
-              launchError
-                ? {
-                    title: launchError.title,
-                    description: launchError.description,
-                    code: launchError.codeLabel,
-                    actionLabel: launchError.actionLabel,
+        <AnimatePresence>
+          {showDesktopLaunchLoading && (
+            <m.div
+              key="stream-loading-transition"
+              className={`stream-loading-transition${streamVideoReady && !launchError ? " stream-loading-transition--warping" : ""}`}
+              initial={false}
+              animate={streamVideoReady && !launchError
+                ? { opacity: 0, scale: 1.025 }
+                : { opacity: 1, scale: 1 }}
+              exit={{ opacity: 0 }}
+              transition={streamVideoReady && !launchError
+                ? { duration: 0.62, ease: standardEase }
+                : { duration: 0.16, ease: standardEase }}
+            >
+              <StreamLoading
+                gameTitle={streamingGame?.title ?? t("app.labels.game")}
+                gameCover={streamingGame?.imageUrl}
+                platformStore={streamingStore ?? undefined}
+                status={loadingStatus}
+                queuePosition={queuePosition}
+                adState={effectiveAdState}
+                activeAd={activeQueueAd}
+                activeAdMediaUrl={activeQueueAdMediaUrl}
+                onAdPlaybackEvent={handleQueueAdPlaybackEvent}
+                adPreviewRef={queueAdPreviewRef}
+                error={
+                  launchError
+                    ? {
+                        title: launchError.title,
+                        description: launchError.description,
+                        code: launchError.codeLabel,
+                        actionLabel: launchError.actionLabel,
+                      }
+                    : undefined
+                }
+                onErrorAction={launchError?.action ? handleLaunchErrorAction : undefined}
+                onCancel={() => {
+                  if (launchError) {
+                    void handleDismissLaunchError();
+                    return;
                   }
-                : undefined
-            }
-            onErrorAction={launchError?.action ? handleLaunchErrorAction : undefined}
-            onCancel={() => {
-              if (launchError) {
-                void handleDismissLaunchError();
-                return;
-              }
-              void handlePromptedStopStream();
-            }}
-          />
-        )}
+                  void handlePromptedStopStream();
+                }}
+              />
+            </m.div>
+          )}
+        </AnimatePresence>
       </>
     );
   }
 
   // Main app layout
+  const showCatalogAtmosphere = currentPage === "home" || currentPage === "library";
   return (
-    <div className={`app-container${effectiveControllerMode ? " app-container--controller" : ""}`} style={getAppStyle(settings.posterSizeScale)}>
-      {startupRefreshNotice && (
-        <div className={`auth-refresh-notice auth-refresh-notice--${startupRefreshNotice.tone}`}>
-          {startupRefreshNotice.text}
-        </div>
-      )}
-      {catalogActionNotice && (
-        <div className={`auth-refresh-notice auth-refresh-notice--${catalogActionNotice.tone}`}>
-          {catalogActionNotice.text}
-        </div>
-      )}
+    <div className={`app-container${effectiveControllerMode ? " app-container--controller" : ""}${showCatalogAtmosphere ? " app-container--atmosphere" : ""}`} style={getAppStyle(settings.posterSizeScale)}>
+      {showCatalogAtmosphere && <LazyShaderAtmosphere variant="controller" className="catalog-atmosphere" />}
+      <AnimatePresence>
+        {startupRefreshNotice && (
+          <m.div
+            key="startup-refresh-notice"
+            className={`auth-refresh-notice auth-refresh-notice--${startupRefreshNotice.tone}`}
+            {...overlayMotion}
+          >
+            {startupRefreshNotice.text}
+          </m.div>
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {catalogActionNotice && (
+          <m.div
+            key="catalog-action-notice"
+            className={`auth-refresh-notice auth-refresh-notice--${catalogActionNotice.tone}`}
+            {...overlayMotion}
+          >
+            {catalogActionNotice.text}
+          </m.div>
+        )}
+      </AnimatePresence>
       <Navbar
         currentPage={currentPage}
         onNavigate={handleNavigate}

--- a/opennow-stable/src/renderer/src/components/GameCard.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCard.tsx
@@ -1,6 +1,7 @@
 import { Play, Monitor } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
 import type { JSX } from "react";
+import { m } from "motion/react";
 import { normalizeGameStore } from "@shared/gfn";
 import type { GameInfo } from "@shared/gfn";
 import { getActiveGameAvailabilityBadge } from "../lib/gameCardStatus";
@@ -187,8 +188,10 @@ export const GameCard = memo(function GameCard({
   };
 
   return (
-    <div
+    <m.div
       className={`game-card ${isSelected ? "selected" : ""}`}
+      whileHover={{ y: -2, scale: 1.01 }}
+      whileTap={{ scale: 0.985 }}
       onClick={onSelect}
       onKeyDown={(event) => {
         if (event.target !== event.currentTarget) {
@@ -294,6 +297,6 @@ export const GameCard = memo(function GameCard({
           </h3>
         </div>
       </div>
-    </div>
+    </m.div>
   );
 }, gameCardPropsAreEqual);

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Search, LayoutGrid, Loader2, ArrowUpDown, Filter, ChevronDown, Gamepad2, Menu } from "lucide-react";
+import { Search, LayoutGrid, ArrowUpDown, Filter, ChevronDown, Gamepad2, Menu } from "lucide-react";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import { AnimatePresence, m } from "motion/react";
@@ -11,6 +11,7 @@ import { useTranslation } from "../i18n";
 import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
 import { pageTransition, panelSpring } from "./MotionProvider";
 import { SelectDropdown } from "./ui/SelectDropdown";
+import { MotionSpinner } from "./MotionSpinner";
 
 const CONTROLLER_STORE_HERO_ROTATION_MS = 7000;
 const CONTROLLER_MOVE_REPEAT_MS = 140;
@@ -513,7 +514,7 @@ export const HomePage = memo(function HomePage({
       <div className="home-page controller-store-page">
         {showInitialLoading ? (
           <div className="home-empty-state controller-store-empty">
-            <Loader2 className="home-spinner" size={54} />
+            <MotionSpinner className="home-spinner" size={54} label={t("common.loading")} />
             <p>{t("home.empty.loadingGames")}</p>
           </div>
         ) : controllerSections.length === 0 ? (
@@ -762,7 +763,7 @@ export const HomePage = memo(function HomePage({
       <div className="home-grid-area">
         {showInitialLoading ? (
           <div className="home-empty-state">
-            <Loader2 className="home-spinner" size={36} />
+            <MotionSpinner className="home-spinner" size={36} label={t("common.loading")} />
             <p>{t("home.empty.loadingGames")}</p>
           </div>
         ) : !hasGames ? (

--- a/opennow-stable/src/renderer/src/components/LazyShaderAtmosphere.tsx
+++ b/opennow-stable/src/renderer/src/components/LazyShaderAtmosphere.tsx
@@ -1,0 +1,25 @@
+import { lazy, Suspense } from "react";
+import type { JSX } from "react";
+import type { ShaderAtmosphereProps } from "./ShaderAtmosphere";
+
+const ShaderAtmosphereCanvas = lazy(async () => {
+  const module = await import("./ShaderAtmosphere");
+  return { default: module.ShaderAtmosphere };
+});
+
+export function LazyShaderAtmosphere({
+  variant = "controller",
+  className,
+}: ShaderAtmosphereProps): JSX.Element {
+  const fallbackClassName = [
+    "shader-atmosphere",
+    `shader-atmosphere--${variant}`,
+    className,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <Suspense fallback={<div className={fallbackClassName} aria-hidden="true" />}>
+      <ShaderAtmosphereCanvas variant={variant} className={className} />
+    </Suspense>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { Library, Search, Clock, Gamepad2, Loader2, ArrowUpDown, Filter, ChevronDown, X } from "lucide-react";
+import { Library, Search, Clock, Gamepad2, ArrowUpDown, Filter, ChevronDown, X } from "lucide-react";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import { AnimatePresence, m } from "motion/react";
@@ -21,6 +21,7 @@ import { controllerButton, readControllerGamepadButtons } from "../utils/control
 import { pageTransition } from "./MotionProvider";
 import { SelectDropdown } from "./ui/SelectDropdown";
 import { LibraryControllerView } from "./library/LibraryControllerView";
+import { MotionSpinner } from "./MotionSpinner";
 
 const CONTROLLER_HERO_ROTATION_MS = 8000;
 const CONTROLLER_MOVE_REPEAT_MS = 140;
@@ -464,12 +465,13 @@ export const LibraryPage = memo(function LibraryPage({
           selectedVariantId={selectedVariantByGameId[game.id]}
           actionsRef={catalogActionsRef}
         />
-        {game.lastPlayed && (
-          <div className="library-last-played">
-            <Clock size={12} />
-            <span>{formatCatalogLastPlayed(t, game.lastPlayed)}</span>
-          </div>
-        )}
+        <div
+          className={`library-last-played${game.lastPlayed ? "" : " library-last-played--empty"}`}
+          aria-hidden={game.lastPlayed ? undefined : true}
+        >
+          <Clock size={12} />
+          <span>{game.lastPlayed ? formatCatalogLastPlayed(t, game.lastPlayed) : "—"}</span>
+        </div>
       </div>
     )),
     [catalogActionsRef, selectedGameId, selectedVariantByGameId, t, visibleLibraryGames],
@@ -614,7 +616,7 @@ export const LibraryPage = memo(function LibraryPage({
       <div className="library-grid-area">
         {isLoading ? (
           <div className="library-empty-state">
-            <Loader2 className="library-spinner" size={36} />
+            <MotionSpinner className="library-spinner" size={36} label={t("common.loading")} />
             <p>{t("library.empty.loadingLibrary")}</p>
           </div>
         ) : libraryCount === 0 ? (

--- a/opennow-stable/src/renderer/src/components/LoginScreen.tsx
+++ b/opennow-stable/src/renderer/src/components/LoginScreen.tsx
@@ -2,9 +2,12 @@ import { useState, useRef, useEffect } from "react";
 import type { JSX } from "react";
 import QRCode from "qrcode";
 import { LogIn, ChevronDown, QrCode } from "lucide-react";
+import { AnimatePresence, m } from "motion/react";
 import type { AuthDeviceLoginChallenge, LoginProvider } from "@shared/gfn";
 import { useTranslation } from "../i18n";
 import { OpenNowLogoMark } from "./OpenNowLogoMark";
+import { MotionSpinner } from "./MotionSpinner";
+import { dialogMotion, smoothEase } from "./MotionProvider";
 
 export interface LoginScreenProps {
   providers: LoginProvider[];
@@ -96,13 +99,25 @@ export function LoginScreen({
   return (
     <div className="login-screen">
       <div className="login-bg">
-        <div className="login-bg-orb login-bg-orb--1" />
-        <div className="login-bg-orb login-bg-orb--2" />
-        <div className="login-bg-orb login-bg-orb--3" />
+        <m.div
+          className="login-bg-orb login-bg-orb--1"
+          animate={{ x: [0, -40, 0], y: [0, 30, 0], scale: [1, 1.15, 1] }}
+          transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
+        />
+        <m.div
+          className="login-bg-orb login-bg-orb--2"
+          animate={{ x: [0, 50, 0], y: [0, -35, 0], scale: [1, 1.1, 1] }}
+          transition={{ duration: 28, repeat: Infinity, ease: "easeInOut" }}
+        />
+        <m.div
+          className="login-bg-orb login-bg-orb--3"
+          animate={{ x: [0, 30, 0], y: [0, 20, 0], scale: [1, 0.9, 1] }}
+          transition={{ duration: 18, repeat: Infinity, ease: "easeInOut" }}
+        />
         <div className="login-bg-noise" />
       </div>
 
-      <div className="login-content">
+      <m.div className="login-content" {...dialogMotion}>
         {/* Brand */}
         <div className="login-brand">
           <div className="login-brand-mark">
@@ -127,7 +142,11 @@ export function LoginScreen({
 
           {isInitializing && statusMessage && (
             <div className="login-status" role="status" aria-live="polite">
-              <span className="login-status-dot" />
+              <m.span
+                className="login-status-dot"
+                animate={{ opacity: [0.55, 1, 0.55], scale: [0.9, 1.12, 0.9] }}
+                transition={{ duration: 1.7, repeat: Infinity, ease: "easeInOut" }}
+              />
               {statusMessage}
             </div>
           )}
@@ -151,8 +170,15 @@ export function LoginScreen({
               />
             </button>
 
-            {isDropdownOpen && (
-              <div className="login-dropdown">
+            <AnimatePresence>
+              {isDropdownOpen && (
+              <m.div
+                className="login-dropdown"
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -4 }}
+                transition={{ duration: 0.14, ease: smoothEase }}
+              >
                 {providers.map((provider) => (
                   <button
                     key={provider.idpId}
@@ -168,8 +194,9 @@ export function LoginScreen({
                     )}
                   </button>
                 ))}
-              </div>
-            )}
+              </m.div>
+              )}
+            </AnimatePresence>
           </div>
 
           {isQrLoginActive && (
@@ -178,7 +205,7 @@ export function LoginScreen({
                 {qrLoginChallenge && qrCodeDataUrl ? (
                   <img src={qrCodeDataUrl} alt={t("auth.qr.alt")} />
                 ) : (
-                  <span className="login-spinner" />
+                  <MotionSpinner className="login-motion-spinner" size={16} label={t("common.loading")} />
                 )}
               </div>
               <div className="login-qr-copy">
@@ -209,7 +236,7 @@ export function LoginScreen({
             >
               {isLoading || isInitializing ? (
                 <>
-                  <span className="login-spinner" />
+                  <MotionSpinner className="login-motion-spinner" size={16} label={t("common.loading")} />
                   <span>{isInitializing ? t("auth.actions.restoringSession") : t("auth.actions.connecting")}</span>
                 </>
               ) : (
@@ -232,7 +259,7 @@ export function LoginScreen({
         </div>
 
         <p className="login-footer">{t("app.tagline")}</p>
-      </div>
+      </m.div>
     </div>
   );
 }

--- a/opennow-stable/src/renderer/src/components/MotionProvider.tsx
+++ b/opennow-stable/src/renderer/src/components/MotionProvider.tsx
@@ -2,6 +2,8 @@ import type { JSX, PropsWithChildren } from "react";
 import { LazyMotion, MotionConfig, domAnimation } from "motion/react";
 
 export const smoothEase = [0.16, 1, 0.3, 1] as const;
+export const standardEase = [0.4, 0, 0.2, 1] as const;
+export const exitEase = [0.4, 0, 1, 1] as const;
 
 export const pageTransition = {
   duration: 0.24,
@@ -19,6 +21,26 @@ export const panelSpring = {
   stiffness: 420,
   damping: 36,
   mass: 0.85,
+} as const;
+
+export const overlayMotion = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+  transition: { duration: 0.18, ease: standardEase },
+} as const;
+
+export const dialogMotion = {
+  initial: { opacity: 0, scale: 0.97, y: 10 },
+  animate: { opacity: 1, scale: 1, y: 0 },
+  exit: { opacity: 0, scale: 0.985, y: 6 },
+  transition: { duration: 0.2, ease: smoothEase },
+} as const;
+
+export const spinnerTransition = {
+  duration: 0.85,
+  ease: "linear",
+  repeat: Infinity,
 } as const;
 
 export function MotionProvider({ children }: PropsWithChildren): JSX.Element {

--- a/opennow-stable/src/renderer/src/components/MotionSpinner.tsx
+++ b/opennow-stable/src/renderer/src/components/MotionSpinner.tsx
@@ -1,0 +1,28 @@
+import { Loader2 } from "lucide-react";
+import { m } from "motion/react";
+import type { JSX } from "react";
+import { spinnerTransition } from "./MotionProvider";
+
+interface MotionSpinnerProps {
+  size?: number;
+  className?: string;
+  label?: string;
+}
+
+export function MotionSpinner({
+  size = 20,
+  className,
+  label = "Loading",
+}: MotionSpinnerProps): JSX.Element {
+  return (
+    <m.span
+      className={["motion-spinner", className].filter(Boolean).join(" ")}
+      animate={{ rotate: 360 }}
+      transition={spinnerTransition}
+      role="status"
+      aria-label={label}
+    >
+      <Loader2 size={size} aria-hidden="true" />
+    </m.span>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/Navbar.tsx
+++ b/opennow-stable/src/renderer/src/components/Navbar.tsx
@@ -1,9 +1,10 @@
 import type { ActiveSessionInfo, AuthUser, SavedAccount, SubscriptionInfo } from "@shared/gfn";
-import { House, Library, Settings, User, Timer, HardDrive, X, Loader2, PlayCircle, Square, ChevronDown, Check, Plus, Store as StoreIcon } from "lucide-react";
+import { House, Library, Settings, User, Timer, HardDrive, X, PlayCircle, Square, ChevronDown, Check, Plus, Store as StoreIcon } from "lucide-react";
 import { useEffect, useRef, useState, type JSX } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "../i18n";
 import { OpenNowLogoMark } from "./OpenNowLogoMark";
+import { MotionSpinner } from "./MotionSpinner";
 
 interface NavbarProps {
   currentPage: "home" | "library" | "settings";
@@ -334,7 +335,7 @@ export function Navbar({
               onClick={onResumeSession}
               disabled={isResumingSession || isTerminatingSession || !activeSession.serverIp}
             >
-              {isResumingSession ? <Loader2 size={14} className="navbar-session-resume-spin" /> : <PlayCircle size={14} />}
+              {isResumingSession ? <MotionSpinner size={14} label="Resuming session" /> : <PlayCircle size={14} />}
               <span className="navbar-session-resume-text">{t("app.actions.resume")}</span>
               {activeSessionTitle && <span className="navbar-session-resume-game">{activeSessionTitle}</span>}
             </button>
@@ -349,7 +350,7 @@ export function Navbar({
               onClick={onTerminateSession}
               disabled={isResumingSession || isTerminatingSession}
             >
-              {isTerminatingSession ? <Loader2 size={14} className="navbar-session-resume-spin" /> : <Square size={12} />}
+              {isTerminatingSession ? <MotionSpinner size={14} label="Ending session" /> : <Square size={12} />}
               <span className="navbar-session-terminate-text">{t("session.terminate")}</span>
             </button>
           </div>

--- a/opennow-stable/src/renderer/src/components/QueueAdPreview.tsx
+++ b/opennow-stable/src/renderer/src/components/QueueAdPreview.tsx
@@ -1,5 +1,7 @@
 import { AlertTriangle, Loader2, PauseCircle, PlayCircle, RefreshCcw, XCircle } from "lucide-react";
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState, type JSX } from "react";
+import { m } from "motion/react";
+import { spinnerTransition } from "./MotionProvider";
 
 type QueueAdPlaybackState = "loading" | "playing" | "paused" | "stalled" | "blocked" | "timeout" | "error";
 export type QueueAdPlaybackEvent = "loadstart" | "playing" | "paused" | "ended" | "timeupdate" | "error";
@@ -280,7 +282,13 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
         {showFrameOverlay && (
           <div className="queue-ad-preview-overlay" aria-hidden="true">
             <div className="queue-ad-preview-overlay-inner">
-              <StatusIcon className={`queue-ad-preview-overlay-icon${playbackState === "loading" ? " queue-ad-preview-icon--spinning" : ""}`} size={18} />
+              <m.span
+                className="queue-ad-preview-overlay-icon"
+                animate={playbackState === "loading" ? { rotate: 360 } : { rotate: 0 }}
+                transition={playbackState === "loading" ? spinnerTransition : { duration: 0.16 }}
+              >
+                <StatusIcon size={18} />
+              </m.span>
             </div>
           </div>
         )}

--- a/opennow-stable/src/renderer/src/components/QueueServerSelectModal.tsx
+++ b/opennow-stable/src/renderer/src/components/QueueServerSelectModal.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
+import { m } from "motion/react";
 import type { GameInfo, PrintedWasteQueueData, PrintedWasteZone } from "@shared/gfn";
 import { buildGfnZoneStreamingBaseUrl, isStandardGfnZone } from "@shared/gfn";
 import {
   loadStoredPrintedWastePingResults,
   saveStoredPrintedWastePingResults,
 } from "../utils/pingResultsStorage";
+import { spinnerTransition } from "./MotionProvider";
 
 // ── Constants / helpers ───────────────────────────────────────────────────────
 
@@ -725,18 +727,19 @@ function Chip({ color, children }: { color: string; children: React.ReactNode })
 
 function Spinner(): JSX.Element {
   return (
-    <>
-      <style>{`@keyframes on-spin{to{transform:rotate(360deg)}}`}</style>
-      <div style={{
+      <m.div
+        animate={{ rotate: 360 }}
+        transition={spinnerTransition}
+        role="status"
+        aria-label="Loading servers"
+        style={{
         display: "inline-block",
         width: 26,
         height: 26,
         border: "3px solid rgba(255,255,255,0.08)",
         borderTop: "3px solid var(--accent)",
         borderRadius: "50%",
-        animation: "on-spin 0.75s linear infinite",
       }} />
-    </>
   );
 }
 
@@ -748,13 +751,15 @@ function MiniSpinner({
   borderColor?: string;
 }): JSX.Element {
   return (
-    <div style={{
+    <m.div
+      animate={{ rotate: 360 }}
+      transition={spinnerTransition}
+      style={{
       width: 9,
       height: 9,
       border: `2px solid ${borderColor}`,
       borderTop: `2px solid ${color}`,
       borderRadius: "50%",
-      animation: "on-spin 0.75s linear infinite",
       flexShrink: 0,
     }} />
   );

--- a/opennow-stable/src/renderer/src/components/ShaderAtmosphere.tsx
+++ b/opennow-stable/src/renderer/src/components/ShaderAtmosphere.tsx
@@ -1,0 +1,208 @@
+import { Canvas, useFrame } from "@react-three/fiber";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { JSX, RefObject } from "react";
+import type { ShaderMaterial } from "three";
+import { Vector2 } from "three";
+
+export type ShaderAtmosphereVariant = "controller" | "queue" | "connecting";
+
+export interface ShaderAtmosphereProps {
+  variant?: ShaderAtmosphereVariant;
+  className?: string;
+}
+
+type PointerPosition = { x: number; y: number };
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position, 1.0);
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  precision highp float;
+
+  uniform float uTime;
+  uniform float uEnergy;
+  uniform float uDotted;
+  uniform vec3 uAccent;
+  uniform vec2 uPointer;
+  varying vec2 vUv;
+
+  float hash(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+  }
+
+  float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(
+      mix(hash(i), hash(i + vec2(1.0, 0.0)), f.x),
+      mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), f.x),
+      f.y
+    );
+  }
+
+  float fbm(vec2 p) {
+    float value = 0.0;
+    float amplitude = 0.5;
+    for (int i = 0; i < 4; i++) {
+      value += amplitude * noise(p);
+      p = p * 2.03 + 9.17;
+      amplitude *= 0.5;
+    }
+    return value;
+  }
+
+  void main() {
+    vec2 uv = vUv;
+    vec2 centered = uv - 0.5;
+    centered.x *= 1.65;
+
+    if (uDotted > 0.5) {
+      vec2 pointerDelta = uv - uPointer;
+      pointerDelta.x *= 1.65;
+      float pointerDistance = length(pointerDelta);
+      float pointerInfluence = exp(-pointerDistance * 7.0);
+      vec2 pointerDirection = pointerDelta / max(pointerDistance, 0.001);
+      vec2 warpedPixel = gl_FragCoord.xy - pointerDirection * pointerInfluence * 7.0;
+      vec2 cell = fract(warpedPixel / 18.0) - 0.5;
+      float dotRadius = mix(0.095, 0.19, pointerInfluence);
+      float dotShape = 1.0 - smoothstep(dotRadius, dotRadius + 0.05, length(cell));
+      float distanceFromCenter = length(centered);
+      float signal = 0.55 + 0.45 * sin(distanceFromCenter * 24.0 - uTime * 0.9);
+      float focus = smoothstep(1.05, 0.08, distanceFromCenter);
+      vec3 dottedBase = vec3(0.032, 0.045, 0.037);
+      vec3 dottedColor = dottedBase + uAccent * dotShape * (0.035 + signal * focus * 0.085);
+      dottedColor += uAccent * dotShape * pointerInfluence * 0.16;
+      gl_FragColor = vec4(dottedColor, 1.0);
+      return;
+    }
+
+    float time = uTime * 0.045;
+    float field = fbm(centered * 1.7 + vec2(time, -time * 0.42));
+    float detail = fbm(centered * 3.1 + vec2(-time * 0.36, time * 0.28) + 11.7);
+    float cloud = smoothstep(0.3, 0.78, field) * smoothstep(1.2, 0.12, length(centered));
+    float veil = smoothstep(0.46, 0.84, detail) * (0.4 + cloud * 0.6);
+    float leftPool = pow(max(0.0, 1.0 - length(centered - vec2(-0.48, 0.18))), 3.6);
+    float rightPool = pow(max(0.0, 1.0 - length(centered - vec2(0.52, -0.22))), 4.2);
+    float vignette = smoothstep(1.05, 0.18, length(centered));
+    float grain = (hash(gl_FragCoord.xy + floor(uTime * 8.0)) - 0.5) * 0.028;
+
+    vec3 base = vec3(0.004, 0.008, 0.009);
+    vec3 color = base;
+    color += uAccent * cloud * (0.055 + uEnergy * 0.075);
+    color += mix(uAccent, vec3(0.18, 0.64, 0.72), 0.42) * veil * 0.055;
+    color += uAccent * leftPool * 0.07;
+    color += mix(uAccent, vec3(0.12, 0.5, 0.44), 0.5) * rightPool * 0.06;
+    color *= 0.45 + vignette * 0.72;
+    color += grain;
+
+    gl_FragColor = vec4(color, 1.0);
+  }
+`;
+
+function SignalField({
+  variant,
+  pointerRef,
+}: {
+  variant: ShaderAtmosphereVariant;
+  pointerRef: RefObject<PointerPosition>;
+}): JSX.Element {
+  const materialRef = useRef<ShaderMaterial>(null);
+  const energy = variant === "controller" ? 0.36 : variant === "queue" ? 0.72 : 1;
+  const uniforms = useMemo(
+    () => ({
+      uTime: { value: 0 },
+      uEnergy: { value: energy },
+      uDotted: { value: variant === "controller" ? 0 : 1 },
+      uAccent: { value: [0.18, 0.92, 0.48] },
+      uPointer: { value: new Vector2(-2, -2) },
+    }),
+    [energy],
+  );
+
+  useFrame((state, delta) => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.uTime.value = state.clock.elapsedTime;
+      const pointerUniform = materialRef.current.uniforms.uPointer.value as Vector2;
+      const smoothing = 1 - Math.exp(-delta * 12);
+      pointerUniform.x += (pointerRef.current.x - pointerUniform.x) * smoothing;
+      pointerUniform.y += (pointerRef.current.y - pointerUniform.y) * smoothing;
+    }
+  });
+
+  return (
+    <mesh>
+      <planeGeometry args={[2, 2]} />
+      <shaderMaterial ref={materialRef} uniforms={uniforms} vertexShader={vertexShader} fragmentShader={fragmentShader} />
+    </mesh>
+  );
+}
+
+function supportsWebGl(): boolean {
+  try {
+    const canvas = document.createElement("canvas");
+    return Boolean(canvas.getContext("webgl2") || canvas.getContext("webgl"));
+  } catch {
+    return false;
+  }
+}
+
+export function ShaderAtmosphere({
+  variant = "controller",
+  className,
+}: ShaderAtmosphereProps): JSX.Element {
+  const [canRender, setCanRender] = useState(false);
+  const pointerRef = useRef<PointerPosition>({ x: -2, y: -2 });
+
+  useEffect(() => {
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    setCanRender(!reducedMotion && supportsWebGl());
+  }, []);
+
+  useEffect(() => {
+    if (!canRender || variant === "controller") return undefined;
+
+    const handlePointerMove = (event: PointerEvent): void => {
+      pointerRef.current.x = event.clientX / Math.max(window.innerWidth, 1);
+      pointerRef.current.y = 1 - event.clientY / Math.max(window.innerHeight, 1);
+    };
+    const clearPointer = (): void => {
+      pointerRef.current.x = -2;
+      pointerRef.current.y = -2;
+    };
+
+    window.addEventListener("pointermove", handlePointerMove, { passive: true });
+    window.addEventListener("blur", clearPointer);
+    document.documentElement.addEventListener("mouseleave", clearPointer);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("blur", clearPointer);
+      document.documentElement.removeEventListener("mouseleave", clearPointer);
+    };
+  }, [canRender, variant]);
+
+  return (
+    <div
+      className={["shader-atmosphere", `shader-atmosphere--${variant}`, className].filter(Boolean).join(" ")}
+      aria-hidden="true"
+    >
+      {canRender && (
+        <Canvas
+          dpr={[0.75, 1]}
+          camera={{ position: [0, 0, 1] }}
+          gl={{ antialias: false, alpha: false, powerPreference: "high-performance" }}
+        >
+          <SignalField variant={variant} pointerRef={pointerRef} />
+        </Canvas>
+      )}
+    </div>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/SideBar.tsx
+++ b/opennow-stable/src/renderer/src/components/SideBar.tsx
@@ -1,6 +1,8 @@
 import type { JSX, ReactNode, Ref } from "react";
 import { X } from "lucide-react";
+import { m } from "motion/react";
 import { useTranslation } from "../i18n";
+import { panelSpring } from "./MotionProvider";
 
 interface SideBarProps {
   title?: string;
@@ -24,12 +26,16 @@ export default function SideBar({
   const sidebarTitle = title ?? t("sidebar.title");
 
   return (
-    <aside
+    <m.aside
       ref={elementRef}
       className={classNames}
       role="dialog"
       aria-modal="true"
       aria-label={sidebarTitle}
+      initial={{ opacity: 0, x: -28 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -28 }}
+      transition={panelSpring}
     >
       <div className="sidebar-header">
         <h3>{sidebarTitle}</h3>
@@ -49,6 +55,6 @@ export default function SideBar({
         {children}
       </div>
       {footer && <div className="sidebar-footer">{footer}</div>}
-    </aside>
+    </m.aside>
   );
 }

--- a/opennow-stable/src/renderer/src/components/StreamLoading.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamLoading.tsx
@@ -1,9 +1,9 @@
-import { Loader2, Monitor, Cpu, Wifi, X, XCircle } from "lucide-react";
+import { Cpu, Monitor, Radio, Wifi, X, XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
 import type { JSX, Ref } from "react";
+import { m } from "motion/react";
 import {
   getPreferredSessionAdMediaUrl,
-  getSessionAdDurationMs,
-  getSessionAdGracePeriodSeconds,
   getSessionAdItems,
   getSessionAdMessage,
   isSessionAdsRequired,
@@ -12,9 +12,17 @@ import {
 import type { SessionAdInfo, SessionAdState } from "@shared/gfn";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { QueueAdPreview, type QueueAdPlaybackEvent, type QueueAdPreviewHandle } from "./QueueAdPreview";
+import { LazyShaderAtmosphere } from "./LazyShaderAtmosphere";
 import { useTranslation } from "../i18n";
 
 type TranslateFunction = typeof import("../i18n").t;
+
+const launchStages = [
+  { id: "queue", icon: Radio },
+  { id: "setup", icon: Cpu },
+  { id: "connecting", icon: Wifi },
+  { id: "ready", icon: Monitor },
+] as const;
 
 export interface StreamLoadingProps {
   gameTitle: string;
@@ -38,12 +46,6 @@ export interface StreamLoadingProps {
   onCancel: () => void;
 }
 
-const steps = [
-  { id: "queue", labelKey: "streamLoading.steps.queue", icon: Monitor },
-  { id: "setup", labelKey: "streamLoading.steps.setup", icon: Cpu },
-  { id: "ready", labelKey: "streamLoading.steps.ready", icon: Wifi },
-] as const;
-
 function getStatusMessage(
   t: TranslateFunction,
   status: StreamLoadingProps["status"],
@@ -51,51 +53,66 @@ function getStatusMessage(
   adState?: SessionAdState,
   isError = false,
 ): string {
-  if (isError) {
-    return t("streamLoading.status.gameLaunchFailed");
-  }
-  if (isSessionQueuePaused(adState)) {
-    return t("streamLoading.status.queuePaused");
-  }
+  if (isError) return t("streamLoading.status.gameLaunchFailed");
+  if (isSessionQueuePaused(adState)) return t("streamLoading.status.queuePaused");
+
   switch (status) {
     case "queue":
-      return queuePosition ? t("streamLoading.status.positionInQueue", { position: queuePosition }) : t("streamLoading.status.waitingInQueue");
+      return queuePosition
+        ? t("streamLoading.status.positionInQueue", { position: queuePosition })
+        : t("streamLoading.status.waitingInQueue");
     case "setup":
       return t("streamLoading.status.settingUpRig");
     case "starting":
       return t("streamLoading.status.startingStream");
     case "connecting":
       return t("streamLoading.status.connectingToServer");
-    default:
-      return t("streamLoading.status.loading");
   }
 }
 
-function getActiveStepIndex(status: StreamLoadingProps["status"]): number {
+function getPhaseDetail(t: TranslateFunction, status: StreamLoadingProps["status"]): string {
   switch (status) {
     case "queue":
-      return 0;
+      return t("streamLoading.cozy.queue");
     case "setup":
-      return 1;
+      return t("streamLoading.cozy.setup");
     case "starting":
+      return t("streamLoading.cozy.starting");
     case "connecting":
-      return 2;
-    default:
-      return 0;
+      return t("streamLoading.cozy.connecting");
   }
+}
+
+function getNextStep(t: TranslateFunction, status: StreamLoadingProps["status"]): string {
+  switch (status) {
+    case "queue":
+      return t("streamLoading.steps.setup");
+    case "setup":
+      return t("streamLoading.status.startingStream");
+    case "starting":
+      return t("streamLoading.steps.connect");
+    case "connecting":
+      return t("streamLoading.steps.ready");
+  }
+}
+
+function getActiveStage(status: StreamLoadingProps["status"]): number {
+  if (status === "queue") return 0;
+  if (status === "setup") return 1;
+  return 2;
+}
+
+function formatWaitTime(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
 }
 
 function getAdSummary(t: TranslateFunction, adState?: SessionAdState): string | null {
-  if (!isSessionAdsRequired(adState)) {
-    return null;
-  }
+  if (!isSessionAdsRequired(adState)) return null;
   const message = getSessionAdMessage(adState);
-  if (message) {
-    return message;
-  }
-  if (isSessionQueuePaused(adState)) {
-    return t("streamLoading.ads.resumeToStayInQueue");
-  }
+  if (message) return message;
+  if (isSessionQueuePaused(adState)) return t("streamLoading.ads.resumeToStayInQueue");
   const ads = getSessionAdItems(adState);
   return ads.length > 0
     ? t("streamLoading.ads.availableForProgression", { count: ads.length })
@@ -119,103 +136,88 @@ export function StreamLoading({
   onCancel,
 }: StreamLoadingProps): JSX.Element {
   const { t } = useTranslation();
+  const [startedAt] = useState(() => Date.now());
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const hasError = Boolean(error);
-  const activeStepIndex = getActiveStepIndex(status);
   const statusMessage = getStatusMessage(t, status, queuePosition, adState, hasError);
   const platformName = platformStore ? getStoreDisplayName(platformStore) : "";
   const PlatformIcon = platformStore ? getStoreIconComponent(platformStore) : null;
   const adSummary = getAdSummary(t, adState);
   const cachedAdMediaUrl = activeAdMediaUrl ?? getPreferredSessionAdMediaUrl(activeAd);
-  const activeAdDurationMs = getSessionAdDurationMs(activeAd);
-  const activeAdDurationSeconds = activeAdDurationMs ? Math.round(activeAdDurationMs / 1000) : undefined;
-  const gracePeriodSeconds = getSessionAdGracePeriodSeconds(adState);
+  const activeStage = getActiveStage(status);
+
+  useEffect(() => {
+    if (hasError) return undefined;
+    const timer = window.setInterval(() => {
+      setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [hasError, startedAt]);
 
   return (
     <div className={`sload${hasError ? " sload--error" : ""}`}>
       <div className="sload-backdrop" />
-
-      {/* Animated accent glow behind content */}
-      <div className="sload-glow" />
+      {!hasError && <LazyShaderAtmosphere variant={status === "queue" ? "queue" : "connecting"} />}
+      <div className="sload-backdrop-wash" />
 
       <div className="sload-content">
-        {/* Game Info Header */}
         <div className="sload-game">
           <div className="sload-cover">
             {gameCover ? (
-              <img src={gameCover} alt={gameTitle} className="sload-cover-img" />
+              <img src={gameCover} alt="" className="sload-cover-img" />
             ) : (
-              <div className="sload-cover-empty">
-                <Monitor size={28} />
-              </div>
+              <div className="sload-cover-empty"><Monitor size={24} /></div>
             )}
-            <div className="sload-cover-shine" />
           </div>
           <div className="sload-game-meta">
-            <span className="sload-label">{hasError ? t("streamLoading.labels.launchError") : t("streamLoading.labels.nowLoading")}</span>
-            <h2 className="sload-title" title={gameTitle}>
-              {gameTitle}
-            </h2>
+            <p className="sload-label">{hasError ? t("streamLoading.labels.launchError") : t("streamLoading.labels.nowLoading")}</p>
+            <h2 className="sload-title" title={gameTitle}>{gameTitle}</h2>
             {PlatformIcon && (
               <div className="sload-platform" title={platformName}>
-                <span className="sload-platform-icon">
-                  <PlatformIcon />
-                </span>
+                <span className="sload-platform-icon"><PlatformIcon /></span>
                 <span>{platformName}</span>
               </div>
             )}
           </div>
         </div>
 
-        {/* Progress Steps */}
-        <div className="sload-steps">
-          {steps.map((step, index) => {
-            const StepIcon = step.icon;
-            const isFailed = hasError && index === activeStepIndex;
-            const isActive = !isFailed && index === activeStepIndex;
-            const isCompleted = index < activeStepIndex;
-            const isPending = index > activeStepIndex;
-            const nextIsFailed = hasError && index + 1 === activeStepIndex;
-
-            return (
-              <div
-                key={step.id}
-                className={`sload-step${isActive ? " active" : ""}${isCompleted ? " completed" : ""}${isPending ? " pending" : ""}${isFailed ? " failed" : ""}`}
-              >
-                <div className="sload-step-dot">
-                  {isFailed ? <X size={18} /> : <StepIcon size={18} />}
+        {!hasError && (
+          <div className="sload-stage-rail" aria-label={t("streamLoading.labels.launchProgress")}>
+            {launchStages.map((stage, index) => {
+              const StageIcon = stage.icon;
+              const state = index < activeStage ? "completed" : index === activeStage ? "active" : "pending";
+              return (
+                <div className={`sload-stage sload-stage--${state}`} key={stage.id}>
+                  <m.span
+                    className="sload-stage-icon"
+                    animate={state === "active" ? { scale: [1, 1.08, 1] } : { scale: 1 }}
+                    transition={state === "active"
+                      ? { duration: 1.8, repeat: Infinity, ease: "easeInOut" }
+                      : { duration: 0.2 }}
+                  >
+                    <StageIcon size={18} />
+                  </m.span>
+                  {index < launchStages.length - 1 && <span className="sload-stage-line" />}
                 </div>
-                <span className="sload-step-name">{t(step.labelKey)}</span>
-                {index < steps.length - 1 && (
-                  <div className={`sload-step-line${nextIsFailed ? " failed" : ""}`}>
-                    <div className="sload-step-line-fill" />
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        )}
 
-        {/* Status Display */}
         <div className={`sload-status${hasError ? " sload-status--error" : ""}`}>
-          {hasError ? <XCircle size={28} className="sload-error-icon" /> : <Loader2 size={28} className="sload-spin" />}
+          {hasError ? (
+            <XCircle size={24} className="sload-error-icon" />
+          ) : (
+            <m.span
+              className="sload-live-dot"
+              aria-hidden="true"
+              animate={{ opacity: [0.55, 1, 0.55], scale: [0.9, 1.12, 0.9] }}
+              transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
+            />
+          )}
           <div className="sload-status-text">
-            <p className="sload-message">{statusMessage}</p>
-            {!hasError && activeAd && cachedAdMediaUrl && (
-              <div className={`sload-ad${isSessionQueuePaused(adState) ? " sload-ad--paused" : ""}`}>
-                <div className="sload-ad-copy">
-                  <span className="sload-ad-chip">{t("streamLoading.labels.adQueue")}</span>
-                  {adSummary && <p className="sload-ad-message">{adSummary}</p>}
-                </div>
-                <div className="sload-ad-media">
-                  <QueueAdPreview
-                    ref={adPreviewRef}
-                    mediaUrl={cachedAdMediaUrl}
-                    title={activeAd.title}
-                    onPlaybackEvent={(event) => onAdPlaybackEvent?.(event, activeAd.adId)}
-                  />
-                </div>
-              </div>
-            )}
+            <p className="sload-message" role="status" aria-live="polite">{statusMessage}</p>
+            {!hasError && <p className="sload-detail">{getPhaseDetail(t, status)}</p>}
             {hasError && error && (
               <>
                 <p className="sload-error-title">{error.title}</p>
@@ -223,13 +225,46 @@ export function StreamLoading({
                 {error.code && <p className="sload-error-code">{error.code}</p>}
               </>
             )}
-            {status === "queue" && estimatedWait && (
-              <p className="sload-queue">
-                <span className="sload-wait">~{estimatedWait}</span>
-              </p>
-            )}
           </div>
         </div>
+
+        {!hasError && (
+          <div className="sload-facts">
+            <div className="sload-fact">
+              <p>{t("streamLoading.telemetry.queuePosition")}</p>
+              <strong>{status === "queue" && queuePosition ? `#${queuePosition}` : status === "queue" ? t("streamLoading.telemetry.calculating") : t("streamLoading.telemetry.cleared")}</strong>
+            </div>
+            <div className="sload-fact">
+              <p>{t("streamLoading.telemetry.elapsed")}</p>
+              <strong>{formatWaitTime(elapsedSeconds)}</strong>
+            </div>
+            <div className="sload-fact">
+              <p>{t("streamLoading.cozy.next")}</p>
+              <strong>{getNextStep(t, status)}</strong>
+            </div>
+          </div>
+        )}
+
+        {!hasError && activeAd && cachedAdMediaUrl && (
+          <div className={`sload-ad${isSessionQueuePaused(adState) ? " sload-ad--paused" : ""}`}>
+            <div className="sload-ad-copy">
+              <span className="sload-ad-chip">{t("streamLoading.labels.adQueue")}</span>
+              {adSummary && <p className="sload-ad-message">{adSummary}</p>}
+            </div>
+            <div className="sload-ad-media">
+              <QueueAdPreview
+                ref={adPreviewRef}
+                mediaUrl={cachedAdMediaUrl}
+                title={activeAd.title}
+                onPlaybackEvent={(event) => onAdPlaybackEvent?.(event, activeAd.adId)}
+              />
+            </div>
+          </div>
+        )}
+
+        {status === "queue" && estimatedWait && !hasError && (
+          <p className="sload-queue"><span className="sload-wait">~{estimatedWait}</span></p>
+        )}
 
         <div className="sload-actions">
           {hasError && error?.actionLabel && onErrorAction && (

--- a/opennow-stable/src/renderer/src/components/StreamStatsHud.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamStatsHud.tsx
@@ -198,9 +198,14 @@ export function StreamStatsHud({
             {inputLive ? t("stream.stats.live") : t("stream.stats.sync")}
           </span>
           {hasIssues && (
-            <span className="sv-stats-alert-dot" aria-hidden>
+            <m.span
+              className="sv-stats-alert-dot"
+              aria-hidden
+              animate={{ opacity: [0.6, 1, 0.6], scale: [0.94, 1.06, 0.94] }}
+              transition={{ duration: 1.6, repeat: Infinity, ease: "easeInOut" }}
+            >
               <AlertTriangle size={11} />
-            </span>
+            </m.span>
           )}
           <m.span
             className="sv-stats-chevron"

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
-import { AnimatePresence } from "motion/react";
+import { AnimatePresence, m } from "motion/react";
 import type { JSX } from "react";
-import { Maximize, Minimize, Loader2, LogOut, Clock3, AlertTriangle, Mic, Camera, ChevronLeft, ChevronRight, Save, Trash2, X, Circle, Square, Video, FolderOpen, Gamepad2, Gauge, Images, Keyboard, MousePointer2, SlidersHorizontal } from "lucide-react";
+import { Maximize, Minimize, LogOut, Clock3, AlertTriangle, Mic, Camera, ChevronLeft, ChevronRight, Save, Trash2, X, Circle, Square, Video, FolderOpen, Gamepad2, Gauge, Images, Keyboard, MousePointer2, SlidersHorizontal } from "lucide-react";
 import SideBar from "./SideBar";
 import { SessionStartedSplash } from "./SessionStartedSplash";
 import { StreamStatsHud } from "./StreamStatsHud";
@@ -29,6 +29,7 @@ import {
   StreamWaitingForVideo,
   VideoFocusOnReady,
 } from "./stream/StreamEmptyStates";
+import { MotionSpinner } from "./MotionSpinner";
 
 const ANTI_AFK_TOGGLE_ACK_MS = 5000;
 const CONTROLLER_MENU_REPEAT_MS = 180;
@@ -1406,14 +1407,19 @@ export function StreamView({
   }, [exitPrompt.open, isConnecting, showSideBar]);
 
   return (
-    <div className={["sv", className].filter(Boolean).join(" ")}>
-      <video
+    <div className={["sv", streamVideoReady ? "sv--video-ready" : "sv--video-pending", className].filter(Boolean).join(" ")}>
+      <m.video
         ref={setVideoRef}
         autoPlay
         playsInline
         muted
         tabIndex={-1}
         className="sv-video"
+        initial={false}
+        animate={streamVideoReady
+          ? { opacity: 1, scale: 1 }
+          : { opacity: 0, scale: 1.008 }}
+        transition={{ duration: 0.9, ease: [0.22, 1, 0.36, 1] }}
         onClick={() => {
           if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
             localVideoRef.current.focus({ preventScroll: true });
@@ -1438,14 +1444,24 @@ export function StreamView({
         </div>
       )}
 
-      {showSideBar && (
-        <>
-          <div
+      <AnimatePresence>
+        {showSideBar && (
+          <m.div
+            key="quick-menu-backdrop"
             className="sv-sidebar-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
             onMouseDown={(event) => event.stopPropagation()}
             onClick={() => setShowSideBar(false)}
           />
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {showSideBar && (
           <SideBar
+            key="quick-menu-sidebar"
             title="Quick menu"
             className="sv-sidebar"
             elementRef={sidebarRef}
@@ -2037,8 +2053,8 @@ export function StreamView({
               </div>
             )}
           </SideBar>
-        </>
-      )}
+        )}
+      </AnimatePresence>
 
       {selectedScreenshot && (
         <div className="sv-shot-modal" role="dialog" aria-modal="true" aria-label="Screenshot preview">
@@ -2099,7 +2115,7 @@ export function StreamView({
       {isConnecting && (
         <div className="sv-connect">
           <div className="sv-connect-inner">
-            <Loader2 className="sv-connect-spin" size={44} />
+            <MotionSpinner className="sv-connect-spin" size={44} label="Connecting to stream" />
             <p className="sv-connect-title">Connecting to {gameTitle}</p>
             {PlatformIcon && (
               <div className="sv-connect-platform" title={platformName}>

--- a/opennow-stable/src/renderer/src/components/library/LibraryControllerView.tsx
+++ b/opennow-stable/src/renderer/src/components/library/LibraryControllerView.tsx
@@ -1,4 +1,4 @@
-import { Search, Gamepad2, Loader2, MoreHorizontal, Menu } from "lucide-react";
+import { Search, Gamepad2, MoreHorizontal, Menu } from "lucide-react";
 import type { JSX, RefObject } from "react";
 import type { GameInfo } from "@shared/gfn";
 import {
@@ -12,6 +12,7 @@ import {
 import type { ControllerStoreFilterItem } from "../../lib/libraryFilters";
 import { useTranslation } from "../../i18n";
 import { ControllerGameCard } from "./ControllerGameCard";
+import { MotionSpinner } from "../MotionSpinner";
 
 export interface LibraryControllerViewProps {
   isLoading: boolean;
@@ -87,7 +88,7 @@ export function LibraryControllerView({
     <div className="library-page controller-library-page">
       {isLoading ? (
         <div className="library-empty-state controller-library-empty">
-          <Loader2 className="library-spinner" size={54} />
+            <MotionSpinner className="library-spinner" size={54} label={t("common.loading")} />
           <p>{t("library.empty.loadingLibrary")}</p>
         </div>
       ) : libraryCount === 0 ? (

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsAboutSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsAboutSection.tsx
@@ -1,8 +1,9 @@
-import { Info, Loader, RefreshCcw, Download, FileDown, Trash2 } from "lucide-react";
+import { Info, RefreshCcw, Download, FileDown, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState, type JSX } from "react";
 import type { AppUpdaterState, Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
 import { formatBytes, formatUpdaterTimestamp, getUpdaterBadgeLabel } from "../settingsFormatters";
+import { MotionSpinner } from "../../MotionSpinner";
 
 export interface SettingsAboutSectionProps {
   settings: Settings;
@@ -121,7 +122,7 @@ export function SettingsAboutSection({ settings, showAll, handleChange, onOpenWh
                 });
               }}
             >
-              {updaterState.status === "checking" ? <Loader size={16} className="spin" /> : <RefreshCcw size={16} />}
+              {updaterState.status === "checking" ? <MotionSpinner size={16} label="Checking for updates" /> : <RefreshCcw size={16} />}
               {t("settings.about.checkForUpdates")}
             </button>
             {updaterState.status === "available" ? (

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsAccountSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsAccountSection.tsx
@@ -1,4 +1,4 @@
-import { HardDrive, Users, ExternalLink, Loader, RefreshCcw, Trash2, AlertTriangle, Check } from "lucide-react";
+import { HardDrive, Users, ExternalLink, RefreshCcw, Trash2, AlertTriangle, Check } from "lucide-react";
 import { useCallback, useEffect, useState, type JSX } from "react";
 import type { GameAccountConnection, Settings, SubscriptionInfo } from "@shared/gfn";
 import { GFN_STORAGE_MANAGER_URL } from "@shared/gfn";
@@ -6,6 +6,7 @@ import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
 import { formatGameAccountSyncDate, formatStorageGb } from "../settingsFormatters";
 import type { GameAccountBusyAction, StorageResetState } from "../settingsTypes";
+import { MotionSpinner } from "../../MotionSpinner";
 
 export interface SettingsAccountSectionProps {
   settings: Settings;
@@ -272,7 +273,7 @@ export function SettingsAccountSection({
                 void handleGameAccountAction(account, "resync");
               }}
             >
-              {busyAction === "resync" ? <Loader size={15} className="spin" /> : <RefreshCcw size={15} />}
+              {busyAction === "resync" ? <MotionSpinner size={15} label="Resyncing" /> : <RefreshCcw size={15} />}
               {busyAction === "resync"
                 ? t("settings.accountConnections.resyncing")
                 : t("settings.accountConnections.resync")}
@@ -289,7 +290,7 @@ export function SettingsAccountSection({
                 void handleGameAccountAction(account, primaryAction);
               }}
             >
-              {busyAction === primaryAction ? <Loader size={15} className="spin" /> : primaryIcon}
+              {busyAction === primaryAction ? <MotionSpinner size={15} label="Updating" /> : primaryIcon}
               {busyAction === primaryAction
                 ? primaryAction === "unlink"
                   ? t("settings.accountConnections.unlinking")
@@ -433,7 +434,7 @@ export function SettingsAccountSection({
             void loadGameAccounts();
           }}
         >
-          {gameAccountsLoading ? <Loader size={15} className="spin" /> : <RefreshCcw size={15} />}
+          {gameAccountsLoading ? <MotionSpinner size={15} label="Refreshing accounts" /> : <RefreshCcw size={15} />}
           {t("settings.accountConnections.refresh")}
         </button>
       </div>
@@ -452,7 +453,7 @@ export function SettingsAccountSection({
         ) : null}
         {gameAccountsLoading ? (
           <div className="settings-game-account-state settings-game-account-state--muted">
-            <Loader size={16} className="spin" />
+            <MotionSpinner size={16} />
             <span>{t("settings.accountConnections.loading")}</span>
           </div>
         ) : gameAccounts.length > 0 ? (

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
@@ -1,5 +1,6 @@
-import { AlertTriangle, Cpu, ExternalLink, Keyboard, Loader, Monitor, RefreshCcw } from "lucide-react";
+import { AlertTriangle, Cpu, ExternalLink, Keyboard, Monitor, RefreshCcw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { m } from "motion/react";
 import type { NativeStreamerStatus, Settings } from "@shared/gfn";
 import {
   createUnsupportedNativeStreamerStatus,
@@ -15,6 +16,8 @@ import {
   nativeVideoBackendOptions,
   NATIVE_STREAMER_ENABLE_PROMPT_EXIT_MS,
 } from "../settingsFormatters";
+import { dialogMotion, overlayMotion } from "../../MotionProvider";
+import { MotionSpinner } from "../../MotionSpinner";
 
 export interface SettingsNativeStreamerSectionProps {
   settings: Settings;
@@ -309,7 +312,7 @@ export function SettingsNativeStreamerSection({
                     title={t("settings.nativeStreamer.checkNativeStreamer")}
                     aria-label={t("settings.nativeStreamer.checkNativeStreamer")}
                   >
-                    {nativeStreamerStatusLoading ? <Loader size={15} className="spin" /> : <RefreshCcw size={15} />}
+                    {nativeStreamerStatusLoading ? <MotionSpinner size={15} label="Checking streamer status" /> : <RefreshCcw size={15} />}
                   </button>
                 </div>
                 <div className="settings-chip-row">
@@ -441,22 +444,35 @@ export function SettingsNativeStreamerSection({
       </section>
       )}
       {nativeStreamerEnablePromptVisible && (
-        <div
+        <m.div
           className={`native-streamer-warning ${nativeStreamerEnablePromptClosing ? "native-streamer-warning--closing" : ""}`}
           role="dialog"
           aria-modal="true"
           aria-labelledby="native-streamer-warning-title"
           aria-describedby="native-streamer-warning-copy"
+          initial={overlayMotion.initial}
+          animate={nativeStreamerEnablePromptClosing ? overlayMotion.exit : overlayMotion.animate}
+          transition={overlayMotion.transition}
         >
-          <button
+          <m.button
             type="button"
             className="native-streamer-warning-backdrop"
             aria-label={t("app.actions.cancel")}
             aria-hidden="true"
             tabIndex={-1}
             onClick={closeNativeStreamerEnablePrompt}
+            initial={overlayMotion.initial}
+            animate={nativeStreamerEnablePromptClosing ? overlayMotion.exit : overlayMotion.animate}
+            transition={overlayMotion.transition}
           />
-          <div ref={nativeStreamerEnablePromptRef} className="native-streamer-warning-card" tabIndex={-1}>
+          <m.div
+            ref={nativeStreamerEnablePromptRef}
+            className="native-streamer-warning-card"
+            tabIndex={-1}
+            initial={dialogMotion.initial}
+            animate={nativeStreamerEnablePromptClosing ? dialogMotion.exit : dialogMotion.animate}
+            transition={dialogMotion.transition}
+          >
             <div className="native-streamer-warning-kicker">
               <AlertTriangle size={14} />
               {t("settings.nativeStreamer.enablePromptKicker")}
@@ -504,8 +520,8 @@ export function SettingsNativeStreamerSection({
             <div className="native-streamer-warning-hint">
               <kbd>Esc</kbd> {t("settings.nativeStreamer.enablePromptEsc")}
             </div>
-          </div>
-        </div>
+          </m.div>
+        </m.div>
       )}
     </>
   );

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsStreamSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsStreamSection.tsx
@@ -1,7 +1,8 @@
 import {
-  Check, Globe, Heart, Loader, MapPin, Monitor, ScanLine, Gauge, Film, SlidersHorizontal, HardDrive, Sparkles, Wifi, Zap, Search, X, Cpu,
+  Check, Globe, Heart, MapPin, Monitor, ScanLine, Gauge, Film, SlidersHorizontal, HardDrive, Sparkles, Wifi, Zap, Search, X, Cpu,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { m } from "motion/react";
 import type {
   ColorQuality,
   EntitledResolution,
@@ -36,6 +37,8 @@ import {
   STATIC_FPS_PRESETS,
   STATIC_RESOLUTION_PRESETS,
 } from "../settingsFormatters";
+import { dialogMotion, overlayMotion } from "../../MotionProvider";
+import { MotionSpinner } from "../../MotionSpinner";
 
 export interface SettingsStreamSectionProps {
   settings: Settings;
@@ -468,7 +471,7 @@ export function SettingsStreamSection({
               title={t("settings.region.refreshPing")}
             >
               {isPinging ? (
-                <Loader size={14} className="spin" />
+                <MotionSpinner size={14} label="Testing regions" />
               ) : (
                 <Wifi size={14} />
               )}
@@ -571,7 +574,7 @@ export function SettingsStreamSection({
           <label className="settings-label settings-label--with-icon">
             <ScanLine size={15} className="settings-label-icon" />
             {t("settings.video.resolution")}
-            {subscriptionLoading && <Loader size={12} className="settings-loading-icon" />}
+            {subscriptionLoading && <MotionSpinner size={12} className="settings-loading-icon" />}
           </label>
           <div className="settings-dropdown settings-resolution-dropdown" ref={resolutionDropdownRef}>
             <button
@@ -991,7 +994,7 @@ export function SettingsStreamSection({
               >
                 {codecTesting ? (
                   <>
-                    <Loader size={16} className="settings-loading-icon" />
+                    <MotionSpinner size={16} className="settings-loading-icon" />
                     {t("settings.video.testing")}
                   </>
                 ) : (
@@ -1056,14 +1059,17 @@ export function SettingsStreamSection({
                   )}
                 </>
       {zortosCommunityProxyPromptVisible && (
-        <div
+        <m.div
           className={`native-streamer-warning ${zortosCommunityProxyPromptClosing ? "native-streamer-warning--closing" : ""}`}
           role="dialog"
           aria-modal="true"
           aria-labelledby="zortos-community-proxy-title"
           aria-describedby="zortos-community-proxy-copy"
+          initial={overlayMotion.initial}
+          animate={zortosCommunityProxyPromptClosing ? overlayMotion.exit : overlayMotion.animate}
+          transition={overlayMotion.transition}
         >
-          <button
+          <m.button
             type="button"
             className="native-streamer-warning-backdrop"
             aria-label={t("app.actions.cancel")}
@@ -1071,8 +1077,18 @@ export function SettingsStreamSection({
             tabIndex={-1}
             disabled={zortosCommunityProxyProvisioning}
             onClick={closeZortosCommunityProxyPrompt}
+            initial={overlayMotion.initial}
+            animate={zortosCommunityProxyPromptClosing ? overlayMotion.exit : overlayMotion.animate}
+            transition={overlayMotion.transition}
           />
-          <div ref={zortosCommunityProxyPromptRef} className="native-streamer-warning-card" tabIndex={-1}>
+          <m.div
+            ref={zortosCommunityProxyPromptRef}
+            className="native-streamer-warning-card"
+            tabIndex={-1}
+            initial={dialogMotion.initial}
+            animate={zortosCommunityProxyPromptClosing ? dialogMotion.exit : dialogMotion.animate}
+            transition={dialogMotion.transition}
+          >
             <div className="native-streamer-warning-kicker">
               <Heart size={14} />
               {t("settings.video.zortosCommunityProxy.enablePromptKicker")}
@@ -1116,8 +1132,8 @@ export function SettingsStreamSection({
             <div className="native-streamer-warning-hint">
               <kbd>Esc</kbd> {t("settings.video.zortosCommunityProxy.enablePromptEsc")}
             </div>
-          </div>
-        </div>
+          </m.div>
+        </m.div>
       )}
     </>
   );

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsThanksSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsThanksSection.tsx
@@ -1,8 +1,9 @@
-import { Heart, Users, ExternalLink, Loader } from "lucide-react";
+import { Heart, Users, ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import type { ThankYouContributor, ThankYouDataResult, ThankYouSupporter } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
 import type { ThanksLoadState } from "../settingsTypes";
+import { MotionSpinner } from "../../MotionSpinner";
 
 let thanksDataCache: ThankYouDataResult | null = null;
 
@@ -177,7 +178,7 @@ export function SettingsThanksSection(): JSX.Element {
           </div>
           {thanksLoadState === "loading" && !thanksData ? (
             <div className="settings-thanks-state">
-              <Loader size={16} className="settings-loading-icon" />
+              <MotionSpinner size={16} className="settings-loading-icon" />
               <span>{t("settings.thanks.loadingContributors")}</span>
             </div>
           ) : thanksContributors.length > 0 ? (
@@ -203,7 +204,7 @@ export function SettingsThanksSection(): JSX.Element {
           </div>
           {thanksLoadState === "loading" && !thanksData ? (
             <div className="settings-thanks-state">
-              <Loader size={16} className="settings-loading-icon" />
+              <MotionSpinner size={16} className="settings-loading-icon" />
               <span>{t("settings.thanks.loadingSupporters")}</span>
             </div>
           ) : thanksSupporters.length > 0 ? (

--- a/opennow-stable/src/renderer/src/components/stream/StreamEmptyStates.tsx
+++ b/opennow-stable/src/renderer/src/components/stream/StreamEmptyStates.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
 import type { JSX } from "react";
-import { Loader2 } from "lucide-react";
+import { AnimatePresence, m } from "motion/react";
 import type { StreamDiagnosticsStore } from "../../utils/streamDiagnosticsStore";
 import { useStreamDiagnosticsSelector } from "../../utils/streamDiagnosticsStore";
 import { useTranslation } from "../../i18n";
+import { MotionSpinner } from "../MotionSpinner";
 
 export function hasVisibleStreamVideo(stats: {
   nativeRendererActive: boolean;
@@ -26,14 +27,20 @@ export function StreamEmptyState({
     (stats) => hasVisibleStreamVideo(stats),
   );
 
-  if (hasVisibleVideo) {
-    return null;
-  }
-
   return (
-    <div className="sv-empty">
-      <div className="sv-empty-grad" />
-    </div>
+    <AnimatePresence>
+      {!hasVisibleVideo && (
+        <m.div
+          className="sv-empty"
+          initial={{ opacity: 1, scale: 1 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 1.03 }}
+          transition={{ duration: 0.7, ease: "easeOut" }}
+        >
+          <div className="sv-empty-grad" />
+        </m.div>
+      )}
+    </AnimatePresence>
   );
 }
 
@@ -55,15 +62,23 @@ export function StreamWaitingForVideo({
     },
   );
 
-  if (isConnecting || !waitingForFirstFrame) {
-    return null;
-  }
-
   return (
-    <div className="sv-warm" role="status" aria-live="polite">
-      <Loader2 className="sv-warm-spin" size={34} />
-      <p className="sv-warm-text">{t("stream.stats.waitingForVideo")}</p>
-    </div>
+    <AnimatePresence>
+      {!isConnecting && waitingForFirstFrame && (
+        <m.div
+          className="sv-warm"
+          role="status"
+          aria-live="polite"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.28 }}
+        >
+          <MotionSpinner className="sv-warm-spin" size={34} label="Preparing stream" />
+          <p className="sv-warm-text">{t("stream.stats.waitingForVideo")}</p>
+        </m.div>
+      )}
+    </AnimatePresence>
   );
 }
 

--- a/opennow-stable/src/renderer/src/components/stream/StreamIndicators.tsx
+++ b/opennow-stable/src/renderer/src/components/stream/StreamIndicators.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 import { Mic, MicOff } from "lucide-react";
+import { m } from "motion/react";
 import type { StreamDiagnosticsStore } from "../../utils/streamDiagnosticsStore";
 import { useStreamDiagnosticsSelector } from "../../utils/streamDiagnosticsStore";
 import type { MicState } from "../../platforms/gfn/microphoneManager";
@@ -130,7 +131,11 @@ export function RecordingIndicator({
       style={{ top: 14 + 42 * stackedBadges }}
       title={`Recording · ${formatElapsed(Math.round(recordingDurationMs / 1000))}`}
     >
-      <span className="sv-rec-dot" />
+      <m.span
+        className="sv-rec-dot"
+        animate={{ opacity: [0.45, 1, 0.45], scale: [0.85, 1, 0.85] }}
+        transition={{ duration: 1.2, repeat: Infinity, ease: "easeInOut" }}
+      />
       <span className="sv-rec-label">REC {formatElapsed(Math.round(recordingDurationMs / 1000))}</span>
     </div>
   );

--- a/opennow-stable/src/renderer/src/lib/sessionState.test.ts
+++ b/opennow-stable/src/renderer/src/lib/sessionState.test.ts
@@ -3,7 +3,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { toLaunchErrorState } from "./sessionState";
+import { isStreamVideoReady, toLaunchErrorState } from "./sessionState";
 
 const translations: Record<string, string> = {
   "errors.duplicateSessionTitle": "Duplicate Session Detected",
@@ -70,4 +70,11 @@ test("launch error state treats NVIDIA user storage failures as persistent stora
   assert.equal(state.codeLabel, "UserStorageNotAvailable (3237093721)");
   assert.equal(state.action, "persistent-storage-settings");
   assert.equal(state.actionLabel, "Open Storage Settings");
+});
+
+test("stream video stays covered until the session is streaming and a frame source is ready", () => {
+  assert.equal(isStreamVideoReady("connecting", true, true), false);
+  assert.equal(isStreamVideoReady("streaming", false, false), false);
+  assert.equal(isStreamVideoReady("streaming", true, false), true);
+  assert.equal(isStreamVideoReady("streaming", false, true), true);
 });

--- a/opennow-stable/src/renderer/src/lib/sessionState.ts
+++ b/opennow-stable/src/renderer/src/lib/sessionState.ts
@@ -83,6 +83,14 @@ export function toLoadingStatus(status: StreamStatus): StreamLoadingStatus {
   }
 }
 
+export function isStreamVideoReady(
+  status: StreamStatus,
+  diagnosticsReady: boolean,
+  videoElementHasFrame: boolean,
+): boolean {
+  return status === "streaming" && (diagnosticsReady || videoElementHasFrame);
+}
+
 export function toCodeLabel(code: number | undefined): string | undefined {
   if (code === undefined) return undefined;
   if (code === GFN_SESSION_LIMIT_EXCEEDED_CODE) return `SessionLimitExceeded (${code})`;

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1,7 +1,7 @@
 /* ---------- Design Tokens ---------- */
 :root {
   color-scheme: dark;
-  --game-poster-scale: 1;
+  --game-poster-scale: 1.05;
 
   /* Backgrounds — layered obsidian-charcoal */
   --bg-a: #101014;
@@ -129,189 +129,6 @@ body,
   background: var(--ink-muted);
 }
 
-/* ---------- Animations ---------- */
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-
-
-
-
-
-@keyframes float-a {
-
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-
-  50% {
-    transform: translate(-40px, 30px) scale(1.15);
-  }
-}
-
-@keyframes float-b {
-
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-
-  50% {
-    transform: translate(30px, -25px) scale(1.08);
-  }
-}
-
-@keyframes float-c {
-
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-
-  50% {
-    transform: translate(-20px, -30px) scale(1.12);
-  }
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes fade-in-down {
-  from {
-    opacity: 0;
-    transform: translateY(-6px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes native-streamer-warning-backdrop-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes native-streamer-warning-card-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes native-streamer-warning-backdrop-out {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes native-streamer-warning-card-out {
-  from {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  to {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-}
-
-@keyframes native-streamer-warning-item-in {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes pulse-glow {
-
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-
-  50% {
-    transform: scale(1.08);
-    opacity: 0.85;
-  }
-}
-
-@keyframes float-subtle {
-
-  0%,
-  100% {
-    transform: translateY(0) rotate(0);
-  }
-
-  33% {
-    transform: translateY(-3px) rotate(0.1deg);
-  }
-
-  66% {
-    transform: translateY(1px) rotate(-0.1deg);
-  }
-}
-
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%) skewX(-15deg);
-  }
-
-  100% {
-    transform: translateX(200%) skewX(-15deg);
-  }
-}
-
-
-@keyframes bg-pan {
-  0% {
-    background-position: 0% 50%;
-  }
-
-  50% {
-    background-position: 100% 50%;
-  }
-
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -327,6 +144,8 @@ body,
    APP SHELL
    ====================================================== */
 .app-container {
+  position: relative;
+  isolation: isolate;
   width: 100%;
   height: 100%;
   display: flex;
@@ -358,7 +177,6 @@ body,
   font-weight: 600;
   letter-spacing: 0.01em;
   box-shadow: var(--shadow-sm);
-  animation: fade-in 220ms var(--ease);
 }
 
 .auth-refresh-notice--success {
@@ -663,13 +481,13 @@ body,
   color: #ffe7e7;
 }
 
-.navbar-session-resume-spin {
-  animation: spin 1s linear infinite;
-}
-
-.navbar-session-resume.is-loading,
-.navbar-session-terminate.is-loading {
-  animation: none;
+.motion-spinner {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: currentColor;
+  line-height: 0;
 }
 
 .navbar-user {
@@ -778,7 +596,6 @@ body,
   box-shadow: var(--shadow-md);
   z-index: 1100;
   overflow: hidden;
-  animation: fade-in 120ms var(--ease);
 }
 
 .navbar-account-dropdown-header {
@@ -1040,7 +857,6 @@ body,
     0 0 0 1px color-mix(in srgb, var(--error) 18%, transparent);
   backdrop-filter: blur(24px) saturate(140%);
   overflow: hidden;
-  animation: fade-in 170ms var(--ease);
 }
 
 .logout-confirm-card::before {
@@ -1196,7 +1012,6 @@ body,
   background: var(--panel);
   box-shadow: var(--shadow-md);
   overflow: hidden;
-  animation: fade-in 130ms var(--ease);
   display: flex;
   flex-direction: column;
 }
@@ -1626,7 +1441,6 @@ body,
   top: -180px;
   right: -80px;
   background: radial-gradient(circle, var(--accent) 0%, transparent 70%);
-  animation: float-a 22s ease-in-out infinite;
 }
 
 .login-bg-orb--2 {
@@ -1635,7 +1449,6 @@ body,
   bottom: -120px;
   left: -80px;
   background: radial-gradient(circle, #4a90d9 0%, transparent 70%);
-  animation: float-b 28s ease-in-out infinite;
 }
 
 .login-bg-orb--3 {
@@ -1644,7 +1457,6 @@ body,
   top: 40%;
   left: 50%;
   background: radial-gradient(circle, rgba(var(--accent-rgb), 0.5) 0%, transparent 70%);
-  animation: float-c 18s ease-in-out infinite;
 }
 
 .login-bg-noise {
@@ -1664,7 +1476,6 @@ body,
   flex-direction: column;
   align-items: center;
   gap: 28px;
-  animation: fade-in 500ms var(--ease);
 }
 
 .login-brand {
@@ -1764,7 +1575,6 @@ body,
   border-radius: 50%;
   flex-shrink: 0;
   background: var(--info);
-  animation: pulse-glow 1.7s ease-in-out infinite;
 }
 
 /* Field */
@@ -1852,7 +1662,6 @@ body,
   border-radius: 0 0 var(--r-sm) var(--r-sm);
   z-index: 10;
   box-shadow: 0 10px 36px rgba(0, 0, 0, 0.5);
-  animation: fade-in-down 120ms var(--ease);
 }
 
 .login-dropdown-item {
@@ -2027,14 +1836,8 @@ body,
   cursor: not-allowed;
 }
 
-.login-spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid rgba(6, 35, 21, 0.3);
-  border-top-color: var(--accent-on);
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  display: inline-block;
+.login-motion-spinner {
+  color: var(--accent-on);
 }
 
 .login-footer {
@@ -2551,7 +2354,6 @@ body,
     linear-gradient(180deg, color-mix(in srgb, var(--ink) 4%, transparent), color-mix(in srgb, var(--ink) 1.5%, transparent)),
     var(--card);
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.42);
-  animation: fade-in-down 120ms var(--ease);
 }
 
 .select-dropdown__option {
@@ -2798,7 +2600,6 @@ body,
 }
 
 .home-spinner {
-  animation: spin 1s linear infinite;
   color: var(--accent);
 }
 
@@ -3109,6 +2910,10 @@ body,
   color: var(--ink-muted);
 }
 
+.library-last-played--empty {
+  visibility: hidden;
+}
+
 .library-empty-state {
   display: flex;
   flex-direction: column;
@@ -3139,7 +2944,6 @@ body,
 }
 
 .library-spinner {
-  animation: spin 1s linear infinite;
   color: var(--accent);
 }
 
@@ -3814,7 +3618,7 @@ body,
   border-radius: var(--r-md);
   overflow: hidden;
   cursor: pointer;
-  transition: transform var(--t-normal), border-color var(--t-normal), box-shadow var(--t-normal);
+  transition: border-color var(--t-normal), box-shadow var(--t-normal);
   contain: layout style;
   transform: translate3d(0, 0, 0);
   backface-visibility: hidden;
@@ -3842,12 +3646,7 @@ body,
 }
 
 .game-card:hover {
-  transform: translate3d(0, -2px, 0) scale(1.01);
   border-color: color-mix(in srgb, var(--ink) 10%, transparent);
-}
-
-.game-card:active {
-  transform: translate3d(0, 0, 0) scale(0.985);
 }
 
 .game-card:hover::after {
@@ -5430,11 +5229,6 @@ button.game-card-store-chip.owned.active:hover {
   -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
   cursor: pointer;
-  animation: native-streamer-warning-backdrop-in 150ms var(--ease);
-}
-
-.native-streamer-warning--closing .native-streamer-warning-backdrop {
-  animation: native-streamer-warning-backdrop-out 140ms var(--ease) forwards;
 }
 
 .native-streamer-warning-card {
@@ -5447,11 +5241,6 @@ button.game-card-store-chip.owned.active:hover {
   background: var(--panel);
   box-shadow: var(--shadow-md);
   overflow: hidden;
-  animation: native-streamer-warning-card-in 160ms var(--ease);
-}
-
-.native-streamer-warning--closing .native-streamer-warning-card {
-  animation: native-streamer-warning-card-out 140ms var(--ease) forwards;
 }
 
 .native-streamer-warning-kicker {
@@ -5502,20 +5291,7 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--ink-soft);
   font-size: 0.82rem;
   line-height: 1.45;
-  opacity: 0;
-  animation: native-streamer-warning-item-in 160ms var(--ease) forwards;
-}
-
-.native-streamer-warning-list-item:nth-child(1) {
-  animation-delay: 40ms;
-}
-
-.native-streamer-warning-list-item:nth-child(2) {
-  animation-delay: 70ms;
-}
-
-.native-streamer-warning-list-item:nth-child(3) {
-  animation-delay: 100ms;
+  opacity: 1;
 }
 
 .native-streamer-warning-list-item svg {
@@ -5907,7 +5683,6 @@ button.game-card-store-chip.owned.active:hover {
   margin-left: 6px;
   vertical-align: middle;
   color: var(--ink-muted);
-  animation: spin 1s linear infinite;
 }
 
 /* Value badge */
@@ -6082,7 +5857,6 @@ button.game-card-store-chip.owned.active:hover {
   box-shadow: 0 12px 36px rgba(0, 0, 0, 0.5);
   max-height: 220px;
   overflow-y: auto;
-  animation: fade-in-down 120ms var(--ease);
 }
 
 .settings-dropdown-menu--tall {
@@ -6273,7 +6047,6 @@ button.game-card-store-chip.owned.active:hover {
   border-radius: 0 0 6px 6px;
   z-index: 20;
   box-shadow: 0 12px 36px rgba(0, 0, 0, 0.5);
-  animation: fade-in-down 120ms var(--ease);
 }
 
 .region-dropdown-search {
@@ -6410,10 +6183,6 @@ button.game-card-store-chip.owned.active:hover {
 .region-ping-refresh:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-.region-ping-refresh .spin {
-  animation: spin 1s linear infinite;
 }
 
 .region-ping {
@@ -6985,12 +6754,10 @@ button.game-card-store-chip.owned.active:hover {
   flex-direction: column;
   align-items: center;
   gap: 14px;
-  animation: fade-in 300ms var(--ease);
 }
 
 .sv-connect-spin {
   color: var(--accent);
-  animation: spin 1s linear infinite;
 }
 
 .sv-connect-title {
@@ -7091,7 +6858,6 @@ button.game-card-store-chip.owned.active:hover {
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.01em;
-  animation: fade-in 140ms var(--ease);
 }
 
 [data-translucent="true"] .sv-time-warning {
@@ -7136,7 +6902,6 @@ button.game-card-store-chip.owned.active:hover {
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.01em;
-  animation: fade-in 140ms var(--ease);
 }
 
 [data-translucent="true"] .sv-afk-ack {
@@ -7307,7 +7072,6 @@ button.game-card-store-chip.owned.active:hover {
   align-items: center;
   justify-content: center;
   color: var(--warning);
-  animation: sv-stats-pulse 1.6s ease-in-out infinite;
 }
 
 .sv-stats-warn-strip {
@@ -7476,20 +7240,6 @@ button.game-card-store-chip.owned.active:hover {
   text-overflow: ellipsis;
 }
 
-@keyframes sv-stats-pulse {
-
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-  50% {
-    opacity: 0.55;
-    transform: scale(0.92);
-  }
-}
-
 /* Session ready badge */
 .sv-ready-splash {
   position: fixed;
@@ -7557,12 +7307,10 @@ button.game-card-store-chip.owned.active:hover {
   justify-content: center;
   gap: 12px;
   pointer-events: none;
-  animation: fade-in 280ms var(--ease);
 }
 
 .sv-warm-spin {
   color: var(--accent);
-  animation: spin 1s linear infinite;
 }
 
 .sv-warm-text {
@@ -7624,7 +7372,6 @@ button.game-card-store-chip.owned.active:hover {
   height: 8px;
   border-radius: 999px;
   background: var(--error);
-  animation: rec-pulse 1.2s ease-in-out infinite;
 }
 
 .sv-rec-label {
@@ -7632,18 +7379,6 @@ button.game-card-store-chip.owned.active:hover {
   font-weight: 700;
   color: var(--error);
   letter-spacing: 0.06em;
-}
-
-@keyframes rec-pulse {
-
-  0%,
-  100% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.25;
-  }
 }
 
 .sv-mic {
@@ -7727,7 +7462,6 @@ button.game-card-store-chip.owned.active:hover {
   background: var(--panel);
   box-shadow: var(--shadow-md);
   padding: 20px 20px 16px;
-  animation: fade-in 130ms var(--ease);
 }
 
 .sv-exit-kicker {
@@ -7920,7 +7654,6 @@ button.game-card-store-chip.owned.active:hover {
   background: rgba(10, 10, 12, 0.9);
   border: 1px solid var(--panel-border);
   border-radius: var(--r-md);
-  animation: fade-in 300ms var(--ease);
   opacity: 0.65;
 }
 
@@ -7961,7 +7694,6 @@ button.game-card-store-chip.owned.active:hover {
   font-weight: 600;
   color: var(--ink);
   white-space: nowrap;
-  animation: fade-in 400ms var(--ease);
 }
 
 .sv-title-game {
@@ -8074,7 +7806,6 @@ button.game-card-store-chip.owned.active:hover {
   height: 400px;
   background: radial-gradient(circle, rgba(var(--accent-rgb), 0.06) 0%, transparent 70%);
   pointer-events: none;
-  animation: float-a 16s ease-in-out infinite;
 }
 
 .sload.sload--error .sload-glow {
@@ -8090,7 +7821,6 @@ button.game-card-store-chip.owned.active:hover {
   gap: 32px;
   max-width: 440px;
   width: 100%;
-  animation: fade-in 350ms var(--ease);
 }
 
 /* Game info */
@@ -8221,7 +7951,6 @@ button.game-card-store-chip.owned.active:hover {
   background: linear-gradient(135deg, var(--accent), var(--accent-press));
   border-color: var(--accent);
   color: var(--accent-on);
-  animation: pulse-glow 2s ease-in-out infinite;
 }
 
 .sload-step.completed .sload-step-dot {
@@ -8238,7 +7967,6 @@ button.game-card-store-chip.owned.active:hover {
   background: linear-gradient(135deg, rgba(248, 113, 113, 0.28), rgba(239, 68, 68, 0.32));
   border-color: var(--error);
   color: #ffe3e3;
-  animation: pulse-glow 2s ease-in-out infinite;
 }
 
 .sload-step-name {
@@ -8303,7 +8031,6 @@ button.game-card-store-chip.owned.active:hover {
 
 .sload-spin {
   color: var(--accent);
-  animation: spin 1s linear infinite;
 }
 
 .sload-error-icon {
@@ -8610,10 +8337,6 @@ button.game-card-store-chip.owned.active:hover {
   flex: 0 0 auto;
   color: var(--accent);
   margin-top: 1px;
-}
-
-.queue-ad-preview-icon--spinning {
-  animation: spin 1s linear infinite;
 }
 
 .queue-ad-preview--blocked .queue-ad-preview-icon,
@@ -9451,10 +9174,16 @@ button.game-card-store-chip.owned.active:hover {
   --card: #191d21;
   --card-hover: #20252a;
   --chip: #24292e;
-  width: min(460px, calc(100vw - 28px));
-  height: min(720px, calc(100vh - 28px));
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: min(460px, 100vw);
+  height: 100dvh;
+  max-height: none;
   background: #121519;
+  border-width: 0 1px 0 0;
   border-color: rgba(255, 255, 255, 0.11);
+  border-radius: 0 16px 16px 0;
   color-scheme: dark;
 }
 
@@ -9476,6 +9205,7 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sv-sidebar .sidebar-body {
+  flex: 1 1 auto;
   gap: 18px;
   padding: 14px 16px 18px;
 }
@@ -9572,19 +9302,6 @@ button.game-card-store-chip.owned.active:hover {
   flex-direction: column;
   gap: 18px;
   min-height: 0;
-  animation: sidebar-page-in 120ms ease-out both;
-}
-
-@keyframes sidebar-page-in {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 .sidebar-page .sidebar-section {
@@ -9787,12 +9504,14 @@ button.game-card-store-chip.owned.active:hover {
 
 @media (max-width: 560px) {
   .sv-sidebar {
-    top: 8px;
-    left: 8px;
-    width: calc(100vw - 16px);
-    height: calc(100vh - 16px);
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    height: 100dvh;
     max-height: none;
-    border-radius: 12px;
+    border-right: 0;
+    border-radius: 0;
   }
 
   .sv-sidebar .sidebar-body {
@@ -10221,4 +9940,736 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--accent, #76b900);
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+/* ======================================================
+   IMMERSIVE CONTROLLER + SESSION LAUNCH EXPERIENCE
+   ====================================================== */
+.shader-atmosphere {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 18% 78%, rgba(32, 224, 112, 0.1), transparent 48%),
+    radial-gradient(ellipse at 82% 22%, rgba(46, 174, 202, 0.07), transparent 42%),
+    #020605;
+}
+
+.shader-atmosphere canvas {
+  width: 100% !important;
+  height: 100% !important;
+  opacity: 0.88;
+}
+
+.shader-atmosphere--controller {
+  position: fixed;
+  z-index: 0;
+  opacity: 0.72;
+}
+
+.catalog-atmosphere.shader-atmosphere--controller {
+  opacity: 0.46;
+}
+
+.shader-atmosphere--queue,
+.shader-atmosphere--connecting {
+  z-index: 0;
+}
+
+.shader-atmosphere--connecting canvas {
+  opacity: 1;
+}
+
+.app-container--controller > .main-content {
+  position: relative;
+  z-index: 1;
+}
+
+.app-container--atmosphere > .main-content {
+  position: relative;
+  z-index: 1;
+}
+
+.app-container--controller > .navbar,
+.app-container--atmosphere > .navbar {
+  z-index: 1000;
+}
+
+.app-container--controller .navbar--controller {
+  background: linear-gradient(180deg, rgba(2, 5, 4, 0.88), rgba(2, 5, 4, 0.42) 72%, transparent);
+  backdrop-filter: blur(18px) saturate(1.1);
+}
+
+.app-container--controller .controller-store-hero {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow:
+    0 30px 90px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(65, 235, 128, 0.04) inset;
+}
+
+.app-container--controller .controller-store-section::before {
+  border-color: rgba(255, 255, 255, 0.065);
+  background: linear-gradient(115deg, rgba(10, 20, 16, 0.68), rgba(6, 10, 9, 0.5));
+  box-shadow: 0 18px 52px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(16px);
+}
+
+.app-container--controller .controller-store-tile {
+  transition:
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 220ms ease,
+    box-shadow 320ms ease,
+    filter 320ms ease;
+}
+
+.app-container--controller .controller-store-tile.focused {
+  transform: translate3d(0, -7px, 0) scale(1.035);
+  border-color: #63f296;
+  box-shadow:
+    0 0 0 2px rgba(99, 242, 150, 0.9),
+    0 18px 42px rgba(0, 0, 0, 0.56),
+    0 0 34px rgba(50, 229, 119, 0.26);
+  filter: saturate(1.08) brightness(1.04);
+}
+
+.stream-loading-transition {
+  position: fixed;
+  inset: 0;
+  z-index: 1090;
+  transform-origin: 50% 50%;
+}
+
+.sload {
+  overflow: hidden;
+  padding: clamp(18px, 3vw, 46px);
+  color: #f4faf6;
+}
+
+.sload-backdrop {
+  z-index: 0;
+  background: rgba(1, 4, 3, 0.46);
+}
+
+.sload-noise {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.22;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
+  background-size: 46px 46px;
+  mask-image: linear-gradient(to bottom, transparent, black 22%, black 78%, transparent);
+}
+
+.sload.sload--error .sload-backdrop {
+  background:
+    radial-gradient(circle at 50% 38%, rgba(150, 28, 28, 0.18), transparent 45%),
+    #070909;
+}
+
+.sload-content {
+  z-index: 2;
+  width: min(920px, 100%);
+  max-width: 920px;
+  max-height: calc(100vh - 52px);
+  gap: clamp(20px, 2.8vh, 32px);
+  padding: clamp(26px, 4vw, 50px);
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.105);
+  border-radius: 30px;
+  background:
+    linear-gradient(145deg, rgba(9, 18, 14, 0.84), rgba(4, 8, 7, 0.76)),
+    rgba(3, 7, 5, 0.8);
+  box-shadow:
+    0 48px 120px rgba(0, 0, 0, 0.6),
+    0 1px 0 rgba(255, 255, 255, 0.08) inset,
+    0 0 80px rgba(39, 229, 113, 0.055) inset;
+  backdrop-filter: blur(28px) saturate(1.18);
+  scrollbar-width: none;
+}
+
+.sload-content::-webkit-scrollbar {
+  display: none;
+}
+
+.sload-game {
+  width: 100%;
+  gap: 18px;
+}
+
+.sload-cover {
+  width: 78px;
+  height: 78px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.42);
+}
+
+.sload-label {
+  color: #63f296;
+  font-size: 0.66rem;
+  font-weight: 850;
+  letter-spacing: 0.18em;
+}
+
+.sload-title {
+  max-width: min(620px, 65vw);
+  font-size: clamp(1.45rem, 2.2vw, 2.1rem);
+  font-weight: 780;
+  letter-spacing: -0.035em;
+}
+
+.sload-platform {
+  color: rgba(225, 237, 230, 0.62);
+}
+
+.sload-steps {
+  gap: 0;
+  padding: 2px 4px;
+}
+
+.sload-step {
+  gap: 9px;
+}
+
+.sload-step-dot {
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(4, 11, 8, 0.82);
+  color: rgba(225, 237, 230, 0.42);
+  box-shadow: 0 9px 24px rgba(0, 0, 0, 0.24);
+}
+
+.sload-step.active .sload-step-dot {
+  color: #031007;
+  border-color: #63f296;
+  background: #63f296;
+  box-shadow: 0 0 0 6px rgba(99, 242, 150, 0.08), 0 0 34px rgba(99, 242, 150, 0.32);
+}
+
+.sload-step.completed .sload-step-dot {
+  border-color: rgba(99, 242, 150, 0.58);
+  background: rgba(38, 159, 85, 0.16);
+  color: #63f296;
+}
+
+.sload-step-name {
+  color: rgba(225, 237, 230, 0.38);
+  font-size: 0.64rem;
+  font-weight: 780;
+  letter-spacing: 0.12em;
+}
+
+.sload-step.active .sload-step-name {
+  color: #f4faf6;
+}
+
+.sload-step-line {
+  top: 21px;
+  left: calc(50% + 27px);
+  width: calc(100% - 54px);
+  background: rgba(255, 255, 255, 0.09);
+}
+
+.sload-step-line-fill {
+  background: linear-gradient(90deg, #35da78, #83f7aa);
+  box-shadow: 0 0 12px rgba(76, 235, 134, 0.48);
+}
+
+.sload-status {
+  width: 100%;
+  gap: 18px;
+}
+
+.sload-orbit {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 68px;
+  height: 68px;
+}
+
+.sload-orbit-ring {
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(99, 242, 150, 0.24);
+  border-top-color: #63f296;
+  border-radius: 50%;
+  box-shadow: 0 0 28px rgba(99, 242, 150, 0.12);
+}
+
+.sload-orbit-ring::after {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border: 1px dashed rgba(99, 242, 150, 0.24);
+  border-radius: inherit;
+}
+
+.sload-orbit-core {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: rgba(99, 242, 150, 0.12);
+  color: #63f296;
+}
+
+
+.sload-status-text {
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+}
+
+.sload-message {
+  font-size: clamp(1.15rem, 1.8vw, 1.5rem);
+  font-weight: 740;
+  letter-spacing: -0.025em;
+}
+
+.sload-detail {
+  max-width: 620px;
+  margin: 0;
+  color: rgba(225, 237, 230, 0.58);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+.sload-telemetry {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  width: min(680px, 100%);
+  margin-top: 12px;
+}
+
+.sload-telemetry-item {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.035);
+  text-align: left;
+}
+
+.sload-telemetry-icon {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  border-radius: 10px;
+  background: rgba(99, 242, 150, 0.1);
+  color: #63f296;
+}
+
+.sload-telemetry-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.sload-telemetry-copy small {
+  color: rgba(225, 237, 230, 0.42);
+  font-size: 0.62rem;
+  font-weight: 720;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.sload-telemetry-copy strong {
+  overflow: hidden;
+  color: #f4faf6;
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sload-ad {
+  width: min(680px, 100%);
+  margin-top: 14px;
+  border-color: rgba(99, 242, 150, 0.16);
+  background: rgba(3, 10, 7, 0.6);
+}
+
+.sload-actions {
+  margin-top: -6px;
+}
+
+.sload-cancel {
+  min-height: 40px;
+  padding: 0 18px;
+  border-color: rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.045);
+  color: rgba(225, 237, 230, 0.65);
+}
+
+.sload-cancel:hover {
+  border-color: rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.09);
+}
+
+.sv-video {
+  will-change: opacity, transform;
+}
+
+@media (max-width: 720px), (max-height: 700px) {
+  .sload-content {
+    padding: 24px;
+    border-radius: 22px;
+  }
+
+  .sload-cover {
+    width: 62px;
+    height: 62px;
+  }
+
+  .sload-telemetry {
+    grid-template-columns: 1fr;
+  }
+
+  .sload-telemetry-item {
+    padding: 9px 11px;
+  }
+
+  .sload-step-name {
+    font-size: 0.56rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shader-atmosphere canvas {
+    display: none;
+  }
+
+  .sv-video {
+    filter: none;
+    transform: none;
+  }
+}
+
+/* Cozy launch room: intentionally quiet until the first video frame arrives. */
+.stream-loading-transition--warping {
+  pointer-events: none;
+}
+
+.sload {
+  --sload-radius: 26px;
+  --sload-padding: clamp(24px, 3.2vw, 38px);
+  padding: clamp(18px, 4vw, 56px);
+  background: #111210;
+}
+
+.sload-backdrop {
+  background: #08100b;
+}
+
+.sload-backdrop-art {
+  display: none;
+}
+
+.sload-backdrop-wash {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(7, 16, 10, 0.94) 0%, rgba(7, 16, 10, 0.68) 26%, rgba(7, 16, 10, 0.12) 58%, transparent 76%),
+    linear-gradient(180deg, rgba(5, 10, 7, 0.06), rgba(5, 10, 7, 0.24));
+}
+
+.sload-content {
+  width: min(720px, 100%);
+  max-width: 720px;
+  max-height: calc(100vh - 48px);
+  align-items: center;
+  gap: 32px;
+  padding: var(--sload-padding) 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.sload-stage-rail {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: min(520px, 88%);
+  margin: 0 auto;
+}
+
+.sload-stage {
+  display: flex;
+  align-items: center;
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.sload-stage:last-child {
+  flex: 0 0 auto;
+}
+
+.sload-stage-icon {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  color: rgba(237, 235, 224, 0.24);
+}
+
+.sload-stage-icon svg {
+  flex-shrink: 0;
+}
+
+.sload-stage-line {
+  flex: 1 1 auto;
+  height: 1px;
+  margin: 0 8px;
+  background: rgba(237, 235, 224, 0.12);
+}
+
+.sload-stage--completed .sload-stage-icon,
+.sload-stage--active .sload-stage-icon {
+  color: #77d59a;
+}
+
+.sload-stage--completed .sload-stage-line {
+  background: rgba(119, 213, 154, 0.72);
+}
+
+.sload-stage--active .sload-stage-icon {
+  outline: 1px solid rgba(119, 213, 154, 0.54);
+  outline-offset: -1px;
+  border-radius: 50%;
+}
+
+.sload-game {
+  justify-content: center;
+  width: auto;
+  gap: 16px;
+}
+
+.sload-cover {
+  width: 78px;
+  height: 78px;
+  border: 0;
+  border-radius: min(1vw, 14px);
+  outline: 1px solid rgba(255, 255, 255, 0.1);
+  outline-offset: -1px;
+  box-shadow: none;
+}
+
+.sload-cover-shine {
+  display: none;
+}
+
+.sload-game-meta {
+  min-width: 0;
+  justify-content: center;
+  gap: 2px;
+  text-align: left;
+}
+
+.sload-label {
+  margin: 0;
+  color: rgba(237, 235, 224, 0.5);
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 0.66rem;
+  font-weight: 650;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.sload-title {
+  max-width: min(480px, 68vw);
+  color: #f2f0e8;
+  font-size: clamp(1.5rem, 2.2vw, 1.9rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+}
+
+.sload-platform {
+  color: rgba(237, 235, 224, 0.48);
+  font-size: 0.78rem;
+  font-weight: 520;
+}
+
+.sload-platform-icon {
+  color: #77d59a;
+}
+
+.sload-status {
+  width: min(640px, 100%);
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+}
+
+.sload-live-dot {
+  display: none;
+}
+
+.sload-status-text {
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+.sload-message {
+  color: #f2f0e8;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  text-align: center;
+}
+
+.sload-detail {
+  max-width: 54ch;
+  color: rgba(237, 235, 224, 0.54);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  text-align: center;
+}
+
+.sload-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: min(600px, 100%);
+  border-top: 1px solid rgba(245, 240, 226, 0.1);
+  border-bottom: 0;
+}
+
+.sload-fact {
+  min-width: 0;
+  padding: 18px 22px 0;
+  text-align: center;
+}
+
+.sload-fact:first-child {
+  padding-left: 0;
+}
+
+.sload-fact:last-child {
+  padding-right: 0;
+}
+
+.sload-fact + .sload-fact {
+  border-left: 1px solid rgba(245, 240, 226, 0.08);
+}
+
+.sload-fact p {
+  margin: 0 0 4px;
+  overflow: hidden;
+  color: rgba(237, 235, 224, 0.46);
+  font-size: 0.68rem;
+  font-weight: 620;
+  letter-spacing: 0.06em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.sload-fact strong {
+  display: block;
+  overflow: hidden;
+  color: rgba(242, 240, 232, 0.94);
+  font-size: 0.9rem;
+  font-weight: 580;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sload-ad {
+  width: min(680px, 100%);
+  margin: 0;
+  border-color: rgba(245, 240, 226, 0.08);
+  background: rgba(11, 12, 10, 0.48);
+}
+
+.sload-actions {
+  margin: -12px 0 0;
+}
+
+.sload-cancel {
+  min-height: 36px;
+  padding: 0 12px 0 9px;
+  border-color: rgba(245, 240, 226, 0.1);
+  background: transparent;
+  color: rgba(237, 235, 224, 0.56);
+  box-shadow: none;
+}
+
+.sload-cancel:hover {
+  border-color: rgba(245, 240, 226, 0.18);
+  background: rgba(245, 240, 226, 0.05);
+  color: rgba(242, 240, 232, 0.84);
+}
+
+.sload.sload--error .sload-backdrop,
+.sload.sload--error .sload-backdrop-wash {
+  background: #151312;
+}
+
+@media (max-width: 620px) {
+  .sload {
+    --sload-padding: 22px;
+    align-items: flex-end;
+    padding: 12px;
+  }
+
+  .sload-content {
+    max-height: calc(100vh - 24px);
+    gap: 24px;
+    padding-inline: 12px;
+  }
+
+  .sload-title {
+    max-width: calc(100vw - 148px);
+    font-size: 1.3rem;
+  }
+
+  .sload-detail {
+    font-size: 1rem;
+  }
+
+  .sload-facts {
+    grid-template-columns: 1fr;
+  }
+
+  .sload-fact,
+  .sload-fact:first-child,
+  .sload-fact:last-child {
+    padding: 12px 0;
+  }
+
+  .sload-fact + .sload-fact {
+    border-top: 1px solid rgba(245, 240, 226, 0.08);
+    border-left: 0;
+  }
+
+  .sload-fact p,
+  .sload-fact strong {
+    font-size: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stream-loading-transition--warping {
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
## Summary

- redesign the queue and stream handoff with the interactive React Three Fiber shader background
- standardize renderer animation on Motion primitives, including dialogs, sidebars, spinners, cards, status indicators, and the first-frame reveal
- add the catalog atmosphere, symmetrical library cards, 105% default card scale, and the Ctrl+G sidebar treatment
- keep the queue visible until video is actually ready, then perform the Motion-controlled handoff
- preserve Electron runtime installation fallback behavior
- port the implementation onto the focused modules introduced by #626

## Refactor compatibility

- rebased directly onto `dev` at `8b27533a`
- moved library behavior into `components/library/LibraryControllerView.tsx`
- moved settings behavior into the corresponding `components/settings/sections/*` owners
- moved stream behavior into `components/stream/StreamEmptyStates.tsx` and `StreamIndicators.tsx`
- does not restore the previous oversized module implementations

## Verification

- `npm.cmd run typecheck`
- `npm.cmd test` — 196 passing
- `npm.cmd run lint` — passes with existing warnings
- `npm.cmd run build`
- `git diff --check origin/dev...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the critical launch-to-play path (overlay timing, first-frame detection) and adds a runtime WebGL dependency; behavior is partially covered by new `isStreamVideoReady` tests.
> 
> **Overview**
> This PR refreshes **queue → stream launch** and **catalog** presentation with WebGL shader backdrops (`three` / `@react-three/fiber` via lazy `ShaderAtmosphere`), a redesigned **StreamLoading** flow (stage rail, cozy copy, elapsed/queue facts, queue vs connecting shader variants), and a **Motion-controlled handoff** that keeps the loading overlay until a real frame is ready—not merely when status flips to `streaming`.
> 
> **Stream readiness** is centralized in `isStreamVideoReady` (diagnostics or video element dimensions) plus a short reveal delay; `App` mounts `StreamView` underneath while the overlay warps/fades out. **StreamView** fades video in and animates empty/waiting states; the quick-menu sidebar is full-height with `AnimatePresence` on the backdrop.
> 
> **Motion** replaces many CSS keyframe spinners/pulses with shared tokens (`overlayMotion`, `dialogMotion`, `MotionSpinner`) across login, settings prompts, cards, ads, and stats. Home/library get the catalog atmosphere layer; default **poster scale** moves to **1.05**.
> 
> **Build tooling**: Windows Electron install uses `tar.exe` when `extract-zip` hangs on newer Node; non-Windows still resolves `extract-zip` from Electron’s package boundary.
> 
> New `streamLoading` locale strings support the expanded launch UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0068d7dbfcd5aa9d3d57b0fcaa38d908ae23c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->