### PR TITLE
fix(ci): align Windows GStreamer Vulkan runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,7 +286,7 @@ jobs:
       npm_config_audit: "false"
       npm_config_fund: "false"
       GSTREAMER_VERSION: "1.28.2"
-      GSTREAMER_WINDOWS_VERSION: "1.26.8"
+      GSTREAMER_WINDOWS_VERSION: "1.28.3"
       CARGO_NET_RETRY: "10"
       CARGO_HTTP_MULTIPLEXING: "false"
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
@@ -421,15 +421,14 @@ jobs:
         if: matrix.native_build == 'true' && runner.os == 'Windows'
         shell: pwsh
         run: |
-          $installBase = "C:\gstreamer"
+          $installRoot = "C:\gstreamer\1.0\msvc_x86_64"
           $roots = @(
-            "C:\gstreamer\1.0\msvc_x86_64",
+            $installRoot,
             "C:\Program Files\gstreamer\1.0\msvc_x86_64"
           )
           $searchBases = @("C:\gstreamer", "C:\Program Files\gstreamer")
           $script:gstreamerPcPaths = @()
-          $script:lastRuntimeMsiExitCode = $null
-          $script:lastDevelMsiExitCode = $null
+          $script:lastInstallerExitCode = $null
           function Test-GStreamerRoot([string] $candidate) {
             return [bool]($candidate -and
               (Test-Path (Join-Path $candidate "lib\pkgconfig\gstreamer-1.0.pc")) -and
@@ -451,7 +450,7 @@ jobs:
             }
             return $null
           }
-          function Get-GStreamerMsi([string] $fileName, [string] $downloadDir, [string[]] $urlBases) {
+          function Get-GStreamerInstaller([string] $fileName, [string] $downloadDir, [string[]] $urlBases) {
             New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null
             $output = Join-Path $downloadDir $fileName
             $partial = "$output.part"
@@ -487,33 +486,34 @@ jobs:
             }
             return $null
           }
-          function Install-GStreamerMsiSdk([string] $version) {
+          function Install-GStreamerSdk([string] $version) {
             $urlBases = @(
               "https://gstreamer.freedesktop.org/data/pkg/windows/$version/msvc",
               "https://gstreamer.freedesktop.org/pkg/windows/$version/msvc"
             )
             $downloadDir = Join-Path $env:GITHUB_WORKSPACE ".cache\gstreamer-windows\$version"
-            $runtime = Get-GStreamerMsi "gstreamer-1.0-msvc-x86_64-$version.msi" $downloadDir $urlBases
-            if (-not $runtime) { return $false }
-            $devel = Get-GStreamerMsi "gstreamer-1.0-devel-msvc-x86_64-$version.msi" $downloadDir $urlBases
-            if (-not $devel) { return $false }
-            $runtimeInstall = Start-Process msiexec.exe -ArgumentList @("/i", $runtime, "/qn", "/norestart", "INSTALLDIR=$installBase", "ADDLOCAL=ALL") -Wait -PassThru
-            $script:lastRuntimeMsiExitCode = $runtimeInstall.ExitCode
-            if ($runtimeInstall.ExitCode -ne 0) { return $false }
-            $develInstall = Start-Process msiexec.exe -ArgumentList @("/i", $devel, "/qn", "/norestart", "INSTALLDIR=$installBase", "ADDLOCAL=ALL") -Wait -PassThru
-            $script:lastDevelMsiExitCode = $develInstall.ExitCode
-            if ($develInstall.ExitCode -ne 0) { return $false }
+            $installer = Get-GStreamerInstaller "gstreamer-1.0-msvc-x86_64-$version.exe" $downloadDir $urlBases
+            if (-not $installer) { return $false }
+            $install = Start-Process -FilePath $installer -ArgumentList @(
+              "/VERYSILENT",
+              "/SUPPRESSMSGBOXES",
+              "/NORESTART",
+              "/TYPE=devel",
+              "/DIR=$installRoot"
+            ) -Wait -PassThru -NoNewWindow
+            $script:lastInstallerExitCode = $install.ExitCode
+            if ($install.ExitCode -ne 0) { return $false }
             return [bool](Find-GStreamerRoot)
           }
           $root = Find-GStreamerRoot
           if ($root) {
             Write-Host "Using cached GStreamer Windows SDK: $root"
-          } elseif (-not (Install-GStreamerMsiSdk $env:GSTREAMER_WINDOWS_VERSION)) {
+          } elseif (-not (Install-GStreamerSdk $env:GSTREAMER_WINDOWS_VERSION)) {
             [void](Find-GStreamerRoot)
             Write-Host "GStreamer explicit roots searched: $($roots -join ', ')"
             Write-Host "GStreamer recursive search bases: $($searchBases -join ', ')"
             Write-Host "Discovered gstreamer-1.0.pc paths: $(if ($script:gstreamerPcPaths.Count) { $script:gstreamerPcPaths -join ', ' } else { 'none' })"
-            Write-Error "Failed to install/discover GStreamer Windows MSI SDK version $env:GSTREAMER_WINDOWS_VERSION. Runtime MSI exit code: $script:lastRuntimeMsiExitCode; devel MSI exit code: $script:lastDevelMsiExitCode."
+            Write-Error "Failed to install/discover GStreamer Windows SDK version $env:GSTREAMER_WINDOWS_VERSION. Installer exit code: $script:lastInstallerExitCode."
             exit 1
           }
           $root = Find-GStreamerRoot

--- a/opennow-stable/scripts/inject-gstreamer-vulkan-windows.mjs
+++ b/opennow-stable/scripts/inject-gstreamer-vulkan-windows.mjs
@@ -75,6 +75,7 @@ function resolveVendorDir(runtimeVersion) {
     const [major, minor] = runtimeVersion.split(".");
     const sameSeries = versions.find((version) => version.startsWith(`${major}.${minor}.`));
     if (sameSeries) return join(vendorRoot, sameSeries);
+    return null;
   }
   return join(vendorRoot, versions[0]);
 }
@@ -130,7 +131,7 @@ try {
   const vendorDir = resolveVendorDir(runtimeVersion);
   if (!vendorDir) {
     throw new Error(
-      "No vendored Windows GStreamer Vulkan plugins were found. "
+      `No compatible vendored Windows GStreamer Vulkan plugins were found for runtime ${runtimeVersion ?? "unknown"}. `
       + `Expected artifacts under ${vendorRoot}/<gstreamer-version>/.`,
     );
   }


### PR DESCRIPTION
The Windows release bundled GStreamer 1.26.8 but injected a Vulkan plugin built for 1.28.3, so GStreamer rejected the plugin and native capability verification found neither `vulkansink` nor Vulkan decoders.

- Install the matching GStreamer 1.28.3 MSVC SDK through its current single Inno Setup executable and `devel` install type.
- Refuse to inject a vendored Vulkan plugin from a different GStreamer minor series, turning future version drift into an explicit compatibility error.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cf40e968-9a3f-4a38-afd5-035eba74b819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-272" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cf40e968-9a3f-4a38-afd5-035eba74b819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-272&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-272"><img alt="OPE-272" src="https://capy.ai/api/badge/thread.svg?label=OPE-272"></picture></a>
<!-- capy-pr-badge:end -->