### PR TITLE
fix(ui): smooth animation lifecycles

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, JSX } from "react";
-import { createPortal } from "react-dom";
-import { AnimatePresence, m } from "motion/react";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 
 import type {
   ActiveSessionInfo,
@@ -116,7 +115,8 @@ import { StreamLoading } from "./components/StreamLoading";
 import { StreamView } from "./components/StreamView";
 import { QueueServerSelectModal } from "./components/QueueServerSelectModal";
 import { ReleaseHighlightsModal } from "./components/ReleaseHighlightsModal";
-import { overlayMotion, pageTransition, standardEase } from "./components/MotionProvider";
+import { ModalSurface } from "./components/ui/ModalSurface";
+import { overlayMotion, pageTransition, streamRevealTransition } from "./components/MotionProvider";
 import { LazyShaderAtmosphere } from "./components/LazyShaderAtmosphere";
 
 const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
@@ -161,13 +161,13 @@ const DEFAULT_SHORTCUTS = {
 
 export function App(): JSX.Element {
   const { locale, t } = useTranslation();
+  const reducedMotion = useReducedMotion();
 
   // Navigation / settings / stream state below; auth + catalog come from hooks after deps are ready.
 
   // Navigation
   const [currentPage, setCurrentPage] = useState<AppPage>("home");
   const [pageBeforeSettings, setPageBeforeSettings] = useState<AppPage>("home");
-  const [settingsMounted, setSettingsMounted] = useState(false);
   const [sessionFullscreen, setSessionFullscreenState] = useState(false);
 
   // Settings State
@@ -335,8 +335,19 @@ export function App(): JSX.Element {
   // Refs
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const accountConfirmRestoreFocusRef = useRef<HTMLElement | null>(null);
+  const logoutConfirmCancelRef = useRef<HTMLButtonElement | null>(null);
+  const removeAccountConfirmCancelRef = useRef<HTMLButtonElement | null>(null);
   const [videoElementHasFrame, setVideoElementHasFrame] = useState(false);
-  const [streamRevealComplete, setStreamRevealComplete] = useState(false);
+  const [streamRevealPhase, setStreamRevealPhase] = useState<"covered" | "revealing" | "revealed">("covered");
+  const [streamSurfacePresent, setStreamSurfacePresent] = useState(false);
+  const [launchSurfacePresent, setLaunchSurfacePresent] = useState(false);
+  const [settingsSurfacePresent, setSettingsSurfacePresent] = useState(false);
+  const [navbarOverlayBlocking, setNavbarOverlayBlocking] = useState(false);
+  const [logoutConfirmSurfacePresent, setLogoutConfirmSurfacePresent] = useState(false);
+  const [removeAccountConfirmSurfacePresent, setRemoveAccountConfirmSurfacePresent] = useState(false);
+  const [releaseHighlightsSurfacePresent, setReleaseHighlightsSurfacePresent] = useState(false);
+  const streamRevealComplete = streamRevealPhase === "revealed";
   const clientRef = useRef<GfnWebRtcClient | null>(null);
   const isStreamingRef = useRef(streamStatus === "streaming");
 
@@ -347,7 +358,7 @@ export function App(): JSX.Element {
   useEffect(() => {
     if (streamStatus !== "streaming") {
       setVideoElementHasFrame(false);
-      setStreamRevealComplete(false);
+      setStreamRevealPhase("covered");
     }
 
     if (streamStatus === "idle") return undefined;
@@ -373,10 +384,25 @@ export function App(): JSX.Element {
   const streamVideoReady = isStreamVideoReady(streamStatus, diagnosticsVideoReady, videoElementHasFrame);
 
   useEffect(() => {
-    if (streamStatus === "idle" || !streamVideoReady || streamRevealComplete) return undefined;
-    const timer = window.setTimeout(() => setStreamRevealComplete(true), 680);
-    return () => window.clearTimeout(timer);
-  }, [streamRevealComplete, streamStatus, streamVideoReady]);
+    if (streamStatus === "idle" || !streamVideoReady || streamRevealPhase !== "covered") return;
+    setStreamRevealPhase(reducedMotion ? "revealed" : "revealing");
+  }, [reducedMotion, streamRevealPhase, streamStatus, streamVideoReady]);
+
+  useEffect(() => {
+    if (streamStatus !== "idle") setStreamSurfacePresent(true);
+  }, [streamStatus]);
+
+  useEffect(() => {
+    if (streamStatus !== "idle" || launchError) setLaunchSurfacePresent(true);
+  }, [launchError, streamStatus]);
+
+  useEffect(() => {
+    if (currentPage === "settings") setSettingsSurfacePresent(true);
+  }, [currentPage]);
+
+  useEffect(() => {
+    if (releaseHighlightsPayload) setReleaseHighlightsSurfacePresent(true);
+  }, [releaseHighlightsPayload]);
 
   useEffect(() => {
     if (streamStatus === "streaming" && audioRef.current) {
@@ -500,6 +526,14 @@ export function App(): JSX.Element {
     setNavbarActiveSession,
     setIsResumingNavbarSession,
   });
+
+  useEffect(() => {
+    if (logoutConfirmOpen) setLogoutConfirmSurfacePresent(true);
+  }, [logoutConfirmOpen]);
+
+  useEffect(() => {
+    if (removeAccountConfirmOpen) setRemoveAccountConfirmSurfacePresent(true);
+  }, [removeAccountConfirmOpen]);
 
   const effectiveControllerModeForCatalog = settings.controllerMode || directLaunchConsoleMode;
   const effectiveStreamingBaseUrlForCatalog = settings.region.trim()
@@ -1534,13 +1568,10 @@ export function App(): JSX.Element {
   }, [settings.translucentUI]);
 
 
-  // Save settings when changed
-  const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]) => {
-    setSettings((prev) => ({ ...prev, [key]: value }));
-    if (settingsLoaded) {
-      await window.openNow.setSetting(key, value);
-    }
-    // If a running client exists, push certain settings live
+  const previewSetting = useCallback(<K extends keyof Settings>(key: K, value: Settings[K]): void => {
+    setSettings((prev) => (Object.is(prev[key], value) ? prev : { ...prev, [key]: value }));
+
+    // If a running client exists, push supported settings live while controls move.
     if (key === "mouseSensitivity") {
       try {
         (clientRef.current as any)?.setMouseSensitivity?.(value as number);
@@ -1583,7 +1614,14 @@ export function App(): JSX.Element {
         // ignore
       }
     }
-  }, [settingsLoaded]);
+  }, []);
+
+  const updateSetting = useCallback(async <K extends keyof Settings>(key: K, value: Settings[K]): Promise<void> => {
+    previewSetting(key, value);
+    if (settingsLoaded) {
+      await window.openNow.setSetting(key, value);
+    }
+  }, [previewSetting, settingsLoaded]);
 
   useEffect(() => {
     if (!settingsLoaded || !subscriptionInfo) {
@@ -2992,133 +3030,110 @@ export function App(): JSX.Element {
     });
   }, [activeSessionProxyUrl, authSession, effectiveStreamingBaseUrl, handleOpenStoreUrl]);
 
-  useEffect(() => {
-    if (!logoutConfirmOpen && !removeAccountConfirmOpen) return;
+  const closeRemoveAccountConfirm = (): void => {
+    setRemoveAccountConfirmOpen(false);
+    setAccountToRemove(null);
+  };
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        if (removeAccountConfirmOpen) {
-          setRemoveAccountConfirmOpen(false);
-          setAccountToRemove(null);
-        } else if (logoutConfirmOpen) {
-          setLogoutConfirmOpen(false);
-        }
-      }
-      if (event.key === "Enter") {
-        event.preventDefault();
-        if (removeAccountConfirmOpen) {
-          void confirmRemoveAccount();
-        } else if (logoutConfirmOpen) {
-          void confirmLogout();
-        }
-      }
-    };
+  const logoutConfirmModal = (
+    <ModalSurface
+      open={logoutConfirmOpen}
+      onClose={() => setLogoutConfirmOpen(false)}
+      onConfirm={() => {
+        void confirmLogout();
+      }}
+      onExitComplete={() => setLogoutConfirmSurfacePresent(false)}
+      motion="compact"
+      overlayClassName="logout-confirm"
+      backdropClassName="logout-confirm-backdrop"
+      panelClassName="logout-confirm-card"
+      ariaLabel={t("auth.accounts.logOutConfirmation")}
+      backdropLabel={t("auth.accounts.cancelLogOut")}
+      initialFocusRef={logoutConfirmCancelRef}
+      restoreFocusRef={accountConfirmRestoreFocusRef}
+    >
+      <div className="logout-confirm-kicker">{t("auth.accounts.kicker")}</div>
+      <h3 className="logout-confirm-title">{t("auth.accounts.signOutAllTitle")}</h3>
+      <p className="logout-confirm-text">
+        {t("auth.accounts.signOutAllDescription")}
+      </p>
+      <p className="logout-confirm-subtext">
+        {t("auth.accounts.signOutAllSubtext")}
+      </p>
+      <div className="logout-confirm-actions">
+        <button
+          ref={logoutConfirmCancelRef}
+          type="button"
+          className="logout-confirm-btn logout-confirm-btn-cancel"
+          onClick={() => setLogoutConfirmOpen(false)}
+        >
+          {t("auth.accounts.staySignedIn")}
+        </button>
+        <button
+          type="button"
+          className="logout-confirm-btn logout-confirm-btn-confirm"
+          onClick={() => {
+            void confirmLogout();
+          }}
+        >
+          {t("auth.accounts.signOutAll")}
+        </button>
+      </div>
+      <div className="logout-confirm-hint">
+        <kbd>Enter</kbd> {t("app.actions.confirm")} · <kbd>Esc</kbd> {t("app.actions.cancel")}
+      </div>
+    </ModalSurface>
+  );
 
-    window.addEventListener("keydown", handleKeyDown);
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [confirmLogout, confirmRemoveAccount, logoutConfirmOpen, removeAccountConfirmOpen]);
-
-  const logoutConfirmModal = logoutConfirmOpen && typeof document !== "undefined"
-    ? createPortal(
-        <div className="logout-confirm" role="dialog" aria-modal="true" aria-label={t("auth.accounts.logOutConfirmation")}>
-          <button
-            type="button"
-            className="logout-confirm-backdrop"
-            onClick={() => setLogoutConfirmOpen(false)}
-            aria-label={t("auth.accounts.cancelLogOut")}
-          />
-          <div className="logout-confirm-card">
-            <div className="logout-confirm-kicker">{t("auth.accounts.kicker")}</div>
-            <h3 className="logout-confirm-title">{t("auth.accounts.signOutAllTitle")}</h3>
-            <p className="logout-confirm-text">
-              {t("auth.accounts.signOutAllDescription")}
-            </p>
-            <p className="logout-confirm-subtext">
-              {t("auth.accounts.signOutAllSubtext")}
-            </p>
-            <div className="logout-confirm-actions">
-              <button
-                type="button"
-                className="logout-confirm-btn logout-confirm-btn-cancel"
-                onClick={() => setLogoutConfirmOpen(false)}
-              >
-                {t("auth.accounts.staySignedIn")}
-              </button>
-              <button
-                type="button"
-                className="logout-confirm-btn logout-confirm-btn-confirm"
-                onClick={() => {
-                  void confirmLogout();
-                }}
-              >
-                {t("auth.accounts.signOutAll")}
-              </button>
-            </div>
-            <div className="logout-confirm-hint">
-              <kbd>Enter</kbd> {t("app.actions.confirm")} · <kbd>Esc</kbd> {t("app.actions.cancel")}
-            </div>
-          </div>
-        </div>,
-        document.body,
-      )
-    : null;
-
-  const removeAccountConfirmModal = removeAccountConfirmOpen && typeof document !== "undefined"
-    ? createPortal(
-        <div className="logout-confirm" role="dialog" aria-modal="true" aria-label={t("auth.accounts.removeAccountConfirmation")}>
-          <button
-            type="button"
-            className="logout-confirm-backdrop"
-            onClick={() => {
-              setRemoveAccountConfirmOpen(false);
-              setAccountToRemove(null);
-            }}
-            aria-label={t("auth.accounts.cancelAccountRemoval")}
-          />
-          <div className="logout-confirm-card">
-            <div className="logout-confirm-kicker">{t("auth.accounts.kicker")}</div>
-            <h3 className="logout-confirm-title">{t("auth.accounts.removeAccountTitle")}</h3>
-            <p className="logout-confirm-text">
-              {t("auth.accounts.removeAccountDescription", { name: accountToRemoveDisplayName })}
-            </p>
-            <p className="logout-confirm-subtext">
-              {t("auth.accounts.removeAccountSubtext")}
-            </p>
-            <div className="logout-confirm-actions">
-              <button
-                type="button"
-                className="logout-confirm-btn logout-confirm-btn-cancel"
-                onClick={() => {
-                  setRemoveAccountConfirmOpen(false);
-                  setAccountToRemove(null);
-                }}
-              >
-                {t("app.actions.cancel")}
-              </button>
-              <button
-                type="button"
-                className="logout-confirm-btn logout-confirm-btn-confirm"
-                onClick={() => {
-                  void confirmRemoveAccount();
-                }}
-              >
-                {t("app.actions.remove")}
-              </button>
-            </div>
-            <div className="logout-confirm-hint">
-              <kbd>Enter</kbd> {t("app.actions.confirm")} · <kbd>Esc</kbd> {t("app.actions.cancel")}
-            </div>
-          </div>
-        </div>,
-        document.body,
-      )
-    : null;
+  const removeAccountConfirmModal = (
+    <ModalSurface
+      open={removeAccountConfirmOpen}
+      onClose={closeRemoveAccountConfirm}
+      onConfirm={() => {
+        void confirmRemoveAccount();
+      }}
+      onExitComplete={() => setRemoveAccountConfirmSurfacePresent(false)}
+      motion="compact"
+      overlayClassName="logout-confirm"
+      backdropClassName="logout-confirm-backdrop"
+      panelClassName="logout-confirm-card"
+      ariaLabel={t("auth.accounts.removeAccountConfirmation")}
+      backdropLabel={t("auth.accounts.cancelAccountRemoval")}
+      initialFocusRef={removeAccountConfirmCancelRef}
+      restoreFocusRef={accountConfirmRestoreFocusRef}
+    >
+      <div className="logout-confirm-kicker">{t("auth.accounts.kicker")}</div>
+      <h3 className="logout-confirm-title">{t("auth.accounts.removeAccountTitle")}</h3>
+      <p className="logout-confirm-text">
+        {t("auth.accounts.removeAccountDescription", { name: accountToRemoveDisplayName })}
+      </p>
+      <p className="logout-confirm-subtext">
+        {t("auth.accounts.removeAccountSubtext")}
+      </p>
+      <div className="logout-confirm-actions">
+        <button
+          ref={removeAccountConfirmCancelRef}
+          type="button"
+          className="logout-confirm-btn logout-confirm-btn-cancel"
+          onClick={closeRemoveAccountConfirm}
+        >
+          {t("app.actions.cancel")}
+        </button>
+        <button
+          type="button"
+          className="logout-confirm-btn logout-confirm-btn-confirm"
+          onClick={() => {
+            void confirmRemoveAccount();
+          }}
+        >
+          {t("app.actions.remove")}
+        </button>
+      </div>
+      <div className="logout-confirm-hint">
+        <kbd>Enter</kbd> {t("app.actions.confirm")} · <kbd>Esc</kbd> {t("app.actions.cancel")}
+      </div>
+    </ModalSurface>
+  );
 
   const handleResumeFromNavbar = useCallback(async () => {
     if (
@@ -3571,16 +3586,6 @@ export function App(): JSX.Element {
     setReleaseHighlightsIsAuto(false);
   }, [releaseHighlightsIsAuto]);
 
-  const handleSettingsExitComplete = useCallback((): void => {
-    setSettingsMounted(false);
-  }, []);
-
-  useEffect(() => {
-    if (currentPage === "settings") {
-      setSettingsMounted(true);
-    }
-  }, [currentPage]);
-
   const mainPage: AppPage = currentPage === "settings" ? pageBeforeSettings : currentPage;
 
   // Show login screen if not authenticated
@@ -3601,13 +3606,11 @@ export function App(): JSX.Element {
           qrLoginChallenge={qrLoginChallenge}
           isQrLoginPending={activeLoginMode === "qr" && !qrLoginChallenge}
         />
-        {releaseHighlightsPayload && (
-          <ReleaseHighlightsModal
-            payload={releaseHighlightsPayload}
-            version={releaseHighlightsPayload.version}
-            onDismiss={handleDismissReleaseHighlights}
-          />
-        )}
+        <ReleaseHighlightsModal
+          payload={releaseHighlightsPayload}
+          onDismiss={handleDismissReleaseHighlights}
+          onExitComplete={() => setReleaseHighlightsSurfacePresent(false)}
+        />
       </>
     );
   }
@@ -3615,149 +3618,43 @@ export function App(): JSX.Element {
   const showLaunchOverlay = streamStatus !== "idle" || launchError !== null;
   const hasActiveStreamView = streamStatus !== "idle";
   const showLaunchErrorOverlay = launchError !== null;
-  const showDesktopLaunchLoading = showLaunchErrorOverlay || (streamStatus !== "idle" && !streamRevealComplete);
-  // Show stream lifecycle (waiting/connecting/streaming/failure)
-  if (showLaunchOverlay) {
-    const loadingStatus = launchError
-      ? launchError.stage
-      : streamStatus === "streaming"
-        ? "connecting"
-        : toLoadingStatus(streamStatus);
-    return (
-      <>
-        {hasActiveStreamView && (
-          <StreamView
-            videoRef={videoRef}
-            audioRef={audioRef}
-            diagnosticsStore={diagnosticsStore}
-            showStats={showStatsOverlay}
-            showNativeStats={settings.showNativeStreamerStats}
-            nativeInputCaptureActive={nativeInputCaptureActive}
-            gstreamerEnabled={settings.streamClientMode === "native"}
-            nativeExternalRenderer={settings.nativeExternalRenderer}
-            shortcuts={{
-              toggleStats: formatShortcutForDisplay(settings.shortcutToggleStats, isMac),
-              togglePointerLock: formatShortcutForDisplay(settings.shortcutTogglePointerLock, isMac),
-              toggleFullscreen: formatShortcutForDisplay(settings.shortcutToggleFullscreen, isMac),
-              stopStream: formatShortcutForDisplay(settings.shortcutStopStream, isMac),
-              toggleAntiAfk: shortcuts.toggleAntiAfk.canonical,
-              toggleMicrophone: formatShortcutForDisplay(settings.shortcutToggleMicrophone, isMac),
-              screenshot: shortcuts.screenshot.canonical,
-              recording: shortcuts.recording.canonical,
-            }}
-            hideStreamButtons={settings.hideStreamButtons}
-            serverRegion={session?.serverIp}
-            antiAfkEnabled={antiAfkEnabled}
-            antiAfkAckNonce={antiAfkAckNonce}
-            showAntiAfkIndicator={settings.showAntiAfkIndicator}
-            exitPrompt={exitPrompt}
-            sessionStartedAtMs={sessionStartedAtMs}
-            sessionCounterEnabled={settings.sessionCounterEnabled}
-            showSessionTimeRemainingInStatsOverlay={settings.showSessionTimeRemainingInStatsOverlay}
-            sessionTimeRemainingSeconds={sessionTimeRemainingSeconds}
-            sessionClockShowEveryMinutes={settings.sessionClockShowEveryMinutes}
-            sessionClockShowDurationSeconds={settings.sessionClockShowDurationSeconds}
-            streamWarning={streamWarning}
-            isFullscreen={sessionFullscreen || !!document.fullscreenElement}
-            isConnecting={streamStatus === "connecting"}
-            isStreaming={isStreaming}
-            recordingBitrateMbps={settings.recordingBitrateMbps}
-            gameTitle={streamingGame?.title ?? t("app.labels.game")}
-            platformStore={streamingStore ?? undefined}
-            onToggleFullscreen={() => {
-              void toggleSessionFullscreen();
-            }}
-            onConfirmExit={handleExitPromptConfirm}
-            onCancelExit={handleExitPromptCancel}
-            onEndSession={() => {
-              void handlePromptedStopStream();
-            }}
-            onToggleMicrophone={() => {
-              clientRef.current?.toggleMicrophone();
-            }}
-            mouseSensitivity={settings.mouseSensitivity}
-            onMouseSensitivityChange={handleMouseSensitivityChange}
-            mouseAcceleration={settings.mouseAcceleration}
-            onMouseAccelerationChange={handleMouseAccelerationChange}
-            microphoneMode={settings.microphoneMode}
-            onMicrophoneModeChange={handleMicrophoneModeChange}
-            onScreenshotShortcutChange={(value) => {
-              void updateSetting("shortcutScreenshot", value);
-            }}
-            onRecordingShortcutChange={(value) => {
-              void updateSetting("shortcutToggleRecording", value);
-            }}
-            onShowSessionTimeRemainingInStatsOverlayChange={(value) => {
-              void updateSetting("showSessionTimeRemainingInStatsOverlay", value);
-            }}
-            subscriptionInfo={subscriptionInfo}
-            micTrack={clientRef.current?.getMicTrack() ?? null}
-            onRequestPointerLock={handleRequestPointerLock}
-            onReleasePointerLock={() => {
-              void releasePointerLockIfNeeded();
-            }}
-            onNativeInputPaused={setNativeInputPaused}
-            allowEscapeToExitFullscreen={settings.allowEscapeToExitFullscreen}
-            videoShader={settings.videoShader}
-            onVideoShaderChange={handleVideoShaderChange}
-          />
-        )}
-        <AnimatePresence>
-          {showDesktopLaunchLoading && (
-            <m.div
-              key="stream-loading-transition"
-              className={`stream-loading-transition${streamVideoReady && !launchError ? " stream-loading-transition--warping" : ""}`}
-              initial={false}
-              animate={streamVideoReady && !launchError
-                ? { opacity: 0, scale: 1.025 }
-                : { opacity: 1, scale: 1 }}
-              exit={{ opacity: 0 }}
-              transition={streamVideoReady && !launchError
-                ? { duration: 0.62, ease: standardEase }
-                : { duration: 0.16, ease: standardEase }}
-            >
-              <StreamLoading
-                gameTitle={streamingGame?.title ?? t("app.labels.game")}
-                gameCover={streamingGame?.imageUrl}
-                platformStore={streamingStore ?? undefined}
-                status={loadingStatus}
-                queuePosition={queuePosition}
-                adState={effectiveAdState}
-                activeAd={activeQueueAd}
-                activeAdMediaUrl={activeQueueAdMediaUrl}
-                onAdPlaybackEvent={handleQueueAdPlaybackEvent}
-                adPreviewRef={queueAdPreviewRef}
-                error={
-                  launchError
-                    ? {
-                        title: launchError.title,
-                        description: launchError.description,
-                        code: launchError.codeLabel,
-                        actionLabel: launchError.actionLabel,
-                      }
-                    : undefined
-                }
-                onErrorAction={launchError?.action ? handleLaunchErrorAction : undefined}
-                onCancel={() => {
-                  if (launchError) {
-                    void handleDismissLaunchError();
-                    return;
-                  }
-                  void handlePromptedStopStream();
-                }}
-              />
-            </m.div>
-          )}
-        </AnimatePresence>
-      </>
-    );
-  }
+  const showDesktopLaunchLoading = showLaunchErrorOverlay
+    || (streamStatus !== "idle" && streamRevealPhase !== "revealed");
+  const loadingStatus = launchError
+    ? launchError.stage
+    : streamStatus === "streaming"
+      ? "connecting"
+      : toLoadingStatus(streamStatus);
+  const showCatalogAtmosphere = mainPage === "home" || mainPage === "library";
+  const shellBlocked = showLaunchOverlay
+    || streamSurfacePresent
+    || launchSurfacePresent
+    || currentPage === "settings"
+    || settingsSurfacePresent
+    || navbarOverlayBlocking
+    || queueModalGame !== null
+    || releaseHighlightsPayload !== null
+    || releaseHighlightsSurfacePresent
+    || logoutConfirmOpen
+    || logoutConfirmSurfacePresent
+    || removeAccountConfirmOpen
+    || removeAccountConfirmSurfacePresent;
+  const catalogSurfaceActive = !shellBlocked;
 
-  // Main app layout
-  const showCatalogAtmosphere = currentPage === "home" || currentPage === "library";
   return (
     <div className={`app-container${effectiveControllerMode ? " app-container--controller" : ""}${showCatalogAtmosphere ? " app-container--atmosphere" : ""}`} style={getAppStyle(settings.posterSizeScale)}>
-      {showCatalogAtmosphere && <LazyShaderAtmosphere variant="controller" className="catalog-atmosphere" />}
+      <div
+        className="app-shell"
+        inert={shellBlocked ? true : undefined}
+        aria-hidden={shellBlocked || undefined}
+      >
+      {showCatalogAtmosphere && (
+        <LazyShaderAtmosphere
+          variant="controller"
+          className="catalog-atmosphere"
+          active={catalogSurfaceActive}
+        />
+      )}
       <AnimatePresence>
         {startupRefreshNotice && (
           <m.div
@@ -3797,11 +3694,16 @@ export function App(): JSX.Element {
         }}
         savedAccounts={savedAccounts}
         onSwitchAccount={handleSwitchAccount}
-        onRemoveAccount={(userId) => {
+        onRemoveAccount={(userId, restoreFocusTarget) => {
+          accountConfirmRestoreFocusRef.current = restoreFocusTarget ?? null;
           void handleRemoveAccount(userId);
         }}
         onAddAccount={handleAddAccount}
-        onLogoutAll={handleLogout}
+        onLogoutAll={(restoreFocusTarget) => {
+          accountConfirmRestoreFocusRef.current = restoreFocusTarget ?? null;
+          handleLogout();
+        }}
+        onBlockingOverlayChange={setNavbarOverlayBlocking}
         controllerMode={effectiveControllerMode}
       />
 
@@ -3836,6 +3738,7 @@ export function App(): JSX.Element {
                 totalCount={catalogTotalCount}
                 supportedCount={catalogSupportedCount}
                 controllerMode={effectiveControllerMode}
+                surfaceActive={catalogSurfaceActive}
                 storePanels={storePanels}
                 storeHeroGames={featuredGames}
                 activeSessionAppIds={activeSessionAppIds}
@@ -3866,6 +3769,7 @@ export function App(): JSX.Element {
                   selectedSortId={catalogSelectedSortId === "relevance" ? "last_played" : catalogSelectedSortId}
                   onSortChange={setCatalogSelectedSortId}
                   controllerMode={effectiveControllerMode}
+                  surfaceActive={catalogSurfaceActive}
                   featuredGames={featuredGames.length > 0 ? featuredGames : games}
                   activeSessionAppIds={activeSessionAppIds}
                   onBuyGame={handleBuyGame}
@@ -3878,24 +3782,170 @@ export function App(): JSX.Element {
         </AnimatePresence>
         </PageErrorBoundary>
       </main>
+      </div>
+
+      <AnimatePresence
+        initial={false}
+        onExitComplete={() => setStreamSurfacePresent(false)}
+      >
+        {hasActiveStreamView && (
+          <m.div
+            key="stream-view-layer"
+            className="stream-view-layer"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={pageTransition}
+          >
+            <StreamView
+              videoRef={videoRef}
+              audioRef={audioRef}
+              diagnosticsStore={diagnosticsStore}
+              showStats={showStatsOverlay}
+              showNativeStats={settings.showNativeStreamerStats}
+              nativeInputCaptureActive={nativeInputCaptureActive}
+              gstreamerEnabled={settings.streamClientMode === "native"}
+              nativeExternalRenderer={settings.nativeExternalRenderer}
+              shortcuts={{
+                toggleStats: formatShortcutForDisplay(settings.shortcutToggleStats, isMac),
+                togglePointerLock: formatShortcutForDisplay(settings.shortcutTogglePointerLock, isMac),
+                toggleFullscreen: formatShortcutForDisplay(settings.shortcutToggleFullscreen, isMac),
+                stopStream: formatShortcutForDisplay(settings.shortcutStopStream, isMac),
+                toggleAntiAfk: shortcuts.toggleAntiAfk.canonical,
+                toggleMicrophone: formatShortcutForDisplay(settings.shortcutToggleMicrophone, isMac),
+                screenshot: shortcuts.screenshot.canonical,
+                recording: shortcuts.recording.canonical,
+              }}
+              hideStreamButtons={settings.hideStreamButtons}
+              serverRegion={session?.serverIp}
+              antiAfkEnabled={antiAfkEnabled}
+              antiAfkAckNonce={antiAfkAckNonce}
+              showAntiAfkIndicator={settings.showAntiAfkIndicator}
+              exitPrompt={exitPrompt}
+              sessionStartedAtMs={sessionStartedAtMs}
+              sessionCounterEnabled={settings.sessionCounterEnabled}
+              showSessionTimeRemainingInStatsOverlay={settings.showSessionTimeRemainingInStatsOverlay}
+              sessionTimeRemainingSeconds={sessionTimeRemainingSeconds}
+              sessionClockShowEveryMinutes={settings.sessionClockShowEveryMinutes}
+              sessionClockShowDurationSeconds={settings.sessionClockShowDurationSeconds}
+              streamWarning={streamWarning}
+              isFullscreen={sessionFullscreen || !!document.fullscreenElement}
+              isConnecting={streamStatus === "connecting"}
+              streamRevealComplete={streamRevealComplete}
+              isStreaming={isStreaming}
+              recordingBitrateMbps={settings.recordingBitrateMbps}
+              gameTitle={streamingGame?.title ?? t("app.labels.game")}
+              platformStore={streamingStore ?? undefined}
+              onToggleFullscreen={() => {
+                void toggleSessionFullscreen();
+              }}
+              onConfirmExit={handleExitPromptConfirm}
+              onCancelExit={handleExitPromptCancel}
+              onEndSession={() => {
+                void handlePromptedStopStream();
+              }}
+              onToggleMicrophone={() => {
+                clientRef.current?.toggleMicrophone();
+              }}
+              mouseSensitivity={settings.mouseSensitivity}
+              onMouseSensitivityChange={handleMouseSensitivityChange}
+              mouseAcceleration={settings.mouseAcceleration}
+              onMouseAccelerationChange={handleMouseAccelerationChange}
+              microphoneMode={settings.microphoneMode}
+              onMicrophoneModeChange={handleMicrophoneModeChange}
+              onScreenshotShortcutChange={(value) => {
+                void updateSetting("shortcutScreenshot", value);
+              }}
+              onRecordingShortcutChange={(value) => {
+                void updateSetting("shortcutToggleRecording", value);
+              }}
+              onShowSessionTimeRemainingInStatsOverlayChange={(value) => {
+                void updateSetting("showSessionTimeRemainingInStatsOverlay", value);
+              }}
+              subscriptionInfo={subscriptionInfo}
+              micTrack={clientRef.current?.getMicTrack() ?? null}
+              onRequestPointerLock={handleRequestPointerLock}
+              onReleasePointerLock={() => {
+                void releasePointerLockIfNeeded();
+              }}
+              onNativeInputPaused={setNativeInputPaused}
+              allowEscapeToExitFullscreen={settings.allowEscapeToExitFullscreen}
+              videoShader={settings.videoShader}
+              onVideoShaderChange={handleVideoShaderChange}
+            />
+          </m.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence
+        initial={false}
+        onExitComplete={() => setLaunchSurfacePresent(false)}
+      >
+        {showDesktopLaunchLoading && (
+          <m.div
+            key="stream-loading-transition"
+            className={`stream-loading-transition${streamRevealPhase === "revealing" && !launchError ? " stream-loading-transition--warping" : ""}`}
+            initial={{ opacity: 1, scale: 1 }}
+            animate={streamRevealPhase === "revealing" && !launchError
+              ? { opacity: 0, scale: 1.025 }
+              : { opacity: 1, scale: 1 }}
+            exit={{ opacity: 0 }}
+            transition={streamRevealPhase === "revealing" && !launchError
+              ? streamRevealTransition
+              : { duration: reducedMotion ? 0 : 0.16 }}
+            onAnimationComplete={() => {
+              if (streamRevealPhase === "revealing" && !launchError) {
+                setStreamRevealPhase("revealed");
+              }
+            }}
+          >
+            <StreamLoading
+              gameTitle={streamingGame?.title ?? t("app.labels.game")}
+              gameCover={streamingGame?.imageUrl}
+              platformStore={streamingStore ?? undefined}
+              status={loadingStatus}
+              queuePosition={queuePosition}
+              adState={effectiveAdState}
+              activeAd={activeQueueAd}
+              activeAdMediaUrl={activeQueueAdMediaUrl}
+              onAdPlaybackEvent={handleQueueAdPlaybackEvent}
+              adPreviewRef={queueAdPreviewRef}
+              error={launchError ? {
+                title: launchError.title,
+                description: launchError.description,
+                code: launchError.codeLabel,
+                actionLabel: launchError.actionLabel,
+              } : undefined}
+              onErrorAction={launchError?.action ? handleLaunchErrorAction : undefined}
+              onCancel={() => {
+                if (launchError) {
+                  void handleDismissLaunchError();
+                  return;
+                }
+                void handlePromptedStopStream();
+              }}
+            />
+          </m.div>
+        )}
+      </AnimatePresence>
+
       <SettingsModalHost
         open={currentPage === "settings"}
         onClose={handleCloseSettings}
-        onExitComplete={handleSettingsExitComplete}
+        onExitComplete={() => setSettingsSurfacePresent(false)}
       >
-        {settingsMounted && (
-          <SettingsPage
-            settings={settings}
-            regions={regions}
-            codecResults={codecResults}
-            codecTesting={codecTesting}
-            onRunCodecTest={runCodecTest}
-            onSettingChange={updateSetting}
-            onClose={handleCloseSettings}
-            focusSection={settingsFocusSection}
-            onOpenWhatsNew={handleOpenWhatsNew}
-          />
-        )}
+        <SettingsPage
+          settings={settings}
+          regions={regions}
+          codecResults={codecResults}
+          codecTesting={codecTesting}
+          onRunCodecTest={runCodecTest}
+          onSettingPreview={previewSetting}
+          onSettingChange={updateSetting}
+          onClose={handleCloseSettings}
+          focusSection={settingsFocusSection}
+          onOpenWhatsNew={handleOpenWhatsNew}
+        />
       </SettingsModalHost>
       {logoutConfirmModal}
       {removeAccountConfirmModal}
@@ -3907,13 +3957,11 @@ export function App(): JSX.Element {
           onCancel={handleQueueModalCancel}
         />
       )}
-      {releaseHighlightsPayload && (
-        <ReleaseHighlightsModal
-          payload={releaseHighlightsPayload}
-          version={releaseHighlightsPayload.version}
-          onDismiss={handleDismissReleaseHighlights}
-        />
-      )}
+      <ReleaseHighlightsModal
+        payload={releaseHighlightsPayload}
+        onDismiss={handleDismissReleaseHighlights}
+        onExitComplete={() => setReleaseHighlightsSurfacePresent(false)}
+      />
     </div>
   );
 }

--- a/opennow-stable/src/renderer/src/components/GameCard.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCard.tsx
@@ -1,5 +1,5 @@
 import { Play, Monitor } from "lucide-react";
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { JSX } from "react";
 import { m } from "motion/react";
 import { normalizeGameStore } from "@shared/gfn";
@@ -11,6 +11,7 @@ import { useTranslation } from "../i18n";
 interface GameCardProps {
   game: GameInfo;
   isSelected?: boolean;
+  surface?: "home" | "library";
   onPlay: () => void;
   onSelect: () => void;
   selectedVariantId?: string;
@@ -133,10 +134,17 @@ const StoreBrandIcon = memo(function StoreBrandIcon({ store }: { store: string }
   return <IconComponent />;
 });
 
+const GAME_CARD_FALLBACK_ASPECT: Record<"home" | "library", number> = {
+  home: 56.25,
+  library: 150,
+};
+const gameCardAspectByImageUrl = new Map<string, number>();
+
 function gameCardPropsAreEqual(prev: GameCardProps, next: GameCardProps): boolean {
   return (
     prev.game === next.game
     && prev.isSelected === next.isSelected
+    && prev.surface === next.surface
     && prev.selectedVariantId === next.selectedVariantId
     && prev.onPlay === next.onPlay
     && prev.onSelect === next.onSelect
@@ -147,6 +155,7 @@ function gameCardPropsAreEqual(prev: GameCardProps, next: GameCardProps): boolea
 export const GameCard = memo(function GameCard({
   game,
   isSelected = false,
+  surface = "home",
   onPlay,
   onSelect,
   selectedVariantId,
@@ -166,16 +175,29 @@ export const GameCard = memo(function GameCard({
     [game, selectedVariantId],
   );
 
-  const [aspectPct, setAspectPct] = useState<number | undefined>(undefined);
+  const fallbackAspectPct = GAME_CARD_FALLBACK_ASPECT[surface];
+  const [aspectPct, setAspectPct] = useState(
+    () => (game.imageUrl ? gameCardAspectByImageUrl.get(game.imageUrl) : undefined) ?? fallbackAspectPct,
+  );
+
+  useEffect(() => {
+    setAspectPct(
+      (game.imageUrl ? gameCardAspectByImageUrl.get(game.imageUrl) : undefined) ?? fallbackAspectPct,
+    );
+  }, [fallbackAspectPct, game.imageUrl]);
 
   const handleImageLoad = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
     const img = event.currentTarget;
     const w = img.naturalWidth;
     const h = img.naturalHeight;
     if (w && h) {
-      setAspectPct((h / w) * 100);
+      const measuredAspectPct = (h / w) * 100;
+      if (game.imageUrl) {
+        gameCardAspectByImageUrl.set(game.imageUrl, measuredAspectPct);
+      }
+      setAspectPct(measuredAspectPct);
     }
-  }, []);
+  }, [game.imageUrl]);
 
   const handlePlayClick = (event: React.MouseEvent): void => {
     event.stopPropagation();

--- a/opennow-stable/src/renderer/src/components/GameCardListItem.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCardListItem.tsx
@@ -12,6 +12,7 @@ export interface GameCardListItemProps {
   game: GameInfo;
   selectedVariantId?: string;
   isSelected?: boolean;
+  surface?: "home" | "library";
   actionsRef: RefObject<CatalogCardActions>;
 }
 
@@ -23,6 +24,7 @@ function gameCardListItemPropsAreEqual(
     prev.game === next.game
     && prev.selectedVariantId === next.selectedVariantId
     && prev.isSelected === next.isSelected
+    && prev.surface === next.surface
     && prev.actionsRef === next.actionsRef
   );
 }
@@ -31,6 +33,7 @@ export const GameCardListItem = memo(function GameCardListItem({
   game,
   selectedVariantId,
   isSelected = false,
+  surface = "home",
   actionsRef,
 }: GameCardListItemProps) {
   const handleSelect = useCallback(() => {
@@ -50,6 +53,7 @@ export const GameCardListItem = memo(function GameCardListItem({
       game={game}
       isSelected={isSelected}
       selectedVariantId={selectedVariantId}
+      surface={surface}
       onSelect={handleSelect}
       onPlay={handlePlay}
       onSelectStore={handleSelectStore}

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -6,7 +6,7 @@ import { isOwnedLibraryStatus } from "@shared/gfn";
 import type { CatalogFilterGroup, CatalogSortOption, GameInfo, GamePanelResult, GameVariant } from "@shared/gfn";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
-import { appendImageType, appendUnique, gameMatchesActiveSession } from "../lib/controllerCatalogUi";
+import { appendImageType, appendUnique } from "../lib/controllerCatalogUi";
 import { useTranslation } from "../i18n";
 import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
 import { pageTransition, panelSpring } from "./MotionProvider";
@@ -54,6 +54,7 @@ export interface HomePageProps {
   totalCount: number;
   supportedCount: number;
   controllerMode?: boolean;
+  surfaceActive?: boolean;
   storePanels?: GamePanelResult[];
   storeHeroGames?: GameInfo[];
   activeSessionAppIds?: number[];
@@ -91,6 +92,20 @@ function getControllerStoreLogoUrl(game: GameInfo): string | undefined {
     ?? game.imageUrlsByType?.TITLE_LOGO?.[0];
 }
 
+function preloadControllerHeroImage(imageUrl: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const image = new Image();
+    image.decoding = "async";
+    image.onload = () => {
+      void image.decode()
+        .catch(() => undefined)
+        .then(() => resolve(image.naturalWidth > 0));
+    };
+    image.onerror = () => resolve(false);
+    image.src = imageUrl;
+  });
+}
+
 function getSelectedVariant(game: GameInfo, selectedVariantId?: string): GameVariant | undefined {
   return game.variants.find((variant) => variant.id === selectedVariantId)
     ?? game.variants[game.selectedVariantIndex]
@@ -103,13 +118,6 @@ function storeVariantIsOwned(variant: GameVariant | undefined): boolean {
 
 function getVariantDisplayName(variant: GameVariant | undefined, fallback: string): string {
   return variant?.store ? getStoreDisplayName(variant.store) : fallback;
-}
-
-function getPurchaseUrl(game: GameInfo, selectedVariantId?: string): string | undefined {
-  const selectedVariant = getSelectedVariant(game, selectedVariantId);
-  if (selectedVariant?.storeUrl) return selectedVariant.storeUrl;
-  return game.variants.find((variant) => !storeVariantIsOwned(variant) && variant.storeUrl)?.storeUrl
-    ?? game.variants.find((variant) => variant.storeUrl)?.storeUrl;
 }
 
 function gameNeedsPurchase(game: GameInfo, selectedVariantId?: string): boolean {
@@ -177,8 +185,8 @@ function ControllerStoreTile({
         onPlay();
       }}
       aria-label={game.title}
-      animate={{ scale: focused ? 1.055 : 1 }}
-      whileTap={{ scale: 0.98 }}
+      animate={{ y: focused ? -7 : 0, scale: focused ? 1.035 : 1 }}
+      whileTap={{ y: focused ? -5 : 0, scale: 0.98 }}
       transition={panelSpring}
     >
       <span className="controller-store-tile-art">
@@ -238,6 +246,7 @@ export const HomePage = memo(function HomePage({
   totalCount,
   supportedCount,
   controllerMode = false,
+  surfaceActive = true,
   storePanels = [],
   storeHeroGames = [],
   activeSessionAppIds: _activeSessionAppIds = [],
@@ -262,6 +271,7 @@ export const HomePage = memo(function HomePage({
   const gamepadPreviousButtonsRef = useRef(0);
   const gamepadLastMoveAtRef = useRef(0);
   const gamepadFrameRef = useRef<number | null>(null);
+  const pendingScrollFrameRef = useRef<number | null>(null);
   const controllerInputStateRef = useRef({
     focusTile: (_row: number, _column: number): void => {},
     launchFocusedTile: (): void => {},
@@ -269,6 +279,23 @@ export const HomePage = memo(function HomePage({
     focusedRowIndex: 0,
     focusedColumnIndex: 0,
   });
+
+  useEffect(() => {
+    if (surfaceActive) return undefined;
+    if (pendingScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingScrollFrameRef.current);
+      pendingScrollFrameRef.current = null;
+    }
+    gamepadPreviousButtonsRef.current = 0;
+    gamepadLastMoveAtRef.current = 0;
+    return undefined;
+  }, [surfaceActive]);
+
+  useEffect(() => () => {
+    if (pendingScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingScrollFrameRef.current);
+    }
+  }, []);
 
   const controllerSections = useMemo(
     () => storePanels.flatMap((panel) => panel.sections).filter((section) => section.games.length > 0),
@@ -280,7 +307,7 @@ export const HomePage = memo(function HomePage({
   );
 
   const focusTile = (rowIndex: number, columnIndex: number): void => {
-    if (controllerSections.length === 0) return;
+    if (!surfaceActive || controllerSections.length === 0) return;
     const nextRowIndex = Math.max(0, Math.min(rowIndex, controllerSections.length - 1));
     const row = controllerSections[nextRowIndex];
     if (!row || row.games.length === 0) return;
@@ -289,7 +316,12 @@ export const HomePage = memo(function HomePage({
     setFocusedRowIndex(nextRowIndex);
     setFocusedColumnIndex(nextColumnIndex);
     onSelectGame(nextGame.id);
-    window.requestAnimationFrame(() => {
+    if (pendingScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingScrollFrameRef.current);
+    }
+    pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
+      pendingScrollFrameRef.current = null;
+      if (!surfaceActive) return;
       const tile = rowRefs.current[nextRowIndex]?.querySelector<HTMLElement>(`[data-controller-store-column="${nextColumnIndex}"]`);
       tile?.scrollIntoView({ inline: "nearest", block: "nearest", behavior: "auto" });
       tile?.closest(".controller-store-section")?.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "auto" });
@@ -330,32 +362,57 @@ export const HomePage = memo(function HomePage({
   }, [cycleFocusedVariant, focusedColumnIndex, focusedRowIndex, focusTile, launchFocusedTile]);
 
   useEffect(() => {
-    if (!controllerMode || !controllerSearchOpen) return;
+    if (!controllerMode || !surfaceActive || !controllerSearchOpen) return;
     controllerSearchInputRef.current?.focus();
-  }, [controllerMode, controllerSearchOpen]);
+  }, [controllerMode, controllerSearchOpen, surfaceActive]);
 
   useEffect(() => {
-    if (!controllerMode) return;
+    if (!controllerMode || !surfaceActive) return;
     setControllerHeroIndex(0);
-  }, [controllerHeroGames, controllerMode]);
+  }, [controllerHeroGames, controllerMode, surfaceActive]);
 
   useEffect(() => {
-    if (!controllerMode || controllerHeroGames.length <= 1) return;
+    if (!controllerMode || !surfaceActive || controllerHeroGames.length <= 1) return;
+    let cancelled = false;
+    let advancing = false;
+
+    const advanceHero = async (): Promise<void> => {
+      if (advancing) return;
+      advancing = true;
+      try {
+        for (let offset = 1; offset < controllerHeroGames.length; offset += 1) {
+          const nextIndex = (controllerHeroIndex + offset) % controllerHeroGames.length;
+          const nextGame = controllerHeroGames[nextIndex];
+          const nextImageUrl = nextGame ? getControllerStoreImageCandidates(nextGame, true)[0] : undefined;
+          if (!nextImageUrl || await preloadControllerHeroImage(nextImageUrl)) {
+            if (!cancelled) setControllerHeroIndex(nextIndex);
+            return;
+          }
+          if (cancelled) return;
+        }
+      } finally {
+        advancing = false;
+      }
+    };
+
     const interval = window.setInterval(() => {
-      setControllerHeroIndex((index) => (index + 1) % controllerHeroGames.length);
+      void advanceHero();
     }, CONTROLLER_STORE_HERO_ROTATION_MS);
-    return () => window.clearInterval(interval);
-  }, [controllerHeroGames.length, controllerMode]);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [controllerHeroIndex, controllerHeroGames, controllerMode, surfaceActive]);
 
   useEffect(() => {
-    if (!controllerMode || controllerSections.length === 0) return;
+    if (!controllerMode || !surfaceActive || controllerSections.length === 0) return;
     const currentRow = controllerSections[focusedRowIndex];
     if (currentRow?.games.some((game) => game.id === selectedGameId)) return;
     focusTile(0, 0);
-  }, [controllerMode, controllerSections, focusedRowIndex, selectedGameId]);
+  }, [controllerMode, controllerSections, focusedRowIndex, selectedGameId, surfaceActive]);
 
   useEffect(() => {
-    if (!controllerMode) return;
+    if (!controllerMode || !surfaceActive) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (controllerSearchOpen) {
         if (event.key === "Escape") {
@@ -401,10 +458,10 @@ export const HomePage = memo(function HomePage({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [controllerMode, controllerSearchOpen, cycleFocusedVariant, focusedColumnIndex, focusedRowIndex, focusTile, launchFocusedTile, onNextControllerPage, onPreviousControllerPage]);
+  }, [controllerMode, controllerSearchOpen, cycleFocusedVariant, focusedColumnIndex, focusedRowIndex, focusTile, launchFocusedTile, onNextControllerPage, onPreviousControllerPage, surfaceActive]);
 
   useEffect(() => {
-    if (!controllerMode) return;
+    if (!controllerMode || !surfaceActive) return;
     const readButtons = (): number => {
       const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
       return readControllerGamepadButtons(pad);
@@ -483,7 +540,7 @@ export const HomePage = memo(function HomePage({
       window.removeEventListener("gamepaddisconnected", handleDisconnect);
       stopGamepadNavigation();
     };
-  }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage]);
+  }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage, surfaceActive]);
 
   const gameGridItems = useMemo(
     () => games.map((game) => (
@@ -492,6 +549,7 @@ export const HomePage = memo(function HomePage({
         game={game}
         isSelected={game.id === selectedGameId}
         selectedVariantId={selectedVariantByGameId[game.id]}
+        surface="home"
         actionsRef={catalogActionsRef}
       />
     )),

--- a/opennow-stable/src/renderer/src/components/LazyShaderAtmosphere.tsx
+++ b/opennow-stable/src/renderer/src/components/LazyShaderAtmosphere.tsx
@@ -10,6 +10,7 @@ const ShaderAtmosphereCanvas = lazy(async () => {
 export function LazyShaderAtmosphere({
   variant = "controller",
   className,
+  active = true,
 }: ShaderAtmosphereProps): JSX.Element {
   const fallbackClassName = [
     "shader-atmosphere",
@@ -19,7 +20,7 @@ export function LazyShaderAtmosphere({
 
   return (
     <Suspense fallback={<div className={fallbackClassName} aria-hidden="true" />}>
-      <ShaderAtmosphereCanvas variant={variant} className={className} />
+      <ShaderAtmosphereCanvas variant={variant} className={className} active={active} />
     </Suspense>
   );
 }

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, m } from "motion/react";
 import type { CatalogSortOption, GameInfo } from "@shared/gfn";
 import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
 import type { PlaytimeData } from "../lib/gameCatalog";
-import { getControllerFeaturedGames } from "../lib/controllerCatalogUi";
+import { getControllerFeaturedGames, getControllerHeroBackgroundCandidates } from "../lib/controllerCatalogUi";
 import {
   gameMatchesLibraryFilters,
   gameMatchesStoreFilter,
@@ -45,6 +45,7 @@ export interface LibraryPageProps {
   selectedSortId: string;
   onSortChange: (sortId: string) => void;
   controllerMode?: boolean;
+  surfaceActive?: boolean;
   featuredGames?: GameInfo[];
   activeSessionAppIds?: number[];
   onPreviousControllerPage?: () => void;
@@ -69,6 +70,7 @@ export const LibraryPage = memo(function LibraryPage({
   selectedSortId,
   onSortChange,
   controllerMode = false,
+  surfaceActive = true,
   featuredGames = [],
   activeSessionAppIds = [],
   onPreviousControllerPage,
@@ -91,6 +93,7 @@ export const LibraryPage = memo(function LibraryPage({
   const gamepadPreviousButtonsRef = useRef(0);
   const gamepadLastMoveAtRef = useRef(0);
   const gamepadFrameRef = useRef<number | null>(null);
+  const pendingScrollFrameRef = useRef<number | null>(null);
   const controllerYPressedAtRef = useRef(0);
   const controllerYConsumedByHoldRef = useRef(false);
   const controllerGameRowRef = useRef<HTMLDivElement | null>(null);
@@ -111,9 +114,28 @@ export const LibraryPage = memo(function LibraryPage({
   });
 
   useEffect(() => {
-    if (!controllerMode || !controllerSearchOpen) return;
+    if (surfaceActive) return undefined;
+    if (pendingScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingScrollFrameRef.current);
+      pendingScrollFrameRef.current = null;
+    }
+    gamepadPreviousButtonsRef.current = 0;
+    gamepadLastMoveAtRef.current = 0;
+    controllerYPressedAtRef.current = 0;
+    controllerYConsumedByHoldRef.current = false;
+    return undefined;
+  }, [surfaceActive]);
+
+  useEffect(() => () => {
+    if (pendingScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingScrollFrameRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!controllerMode || !surfaceActive || !controllerSearchOpen) return;
     controllerSearchInputRef.current?.focus();
-  }, [controllerMode, controllerSearchOpen]);
+  }, [controllerMode, controllerSearchOpen, surfaceActive]);
 
   const librarySearchHasQuery = searchQuery.trim().length > 0;
   const libraryFilterGroups = useMemo(
@@ -144,10 +166,10 @@ export const LibraryPage = memo(function LibraryPage({
   }, [libraryFilterGroups]);
 
   useEffect(() => {
-    if (controllerMode || visibleLibraryGames.length === 0) return;
+    if (!surfaceActive || controllerMode || visibleLibraryGames.length === 0) return;
     if (visibleLibraryGames.some((game) => game.id === selectedGameId)) return;
     onSelectGame(visibleLibraryGames[0].id);
-  }, [controllerMode, onSelectGame, selectedGameId, visibleLibraryGames]);
+  }, [controllerMode, onSelectGame, selectedGameId, surfaceActive, visibleLibraryGames]);
 
   const toggleLibraryFilter = (filterId: string): void => {
     setSelectedLibraryFilterIds((previous) => (
@@ -175,9 +197,9 @@ export const LibraryPage = memo(function LibraryPage({
   );
 
   useEffect(() => {
-    if (!controllerMode) return;
+    if (!controllerMode || !surfaceActive) return;
     setControllerHeroIndex(0);
-  }, [controllerMode, controllerStoreFilterId, controllerFeaturedGames.length, controllerFeaturedGames[0]?.id]);
+  }, [controllerMode, controllerStoreFilterId, controllerFeaturedGames.length, controllerFeaturedGames[0]?.id, surfaceActive]);
 
   useEffect(() => {
     if (controllerMode) return;
@@ -186,18 +208,43 @@ export const LibraryPage = memo(function LibraryPage({
   }, [controllerMode]);
 
   useEffect(() => {
-    if (!controllerMode || controllerFeaturedGames.length <= 1) return;
+    if (!controllerMode || !surfaceActive || controllerFeaturedGames.length <= 1) return;
+    let cancelled = false;
+    let advancing = false;
     const interval = window.setInterval(() => {
-      setControllerHeroIndex((index) => (index + 1) % controllerFeaturedGames.length);
+      if (advancing) return;
+      advancing = true;
+      const nextIndex = (controllerHeroIndex + 1) % controllerFeaturedGames.length;
+      const nextGame = controllerFeaturedGames[nextIndex];
+      const nextImageUrl = nextGame ? getControllerHeroBackgroundCandidates(nextGame)[0] : undefined;
+      if (!nextImageUrl) {
+        if (!cancelled) setControllerHeroIndex(nextIndex);
+        advancing = false;
+        return;
+      }
+
+      const image = new Image();
+      image.src = nextImageUrl;
+      void image.decode()
+        .catch(() => undefined)
+        .then(() => {
+          if (!cancelled) setControllerHeroIndex(nextIndex);
+        })
+        .finally(() => {
+          advancing = false;
+        });
     }, CONTROLLER_HERO_ROTATION_MS);
-    return () => window.clearInterval(interval);
-  }, [controllerMode, controllerFeaturedGames.length]);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [controllerHeroIndex, controllerMode, controllerFeaturedGames, surfaceActive]);
 
   useEffect(() => {
-    if (!controllerMode || games.length === 0) return;
+    if (!controllerMode || !surfaceActive || games.length === 0) return;
     if (controllerGames.some((game) => game.id === selectedGameId)) return;
     onSelectGame(controllerGames[0]?.id ?? games[0].id);
-  }, [controllerGames, controllerMode, games, onSelectGame, selectedGameId]);
+  }, [controllerGames, controllerMode, games, onSelectGame, selectedGameId, surfaceActive]);
 
   useEffect(() => {
     if (controllerStoreFilterItems.some((item) => item.id === controllerStoreFilterId)) return;
@@ -209,11 +256,16 @@ export const LibraryPage = memo(function LibraryPage({
   const selectedControllerGame = controllerGames[selectedControllerGameIndex] ?? controllerGames[0];
 
   const focusControllerGame = (index: number): void => {
-    if (controllerGames.length === 0) return;
+    if (!surfaceActive || controllerGames.length === 0) return;
     const nextIndex = Math.max(0, Math.min(index, controllerGames.length - 1));
     const nextGame = controllerGames[nextIndex];
     onSelectGame(nextGame.id);
-    window.requestAnimationFrame(() => {
+    if (pendingScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingScrollFrameRef.current);
+    }
+    pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
+      pendingScrollFrameRef.current = null;
+      if (!surfaceActive) return;
       const row = controllerGameRowRef.current;
       const card = row?.querySelector<HTMLElement>(`[data-controller-game-id="${CSS.escape(nextGame.id)}"]`);
       card?.scrollIntoView({ inline: "nearest", block: "nearest", behavior: "auto" });
@@ -283,7 +335,7 @@ export const LibraryPage = memo(function LibraryPage({
   };
 
   useEffect(() => {
-    if (!controllerMode) return;
+    if (!controllerMode || !surfaceActive) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (detailsGame) {
         if (event.key === "Escape" || event.key.toLowerCase() === "b") {
@@ -334,10 +386,10 @@ export const LibraryPage = memo(function LibraryPage({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [controllerMode, controllerSearchOpen, detailsGame, onNextControllerPage, onPlayGame, onPreviousControllerPage, selectedControllerGame, selectedControllerGameIndex]);
+  }, [controllerMode, controllerSearchOpen, detailsGame, onNextControllerPage, onPlayGame, onPreviousControllerPage, selectedControllerGame, selectedControllerGameIndex, surfaceActive]);
 
   useEffect(() => {
-    if (!controllerMode) return;
+    if (!controllerMode || !surfaceActive) return;
     const readButtons = (): number => {
       const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
       return readControllerGamepadButtons(pad);
@@ -454,7 +506,7 @@ export const LibraryPage = memo(function LibraryPage({
       window.removeEventListener("gamepaddisconnected", handleDisconnect);
       stopGamepadNavigation();
     };
-  }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage]);
+  }, [controllerMode, controllerSearchOpen, onNextControllerPage, onPreviousControllerPage, surfaceActive]);
 
   const libraryGridItems = useMemo(
     () => visibleLibraryGames.map((game) => (
@@ -463,6 +515,7 @@ export const LibraryPage = memo(function LibraryPage({
           game={game}
           isSelected={game.id === selectedGameId}
           selectedVariantId={selectedVariantByGameId[game.id]}
+          surface="library"
           actionsRef={catalogActionsRef}
         />
         <div

--- a/opennow-stable/src/renderer/src/components/MotionProvider.tsx
+++ b/opennow-stable/src/renderer/src/components/MotionProvider.tsx
@@ -10,6 +10,32 @@ export const pageTransition = {
   ease: smoothEase,
 } as const;
 
+export const largeSurfaceTransition = {
+  duration: 0.28,
+  ease: smoothEase,
+} as const;
+
+export const compactDialogTransition = {
+  duration: 0.2,
+  ease: smoothEase,
+} as const;
+
+export const disclosureTransition = {
+  duration: 0.24,
+  ease: smoothEase,
+} as const;
+
+export const streamRevealTransition = {
+  duration: 0.62,
+  ease: standardEase,
+} as const;
+
+export const statusPulseTransition = {
+  duration: 1.8,
+  repeat: Infinity,
+  ease: "easeInOut",
+} as const;
+
 /** Shared reveal timing for floating panels (stats HUD, settings modal, etc.). */
 export const surfaceRevealTransition = {
   duration: 0.34,
@@ -30,12 +56,36 @@ export const overlayMotion = {
   transition: { duration: 0.18, ease: standardEase },
 } as const;
 
+export const largeSurfaceMotion = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: 8 },
+  transition: largeSurfaceTransition,
+} as const;
+
 export const dialogMotion = {
   initial: { opacity: 0, scale: 0.97, y: 10 },
   animate: { opacity: 1, scale: 1, y: 0 },
   exit: { opacity: 0, scale: 0.985, y: 6 },
-  transition: { duration: 0.2, ease: smoothEase },
+  transition: compactDialogTransition,
 } as const;
+
+export function getStatusPulseMotion(reducedMotion: boolean | null): {
+  animate: { opacity: number | number[]; scale: number | number[] };
+  transition: typeof statusPulseTransition | { duration: 0 };
+} {
+  if (reducedMotion) {
+    return {
+      animate: { opacity: 1, scale: 1 },
+      transition: { duration: 0 },
+    };
+  }
+
+  return {
+    animate: { opacity: [0.55, 1, 0.55], scale: [0.94, 1.06, 0.94] },
+    transition: statusPulseTransition,
+  };
+}
 
 export const spinnerTransition = {
   duration: 0.85,

--- a/opennow-stable/src/renderer/src/components/Navbar.tsx
+++ b/opennow-stable/src/renderer/src/components/Navbar.tsx
@@ -1,10 +1,10 @@
 import type { ActiveSessionInfo, AuthUser, SavedAccount, SubscriptionInfo } from "@shared/gfn";
 import { House, Library, Settings, User, Timer, HardDrive, X, PlayCircle, Square, ChevronDown, Check, Plus, Store as StoreIcon } from "lucide-react";
 import { useEffect, useRef, useState, type JSX } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "../i18n";
 import { OpenNowLogoMark } from "./OpenNowLogoMark";
 import { MotionSpinner } from "./MotionSpinner";
+import { ModalSurface } from "./ui/ModalSurface";
 
 interface NavbarProps {
   currentPage: "home" | "library" | "settings";
@@ -19,9 +19,10 @@ interface NavbarProps {
   onTerminateSession: () => void;
   savedAccounts: SavedAccount[];
   onSwitchAccount: (userId: string) => void;
-  onRemoveAccount: (userId: string) => void;
+  onRemoveAccount: (userId: string, restoreFocusTarget?: HTMLElement) => void;
   onAddAccount: () => void;
-  onLogoutAll: () => void;
+  onLogoutAll: (restoreFocusTarget?: HTMLElement) => void;
+  onBlockingOverlayChange?: (blocking: boolean) => void;
   controllerMode?: boolean;
 }
 
@@ -50,12 +51,21 @@ export function Navbar({
   onRemoveAccount,
   onAddAccount,
   onLogoutAll,
+  onBlockingOverlayChange,
   controllerMode = false,
 }: NavbarProps): JSX.Element {
   const { t } = useTranslation();
   const [modalType, setModalType] = useState<NavbarModalType>(null);
   const [accountDropdownOpen, setAccountDropdownOpen] = useState(false);
   const accountContainerRef = useRef<HTMLDivElement | null>(null);
+  const accountButtonRef = useRef<HTMLButtonElement | null>(null);
+  const modalCloseButtonRef = useRef<HTMLButtonElement | null>(null);
+  const modalTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const retainedModalTypeRef = useRef<Exclude<NavbarModalType, null> | null>(null);
+  if (modalType) {
+    retainedModalTypeRef.current = modalType;
+  }
+  const renderedModalType = retainedModalTypeRef.current;
 
   const navItems = controllerMode
     ? [
@@ -146,7 +156,7 @@ export function Navbar({
   const spanStart = formatDateTime(subscription?.currentSpanStartDateTime);
   const spanEnd = formatDateTime(subscription?.currentSpanEndDateTime);
   const firstEntitlementStart = formatDateTime(subscription?.firstEntitlementStartDateTime);
-  const modalTitle = modalType === "time" ? t("navbar.playtimeDetails") : t("navbar.storageDetails");
+  const modalTitle = renderedModalType === "time" ? t("navbar.playtimeDetails") : t("navbar.storageDetails");
   const activeSessionTitle = activeSessionGameTitle?.trim() || null;
   const activeUserId = user?.userId ?? null;
 
@@ -161,45 +171,46 @@ export function Navbar({
     return () => window.removeEventListener("mousedown", onDocumentPointerDown);
   }, [accountDropdownOpen]);
 
-  useEffect(() => {
-    if (!modalType) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setModalType(null);
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      window.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [modalType]);
+  const closeModal = (): void => setModalType(null);
+  const openModal = (
+    nextModalType: Exclude<NavbarModalType, null>,
+    trigger: HTMLButtonElement,
+  ): void => {
+    modalTriggerRef.current = trigger;
+    onBlockingOverlayChange?.(true);
+    setModalType(nextModalType);
+  };
 
-  const modal = modalType && subscription
-    ? createPortal(
-        <div className="navbar-modal-backdrop" onClick={() => setModalType(null)}>
-          <div
-            className="navbar-modal"
-            role="dialog"
-            aria-modal="true"
-            aria-label={modalTitle}
-            onClick={(event) => event.stopPropagation()}
-          >
+  const modal = subscription
+    ? (
+        <ModalSurface
+          open={modalType !== null}
+          onClose={closeModal}
+          onExitComplete={() => onBlockingOverlayChange?.(false)}
+          motion="compact"
+          overlayClassName="navbar-modal-backdrop"
+          backdropClassName="navbar-modal-scrim"
+          panelClassName="navbar-modal"
+          ariaLabel={modalTitle}
+          backdropLabel={t("app.actions.close")}
+          initialFocusRef={modalCloseButtonRef}
+          restoreFocusRef={modalTriggerRef}
+        >
             <div className="navbar-modal-header">
               <h3>{modalTitle}</h3>
               <button
+                ref={modalCloseButtonRef}
                 type="button"
                 className="navbar-modal-close"
-                onClick={() => setModalType(null)}
+                onClick={closeModal}
                 title={t("app.actions.close")}
+                aria-label={t("app.actions.close")}
               >
                 <X size={16} />
               </button>
             </div>
 
-            {modalType === "time" && (
+            {renderedModalType === "time" && (
               <div className="navbar-modal-body">
                 {!subscription.isUnlimited && timeTotal > 0 && (
                   <div className="navbar-meter">
@@ -250,7 +261,7 @@ export function Navbar({
               </div>
             )}
 
-            {modalType === "storage" && (
+            {renderedModalType === "storage" && (
               <div className="navbar-modal-body">
                 {storageHasData && (
                   <div className="navbar-meter">
@@ -284,9 +295,7 @@ export function Navbar({
                 )}
               </div>
             )}
-          </div>
-        </div>,
-        document.body,
+        </ModalSurface>
       )
     : null;
 
@@ -362,7 +371,7 @@ export function Navbar({
                 type="button"
                 className={`navbar-subscription-chip navbar-subscription-chip--${timeTone}`}
                 title={t("navbar.showPlaytimeDetails")}
-                onClick={() => setModalType("time")}
+                onClick={(event) => openModal("time", event.currentTarget)}
               >
                 <Timer size={14} />
                 <span>{timeLabel}</span>
@@ -373,7 +382,7 @@ export function Navbar({
                 type="button"
                 className={`navbar-subscription-chip navbar-subscription-chip--${storageTone}`}
                 title={t("navbar.showStorageDetails")}
-                onClick={() => setModalType("storage")}
+                onClick={(event) => openModal("storage", event.currentTarget)}
               >
                 <HardDrive size={14} />
                 <span>{storageLabel}</span>
@@ -385,6 +394,7 @@ export function Navbar({
           <>
             <div className="navbar-account-container" ref={accountContainerRef}>
               <button
+                ref={accountButtonRef}
                 type="button"
                 className="navbar-user navbar-user--clickable"
                 onClick={() => setAccountDropdownOpen((previous) => !previous)}
@@ -477,7 +487,7 @@ export function Navbar({
                               aria-label={t("auth.accounts.removeNamedAccount", { name: account.displayName })}
                               onClick={() => {
                                 setAccountDropdownOpen(false);
-                                onRemoveAccount(account.userId);
+                                onRemoveAccount(account.userId, accountButtonRef.current ?? undefined);
                               }}
                             >
                               <X size={12} />
@@ -506,7 +516,7 @@ export function Navbar({
                     role="menuitem"
                     onClick={() => {
                       setAccountDropdownOpen(false);
-                      onLogoutAll();
+                      onLogoutAll(accountButtonRef.current ?? undefined);
                     }}
                   >
                     {t("auth.accounts.signOutAllAccounts")}

--- a/opennow-stable/src/renderer/src/components/ReleaseHighlightsModal.tsx
+++ b/opennow-stable/src/renderer/src/components/ReleaseHighlightsModal.tsx
@@ -1,8 +1,8 @@
-import { createPortal } from "react-dom";
 import { ExternalLink, X } from "lucide-react";
-import type { JSX } from "react";
+import { useRef, type JSX } from "react";
 import type { ReleaseHighlightsPayload } from "@shared/gfn";
 import { useTranslation } from "../i18n";
+import { ModalSurface } from "./ui/ModalSurface";
 
 // ---------------------------------------------------------------------------
 // Simple inline markdown renderer
@@ -136,46 +136,50 @@ function renderMarkdown(markdown: string): JSX.Element[] {
 // ---------------------------------------------------------------------------
 
 export interface ReleaseHighlightsModalProps {
-  payload: ReleaseHighlightsPayload;
+  payload: ReleaseHighlightsPayload | null;
   /**
    * Called when the user dismisses the modal via "Got it".
    * The caller decides whether to ack (auto-show) or just close (manual-show).
    */
   onDismiss: () => void;
-  /** Called for manual "View on GitHub" link */
-  version: string;
+  onExitComplete?: () => void;
 }
 
 export function ReleaseHighlightsModal({
   payload,
   onDismiss,
-  version,
+  onExitComplete,
 }: ReleaseHighlightsModalProps): JSX.Element | null {
   const { t } = useTranslation();
+  const retainedPayloadRef = useRef<ReleaseHighlightsPayload | null>(payload);
+  const primaryActionRef = useRef<HTMLButtonElement | null>(null);
+  if (payload) {
+    retainedPayloadRef.current = payload;
+  }
+  const retainedPayload = retainedPayloadRef.current;
+  const githubReleaseUrl = retainedPayload
+    ? `https://github.com/OpenCloudGaming/OpenNOW/releases/tag/v${retainedPayload.version}`
+    : "";
 
-  const githubReleaseUrl = `https://github.com/OpenCloudGaming/OpenNOW/releases/tag/v${version}`;
-
-  if (typeof document === "undefined") return null;
-
-  return createPortal(
-    <div
-      className="rh-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-label={t("releaseHighlights.kicker")}
+  return (
+    <ModalSurface
+      open={payload !== null && retainedPayload !== null}
+      onClose={onDismiss}
+      onExitComplete={onExitComplete}
+      motion="large"
+      overlayClassName="rh-overlay"
+      backdropClassName="rh-backdrop"
+      panelClassName="rh-card"
+      ariaLabel={t("releaseHighlights.kicker")}
+      backdropLabel={t("app.actions.close")}
+      initialFocusRef={primaryActionRef}
     >
-      <button
-        type="button"
-        className="rh-backdrop"
-        onClick={onDismiss}
-        aria-label={t("app.actions.close")}
-      />
-
-      <div className="rh-card">
+      {retainedPayload ? (
+        <>
         {/* Header */}
         <div className="rh-header">
           <div className="rh-kicker">{t("releaseHighlights.kicker")}</div>
-          <h2 className="rh-title">{payload.title}</h2>
+          <h2 className="rh-title">{retainedPayload.title}</h2>
           <button
             type="button"
             className="rh-close-btn"
@@ -188,10 +192,10 @@ export function ReleaseHighlightsModal({
 
         {/* Scrollable body */}
         <div className="rh-body">
-          {payload.source === "fallback" ? (
+          {retainedPayload.source === "fallback" ? (
             <p className="rh-fallback-text">{t("releaseHighlights.unavailable")}</p>
           ) : (
-            <div className="rh-markdown">{renderMarkdown(payload.bodyMarkdown)}</div>
+            <div className="rh-markdown">{renderMarkdown(retainedPayload.bodyMarkdown)}</div>
           )}
         </div>
 
@@ -211,13 +215,13 @@ export function ReleaseHighlightsModal({
             type="button"
             className="rh-btn-primary"
             onClick={onDismiss}
-            autoFocus
+            ref={primaryActionRef}
           >
             {t("releaseHighlights.gotIt")}
           </button>
         </div>
-      </div>
-    </div>,
-    document.body,
+        </>
+      ) : null}
+    </ModalSurface>
   );
 }

--- a/opennow-stable/src/renderer/src/components/SessionStartedSplash.tsx
+++ b/opennow-stable/src/renderer/src/components/SessionStartedSplash.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
-import { AnimatePresence, m } from "motion/react";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { Check } from "lucide-react";
 import type { JSX } from "react";
-import { smoothEase } from "./MotionProvider";
+import { compactDialogTransition } from "./MotionProvider";
 import { useTranslation } from "../i18n";
 
 const CONNECTED_BADGE_VISIBLE_MS = 2400;
@@ -20,8 +20,7 @@ const badgeVariants = {
     y: 0,
     filter: "blur(0px)",
     transition: {
-      duration: 0.5,
-      ease: smoothEase,
+      ...compactDialogTransition,
     },
   },
   exit: {
@@ -29,7 +28,7 @@ const badgeVariants = {
     scale: 0.96,
     y: -20,
     filter: "blur(6px)",
-    transition: { duration: 0.34, ease: smoothEase },
+    transition: compactDialogTransition,
   },
 } as const;
 
@@ -44,6 +43,7 @@ export function SessionStartedSplash({
   onFinished,
 }: SessionStartedSplashProps): JSX.Element | null {
   const { t } = useTranslation();
+  const reducedMotion = useReducedMotion();
 
   useEffect(() => {
     if (!visible) {
@@ -60,10 +60,11 @@ export function SessionStartedSplash({
           className="sv-ready-splash"
           role="status"
           aria-live="polite"
-          variants={badgeVariants}
-          initial="hidden"
-          animate="visible"
-          exit="exit"
+          variants={reducedMotion ? undefined : badgeVariants}
+          initial={reducedMotion ? { opacity: 1, scale: 1, y: 0, filter: "blur(0px)" } : "hidden"}
+          animate={reducedMotion ? { opacity: 1, scale: 1, y: 0, filter: "blur(0px)" } : "visible"}
+          exit={reducedMotion ? { opacity: 0 } : "exit"}
+          transition={reducedMotion ? { duration: 0 } : undefined}
         >
           <span className="sv-ready-splash-card">
             <span className="sv-ready-splash-emblem" aria-hidden>

--- a/opennow-stable/src/renderer/src/components/SettingsModalHost.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsModalHost.tsx
@@ -1,13 +1,6 @@
-import { useEffect, useState, type JSX, type ReactNode } from "react";
-import { createPortal } from "react-dom";
-import { AnimatePresence, m } from "motion/react";
-import { smoothEase } from "./MotionProvider";
+import type { JSX, ReactNode } from "react";
 import { useTranslation } from "../i18n";
-
-const overlayExitTransition = {
-  duration: 0.22,
-  ease: smoothEase,
-} as const;
+import { ModalSurface } from "./ui/ModalSurface";
 
 export interface SettingsModalHostProps {
   open: boolean;
@@ -23,61 +16,20 @@ export function SettingsModalHost({
   children,
 }: SettingsModalHostProps): JSX.Element | null {
   const { t } = useTranslation();
-  const [contentReady, setContentReady] = useState(false);
 
-  useEffect(() => {
-    if (!open) {
-      return undefined;
-    }
-
-    setContentReady(false);
-    const frame = window.requestAnimationFrame(() => {
-      setContentReady(true);
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [open]);
-
-  const handleExitComplete = (): void => {
-    setContentReady(false);
-    onExitComplete?.();
-  };
-
-  if (typeof document === "undefined") {
-    return null;
-  }
-
-  return createPortal(
-    <AnimatePresence initial={false} onExitComplete={handleExitComplete}>
-      {open ? (
-        <m.div
-          key="settings-modal"
-          className="animated-modal-overlay"
-          role="dialog"
-          aria-modal="true"
-          aria-label={t("settings.title")}
-          initial={false}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={overlayExitTransition}
-        >
-          <button
-            type="button"
-            className="animated-modal-scrim"
-            onClick={onClose}
-            aria-label={t("app.actions.close")}
-          />
-
-          <div
-            className="animated-modal-panel settings-modal"
-            onClick={(event) => event.stopPropagation()}
-          >
-            {contentReady ? children : (
-              <div className="settings-modal-placeholder" aria-hidden />
-            )}
-          </div>
-        </m.div>
-      ) : null}
-    </AnimatePresence>,
-    document.body,
+  return (
+    <ModalSurface
+      open={open}
+      onClose={onClose}
+      onExitComplete={onExitComplete}
+      motion="large"
+      overlayClassName="animated-modal-overlay modal-portal-layer"
+      backdropClassName="animated-modal-scrim"
+      panelClassName="animated-modal-panel settings-modal"
+      ariaLabel={t("settings.title")}
+      backdropLabel={t("app.actions.close")}
+    >
+      {children}
+    </ModalSurface>
   );
 }

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -34,7 +34,8 @@ interface SettingsPageProps {
   codecResults: CodecTestResult[] | null;
   codecTesting: boolean;
   onRunCodecTest: () => Promise<void>;
-  onSettingChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  onSettingPreview: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  onSettingChange: <K extends keyof Settings>(key: K, value: Settings[K]) => Promise<void>;
   onClose: () => void;
   focusSection?: SettingsSectionId;
   /** Called when the user clicks "What's new" in the About section */
@@ -44,6 +45,7 @@ interface SettingsPageProps {
 export function SettingsPage({
   settings,
   regions,
+  onSettingPreview,
   onSettingChange,
   codecResults,
   codecTesting,
@@ -60,6 +62,8 @@ export function SettingsPage({
   const settingsContentRef = useRef<HTMLDivElement | null>(null);
   const [nativeOverlayBlocking, setNativeOverlayBlocking] = useState(false);
   const [streamOverlayBlocking, setStreamOverlayBlocking] = useState(false);
+  const saveRequestRef = useRef(0);
+  const savedIndicatorTimerRef = useRef<number | null>(null);
 
   const [entitledResolutions, setEntitledResolutions] = useState<EntitledResolution[]>([]);
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
@@ -75,21 +79,55 @@ export function SettingsPage({
     setSettingsSearch("");
   }, [focusSection]);
 
+  const showSavedIndicator = useCallback((requestId: number): void => {
+    if (requestId !== saveRequestRef.current) return;
+    if (savedIndicatorTimerRef.current !== null) {
+      window.clearTimeout(savedIndicatorTimerRef.current);
+    }
+    setSavedIndicator(true);
+    savedIndicatorTimerRef.current = window.setTimeout(() => {
+      savedIndicatorTimerRef.current = null;
+      if (requestId === saveRequestRef.current) {
+        setSavedIndicator(false);
+      }
+    }, 1500);
+  }, []);
+
   const handleChange = useCallback(
-    <K extends keyof Settings>(key: K, value: Settings[K]) => {
-      onSettingChange(key, value);
-      setSavedIndicator(true);
-      setTimeout(() => setSavedIndicator(false), 1500);
+    <K extends keyof Settings>(key: K, value: Settings[K]): void => {
+      const requestId = ++saveRequestRef.current;
+      if (savedIndicatorTimerRef.current !== null) {
+        window.clearTimeout(savedIndicatorTimerRef.current);
+        savedIndicatorTimerRef.current = null;
+      }
+      setSavedIndicator(false);
+      void onSettingChange(key, value)
+        .then(() => showSavedIndicator(requestId))
+        .catch((error) => {
+          if (requestId === saveRequestRef.current) {
+            console.warn(`[Settings] Failed to save ${String(key)}:`, error);
+          }
+        });
     },
-    [onSettingChange],
+    [onSettingChange, showSavedIndicator],
+  );
+
+  const handlePreview = useCallback(
+    <K extends keyof Settings>(key: K, value: Settings[K]): void => {
+      onSettingPreview(key, value);
+    },
+    [onSettingPreview],
   );
 
   const markSaved = useCallback(() => {
-    setSavedIndicator(true);
-    setTimeout(() => setSavedIndicator(false), 1500);
-  }, []);
+    showSavedIndicator(++saveRequestRef.current);
+  }, [showSavedIndicator]);
 
-  const escapeBlocked = nativeOverlayBlocking || streamOverlayBlocking;
+  useEffect(() => () => {
+    if (savedIndicatorTimerRef.current !== null) {
+      window.clearTimeout(savedIndicatorTimerRef.current);
+    }
+  }, []);
 
   const loadSubscriptionData = useCallback(async (isCancelled: () => boolean = () => false): Promise<void> => {
     setSubscriptionLoading(true);
@@ -183,24 +221,6 @@ export function SettingsPage({
   const hasAnySearchMatches = showAccount || showStream || showNativeStreamer || showGame || showAudio || showInput || showInterface || showAbout || showThanks;
   const shouldRenderSettingsSections = showAll || activeSection !== "thanks";
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === "Escape" && !escapeBlocked) {
-        event.preventDefault();
-        onClose();
-      }
-    };
-
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [escapeBlocked, onClose]);
-
   return (
     <>
       <header className="settings-modal-header">
@@ -260,6 +280,7 @@ export function SettingsPage({
                       showStreamVideo={showStream && showStreamVideo}
                       showStreamCodecDiagnostics={showStream && showStreamCodecDiagnostics}
                       handleChange={handleChange}
+                      handlePreview={handlePreview}
                       codecResults={codecResults}
                       codecTesting={codecTesting}
                       onRunCodecTest={onRunCodecTest}
@@ -297,6 +318,7 @@ export function SettingsPage({
                       settings={settings}
                       showAll={showAll}
                       handleChange={handleChange}
+                      handlePreview={handlePreview}
                     />
                   )}
                   {showInterface && (
@@ -304,6 +326,7 @@ export function SettingsPage({
                       settings={settings}
                       showAll={showAll}
                       handleChange={handleChange}
+                      handlePreview={handlePreview}
                       onSaved={markSaved}
                     />
                   )}

--- a/opennow-stable/src/renderer/src/components/ShaderAtmosphere.tsx
+++ b/opennow-stable/src/renderer/src/components/ShaderAtmosphere.tsx
@@ -9,6 +9,7 @@ export type ShaderAtmosphereVariant = "controller" | "queue" | "connecting";
 export interface ShaderAtmosphereProps {
   variant?: ShaderAtmosphereVariant;
   className?: string;
+  active?: boolean;
 }
 
 type PointerPosition = { x: number; y: number };
@@ -158,17 +159,40 @@ function supportsWebGl(): boolean {
 export function ShaderAtmosphere({
   variant = "controller",
   className,
+  active = true,
 }: ShaderAtmosphereProps): JSX.Element {
-  const [canRender, setCanRender] = useState(false);
+  const [webGlSupported, setWebGlSupported] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(
+    () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  const [documentVisible, setDocumentVisible] = useState(() => document.visibilityState !== "hidden");
   const pointerRef = useRef<PointerPosition>({ x: -2, y: -2 });
+  const renderActive = active && documentVisible && !reducedMotion;
 
   useEffect(() => {
-    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    setCanRender(!reducedMotion && supportsWebGl());
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const syncReducedMotion = (): void => setReducedMotion(mediaQuery.matches);
+    const syncVisibility = (): void => setDocumentVisible(document.visibilityState !== "hidden");
+    syncReducedMotion();
+    syncVisibility();
+    mediaQuery.addEventListener("change", syncReducedMotion);
+    document.addEventListener("visibilitychange", syncVisibility);
+    return () => {
+      mediaQuery.removeEventListener("change", syncReducedMotion);
+      document.removeEventListener("visibilitychange", syncVisibility);
+    };
   }, []);
 
   useEffect(() => {
-    if (!canRender || variant === "controller") return undefined;
+    if (reducedMotion) {
+      setWebGlSupported(false);
+      return;
+    }
+    setWebGlSupported(supportsWebGl());
+  }, [reducedMotion]);
+
+  useEffect(() => {
+    if (!renderActive || variant === "controller") return undefined;
 
     const handlePointerMove = (event: PointerEvent): void => {
       pointerRef.current.x = event.clientX / Math.max(window.innerWidth, 1);
@@ -187,16 +211,22 @@ export function ShaderAtmosphere({
       window.removeEventListener("blur", clearPointer);
       document.documentElement.removeEventListener("mouseleave", clearPointer);
     };
-  }, [canRender, variant]);
+  }, [renderActive, variant]);
 
   return (
     <div
-      className={["shader-atmosphere", `shader-atmosphere--${variant}`, className].filter(Boolean).join(" ")}
+      className={[
+        "shader-atmosphere",
+        `shader-atmosphere--${variant}`,
+        reducedMotion ? "shader-atmosphere--reduced-motion" : "",
+        className,
+      ].filter(Boolean).join(" ")}
       aria-hidden="true"
     >
-      {canRender && (
+      {!reducedMotion && webGlSupported && (
         <Canvas
           dpr={[0.75, 1]}
+          frameloop={renderActive ? "always" : "never"}
           camera={{ position: [0, 0, 1] }}
           gl={{ antialias: false, alpha: false, powerPreference: "high-performance" }}
         >

--- a/opennow-stable/src/renderer/src/components/StreamLoading.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamLoading.tsx
@@ -1,7 +1,7 @@
 import { Cpu, Monitor, Radio, Wifi, X, XCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { JSX, Ref } from "react";
-import { m } from "motion/react";
+import { m, useReducedMotion } from "motion/react";
 import {
   getPreferredSessionAdMediaUrl,
   getSessionAdItems,
@@ -14,6 +14,7 @@ import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { QueueAdPreview, type QueueAdPlaybackEvent, type QueueAdPreviewHandle } from "./QueueAdPreview";
 import { LazyShaderAtmosphere } from "./LazyShaderAtmosphere";
 import { useTranslation } from "../i18n";
+import { getStatusPulseMotion } from "./MotionProvider";
 
 type TranslateFunction = typeof import("../i18n").t;
 
@@ -136,6 +137,8 @@ export function StreamLoading({
   onCancel,
 }: StreamLoadingProps): JSX.Element {
   const { t } = useTranslation();
+  const reducedMotion = useReducedMotion();
+  const statusPulseMotion = getStatusPulseMotion(reducedMotion);
   const [startedAt] = useState(() => Date.now());
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const hasError = Boolean(error);
@@ -190,9 +193,11 @@ export function StreamLoading({
                 <div className={`sload-stage sload-stage--${state}`} key={stage.id}>
                   <m.span
                     className="sload-stage-icon"
-                    animate={state === "active" ? { scale: [1, 1.08, 1] } : { scale: 1 }}
+                    animate={state === "active"
+                      ? statusPulseMotion.animate
+                      : { opacity: 1, scale: 1 }}
                     transition={state === "active"
-                      ? { duration: 1.8, repeat: Infinity, ease: "easeInOut" }
+                      ? statusPulseMotion.transition
                       : { duration: 0.2 }}
                   >
                     <StageIcon size={18} />
@@ -211,8 +216,8 @@ export function StreamLoading({
             <m.span
               className="sload-live-dot"
               aria-hidden="true"
-              animate={{ opacity: [0.55, 1, 0.55], scale: [0.9, 1.12, 0.9] }}
-              transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
+              animate={statusPulseMotion.animate}
+              transition={statusPulseMotion.transition}
             />
           )}
           <div className="sload-status-text">

--- a/opennow-stable/src/renderer/src/components/StreamStatsHud.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamStatsHud.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { AnimatePresence, m } from "motion/react";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { AlertTriangle, ChevronDown } from "lucide-react";
 import type { JSX } from "react";
 import type { StreamLagReason } from "../platforms/gfn/webrtcClient";
@@ -12,7 +12,12 @@ import {
   getRttColor,
   getTimingColor,
 } from "../utils/streamDiagnosticsFormat";
-import { panelSpring, smoothEase, surfaceRevealTransition } from "./MotionProvider";
+import {
+  disclosureTransition,
+  getStatusPulseMotion,
+  smoothEase,
+  surfaceRevealTransition,
+} from "./MotionProvider";
 import { useTranslation } from "../i18n";
 
 function getLagReasonLabel(reason: StreamLagReason): string {
@@ -63,6 +68,8 @@ export function StreamStatsHud({
   hintsVisible = false,
 }: StreamStatsHudProps): JSX.Element {
   const { t } = useTranslation();
+  const reducedMotion = useReducedMotion();
+  const statusPulseMotion = getStatusPulseMotion(reducedMotion);
   const stats = useStreamDiagnosticsStore(diagnosticsStore);
   const [expanded, setExpanded] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -166,7 +173,6 @@ export function StreamStatsHud({
       animate={{ opacity: 1, x: 0, y: 0 }}
       exit={{ opacity: 0, x: -10, y: 6 }}
       transition={surfaceRevealTransition}
-      layout
       aria-label={t("stream.stats.overlayLabel")}
     >
       <button
@@ -201,8 +207,8 @@ export function StreamStatsHud({
             <m.span
               className="sv-stats-alert-dot"
               aria-hidden
-              animate={{ opacity: [0.6, 1, 0.6], scale: [0.94, 1.06, 0.94] }}
-              transition={{ duration: 1.6, repeat: Infinity, ease: "easeInOut" }}
+              animate={statusPulseMotion.animate}
+              transition={statusPulseMotion.transition}
             >
               <AlertTriangle size={11} />
             </m.span>
@@ -226,7 +232,7 @@ export function StreamStatsHud({
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.24, ease: smoothEase }}
+            transition={disclosureTransition}
           >
             {hasPacketLoss && (
               <span className="sv-stats-warn-pill">
@@ -250,7 +256,7 @@ export function StreamStatsHud({
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={panelSpring}
+            transition={disclosureTransition}
           >
             <div className="sv-stats-details-inner">
               <div className="sv-stats-sub">
@@ -348,7 +354,7 @@ export function StreamStatsHud({
                         initial={{ height: 0, opacity: 0 }}
                         animate={{ height: "auto", opacity: 1 }}
                         exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.26, ease: smoothEase }}
+                        transition={disclosureTransition}
                       >
                         {advancedLines.map((line) => (
                           <p key={line} className="sv-stats-foot">

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -80,6 +80,7 @@ interface StreamViewProps {
   } | null;
   isFullscreen: boolean;
   isConnecting: boolean;
+  streamRevealComplete: boolean;
   gameTitle: string;
   recordingBitrateMbps: number | null;
   platformStore?: string;
@@ -133,6 +134,7 @@ export function StreamView({
   streamWarning,
   isFullscreen,
   isConnecting,
+  streamRevealComplete,
   gameTitle,
   recordingBitrateMbps,
   platformStore,
@@ -238,12 +240,17 @@ export function StreamView({
       setSessionReadySplashVisible(false);
       return;
     }
-    if (nativeRendererActive || !streamVideoReady || sessionReadySplashShownRef.current) {
+    if (
+      nativeRendererActive
+      || !streamVideoReady
+      || !streamRevealComplete
+      || sessionReadySplashShownRef.current
+    ) {
       return;
     }
     sessionReadySplashShownRef.current = true;
     setSessionReadySplashVisible(true);
-  }, [isConnecting, nativeRendererActive, streamVideoReady]);
+  }, [isConnecting, nativeRendererActive, streamRevealComplete, streamVideoReady]);
 
   const handleSessionReadySplashFinished = useCallback(() => {
     setSessionReadySplashVisible(false);
@@ -1413,24 +1420,40 @@ export function StreamView({
 
   return (
     <div className={["sv", streamVideoReady ? "sv--video-ready" : "sv--video-pending", nativeInternalHole ? "sv--native-hole" : "", className].filter(Boolean).join(" ")}>
-      <m.video
-        ref={setVideoRef}
-        autoPlay
-        playsInline
-        muted
-        tabIndex={-1}
-        className={["sv-video", nativeInternalHole ? "sv-video--native-hole" : ""].filter(Boolean).join(" ")}
-        initial={false}
-        animate={streamVideoReady
-          ? { opacity: 1, scale: 1 }
-          : { opacity: 0, scale: 1.008 }}
-        transition={{ duration: 0.9, ease: [0.22, 1, 0.36, 1] }}
-        onClick={() => {
-          if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
-            localVideoRef.current.focus({ preventScroll: true });
-          }
-        }}
-      />
+      {nativeInternalHole ? (
+        <video
+          ref={setVideoRef}
+          autoPlay
+          playsInline
+          muted
+          tabIndex={-1}
+          className="sv-video sv-video--native-hole"
+          onClick={() => {
+            if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
+              localVideoRef.current.focus({ preventScroll: true });
+            }
+          }}
+        />
+      ) : (
+        <m.video
+          ref={setVideoRef}
+          autoPlay
+          playsInline
+          muted
+          tabIndex={-1}
+          className="sv-video"
+          initial={false}
+          animate={streamVideoReady
+            ? { opacity: 1, scale: 1 }
+            : { opacity: 0, scale: 1.008 }}
+          transition={{ duration: 0.9, ease: [0.22, 1, 0.36, 1] }}
+          onClick={() => {
+            if (localVideoRef.current && document.activeElement !== localVideoRef.current) {
+              localVideoRef.current.focus({ preventScroll: true });
+            }
+          }}
+        />
+      )}
       <audio ref={setAudioRef} autoPlay playsInline />
       <VideoFocusOnReady
         diagnosticsStore={diagnosticsStore}

--- a/opennow-stable/src/renderer/src/components/settings/SettingRange.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/SettingRange.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useRef, type InputHTMLAttributes, type JSX, type KeyboardEvent, type PointerEvent } from "react";
+
+export interface SettingRangeProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "type" | "value" | "onChange" | "onInput"
+> {
+  value: number;
+  onPreview: (value: number) => void;
+  onCommit: (value: number) => void | Promise<void>;
+  normalize?: (value: number) => number;
+}
+
+const COMMIT_KEYS = new Set([
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "End",
+  "Home",
+  "PageDown",
+  "PageUp",
+]);
+
+export function SettingRange({
+  value,
+  onPreview,
+  onCommit,
+  normalize = (nextValue) => nextValue,
+  onBlur,
+  onKeyUp,
+  onPointerCancel,
+  onPointerUp,
+  ...inputProps
+}: SettingRangeProps): JSX.Element {
+  const currentValueRef = useRef(value);
+  const dirtyRef = useRef(false);
+  if (!dirtyRef.current) {
+    currentValueRef.current = value;
+  }
+
+  const commitPreview = useCallback((): void => {
+    if (!dirtyRef.current) return;
+    dirtyRef.current = false;
+    void onCommit(currentValueRef.current);
+  }, [onCommit]);
+
+  return (
+    <input
+      {...inputProps}
+      type="range"
+      value={value}
+      onChange={(event) => {
+        const nextValue = normalize(Number(event.currentTarget.value));
+        if (!Number.isFinite(nextValue)) return;
+        currentValueRef.current = nextValue;
+        dirtyRef.current = true;
+        onPreview(nextValue);
+      }}
+      onBlur={(event) => {
+        commitPreview();
+        onBlur?.(event);
+      }}
+      onKeyUp={(event: KeyboardEvent<HTMLInputElement>) => {
+        if (COMMIT_KEYS.has(event.key)) {
+          commitPreview();
+        }
+        onKeyUp?.(event);
+      }}
+      onPointerUp={(event: PointerEvent<HTMLInputElement>) => {
+        queueMicrotask(commitPreview);
+        onPointerUp?.(event);
+      }}
+      onPointerCancel={(event: PointerEvent<HTMLInputElement>) => {
+        queueMicrotask(commitPreview);
+        onPointerCancel?.(event);
+      }}
+    />
+  );
+}

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsInputSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsInputSection.tsx
@@ -4,6 +4,7 @@ import { keyboardLayoutOptions } from "@shared/gfn";
 import { formatShortcutForDisplay, normalizeShortcut, shortcutFromKeyboardEvent } from "../../../shortcuts";
 import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
+import { SettingRange } from "../SettingRange";
 import {
   getShortcutConflictMessage,
   isMac,
@@ -17,6 +18,7 @@ export interface SettingsInputSectionProps {
   settings: Settings;
   showAll: boolean;
   handleChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  handlePreview: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
 }
 
 function formatMouseSensitivityDraft(value: number): string {
@@ -27,7 +29,7 @@ function formatMouseAccelerationDraft(value: number): string {
   return String(Math.round(value));
 }
 
-export function SettingsInputSection({ settings, showAll, handleChange }: SettingsInputSectionProps): JSX.Element {
+export function SettingsInputSection({ settings, showAll, handleChange, handlePreview }: SettingsInputSectionProps): JSX.Element {
   const { t } = useTranslation();
   const [toggleStatsInput, setToggleStatsInput] = useState(settings.shortcutToggleStats);
   const [togglePointerLockInput, setTogglePointerLockInput] = useState(settings.shortcutTogglePointerLock);
@@ -410,19 +412,18 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
             <span className="settings-value-badge">{settings.mouseSensitivity.toFixed(2)}x</span>
           </div>
           <div className="settings-slider-control">
-            <input
+            <SettingRange
               id="settings-input-mouse-sensitivity-slider"
-              type="range"
               className="settings-slider"
               min={0.1}
               max={4}
               step={0.01}
               value={settings.mouseSensitivity}
-              onChange={(e) => {
-                const value = parseFloat(e.target.value);
+              onPreview={(value) => {
                 setMouseSensitivityDraft(formatMouseSensitivityDraft(value));
-                handleChange("mouseSensitivity", value);
+                handlePreview("mouseSensitivity", value);
               }}
+              onCommit={(value) => handleChange("mouseSensitivity", value)}
             />
             <input
               id="settings-input-mouse-sensitivity-number"
@@ -453,19 +454,19 @@ export function SettingsInputSection({ settings, showAll, handleChange }: Settin
             <span className="settings-value-badge">{Math.round(settings.mouseAcceleration)}%</span>
           </div>
           <div className="settings-slider-control">
-            <input
+            <SettingRange
               id="settings-input-mouse-acceleration-slider"
-              type="range"
               className="settings-slider"
               min={1}
               max={150}
               step={1}
               value={Math.round(settings.mouseAcceleration)}
-              onChange={(e) => {
-                const value = Math.max(1, Math.min(150, Math.round(Number(e.target.value) || 1)));
+              normalize={(value) => Math.max(1, Math.min(150, Math.round(value || 1)))}
+              onPreview={(value) => {
                 setMouseAccelerationDraft(formatMouseAccelerationDraft(value));
-                handleChange("mouseAcceleration", value);
+                handlePreview("mouseAcceleration", value);
               }}
+              onCommit={(value) => handleChange("mouseAcceleration", value)}
             />
             <input
               id="settings-input-mouse-acceleration-number"

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, type JSX } from "react";
 import type { AppAccentColor, Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
+import { SettingRange } from "../SettingRange";
 import {
   accentColorOptions,
   getAppLanguageLabel,
@@ -14,10 +15,11 @@ export interface SettingsInterfaceSectionProps {
   settings: Settings;
   showAll: boolean;
   handleChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  handlePreview: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
   onSaved: () => void;
 }
 
-export function SettingsInterfaceSection({ settings, showAll, handleChange, onSaved }: SettingsInterfaceSectionProps): JSX.Element {
+export function SettingsInterfaceSection({ settings, showAll, handleChange, handlePreview, onSaved }: SettingsInterfaceSectionProps): JSX.Element {
   const { locale, availableLocales, setLocale, t } = useTranslation();
   const posterSizePercent = Math.round(settings.posterSizeScale * 100);
 
@@ -47,10 +49,11 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
   );
 
   const handleAppLanguageChange = useCallback((nextLocale: string): void => {
-    void setLocale(nextLocale).catch((error) => {
-      console.warn("[Settings] Failed to change app language:", error);
-    });
-    onSaved();
+    void setLocale(nextLocale)
+      .then(onSaved)
+      .catch((error) => {
+        console.warn("[Settings] Failed to change app language:", error);
+      });
   }, [onSaved, setLocale]);
 
   return (
@@ -280,15 +283,16 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
               <label className="settings-label" htmlFor="settings-interface-poster-size">{t("settings.interface.posterSize")}</label>
               <span className="settings-value-badge">{posterSizePercent}%</span>
             </div>
-            <input
+            <SettingRange
               id="settings-interface-poster-size"
-              type="range"
               className="settings-slider"
               min={POSTER_SIZE_MIN}
               max={POSTER_SIZE_MAX}
               step={POSTER_SIZE_STEP}
               value={posterSizePercent}
-              onChange={(e) => handleChange("posterSizeScale", Number(e.target.value) / 100)}
+              normalize={(value) => value / 100}
+              onPreview={(value) => handlePreview("posterSizeScale", value)}
+              onCommit={(value) => handleChange("posterSizeScale", value)}
             />
             <span className="settings-subtle-hint">{t("settings.interface.posterSizeHint")}</span>
           </div>
@@ -341,15 +345,15 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                       : t("settings.interface.everyMinutes", { count: settings.sessionClockShowEveryMinutes })}
                   </span>
                 </div>
-                <input
+                <SettingRange
                   id="settings-interface-session-timer-reappear"
-                  type="range"
                   className="settings-slider"
                   min={0}
                   max={120}
                   step={5}
                   value={settings.sessionClockShowEveryMinutes}
-                  onChange={(e) => handleChange("sessionClockShowEveryMinutes", parseInt(e.target.value, 10))}
+                  onPreview={(value) => handlePreview("sessionClockShowEveryMinutes", value)}
+                  onCommit={(value) => handleChange("sessionClockShowEveryMinutes", value)}
                 />
                 <span className="settings-subtle-hint">{t("settings.interface.sessionTimerReappearHint")}</span>
               </div>
@@ -361,15 +365,15 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, onSa
                     {t("app.units.seconds", { value: settings.sessionClockShowDurationSeconds })}
                   </span>
                 </div>
-                <input
+                <SettingRange
                   id="settings-interface-session-timer-visible-time"
-                  type="range"
                   className="settings-slider"
                   min={5}
                   max={120}
                   step={5}
                   value={settings.sessionClockShowDurationSeconds}
-                  onChange={(e) => handleChange("sessionClockShowDurationSeconds", parseInt(e.target.value, 10))}
+                  onPreview={(value) => handlePreview("sessionClockShowDurationSeconds", value)}
+                  onCommit={(value) => handleChange("sessionClockShowDurationSeconds", value)}
                 />
                 <span className="settings-subtle-hint">{t("settings.interface.sessionTimerVisibleTimeHint")}</span>
               </div>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
@@ -1,6 +1,5 @@
 import { AlertTriangle, CheckCircle2, Cpu, ExternalLink, Keyboard, Monitor, RefreshCcw, XCircle } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
-import { m } from "motion/react";
 import type { NativeStreamerStatus, NativeVideoBackendCapability, Settings } from "@shared/gfn";
 import {
   createUnsupportedNativeStreamerStatus,
@@ -17,10 +16,9 @@ import {
   getAvailableNativeCodecLabels,
   getGstreamerRuntimeBadgeClass,
   nativeVideoBackendOptions,
-  NATIVE_STREAMER_ENABLE_PROMPT_EXIT_MS,
 } from "../settingsFormatters";
-import { dialogMotion, overlayMotion } from "../../MotionProvider";
 import { MotionSpinner } from "../../MotionSpinner";
+import { ModalSurface } from "../../ui/ModalSurface";
 
 const nativePlatformHint = `${navigator.platform} ${navigator.userAgent}`;
 const isNativeStreamerPlatform = isNativeStreamerSupportedPlatform(nativePlatformHint);
@@ -61,13 +59,7 @@ export function SettingsNativeStreamerSection({
   const [nativeStreamerStatus, setNativeStreamerStatus] = useState<NativeStreamerStatus | null>(null);
   const [nativeStreamerStatusLoading, setNativeStreamerStatusLoading] = useState(false);
   const [nativeStreamerEnablePromptOpen, setNativeStreamerEnablePromptOpen] = useState(false);
-  const [nativeStreamerEnablePromptClosing, setNativeStreamerEnablePromptClosing] = useState(false);
-  const nativeStreamerEnablePromptRef = useRef<HTMLDivElement | null>(null);
   const nativeStreamerEnablePromptConfirmRef = useRef<HTMLButtonElement | null>(null);
-  const nativeStreamerEnablePromptPreviousFocusRef = useRef<HTMLElement | null>(null);
-  const nativeStreamerEnablePromptCloseTimerRef = useRef<number | null>(null);
-  const nativeStreamerEnablePromptVisible =
-    nativeStreamerEnablePromptOpen || nativeStreamerEnablePromptClosing;
   const hostVideoBackends = getHostVideoBackends(nativeStreamerStatus);
   const readyHardwareBackendCount = hostVideoBackends.filter(
     (backend) => backend.available && backend.backend !== "software",
@@ -113,32 +105,24 @@ export function SettingsNativeStreamerSection({
   }, [refreshNativeStreamerStatus]);
 
   useEffect(() => {
-    onBlockingOverlayChange?.(nativeStreamerEnablePromptVisible);
-    return () => onBlockingOverlayChange?.(false);
-  }, [nativeStreamerEnablePromptVisible, onBlockingOverlayChange]);
+    if (nativeStreamerEnablePromptOpen) {
+      onBlockingOverlayChange?.(true);
+    }
+  }, [nativeStreamerEnablePromptOpen, onBlockingOverlayChange]);
+
+  useEffect(() => () => onBlockingOverlayChange?.(false), [onBlockingOverlayChange]);
 
   const openNativeStreamerEnablePrompt = useCallback((): void => {
-    if (nativeStreamerEnablePromptCloseTimerRef.current !== null) {
-      window.clearTimeout(nativeStreamerEnablePromptCloseTimerRef.current);
-      nativeStreamerEnablePromptCloseTimerRef.current = null;
-    }
-
-    setNativeStreamerEnablePromptClosing(false);
     setNativeStreamerEnablePromptOpen(true);
   }, []);
 
   const closeNativeStreamerEnablePrompt = useCallback((): void => {
-    if (nativeStreamerEnablePromptCloseTimerRef.current !== null) {
-      return;
-    }
-
     setNativeStreamerEnablePromptOpen(false);
-    setNativeStreamerEnablePromptClosing(true);
-    nativeStreamerEnablePromptCloseTimerRef.current = window.setTimeout(() => {
-      nativeStreamerEnablePromptCloseTimerRef.current = null;
-      setNativeStreamerEnablePromptClosing(false);
-    }, NATIVE_STREAMER_ENABLE_PROMPT_EXIT_MS);
   }, []);
+
+  const handleNativeStreamerEnablePromptExit = useCallback((): void => {
+    onBlockingOverlayChange?.(false);
+  }, [onBlockingOverlayChange]);
 
   const confirmNativeStreamerEnablePrompt = useCallback((): void => {
     handleChange("streamClientMode", "native");
@@ -170,96 +154,6 @@ export function SettingsNativeStreamerSection({
     handleChange("nativeCloudGsyncMode", "auto");
     handleChange("nativeD3dFullscreenMode", "auto");
   }, [handleChange]);
-
-  useEffect(() => {
-    return () => {
-      if (nativeStreamerEnablePromptCloseTimerRef.current !== null) {
-        window.clearTimeout(nativeStreamerEnablePromptCloseTimerRef.current);
-        nativeStreamerEnablePromptCloseTimerRef.current = null;
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!nativeStreamerEnablePromptVisible) {
-      return;
-    }
-
-    nativeStreamerEnablePromptPreviousFocusRef.current =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null;
-
-    const getFocusableElements = (): HTMLElement[] => {
-      const dialog = nativeStreamerEnablePromptRef.current;
-      if (!dialog) {
-        return [];
-      }
-
-      return Array.from(
-        dialog.querySelectorAll<HTMLElement>(
-          [
-            "a[href]",
-            "button:not([disabled])",
-            "input:not([disabled])",
-            "select:not([disabled])",
-            "textarea:not([disabled])",
-            '[tabindex]:not([tabindex="-1"])',
-          ].join(","),
-        ),
-      ).filter((element) => element.tabIndex >= 0 && element.getAttribute("aria-hidden") !== "true");
-    };
-
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeNativeStreamerEnablePrompt();
-        return;
-      }
-
-      if (event.key !== "Tab") {
-        return;
-      }
-
-      const dialog = nativeStreamerEnablePromptRef.current;
-      const focusableElements = getFocusableElements();
-      if (!dialog || focusableElements.length === 0) {
-        event.preventDefault();
-        dialog?.focus({ preventScroll: true });
-        return;
-      }
-
-      const activeElement = document.activeElement;
-      const firstElement = focusableElements[0];
-      const lastElement = focusableElements[focusableElements.length - 1];
-      const focusIsOnDialog = activeElement === dialog;
-
-      if (event.shiftKey && (focusIsOnDialog || activeElement === firstElement || !dialog.contains(activeElement))) {
-        event.preventDefault();
-        lastElement.focus({ preventScroll: true });
-        return;
-      }
-
-      if (!event.shiftKey && (focusIsOnDialog || activeElement === lastElement || !dialog.contains(activeElement))) {
-        event.preventDefault();
-        firstElement.focus({ preventScroll: true });
-      }
-    };
-
-    const focusFrame = window.requestAnimationFrame(() => {
-      nativeStreamerEnablePromptConfirmRef.current?.focus({ preventScroll: true });
-    });
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.cancelAnimationFrame(focusFrame);
-      document.removeEventListener("keydown", handleKeyDown);
-
-      const previousFocus = nativeStreamerEnablePromptPreviousFocusRef.current;
-      nativeStreamerEnablePromptPreviousFocusRef.current = null;
-      if (previousFocus?.isConnected) {
-        previousFocus.focus({ preventScroll: true });
-      }
-    };
-  }, [closeNativeStreamerEnablePrompt, nativeStreamerEnablePromptVisible]);
 
   return (
     <>
@@ -575,36 +469,19 @@ export function SettingsNativeStreamerSection({
         </div>
       </section>
       )}
-      {nativeStreamerEnablePromptVisible && (
-        <m.div
-          className={`native-streamer-warning ${nativeStreamerEnablePromptClosing ? "native-streamer-warning--closing" : ""}`}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="native-streamer-warning-title"
-          aria-describedby="native-streamer-warning-copy"
-          initial={overlayMotion.initial}
-          animate={nativeStreamerEnablePromptClosing ? overlayMotion.exit : overlayMotion.animate}
-          transition={overlayMotion.transition}
-        >
-          <m.button
-            type="button"
-            className="native-streamer-warning-backdrop"
-            aria-label={t("app.actions.cancel")}
-            aria-hidden="true"
-            tabIndex={-1}
-            onClick={closeNativeStreamerEnablePrompt}
-            initial={overlayMotion.initial}
-            animate={nativeStreamerEnablePromptClosing ? overlayMotion.exit : overlayMotion.animate}
-            transition={overlayMotion.transition}
-          />
-          <m.div
-            ref={nativeStreamerEnablePromptRef}
-            className="native-streamer-warning-card"
-            tabIndex={-1}
-            initial={dialogMotion.initial}
-            animate={nativeStreamerEnablePromptClosing ? dialogMotion.exit : dialogMotion.animate}
-            transition={dialogMotion.transition}
-          >
+      <ModalSurface
+        open={nativeStreamerEnablePromptOpen}
+        onClose={closeNativeStreamerEnablePrompt}
+        onExitComplete={handleNativeStreamerEnablePromptExit}
+        motion="compact"
+        overlayClassName="native-streamer-warning"
+        backdropClassName="native-streamer-warning-backdrop"
+        panelClassName="native-streamer-warning-card"
+        ariaLabelledBy="native-streamer-warning-title"
+        ariaDescribedBy="native-streamer-warning-copy"
+        backdropLabel={t("app.actions.cancel")}
+        initialFocusRef={nativeStreamerEnablePromptConfirmRef}
+      >
             <div className="native-streamer-warning-kicker">
               <AlertTriangle size={14} />
               {t("settings.nativeStreamer.enablePromptKicker")}
@@ -644,7 +521,6 @@ export function SettingsNativeStreamerSection({
                 className="native-streamer-warning-btn native-streamer-warning-btn--primary"
                 onClick={confirmNativeStreamerEnablePrompt}
                 ref={nativeStreamerEnablePromptConfirmRef}
-                autoFocus
               >
                 {t("settings.nativeStreamer.enablePromptEnable")}
               </button>
@@ -652,9 +528,7 @@ export function SettingsNativeStreamerSection({
             <div className="native-streamer-warning-hint">
               <kbd>Esc</kbd> {t("settings.nativeStreamer.enablePromptEsc")}
             </div>
-          </m.div>
-        </m.div>
-      )}
+      </ModalSurface>
     </>
   );
 }

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsStreamSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsStreamSection.tsx
@@ -2,7 +2,6 @@ import {
   Check, Globe, Heart, MapPin, Monitor, SlidersHorizontal, Wifi, Zap, Search, X, Cpu,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type JSX, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { m } from "motion/react";
 import type {
   ColorQuality,
   EntitledResolution,
@@ -33,13 +32,13 @@ import {
   getFpsForResolution,
   groupResolutions,
   inferAspectRatioFromResolution,
-  NATIVE_STREAMER_ENABLE_PROMPT_EXIT_MS,
   STATIC_FPS_PRESETS,
   STATIC_RESOLUTION_PRESETS,
 } from "../settingsFormatters";
-import { dialogMotion, overlayMotion } from "../../MotionProvider";
 import { MotionSpinner } from "../../MotionSpinner";
+import { ModalSurface } from "../../ui/ModalSurface";
 import { SelectDropdown, type SelectDropdownOption } from "../../ui/SelectDropdown";
+import { SettingRange } from "../SettingRange";
 
 export interface SettingsStreamSectionProps {
   settings: Settings;
@@ -49,6 +48,7 @@ export interface SettingsStreamSectionProps {
   showStreamVideo: boolean;
   showStreamCodecDiagnostics: boolean;
   handleChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  handlePreview: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
   codecResults: CodecTestResult[] | null;
   codecTesting: boolean;
   onRunCodecTest: () => Promise<void>;
@@ -66,6 +66,7 @@ export function SettingsStreamSection({
   showStreamVideo,
   showStreamCodecDiagnostics,
   handleChange,
+  handlePreview,
   codecResults,
   codecTesting,
   onRunCodecTest,
@@ -102,24 +103,21 @@ export function SettingsStreamSection({
   });
 
   const [zortosCommunityProxyPromptOpen, setZortosCommunityProxyPromptOpen] = useState(false);
-  const [zortosCommunityProxyPromptClosing, setZortosCommunityProxyPromptClosing] = useState(false);
   const [zortosCommunityProxyProvisioning, setZortosCommunityProxyProvisioning] = useState(false);
   const [zortosCommunityProxyError, setZortosCommunityProxyError] = useState<string | null>(null);
-  const zortosCommunityProxyPromptRef = useRef<HTMLDivElement | null>(null);
   const zortosCommunityProxyPromptContinueRef = useRef<HTMLButtonElement | null>(null);
-  const zortosCommunityProxyPromptPreviousFocusRef = useRef<HTMLElement | null>(null);
-  const zortosCommunityProxyPromptCloseTimerRef = useRef<number | null>(null);
-  const zortosCommunityProxyPromptVisible =
-    zortosCommunityProxyPromptOpen || zortosCommunityProxyPromptClosing;
   const isUsingZortosCommunityProxy = useMemo(
     () => settings.sessionProxyEnabled && isZortosCommunityProxyUrl(settings.sessionProxyUrl),
     [settings.sessionProxyEnabled, settings.sessionProxyUrl],
   );
 
   useEffect(() => {
-    onBlockingOverlayChange?.(zortosCommunityProxyPromptVisible);
-    return () => onBlockingOverlayChange?.(false);
-  }, [zortosCommunityProxyPromptVisible, onBlockingOverlayChange]);
+    if (zortosCommunityProxyPromptOpen) {
+      onBlockingOverlayChange?.(true);
+    }
+  }, [onBlockingOverlayChange, zortosCommunityProxyPromptOpen]);
+
+  useEffect(() => () => onBlockingOverlayChange?.(false), [onBlockingOverlayChange]);
 
   const runPingTest = useCallback(async () => {
     if (regions.length === 0) return;
@@ -402,30 +400,22 @@ export function SettingsStreamSection({
   }, [activeRegionOptionId, regionDropdownOpen]);
 
   const openZortosCommunityProxyPrompt = useCallback((): void => {
-    if (zortosCommunityProxyPromptCloseTimerRef.current !== null) {
-      window.clearTimeout(zortosCommunityProxyPromptCloseTimerRef.current);
-      zortosCommunityProxyPromptCloseTimerRef.current = null;
-    }
-
     setZortosCommunityProxyError(null);
     setZortosCommunityProxyProvisioning(false);
-    setZortosCommunityProxyPromptClosing(false);
     setZortosCommunityProxyPromptOpen(true);
   }, []);
 
   const closeZortosCommunityProxyPrompt = useCallback((): void => {
-    if (zortosCommunityProxyPromptCloseTimerRef.current !== null || zortosCommunityProxyProvisioning) {
+    if (zortosCommunityProxyProvisioning) {
       return;
     }
-
     setZortosCommunityProxyPromptOpen(false);
-    setZortosCommunityProxyPromptClosing(true);
-    zortosCommunityProxyPromptCloseTimerRef.current = window.setTimeout(() => {
-      zortosCommunityProxyPromptCloseTimerRef.current = null;
-      setZortosCommunityProxyPromptClosing(false);
-      setZortosCommunityProxyError(null);
-    }, NATIVE_STREAMER_ENABLE_PROMPT_EXIT_MS);
   }, [zortosCommunityProxyProvisioning]);
+
+  const handleZortosCommunityProxyPromptExit = useCallback((): void => {
+    setZortosCommunityProxyError(null);
+    onBlockingOverlayChange?.(false);
+  }, [onBlockingOverlayChange]);
 
   const handleOpenZortosSponsors = useCallback((): void => {
     void window.openNow.openExternalUrl(ZORTOS_GITHUB_SPONSORS_URL).catch((error) => {
@@ -456,46 +446,6 @@ export function SettingsStreamSection({
       setZortosCommunityProxyProvisioning(false);
     }
   }, [closeZortosCommunityProxyPrompt, handleChange, t, zortosCommunityProxyProvisioning]);
-
-  useEffect(() => {
-    return () => {
-      if (zortosCommunityProxyPromptCloseTimerRef.current !== null) {
-        window.clearTimeout(zortosCommunityProxyPromptCloseTimerRef.current);
-        zortosCommunityProxyPromptCloseTimerRef.current = null;
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!zortosCommunityProxyPromptVisible) {
-      return;
-    }
-
-    zortosCommunityProxyPromptPreviousFocusRef.current =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null;
-
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === "Escape" && !zortosCommunityProxyProvisioning) {
-        event.preventDefault();
-        closeZortosCommunityProxyPrompt();
-      }
-    };
-
-    const focusFrame = window.requestAnimationFrame(() => {
-      zortosCommunityProxyPromptContinueRef.current?.focus({ preventScroll: true });
-    });
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.cancelAnimationFrame(focusFrame);
-      document.removeEventListener("keydown", handleKeyDown);
-      const previousFocus = zortosCommunityProxyPromptPreviousFocusRef.current;
-      zortosCommunityProxyPromptPreviousFocusRef.current = null;
-      if (previousFocus?.isConnected) {
-        previousFocus.focus({ preventScroll: true });
-      }
-    };
-  }, [closeZortosCommunityProxyPrompt, zortosCommunityProxyPromptVisible, zortosCommunityProxyProvisioning]);
 
   return (
     <>
@@ -824,15 +774,15 @@ export function SettingsStreamSection({
             <label className="settings-label" htmlFor="settings-stream-max-bitrate">{t("settings.video.maxBitrate")}</label>
             <span className="settings-value-badge">{settings.maxBitrateMbps} Mbps</span>
           </div>
-          <input
+          <SettingRange
             id="settings-stream-max-bitrate"
-            type="range"
             className="settings-slider"
             min={5}
             max={150}
             step={5}
             value={settings.maxBitrateMbps}
-            onChange={(e) => handleChange("maxBitrateMbps", parseInt(e.target.value, 10))}
+            onPreview={(value) => handlePreview("maxBitrateMbps", value)}
+            onCommit={(value) => handleChange("maxBitrateMbps", value)}
           />
         </div>
 
@@ -863,16 +813,16 @@ export function SettingsStreamSection({
               <span>{t("settings.video.customBitrate")}</span>
             </button>
           </div>
-          <input
+          <SettingRange
             id="settings-stream-recording-bitrate"
-            type="range"
             className="settings-slider"
             min={5}
             max={200}
             step={5}
             value={settings.recordingBitrateMbps ?? 75}
             disabled={settings.recordingBitrateMbps === null}
-            onChange={(e) => handleChange("recordingBitrateMbps", parseInt(e.target.value, 10))}
+            onPreview={(value) => handlePreview("recordingBitrateMbps", value)}
+            onCommit={(value) => handleChange("recordingBitrateMbps", value)}
           />
           <span className="settings-subtle-hint">{t("settings.video.recordingBitrateHint")}</span>
         </div>
@@ -1009,19 +959,18 @@ export function SettingsStreamSection({
                     <label className="settings-label" htmlFor={`settings-stream-video-filter-${control.key}`}>{t(control.labelKey)}</label>
                     <span className="settings-value-badge">{settings.videoShader[control.key]}%</span>
                   </div>
-                  <input
+                  <SettingRange
                     id={`settings-stream-video-filter-${control.key}`}
-                    type="range"
                     className="settings-slider"
                     min={control.min}
                     max={control.max}
                     step={1}
                     value={settings.videoShader[control.key]}
-                    onChange={(e) => {
-                      const next = parseInt(e.target.value, 10);
-                      if (Number.isFinite(next)) {
-                        handleChange("videoShader", { ...settings.videoShader, [control.key]: next });
-                      }
+                    onPreview={(value) => {
+                      handlePreview("videoShader", { ...settings.videoShader, [control.key]: value });
+                    }}
+                    onCommit={(value) => {
+                      handleChange("videoShader", { ...settings.videoShader, [control.key]: value });
                     }}
                   />
                 </div>
@@ -1191,37 +1140,21 @@ export function SettingsStreamSection({
                   </div>
                   )}
                 </>
-      {zortosCommunityProxyPromptVisible && (
-        <m.div
-          className={`native-streamer-warning ${zortosCommunityProxyPromptClosing ? "native-streamer-warning--closing" : ""}`}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="zortos-community-proxy-title"
-          aria-describedby="zortos-community-proxy-copy"
-          initial={overlayMotion.initial}
-          animate={zortosCommunityProxyPromptClosing ? overlayMotion.exit : overlayMotion.animate}
-          transition={overlayMotion.transition}
-        >
-          <m.button
-            type="button"
-            className="native-streamer-warning-backdrop"
-            aria-label={t("app.actions.cancel")}
-            aria-hidden="true"
-            tabIndex={-1}
-            disabled={zortosCommunityProxyProvisioning}
-            onClick={closeZortosCommunityProxyPrompt}
-            initial={overlayMotion.initial}
-            animate={zortosCommunityProxyPromptClosing ? overlayMotion.exit : overlayMotion.animate}
-            transition={overlayMotion.transition}
-          />
-          <m.div
-            ref={zortosCommunityProxyPromptRef}
-            className="native-streamer-warning-card"
-            tabIndex={-1}
-            initial={dialogMotion.initial}
-            animate={zortosCommunityProxyPromptClosing ? dialogMotion.exit : dialogMotion.animate}
-            transition={dialogMotion.transition}
-          >
+      <ModalSurface
+        open={zortosCommunityProxyPromptOpen}
+        onClose={closeZortosCommunityProxyPrompt}
+        onExitComplete={handleZortosCommunityProxyPromptExit}
+        motion="compact"
+        overlayClassName="native-streamer-warning"
+        backdropClassName="native-streamer-warning-backdrop"
+        panelClassName="native-streamer-warning-card"
+        ariaLabelledBy="zortos-community-proxy-title"
+        ariaDescribedBy="zortos-community-proxy-copy"
+        backdropLabel={t("app.actions.cancel")}
+        initialFocusRef={zortosCommunityProxyPromptContinueRef}
+        closeOnBackdrop={!zortosCommunityProxyProvisioning}
+        closeOnEscape={!zortosCommunityProxyProvisioning}
+      >
             <div className="native-streamer-warning-kicker">
               <Heart size={14} />
               {t("settings.video.zortosCommunityProxy.enablePromptKicker")}
@@ -1255,7 +1188,6 @@ export function SettingsStreamSection({
                 }}
                 ref={zortosCommunityProxyPromptContinueRef}
                 disabled={zortosCommunityProxyProvisioning}
-                autoFocus
               >
                 {zortosCommunityProxyProvisioning
                   ? t("settings.video.zortosCommunityProxy.provisioning")
@@ -1265,9 +1197,7 @@ export function SettingsStreamSection({
             <div className="native-streamer-warning-hint">
               <kbd>Esc</kbd> {t("settings.video.zortosCommunityProxy.enablePromptEsc")}
             </div>
-          </m.div>
-        </m.div>
-      )}
+      </ModalSurface>
     </>
   );
 }

--- a/opennow-stable/src/renderer/src/components/settings/settingsFormatters.ts
+++ b/opennow-stable/src/renderer/src/components/settings/settingsFormatters.ts
@@ -198,7 +198,6 @@ export const shortcutDefaults = {
 /** Canonical shortcut for toggling the stream sidebar (must match StreamView key handler). */
 export const SIDEBAR_TOGGLE_SHORTCUT_RAW = isMac ? "Meta+G" : "Ctrl+G";
 export const SIDEBAR_TOGGLE_SHORTCUT_ALIASES = isMac ? [SIDEBAR_TOGGLE_SHORTCUT_RAW] : [SIDEBAR_TOGGLE_SHORTCUT_RAW, "Ctrl+Shift+G"];
-export const NATIVE_STREAMER_ENABLE_PROMPT_EXIT_MS = 160;
 
 export function extractRemoteInvokeErrorMessage(error: unknown, fallback: string): string {
   if (!(error instanceof Error) || !error.message.trim()) {

--- a/opennow-stable/src/renderer/src/components/ui/ModalSurface.tsx
+++ b/opennow-stable/src/renderer/src/components/ui/ModalSurface.tsx
@@ -1,0 +1,373 @@
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useSyncExternalStore,
+  type JSX,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, m, useIsPresent } from "motion/react";
+import {
+  dialogMotion,
+  largeSurfaceMotion,
+  overlayMotion,
+} from "../MotionProvider";
+
+type ModalMotion = "large" | "compact" | "none";
+
+export interface ModalSurfaceProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm?: () => void;
+  onExitComplete?: () => void;
+  children: ReactNode;
+  overlayClassName: string;
+  backdropClassName: string;
+  panelClassName: string;
+  motion?: ModalMotion;
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+  ariaDescribedBy?: string;
+  backdropLabel?: string;
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  restoreFocusRef?: RefObject<HTMLElement | null>;
+  closeOnBackdrop?: boolean;
+  closeOnEscape?: boolean;
+}
+
+const modalStack: string[] = [];
+const modalStackListeners = new Set<() => void>();
+let bodyScrollLockCount = 0;
+let bodyOverflowBeforeLock = "";
+
+function emitModalStackChange(): void {
+  for (const listener of modalStackListeners) listener();
+}
+
+function registerModal(stackId: string): void {
+  const existingIndex = modalStack.lastIndexOf(stackId);
+  if (existingIndex >= 0) modalStack.splice(existingIndex, 1);
+  modalStack.push(stackId);
+  emitModalStackChange();
+}
+
+function unregisterModal(stackId: string): boolean {
+  const wasTopmost = modalStack.at(-1) === stackId;
+  const stackIndex = modalStack.lastIndexOf(stackId);
+  if (stackIndex >= 0) {
+    modalStack.splice(stackIndex, 1);
+    emitModalStackChange();
+  }
+  return wasTopmost;
+}
+
+function subscribeToModalStack(listener: () => void): () => void {
+  modalStackListeners.add(listener);
+  return () => modalStackListeners.delete(listener);
+}
+
+function getTopModalId(): string | null {
+  return modalStack.at(-1) ?? null;
+}
+
+function lockBodyScroll(): void {
+  if (bodyScrollLockCount === 0) {
+    bodyOverflowBeforeLock = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+  bodyScrollLockCount += 1;
+}
+
+function unlockBodyScroll(): void {
+  bodyScrollLockCount = Math.max(0, bodyScrollLockCount - 1);
+  if (bodyScrollLockCount === 0) {
+    document.body.style.overflow = bodyOverflowBeforeLock;
+    bodyOverflowBeforeLock = "";
+  }
+}
+
+function getFocusableElements(scope: HTMLElement): HTMLElement[] {
+  return Array.from(scope.querySelectorAll<HTMLElement>([
+    "a[href]",
+    "button:not([disabled])",
+    "input:not([disabled])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(","))).filter((element) => {
+    const style = window.getComputedStyle(element);
+    return element.tabIndex >= 0
+      && element.getAttribute("aria-hidden") !== "true"
+      && style.display !== "none"
+      && style.visibility !== "hidden";
+  });
+}
+
+function isInteractiveKeyboardTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && Boolean(target.closest([
+    "a[href]",
+    "button",
+    "input",
+    "select",
+    "textarea",
+    '[role="button"]',
+    '[role="combobox"]',
+    '[contenteditable="true"]',
+  ].join(",")));
+}
+
+interface ModalSurfaceFrameProps extends Omit<ModalSurfaceProps, "open" | "onExitComplete"> {
+  stackId: string;
+}
+
+function ModalSurfaceFrame({
+  stackId,
+  onClose,
+  onConfirm,
+  children,
+  overlayClassName,
+  backdropClassName,
+  panelClassName,
+  motion = "compact",
+  ariaLabel,
+  ariaLabelledBy,
+  ariaDescribedBy,
+  backdropLabel = "Close dialog",
+  initialFocusRef,
+  restoreFocusRef,
+  closeOnBackdrop = true,
+  closeOnEscape = true,
+}: ModalSurfaceFrameProps): JSX.Element {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const onCloseRef = useRef(onClose);
+  const onConfirmRef = useRef(onConfirm);
+  const closeOnEscapeRef = useRef(closeOnEscape);
+  const initialFocusTargetRef = useRef(initialFocusRef);
+  const restoreFocusTargetRef = useRef(restoreFocusRef);
+  const confirmHandledRef = useRef(false);
+  const isPresent = useIsPresent();
+  const topModalId = useSyncExternalStore(subscribeToModalStack, getTopModalId, () => null);
+  const ownsInteraction = isPresent && topModalId === stackId;
+  const ownsInteractionRef = useRef(ownsInteraction);
+  onCloseRef.current = onClose;
+  onConfirmRef.current = onConfirm;
+  closeOnEscapeRef.current = closeOnEscape;
+  initialFocusTargetRef.current = initialFocusRef;
+  restoreFocusTargetRef.current = restoreFocusRef;
+  ownsInteractionRef.current = ownsInteraction;
+
+  useEffect(() => {
+    if (isPresent) confirmHandledRef.current = false;
+  }, [isPresent]);
+
+  useLayoutEffect(() => {
+    previousFocusRef.current = restoreFocusTargetRef.current?.current
+      ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
+    registerModal(stackId);
+    lockBodyScroll();
+
+    const focusFrame = window.requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      if (!panel || modalStack.at(-1) !== stackId) return;
+      const initialTarget = initialFocusTargetRef.current?.current ?? getFocusableElements(panel)[0] ?? panel;
+      initialTarget.focus({ preventScroll: true });
+    });
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (!ownsInteractionRef.current || event.defaultPrevented) return;
+
+      if (event.key === "Escape" && closeOnEscapeRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        onCloseRef.current();
+        return;
+      }
+
+      if (
+        event.key === "Enter"
+        && !event.repeat
+        && !event.isComposing
+        && onConfirmRef.current
+        && !isInteractiveKeyboardTarget(event.target)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (confirmHandledRef.current) return;
+        confirmHandledRef.current = true;
+        onConfirmRef.current();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = getFocusableElements(panel);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        panel.focus({ preventScroll: true });
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || active === panel || !panel.contains(active))) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      } else if (!event.shiftKey && (active === last || active === panel || !panel.contains(active))) {
+        event.preventDefault();
+        first.focus({ preventScroll: true });
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      document.removeEventListener("keydown", handleKeyDown);
+      const wasTopmost = unregisterModal(stackId);
+      unlockBodyScroll();
+
+      const previousFocus = previousFocusRef.current;
+      previousFocusRef.current = null;
+      if (wasTopmost && previousFocus?.isConnected) {
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(() => {
+            if (previousFocus.isConnected) {
+              previousFocus.focus({ preventScroll: true });
+            }
+          });
+        });
+      }
+    };
+  }, [stackId]);
+
+  const panelMotion = motion === "large" ? largeSurfaceMotion : dialogMotion;
+  const modalState = !isPresent ? "exiting" : ownsInteraction ? "active" : "covered";
+  const closeFromBackdrop = closeOnBackdrop
+    ? () => {
+        if (ownsInteractionRef.current) onCloseRef.current();
+      }
+    : undefined;
+
+  if (motion === "none") {
+    return (
+      <div
+        className={overlayClassName}
+        role="dialog"
+        aria-modal={ownsInteraction ? true : undefined}
+        aria-hidden={ownsInteraction ? undefined : true}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        data-modal-state={modalState}
+        inert={ownsInteraction ? undefined : true}
+        style={ownsInteraction ? undefined : { pointerEvents: "none" }}
+      >
+        <button
+          type="button"
+          className={backdropClassName}
+          aria-label={backdropLabel}
+          tabIndex={-1}
+          onClick={closeFromBackdrop}
+        />
+        <div ref={panelRef} className={panelClassName} tabIndex={-1}>
+          {children}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <m.div
+      className={overlayClassName}
+      role="dialog"
+      aria-modal={ownsInteraction ? true : undefined}
+      aria-hidden={ownsInteraction ? undefined : true}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+      data-modal-state={modalState}
+      inert={ownsInteraction ? undefined : true}
+      style={ownsInteraction ? undefined : { pointerEvents: "none" }}
+      initial={overlayMotion.initial}
+      animate={overlayMotion.animate}
+      exit={overlayMotion.exit}
+      transition={overlayMotion.transition}
+    >
+      <button
+        type="button"
+        className={backdropClassName}
+        aria-label={backdropLabel}
+        tabIndex={-1}
+        onClick={closeFromBackdrop}
+      />
+      <m.div
+        ref={panelRef}
+        className={panelClassName}
+        tabIndex={-1}
+        initial={panelMotion.initial}
+        animate={panelMotion.animate}
+        exit={panelMotion.exit}
+        transition={panelMotion.transition}
+      >
+        {children}
+      </m.div>
+    </m.div>
+  );
+}
+
+export function ModalSurface({
+  open,
+  onExitComplete,
+  motion = "compact",
+  ...frameProps
+}: ModalSurfaceProps): JSX.Element | null {
+  const generatedId = useId();
+  const stackId = `modal-${generatedId}`;
+
+  if (typeof document === "undefined") return null;
+
+  const handleExitComplete = (): void => {
+    onExitComplete?.();
+    const restoreTarget = frameProps.restoreFocusRef?.current;
+    if (!restoreTarget) return;
+
+    let remainingFrames = 12;
+    const restoreWhenInteractive = (): void => {
+      if (!restoreTarget.isConnected) return;
+      if (!restoreTarget.closest("[inert]")) {
+        restoreTarget.focus({ preventScroll: true });
+        return;
+      }
+      if (remainingFrames > 0) {
+        remainingFrames -= 1;
+        window.requestAnimationFrame(restoreWhenInteractive);
+      }
+    };
+    window.requestAnimationFrame(restoreWhenInteractive);
+  };
+
+  if (motion === "none") {
+    return open
+      ? createPortal(<ModalSurfaceFrame {...frameProps} motion="none" stackId={stackId} />, document.body)
+      : null;
+  }
+
+  return createPortal(
+    <AnimatePresence initial={false} onExitComplete={handleExitComplete}>
+      {open ? (
+        <ModalSurfaceFrame
+          key={stackId}
+          {...frameProps}
+          motion={motion}
+          stackId={stackId}
+        />
+      ) : null}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/opennow-stable/src/renderer/src/components/ui/SelectDropdown.tsx
+++ b/opennow-stable/src/renderer/src/components/ui/SelectDropdown.tsx
@@ -274,7 +274,7 @@ export function SelectDropdown({
                       tabIndex={-1}
                       className={cx("select-dropdown__option", selected && "is-selected", active && "is-active")}
                       onClick={() => selectOption(index)}
-                      onMouseEnter={() => {
+                      onPointerMove={() => {
                         if (!option.disabled) setActiveIndex(index);
                       }}
                     >

--- a/opennow-stable/src/renderer/src/hooks/useAuthSession.ts
+++ b/opennow-stable/src/renderer/src/hooks/useAuthSession.ts
@@ -114,6 +114,8 @@ export function useAuthSession({
   const hasInitializedRef = useRef(false);
   const qrLoginAttemptRef = useRef(0);
   const completingQrLoginRef = useRef(false);
+  const removeAccountInFlightRef = useRef(false);
+  const logoutInFlightRef = useRef(false);
 
   const selectedProvider = useMemo(() => {
     return providers.find((p) => p.idpId === providerIdpId) ?? authSession?.provider ?? null;
@@ -367,26 +369,31 @@ export function useAuthSession({
   }, []);
 
   const confirmRemoveAccount = useCallback(async () => {
-    if (!accountToRemove) return;
+    if (!accountToRemove || removeAccountInFlightRef.current) return;
+    removeAccountInFlightRef.current = true;
     const targetUserId = accountToRemove;
     setRemoveAccountConfirmOpen(false);
     setAccountToRemove(null);
 
-    await window.openNow.removeAccount(targetUserId);
-    const [accounts, sessionResult] = await Promise.all([
-      window.openNow.getSavedAccounts(),
-      window.openNow.getAuthSession(),
-    ]);
-    setSavedAccounts(accounts);
-    setAuthSession(sessionResult.session);
-    if (sessionResult.session) {
-      setProviderIdpId(sessionResult.session.provider.idpId);
-      await loadSessionRuntimeData(sessionResult.session);
-      await refreshNavbarActiveSession(sessionResult.session);
-      return;
+    try {
+      await window.openNow.removeAccount(targetUserId);
+      const [accounts, sessionResult] = await Promise.all([
+        window.openNow.getSavedAccounts(),
+        window.openNow.getAuthSession(),
+      ]);
+      setSavedAccounts(accounts);
+      setAuthSession(sessionResult.session);
+      if (sessionResult.session) {
+        setProviderIdpId(sessionResult.session.provider.idpId);
+        await loadSessionRuntimeData(sessionResult.session);
+        await refreshNavbarActiveSession(sessionResult.session);
+        return;
+      }
+      clearSessionCatalog("no-session", { clearFeatured: true });
+      setNavbarActiveSession(null);
+    } finally {
+      removeAccountInFlightRef.current = false;
     }
-    clearSessionCatalog("no-session", { clearFeatured: true });
-    setNavbarActiveSession(null);
   }, [
     accountToRemove,
     clearSessionCatalog,
@@ -401,15 +408,22 @@ export function useAuthSession({
   }, []);
 
   const confirmLogout = useCallback(async () => {
+    if (logoutInFlightRef.current) return;
+    logoutInFlightRef.current = true;
     setLogoutConfirmOpen(false);
     clearSessionCatalog("logout");
-    await window.openNow.logoutAll();
-    setAuthSession(null);
-    setSavedAccounts([]);
-    resetLaunchRuntime();
-    setNavbarActiveSession(null);
-    setIsResumingNavbarSession(false);
-    setCurrentPage("home");
+
+    try {
+      await window.openNow.logoutAll();
+      setAuthSession(null);
+      setSavedAccounts([]);
+      resetLaunchRuntime();
+      setNavbarActiveSession(null);
+      setIsResumingNavbarSession(false);
+      setCurrentPage("home");
+    } finally {
+      logoutInFlightRef.current = false;
+    }
   }, [
     clearSessionCatalog,
     resetLaunchRuntime,

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -155,6 +155,16 @@ body,
     linear-gradient(180deg, var(--bg-a), var(--bg-b));
 }
 
+.app-shell {
+  display: contents;
+}
+
+.stream-view-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1080;
+}
+
 .app-container--controller {
   --navbar-h: 118px;
   background:
@@ -208,7 +218,6 @@ body,
   background: var(--bg-a);
   border-bottom: 1px solid var(--panel-border);
   z-index: 1000;
-  will-change: transform;
 }
 
 [data-translucent="true"] .navbar {
@@ -1004,7 +1013,17 @@ body,
   -webkit-backdrop-filter: blur(3px);
 }
 
+.navbar-modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
 .navbar-modal {
+  position: relative;
+  z-index: 1;
   width: min(760px, calc(100vw - 40px));
   max-height: calc(100vh - 70px);
   border-radius: 12px;
@@ -2021,9 +2040,6 @@ body,
   box-shadow: none;
   cursor: pointer;
   contain: layout style;
-  transform: translate3d(0, 0, 0);
-  backface-visibility: hidden;
-  will-change: transform;
   transition: border-color var(--t-fast), box-shadow var(--t-fast), filter var(--t-fast);
 }
 
@@ -2607,7 +2623,6 @@ body,
   overflow-y: auto;
   min-height: 0;
   padding-right: 2px;
-  will-change: scroll-position;
 }
 
 .home-empty-state {
@@ -2931,7 +2946,6 @@ body,
   overflow-y: auto;
   min-height: 0;
   padding-right: 2px;
-  will-change: scroll-position;
 }
 
 .library-game-wrapper {
@@ -3033,7 +3047,6 @@ body,
   object-fit: cover;
   object-position: center;
   filter: saturate(0.98) brightness(0.78);
-  will-change: opacity, transform;
 }
 
 .controller-hero-placeholder {
@@ -3053,7 +3066,6 @@ body,
   left: clamp(42px, 7vw, 300px);
   bottom: clamp(46px, 6.4vh, 140px);
   z-index: 1;
-  will-change: opacity, transform;
 }
 
 .controller-hero-content h1 {
@@ -3254,19 +3266,17 @@ body,
   box-shadow: 0 18px 38px rgba(0, 0, 0, 0.32);
   cursor: pointer;
   contain: layout style;
-  transform: translate3d(0, 0, 0);
-  backface-visibility: hidden;
   transition: border-color var(--t-fast), box-shadow var(--t-fast), filter var(--t-fast), transform var(--t-fast);
 }
 
 .controller-native-card:hover {
-  transform: translate3d(0, -3px, 0) scale(1.02);
+  transform: translateY(-3px) scale(1.02);
 }
 
 .controller-native-card.selected {
   border-color: #2ee375;
   box-shadow: 0 0 0 2px rgba(var(--accent-rgb), 0.68), 0 24px 48px rgba(0, 0, 0, 0.38);
-  transform: translate3d(0, -3px, 0) scale(1.025);
+  transform: translateY(-3px) scale(1.025);
 }
 
 .controller-native-card-art,
@@ -3659,9 +3669,6 @@ body,
   cursor: pointer;
   transition: border-color var(--t-normal), box-shadow var(--t-normal);
   contain: layout style;
-  transform: translate3d(0, 0, 0);
-  backface-visibility: hidden;
-  will-change: transform;
 }
 
 .home-page .game-card:focus,
@@ -3704,7 +3711,6 @@ body,
   padding-top: var(--game-aspect);
   overflow: hidden;
   background: var(--bg-c);
-  backface-visibility: hidden;
   flex: 1;
 }
 
@@ -3721,7 +3727,6 @@ body,
   object-fit: cover;
   object-position: center;
   transition: transform var(--t-slow);
-  will-change: transform;
 }
 
 .game-card:hover .game-card-image {
@@ -3978,16 +3983,9 @@ button.game-card-store-chip.owned.active:hover {
   cursor: pointer;
 }
 
-.settings-modal-placeholder {
-  flex: 1;
-  min-height: 0;
-}
-
 .animated-modal-panel {
   position: relative;
   z-index: 1;
-  transform: translateZ(0);
-  backface-visibility: hidden;
 }
 
 .settings-modal {
@@ -5375,9 +5373,7 @@ button.game-card-store-chip.owned.active:hover {
   position: absolute;
   inset: 0;
   border: none;
-  background: rgba(8, 9, 11, 0.6);
-  -webkit-backdrop-filter: blur(6px);
-  backdrop-filter: blur(6px);
+  background: rgba(8, 9, 11, 0.68);
   cursor: pointer;
 }
 
@@ -7350,7 +7346,7 @@ button.game-card-store-chip.owned.active:hover {
   border-radius: var(--r-md);
   background: var(--bg-b);
   overflow: hidden;
-  transition: bottom 420ms var(--ease), border-color 320ms var(--ease), box-shadow 320ms var(--ease);
+  transition: border-color 320ms var(--ease), box-shadow 320ms var(--ease);
 }
 
 [data-translucent="true"] .sv-stats {
@@ -7795,7 +7791,7 @@ button.game-card-store-chip.owned.active:hover {
   z-index: 1001;
   color: var(--error);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
 }
 
 .sv-mic:hover {
@@ -8399,23 +8395,25 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .sload-step-line-fill {
+  width: 100%;
   height: 100%;
-  width: 0%;
+  transform: scaleX(0);
+  transform-origin: left center;
   background: linear-gradient(90deg, var(--accent), var(--accent-press));
-  transition: width 500ms var(--ease);
+  transition: transform 500ms var(--ease);
 }
 
 .sload-step-line.failed .sload-step-line-fill {
-  width: 100%;
+  transform: scaleX(1);
   background: linear-gradient(90deg, #f87171, #ef4444);
 }
 
 .sload-step.completed .sload-step-line-fill {
-  width: 100%;
+  transform: scaleX(1);
 }
 
 .sload-step.active .sload-step-line-fill {
-  width: 50%;
+  transform: scaleX(0.5);
 }
 
 /* Status */
@@ -10098,21 +10096,6 @@ button.game-card-store-chip.owned.active:hover {
    REDUCED MOTION
    ====================================================== */
 @media (prefers-reduced-motion: reduce) {
-
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-
-  .sload-spin {
-    animation-name: spin !important;
-    animation-duration: 1s !important;
-    animation-iteration-count: infinite !important;
-  }
-
   .animated-modal-scrim {
     background-color: rgba(6, 7, 9, 0.72);
   }
@@ -10392,18 +10375,14 @@ button.game-card-store-chip.owned.active:hover {
   opacity: 1;
 }
 
-.app-container--controller > .main-content {
+.app-container--controller > .app-shell > .main-content,
+.app-container--atmosphere > .app-shell > .main-content {
   position: relative;
   z-index: 1;
 }
 
-.app-container--atmosphere > .main-content {
-  position: relative;
-  z-index: 1;
-}
-
-.app-container--controller > .navbar,
-.app-container--atmosphere > .navbar {
+.app-container--controller > .app-shell > .navbar,
+.app-container--atmosphere > .app-shell > .navbar {
   z-index: 1000;
 }
 
@@ -10428,14 +10407,12 @@ button.game-card-store-chip.owned.active:hover {
 
 .app-container--controller .controller-store-tile {
   transition:
-    transform 320ms cubic-bezier(0.22, 1, 0.36, 1),
     border-color 220ms ease,
     box-shadow 320ms ease,
     filter 320ms ease;
 }
 
 .app-container--controller .controller-store-tile.focused {
-  transform: translate3d(0, -7px, 0) scale(1.035);
   border-color: #63f296;
   box-shadow:
     0 0 0 2px rgba(99, 242, 150, 0.9),
@@ -10731,10 +10708,6 @@ button.game-card-store-chip.owned.active:hover {
   background: rgba(255, 255, 255, 0.09);
 }
 
-.sv-video {
-  will-change: opacity, transform;
-}
-
 @media (max-width: 720px), (max-height: 700px) {
   .sload-content {
     padding: 24px;
@@ -10761,7 +10734,7 @@ button.game-card-store-chip.owned.active:hover {
 
 @media (prefers-reduced-motion: reduce) {
   .shader-atmosphere canvas {
-    display: none;
+    display: none !important;
   }
 
   .sv-video {


### PR DESCRIPTION
## Summary

- keep the authenticated catalog shell mounted through launch, loading, stream, error, and exit transitions
- consolidate settings and nested dialogs onto a shared, accessible modal lifecycle
- remove competing CSS/Motion transforms, layout-driven transitions, and persistent compositor hints
- suspend covered background input and shader work while preserving page state and scroll position
- make settings sliders preview smoothly while committing persistence once per interaction
- improve runtime `prefers-reduced-motion` behavior and image/card layout stability

## Verification

- `npm --prefix opennow-stable run build`
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable test` — 230/230 passed
- `git diff --check`
- Electron/CDP verification of Settings entry/exit, dropdown Escape ordering, modal stacking, focus restoration, responsive layout, catalog identity/scroll preservation, and runtime reduced-motion changes
- screenshots reviewed at 1400×900 and 1024×680

## Remaining smoke test

A real queue/connect/live-stream/native-renderer session was not started to avoid consuming a cloud session. The affected stream transitions were reviewed structurally and covered by build/tests, but should receive a live-session smoke test before release.

