### PR TITLE
Android native - Analog Fix

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowScreens.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowScreens.kt
@@ -182,7 +182,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInteropFilter
-import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -9954,44 +9953,25 @@ private fun VirtualStick(
             .border(1.dp, Color.White.copy(alpha = opacity * 0.3f), CircleShape)
             .pointerInput(client) {
                 awaitPointerEventScope {
-                    var activePointerId: PointerId? = null
-                    try {
-                        while (true) {
-                            val event = awaitPointerEvent(PointerEventPass.Initial)
-                            val activeChange = activePointerId?.let { pointerId ->
-                                event.changes.firstOrNull { it.id == pointerId }
-                            }
-                            if (activeChange != null && !activeChange.pressed) {
+                    while (true) {
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        val change = event.changes.firstOrNull { it.pressed }
+                        val maxRadius = min(size.width, size.height) * 0.34f
+                        if (change == null) {
+                            if (knobOffset != Offset.Zero) {
                                 currentOnChange(0f, 0f)
                                 knobOffset = Offset.Zero
-                                activePointerId = null
-                                continue
                             }
-                            val change = activeChange ?: if (activePointerId == null) {
-                                event.changes.firstOrNull {
-                                    it.pressed &&
-                                        !it.previousPressed &&
-                                        it.position.x in 0f..size.width.toFloat() &&
-                                        it.position.y in 0f..size.height.toFloat()
-                                }?.also { activePointerId = it.id }
-                            } else {
-                                null
-                            }
-                            if (change == null) continue
-
-                            val maxRadius = min(size.width, size.height) * 0.34f
-                            val center = Offset(size.width / 2f, size.height / 2f)
-                            val clamped = clampStickOffset(change.position - center, maxRadius)
-                            currentOnChange(
-                                (clamped.x / maxRadius).coerceIn(-1f, 1f),
-                                (clamped.y / maxRadius).coerceIn(-1f, 1f),
-                            )
-                            knobOffset = clamped
-                            change.consume()
+                            continue
                         }
-                    } finally {
-                        currentOnChange(0f, 0f)
-                        knobOffset = Offset.Zero
+                        val center = Offset(size.width / 2f, size.height / 2f)
+                        val clamped = clampStickOffset(change.position - center, maxRadius)
+                        currentOnChange(
+                            (clamped.x / maxRadius).coerceIn(-1f, 1f),
+                            (clamped.y / maxRadius).coerceIn(-1f, 1f),
+                        )
+                        knobOffset = clamped
+                        change.consume()
                     }
                 }
             },

--- a/android/app/src/main/java/com/opencloudgaming/opennow/Streaming.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/Streaming.kt
@@ -1105,9 +1105,6 @@ object NativeStreamInputRouter {
                     nativeUiTouchPointerIds += event.getPointerId(index)
                 }
             }
-            MotionEvent.ACTION_UP,
-            MotionEvent.ACTION_CANCEL,
-            -> nativeUiTouchPointerIds.clear()
         }
         uiTouchPassthroughActive = nativeUiTouchPointerIds.isNotEmpty()
     }


### PR DESCRIPTION
This pull request refactors the pointer event handling logic in the `VirtualStick` composable and streamlines touch input management in the streaming input router. The changes simplify how active touch pointers are tracked and reset, resulting in cleaner and more maintainable code.

**VirtualStick pointer handling simplification:**

* Removed manual tracking of `PointerId` and associated logic, now simply processing the first pressed pointer and resetting the stick when no pointer is pressed.
* Eliminated the `finally` block that redundantly reset the stick state, as this is now handled directly in the event loop.
* Removed unused import of `PointerId` from the file.

**Streaming input router cleanup:**

* Removed redundant clearing of `nativeUiTouchPointerIds` on `ACTION_UP` and `ACTION_CANCEL` events, simplifying pointer tracking logic.