### PR TITLE
fix(native): honor Windows DPI scaling

### DIFF
--- a/native/opennow-streamer/src/main.rs
+++ b/native/opennow-streamer/src/main.rs
@@ -23,6 +23,8 @@ mod nvst_video;
 mod protocol;
 mod shortcuts;
 mod sdp;
+#[cfg(target_os = "windows")]
+mod windows_dpi;
 
 use serde::Serialize;
 use serde_json::Value;
@@ -127,6 +129,9 @@ fn handle_command(
 }
 
 fn main() -> io::Result<()> {
+    #[cfg(target_os = "windows")]
+    windows_dpi::enable_per_monitor_awareness();
+
     let stdin = io::stdin();
     let (event_sender, event_receiver) = mpsc::channel::<Event>();
     let event_writer = thread::spawn(move || {

--- a/native/opennow-streamer/src/windows_dpi.rs
+++ b/native/opennow-streamer/src/windows_dpi.rs
@@ -1,0 +1,29 @@
+//! Windows DPI policy for native renderer windows.
+//!
+//! Electron publishes native render-surface bounds in physical pixels. The
+//! streamer must use the same coordinate space or Windows DPI virtualization
+//! can offset or shrink the video window on scaled and mixed-DPI displays.
+
+use std::ffi::c_void;
+
+type DpiAwarenessContext = *mut c_void;
+
+// DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 from winuser.h.
+const PER_MONITOR_AWARE_V2: DpiAwarenessContext = -4_isize as DpiAwarenessContext;
+
+#[link(name = "user32")]
+extern "system" {
+    fn SetProcessDpiAwarenessContext(value: DpiAwarenessContext) -> i32;
+    fn SetProcessDPIAware() -> i32;
+}
+
+/// Opt the streamer into physical-pixel coordinates before GStreamer or any
+/// renderer thread can create a window. The legacy fallback keeps coordinates
+/// unvirtualized on Windows versions that reject the per-monitor-v2 context.
+pub(crate) fn enable_per_monitor_awareness() {
+    unsafe {
+        if SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2) == 0 {
+            let _ = SetProcessDPIAware();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- opt the Windows native streamer into per-monitor-v2 DPI awareness before any renderer or GStreamer window is created
- retain the legacy system-DPI-aware fallback when Windows rejects the newer context
- keep Electron-provided physical-pixel render bounds consistent on scaled and mixed-DPI displays

## Root cause

Electron publishes the native surface rectangle in physical pixels (`CSS bounds × devicePixelRatio`), but the native streamer did not declare a Windows DPI-awareness context. Windows could therefore virtualize native window coordinates at 125% or other custom scaling, shifting or shrinking the video surface and leaving a black band.

This applies the coordinate policy process-wide, covering both the internal renderer and the external floating fallback.

Fixes #575

## Verification

- `cargo test --manifest-path native/opennow-streamer/Cargo.toml` (61 passed)
- `rustfmt --edition 2021 --check native/opennow-streamer/src/windows_dpi.rs`
- `git diff --check`

## Review note

The repository-wide `cargo fmt --check` still reports pre-existing formatting drift in native files outside this focused change.