### PR TITLE
fix(ci): build only patched D3D11 target

### DIFF
--- a/opennow-stable/scripts/build-patched-gstreamer-d3d11.ps1
+++ b/opennow-stable/scripts/build-patched-gstreamer-d3d11.ps1
@@ -62,7 +62,7 @@ if ($LASTEXITCODE -ne 0) {
   throw "Failed to configure the patched GStreamer D3D11 plugin."
 }
 
-meson compile -C $buildRoot
+meson compile -C $buildRoot gstd3d11
 if ($LASTEXITCODE -ne 0) {
   throw "Failed to compile the patched GStreamer D3D11 plugin."
 }


### PR DESCRIPTION
The patched GStreamer step configured successfully but compiled every generated target, including an unrelated `webrtcdsp` plugin whose installed SDK dependency lacks an Abseil header. Compile the `gstd3d11` Meson target directly so Meson builds the patched plugin and its required libraries without pulling unrelated optional plugins into the release path.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cf40e968-9a3f-4a38-afd5-035eba74b819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-272" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cf40e968-9a3f-4a38-afd5-035eba74b819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-272&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-272"><img alt="OPE-272" src="https://capy.ai/api/badge/thread.svg?label=OPE-272"></picture></a>
<!-- capy-pr-badge:end -->