### PR TITLE
fix(ci): bundle and verify Vulkan loader

### DIFF
--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -366,7 +366,7 @@ function parseNativeStreamerResponse(stdout) {
   return response;
 }
 
-function verifyGstreamerBinary(binaryPath, env, requiredVideoBackends = []) {
+function verifyGstreamerBinary(binaryPath, env) {
   const result = spawnSync(binaryPath, {
     input: `${JSON.stringify({ id: verifyCommandId, type: "hello", protocolVersion: nativeStreamerProtocolVersion })}\n`,
     encoding: "utf8",
@@ -432,24 +432,21 @@ function verifyGstreamerBinary(binaryPath, env, requiredVideoBackends = []) {
     process.exit(1);
   }
 
-  for (const required of requiredVideoBackends) {
-    const backend = capabilities.videoBackends.find((candidate) => candidate?.backend === required.backend);
-    const availableCodecs = new Set(
-      Array.isArray(backend?.codecs)
-        ? backend.codecs.filter((codec) => codec?.available).map((codec) => codec.codec)
-        : [],
-    );
-    const missingCodecs = required.codecs.filter((codec) => !availableCodecs.has(codec));
-    if (!backend?.available || backend.sink !== required.sink || missingCodecs.length > 0) {
-      console.error(
-        `Bundled native streamer is missing required ${required.backend} capability `
-        + `(sink=${required.sink}, codecs=${required.codecs.join("/")}): ${JSON.stringify(backend)}`,
-      );
-      process.exit(1);
-    }
-  }
-
   console.log(`Verified native streamer GStreamer capabilities: ${availableVideoBackends.join(", ")}.`);
+}
+
+function verifyBundledWindowsVulkanPlugin(binaryPath, env) {
+  const gstInspect = join(dirname(binaryPath), "gstreamer", "bin", "gst-inspect-1.0.exe");
+  const result = spawnSync(gstInspect, ["vulkanupload"], {
+    encoding: "utf8",
+    env,
+  });
+  if (result.status !== 0) {
+    console.error(result.stderr || result.stdout);
+    console.error("Bundled GStreamer Vulkan plugin failed to load.");
+    process.exit(result.status ?? 1);
+  }
+  console.log("Verified bundled GStreamer Vulkan plugin and loader.");
 }
 
 const cargoArgs = ["build", "--release", "--manifest-path", manifestPath];
@@ -502,14 +499,11 @@ if (process.platform !== "win32") {
 if (hasFeature(nativeFeatures, "gstreamer")) {
   verifyGstreamerBinary(packageBinary, buildEnv);
   if (bundleGstreamerRuntime(gstreamerSdkRoot, nativeFeatures)) {
-    const requiredVideoBackends = process.platform === "win32"
-      ? [{ backend: "vulkan", sink: "vulkansink", codecs: ["h264", "h265"] }]
-      : [];
-    verifyGstreamerBinary(
-      packagePlatformBinary,
-      buildBundledGstreamerEnv(buildEnv, packagePlatformBinary),
-      requiredVideoBackends,
-    );
+    const bundledEnv = buildBundledGstreamerEnv(buildEnv, packagePlatformBinary);
+    if (process.platform === "win32") {
+      verifyBundledWindowsVulkanPlugin(packagePlatformBinary, bundledEnv);
+    }
+    verifyGstreamerBinary(packagePlatformBinary, bundledEnv);
   }
 }
 

--- a/opennow-stable/scripts/inject-gstreamer-vulkan-windows.mjs
+++ b/opennow-stable/scripts/inject-gstreamer-vulkan-windows.mjs
@@ -83,8 +83,12 @@ function resolveVendorDir(runtimeVersion) {
 function injectVulkanPlugins(runtimeRoot, vendorDir) {
   const pluginSource = join(vendorDir, "lib", "gstreamer-1.0", "gstvulkan.dll");
   const librarySource = join(vendorDir, "bin", "gstvulkan-1.0-0.dll");
+  const loaderSource = join(packageRoot, "node_modules", "electron", "dist", "vulkan-1.dll");
   if (!isExistingFile(pluginSource) || !isExistingFile(librarySource)) {
     throw new Error(`Vendored Vulkan artifacts are incomplete under ${vendorDir}`);
+  }
+  if (!isExistingFile(loaderSource)) {
+    throw new Error(`Electron Vulkan loader was not found: ${loaderSource}`);
   }
 
   const pluginDestDir = join(runtimeRoot, "lib", "gstreamer-1.0");
@@ -93,6 +97,7 @@ function injectVulkanPlugins(runtimeRoot, vendorDir) {
   mkdirSync(binDestDir, { recursive: true });
   copyFileSync(pluginSource, join(pluginDestDir, "gstvulkan.dll"));
   copyFileSync(librarySource, join(binDestDir, "gstvulkan-1.0-0.dll"));
+  copyFileSync(loaderSource, join(binDestDir, "vulkan-1.dll"));
 
   const metadataPath = join(runtimeRoot, "OPENNOW-GSTREAMER-RUNTIME.txt");
   if (isExistingFile(metadataPath)) {
@@ -106,7 +111,7 @@ function injectVulkanPlugins(runtimeRoot, vendorDir) {
     }
   }
 
-  console.log(`Injected Windows GStreamer Vulkan plugins from ${vendorDir} into ${runtimeRoot}.`);
+  console.log(`Injected Windows GStreamer Vulkan plugins and loader into ${runtimeRoot}.`);
 }
 
 const args = parseArgs(process.argv.slice(2));


### PR DESCRIPTION
The vendored GStreamer Vulkan DLL imports `vulkan-1.dll`, but the private runtime omitted that loader. Even after the GStreamer versions were aligned, the plugin could not load; the subsequent capability assertion also incorrectly required hardware decoder factories on a headless CI runner.

- Copy Electron's shipped Vulkan loader into the private GStreamer runtime alongside the vendored plugin.
- Verify `vulkanupload` loads through the bundled `gst-inspect`, which checks the plugin and its DLL dependency chain without requiring a physical GPU.
- Keep native streamer verification focused on usable runtime capabilities available on the current machine instead of demanding hardware-only Vulkan codecs in CI.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cf40e968-9a3f-4a38-afd5-035eba74b819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-272" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cf40e968-9a3f-4a38-afd5-035eba74b819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-272&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-272"><img alt="OPE-272" src="https://capy.ai/api/badge/thread.svg?label=OPE-272"></picture></a>
<!-- capy-pr-badge:end -->