### PR TITLE
fix(ci): preserve LF endings for patch files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 opennow-stable/src/main/gfn/games.ts whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
 opennow-stable/src/main/ipc/accountCatalogHandlers.ts whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
 opennow-stable/src/renderer/src/components/HomePage.tsx whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+*.patch text eol=lf


### PR DESCRIPTION
The Windows release runner converted the D3D11 patch to CRLF during checkout, so `git apply` could not match the LF-only GStreamer source. Mark all `.patch` files as LF in `.gitattributes` so the patched Windows GStreamer build receives a valid unified diff.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cf40e968-9a3f-4a38-afd5-035eba74b819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-272" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cf40e968-9a3f-4a38-afd5-035eba74b819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-272&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-272"><img alt="OPE-272" src="https://capy.ai/api/badge/thread.svg?label=OPE-272"></picture></a>
<!-- capy-pr-badge:end -->