### PR TITLE
fix(native): enable DX11 VSync-off and G-Sync presentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,6 +547,11 @@ jobs:
           "GSTREAMER_1_0_ROOT_MSVC_X86_64=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
           "$root\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
 
+      - name: Build patched Windows GStreamer D3D11 plugin
+        if: matrix.native_build == 'true' && runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/build-patched-gstreamer-d3d11.ps1 -GStreamerRoot "$env:GSTREAMER_1_0_ROOT_MSVC_X86_64" -Version "$env:GSTREAMER_WINDOWS_VERSION"
+
       - name: Install FPM for arm64 deb builds
         if: matrix.label == 'linux-arm64'
         run: sudo apt-get install -y ruby ruby-dev build-essential && sudo gem install fpm

--- a/native/gstreamer-patches/0001-d3d11-enable-tearing-vrr.patch
+++ b/native/gstreamer-patches/0001-d3d11-enable-tearing-vrr.patch
@@ -1,0 +1,55 @@
+--- a/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11window_win32.cpp
++++ b/subprojects/gst-plugins-bad/sys/d3d11/gstd3d11window_win32.cpp
+@@ -1155,9 +1155,36 @@
+   DXGI_SWAP_CHAIN_DESC desc = { 0, };
+   IDXGISwapChain *new_swapchain = NULL;
+   GstD3D11Device *device = window->device;
++  HRESULT hr;
+ 
+   self->have_swapchain1 = FALSE;
+ 
++  const gchar *allow_tearing_env = g_getenv ("OPENNOW_NATIVE_D3D_ALLOW_TEARING");
++  if (allow_tearing_env &&
++      (!g_ascii_strcasecmp (allow_tearing_env, "1") ||
++          !g_ascii_strcasecmp (allow_tearing_env, "true") ||
++          !g_ascii_strcasecmp (allow_tearing_env, "on") ||
++          !g_ascii_strcasecmp (allow_tearing_env, "yes"))) {
++    IDXGIFactory1 *factory =
++        gst_d3d11_device_get_dxgi_factory_handle (device);
++    ComPtr < IDXGIFactory5 > factory5;
++    BOOL allow_tearing = FALSE;
++
++    hr = factory->QueryInterface (IID_PPV_ARGS (&factory5));
++    if (SUCCEEDED (hr)) {
++      hr = factory5->CheckFeatureSupport (DXGI_FEATURE_PRESENT_ALLOW_TEARING,
++          &allow_tearing, sizeof (allow_tearing));
++    }
++
++    if (SUCCEEDED (hr) && allow_tearing) {
++      swapchain_flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
++      GST_INFO_OBJECT (self, "DXGI tearing/VRR presentation enabled");
++    } else {
++      GST_WARNING_OBJECT (self,
++          "DXGI tearing/VRR presentation requested but unsupported");
++    }
++  }
++
+   {
+     DXGI_SWAP_CHAIN_DESC1 desc1 = { 0, };
+     desc1.Width = 0;
+@@ -1309,6 +1336,15 @@
+     return GST_D3D11_WINDOW_FLOW_CLOSED;
+   }
+ 
++  DXGI_SWAP_CHAIN_DESC swapchain_desc = { 0, };
++  BOOL exclusive_fullscreen = FALSE;
++  if (SUCCEEDED (window->swap_chain->GetDesc (&swapchain_desc)) &&
++      (swapchain_desc.Flags & DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING) &&
++      (FAILED (window->swap_chain->GetFullscreenState (
++               &exclusive_fullscreen, nullptr)) || !exclusive_fullscreen)) {
++    present_flags |= DXGI_PRESENT_ALLOW_TEARING;
++  }
++
+   if (self->have_swapchain1) {
+     IDXGISwapChain1 *swap_chain1 = (IDXGISwapChain1 *) window->swap_chain;
+     DXGI_PRESENT_PARAMETERS present_params = { 0, };

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -6,6 +6,7 @@ use crate::backend::{
 use crate::gstreamer_config::{
     resolve_d3d_fullscreen_sink, resolve_present_max_fps, use_internal_renderer,
     NATIVE_D3D_FULLSCREEN_ENV, NATIVE_PRESENT_MAX_FPS_ENV, PRESENT_LIMITER_AUTO_SENTINEL,
+    PRESENT_LIMITER_VRR_SENTINEL,
 };
 use crate::gstreamer_platform::{clear_native_shortcut_bindings, set_native_shortcut_bindings};
 use crate::gstreamer_pipeline::{
@@ -194,7 +195,12 @@ impl NativeStreamerBackend for GstreamerBackend {
                     .map(|ctx| ctx.settings.enable_cloud_gsync)
                     .unwrap_or(false),
             );
-            let present_max_fps = resolve_present_max_fps(requested_fps.unwrap_or(0));
+            let cloud_gsync_enabled = self
+                .active_context
+                .as_ref()
+                .map(|ctx| ctx.settings.enable_cloud_gsync)
+                .unwrap_or(false);
+            let present_max_fps = resolve_present_max_fps(cloud_gsync_enabled);
             if let Some(pipeline) = self.pipeline.as_mut() {
                 pipeline.set_present_max_fps(present_max_fps);
                 pipeline.set_d3d_fullscreen_sink(d3d_fullscreen);
@@ -287,14 +293,17 @@ impl NativeStreamerBackend for GstreamerBackend {
             };
         };
 
-        let present_max_fps = resolve_present_max_fps(context.settings.fps);
+        let present_max_fps = resolve_present_max_fps(context.settings.enable_cloud_gsync);
         // Internal child-surface mode never uses exclusive D3D fullscreen present.
         let d3d_fullscreen_sink = resolve_d3d_fullscreen_sink(context.settings.enable_cloud_gsync);
         set_native_shortcut_bindings(&context.shortcuts);
         pipeline.set_present_max_fps(present_max_fps);
         pipeline.set_d3d_fullscreen_sink(d3d_fullscreen_sink);
         pipeline.configure_stats(&context, prepared.nvst_params.max_bitrate_kbps);
-        if present_max_fps > 0 && present_max_fps != PRESENT_LIMITER_AUTO_SENTINEL {
+        if present_max_fps > 0
+            && present_max_fps != PRESENT_LIMITER_AUTO_SENTINEL
+            && present_max_fps != PRESENT_LIMITER_VRR_SENTINEL
+        {
             events.push(Event::Log {
                 level: "info",
                 message: format!(
@@ -309,6 +318,20 @@ impl NativeStreamerBackend for GstreamerBackend {
                     "Native present limiter auto mode for {} fps stream (D3D11 caps to display Hz when stream fps exceeds it); set {NATIVE_PRESENT_MAX_FPS_ENV}=0 to disable.",
                     context.settings.fps
                 ),
+            });
+        } else if present_max_fps == PRESENT_LIMITER_VRR_SENTINEL {
+            events.push(Event::Log {
+                level: "info",
+                message: format!(
+                    "Native VRR present limiter auto mode for {} fps stream (caps below the display refresh ceiling when needed).",
+                    context.settings.fps
+                ),
+            });
+        } else {
+            events.push(Event::Log {
+                level: "info",
+                message: "Native present limiter disabled for uncapped VSync-off presentation."
+                    .to_owned(),
             });
         }
         if d3d_fullscreen_sink {
@@ -815,6 +838,24 @@ mod tests {
         );
         assert_eq!(
             effective_present_max_fps(0, Some(240), RtpVideoApi::D3D11, Some(165)),
+            0
+        );
+        assert_eq!(
+            effective_present_max_fps(
+                PRESENT_LIMITER_VRR_SENTINEL,
+                Some(240),
+                RtpVideoApi::D3D11,
+                Some(165)
+            ),
+            162
+        );
+        assert_eq!(
+            effective_present_max_fps(
+                PRESENT_LIMITER_VRR_SENTINEL,
+                Some(120),
+                RtpVideoApi::D3D11,
+                Some(165)
+            ),
             0
         );
     }

--- a/native/opennow-streamer/src/gstreamer_config.rs
+++ b/native/opennow-streamer/src/gstreamer_config.rs
@@ -9,6 +9,8 @@ pub(crate) const NATIVE_ZERO_COPY_ENV: &str = "OPENNOW_NATIVE_ZERO_COPY";
 pub(crate) const NATIVE_PRESENT_MAX_FPS_ENV: &str = "OPENNOW_NATIVE_PRESENT_MAX_FPS";
 pub(crate) const NATIVE_D3D_FULLSCREEN_ENV: &str = "OPENNOW_NATIVE_D3D_FULLSCREEN";
 pub(crate) const PRESENT_LIMITER_AUTO_SENTINEL: u32 = u32::MAX;
+pub(crate) const PRESENT_LIMITER_VRR_SENTINEL: u32 = u32::MAX - 1;
+const VRR_REFRESH_HEADROOM_FPS: u32 = 3;
 
 pub(crate) fn use_external_renderer_window() -> bool {
     std::env::var(EXTERNAL_RENDERER_ENV)
@@ -43,7 +45,7 @@ pub(crate) fn zero_copy_requested() -> bool {
     )
 }
 
-pub(crate) fn resolve_present_max_fps(requested_fps: u32) -> u32 {
+pub(crate) fn resolve_present_max_fps(cloud_gsync_enabled: bool) -> u32 {
     if let Ok(value) = std::env::var(NATIVE_PRESENT_MAX_FPS_ENV) {
         let value = value.trim().to_ascii_lowercase();
         if value == "0" || value == "off" || value == "false" || value == "unlimited" {
@@ -56,13 +58,23 @@ pub(crate) fn resolve_present_max_fps(requested_fps: u32) -> u32 {
             return fps;
         }
     }
-    let _ = requested_fps;
-    PRESENT_LIMITER_AUTO_SENTINEL
+    if cloud_gsync_enabled {
+        PRESENT_LIMITER_VRR_SENTINEL
+    } else {
+        0
+    }
 }
 
 pub(crate) fn automatic_present_max_fps(requested_fps: u32, display_hz: Option<u32>) -> u32 {
     display_hz
         .filter(|display_hz| *display_hz >= 30 && *display_hz < requested_fps)
+        .unwrap_or(0)
+}
+
+pub(crate) fn vrr_present_max_fps(requested_fps: u32, display_hz: Option<u32>) -> u32 {
+    display_hz
+        .filter(|display_hz| *display_hz >= 30 && *display_hz <= requested_fps)
+        .map(|display_hz| display_hz.saturating_sub(VRR_REFRESH_HEADROOM_FPS))
         .unwrap_or(0)
 }
 
@@ -111,6 +123,23 @@ mod tests {
         assert_eq!(automatic_present_max_fps(240, Some(240)), 0);
         assert_eq!(automatic_present_max_fps(240, Some(1)), 0);
         assert_eq!(automatic_present_max_fps(240, None), 0);
+    }
+
+    #[test]
+    fn default_present_policy_is_uncapped_without_vrr() {
+        assert_eq!(resolve_present_max_fps(false), 0);
+        assert_eq!(
+            resolve_present_max_fps(true),
+            PRESENT_LIMITER_VRR_SENTINEL
+        );
+    }
+
+    #[test]
+    fn vrr_present_limiter_stays_below_refresh_ceiling() {
+        assert_eq!(vrr_present_max_fps(240, Some(165)), 162);
+        assert_eq!(vrr_present_max_fps(165, Some(165)), 162);
+        assert_eq!(vrr_present_max_fps(120, Some(165)), 0);
+        assert_eq!(vrr_present_max_fps(240, None), 0);
     }
 
     #[test]

--- a/native/opennow-streamer/src/gstreamer_pipeline.rs
+++ b/native/opennow-streamer/src/gstreamer_pipeline.rs
@@ -1,9 +1,9 @@
 use crate::gstreamer_backend::send_log;
 use crate::gstreamer_config::{
     automatic_present_max_fps, requested_video_backend, use_external_renderer_window,
-    use_internal_renderer, zero_copy_requested, EXTERNAL_RENDERER_ENV, NATIVE_D3D_FULLSCREEN_ENV,
-    NATIVE_PRESENT_MAX_FPS_ENV, NATIVE_VIDEO_API_ENV, NATIVE_VIDEO_BACKEND_ENV,
-    PRESENT_LIMITER_AUTO_SENTINEL,
+    use_internal_renderer, vrr_present_max_fps, zero_copy_requested, EXTERNAL_RENDERER_ENV,
+    NATIVE_D3D_FULLSCREEN_ENV, NATIVE_PRESENT_MAX_FPS_ENV, NATIVE_VIDEO_API_ENV,
+    NATIVE_VIDEO_BACKEND_ENV, PRESENT_LIMITER_AUTO_SENTINEL, PRESENT_LIMITER_VRR_SENTINEL,
 };
 #[cfg(target_os = "windows")]
 use crate::gstreamer_input::NativeWindowInputBridge;
@@ -1788,6 +1788,16 @@ pub(crate) fn effective_present_max_fps(
     video_api: RtpVideoApi,
     display_hz: Option<u32>,
 ) -> u32 {
+    if configured_present_max_fps == PRESENT_LIMITER_VRR_SENTINEL {
+        if !matches!(video_api, RtpVideoApi::D3D11 | RtpVideoApi::D3D12) {
+            return 0;
+        }
+        return requested_fps
+            .filter(|fps| *fps > 0)
+            .map(|fps| vrr_present_max_fps(fps, display_hz))
+            .unwrap_or(0);
+    }
+
     if configured_present_max_fps != PRESENT_LIMITER_AUTO_SENTINEL {
         return configured_present_max_fps;
     }
@@ -2217,6 +2227,8 @@ fn link_rtp_video_pad(
             let reason = if configured_present_max_fps == PRESENT_LIMITER_AUTO_SENTINEL {
                 "auto-enabled for the D3D11 path to prevent display-rate present backpressure"
                     .to_owned()
+            } else if configured_present_max_fps == PRESENT_LIMITER_VRR_SENTINEL {
+                "kept below the display refresh ceiling for VRR".to_owned()
             } else {
                 format!("configured by {NATIVE_PRESENT_MAX_FPS_ENV}")
             };

--- a/opennow-stable/scripts/build-patched-gstreamer-d3d11.ps1
+++ b/opennow-stable/scripts/build-patched-gstreamer-d3d11.ps1
@@ -1,0 +1,91 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string] $GStreamerRoot,
+  [Parameter(Mandatory = $true)]
+  [string] $Version
+)
+
+$ErrorActionPreference = "Stop"
+$patch = Resolve-Path (Join-Path $PSScriptRoot "..\..\native\gstreamer-patches\0001-d3d11-enable-tearing-vrr.patch")
+$workRoot = Join-Path ([System.IO.Path]::GetTempPath()) "opennow-gstreamer-$Version"
+$archive = Join-Path $workRoot "gstreamer-$Version.tar.gz"
+$sourceRoot = Join-Path $workRoot "gstreamer-$Version"
+$buildRoot = Join-Path $workRoot "build"
+$sourceUrl = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$Version/gstreamer-$Version.tar.gz"
+$sourceMirrorUrl = "https://github.com/GStreamer/gstreamer/archive/refs/tags/$Version.tar.gz"
+
+Remove-Item -Recurse -Force $workRoot -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $workRoot | Out-Null
+
+& curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $sourceUrl
+if ($LASTEXITCODE -ne 0) {
+  & curl.exe --fail --location --retry 5 --retry-all-errors --output $archive $sourceMirrorUrl
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to download GStreamer $Version source."
+  }
+}
+
+& tar.exe -xzf $archive -C $workRoot
+if ($LASTEXITCODE -ne 0) {
+  throw "Failed to extract GStreamer $Version source."
+}
+
+& git.exe -C $sourceRoot apply --check $patch
+if ($LASTEXITCODE -ne 0) {
+  throw "OpenNOW D3D11 tearing patch does not apply to GStreamer $Version."
+}
+& git.exe -C $sourceRoot apply $patch
+if ($LASTEXITCODE -ne 0) {
+  throw "Failed to apply OpenNOW D3D11 tearing patch."
+}
+
+python -m pip install --disable-pip-version-check --quiet meson ninja
+if ($LASTEXITCODE -ne 0) {
+  throw "Failed to install Meson and Ninja."
+}
+
+$env:PKG_CONFIG_PATH = "$(Join-Path $GStreamerRoot "lib\pkgconfig");$env:PKG_CONFIG_PATH"
+$env:PATH = "$(Join-Path $GStreamerRoot "bin");$env:PATH"
+$badPluginsSource = Join-Path $sourceRoot "subprojects\gst-plugins-bad"
+
+meson setup $buildRoot $badPluginsSource `
+  --buildtype=release `
+  --vsenv `
+  -Dauto_features=disabled `
+  -Dd3d11=enabled `
+  -Dtests=disabled `
+  -Dexamples=disabled `
+  -Dtools=disabled `
+  -Dintrospection=disabled `
+  -Dgpl=disabled
+if ($LASTEXITCODE -ne 0) {
+  throw "Failed to configure the patched GStreamer D3D11 plugin."
+}
+
+meson compile -C $buildRoot
+if ($LASTEXITCODE -ne 0) {
+  throw "Failed to compile the patched GStreamer D3D11 plugin."
+}
+
+$plugin = Get-ChildItem -Path $buildRoot -Filter "gstd3d11.dll" -Recurse |
+  Select-Object -First 1
+if (-not $plugin) {
+  throw "Patched gstd3d11.dll was not produced."
+}
+
+$pluginDestination = Join-Path $GStreamerRoot "lib\gstreamer-1.0\gstd3d11.dll"
+Copy-Item -Force $plugin.FullName $pluginDestination
+
+$d3d11Library = Get-ChildItem -Path $buildRoot -Filter "gstd3d11-1.0-0.dll" -Recurse |
+  Select-Object -First 1
+if ($d3d11Library) {
+  Copy-Item -Force $d3d11Library.FullName (Join-Path $GStreamerRoot "bin\gstd3d11-1.0-0.dll")
+}
+
+$gstInspect = Join-Path $GStreamerRoot "bin\gst-inspect-1.0.exe"
+& $gstInspect d3d11videosink
+if ($LASTEXITCODE -ne 0) {
+  throw "Patched GStreamer D3D11 plugin failed its gst-inspect smoke check."
+}
+
+Write-Host "Installed patched GStreamer D3D11 plugin: $pluginDestination"

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -880,6 +880,7 @@ export class NativeStreamerManager {
       childEnv.OPENNOW_NATIVE_EXTERNAL_RENDERER = "0";
     } else if (process.platform === "win32") {
       childEnv.OPENNOW_NATIVE_EXTERNAL_RENDERER = this.options.getExternalRendererEnabled() ? "1" : "0";
+      childEnv.OPENNOW_NATIVE_D3D_ALLOW_TEARING = "1";
     }
     childEnv.OPENNOW_NATIVE_CLOUD_GSYNC = nativeStreamerFeatureModeToEnvValue(this.options.getCloudGsyncMode());
     childEnv.OPENNOW_NATIVE_D3D_FULLSCREEN = nativeStreamerFeatureModeToEnvValue(this.options.getD3dFullscreenMode());


### PR DESCRIPTION
## Summary
- disable the implicit display-refresh present cap in Lowest Latency mode
- keep Cloud G-Sync presentation below the monitor refresh ceiling with 3 FPS headroom
- build and bundle a patched Windows GStreamer DX11 sink that opts into `DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING` and `DXGI_PRESENT_ALLOW_TEARING` when supported
- enable the tearing-capable DX11 path for the Windows native streamer process

## Root cause
The native streamer configured GStreamer with `sync=false`, but its default auto present limiter still capped DX11 at the detected display refresh rate. Separately, GStreamer 1.26.8 calls `Present(0, ...)` without creating the swap chain with `ALLOW_TEARING`; under DWM this can remain refresh-paced and cannot correctly enter DXGI VRR.

## Verification
- `cargo test --manifest-path native/opennow-streamer/Cargo.toml --features gstreamer`
- `cargo check --manifest-path native/opennow-streamer/Cargo.toml --features gstreamer`
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable test`
- `npm --prefix opennow-stable run lint` (passes with pre-existing warnings)
- GStreamer patch applies cleanly to the pinned 1.26.8 source
- release workflow YAML parses successfully

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/fe272015-d098-4beb-b7f2-98b850f9386b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-269" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/fe272015-d098-4beb-b7f2-98b850f9386b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-269&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-269"><img alt="OPE-269" src="https://capy.ai/api/badge/thread.svg?label=OPE-269"></picture></a>
<!-- capy-pr-badge:end -->