### PR TITLE
fix: align settings/library UI and preserve GFN auth/library ownership

### DIFF
--- a/opennow-stable/src/main/platforms/gfn/auth.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth.ts
@@ -852,6 +852,8 @@ export class AuthService {
         let refreshedTokens: AuthTokens = {
           ...tokens,
           ...refreshedOAuth,
+          // OAuth refresh often omits id_token; never drop the prior JWT.
+          idToken: refreshedOAuth.idToken ?? tokens.idToken,
           // OAuth refresh does not always return a new client token.
           clientToken: tokens.clientToken,
           clientTokenExpiresAt: tokens.clientTokenExpiresAt,

--- a/opennow-stable/src/main/platforms/gfn/auth/tokenRefresh.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/tokenRefresh.test.ts
@@ -1,0 +1,81 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mergeTokenSnapshot } from "./tokenRefresh";
+
+test("mergeTokenSnapshot keeps the prior id_token when refresh omits it", () => {
+  const merged = mergeTokenSnapshot(
+    {
+      accessToken: "old-access",
+      refreshToken: "refresh",
+      idToken: "prior-id-token",
+      expiresAt: Date.now() + 60_000,
+      clientToken: "client",
+      clientTokenExpiresAt: Date.now() + 120_000,
+      clientTokenLifetimeMs: 120_000,
+      authClientId: "client-id",
+    },
+    {
+      access_token: "new-access",
+      refresh_token: "refresh",
+      expires_in: 3600,
+    },
+  );
+
+  assert.equal(merged.accessToken, "new-access");
+  assert.equal(merged.idToken, "prior-id-token");
+  assert.equal(merged.clientToken, "client");
+  assert.equal(typeof merged.clientTokenExpiresAt, "number");
+});
+
+test("mergeTokenSnapshot clears client-token expiry when client_token rotates", () => {
+  const merged = mergeTokenSnapshot(
+    {
+      accessToken: "old-access",
+      refreshToken: "refresh",
+      idToken: "prior-id-token",
+      expiresAt: Date.now() + 60_000,
+      clientToken: "old-client",
+      clientTokenExpiresAt: Date.now() + 120_000,
+      clientTokenLifetimeMs: 120_000,
+    },
+    {
+      access_token: "new-access",
+      id_token: "new-id-token",
+      client_token: "new-client",
+      expires_in: 3600,
+    },
+  );
+
+  assert.equal(merged.idToken, "new-id-token");
+  assert.equal(merged.clientToken, "new-client");
+  assert.equal(merged.clientTokenExpiresAt, undefined);
+  assert.equal(merged.clientTokenLifetimeMs, undefined);
+});
+
+test("mergeTokenSnapshot keeps client-token expiry when client_token is unchanged", () => {
+  const clientTokenExpiresAt = Date.now() + 120_000;
+  const merged = mergeTokenSnapshot(
+    {
+      accessToken: "old-access",
+      refreshToken: "refresh",
+      idToken: "prior-id-token",
+      expiresAt: Date.now() + 60_000,
+      clientToken: "same-client",
+      clientTokenExpiresAt,
+      clientTokenLifetimeMs: 120_000,
+    },
+    {
+      access_token: "new-access",
+      client_token: "same-client",
+      expires_in: 3600,
+    },
+  );
+
+  assert.equal(merged.clientToken, "same-client");
+  assert.equal(merged.clientTokenExpiresAt, clientTokenExpiresAt);
+  assert.equal(merged.clientTokenLifetimeMs, 120_000);
+  assert.equal(merged.idToken, "prior-id-token");
+});

--- a/opennow-stable/src/main/platforms/gfn/auth/tokenRefresh.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/tokenRefresh.ts
@@ -43,7 +43,9 @@ export async function refreshAuthTokens(
   return {
     accessToken: payload.access_token,
     refreshToken: payload.refresh_token ?? refreshToken,
-    idToken: payload.id_token,
+    // Omit rather than set undefined so callers that spread onto prior tokens
+    // do not wipe a still-valid id_token when the refresh response excludes it.
+    ...(payload.id_token ? { idToken: payload.id_token } : {}),
     expiresAt: toExpiresAt(payload.expires_in),
     authClientId,
   };
@@ -104,14 +106,22 @@ export async function refreshWithClientToken(
 }
 
 export function mergeTokenSnapshot(base: AuthTokens, refreshed: TokenResponse): AuthTokens {
+  const nextClientToken = refreshed.client_token ?? base.clientToken;
+  const clientTokenRotated =
+    typeof refreshed.client_token === "string" &&
+    refreshed.client_token.length > 0 &&
+    refreshed.client_token !== base.clientToken;
+
   return {
     accessToken: refreshed.access_token,
     refreshToken: refreshed.refresh_token ?? base.refreshToken,
-    idToken: refreshed.id_token,
+    // Refresh responses often omit id_token; keep the prior JWT for LCARS callers.
+    idToken: refreshed.id_token ?? base.idToken,
     expiresAt: toExpiresAt(refreshed.expires_in),
     authClientId: base.authClientId ?? CLIENT_ID,
-    clientToken: refreshed.client_token ?? base.clientToken,
-    clientTokenExpiresAt: base.clientTokenExpiresAt,
-    clientTokenLifetimeMs: base.clientTokenLifetimeMs,
+    clientToken: nextClientToken,
+    // Rotated client tokens must not inherit stale expiry metadata.
+    clientTokenExpiresAt: clientTokenRotated ? undefined : base.clientTokenExpiresAt,
+    clientTokenLifetimeMs: clientTokenRotated ? undefined : base.clientTokenLifetimeMs,
   };
 }

--- a/opennow-stable/src/main/platforms/gfn/gameAppMapper.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/gameAppMapper.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { appToGame, dedupeGames } from "./gameAppMapper";
+
+test("appToGame marks owned-but-unselected variants as inLibrary", () => {
+  const game = appToGame({
+    id: "game-1",
+    title: "Owned Game",
+    variants: [
+      {
+        id: "v1",
+        appStore: "Steam",
+        gfn: {
+          library: {
+            status: "PLATFORM_SYNC",
+            selected: false,
+          },
+        },
+      },
+      {
+        id: "v2",
+        appStore: "Epic",
+        gfn: {
+          library: {
+            status: "NOT_OWNED",
+            selected: false,
+          },
+        },
+      },
+    ],
+  });
+
+  assert.equal(game.isInLibrary, true);
+  assert.equal(game.variants[0]?.inLibrary, true);
+  assert.equal(game.variants[0]?.librarySelected, false);
+  assert.equal(game.variants[1]?.inLibrary, false);
+});
+
+test("dedupeGames preserves ownership metadata when merging same-id variants", () => {
+  const [merged] = dedupeGames([
+    {
+      id: "game-1",
+      title: "Game",
+      selectedVariantIndex: 0,
+      isInLibrary: true,
+      variants: [{
+        id: "v1",
+        store: "Steam",
+        supportedControls: [],
+        inLibrary: true,
+        libraryStatus: "MANUAL",
+        librarySelected: true,
+      }],
+    },
+    {
+      id: "game-1",
+      title: "Game",
+      selectedVariantIndex: 0,
+      variants: [{
+        id: "v1",
+        store: "Steam",
+        supportedControls: ["KEYBOARD_MOUSE"],
+        storeUrl: "https://store.example/steam",
+      }],
+    },
+  ]);
+
+  assert.equal(merged?.isInLibrary, true);
+  assert.equal(merged?.variants[0]?.inLibrary, true);
+  assert.equal(merged?.variants[0]?.libraryStatus, "MANUAL");
+  assert.equal(merged?.variants[0]?.librarySelected, true);
+  assert.equal(merged?.variants[0]?.storeUrl, "https://store.example/steam");
+  assert.deepEqual(merged?.variants[0]?.supportedControls, ["KEYBOARD_MOUSE"]);
+});
+
+test("dedupeGames accepts an explicit NOT_OWNED status from a later view", () => {
+  const [merged] = dedupeGames([
+    {
+      id: "game-1",
+      title: "Game",
+      selectedVariantIndex: 0,
+      isInLibrary: true,
+      variants: [{
+        id: "v1",
+        store: "Steam",
+        supportedControls: [],
+        inLibrary: true,
+        libraryStatus: "MANUAL",
+      }],
+    },
+    {
+      id: "game-1",
+      title: "Game",
+      selectedVariantIndex: 0,
+      isInLibrary: false,
+      variants: [{
+        id: "v1",
+        store: "Steam",
+        supportedControls: [],
+        inLibrary: false,
+        libraryStatus: "NOT_OWNED",
+      }],
+    },
+  ]);
+
+  assert.equal(merged?.isInLibrary, false);
+  assert.equal(merged?.variants[0]?.inLibrary, false);
+  assert.equal(merged?.variants[0]?.libraryStatus, "NOT_OWNED");
+});

--- a/opennow-stable/src/main/platforms/gfn/gameAppMapper.ts
+++ b/opennow-stable/src/main/platforms/gfn/gameAppMapper.ts
@@ -336,6 +336,7 @@ export function resolveAppData(app: AppData): AppResolution {
 export function appToVariants(app: AppData): GameVariant[] {
   return app.variants?.map((variant) => {
     const supportsPersistence = supportsInGameSettingsPersistence(variant);
+    const libraryStatus = variant.gfn?.library?.status;
     return {
       id: variant.id,
       store: variant.appStore,
@@ -343,8 +344,9 @@ export function appToVariants(app: AppData): GameVariant[] {
       supportedControls: variant.supportedControls ?? [],
       ...(supportsPersistence ? { supportsInGameSettingsPersistence: true } : {}),
       librarySelected: variant.gfn?.library?.selected,
-      inLibrary: variant.gfn?.library?.selected === true,
-      libraryStatus: variant.gfn?.library?.status,
+      // Owned via PLATFORM_SYNC/MANUAL/IN_LIBRARY even when not the selected variant.
+      inLibrary: isOwnedLibraryStatus(libraryStatus),
+      libraryStatus,
       lastPlayedDate: variant.gfn?.library?.lastPlayedDate,
       gfnStatus: variant.gfn?.status,
     };
@@ -398,16 +400,34 @@ export function appToGame(app: AppData): GameInfo {
   };
 }
 
+function resolveMergedLibraryOwnership(
+  primary?: Pick<GameVariant, "inLibrary" | "libraryStatus">,
+  fallback?: Pick<GameVariant, "inLibrary" | "libraryStatus">,
+): { inLibrary: boolean; libraryStatus?: string } {
+  const libraryStatus = primary?.libraryStatus ?? fallback?.libraryStatus;
+  if (libraryStatus !== undefined) {
+    return {
+      libraryStatus,
+      inLibrary: isOwnedLibraryStatus(libraryStatus),
+    };
+  }
+  return {
+    libraryStatus,
+    inLibrary: Boolean(primary?.inLibrary || fallback?.inLibrary),
+  };
+}
+
 function mergeAppMetaIntoGame(game: GameInfo, app: AppData): GameInfo {
   const merged = appToGame(app);
   const selectedVariantId = game.variants[game.selectedVariantIndex]?.id;
   const variants = merged.variants.map((variant) => {
     const existing = game.variants.find((candidate) => candidate.id === variant.id);
+    const ownership = resolveMergedLibraryOwnership(variant, existing);
     return {
       ...variant,
       librarySelected: variant.librarySelected ?? existing?.librarySelected,
-      inLibrary: variant.inLibrary ?? existing?.inLibrary,
-      libraryStatus: variant.libraryStatus ?? existing?.libraryStatus,
+      inLibrary: ownership.inLibrary,
+      libraryStatus: ownership.libraryStatus,
       lastPlayedDate: variant.lastPlayedDate ?? existing?.lastPlayedDate,
     };
   });
@@ -419,10 +439,30 @@ function mergeAppMetaIntoGame(game: GameInfo, app: AppData): GameInfo {
     ...game,
     ...merged,
     id: game.id,
-    isInLibrary: merged.isInLibrary || game.isInLibrary,
+    isInLibrary: merged.isInLibrary || game.isInLibrary || variants.some((variant) => variant.inLibrary),
     lastPlayed: merged.lastPlayed ?? game.lastPlayed,
     variants,
     selectedVariantIndex: selectedVariantIndex >= 0 ? selectedVariantIndex : merged.selectedVariantIndex,
+  };
+}
+
+function mergeGameVariants(existing: GameVariant, incoming: GameVariant): GameVariant {
+  const ownership = resolveMergedLibraryOwnership(incoming, existing);
+  return {
+    ...existing,
+    ...incoming,
+    storeUrl: incoming.storeUrl ?? existing.storeUrl,
+    supportedControls:
+      incoming.supportedControls.length > 0
+        ? incoming.supportedControls
+        : existing.supportedControls,
+    supportsInGameSettingsPersistence:
+      incoming.supportsInGameSettingsPersistence ?? existing.supportsInGameSettingsPersistence,
+    librarySelected: incoming.librarySelected ?? existing.librarySelected,
+    inLibrary: ownership.inLibrary,
+    libraryStatus: ownership.libraryStatus,
+    lastPlayedDate: incoming.lastPlayedDate ?? existing.lastPlayedDate,
+    gfnStatus: incoming.gfnStatus ?? existing.gfnStatus,
   };
 }
 
@@ -438,9 +478,14 @@ export function dedupeGames(games: GameInfo[]): GameInfo[] {
 
     const mergedVariants = new Map<string, GameVariant>();
     for (const variant of [...existing.variants, ...game.variants]) {
-      mergedVariants.set(variant.id, variant);
+      const prior = mergedVariants.get(variant.id);
+      mergedVariants.set(variant.id, prior ? mergeGameVariants(prior, variant) : variant);
     }
 
+    const mergedVariantList = [...mergedVariants.values()];
+    const hasResolvedLibraryStatus = mergedVariantList.some(
+      (variant) => variant.libraryStatus !== undefined,
+    );
     const merged: GameInfo = {
       ...existing,
       ...game,
@@ -468,8 +513,15 @@ export function dedupeGames(games: GameInfo[]): GameInfo[] {
       publisherName: existing.publisherName ?? game.publisherName,
       playabilityState: existing.playabilityState ?? game.playabilityState,
       lastPlayed: existing.lastPlayed ?? game.lastPlayed,
-      isInLibrary: existing.isInLibrary || game.isInLibrary,
-      variants: [...mergedVariants.values()],
+      variants: mergedVariantList,
+      // Prefer variant libraryStatus when present so NOT_OWNED can clear stale flags.
+      isInLibrary: hasResolvedLibraryStatus
+        ? mergedVariantList.some((variant) => variant.inLibrary)
+        : Boolean(
+          existing.isInLibrary ||
+          game.isInLibrary ||
+          mergedVariantList.some((variant) => variant.inLibrary),
+        ),
       genres: [...new Set([...(existing.genres ?? []), ...(game.genres ?? [])])],
       featureLabels: [...new Set([...(existing.featureLabels ?? []), ...(game.featureLabels ?? [])])],
       supportedControls: [...new Set([...(existing.supportedControls ?? []), ...(game.supportedControls ?? [])])],
@@ -478,7 +530,7 @@ export function dedupeGames(games: GameInfo[]): GameInfo[] {
       availableStores: [...new Set([...(existing.availableStores ?? []), ...(game.availableStores ?? [])])],
       searchText: [existing.searchText, game.searchText].filter(Boolean).join(" ").trim() || undefined,
       selectedVariantIndex: Math.max(0, existing.variants[existing.selectedVariantIndex]
-        ? [...mergedVariants.values()].findIndex((variant) => variant.id === existing.variants[existing.selectedVariantIndex]?.id)
+        ? mergedVariantList.findIndex((variant) => variant.id === existing.variants[existing.selectedVariantIndex]?.id)
         : game.selectedVariantIndex),
     };
 

--- a/opennow-stable/src/renderer/src/components/GameCard.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCard.tsx
@@ -246,50 +246,54 @@ export const GameCard = memo(function GameCard({
               {t(availabilityBadge.labelKey)}
             </span>
           )}
-          {activeStoreOption && (
-            <p className="game-card-platform" title={activeStoreOption.displayName}>
-              {activeStoreOption.displayName}
-            </p>
-          )}
-          {storeOptions.length > 0 && (
-            <div className="game-card-stores">
-              {storeOptions.map((store) => {
-                const className = [
-                  "game-card-store-chip",
-                  store.isActive ? "active" : "",
-                  store.isOwned ? "owned" : "",
-                ].filter(Boolean).join(" ");
-                const titleParts = [store.displayName];
-                if (store.isOwned) {
-                  titleParts.push(t("gameCard.owned"));
-                }
-                if (store.isActive) {
-                  titleParts.push(t("app.actions.select"));
-                }
-                const title = titleParts.join(" · ");
+          {(activeStoreOption || storeOptions.length > 0) && (
+            <div className="game-card-storefront">
+              {activeStoreOption && (
+                <p className="game-card-platform" title={activeStoreOption.displayName}>
+                  {activeStoreOption.displayName}
+                </p>
+              )}
+              {storeOptions.length > 0 && (
+                <div className="game-card-stores">
+                  {storeOptions.map((store) => {
+                    const className = [
+                      "game-card-store-chip",
+                      store.isActive ? "active" : "",
+                      store.isOwned ? "owned" : "",
+                    ].filter(Boolean).join(" ");
+                    const titleParts = [store.displayName];
+                    if (store.isOwned) {
+                      titleParts.push(t("gameCard.owned"));
+                    }
+                    if (store.isActive) {
+                      titleParts.push(t("app.actions.select"));
+                    }
+                    const title = titleParts.join(" · ");
 
-                if (onSelectStore) {
-                  return (
-                    <button
-                      key={store.storeKey}
-                      type="button"
-                      className={className}
-                      title={title}
-                      onClick={(event) => handleStoreClick(event, store.variantId)}
-                      aria-label={t("gameCard.store", { store: store.displayName })}
-                      aria-pressed={store.isActive}
-                    >
-                      <StoreBrandIcon store={store.store} />
-                    </button>
-                  );
-                }
+                    if (onSelectStore) {
+                      return (
+                        <button
+                          key={store.storeKey}
+                          type="button"
+                          className={className}
+                          title={title}
+                          onClick={(event) => handleStoreClick(event, store.variantId)}
+                          aria-label={t("gameCard.store", { store: store.displayName })}
+                          aria-pressed={store.isActive}
+                        >
+                          <StoreBrandIcon store={store.store} />
+                        </button>
+                      );
+                    }
 
-                return (
-                  <span key={store.storeKey} className={className} title={title}>
-                    <StoreBrandIcon store={store.store} />
-                  </span>
-                );
-              })}
+                    return (
+                      <span key={store.storeKey} className={className} title={title}>
+                        <StoreBrandIcon store={store.store} />
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           )}
           <h3 className="game-card-title" title={game.title}>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsStreamSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsStreamSection.tsx
@@ -570,13 +570,13 @@ export function SettingsStreamSection({
       </div>
       <div className="settings-rows">
         {/* Resolution — grouped dropdown */}
-        <div className="settings-row settings-row--column">
+        <div className="settings-row">
           <label className="settings-label settings-label--with-icon">
             <ScanLine size={15} className="settings-label-icon" />
             {t("settings.video.resolution")}
             {subscriptionLoading && <MotionSpinner size={12} className="settings-loading-icon" />}
           </label>
-          <div className="settings-dropdown settings-resolution-dropdown" ref={resolutionDropdownRef}>
+          <div className="settings-dropdown settings-dropdown--constrained settings-resolution-dropdown" ref={resolutionDropdownRef}>
             <button
               type="button"
               className={`settings-dropdown-selected ${resolutionDropdownOpen ? "open" : ""}`}
@@ -657,36 +657,38 @@ export function SettingsStreamSection({
         </div>
 
         {/* Color Quality */}
-        <div className="settings-row settings-row--column">
+        <div className="settings-row">
           <label className="settings-label settings-label--with-icon">
             <SlidersHorizontal size={15} className="settings-label-icon" />
             {t("settings.video.colorDepth")}
           </label>
-          <div className="settings-chip-row">
-            {colorQualityOptions.map((opt) => {
-              const needsHevc = colorQualityRequiresHevc(opt.value);
-              const colorDescription = opt.value === "8bit_420"
-                ? t("settings.colorQuality.mostCompatible")
-                : opt.value === "8bit_444"
-                  ? t("settings.colorQuality.sharperChroma")
-                  : opt.value === "10bit_420"
-                    ? t("settings.colorQuality.higherBitDepth")
-                    : t("settings.colorQuality.highestChromaAndBitDepth");
-              return (
-                <button
-                  key={opt.value}
-                  className={`settings-chip ${settings.colorQuality === opt.value ? "active" : ""}`}
-                  onClick={() => handleColorQualityChange(opt.value)}
-                  title={needsHevc ? t("settings.colorQuality.requiresH265OrAv1Title", { description: colorDescription }) : colorDescription}
-                >
-                  <span>{opt.label}</span>
-                </button>
-              );
-            })}
+          <div className="settings-row-control">
+            <div className="settings-chip-row">
+              {colorQualityOptions.map((opt) => {
+                const needsHevc = colorQualityRequiresHevc(opt.value);
+                const colorDescription = opt.value === "8bit_420"
+                  ? t("settings.colorQuality.mostCompatible")
+                  : opt.value === "8bit_444"
+                    ? t("settings.colorQuality.sharperChroma")
+                    : opt.value === "10bit_420"
+                      ? t("settings.colorQuality.higherBitDepth")
+                      : t("settings.colorQuality.highestChromaAndBitDepth");
+                return (
+                  <button
+                    key={opt.value}
+                    className={`settings-chip ${settings.colorQuality === opt.value ? "active" : ""}`}
+                    onClick={() => handleColorQualityChange(opt.value)}
+                    title={needsHevc ? t("settings.colorQuality.requiresH265OrAv1Title", { description: colorDescription }) : colorDescription}
+                  >
+                    <span>{opt.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+            {colorQualityRequiresHevc(settings.colorQuality) && settings.codec === "H264" && (
+              <span className="settings-input-hint">{t("settings.video.requiresH265OrAv1")}</span>
+            )}
           </div>
-          {colorQualityRequiresHevc(settings.colorQuality) && settings.codec === "H264" && (
-            <span className="settings-input-hint">{t("settings.video.requiresH265OrAv1")}</span>
-          )}
         </div>
 
         {/* Bitrate slider */}
@@ -931,50 +933,54 @@ export function SettingsStreamSection({
           <div className="settings-rows">
             {showStreamVideo && (
               <>
-                <div className="settings-row settings-row--column">
+                <div className="settings-row">
                   <label className="settings-label settings-label--with-icon">
                     <Cpu size={15} className="settings-label-icon" />
                     {t("settings.video.decoder")}
                   </label>
-                  <div className="settings-chip-row">
-                    {accelerationOptions.map((option) => (
-                      <button
-                        key={`decoder-${option.value}`}
-                        className={`settings-chip ${settings.decoderPreference === option.value ? "active" : ""}`}
-                        onClick={() => handleChange("decoderPreference", option.value)}
-                      >
-                        {option.value === "auto"
-                          ? t("app.labels.auto")
-                          : option.value === "hardware"
-                            ? t("app.labels.hardware")
-                            : t("settings.video.softwareCpu")}
-                      </button>
-                    ))}
+                  <div className="settings-row-control">
+                    <div className="settings-chip-row">
+                      {accelerationOptions.map((option) => (
+                        <button
+                          key={`decoder-${option.value}`}
+                          className={`settings-chip ${settings.decoderPreference === option.value ? "active" : ""}`}
+                          onClick={() => handleChange("decoderPreference", option.value)}
+                        >
+                          {option.value === "auto"
+                            ? t("app.labels.auto")
+                            : option.value === "hardware"
+                              ? t("app.labels.hardware")
+                              : t("settings.video.softwareCpu")}
+                        </button>
+                      ))}
+                    </div>
+                    <span className="settings-subtle-hint">{t("settings.video.appliesAfterRestart")}</span>
                   </div>
-                  <span className="settings-subtle-hint">{t("settings.video.appliesAfterRestart")}</span>
                 </div>
 
-                <div className="settings-row settings-row--column">
+                <div className="settings-row">
                   <label className="settings-label settings-label--with-icon">
                     <Film size={15} className="settings-label-icon" />
                     {t("settings.video.encoder")}
                   </label>
-                  <div className="settings-chip-row">
-                    {accelerationOptions.map((option) => (
-                      <button
-                        key={`encoder-${option.value}`}
-                        className={`settings-chip ${settings.encoderPreference === option.value ? "active" : ""}`}
-                        onClick={() => handleChange("encoderPreference", option.value)}
-                      >
-                        {option.value === "auto"
-                          ? t("app.labels.auto")
-                          : option.value === "hardware"
-                            ? t("app.labels.hardware")
-                            : t("settings.video.softwareCpu")}
-                      </button>
-                    ))}
+                  <div className="settings-row-control">
+                    <div className="settings-chip-row">
+                      {accelerationOptions.map((option) => (
+                        <button
+                          key={`encoder-${option.value}`}
+                          className={`settings-chip ${settings.encoderPreference === option.value ? "active" : ""}`}
+                          onClick={() => handleChange("encoderPreference", option.value)}
+                        >
+                          {option.value === "auto"
+                            ? t("app.labels.auto")
+                            : option.value === "hardware"
+                              ? t("app.labels.hardware")
+                              : t("settings.video.softwareCpu")}
+                        </button>
+                      ))}
+                    </div>
+                    <span className="settings-subtle-hint">{t("settings.video.appliesAfterRestart")}</span>
                   </div>
-                  <span className="settings-subtle-hint">{t("settings.video.appliesAfterRestart")}</span>
                 </div>
               </>
             )}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -4309,7 +4309,8 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 11px;
+  padding: 0 11px;
+  min-height: 36px;
   background: color-mix(in srgb, var(--ink) 4%, transparent);
   border: 1px solid var(--panel-border);
   border-radius: 6px;
@@ -4318,8 +4319,12 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-search-icon {
+  display: block;
+  width: 13px;
+  height: 13px;
   color: var(--ink-muted);
   flex-shrink: 0;
+  align-self: center;
 }
 
 .settings-search-input {
@@ -4329,8 +4334,12 @@ button.game-card-store-chip.owned.active:hover {
   outline: none;
   color: var(--ink);
   font-size: 0.82rem;
+  line-height: 1.25;
   font-family: inherit;
   min-width: 0;
+  padding: 0;
+  margin: 0;
+  align-self: center;
 }
 
 .settings-search-input::placeholder {
@@ -4341,6 +4350,7 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   align-items: center;
   justify-content: center;
+  align-self: center;
   background: none;
   border: none;
   color: var(--ink-muted);
@@ -4381,12 +4391,14 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 9px 12px 9px 14px;
+  padding: 0 12px 0 14px;
+  min-height: 38px;
   border-radius: 6px;
   border: none;
   background: transparent;
   color: var(--ink-soft);
   font-size: 0.86rem;
+  line-height: 1.2;
   font-weight: 500;
   font-family: inherit;
   cursor: pointer;
@@ -4396,6 +4408,9 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-nav-item svg {
+  display: block;
+  width: 15px;
+  height: 15px;
   flex-shrink: 0;
   color: var(--ink-muted);
   transition: color var(--t-fast);
@@ -4420,11 +4435,12 @@ button.game-card-store-chip.owned.active:hover {
   content: "";
   position: absolute;
   left: 0;
-  top: 8px;
-  bottom: 8px;
+  top: 50%;
   width: 2px;
+  height: 16px;
   border-radius: 999px;
   background: var(--accent);
+  transform: translateY(-50%);
 }
 
 .settings-nav-item.active svg {
@@ -4605,11 +4621,13 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-row {
-  display: flex;
+  --settings-label-col: minmax(10.5rem, 32%);
+  display: grid;
+  grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
   align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  padding: 14px 0;
+  column-gap: 16px;
+  row-gap: 6px;
+  padding: 13px 0;
   border-bottom: 1px solid color-mix(in srgb, var(--ink) 4%, transparent);
 }
 
@@ -4617,24 +4635,101 @@ button.game-card-store-chip.owned.active:hover {
   border-bottom: none;
 }
 
+.settings-row > .settings-label {
+  grid-column: 1;
+  flex: none;
+  max-width: none;
+}
+
+.settings-row-control {
+  grid-column: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  min-width: 0;
+  width: 100%;
+}
+
+.settings-row > .settings-chip-row,
+.settings-row > .settings-dropdown,
+.settings-row > .select-dropdown,
+.settings-row > .settings-toggle,
+.settings-row > .settings-text-input,
+.settings-row > .settings-slider,
+.settings-row > .settings-mic-device-wrap,
+.settings-row > .settings-path-setting,
+.settings-row > .settings-shortcut-actions,
+.settings-row > .settings-shortcut-grid,
+.settings-row > .settings-updater-actions,
+.settings-row > .settings-community-proxy-row,
+.settings-row > .settings-export-logs-btn,
+.settings-row > .settings-delete-cache-btn,
+.settings-row > .settings-save-btn,
+.settings-row > .codec-test-btn,
+.settings-row > .settings-subtle-hint,
+.settings-row > .settings-input-hint,
+.settings-row > .settings-row-control {
+  grid-column: 2;
+  justify-self: start;
+  min-width: 0;
+}
+
+.settings-row > .settings-toggle {
+  justify-self: end;
+}
+
+.settings-row > .settings-dropdown,
+.settings-row > .select-dropdown {
+  width: min(280px, 100%);
+}
+
+.settings-row > .settings-mic-device-wrap,
+.settings-row > .settings-path-setting {
+  width: 100%;
+}
+
 .settings-row--column {
+  display: flex;
   flex-direction: column;
   align-items: stretch;
+  gap: 8px;
+}
+
+.settings-row--column > .settings-label,
+.settings-row--column > .settings-chip-row,
+.settings-row--column > .settings-dropdown,
+.settings-row--column > .select-dropdown,
+.settings-row--column > .settings-toggle,
+.settings-row--column > .settings-text-input,
+.settings-row--column > .settings-slider,
+.settings-row--column > .settings-subtle-hint,
+.settings-row--column > .settings-input-hint,
+.settings-row--column > .settings-row-control {
+  grid-column: auto;
+  justify-self: stretch;
+  width: 100%;
 }
 
 .settings-row--top-aligned {
   align-items: flex-start;
 }
 
+.settings-row:has(.settings-hint) {
+  align-items: start;
+}
+
 .settings-row-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 8px;
+  gap: 12px;
+  width: 100%;
+  margin-bottom: 0;
 }
 
 .settings-row-top--compact {
-  margin-bottom: 4px;
+  margin-bottom: 0;
 }
 
 .settings-shortcut-actions {
@@ -4669,6 +4764,7 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-label {
   font-size: 0.92rem;
+  line-height: 1.3;
   color: var(--ink-soft);
   font-weight: 500;
   flex: 1 1 auto;
@@ -4682,6 +4778,7 @@ button.game-card-store-chip.owned.active:hover {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
 .settings-label-icon {
@@ -5494,9 +5591,16 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-subtle-hint {
+  display: block;
   font-size: 0.8rem;
+  line-height: 1.35;
   color: var(--ink-muted);
   font-weight: 500;
+}
+
+.settings-row-control > .settings-subtle-hint,
+.settings-row-control > .settings-input-hint {
+  width: 100%;
 }
 
 .settings-install-steps {
@@ -5789,6 +5893,7 @@ button.game-card-store-chip.owned.active:hover {
 .settings-chip-row {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 4px;
 }
 
@@ -6001,8 +6106,9 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-dropdown--constrained {
-  flex: 0 1 320px;
-  width: min(320px, 100%);
+  flex: 0 1 280px;
+  width: min(280px, 100%);
+  max-width: 100%;
 }
 
 .settings-dropdown-selected {
@@ -6677,24 +6783,26 @@ button.game-card-store-chip.owned.active:hover {
   font-size: 0.9rem;
   line-height: 1.4;
   color: var(--ink-soft);
-  flex: 1 1 320px;
   min-width: 0;
-  flex-shrink: 1;
   white-space: normal;
 }
 
 .codec-test-row {
-  align-items: flex-start;
-  flex-wrap: wrap;
+  align-items: start;
 }
 
 .codec-test-row .codec-test-btn {
-  margin-left: auto;
+  margin-left: 0;
+  justify-self: end;
 }
 
 @media (max-width: 820px) {
+  .codec-test-row {
+    grid-template-columns: 1fr;
+  }
+
   .codec-test-row .codec-test-btn {
-    margin-left: 0;
+    justify-self: stretch;
     width: 100%;
     justify-content: center;
   }


### PR DESCRIPTION
## Summary
- Unify Settings Video rows onto a shared label/control grid and fix sidebar search/nav vertical centering
- Align Library toolbar, top-nav controls, and game-card storefront badges to reduce misalignment/overlap
- Fix GFN token refresh dropping `id_token` / stale client-token expiry, and correct library ownership mapping/merge so owned variants stay owned

## Test plan
- [ ] Open Settings > Stream and confirm Resolution/FPS/Codec/Decoder/Encoder/Color Depth share one control column
- [ ] Check Settings sidebar active item and search icon are vertically centered
- [ ] Open Library and verify nav/profile cluster alignment and non-overlapping storefront badges
- [ ] `npm --prefix opennow-stable run typecheck`
- [ ] `npm --prefix opennow-stable test -- --test-name-pattern gfn`

Made with [Cursor](https://cursor.com)