### PR TITLE
fix(ui): repair settings interactions and accessibility

### DIFF
--- a/opennow-stable/.claude/skills/verify/SKILL.md
+++ b/opennow-stable/.claude/skills/verify/SKILL.md
@@ -1,0 +1,50 @@
+---
+description: Build, launch, drive, and screenshot the OpenNOW Electron settings UI on Windows.
+---
+
+# Verify OpenNOW desktop UI
+
+## Build and launch
+
+1. Build the current tree from the repository root:
+   ```powershell
+   npm --prefix opennow-stable run build
+   ```
+2. Launch Electron with Chrome DevTools Protocol enabled. Run this as a background command so Electron remains available:
+   ```powershell
+   $env:OPENNOW_REMOTE_DEBUG = '1'; & "opennow-stable\node_modules\electron\dist\electron.exe" "opennow-stable"
+   ```
+3. Wait for `http://127.0.0.1:9222/json/list` to expose a page titled `OpenNOW`. The renderer URL should end in `opennow-stable/dist/index.html`.
+
+## Drive the renderer
+
+Use CDP against the target's `webSocketDebuggerUrl`. Node in this environment provides the global `WebSocket` API. The working driver supports:
+
+- `Runtime.evaluate` with `awaitPromise: true`, `returnByValue: true`, and `userGesture: true` for DOM inspection and clicks.
+- `Input.dispatchKeyEvent` (`keyDown`, then `keyUp`) for real keyboard behavior. This is required for native range-input arrow-key changes; synthetic DOM keyboard events do not invoke browser default actions.
+- `Input.insertText` for typing into the focused control.
+- `Page.captureScreenshot` with `{ format: "png", fromSurface: true, captureBeyondViewport: false }`.
+
+The target can be found with:
+```js
+const targets = await fetch("http://127.0.0.1:9222/json/list").then((response) => response.json());
+const target = targets.find((item) => item.type === "page" && item.title === "OpenNOW") ?? targets[0];
+```
+
+Send CDP requests as incrementing `{ id, method, params }` JSON messages and resolve responses by matching `id`.
+
+## Settings flows worth exercising
+
+- Click the navbar `Settings` button; the modal root is `.settings-modal`.
+- Section navigation buttons are `.settings-nav-item`.
+- Shared dropdowns use `[role="combobox"]`, `aria-controls`, and `aria-activedescendant`.
+- Region controls use `#settings-stream-region-trigger`, `.region-dropdown`, and `.region-dropdown-search-input`.
+- Numeric mouse controls are `#settings-input-mouse-sensitivity-number` and `#settings-input-mouse-acceleration-number`.
+- Resize through `window.resizeTo(1024, 680)` and `window.resizeTo(1400, 900)`; verify `outerWidth`/`outerHeight` afterward.
+- Switch Interface theme through `#appTheme`, capture light and dark screenshots, then restore the original theme.
+
+For popup Escape behavior, use real CDP key events: the first Escape closes the focused popup while Settings remains open; after the close transition, the next Escape closes Settings. Restore any changed theme, region, toggle, slider, or numeric setting before finishing.
+
+## Evidence
+
+Capture screenshots to a stable local path and read them visually. Useful frames include an open grouped resolution dropdown, filtered region results, focused toggle/slider/chip/region trigger, Account action sizing, About action sizing, and Native Streamer diagnostics at both 1400×900 and 1024×680.

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsAboutSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsAboutSection.tsx
@@ -58,9 +58,14 @@ export function SettingsAboutSection({ settings, showAll, handleChange, onOpenWh
     ? `${formatBytes(updaterState.progress.bytesPerSecond)}/s`
     : null;
   const updaterBadgeLabel = useMemo(() => getUpdaterBadgeLabel(updaterState), [updaterState]);
+  const updaterProgressAriaText = [
+    t("settings.about.downloadProgress", { percent: updaterProgressPercent }),
+    updaterProgressLabel,
+    updaterDownloadRateLabel,
+  ].filter(Boolean).join(" · ");
 
   return (
-    <section className="settings-section">
+    <section className="settings-section settings-about-section">
       {showAll && <div className="settings-section-context">{t("settings.sections.about")}</div>}
       <div className="settings-section-header">
         <h2>{t("settings.sections.about")}</h2>
@@ -91,17 +96,19 @@ export function SettingsAboutSection({ settings, showAll, handleChange, onOpenWh
               </span>
             ) : null}
           </label>
-          <SelectDropdown
-            id="updateChannel"
-            value={settings.updateChannel}
-            options={[
-              { value: "stable", label: t("settings.about.updateChannelStable") },
-              { value: "nightly", label: t("settings.about.updateChannelNightly") },
-            ]}
-            onChange={(value) => handleChange("updateChannel", value as Settings["updateChannel"])}
-            disabled={updaterState.status === "checking" || updaterState.status === "downloading"}
-            ariaLabel={t("settings.about.updateChannel")}
-          />
+          <div className="settings-row-control">
+            <SelectDropdown
+              id="updateChannel"
+              value={settings.updateChannel}
+              options={[
+                { value: "stable", label: t("settings.about.updateChannelStable") },
+                { value: "nightly", label: t("settings.about.updateChannelNightly") },
+              ]}
+              onChange={(value) => handleChange("updateChannel", value as Settings["updateChannel"])}
+              disabled={updaterState.status === "checking" || updaterState.status === "downloading"}
+              ariaLabel={t("settings.about.updateChannel")}
+            />
+          </div>
         </div>
 
         <div className="settings-row">
@@ -130,8 +137,8 @@ export function SettingsAboutSection({ settings, showAll, handleChange, onOpenWh
               <span className="settings-hint">{t("settings.about.downloadedVersion", { version: updaterState.downloadedVersion })}</span>
             ) : null}
             {updaterState.status === "downloading" && updaterState.progress ? (
-              <span className="settings-hint">
-                {t("settings.about.downloadProgress", { percent: updaterProgressPercent })}{updaterProgressLabel ? ` · ${updaterProgressLabel}` : ""}{updaterDownloadRateLabel ? ` · ${updaterDownloadRateLabel}` : ""}
+              <span className="settings-hint" role="status" aria-live="polite" aria-atomic="true">
+                {updaterProgressAriaText}
               </span>
             ) : null}
           </label>
@@ -182,29 +189,40 @@ export function SettingsAboutSection({ settings, showAll, handleChange, onOpenWh
           </div>
         </div>
 
-        <div className="settings-row">
-          <label className="settings-label settings-label--wrap">
-            {t("settings.about.automaticallyCheckForUpdates")}
-            <span className="settings-hint">
-              {t("settings.about.automaticallyCheckForUpdatesOnHint")}
-            </span>
-            <span className="settings-hint">
-              {t("settings.about.automaticallyCheckForUpdatesOffHint")}
-            </span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              type="checkbox"
-              checked={settings.autoCheckForUpdates}
-              onChange={(e) => handleChange("autoCheckForUpdates", e.target.checked)}
-            />
-            <span className="settings-toggle-track" />
-          </label>
+        <div className="settings-row settings-row--column">
+          <div className="settings-row-top settings-row-top--compact">
+            <label className="settings-label settings-label--wrap" htmlFor="settings-about-auto-check-updates">
+              <span className="settings-label-title">{t("settings.about.automaticallyCheckForUpdates")}</span>
+            </label>
+            <label className="settings-toggle">
+              <input
+                id="settings-about-auto-check-updates"
+                type="checkbox"
+                checked={settings.autoCheckForUpdates}
+                onChange={(e) => handleChange("autoCheckForUpdates", e.target.checked)}
+              />
+              <span className="settings-toggle-track" />
+            </label>
+          </div>
+          <span className="settings-subtle-hint">
+            {t("settings.about.automaticallyCheckForUpdatesOnHint")}
+          </span>
+          <span className="settings-subtle-hint">
+            {t("settings.about.automaticallyCheckForUpdatesOffHint")}
+          </span>
         </div>
 
         {updaterState.status === "downloading" && updaterState.progress ? (
           <div className="settings-row settings-row--column">
-            <div className="settings-updater-progress">
+            <div
+              className="settings-updater-progress"
+              role="progressbar"
+              aria-label={t("settings.about.downloadUpdate")}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={updaterProgressPercent}
+              aria-valuetext={updaterProgressAriaText}
+            >
               <div className="settings-updater-progress-bar" style={{ width: `${updaterProgressPercent}%` }} />
             </div>
           </div>
@@ -262,9 +280,9 @@ export function SettingsAboutSection({ settings, showAll, handleChange, onOpenWh
               }
             }}
           >
-    	                  <Trash2 size={16} />
-    	                  {t("settings.about.deleteCache")}
-    	                </button>
+            <Trash2 size={16} />
+            {t("settings.about.deleteCache")}
+          </button>
         </div>
 
       </div>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsAudioSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsAudioSection.tsx
@@ -1,7 +1,8 @@
-import { Check, Mic } from "lucide-react";
+import { Mic } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
 import type { MicrophoneMode, Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
+import { SelectDropdown } from "../../ui/SelectDropdown";
 import { getMicrophonePermissionError, microphoneModeOptions } from "../settingsFormatters";
 
 export interface SettingsAudioSectionProps {
@@ -14,11 +15,9 @@ export function SettingsAudioSection({ settings, showAll, handleChange }: Settin
   const { locale, t } = useTranslation();
   const [microphoneDevices, setMicrophoneDevices] = useState<MediaDeviceInfo[]>([]);
   const [microphonePermissionError, setMicrophonePermissionError] = useState<string | null>(null);
-  const [microphoneModeDropdownOpen, setMicrophoneModeDropdownOpen] = useState(false);
-  const [microphoneDeviceDropdownOpen, setMicrophoneDeviceDropdownOpen] = useState(false);
-  const microphoneModeDropdownRef = useRef<HTMLDivElement | null>(null);
-  const microphoneDeviceDropdownRef = useRef<HTMLDivElement | null>(null);
   const latestMicrophoneDeviceIdRef = useRef(settings.microphoneDeviceId);
+  const microphoneModeId = "settings-audio-microphone-mode";
+  const microphoneDeviceId = "settings-audio-microphone-device";
 
   useEffect(() => {
     latestMicrophoneDeviceIdRef.current = settings.microphoneDeviceId;
@@ -120,35 +119,24 @@ export function SettingsAudioSection({ settings, showAll, handleChange }: Settin
     }
   }, [locale, t]);
 
-  const selectedMicrophoneModeName = useMemo(() => {
-    return getMicrophoneModeLabel(settings.microphoneMode);
-  }, [settings.microphoneMode, getMicrophoneModeLabel]);
+  const localizedMicrophoneModeOptions = useMemo(
+    () => microphoneModeOptions.map((option) => ({
+      value: option.value,
+      label: getMicrophoneModeLabel(option.value),
+    })),
+    [getMicrophoneModeLabel],
+  );
 
-  const selectedMicrophoneDeviceName = useMemo(() => {
-    if (!settings.microphoneDeviceId) return t("app.labels.defaultDevice");
-    const found = microphoneDevices.find((device) => device.deviceId === settings.microphoneDeviceId);
-    return found?.label || t("settings.audio.selectedDevice");
-  }, [settings.microphoneDeviceId, microphoneDevices, locale, t]);
-
-  useEffect(() => {
-    if (settings.microphoneMode === "disabled") {
-      setMicrophoneDeviceDropdownOpen(false);
-    }
-  }, [settings.microphoneMode]);
-
-  useEffect(() => {
-    const handlePointerDown = (event: MouseEvent): void => {
-      const target = event.target as Node;
-      if (microphoneModeDropdownRef.current && !microphoneModeDropdownRef.current.contains(target)) {
-        setMicrophoneModeDropdownOpen(false);
-      }
-      if (microphoneDeviceDropdownRef.current && !microphoneDeviceDropdownRef.current.contains(target)) {
-        setMicrophoneDeviceDropdownOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, []);
+  const microphoneDeviceOptions = useMemo(
+    () => [
+      { value: "", label: t("app.labels.defaultDevice") },
+      ...microphoneDevices.map((device, index) => ({
+        value: device.deviceId,
+        label: device.label || t("settings.audio.microphoneIndexed", { index: index + 1 }),
+      })),
+    ],
+    [locale, microphoneDevices, t],
+  );
 
   return (
     <section className="settings-section">
@@ -156,113 +144,50 @@ export function SettingsAudioSection({ settings, showAll, handleChange }: Settin
       <div className="settings-section-header">
         <h2>{t("settings.audio.title")}</h2>
       </div>
-        <div className="settings-rows">
+      <div className="settings-rows">
+        <div className="settings-row">
+          <label className="settings-label" htmlFor={microphoneModeId}>
+            {t("settings.audio.microphone")}
+            <span className="settings-hint">{t("settings.audio.microphoneHint")}</span>
+          </label>
+          <div className="settings-row-control">
+            <SelectDropdown
+              id={microphoneModeId}
+              value={settings.microphoneMode}
+              options={localizedMicrophoneModeOptions}
+              onChange={(value) => handleChange("microphoneMode", value as MicrophoneMode)}
+            />
+          </div>
+        </div>
+
+        {settings.microphoneMode !== "disabled" && (
           <div className="settings-row">
-            <label className="settings-label">
-              {t("settings.audio.microphone")}
-              <span className="settings-hint">{t("settings.audio.microphoneHint")}</span>
+            <label className="settings-label" htmlFor={microphoneDeviceId}>
+              <span className="settings-label--with-icon">
+                <Mic size={14} aria-hidden="true" />
+                {t("settings.audio.microphoneDevice")}
+              </span>
+              <span className="settings-hint">{t("settings.audio.microphoneDeviceHint")}</span>
             </label>
-            <div className="settings-dropdown" ref={microphoneModeDropdownRef}>
-              <button
-                type="button"
-                className={`settings-dropdown-selected ${microphoneModeDropdownOpen ? "open" : ""}`}
-                onClick={() => {
-                  setMicrophoneModeDropdownOpen((open) => !open);
-                  setMicrophoneDeviceDropdownOpen(false);
-                }}
-              >
-                <span className="settings-dropdown-selected-name">{selectedMicrophoneModeName}</span>
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className={`settings-dropdown-chevron ${microphoneModeDropdownOpen ? "flipped" : ""}`}>
-                  <path d="M4.47 5.97a.75.75 0 0 1 1.06 0L8 8.44l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
-                </svg>
-              </button>
-              {microphoneModeDropdownOpen && (
-                <div className="settings-dropdown-menu">
-                  {microphoneModeOptions.map((option) => (
-                    <button
-                      key={option.value}
-                      type="button"
-                      className={`settings-dropdown-item ${settings.microphoneMode === option.value ? "active" : ""}`}
-                      onClick={() => {
-                        handleChange("microphoneMode", option.value);
-                        setMicrophoneModeDropdownOpen(false);
-                      }}
-                    >
-                      <span>{getMicrophoneModeLabel(option.value)}</span>
-                      {settings.microphoneMode === option.value && <Check size={14} className="settings-dropdown-check" />}
-                    </button>
-                  ))}
-                </div>
+            <div className="settings-mic-device-wrap">
+              <SelectDropdown
+                id={microphoneDeviceId}
+                value={settings.microphoneDeviceId}
+                options={microphoneDeviceOptions}
+                onChange={(value) => handleChange("microphoneDeviceId", value)}
+                disabled={microphoneDevices.length === 0}
+                menuClassName="select-dropdown__menu--tall"
+              />
+              {microphonePermissionError && (
+                <span className="settings-input-hint">{microphonePermissionError}</span>
+              )}
+              {microphoneDevices.length === 0 && !microphonePermissionError && (
+                <span className="settings-subtle-hint">{t("settings.audio.noMicrophoneDevicesFound")}</span>
               )}
             </div>
           </div>
-
-          {settings.microphoneMode !== "disabled" && (
-            <div className="settings-row">
-              <label className="settings-label">
-                <div className="flex items-center gap-2">
-                  <Mic size={14} />
-                  {t("settings.audio.microphoneDevice")}
-                </div>
-                <span className="settings-hint">{t("settings.audio.microphoneDeviceHint")}</span>
-              </label>
-              <div className="settings-mic-device-wrap">
-                <div className="settings-dropdown" ref={microphoneDeviceDropdownRef}>
-                  <button
-                    type="button"
-                    className={`settings-dropdown-selected ${microphoneDeviceDropdownOpen ? "open" : ""}`}
-                    onClick={() => {
-                      if (microphoneDevices.length === 0) return;
-                      setMicrophoneDeviceDropdownOpen((open) => !open);
-                      setMicrophoneModeDropdownOpen(false);
-                    }}
-                    disabled={microphoneDevices.length === 0}
-                  >
-                    <span className="settings-dropdown-selected-name">{selectedMicrophoneDeviceName}</span>
-                    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className={`settings-dropdown-chevron ${microphoneDeviceDropdownOpen ? "flipped" : ""}`}>
-                      <path d="M4.47 5.97a.75.75 0 0 1 1.06 0L8 8.44l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
-                    </svg>
-                  </button>
-                  {microphoneDeviceDropdownOpen && (
-                    <div className="settings-dropdown-menu settings-dropdown-menu--tall">
-                      <button
-                        type="button"
-                        className={`settings-dropdown-item ${settings.microphoneDeviceId === "" ? "active" : ""}`}
-                        onClick={() => {
-                          handleChange("microphoneDeviceId", "");
-                          setMicrophoneDeviceDropdownOpen(false);
-                        }}
-                      >
-                        <span>{t("app.labels.defaultDevice")}</span>
-                        {settings.microphoneDeviceId === "" && <Check size={14} className="settings-dropdown-check" />}
-                      </button>
-                      {microphoneDevices.map((device, index) => (
-                        <button
-                          key={device.deviceId}
-                          type="button"
-                          className={`settings-dropdown-item ${settings.microphoneDeviceId === device.deviceId ? "active" : ""}`}
-                          onClick={() => {
-                            handleChange("microphoneDeviceId", device.deviceId);
-                            setMicrophoneDeviceDropdownOpen(false);
-                          }}
-                        >
-                          <span>{device.label || t("settings.audio.microphoneIndexed", { index: index + 1 })}</span>
-                          {settings.microphoneDeviceId === device.deviceId && <Check size={14} className="settings-dropdown-check" />}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                {microphonePermissionError && (
-                  <span className="text-red-400 text-xs mt-1">{microphonePermissionError}</span>
-                )}
-                {microphoneDevices.length === 0 && !microphonePermissionError && (
-                  <span className="text-yellow-400 text-xs mt-1">{t("settings.audio.noMicrophoneDevicesFound")}</span>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
+        )}
+      </div>
+    </section>
   );
 }

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsGameSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsGameSection.tsx
@@ -1,7 +1,7 @@
-import { Check } from "lucide-react";
-import { useEffect, useMemo, useRef, useState, type JSX } from "react";
-import type { Settings } from "@shared/gfn";
+import type { JSX } from "react";
+import type { GameLanguage, Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
+import { SelectDropdown } from "../../ui/SelectDropdown";
 import { gameLanguageOptions } from "../settingsFormatters";
 
 export interface SettingsGameSectionProps {
@@ -12,23 +12,8 @@ export interface SettingsGameSectionProps {
 
 export function SettingsGameSection({ settings, showAll, handleChange }: SettingsGameSectionProps): JSX.Element {
   const { t } = useTranslation();
-  const [gameLanguageDropdownOpen, setGameLanguageDropdownOpen] = useState(false);
-  const gameLanguageDropdownRef = useRef<HTMLDivElement | null>(null);
-
-  const selectedGameLanguageName = useMemo(() => {
-    return gameLanguageOptions.find((option) => option.value === settings.gameLanguage)?.label ?? "English (US)";
-  }, [settings.gameLanguage]);
-
-  useEffect(() => {
-    const handlePointerDown = (event: MouseEvent): void => {
-      const target = event.target as Node;
-      if (gameLanguageDropdownRef.current && !gameLanguageDropdownRef.current.contains(target)) {
-        setGameLanguageDropdownOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, []);
+  const gameLanguageId = "settings-game-language";
+  const persistSettingsId = "settings-game-persist-in-game-settings";
 
   return (
     <section className="settings-section">
@@ -38,50 +23,30 @@ export function SettingsGameSection({ settings, showAll, handleChange }: Setting
       </div>
       <div className="settings-rows">
         <div className="settings-row">
-          <label className="settings-label">
+          <label className="settings-label" htmlFor={gameLanguageId}>
             {t("settings.game.language")}
             <span className="settings-hint">{t("settings.game.inGameLanguageHint")}</span>
           </label>
-          <div className="settings-dropdown" ref={gameLanguageDropdownRef}>
-            <button
-              type="button"
-              className={`settings-dropdown-selected ${gameLanguageDropdownOpen ? "open" : ""}`}
-              onClick={() => setGameLanguageDropdownOpen((open) => !open)}
-            >
-              <span className="settings-dropdown-selected-name">{selectedGameLanguageName}</span>
-              <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className={`settings-dropdown-chevron ${gameLanguageDropdownOpen ? "flipped" : ""}`}>
-                <path d="M4.47 5.97a.75.75 0 0 1 1.06 0L8 8.44l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
-              </svg>
-            </button>
-            {gameLanguageDropdownOpen && (
-              <div className="settings-dropdown-menu settings-dropdown-menu--tall">
-                {gameLanguageOptions.map((option) => (
-                  <button
-                    key={option.value}
-                    type="button"
-                    className={`settings-dropdown-item ${settings.gameLanguage === option.value ? "active" : ""}`}
-                    onClick={() => {
-                      handleChange("gameLanguage", option.value);
-                      setGameLanguageDropdownOpen(false);
-                    }}
-                  >
-                    <span>{option.label}</span>
-                    {settings.gameLanguage === option.value && <Check size={14} className="settings-dropdown-check" />}
-                  </button>
-                ))}
-              </div>
-            )}
+          <div className="settings-row-control">
+            <SelectDropdown
+              id={gameLanguageId}
+              value={settings.gameLanguage}
+              options={gameLanguageOptions}
+              onChange={(value) => handleChange("gameLanguage", value as GameLanguage)}
+              menuClassName="select-dropdown__menu--tall"
+            />
           </div>
         </div>
         <div className="settings-row settings-row--column">
           <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap">
+            <label className="settings-label settings-label--wrap" htmlFor={persistSettingsId}>
               <span className="settings-label-title">
                 {t("settings.game.persistInGameSettings")}
               </span>
             </label>
             <label className="settings-toggle">
               <input
+                id={persistSettingsId}
                 type="checkbox"
                 checked={settings.enablePersistingInGameSettings}
                 onChange={(e) => handleChange("enablePersistingInGameSettings", e.target.checked)}

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsInputSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsInputSection.tsx
@@ -1,9 +1,9 @@
-import { Check } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
-import type { Settings } from "@shared/gfn";
+import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
+import type { KeyboardLayout, Settings } from "@shared/gfn";
 import { keyboardLayoutOptions } from "@shared/gfn";
 import { formatShortcutForDisplay, normalizeShortcut, shortcutFromKeyboardEvent } from "../../../shortcuts";
 import { useTranslation } from "../../../i18n";
+import { SelectDropdown } from "../../ui/SelectDropdown";
 import {
   getShortcutConflictMessage,
   isMac,
@@ -17,6 +17,14 @@ export interface SettingsInputSectionProps {
   settings: Settings;
   showAll: boolean;
   handleChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+}
+
+function formatMouseSensitivityDraft(value: number): string {
+  return String(Number(value.toFixed(2)));
+}
+
+function formatMouseAccelerationDraft(value: number): string {
+  return String(Math.round(value));
 }
 
 export function SettingsInputSection({ settings, showAll, handleChange }: SettingsInputSectionProps): JSX.Element {
@@ -37,8 +45,8 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
   const [toggleMicrophoneError, setToggleMicrophoneError] = useState<string | null>(null);
   const [screenshotError, setScreenshotError] = useState<string | null>(null);
   const [recordingError, setRecordingError] = useState<string | null>(null);
-  const [keyboardLayoutDropdownOpen, setKeyboardLayoutDropdownOpen] = useState(false);
-  const keyboardLayoutDropdownRef = useRef<HTMLDivElement | null>(null);
+  const [mouseSensitivityDraft, setMouseSensitivityDraft] = useState(() => formatMouseSensitivityDraft(settings.mouseSensitivity));
+  const [mouseAccelerationDraft, setMouseAccelerationDraft] = useState(() => formatMouseAccelerationDraft(settings.mouseAcceleration));
 
   useEffect(() => { setToggleStatsInput(settings.shortcutToggleStats); }, [settings.shortcutToggleStats]);
   useEffect(() => { setTogglePointerLockInput(settings.shortcutTogglePointerLock); }, [settings.shortcutTogglePointerLock]);
@@ -48,21 +56,38 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
   useEffect(() => { setToggleMicrophoneInput(settings.shortcutToggleMicrophone); }, [settings.shortcutToggleMicrophone]);
   useEffect(() => { setScreenshotInput(settings.shortcutScreenshot); }, [settings.shortcutScreenshot]);
   useEffect(() => { setRecordingInput(settings.shortcutToggleRecording); }, [settings.shortcutToggleRecording]);
+  useEffect(() => { setMouseSensitivityDraft(formatMouseSensitivityDraft(settings.mouseSensitivity)); }, [settings.mouseSensitivity]);
+  useEffect(() => { setMouseAccelerationDraft(formatMouseAccelerationDraft(settings.mouseAcceleration)); }, [settings.mouseAcceleration]);
 
-  const selectedKeyboardLayoutName = useMemo(() => {
-    return keyboardLayoutOptions.find((option) => option.value === settings.keyboardLayout)?.label ?? "English (US)";
-  }, [settings.keyboardLayout]);
+  const commitMouseSensitivityDraft = (): void => {
+    const trimmed = mouseSensitivityDraft.trim();
+    const parsed = Number(trimmed);
+    if (!trimmed || !Number.isFinite(parsed)) {
+      setMouseSensitivityDraft(formatMouseSensitivityDraft(settings.mouseSensitivity));
+      return;
+    }
 
-  useEffect(() => {
-    const handlePointerDown = (event: MouseEvent): void => {
-      const target = event.target as Node;
-      if (keyboardLayoutDropdownRef.current && !keyboardLayoutDropdownRef.current.contains(target)) {
-        setKeyboardLayoutDropdownOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, []);
+    const normalized = Math.round(Math.max(0.1, Math.min(4, parsed)) * 100) / 100;
+    if (normalized !== settings.mouseSensitivity) {
+      handleChange("mouseSensitivity", normalized);
+    }
+    setMouseSensitivityDraft(formatMouseSensitivityDraft(normalized));
+  };
+
+  const commitMouseAccelerationDraft = (): void => {
+    const trimmed = mouseAccelerationDraft.trim();
+    const parsed = Number(trimmed);
+    if (!trimmed || !Number.isFinite(parsed)) {
+      setMouseAccelerationDraft(formatMouseAccelerationDraft(settings.mouseAcceleration));
+      return;
+    }
+
+    const normalized = Math.max(1, Math.min(150, Math.round(parsed)));
+    if (normalized !== settings.mouseAcceleration) {
+      handleChange("mouseAcceleration", normalized);
+    }
+    setMouseAccelerationDraft(formatMouseAccelerationDraft(normalized));
+  };
 
   const handleShortcutBlur = (key: ShortcutSettingKey, rawValue: string): void => {
     const trimmed = rawValue.trim();
@@ -282,21 +307,24 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
         <h2>{t("settings.input.title")}</h2>
       </div>
       <div className="settings-rows">
-        <div className="settings-row">
-          <label className="settings-label">{t("settings.input.clipboardPaste")}</label>
-          <label className="settings-toggle">
-            <input
-              type="checkbox"
-              checked={settings.clipboardPaste}
-              onChange={(e) => handleChange("clipboardPaste", e.target.checked)}
-            />
-            <span className="settings-toggle-track" />
-          </label>
+        <div className="settings-row settings-row--column">
+          <div className="settings-row-top settings-row-top--compact">
+            <label className="settings-label" htmlFor="settings-input-clipboard-paste">{t("settings.input.clipboardPaste")}</label>
+            <label className="settings-toggle">
+              <input
+                id="settings-input-clipboard-paste"
+                type="checkbox"
+                checked={settings.clipboardPaste}
+                onChange={(e) => handleChange("clipboardPaste", e.target.checked)}
+              />
+              <span className="settings-toggle-track" />
+            </label>
+          </div>
         </div>
 
         <div className="settings-row settings-row--column">
           <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap">
+            <label className="settings-label settings-label--wrap" htmlFor="settings-input-gyroscope-controls">
               <span className="settings-label-title">
                 {t("settings.input.gyroscopeControls")}
                 <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span>
@@ -304,6 +332,7 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
             </label>
             <label className="settings-toggle">
               <input
+                id="settings-input-gyroscope-controls"
                 type="checkbox"
                 checked={settings.enableGyroscopeControls}
                 onChange={(e) => handleChange("enableGyroscopeControls", e.target.checked)}
@@ -317,7 +346,7 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
         {isMac && (
           <div className="settings-row settings-row--column">
             <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-input-steam-controller-compatibility">
                 <span className="settings-label-title">
                   {t("settings.input.steamControllerCompatibilityMode")}
                   <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span>
@@ -325,6 +354,7 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-input-steam-controller-compatibility"
                   type="checkbox"
                   checked={settings.steamControllerCompatibilityMode}
                   onChange={(e) => handleChange("steamControllerCompatibilityMode", e.target.checked)}
@@ -338,7 +368,7 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
 
         <div className="settings-row settings-row--column">
           <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap">
+            <label className="settings-label settings-label--wrap" htmlFor="settings-input-native-cursor-overlay">
               <span className="settings-label-title">
                 {t("settings.input.nativeCursorOverlay")}
                 <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span>
@@ -346,6 +376,7 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
             </label>
             <label className="settings-toggle">
               <input
+                id="settings-input-native-cursor-overlay"
                 type="checkbox"
                 checked={settings.nativeCursorOverlay}
                 onChange={(e) => handleChange("nativeCursorOverlay", e.target.checked)}
@@ -356,70 +387,60 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
           <span className="settings-subtle-hint">{t("settings.input.nativeCursorOverlayHint")}</span>
         </div>
 
-        <div className="settings-row settings-row--top-aligned">
-          <label className="settings-label settings-label--wrap">
+        <div className="settings-row">
+          <label className="settings-label settings-label--wrap" htmlFor="settings-input-keyboard-layout">
             {t("settings.game.keyboardLayout")}
             <span className="settings-hint">{t("settings.input.keyboardLayoutHint")}</span>
           </label>
-          <div className="settings-dropdown settings-dropdown--constrained" ref={keyboardLayoutDropdownRef}>
-            <button
-              type="button"
-              className={`settings-dropdown-selected ${keyboardLayoutDropdownOpen ? "open" : ""}`}
-              onClick={() => setKeyboardLayoutDropdownOpen((open) => !open)}
-            >
-              <span className="settings-dropdown-selected-name">{selectedKeyboardLayoutName}</span>
-              <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className={`settings-dropdown-chevron ${keyboardLayoutDropdownOpen ? "flipped" : ""}`}>
-                <path d="M4.47 5.97a.75.75 0 0 1 1.06 0L8 8.44l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
-              </svg>
-            </button>
-            {keyboardLayoutDropdownOpen && (
-              <div className="settings-dropdown-menu settings-dropdown-menu--tall">
-                {keyboardLayoutOptions.map((option) => (
-                  <button
-                    key={option.value}
-                    type="button"
-                    className={`settings-dropdown-item ${settings.keyboardLayout === option.value ? "active" : ""}`}
-                    onClick={() => {
-                      handleChange("keyboardLayout", option.value);
-                      setKeyboardLayoutDropdownOpen(false);
-                    }}
-                  >
-                    <span>{option.label}</span>
-                    {settings.keyboardLayout === option.value && <Check size={14} className="settings-dropdown-check" />}
-                  </button>
-                ))}
-              </div>
-            )}
+          <div className="settings-row-control">
+            <SelectDropdown
+              id="settings-input-keyboard-layout"
+              value={settings.keyboardLayout}
+              options={keyboardLayoutOptions}
+              onChange={(value) => handleChange("keyboardLayout", value as KeyboardLayout)}
+              menuClassName="select-dropdown__menu--tall"
+            />
           </div>
         </div>
 
         {/* Mouse Sensitivity */}
         <div className="settings-row settings-row--column">
           <div className="settings-row-top">
-            <label className="settings-label">{t("settings.input.mouseSensitivity")}</label>
+            <label id="settings-input-mouse-sensitivity-label" className="settings-label" htmlFor="settings-input-mouse-sensitivity-slider">{t("settings.input.mouseSensitivity")}</label>
             <span className="settings-value-badge">{settings.mouseSensitivity.toFixed(2)}x</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <div className="settings-slider-control">
             <input
+              id="settings-input-mouse-sensitivity-slider"
               type="range"
               className="settings-slider"
               min={0.1}
               max={4}
               step={0.01}
               value={settings.mouseSensitivity}
-              onChange={(e) => handleChange("mouseSensitivity", parseFloat(e.target.value))}
+              onChange={(e) => {
+                const value = parseFloat(e.target.value);
+                setMouseSensitivityDraft(formatMouseSensitivityDraft(value));
+                handleChange("mouseSensitivity", value);
+              }}
             />
             <input
+              id="settings-input-mouse-sensitivity-number"
               type="number"
-              className="settings-number-input"
-              style={{ width: 80 }}
+              className="settings-text-input settings-number-input"
+              aria-labelledby="settings-input-mouse-sensitivity-label"
               min={0.1}
               max={4}
               step={0.01}
-              value={Number(settings.mouseSensitivity.toFixed(2))}
-              onChange={(e) => {
-                const v = parseFloat(e.target.value || "0");
-                if (Number.isFinite(v)) handleChange("mouseSensitivity", Math.max(0.1, Math.min(4, v)));
+              value={mouseSensitivityDraft}
+              onChange={(e) => setMouseSensitivityDraft(e.target.value)}
+              onBlur={commitMouseSensitivityDraft}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.currentTarget.blur();
+                } else if (e.key === "Escape") {
+                  commitMouseSensitivityDraft();
+                }
               }}
             />
           </div>
@@ -428,31 +449,40 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
 
         <div className="settings-row settings-row--column">
           <div className="settings-row-top">
-            <label className="settings-label">{t("settings.input.mouseAccelerator")}</label>
+            <label id="settings-input-mouse-acceleration-label" className="settings-label" htmlFor="settings-input-mouse-acceleration-slider">{t("settings.input.mouseAccelerator")}</label>
             <span className="settings-value-badge">{Math.round(settings.mouseAcceleration)}%</span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <div className="settings-slider-control">
             <input
+              id="settings-input-mouse-acceleration-slider"
               type="range"
               className="settings-slider"
               min={1}
               max={150}
               step={1}
               value={Math.round(settings.mouseAcceleration)}
-              onChange={(e) => handleChange("mouseAcceleration", Math.max(1, Math.min(150, Math.round(Number(e.target.value) || 1))))}
+              onChange={(e) => {
+                const value = Math.max(1, Math.min(150, Math.round(Number(e.target.value) || 1)));
+                setMouseAccelerationDraft(formatMouseAccelerationDraft(value));
+                handleChange("mouseAcceleration", value);
+              }}
             />
             <input
+              id="settings-input-mouse-acceleration-number"
               type="number"
-              className="settings-number-input"
-              style={{ width: 80 }}
+              className="settings-text-input settings-number-input"
+              aria-labelledby="settings-input-mouse-acceleration-label"
               min={1}
               max={150}
               step={1}
-              value={Math.round(settings.mouseAcceleration)}
-              onChange={(e) => {
-                const v = Number(e.target.value || "1");
-                if (Number.isFinite(v)) {
-                  handleChange("mouseAcceleration", Math.max(1, Math.min(150, Math.round(v))));
+              value={mouseAccelerationDraft}
+              onChange={(e) => setMouseAccelerationDraft(e.target.value)}
+              onBlur={commitMouseAccelerationDraft}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.currentTarget.blur();
+                } else if (e.key === "Escape") {
+                  commitMouseAccelerationDraft();
                 }
               }}
             />

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
@@ -1,7 +1,5 @@
-import { Check } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
-import type { Settings } from "@shared/gfn";
-import { getAccentColorOption } from "../../../lib/uiCustomization";
+import { useCallback, useMemo, type JSX } from "react";
+import type { AppAccentColor, Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
 import {
@@ -21,10 +19,6 @@ export interface SettingsInterfaceSectionProps {
 
 export function SettingsInterfaceSection({ settings, showAll, handleChange, onSaved }: SettingsInterfaceSectionProps): JSX.Element {
   const { locale, availableLocales, setLocale, t } = useTranslation();
-  const [appLanguageDropdownOpen, setAppLanguageDropdownOpen] = useState(false);
-  const appLanguageDropdownRef = useRef<HTMLDivElement | null>(null);
-  const [accentColorDropdownOpen, setAccentColorDropdownOpen] = useState(false);
-  const accentColorDropdownRef = useRef<HTMLDivElement | null>(null);
   const posterSizePercent = Math.round(settings.posterSizeScale * 100);
 
   const appLanguageOptions = useMemo(
@@ -32,33 +26,32 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
     [availableLocales],
   );
 
-  const selectedAppLanguageName = useMemo(() => {
-    return appLanguageOptions.find((option) => option.value === locale)?.label ?? getAppLanguageLabel(locale);
-  }, [appLanguageOptions, locale]);
-
-  const selectedAccentColor = useMemo(() => getAccentColorOption(settings.appAccentColor), [settings.appAccentColor]);
+  const accentDropdownOptions = useMemo(
+    () => accentColorOptions.map((option) => ({
+      value: option.value,
+      label: (
+        <span className="settings-accent-option">
+          <span
+            className="settings-accent-swatch"
+            aria-hidden="true"
+            style={{
+              background: option.hex,
+              boxShadow: `0 0 0 1px color-mix(in srgb, ${option.hex} 48%, rgba(255, 255, 255, 0.22))`,
+            }}
+          />
+          <span>{t(option.labelKey)}</span>
+        </span>
+      ),
+    })),
+    [locale, t],
+  );
 
   const handleAppLanguageChange = useCallback((nextLocale: string): void => {
-    setAppLanguageDropdownOpen(false);
     void setLocale(nextLocale).catch((error) => {
       console.warn("[Settings] Failed to change app language:", error);
     });
     onSaved();
   }, [onSaved, setLocale]);
-
-  useEffect(() => {
-    const handlePointerDown = (event: MouseEvent): void => {
-      const target = event.target as Node;
-      if (appLanguageDropdownRef.current && !appLanguageDropdownRef.current.contains(target)) {
-        setAppLanguageDropdownOpen(false);
-      }
-      if (accentColorDropdownRef.current && !accentColorDropdownRef.current.contains(target)) {
-        setAccentColorDropdownOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, []);
 
   return (
     <>
@@ -70,36 +63,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
         </div>
         <div className="settings-rows">
           <div className="settings-row">
-            <label className="settings-label">
+            <label className="settings-label" htmlFor="settings-interface-app-language">
               {t("settings.interface.appLanguage")}
               <span className="settings-hint">{t("settings.interface.appLanguageHint")}</span>
             </label>
-            <div className="settings-dropdown" ref={appLanguageDropdownRef}>
-              <button
-                type="button"
-                className={`settings-dropdown-selected ${appLanguageDropdownOpen ? "open" : ""}`}
-                onClick={() => setAppLanguageDropdownOpen((open) => !open)}
-              >
-                <span className="settings-dropdown-selected-name">{selectedAppLanguageName}</span>
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className={`settings-dropdown-chevron ${appLanguageDropdownOpen ? "flipped" : ""}`}>
-                  <path d="M4.47 5.97a.75.75 0 0 1 1.06 0L8 8.44l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
-                </svg>
-              </button>
-              {appLanguageDropdownOpen && (
-                <div className="settings-dropdown-menu">
-                  {appLanguageOptions.map((option) => (
-                    <button
-                      key={option.value}
-                      type="button"
-                      className={`settings-dropdown-item ${locale === option.value ? "active" : ""}`}
-                      onClick={() => handleAppLanguageChange(option.value)}
-                    >
-                      <span>{option.label}</span>
-                      {locale === option.value && <Check size={14} className="settings-dropdown-check" />}
-                    </button>
-                  ))}
-                </div>
-              )}
+            <div className="settings-row-control">
+              <SelectDropdown
+                id="settings-interface-app-language"
+                value={locale}
+                options={appLanguageOptions}
+                onChange={handleAppLanguageChange}
+              />
             </div>
           </div>
 
@@ -108,108 +82,63 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
               {t("settings.interface.theme") || "Theme"}
               <span className="settings-hint">{t("settings.interface.themeHint") || "Choose a light, dark, or system-matching theme."}</span>
             </label>
-            <SelectDropdown
-              id="appTheme"
-              value={settings.appTheme}
-              options={[
-                { value: "auto", label: t("settings.interface.themeAuto") || "Auto" },
-                { value: "light", label: t("settings.interface.themeLight") || "Light" },
-                { value: "dark", label: t("settings.interface.themeDark") || "Dark" },
-              ]}
-              onChange={(value) => handleChange("appTheme", value as any)}
-              ariaLabel={t("settings.interface.theme") || "Theme"}
-            />
-          </div>
-
-          <div className="settings-row">
-            <label className="settings-label">
-              {t("settings.interface.translucentUI") || "Translucent UI"}
-              <span className="settings-hint">{t("settings.interface.translucentUIHint") || "Enable glassmorphism and translucent overlays."}</span>
-            </label>
-            <label className="settings-toggle">
-              <input
-                type="checkbox"
-                checked={settings.translucentUI}
-                onChange={(e) => handleChange("translucentUI", e.target.checked)}
+            <div className="settings-row-control">
+              <SelectDropdown
+                id="appTheme"
+                value={settings.appTheme}
+                options={[
+                  { value: "auto", label: t("settings.interface.themeAuto") || "Auto" },
+                  { value: "light", label: t("settings.interface.themeLight") || "Light" },
+                  { value: "dark", label: t("settings.interface.themeDark") || "Dark" },
+                ]}
+                onChange={(value) => handleChange("appTheme", value as any)}
+                ariaLabel={t("settings.interface.theme") || "Theme"}
               />
-              <span className="settings-toggle-track" />
-            </label>
+            </div>
+          </div>
+
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-translucent-ui">
+                <span className="settings-label-title">{t("settings.interface.translucentUI") || "Translucent UI"}</span>
+              </label>
+              <label className="settings-toggle">
+                <input
+                  id="settings-interface-translucent-ui"
+                  type="checkbox"
+                  checked={settings.translucentUI}
+                  onChange={(e) => handleChange("translucentUI", e.target.checked)}
+                />
+                <span className="settings-toggle-track" />
+              </label>
+            </div>
+            <span className="settings-subtle-hint">{t("settings.interface.translucentUIHint") || "Enable glassmorphism and translucent overlays."}</span>
           </div>
 
           <div className="settings-row">
-            <label className="settings-label">
+            <label className="settings-label" htmlFor="settings-interface-accent-color">
               {t("settings.interface.accentColor")}
               <span className="settings-hint">{t("settings.interface.accentColorHint")}</span>
             </label>
-            <div className="settings-dropdown" ref={accentColorDropdownRef}>
-              <button
-                type="button"
-                className={`settings-dropdown-selected ${accentColorDropdownOpen ? "open" : ""}`}
-                onClick={() => setAccentColorDropdownOpen((open) => !open)}
-              >
-                <span className="settings-dropdown-selected-name" style={{ display: "inline-flex", alignItems: "center", gap: 10 }}>
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      width: 12,
-                      height: 12,
-                      borderRadius: 9999,
-                      background: selectedAccentColor.hex,
-                      boxShadow: `0 0 0 1px color-mix(in srgb, ${selectedAccentColor.hex} 48%, rgba(255, 255, 255, 0.22))`,
-                    }}
-                  />
-                  {t(selectedAccentColor.labelKey)}
-                </span>
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className={`settings-dropdown-chevron ${accentColorDropdownOpen ? "flipped" : ""}`}>
-                  <path d="M4.47 5.97a.75.75 0 0 1 1.06 0L8 8.44l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
-                </svg>
-              </button>
-              {accentColorDropdownOpen && (
-                <div className="settings-dropdown-menu">
-                  {accentColorOptions.map((option) => (
-                    <button
-                      key={option.value}
-                      type="button"
-                      className={`settings-dropdown-item ${settings.appAccentColor === option.value ? "active" : ""}`}
-                      onClick={() => {
-                        handleChange("appAccentColor", option.value);
-                        setAccentColorDropdownOpen(false);
-                      }}
-                    >
-                      <span style={{ display: "inline-flex", alignItems: "center", gap: 10, flex: 1 }}>
-                        <span
-                          aria-hidden="true"
-                          style={{
-                            width: 20,
-                            height: 20,
-                            borderRadius: 9999,
-                            flexShrink: 0,
-                            flex: "0 0 20px",
-                            background: option.hex,
-                            boxShadow: `0 0 0 1px color-mix(in srgb, ${option.hex} 48%, rgba(255, 255, 255, 0.22))`,
-                          }}
-                        />
-                        <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                          {t(option.labelKey)}
-                        </span>
-                      </span>
-                      {settings.appAccentColor === option.value && <Check size={14} className="settings-dropdown-check" />}
-                    </button>
-                  ))}
-                </div>
-              )}
+            <div className="settings-row-control">
+              <SelectDropdown
+                id="settings-interface-accent-color"
+                value={settings.appAccentColor}
+                options={accentDropdownOptions}
+                onChange={(value) => handleChange("appAccentColor", value as AppAccentColor)}
+              />
             </div>
           </div>
 
           {/* Appearance toggles */}
-          <div className="settings-toggle-grid">
-            <div className="settings-row">
-              <label className="settings-label">
-                {t("settings.interface.hideStreamOverlayButtons")}
-                <span className="settings-hint">{t("settings.interface.hideStreamOverlayButtonsHint")}</span>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-hide-stream-buttons">
+                <span className="settings-label-title">{t("settings.interface.hideStreamOverlayButtons")}</span>
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-interface-hide-stream-buttons"
                   type="checkbox"
                   checked={settings.hideStreamButtons}
                   onChange={(e) => handleChange("hideStreamButtons", e.target.checked)}
@@ -217,14 +146,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                 <span className="settings-toggle-track" />
               </label>
             </div>
+            <span className="settings-subtle-hint">{t("settings.interface.hideStreamOverlayButtonsHint")}</span>
+          </div>
 
-            <div className="settings-row">
-              <label className="settings-label">
-                {t("settings.interface.showStatsOnStreamLaunch")}
-                <span className="settings-hint">{t("settings.interface.showStatsOnStreamLaunchHint")}</span>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-show-stats-on-launch">
+                <span className="settings-label-title">{t("settings.interface.showStatsOnStreamLaunch")}</span>
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-interface-show-stats-on-launch"
                   type="checkbox"
                   checked={settings.showStatsOnLaunch}
                   onChange={(e) => handleChange("showStatsOnLaunch", e.target.checked)}
@@ -232,14 +164,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                 <span className="settings-toggle-track" />
               </label>
             </div>
+            <span className="settings-subtle-hint">{t("settings.interface.showStatsOnStreamLaunchHint")}</span>
+          </div>
 
-            <div className="settings-row">
-              <label className="settings-label">
-                {t("settings.interface.hideServerSelector")}
-                <span className="settings-hint">{t("settings.interface.hideServerSelectorHint")}</span>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-hide-server-selector">
+                <span className="settings-label-title">{t("settings.interface.hideServerSelector")}</span>
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-interface-hide-server-selector"
                   type="checkbox"
                   checked={settings.hideServerSelector}
                   onChange={(e) => handleChange("hideServerSelector", e.target.checked)}
@@ -247,14 +182,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                 <span className="settings-toggle-track" />
               </label>
             </div>
+            <span className="settings-subtle-hint">{t("settings.interface.hideServerSelectorHint")}</span>
+          </div>
 
-            <div className="settings-row">
-              <label className="settings-label">
-                {t("settings.interface.showAntiAfkIndicator")}
-                <span className="settings-hint">{t("settings.interface.showAntiAfkIndicatorHint")}</span>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-show-anti-afk-indicator">
+                <span className="settings-label-title">{t("settings.interface.showAntiAfkIndicator")}</span>
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-interface-show-anti-afk-indicator"
                   type="checkbox"
                   checked={settings.showAntiAfkIndicator}
                   onChange={(e) => handleChange("showAntiAfkIndicator", e.target.checked)}
@@ -262,14 +200,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                 <span className="settings-toggle-track" />
               </label>
             </div>
+            <span className="settings-subtle-hint">{t("settings.interface.showAntiAfkIndicatorHint")}</span>
+          </div>
 
-            <div className="settings-row">
-              <label className="settings-label">
-                {t("settings.interface.autoFullScreen")}
-                <span className="settings-hint">{t("settings.interface.autoFullScreenHint")}</span>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-auto-fullscreen">
+                <span className="settings-label-title">{t("settings.interface.autoFullScreen")}</span>
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-interface-auto-fullscreen"
                   type="checkbox"
                   checked={settings.autoFullScreen}
                   onChange={(e) => handleChange("autoFullScreen", e.target.checked)}
@@ -277,14 +218,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                 <span className="settings-toggle-track" />
               </label>
             </div>
+            <span className="settings-subtle-hint">{t("settings.interface.autoFullScreenHint")}</span>
+          </div>
 
-            <div className="settings-row">
-              <label className="settings-label">
-                {t("settings.interface.controllerMode")}
-                <span className="settings-hint">{t("settings.interface.controllerModeHint")}</span>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-controller-mode">
+                <span className="settings-label-title">{t("settings.interface.controllerMode")}</span>
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-interface-controller-mode"
                   type="checkbox"
                   checked={settings.controllerMode}
                   onChange={(e) => handleChange("controllerMode", e.target.checked)}
@@ -292,14 +236,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                 <span className="settings-toggle-track" />
               </label>
             </div>
+            <span className="settings-subtle-hint">{t("settings.interface.controllerModeHint")}</span>
+          </div>
 
-            <div className="settings-row">
-              <label className="settings-label">
-                {t("settings.interface.escapeExitsFullscreen")}
-                <span className="settings-hint">{t("settings.interface.escapeExitsFullscreenHint")}</span>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-escape-exits-fullscreen">
+                <span className="settings-label-title">{t("settings.interface.escapeExitsFullscreen")}</span>
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-interface-escape-exits-fullscreen"
                   type="checkbox"
                   checked={Boolean(settings.allowEscapeToExitFullscreen)}
                   onChange={(e) => handleChange("allowEscapeToExitFullscreen", e.target.checked)}
@@ -307,14 +254,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                 <span className="settings-toggle-track" />
               </label>
             </div>
+            <span className="settings-subtle-hint">{t("settings.interface.escapeExitsFullscreenHint")}</span>
+          </div>
 
-            <div className="settings-row">
-              <label className="settings-label">
-                {t("settings.interface.discordRichPresence")}
-                <span className="settings-hint">{t("settings.interface.discordRichPresenceHint")}</span>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-discord-rich-presence">
+                <span className="settings-label-title">{t("settings.interface.discordRichPresence")}</span>
               </label>
               <label className="settings-toggle">
                 <input
+                  id="settings-interface-discord-rich-presence"
                   type="checkbox"
                   checked={settings.discordRichPresence}
                   onChange={(e) => handleChange("discordRichPresence", e.target.checked)}
@@ -322,14 +272,16 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                 <span className="settings-toggle-track" />
               </label>
             </div>
+            <span className="settings-subtle-hint">{t("settings.interface.discordRichPresenceHint")}</span>
           </div>
 
           <div className="settings-row settings-row--column">
             <div className="settings-row-top">
-              <label className="settings-label">{t("settings.interface.posterSize")}</label>
+              <label className="settings-label" htmlFor="settings-interface-poster-size">{t("settings.interface.posterSize")}</label>
               <span className="settings-value-badge">{posterSizePercent}%</span>
             </div>
             <input
+              id="settings-interface-poster-size"
               type="range"
               className="settings-slider"
               min={POSTER_SIZE_MIN}
@@ -341,42 +293,48 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
             <span className="settings-subtle-hint">{t("settings.interface.posterSizeHint")}</span>
           </div>
 
-          <div className="settings-row">
-            <label className="settings-label">
-              {t("settings.interface.showSessionTimeRemainingInStatsOverlay")}
-              <span className="settings-hint">{t("settings.interface.showSessionTimeRemainingInStatsOverlayHint")}</span>
-            </label>
-            <label className="settings-toggle">
-              <input
-                type="checkbox"
-                checked={settings.showSessionTimeRemainingInStatsOverlay}
-                onChange={(e) => handleChange("showSessionTimeRemainingInStatsOverlay", e.target.checked)}
-              />
-              <span className="settings-toggle-track" />
-            </label>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-show-session-time-remaining">
+                <span className="settings-label-title">{t("settings.interface.showSessionTimeRemainingInStatsOverlay")}</span>
+              </label>
+              <label className="settings-toggle">
+                <input
+                  id="settings-interface-show-session-time-remaining"
+                  type="checkbox"
+                  checked={settings.showSessionTimeRemainingInStatsOverlay}
+                  onChange={(e) => handleChange("showSessionTimeRemainingInStatsOverlay", e.target.checked)}
+                />
+                <span className="settings-toggle-track" />
+              </label>
+            </div>
+            <span className="settings-subtle-hint">{t("settings.interface.showSessionTimeRemainingInStatsOverlayHint")}</span>
           </div>
 
           {/* Session Counter */}
-          <div className="settings-row">
-            <label className="settings-label">
-              {t("settings.interface.sessionElapsedCounter")}
-              <span className="settings-hint">{t("settings.interface.sessionElapsedCounterHint")}</span>
-            </label>
-            <label className="settings-toggle">
-              <input
-                type="checkbox"
-                checked={settings.sessionCounterEnabled}
-                onChange={(e) => handleChange("sessionCounterEnabled", e.target.checked)}
-              />
-              <span className="settings-toggle-track" />
-            </label>
+          <div className="settings-row settings-row--column">
+            <div className="settings-row-top settings-row-top--compact">
+              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-session-counter">
+                <span className="settings-label-title">{t("settings.interface.sessionElapsedCounter")}</span>
+              </label>
+              <label className="settings-toggle">
+                <input
+                  id="settings-interface-session-counter"
+                  type="checkbox"
+                  checked={settings.sessionCounterEnabled}
+                  onChange={(e) => handleChange("sessionCounterEnabled", e.target.checked)}
+                />
+                <span className="settings-toggle-track" />
+              </label>
+            </div>
+            <span className="settings-subtle-hint">{t("settings.interface.sessionElapsedCounterHint")}</span>
           </div>
 
           {settings.sessionCounterEnabled && (
             <>
               <div className="settings-row settings-row--column">
                 <div className="settings-row-top">
-                  <label className="settings-label">{t("settings.interface.sessionTimerReappear")}</label>
+                  <label className="settings-label" htmlFor="settings-interface-session-timer-reappear">{t("settings.interface.sessionTimerReappear")}</label>
                   <span className="settings-value-badge">
                     {settings.sessionClockShowEveryMinutes === 0
                       ? t("settings.interface.off")
@@ -384,6 +342,7 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                   </span>
                 </div>
                 <input
+                  id="settings-interface-session-timer-reappear"
                   type="range"
                   className="settings-slider"
                   min={0}
@@ -397,12 +356,13 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
 
               <div className="settings-row settings-row--column">
                 <div className="settings-row-top">
-                  <label className="settings-label">{t("settings.interface.sessionTimerVisibleTime")}</label>
+                  <label className="settings-label" htmlFor="settings-interface-session-timer-visible-time">{t("settings.interface.sessionTimerVisibleTime")}</label>
                   <span className="settings-value-badge">
                     {t("app.units.seconds", { value: settings.sessionClockShowDurationSeconds })}
                   </span>
                 </div>
                 <input
+                  id="settings-interface-session-timer-visible-time"
                   type="range"
                   className="settings-slider"
                   min={5}

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
@@ -73,6 +73,12 @@ export function SettingsNativeStreamerSection({
     (backend) => backend.available && backend.backend !== "software",
   ).length;
   const activeVideoBackendId = nativeStreamerStatus?.activeVideoBackend?.backend;
+  const primaryStatusMessage = nativeStreamerStatus?.message.trim() ?? "";
+  const runtimeStatusMessage = nativeStreamerStatus?.gstreamerRuntime.message.trim() ?? "";
+  const distinctRuntimeStatusMessage = runtimeStatusMessage && runtimeStatusMessage !== primaryStatusMessage
+    ? runtimeStatusMessage
+    : "";
+  const runtimePath = nativeStreamerStatus?.gstreamerRuntime.path?.trim() ?? "";
 
   const refreshNativeStreamerStatus = useCallback(async () => {
     if (!isNativeStreamerPlatform) {
@@ -282,7 +288,7 @@ export function SettingsNativeStreamerSection({
             <>
               <div className="settings-row settings-row--column">
                 <div className="settings-row-top settings-row-top--compact">
-                  <label className="settings-label settings-label--wrap">
+                  <label className="settings-label settings-label--wrap" htmlFor="settings-native-streaming-enabled">
                     <span className="settings-label-title">
                       {t("settings.nativeStreamer.nativeStreaming")}
                       <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span>
@@ -290,6 +296,7 @@ export function SettingsNativeStreamerSection({
                   </label>
                   <label className="settings-toggle">
                     <input
+                      id="settings-native-streaming-enabled"
                       type="checkbox"
                       checked={settings.streamClientMode === "native"}
                       onChange={(e) => handleNativeStreamerToggleChange(e.target.checked)}
@@ -300,31 +307,36 @@ export function SettingsNativeStreamerSection({
                 <span className="settings-subtle-hint">
                   {t("settings.nativeStreamer.nativeStreamingHint")}
                 </span>
-                <div className="settings-chip-row">
-                  <a className="settings-chip" href="https://github.com/OpenCloudGaming/OpenNOW/issues" target="_blank" rel="noreferrer">
+                <div className="settings-native-report-links">
+                  <a href="https://github.com/OpenCloudGaming/OpenNOW/issues" target="_blank" rel="noreferrer">
                     <span>{t("settings.nativeStreamer.reportOnGithubIssues")}</span>
-                    <ExternalLink size={13} />
+                    <ExternalLink size={12} />
                   </a>
-                  <a className="settings-chip" href="https://discord.gg/8EJYaJcNfD" target="_blank" rel="noreferrer">
+                  <a href="https://discord.gg/8EJYaJcNfD" target="_blank" rel="noreferrer">
                     <span>{t("settings.nativeStreamer.reportOnDiscord")}</span>
-                    <ExternalLink size={13} />
+                    <ExternalLink size={12} />
                   </a>
                 </div>
               </div>
 
-              <div className="settings-row">
-                <label className="settings-label">
-                  {t("settings.nativeStreamer.showNativeStreamerStats")}
-                  <span className="settings-hint">{t("settings.nativeStreamer.showNativeStreamerStatsHint")}</span>
-                </label>
-                <label className="settings-toggle">
-                  <input
-                    type="checkbox"
-                    checked={settings.showNativeStreamerStats}
-                    onChange={(e) => handleChange("showNativeStreamerStats", e.target.checked)}
-                  />
-                  <span className="settings-toggle-track" />
-                </label>
+              <div className="settings-row settings-row--column">
+                <div className="settings-row-top settings-row-top--compact">
+                  <label className="settings-label settings-label--wrap" htmlFor="settings-native-show-stats">
+                    <span className="settings-label-title">{t("settings.nativeStreamer.showNativeStreamerStats")}</span>
+                  </label>
+                  <label className="settings-toggle">
+                    <input
+                      id="settings-native-show-stats"
+                      type="checkbox"
+                      checked={settings.showNativeStreamerStats}
+                      onChange={(e) => handleChange("showNativeStreamerStats", e.target.checked)}
+                    />
+                    <span className="settings-toggle-track" />
+                  </label>
+                </div>
+                <span className="settings-subtle-hint">
+                  {t("settings.nativeStreamer.showNativeStreamerStatsHint")}
+                </span>
               </div>
 
               <div className="settings-row settings-row--column">
@@ -359,27 +371,26 @@ export function SettingsNativeStreamerSection({
                         ? t("settings.nativeStreamer.gstreamerReady")
                         : t("settings.nativeStreamer.notReady")}
                   </span>
-                </div>
-                <span className="settings-subtle-hint">
-                  {nativeStreamerStatus?.message ?? t("settings.nativeStreamer.statusDefaultHint")}
-                </span>
-              </div>
-
-              <div className="settings-row settings-row--column">
-                <label className="settings-label">{t("settings.nativeStreamer.gstreamerRuntime")}</label>
-                <div className="settings-chip-row">
                   <span className={`settings-inline-badge ${getGstreamerRuntimeBadgeClass(nativeStreamerStatus)}`}>
                     {formatGstreamerRuntimeLabel(nativeStreamerStatus)}
                   </span>
-                  {nativeStreamerStatus?.gstreamerRuntime.path ? (
-                    <span className="settings-inline-badge settings-inline-badge--codec">
-                      {t("settings.nativeStreamer.bundledPathDetected")}
-                    </span>
-                  ) : null}
                 </div>
                 <span className="settings-subtle-hint">
-                  {nativeStreamerStatus?.gstreamerRuntime.message ?? t("settings.nativeStreamer.runtimeDefaultHint")}
+                  {primaryStatusMessage || t("settings.nativeStreamer.statusDefaultHint")}
                 </span>
+                {distinctRuntimeStatusMessage ? (
+                  <span className="settings-subtle-hint">{distinctRuntimeStatusMessage}</span>
+                ) : null}
+                {runtimePath ? (
+                  <span className="settings-native-runtime-path">
+                    <strong>
+                      {nativeStreamerStatus?.gstreamerRuntime.bundled
+                        ? t("settings.nativeStreamer.bundledPathDetected")
+                        : t("settings.nativeStreamer.gstreamerRuntime")}
+                    </strong>
+                    <code>{runtimePath}</code>
+                  </span>
+                ) : null}
                 {!nativeStreamerStatus?.gstreamerAvailable && nativeStreamerStatus?.gstreamerRuntime.installInstructions?.length ? (
                   <div className="settings-install-steps">
                     <span className="settings-subtle-hint">
@@ -472,12 +483,12 @@ export function SettingsNativeStreamerSection({
                   </span>
                 )}
 
-                <span className="settings-subtle-hint">
-                  {nativeStreamerStatus?.gstreamerAvailable
-                    ? `${t("settings.nativeStreamer.activePath")}: ${formatNativeVideoBackendName(activeVideoBackendId)}. ${nativeStreamerStatus.codecSummary ?? t("settings.nativeStreamer.codecSupportUnknown")}. ${nativeStreamerStatus.zeroCopySummary ?? t("settings.nativeStreamer.memoryPathUnknown")}.`
-                    : nativeStreamerStatus?.activeVideoBackend?.reason
+                {(!nativeStreamerStatus?.gstreamerAvailable || hostVideoBackends.length === 0) && (
+                  <span className="settings-subtle-hint">
+                    {nativeStreamerStatus?.activeVideoBackend?.reason
                       ?? t("settings.nativeStreamer.capabilityProbeHint")}
-                </span>
+                  </span>
+                )}
               </div>
 
               {supportsNativeDirectXBackend && <div className="settings-row settings-row--column">
@@ -495,6 +506,7 @@ export function SettingsNativeStreamerSection({
                         key={option.value}
                         type="button"
                         className={`settings-chip ${settings.nativeVideoBackend === option.value ? "active" : ""}`}
+                        aria-pressed={settings.nativeVideoBackend === option.value}
                         onClick={() => handleChange("nativeVideoBackend", option.value)}
                         title={unavailable ? capability?.reason ?? t("settings.nativeStreamer.backendUnavailableOnPc") : option.description}
                         disabled={unavailable}
@@ -518,6 +530,7 @@ export function SettingsNativeStreamerSection({
                   <button
                     type="button"
                     className={`settings-chip ${!settings.enableCloudGsync ? "active" : ""}`}
+                    aria-pressed={!settings.enableCloudGsync}
                     onClick={() => setNativeFramePacing("low-latency")}
                   >
                     <span>{t("settings.nativeStreamer.lowestLatency")}</span>
@@ -525,6 +538,7 @@ export function SettingsNativeStreamerSection({
                   <button
                     type="button"
                     className={`settings-chip ${settings.enableCloudGsync ? "active" : ""}`}
+                    aria-pressed={settings.enableCloudGsync}
                     onClick={() => setNativeFramePacing("smooth")}
                   >
                     <span>{t("settings.nativeStreamer.smoothGsync")}</span>
@@ -539,10 +553,10 @@ export function SettingsNativeStreamerSection({
                 <div className="settings-row settings-row--column">
                   <label className="settings-label">{t("settings.nativeStreamer.renderMode")}</label>
                   <div className="settings-chip-row">
-                    <button type="button" className={`settings-chip ${!settings.nativeExternalRenderer ? "active" : ""}`} onClick={() => handleChange("nativeExternalRenderer", false)}>
+                    <button type="button" className={`settings-chip ${!settings.nativeExternalRenderer ? "active" : ""}`} aria-pressed={!settings.nativeExternalRenderer} onClick={() => handleChange("nativeExternalRenderer", false)}>
                       <span>{t("settings.nativeStreamer.renderModeInternal")}</span>
                     </button>
-                    <button type="button" className={`settings-chip ${settings.nativeExternalRenderer ? "active" : ""}`} onClick={() => handleChange("nativeExternalRenderer", true)}>
+                    <button type="button" className={`settings-chip ${settings.nativeExternalRenderer ? "active" : ""}`} aria-pressed={settings.nativeExternalRenderer} onClick={() => handleChange("nativeExternalRenderer", true)}>
                       <span>{t("settings.nativeStreamer.renderModeExternal")}</span>
                     </button>
                   </div>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsStreamSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsStreamSection.tsx
@@ -1,7 +1,7 @@
 import {
-  Check, Globe, Heart, MapPin, Monitor, ScanLine, Gauge, Film, SlidersHorizontal, HardDrive, Sparkles, Wifi, Zap, Search, X, Cpu,
+  Check, Globe, Heart, MapPin, Monitor, SlidersHorizontal, Wifi, Zap, Search, X, Cpu,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { m } from "motion/react";
 import type {
   ColorQuality,
@@ -39,6 +39,7 @@ import {
 } from "../settingsFormatters";
 import { dialogMotion, overlayMotion } from "../../MotionProvider";
 import { MotionSpinner } from "../../MotionSpinner";
+import { SelectDropdown, type SelectDropdownOption } from "../../ui/SelectDropdown";
 
 export interface SettingsStreamSectionProps {
   settings: Settings;
@@ -76,10 +77,13 @@ export function SettingsStreamSection({
   const { locale, t } = useTranslation();
   const [regionSearch, setRegionSearch] = useState("");
   const [regionDropdownOpen, setRegionDropdownOpen] = useState(false);
+  const [activeRegionValue, setActiveRegionValue] = useState("");
+  const regionSelectorRef = useRef<HTMLDivElement | null>(null);
+  const regionTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const regionSearchInputRef = useRef<HTMLInputElement | null>(null);
+  const regionListboxId = "settings-stream-region-listbox";
   const codecTestOpen = codecResults !== null || codecTesting;
   const [codecAdvancedOpen, setCodecAdvancedOpen] = useState(false);
-  const [resolutionDropdownOpen, setResolutionDropdownOpen] = useState(false);
-  const resolutionDropdownRef = useRef<HTMLDivElement | null>(null);
 
   const initialPingResults = useMemo(() => loadStoredRegionPingResults(), []);
   const [pingResults, setPingResults] = useState<Map<string, number | null>>(initialPingResults ?? new Map());
@@ -191,17 +195,19 @@ export function SettingsStreamSection({
     [effectiveEntitledResolutions, settings.fps, settings.resolution],
   );
 
-  const selectedResolutionLabel = useMemo(() => {
-    if (useEntitledStreamOptions) {
-      for (const group of resolutionGroups) {
-        const found = group.resolutions.find(r => r.value === settings.resolution);
-        if (found) return found.label;
-      }
-      return settings.resolution || "Select";
-    }
-    const found = STATIC_RESOLUTION_PRESETS.find(r => r.value === settings.resolution);
-    return found ? found.label : settings.resolution || "Select";
-  }, [settings.resolution, useEntitledStreamOptions, resolutionGroups]);
+  const resolutionOptions = useMemo<SelectDropdownOption[]>(
+    () => useEntitledStreamOptions
+      ? resolutionGroups.flatMap((group) => group.resolutions.map((resolution) => ({
+          value: resolution.value,
+          label: resolution.label,
+          group: group.category,
+        })))
+      : STATIC_RESOLUTION_PRESETS.map((resolution) => ({
+          value: resolution.value,
+          label: resolution.label,
+        })),
+    [resolutionGroups, useEntitledStreamOptions],
+  );
 
   const handleResolutionChange = useCallback((resolution: string) => {
     handleChange("resolution", resolution);
@@ -278,16 +284,122 @@ export function SettingsStreamSection({
     return found?.name ?? settings.region;
   }, [settings.region, regions, locale, t]);
 
+  const regionOptionValues = useMemo(
+    () => ["", ...filteredRegions.map((region) => region.url)],
+    [filteredRegions],
+  );
+  const activeRegionIndex = Math.max(0, regionOptionValues.indexOf(activeRegionValue));
+  const activeRegionOptionId = regionDropdownOpen && regionOptionValues[activeRegionIndex] !== undefined
+    ? `${regionListboxId}-option-${activeRegionIndex}`
+    : undefined;
+
+  const openRegionDropdown = useCallback((preferredIndex?: number): void => {
+    const selectedIndex = regionOptionValues.indexOf(settings.region);
+    const nextIndex = Math.max(
+      0,
+      Math.min(regionOptionValues.length - 1, preferredIndex ?? (selectedIndex >= 0 ? selectedIndex : 0)),
+    );
+    setActiveRegionValue(regionOptionValues[nextIndex] ?? "");
+    setRegionDropdownOpen(true);
+  }, [regionOptionValues, settings.region]);
+
+  const selectRegion = useCallback((regionUrl: string): void => {
+    handleChange("region", regionUrl);
+    setActiveRegionValue(regionUrl);
+    setRegionDropdownOpen(false);
+    setRegionSearch("");
+    regionTriggerRef.current?.focus({ preventScroll: true });
+  }, [handleChange]);
+
+  const handleRegionTriggerKeyDown = useCallback((event: ReactKeyboardEvent<HTMLButtonElement>): void => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const selectedIndex = regionOptionValues.indexOf(settings.region);
+      const fallbackIndex = event.key === "ArrowDown" ? 0 : regionOptionValues.length - 1;
+      openRegionDropdown(selectedIndex >= 0 ? selectedIndex : fallbackIndex);
+    } else if (event.key === "Escape" && regionDropdownOpen) {
+      event.preventDefault();
+      event.stopPropagation();
+      setRegionDropdownOpen(false);
+      setRegionSearch("");
+    }
+  }, [openRegionDropdown, regionDropdownOpen, regionOptionValues, settings.region]);
+
+  const handleRegionSearchKeyDown = useCallback((event: ReactKeyboardEvent<HTMLInputElement>): void => {
+    if (regionOptionValues.length === 0) return;
+
+    const currentIndex = Math.max(0, regionOptionValues.indexOf(activeRegionValue));
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setActiveRegionValue(regionOptionValues[(currentIndex + 1) % regionOptionValues.length] ?? "");
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setActiveRegionValue(regionOptionValues[(currentIndex - 1 + regionOptionValues.length) % regionOptionValues.length] ?? "");
+        break;
+      case "Home":
+        event.preventDefault();
+        setActiveRegionValue(regionOptionValues[0] ?? "");
+        break;
+      case "End":
+        event.preventDefault();
+        setActiveRegionValue(regionOptionValues.at(-1) ?? "");
+        break;
+      case "Enter":
+        event.preventDefault();
+        selectRegion(regionOptionValues.includes(activeRegionValue) ? activeRegionValue : (regionOptionValues[0] ?? ""));
+        break;
+      case "Escape":
+        event.preventDefault();
+        event.stopPropagation();
+        setRegionDropdownOpen(false);
+        setRegionSearch("");
+        regionTriggerRef.current?.focus({ preventScroll: true });
+        break;
+      default:
+        break;
+    }
+  }, [activeRegionValue, regionOptionValues, selectRegion]);
+
   useEffect(() => {
-    const handlePointerDown = (event: MouseEvent): void => {
-      const target = event.target as Node;
-      if (resolutionDropdownRef.current && !resolutionDropdownRef.current.contains(target)) {
-        setResolutionDropdownOpen(false);
+    if (!regionDropdownOpen) return;
+
+    const focusFrame = window.requestAnimationFrame(() => {
+      regionSearchInputRef.current?.focus({ preventScroll: true });
+    });
+    const closeRegionDropdownWhenOutside = (target: EventTarget | null): void => {
+      if (!regionSelectorRef.current?.contains(target as Node)) {
+        setRegionDropdownOpen(false);
+        setRegionSearch("");
       }
     };
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, []);
+    const handlePointerDown = (event: PointerEvent): void => {
+      closeRegionDropdownWhenOutside(event.target);
+    };
+    const handleFocusIn = (event: FocusEvent): void => {
+      closeRegionDropdownWhenOutside(event.target);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("focusin", handleFocusIn);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, [regionDropdownOpen]);
+
+  useEffect(() => {
+    if (!regionDropdownOpen) return;
+    if (regionOptionValues.includes(activeRegionValue)) return;
+    setActiveRegionValue(regionOptionValues.includes(settings.region) ? settings.region : (regionOptionValues[0] ?? ""));
+  }, [activeRegionValue, regionDropdownOpen, regionOptionValues, settings.region]);
+
+  useEffect(() => {
+    if (!regionDropdownOpen || !activeRegionOptionId) return;
+    document.getElementById(activeRegionOptionId)?.scrollIntoView({ block: "nearest" });
+  }, [activeRegionOptionId, regionDropdownOpen]);
 
   const openZortosCommunityProxyPrompt = useCallback((): void => {
     if (zortosCommunityProxyPromptCloseTimerRef.current !== null) {
@@ -398,11 +510,24 @@ export function SettingsStreamSection({
           </div>
           <div className="settings-rows">
             <div className="settings-row settings-row--column settings-row--region">
-            <div className="region-selector">
+            <div className="region-selector" ref={regionSelectorRef}>
       <button
+        ref={regionTriggerRef}
+        id="settings-stream-region-trigger"
         className={`region-selected ${regionDropdownOpen ? "open" : ""}`}
-        onClick={() => setRegionDropdownOpen(!regionDropdownOpen)}
+        onClick={() => {
+          if (regionDropdownOpen) {
+            setRegionDropdownOpen(false);
+            setRegionSearch("");
+          } else {
+            openRegionDropdown();
+          }
+        }}
+        onKeyDown={handleRegionTriggerKeyDown}
         type="button"
+        aria-haspopup="listbox"
+        aria-expanded={regionDropdownOpen}
+        aria-controls={regionListboxId}
       >
         <span className="region-selected-leading">
           <Globe size={15} className="region-selected-icon" />
@@ -450,16 +575,31 @@ export function SettingsStreamSection({
             <div className="region-dropdown-search">
               <Search size={14} className="region-dropdown-search-icon" />
               <input
+                ref={regionSearchInputRef}
                 type="text"
+                role="combobox"
                 className="region-dropdown-search-input"
                 placeholder={t("settings.region.searchPlaceholder")}
                 value={regionSearch}
                 onChange={(e) => setRegionSearch(e.target.value)}
-                autoFocus
+                onKeyDown={handleRegionSearchKeyDown}
+                aria-label={t("settings.region.searchPlaceholder")}
+                aria-expanded="true"
+                aria-controls={regionListboxId}
+                aria-activedescendant={activeRegionOptionId}
+                aria-autocomplete="list"
               />
               {regionSearch && (
-                <button className="region-dropdown-clear" onClick={() => setRegionSearch("")} type="button">
-                  <X size={12} />
+                <button
+                  className="region-dropdown-clear"
+                  onClick={() => {
+                    setRegionSearch("");
+                    regionSearchInputRef.current?.focus({ preventScroll: true });
+                  }}
+                  type="button"
+                  aria-label="Clear region search"
+                >
+                  <X size={12} aria-hidden="true" />
                 </button>
               )}
             </div>
@@ -469,6 +609,7 @@ export function SettingsStreamSection({
               disabled={isPinging}
               type="button"
               title={t("settings.region.refreshPing")}
+              aria-label={t("settings.region.refreshPing")}
             >
               {isPinging ? (
                 <MotionSpinner size={14} label="Testing regions" />
@@ -478,15 +619,21 @@ export function SettingsStreamSection({
             </button>
           </div>
 
-          <div className="region-dropdown-list">
+          <div
+            id={regionListboxId}
+            className="region-dropdown-list"
+            role="listbox"
+            aria-labelledby="settings-stream-region-trigger"
+          >
             <button
-              className={`region-dropdown-item ${!settings.region ? "active" : ""}`}
-              onClick={() => {
-                handleChange("region", "");
-                setRegionDropdownOpen(false);
-                setRegionSearch("");
-              }}
+              id={`${regionListboxId}-option-0`}
+              className={`region-dropdown-item ${!settings.region ? "active" : ""} ${activeRegionIndex === 0 ? "is-active" : ""}`}
+              onClick={() => selectRegion("")}
+              onMouseEnter={() => setActiveRegionValue("")}
               type="button"
+              role="option"
+              aria-selected={!settings.region}
+              tabIndex={-1}
             >
               <Globe size={14} />
               <div className="region-auto-best-info">
@@ -507,16 +654,19 @@ export function SettingsStreamSection({
               {!settings.region && <Check size={14} className="region-check" />}
             </button>
 
-            {filteredRegions.map((region) => (
+            {filteredRegions.map((region, index) => {
+              const optionIndex = index + 1;
+              return (
               <button
                 key={region.url}
-                className={`region-dropdown-item ${settings.region === region.url ? "active" : ""}`}
-                onClick={() => {
-                  handleChange("region", region.url);
-                  setRegionDropdownOpen(false);
-                  setRegionSearch("");
-                }}
+                id={`${regionListboxId}-option-${optionIndex}`}
+                className={`region-dropdown-item ${settings.region === region.url ? "active" : ""} ${activeRegionIndex === optionIndex ? "is-active" : ""}`}
+                onClick={() => selectRegion(region.url)}
+                onMouseEnter={() => setActiveRegionValue(region.url)}
                 type="button"
+                role="option"
+                aria-selected={settings.region === region.url}
+                tabIndex={-1}
               >
                 <Globe size={14} />
                 <span className="region-name-with-badge">
@@ -547,7 +697,8 @@ export function SettingsStreamSection({
                 </span>
                 {settings.region === region.url && <Check size={14} className="region-check" />}
               </button>
-            ))}
+              );
+            })}
 
             {filteredRegions.length === 0 && regions.length > 0 && (
               <div className="region-dropdown-empty">{t("settings.region.noRegionsMatch", { query: regionSearch })}</div>
@@ -571,97 +722,72 @@ export function SettingsStreamSection({
       <div className="settings-rows">
         {/* Resolution — grouped dropdown */}
         <div className="settings-row">
-          <label className="settings-label settings-label--with-icon">
-            <ScanLine size={15} className="settings-label-icon" />
-            {t("settings.video.resolution")}
-            {subscriptionLoading && <MotionSpinner size={12} className="settings-loading-icon" />}
+          <label className="settings-label" htmlFor="settings-stream-resolution">
+            <span className="settings-label-title">
+              {t("settings.video.resolution")}
+              {subscriptionLoading && <MotionSpinner size={12} className="settings-loading-icon" />}
+            </span>
           </label>
-          <div className="settings-dropdown settings-dropdown--constrained settings-resolution-dropdown" ref={resolutionDropdownRef}>
-            <button
-              type="button"
-              className={`settings-dropdown-selected ${resolutionDropdownOpen ? "open" : ""}`}
-              onClick={() => setResolutionDropdownOpen(o => !o)}
-            >
-              <span className="settings-dropdown-selected-name">{selectedResolutionLabel}</span>
-              <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className={`settings-dropdown-chevron ${resolutionDropdownOpen ? "flipped" : ""}`}>
-                <path d="M4.47 5.97a.75.75 0 0 1 1.06 0L8 8.44l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
-              </svg>
-            </button>
-            {resolutionDropdownOpen && (
-              <div className="settings-dropdown-menu settings-dropdown-menu--grouped">
-                {(useEntitledStreamOptions ? resolutionGroups : [{ category: "All", resolutions: STATIC_RESOLUTION_PRESETS.map(p => ({ ...p, width: 0, height: 0 })) }]).map(group => (
-                  <div key={group.category} className="settings-dropdown-group">
-                    <div className="settings-dropdown-group-label">{group.category}</div>
-                    {group.resolutions.map(res => (
-                      <button
-                        key={res.value}
-                        type="button"
-                        className={`settings-dropdown-item ${settings.resolution === res.value ? "active" : ""}`}
-                        onClick={() => { handleResolutionChange(res.value); setResolutionDropdownOpen(false); }}
-                      >
-                        <span>{res.label}</span>
-                        {settings.resolution === res.value && <Check size={14} className="settings-dropdown-check" />}
-                      </button>
-                    ))}
-                  </div>
-                ))}
-              </div>
-            )}
+          <div className="settings-row-control">
+            <SelectDropdown
+              id="settings-stream-resolution"
+              value={settings.resolution}
+              options={resolutionOptions}
+              onChange={handleResolutionChange}
+              menuClassName="select-dropdown__menu--grouped"
+            />
           </div>
         </div>
 
         {/* FPS — dynamic or static chips */}
         <div className="settings-row">
-          <label className="settings-label settings-label--with-icon">
-            <Gauge size={15} className="settings-label-icon" />
-            {t("settings.video.fps")}
-          </label>
-          <div className="settings-chip-row">
-            {(useEntitledStreamOptions ? dynamicFpsOptions.map((v) => ({ value: v })) : STATIC_FPS_PRESETS).map((preset) => (
-              <button
-                key={preset.value}
-                className={`settings-chip ${settings.fps === preset.value ? "active" : ""}`}
-                onClick={() => { handleChange("fps", preset.value); }}
-              >
-                <span>{preset.value}</span>
-              </button>
-            ))}
+          <label className="settings-label">{t("settings.video.fps")}</label>
+          <div className="settings-row-control">
+            <div className="settings-chip-row">
+              {(useEntitledStreamOptions ? dynamicFpsOptions.map((v) => ({ value: v })) : STATIC_FPS_PRESETS).map((preset) => (
+                <button
+                  key={preset.value}
+                  className={`settings-chip ${settings.fps === preset.value ? "active" : ""}`}
+                  aria-pressed={settings.fps === preset.value}
+                  onClick={() => { handleChange("fps", preset.value); }}
+                >
+                  <span>{preset.value}</span>
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 
         {/* Codec */}
         <div className="settings-row">
-          <label className="settings-label settings-label--with-icon">
-            <Film size={15} className="settings-label-icon" />
-            {t("settings.video.codec")}
-          </label>
-          <div className="settings-chip-row">
-            {codecOptions.map((codec) => {
-              const badgeState = getCodecDecodeBadgeState(codec, codecResults, codecTesting);
-              return (
-                <button
-                  key={codec}
-                  className={`settings-chip settings-chip--codec ${settings.codec === codec ? "active" : ""}`}
-                  onClick={() => handleCodecChange(codec)}
-                >
-                  <span>{codec}</span>
-                  {badgeState && (
-                    <span className={`settings-inline-badge settings-inline-badge--codec settings-inline-badge--codec-${badgeState}`}>
-                      {badgeState === "gpu" ? t("settings.video.gpu") : badgeState === "cpu" ? t("settings.video.cpu") : t("settings.video.testing")}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
+          <label className="settings-label">{t("settings.video.codec")}</label>
+          <div className="settings-row-control">
+            <div className="settings-chip-row">
+              {codecOptions.map((codec) => {
+                const badgeState = getCodecDecodeBadgeState(codec, codecResults, codecTesting);
+                return (
+                  <button
+                    key={codec}
+                    className={`settings-chip settings-chip--codec ${settings.codec === codec ? "active" : ""}`}
+                    aria-pressed={settings.codec === codec}
+                    onClick={() => handleCodecChange(codec)}
+                  >
+                    <span>{codec}</span>
+                    {badgeState && (
+                      <span className={`settings-inline-badge settings-inline-badge--codec settings-inline-badge--codec-${badgeState}`}>
+                        {badgeState === "gpu" ? t("settings.video.gpu") : badgeState === "cpu" ? t("settings.video.cpu") : t("settings.video.testing")}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
 
         {/* Color Quality */}
         <div className="settings-row">
-          <label className="settings-label settings-label--with-icon">
-            <SlidersHorizontal size={15} className="settings-label-icon" />
-            {t("settings.video.colorDepth")}
-          </label>
+          <label className="settings-label">{t("settings.video.colorDepth")}</label>
           <div className="settings-row-control">
             <div className="settings-chip-row">
               {colorQualityOptions.map((opt) => {
@@ -677,6 +803,7 @@ export function SettingsStreamSection({
                   <button
                     key={opt.value}
                     className={`settings-chip ${settings.colorQuality === opt.value ? "active" : ""}`}
+                    aria-pressed={settings.colorQuality === opt.value}
                     onClick={() => handleColorQualityChange(opt.value)}
                     title={needsHevc ? t("settings.colorQuality.requiresH265OrAv1Title", { description: colorDescription }) : colorDescription}
                   >
@@ -694,13 +821,11 @@ export function SettingsStreamSection({
         {/* Bitrate slider */}
         <div className="settings-row settings-row--column">
           <div className="settings-row-top">
-            <label className="settings-label settings-label--with-icon">
-              <HardDrive size={15} className="settings-label-icon" />
-              {t("settings.video.maxBitrate")}
-            </label>
+            <label className="settings-label" htmlFor="settings-stream-max-bitrate">{t("settings.video.maxBitrate")}</label>
             <span className="settings-value-badge">{settings.maxBitrateMbps} Mbps</span>
           </div>
           <input
+            id="settings-stream-max-bitrate"
             type="range"
             className="settings-slider"
             min={5}
@@ -713,7 +838,7 @@ export function SettingsStreamSection({
 
         <div className="settings-row settings-row--column">
           <div className="settings-row-top">
-            <label className="settings-label">{t("settings.video.recordingBitrate")}</label>
+            <label className="settings-label" htmlFor="settings-stream-recording-bitrate">{t("settings.video.recordingBitrate")}</label>
             <span className="settings-value-badge">
               {settings.recordingBitrateMbps === null
                 ? t("app.labels.auto")
@@ -724,6 +849,7 @@ export function SettingsStreamSection({
             <button
               type="button"
               className={`settings-chip ${settings.recordingBitrateMbps === null ? "active" : ""}`}
+              aria-pressed={settings.recordingBitrateMbps === null}
               onClick={() => handleChange("recordingBitrateMbps", null)}
             >
               <span>{t("app.labels.auto")}</span>
@@ -731,12 +857,14 @@ export function SettingsStreamSection({
             <button
               type="button"
               className={`settings-chip ${settings.recordingBitrateMbps !== null ? "active" : ""}`}
+              aria-pressed={settings.recordingBitrateMbps !== null}
               onClick={() => handleChange("recordingBitrateMbps", settings.recordingBitrateMbps ?? 75)}
             >
               <span>{t("settings.video.customBitrate")}</span>
             </button>
           </div>
           <input
+            id="settings-stream-recording-bitrate"
             type="range"
             className="settings-slider"
             min={5}
@@ -751,7 +879,7 @@ export function SettingsStreamSection({
 
         <div className="settings-row settings-row--column">
           <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap">
+            <label className="settings-label settings-label--wrap" htmlFor="settings-stream-session-proxy">
               <span className="settings-label-title">
                 {t("settings.video.sessionProxy")}
                 <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span>
@@ -759,6 +887,7 @@ export function SettingsStreamSection({
             </label>
             <label className="settings-toggle">
               <input
+                id="settings-stream-session-proxy"
                 type="checkbox"
                 checked={settings.sessionProxyEnabled}
                 onChange={(e) => handleChange("sessionProxyEnabled", e.target.checked)}
@@ -798,7 +927,7 @@ export function SettingsStreamSection({
 
         <div className="settings-row settings-row--column">
           <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap">
+            <label className="settings-label settings-label--wrap" htmlFor="settings-stream-enable-l4s">
               <span className="settings-label-title">
                 {t("settings.video.experimentalL4SRequest")}
                 <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span>
@@ -806,6 +935,7 @@ export function SettingsStreamSection({
             </label>
             <label className="settings-toggle">
               <input
+                id="settings-stream-enable-l4s"
                 type="checkbox"
                 checked={settings.enableL4S}
                 onChange={(e) => handleChange("enableL4S", e.target.checked)}
@@ -820,13 +950,14 @@ export function SettingsStreamSection({
 
         <div className="settings-row settings-row--column">
           <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap">
+            <label className="settings-label settings-label--wrap" htmlFor="settings-stream-launch-console-mode">
               <span className="settings-label-title">
                 {t("settings.video.launchInConsoleMode")}
               </span>
             </label>
             <label className="settings-toggle">
               <input
+                id="settings-stream-launch-console-mode"
                 type="checkbox"
                 checked={settings.launchInConsoleMode}
                 onChange={(e) => handleChange("launchInConsoleMode", e.target.checked)}
@@ -842,15 +973,15 @@ export function SettingsStreamSection({
         {/* Video filters (client-side GPU shaders) */}
         <div className="settings-row settings-row--column">
           <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap">
+            <label className="settings-label settings-label--wrap" htmlFor="settings-stream-video-filters-enabled">
               <span className="settings-label-title">
-                <Sparkles size={15} className="settings-label-icon" />
                 {t("settings.videoFilters.title")}
                 <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span>
               </span>
             </label>
             <label className="settings-toggle">
               <input
+                id="settings-stream-video-filters-enabled"
                 type="checkbox"
                 checked={settings.videoShader.enabled}
                 onChange={(e) => handleChange("videoShader", { ...settings.videoShader, enabled: e.target.checked })}
@@ -875,10 +1006,11 @@ export function SettingsStreamSection({
               ] as const).map((control) => (
                 <div key={control.key} className="settings-row settings-row--column">
                   <div className="settings-row-top">
-                    <label className="settings-label">{t(control.labelKey)}</label>
+                    <label className="settings-label" htmlFor={`settings-stream-video-filter-${control.key}`}>{t(control.labelKey)}</label>
                     <span className="settings-value-badge">{settings.videoShader[control.key]}%</span>
                   </div>
                   <input
+                    id={`settings-stream-video-filter-${control.key}`}
                     type="range"
                     className="settings-slider"
                     min={control.min}
@@ -934,16 +1066,14 @@ export function SettingsStreamSection({
             {showStreamVideo && (
               <>
                 <div className="settings-row">
-                  <label className="settings-label settings-label--with-icon">
-                    <Cpu size={15} className="settings-label-icon" />
-                    {t("settings.video.decoder")}
-                  </label>
+                  <label className="settings-label">{t("settings.video.decoder")}</label>
                   <div className="settings-row-control">
                     <div className="settings-chip-row">
                       {accelerationOptions.map((option) => (
                         <button
                           key={`decoder-${option.value}`}
                           className={`settings-chip ${settings.decoderPreference === option.value ? "active" : ""}`}
+                          aria-pressed={settings.decoderPreference === option.value}
                           onClick={() => handleChange("decoderPreference", option.value)}
                         >
                           {option.value === "auto"
@@ -959,16 +1089,14 @@ export function SettingsStreamSection({
                 </div>
 
                 <div className="settings-row">
-                  <label className="settings-label settings-label--with-icon">
-                    <Film size={15} className="settings-label-icon" />
-                    {t("settings.video.encoder")}
-                  </label>
+                  <label className="settings-label">{t("settings.video.encoder")}</label>
                   <div className="settings-row-control">
                     <div className="settings-chip-row">
                       {accelerationOptions.map((option) => (
                         <button
                           key={`encoder-${option.value}`}
                           className={`settings-chip ${settings.encoderPreference === option.value ? "active" : ""}`}
+                          aria-pressed={settings.encoderPreference === option.value}
                           onClick={() => handleChange("encoderPreference", option.value)}
                         >
                           {option.value === "auto"
@@ -988,8 +1116,7 @@ export function SettingsStreamSection({
             {showStreamCodecDiagnostics && (
               <>
             <div className="settings-row codec-test-row">
-              <label className="settings-label codec-test-description settings-label--with-icon">
-                <Zap size={15} className="settings-label-icon" />
+              <label className="settings-label codec-test-description">
                 {t("settings.codecDiagnostics.description")}
               </label>
               <button

--- a/opennow-stable/src/renderer/src/components/ui/SelectDropdown.tsx
+++ b/opennow-stable/src/renderer/src/components/ui/SelectDropdown.tsx
@@ -6,12 +6,13 @@ export interface SelectDropdownOption {
   value: string;
   label: ReactNode;
   disabled?: boolean;
+  group?: string;
 }
 
 interface SelectDropdownProps {
   id?: string;
   value: string;
-  options: SelectDropdownOption[];
+  options: readonly SelectDropdownOption[];
   onChange: (value: string) => void;
   disabled?: boolean;
   placeholder?: ReactNode;
@@ -25,7 +26,7 @@ function cx(...classes: Array<string | false | null | undefined>): string {
   return classes.filter(Boolean).join(" ");
 }
 
-function findEnabledIndex(options: SelectDropdownOption[], startIndex: number, direction: 1 | -1): number {
+function findEnabledIndex(options: readonly SelectDropdownOption[], startIndex: number, direction: 1 | -1): number {
   if (options.length === 0) return -1;
 
   for (let step = 0; step < options.length; step += 1) {
@@ -36,11 +37,11 @@ function findEnabledIndex(options: SelectDropdownOption[], startIndex: number, d
   return -1;
 }
 
-function findFirstEnabledIndex(options: SelectDropdownOption[]): number {
+function findFirstEnabledIndex(options: readonly SelectDropdownOption[]): number {
   return options.findIndex((option) => !option.disabled);
 }
 
-function findLastEnabledIndex(options: SelectDropdownOption[]): number {
+function findLastEnabledIndex(options: readonly SelectDropdownOption[]): number {
   for (let index = options.length - 1; index >= 0; index -= 1) {
     if (!options[index]?.disabled) return index;
   }
@@ -78,6 +79,23 @@ export function SelectDropdown({
     () => options.map((option) => `${option.value}:${option.disabled ? "disabled" : "enabled"}`).join("|"),
     [options],
   );
+  const optionGroups = useMemo(() => {
+    const groups: Array<{
+      label?: string;
+      options: Array<{ option: SelectDropdownOption; index: number }>;
+    }> = [];
+
+    options.forEach((option, index) => {
+      const currentGroup = groups.at(-1);
+      if (!currentGroup || currentGroup.label !== option.group) {
+        groups.push({ label: option.group, options: [{ option, index }] });
+      } else {
+        currentGroup.options.push({ option, index });
+      }
+    });
+
+    return groups;
+  }, [options]);
 
   useEffect(() => {
     optionRefs.current = optionRefs.current.slice(0, options.length);
@@ -185,6 +203,7 @@ export function SelectDropdown({
       case "Escape":
         if (open) {
           event.preventDefault();
+          event.stopPropagation();
           setOpen(false);
         }
         break;
@@ -201,6 +220,7 @@ export function SelectDropdown({
       <button
         id={buttonId}
         type="button"
+        role="combobox"
         className={cx("select-dropdown__trigger", triggerClassName)}
         disabled={effectiveDisabled}
         aria-label={ariaLabel}
@@ -223,30 +243,47 @@ export function SelectDropdown({
 
       {open && (
         <div id={listboxId} className={cx("select-dropdown__menu", menuClassName)} role="listbox" aria-labelledby={buttonId}>
-          {options.map((option, index) => {
-            const selected = option.value === value;
-            const active = index === activeIndex;
+          {optionGroups.map((group, groupIndex) => {
+            const groupLabelId = group.label ? `${listboxId}-group-${groupIndex}` : undefined;
             return (
-              <button
-                key={option.value}
-                id={`${listboxId}-option-${index}`}
-                ref={(element) => {
-                  optionRefs.current[index] = element;
-                }}
-                type="button"
-                role="option"
-                aria-selected={selected}
-                disabled={option.disabled}
-                tabIndex={-1}
-                className={cx("select-dropdown__option", selected && "is-selected", active && "is-active")}
-                onClick={() => selectOption(index)}
-                onMouseEnter={() => {
-                  if (!option.disabled) setActiveIndex(index);
-                }}
+              <div
+                key={`${group.label ?? "ungrouped"}-${groupIndex}`}
+                className={group.label ? "select-dropdown__group" : undefined}
+                role={group.label ? "group" : undefined}
+                aria-labelledby={groupLabelId}
               >
-                <span className="select-dropdown__option-label">{option.label}</span>
-                {selected && <Check size={14} className="select-dropdown__check" aria-hidden="true" />}
-              </button>
+                {group.label && (
+                  <div id={groupLabelId} className="select-dropdown__group-label">
+                    {group.label}
+                  </div>
+                )}
+                {group.options.map(({ option, index }) => {
+                  const selected = option.value === value;
+                  const active = index === activeIndex;
+                  return (
+                    <button
+                      key={option.value}
+                      id={`${listboxId}-option-${index}`}
+                      ref={(element) => {
+                        optionRefs.current[index] = element;
+                      }}
+                      type="button"
+                      role="option"
+                      aria-selected={selected}
+                      disabled={option.disabled}
+                      tabIndex={-1}
+                      className={cx("select-dropdown__option", selected && "is-selected", active && "is-active")}
+                      onClick={() => selectOption(index)}
+                      onMouseEnter={() => {
+                        if (!option.disabled) setActiveIndex(index);
+                      }}
+                    >
+                      <span className="select-dropdown__option-label">{option.label}</span>
+                      {selected && <Check size={14} className="select-dropdown__check" aria-hidden="true" />}
+                    </button>
+                  );
+                })}
+              </div>
             );
           })}
         </div>

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -2308,10 +2308,15 @@ body,
 }
 
 .select-dropdown__trigger:hover:not(:disabled),
-.select-dropdown__trigger:focus-visible,
 .select-dropdown--open .select-dropdown__trigger {
   border-color: rgba(var(--accent-rgb), 0.42);
   box-shadow: 0 0 0 2px var(--accent-surface);
+}
+
+.select-dropdown__trigger:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--ink));
+  outline: 2px solid color-mix(in srgb, var(--accent) 65%, var(--ink));
+  outline-offset: 2px;
 }
 
 .select-dropdown__trigger:disabled {
@@ -2356,6 +2361,26 @@ body,
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.42);
 }
 
+.select-dropdown__menu--tall,
+.select-dropdown__menu--grouped {
+  max-height: min(300px, calc(100vh - 160px));
+}
+
+.select-dropdown__group + .select-dropdown__group {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid var(--panel-border);
+}
+
+.select-dropdown__group-label {
+  padding: 5px 9px 4px;
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
 .select-dropdown__option {
   width: 100%;
   display: flex;
@@ -2384,7 +2409,7 @@ body,
 
 .select-dropdown__option.is-selected {
   background: var(--accent-surface-strong);
-  color: var(--accent);
+  color: color-mix(in srgb, var(--accent) 55%, var(--ink));
 }
 
 .select-dropdown__option:disabled {
@@ -2394,7 +2419,21 @@ body,
 
 .select-dropdown__check {
   flex-shrink: 0;
-  color: var(--accent);
+  color: color-mix(in srgb, var(--accent) 55%, var(--ink));
+}
+
+.settings-accent-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.settings-accent-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 9999px;
+  flex: 0 0 16px;
 }
 
 .home-sort .select-dropdown,
@@ -4052,17 +4091,23 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   gap: 14px;
+  min-width: 0;
+  padding-bottom: 4px;
 }
 
 .settings-thanks-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
   gap: 14px;
+  align-items: start;
+  min-width: 0;
 }
 
 .settings-thanks-grid > .settings-section {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  min-height: 0;
 }
 
 .settings-thanks-hero {
@@ -4110,12 +4155,19 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-section-header--thanks {
   align-items: flex-start;
+  gap: 10px;
+}
+
+.settings-section-header--thanks > svg {
+  margin-top: 2px;
+  flex-shrink: 0;
 }
 
 .settings-section-header--thanks > div {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
 }
 
 .settings-section-subtitle {
@@ -4126,9 +4178,10 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-people-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: 1fr;
   gap: 10px;
-  padding: 0 16px 16px;
+  padding: 0 16px 18px;
+  min-width: 0;
 }
 
 .settings-person-card {
@@ -4454,10 +4507,25 @@ button.game-card-store-chip.owned.active:hover {
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
-  padding: 20px 22px;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--ink) 28%, transparent) transparent;
+  padding: 20px 22px 28px;
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.settings-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.settings-content::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--ink) 22%, transparent);
+  border-radius: 999px;
+}
+
+.settings-content::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--ink) 38%, transparent);
 }
 
 /* Advanced disclosure */
@@ -4499,59 +4567,6 @@ button.game-card-store-chip.owned.active:hover {
   transform: rotate(180deg);
 }
 
-/* Resolution grouped dropdown */
-.settings-dropdown-menu--grouped {
-  max-height: 300px;
-}
-
-.settings-dropdown-group {
-  display: flex;
-  flex-direction: column;
-}
-
-.settings-dropdown-group-label {
-  padding: 8px 14px 4px;
-  font-size: 0.68rem;
-  font-weight: 800;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--ink-muted);
-  background: color-mix(in srgb, var(--ink) 3%, transparent);
-  border-top: 1px solid var(--panel-border);
-}
-
-.settings-dropdown-group:first-child .settings-dropdown-group-label {
-  border-top: none;
-}
-
-/* Compact toggle list */
-.settings-toggle-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0;
-  padding: 4px 0;
-  border-top: 1px solid var(--panel-border);
-  border-bottom: 1px solid var(--panel-border);
-}
-
-.settings-toggle-grid .settings-row {
-  min-height: 58px;
-  padding: 11px 0;
-  border-bottom: 1px solid var(--panel-border);
-}
-
-.settings-toggle-grid .settings-row:last-child {
-  border-bottom: none;
-}
-
-.settings-toggle-grid .settings-label {
-  flex-shrink: 1;
-}
-
-.settings-toggle-grid .settings-toggle {
-  margin-left: 12px;
-}
-
 /* Search result context label */
 .settings-section-context {
   font-size: 0.7rem;
@@ -4586,7 +4601,7 @@ button.game-card-store-chip.owned.active:hover {
   align-items: center;
   gap: 10px;
   margin-bottom: 0;
-  padding: 16px 18px 12px;
+  padding: 18px 18px 12px;
   border-bottom: none;
   color: var(--accent);
 }
@@ -4617,11 +4632,11 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 0 18px 6px;
+  padding: 0 18px 16px;
 }
 
 .settings-row {
-  --settings-label-col: minmax(10.5rem, 32%);
+  --settings-label-col: minmax(12.5rem, 13.5rem);
   display: grid;
   grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
   align-items: center;
@@ -4635,6 +4650,14 @@ button.game-card-store-chip.owned.active:hover {
   border-bottom: none;
 }
 
+.settings-row:has(.settings-hint),
+.settings-row:has(.settings-subtle-hint),
+.settings-row:has(.settings-input-hint),
+.settings-row:has(.settings-label--wrap),
+.settings-row.codec-test-row {
+  align-items: start;
+}
+
 .settings-row > .settings-label {
   grid-column: 1;
   flex: none;
@@ -4645,16 +4668,28 @@ button.game-card-store-chip.owned.active:hover {
   grid-column: 2;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 6px;
   min-width: 0;
+  width: 100%;
+  justify-self: stretch;
+}
+
+.settings-row-control > .select-dropdown {
+  width: min(280px, 100%);
+  max-width: 100%;
+}
+
+.settings-row-control > .settings-chip-row,
+.settings-row-control > .settings-slider,
+.settings-row-control > .settings-text-input,
+.settings-row-control > .settings-mic-device-wrap,
+.settings-row-control > .settings-path-setting {
   width: 100%;
 }
 
 .settings-row > .settings-chip-row,
-.settings-row > .settings-dropdown,
 .settings-row > .select-dropdown,
-.settings-row > .settings-toggle,
 .settings-row > .settings-text-input,
 .settings-row > .settings-slider,
 .settings-row > .settings-mic-device-wrap,
@@ -4671,17 +4706,40 @@ button.game-card-store-chip.owned.active:hover {
 .settings-row > .settings-input-hint,
 .settings-row > .settings-row-control {
   grid-column: 2;
-  justify-self: start;
+  justify-self: stretch;
   min-width: 0;
 }
 
-.settings-row > .settings-toggle {
+.settings-row > .settings-shortcut-actions,
+.settings-row > .settings-updater-actions,
+.settings-row > .settings-export-logs-btn,
+.settings-row > .settings-delete-cache-btn,
+.settings-row > .settings-save-btn,
+.settings-row > .codec-test-btn {
   justify-self: end;
+  width: auto;
 }
 
-.settings-row > .settings-dropdown,
+.settings-row > .settings-toggle {
+  grid-column: 2;
+  justify-self: end;
+  align-self: center;
+  width: 46px;
+  min-width: 46px;
+  flex: none;
+  margin-top: 0;
+}
+
 .settings-row > .select-dropdown {
   width: min(280px, 100%);
+  justify-self: start;
+}
+
+.settings-row > .settings-export-logs-btn,
+.settings-row > .settings-delete-cache-btn,
+.settings-row > .settings-save-btn,
+.settings-row > .codec-test-btn {
+  margin-top: 0;
 }
 
 .settings-row > .settings-mic-device-wrap,
@@ -4698,7 +4756,6 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-row--column > .settings-label,
 .settings-row--column > .settings-chip-row,
-.settings-row--column > .settings-dropdown,
 .settings-row--column > .select-dropdown,
 .settings-row--column > .settings-toggle,
 .settings-row--column > .settings-text-input,
@@ -4709,14 +4766,6 @@ button.game-card-store-chip.owned.active:hover {
   grid-column: auto;
   justify-self: stretch;
   width: 100%;
-}
-
-.settings-row--top-aligned {
-  align-items: flex-start;
-}
-
-.settings-row:has(.settings-hint) {
-  align-items: start;
 }
 
 .settings-row-top {
@@ -4814,13 +4863,13 @@ button.game-card-store-chip.owned.active:hover {
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
-  padding: 2px 8px;
+  padding: 3px 9px;
   border-radius: 999px;
   border: 1px solid transparent;
   font-size: 0.64rem;
   font-weight: 800;
-  line-height: 1;
-  letter-spacing: 0.04em;
+  line-height: 1.15;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
   white-space: nowrap;
 }
@@ -4833,6 +4882,10 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-inline-badge--codec {
   margin-left: 2px;
+}
+
+.settings-chip-row > .settings-inline-badge--codec {
+  margin-left: 0;
 }
 
 .settings-inline-badge--codec-gpu {
@@ -5529,6 +5582,14 @@ button.game-card-store-chip.owned.active:hover {
   max-width: 90px;
 }
 
+.settings-number-input {
+  min-width: 0;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
 .settings-input-group {
   display: flex;
   align-items: center;
@@ -5633,9 +5694,54 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--ink);
 }
 
+.settings-native-report-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 14px;
+}
+
+.settings-native-report-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: color var(--t-fast);
+}
+
+.settings-native-report-links a:hover {
+  color: var(--accent);
+}
+
+.settings-native-report-links a:focus-visible {
+  outline: 2px solid rgba(var(--accent-rgb), 0.8);
+  outline-offset: 3px;
+}
+
+.settings-native-runtime-path {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+}
+
+.settings-native-runtime-path code {
+  color: var(--ink);
+  font-size: 0.74rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .settings-native-capability-row {
   gap: 12px;
-  overflow: hidden;
+  overflow: visible;
+  padding-bottom: 2px;
 }
 
 .settings-native-capability-header {
@@ -5643,6 +5749,7 @@ button.game-card-store-chip.owned.active:hover {
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
+  min-width: 0;
 }
 
 .settings-native-capability-header > div {
@@ -5680,8 +5787,9 @@ button.game-card-store-chip.owned.active:hover {
 .settings-native-capability-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: 12px;
   width: 100%;
+  min-width: 0;
 }
 
 .settings-native-capability-card {
@@ -5690,13 +5798,14 @@ button.game-card-store-chip.owned.active:hover {
   min-width: 0;
   flex-direction: column;
   gap: 9px;
-  padding: 12px;
+  padding: 12px 12px 14px;
   overflow: hidden;
   border: 1px solid var(--panel-border);
   border-radius: 9px;
   background:
     linear-gradient(145deg, color-mix(in srgb, var(--ink) 3%, transparent), transparent 55%),
     var(--bg-e);
+  box-sizing: border-box;
 }
 
 .settings-native-capability-card::before {
@@ -5894,7 +6003,7 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
 }
 
 .settings-chip {
@@ -5920,6 +6029,12 @@ button.game-card-store-chip.owned.active:hover {
   background: var(--panel-border-solid);
   color: var(--ink-soft);
   border-color: var(--panel-border-solid);
+}
+
+.settings-chip:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--ink));
+  outline: 2px solid color-mix(in srgb, var(--accent) 65%, var(--ink));
+  outline-offset: 2px;
 }
 
 .settings-chip:disabled {
@@ -6013,6 +6128,26 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 /* Slider */
+.settings-slider-control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+}
+
+.settings-slider-control .settings-slider {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
+}
+
+.settings-slider-control .settings-number-input {
+  flex: 0 0 4.5rem;
+  width: 4.5rem;
+  min-width: 4.5rem;
+}
+
 .settings-slider {
   width: 100%;
   height: 6px;
@@ -6022,6 +6157,12 @@ button.game-card-store-chip.owned.active:hover {
   -webkit-appearance: none;
   appearance: none;
   cursor: pointer;
+}
+
+.settings-slider:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  box-shadow: 0 0 0 4px var(--accent-surface);
 }
 
 .settings-slider::-webkit-slider-thumb {
@@ -6089,6 +6230,12 @@ button.game-card-store-chip.owned.active:hover {
   transform: translateX(22px);
 }
 
+.settings-toggle input:focus-visible+.settings-toggle-track {
+  box-shadow:
+    inset 0 0 0 1px var(--accent),
+    0 0 0 3px var(--accent-surface-strong);
+}
+
 /* Placeholder */
 .settings-placeholder {
   padding: 14px;
@@ -6096,126 +6243,6 @@ button.game-card-store-chip.owned.active:hover {
   font-size: 0.92rem;
   color: var(--ink-muted);
   font-style: italic;
-}
-
-/* Custom settings dropdown */
-.settings-dropdown {
-  position: relative;
-  width: 100%;
-  min-width: 0;
-}
-
-.settings-dropdown--constrained {
-  flex: 0 1 280px;
-  width: min(280px, 100%);
-  max-width: 100%;
-}
-
-.settings-dropdown-selected {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 11px 14px;
-  background: var(--bg-a);
-  border: 1px solid var(--panel-border-solid);
-  border-radius: var(--r-sm);
-  color: var(--ink);
-  font-size: 0.92rem;
-  font-weight: 500;
-  font-family: inherit;
-  cursor: pointer;
-  transition: border-color var(--t-fast), box-shadow var(--t-fast), opacity var(--t-fast);
-  outline: none;
-}
-
-.settings-dropdown-selected:hover {
-  border-color: #444;
-}
-
-.settings-dropdown-selected.open {
-  border-color: var(--accent);
-  border-radius: var(--r-sm) var(--r-sm) 0 0;
-}
-
-.settings-dropdown-selected:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.settings-dropdown-selected-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.settings-dropdown-chevron {
-  color: var(--ink-muted);
-  transition: transform var(--t-fast), color var(--t-fast);
-  flex-shrink: 0;
-}
-
-.settings-dropdown-chevron.flipped {
-  transform: rotate(180deg);
-  color: var(--accent);
-}
-
-.settings-dropdown-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  background: var(--bg-a);
-  border: 1px solid var(--accent);
-  border-top: none;
-  border-radius: 0 0 var(--r-sm) var(--r-sm);
-  z-index: 22;
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.5);
-  max-height: 220px;
-  overflow-y: auto;
-}
-
-.settings-dropdown-menu--tall {
-  max-height: 260px;
-}
-
-.settings-dropdown-item {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-  background: transparent;
-  border: none;
-  color: var(--ink);
-  font-size: 0.9rem;
-  font-weight: 500;
-  font-family: inherit;
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--t-fast), color var(--t-fast);
-}
-
-.settings-dropdown-item:hover {
-  background: var(--accent-surface);
-}
-
-.settings-dropdown-item.active {
-  background: var(--accent-surface-strong);
-  color: var(--accent);
-}
-
-.settings-dropdown-item span {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.settings-dropdown-check {
-  color: var(--accent);
-  flex-shrink: 0;
 }
 
 .settings-mic-device-wrap {
@@ -6265,6 +6292,12 @@ button.game-card-store-chip.owned.active:hover {
 
 .region-selected:hover {
   border-color: #444;
+}
+
+.region-selected:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--ink));
+  outline: 2px solid color-mix(in srgb, var(--accent) 65%, var(--ink));
+  outline-offset: 2px;
 }
 
 .region-selected.open {
@@ -6414,6 +6447,12 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--ink);
 }
 
+.region-dropdown-clear:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  color: var(--accent);
+}
+
 .region-dropdown-list {
   max-height: 200px;
   overflow-y: auto;
@@ -6438,6 +6477,11 @@ button.game-card-store-chip.owned.active:hover {
 
 .region-dropdown-item:hover {
   background: var(--accent-surface);
+}
+
+.region-dropdown-item.is-active {
+  background: var(--accent-surface);
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .region-dropdown-item.active {
@@ -6493,6 +6537,13 @@ button.game-card-store-chip.owned.active:hover {
 
 .region-ping-refresh:hover:not(:disabled) {
   background: var(--accent-surface);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.region-ping-refresh:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
   color: var(--accent);
   border-color: var(--accent);
 }
@@ -6634,8 +6685,9 @@ button.game-card-store-chip.owned.active:hover {
 
 /* Export Logs Button */
 .settings-export-logs-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   padding: 10px 18px;
   background: var(--bg-c);
@@ -6672,10 +6724,15 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-updater-actions {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 10px;
+}
+
+.settings-row > .settings-updater-actions {
+  width: auto;
+  max-width: 100%;
 }
 
 .settings-save-btn--compact {
@@ -6716,8 +6773,9 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-delete-cache-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   padding: 10px 18px;
   background: var(--bg-c);
@@ -6747,6 +6805,11 @@ button.game-card-store-chip.owned.active:hover {
   opacity: 0.55;
   cursor: not-allowed;
   transform: none;
+}
+
+.settings-about-section .settings-export-logs-btn,
+.settings-about-section .settings-delete-cache-btn {
+  min-width: 11.5rem;
 }
 
 /* Codec Diagnostics */
@@ -10058,6 +10121,19 @@ button.game-card-store-chip.owned.active:hover {
 @media (max-width: 900px) {
   .settings-thanks-grid {
     grid-template-columns: 1fr;
+  }
+
+  .settings-about-section .settings-row > .settings-export-logs-btn,
+  .settings-about-section .settings-row > .settings-delete-cache-btn,
+  .settings-about-section .settings-row > .settings-updater-actions {
+    justify-self: stretch;
+    width: 100%;
+  }
+
+  .settings-about-section .settings-export-logs-btn,
+  .settings-about-section .settings-delete-cache-btn {
+    min-width: 0;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary

- consolidate settings dropdowns onto the shared keyboard-accessible control, including grouped resolution options
- repair region filtering, active-option tracking, keyboard navigation, focus restoration, and two-stage Escape behavior
- add accessible labels and visible focus states for toggles, sliders, chips, numeric fields, and updater progress
- allow mouse numeric fields to be cleared and edited before commit, with clamping, rounding, and slider synchronization
- restore distinct native streamer runtime diagnostics and safely wrap bundled runtime paths
- scope About action sizing so Account actions remain content-sized and remove obsolete settings styles
- add a reusable Electron settings verification recipe

## Verification

- `npm run lint` (passes with pre-existing unrelated warnings)
- `npm run typecheck`
- `npm test` (229 TypeScript tests and macOS signing test passed)
- `npm run build`
- launched and drove the Electron app at 1400×900 and 1024×680 in dark and light themes
- verified shared dropdown and region keyboard behavior, two-stage Escape, numeric draft commits, label/focus behavior, Account/About sizing, and native streamer diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
