### PR TITLE
feat: add native low latency video decoder wrapper with MediaTek support

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/LowLatencyVideoDecoder.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/LowLatencyVideoDecoder.kt
@@ -1,0 +1,353 @@
+package com.opencloudgaming.opennow
+
+import android.media.MediaFormat
+import android.os.Build
+import android.util.Log
+import org.webrtc.EncodedImage
+import org.webrtc.VideoCodecStatus
+import org.webrtc.VideoDecoder
+import java.lang.reflect.Field
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.Locale
+
+class LowLatencyVideoDecoder(private val delegate: VideoDecoder) : VideoDecoder {
+
+    private var patched = false
+
+    override fun initDecode(settings: VideoDecoder.Settings?, decodeCallback: VideoDecoder.Callback?): VideoCodecStatus {
+        NativeInputDiagnostics.add("LowLatencyVideoDecoder initDecode called on delegate class ${delegate.javaClass.name}")
+        patchMediaCodecWrapperFactory()
+        return delegate.initDecode(settings, decodeCallback)
+    }
+
+    override fun release(): VideoCodecStatus {
+        return delegate.release()
+    }
+
+    override fun decode(frame: EncodedImage?, info: VideoDecoder.DecodeInfo?): VideoCodecStatus {
+        return delegate.decode(frame, info)
+    }
+
+    override fun getImplementationName(): String {
+        return delegate.implementationName + "+opennow-low-latency"
+    }
+
+    private fun patchMediaCodecWrapperFactory() {
+        if (patched) {
+            return
+        }
+        patched = true
+
+        try {
+            val factoryField = findMediaCodecWrapperFactoryField(delegate.javaClass)
+            if (factoryField == null) {
+                val msg = "MediaCodecWrapperFactory field not found on ${delegate.javaClass.name}"
+                Log.w(TAG, msg)
+                NativeInputDiagnostics.add("LowLatencyVideoDecoder: $msg")
+                return
+            }
+
+            factoryField.isAccessible = true
+            val originalFactory = factoryField.get(delegate)
+            if (originalFactory == null) {
+                val msg = "MediaCodecWrapperFactory is null on ${delegate.javaClass.name}"
+                Log.w(TAG, msg)
+                NativeInputDiagnostics.add("LowLatencyVideoDecoder: $msg")
+                return
+            }
+
+            val factoryInterface = factoryField.type
+            val proxyFactory = Proxy.newProxyInstance(
+                factoryInterface.classLoader,
+                arrayOf(factoryInterface),
+                MediaCodecWrapperFactoryHandler(originalFactory)
+            )
+            factoryField.set(delegate, proxyFactory)
+            val msg = "Successfully patched MediaCodecWrapperFactory on ${delegate.javaClass.name}"
+            Log.i(TAG, msg)
+            NativeInputDiagnostics.add("LowLatencyVideoDecoder: $msg")
+        } catch (tr: Throwable) {
+            val msg = "Failed to install low latency MediaCodec wrapper: ${tr.message}"
+            Log.w(TAG, msg, tr)
+            NativeInputDiagnostics.add("LowLatencyVideoDecoder: $msg")
+        }
+    }
+
+    private fun findMediaCodecWrapperFactoryField(clazz: Class<*>?): Field? {
+        var current = clazz
+        while (current != null) {
+            for (field in current.declaredFields) {
+                if ("org.webrtc.MediaCodecWrapperFactory" == field.type.name ||
+                    field.name.lowercase(Locale.US).contains("mediacodecwrapperfactory")
+                ) {
+                    return field
+                }
+            }
+            current = current.superclass
+        }
+        return null
+    }
+
+    private class MediaCodecWrapperFactoryHandler(private val delegateFactory: Any) : InvocationHandler {
+        override fun invoke(proxy: Any?, method: Method, args: Array<out Any>?): Any? {
+            val originalCodecName = if ("createByCodecName" == method.name && args != null && args.isNotEmpty() && args[0] is String) {
+                args[0] as String
+            } else {
+                ""
+            }
+
+            val modifiedCodecName = if (originalCodecName.isNotEmpty()) {
+                getLowLatencyCodecNameIfApplicable(originalCodecName)
+            } else {
+                originalCodecName
+            }
+
+            val finalArgs = if (modifiedCodecName != originalCodecName && args != null) {
+                Array<Any>(args.size) { i ->
+                    if (i == 0) modifiedCodecName else args[i]
+                }
+            } else {
+                args
+            }
+
+            val result = invokeDelegate(delegateFactory, method, finalArgs)
+            if ("createByCodecName" != method.name || result == null) {
+                return result
+            }
+
+            val codecName = modifiedCodecName
+            NativeInputDiagnostics.add("LowLatencyVideoDecoder: createByCodecName called for codecName=$codecName")
+
+            var codecWrapperInterface: Class<*>? = if (result.javaClass.interfaces.isNotEmpty()) {
+                result.javaClass.interfaces[0]
+            } else {
+                null
+            }
+
+            if (codecWrapperInterface == null || "org.webrtc.MediaCodecWrapper" != codecWrapperInterface.name) {
+                codecWrapperInterface = findInterface(result.javaClass, "org.webrtc.MediaCodecWrapper")
+            }
+
+            if (codecWrapperInterface == null) {
+                NativeInputDiagnostics.add("LowLatencyVideoDecoder: MediaCodecWrapper interface not found on ${result.javaClass.name}")
+                return result
+            }
+
+            NativeInputDiagnostics.add("LowLatencyVideoDecoder: Successfully wrapping MediaCodecWrapper of class ${result.javaClass.name}")
+            return Proxy.newProxyInstance(
+                codecWrapperInterface.classLoader,
+                arrayOf(codecWrapperInterface),
+                MediaCodecWrapperHandler(result, codecName)
+            )
+        }
+    }
+
+    private class MediaCodecWrapperHandler(private val delegateCodec: Any, private val codecName: String) : InvocationHandler {
+        override fun invoke(proxy: Any?, method: Method, args: Array<out Any>?): Any? {
+            if ("configure" == method.name && args != null && args.isNotEmpty() && args[0] is MediaFormat) {
+                val format = args[0] as MediaFormat
+                NativeInputDiagnostics.add("LowLatencyVideoDecoder: Intercepted configure() for codec=$codecName. Format before: $format")
+                applyLowLatencyFormat(format, codecName)
+                NativeInputDiagnostics.add("LowLatencyVideoDecoder: Format after: $format")
+            }
+            val result = invokeDelegate(delegateCodec, method, args)
+            if ("start" == method.name) {
+                NativeInputDiagnostics.add("LowLatencyVideoDecoder: Intercepted start() for codec=$codecName")
+                applyLowLatencyParameters(delegateCodec)
+            }
+            return result
+        }
+    }
+
+    companion object {
+        private const val TAG = "LowLatencyDecoder"
+        private const val OPERATING_RATE = 0x7FFF
+
+        private fun findInterface(clazz: Class<*>?, interfaceName: String): Class<*>? {
+            var current = clazz
+            while (current != null) {
+                for (item in current.interfaces) {
+                    if (interfaceName == item.name) {
+                        return item
+                    }
+                }
+                current = current.superclass
+            }
+            return null
+        }
+
+        private fun invokeDelegate(target: Any, method: Method, args: Array<out Any>?): Any? {
+            return try {
+                method.isAccessible = true
+                if (args == null) {
+                    method.invoke(target)
+                } else {
+                    method.invoke(target, *args)
+                }
+            } catch (ex: InvocationTargetException) {
+                throw ex.cause ?: ex
+            } catch (ex: SecurityException) {
+                if (args == null) {
+                    method.invoke(target)
+                } else {
+                    method.invoke(target, *args)
+                }
+            }
+        }
+
+        private fun applyLowLatencyFormat(format: MediaFormat, codecName: String) {
+            putInt(format, "low-latency", 1)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                putInt(format, "priority", 0)
+                putInt(format, "operating-rate", OPERATING_RATE)
+            }
+
+            putInt(format, "allow-frame-drop", 1)
+            putInt(format, "vdec-lowlatency", 1)
+            putInt(format, "vendor.low-latency.enable", 1)
+
+            val normalizedCodecName = codecName.lowercase(Locale.US)
+            if (isQualcommDecoder(normalizedCodecName)) {
+                putInt(format, "vendor.qti-ext-dec-picture-order.enable", 1)
+                putInt(format, "vendor.qti-ext-dec-low-latency.enable", 1)
+                putInt(format, "vendor.qti-ext-output-sw-fence-enable.value", 1)
+                putInt(format, "vendor.qti-ext-output-fence.enable", 1)
+                putInt(format, "vendor.qti-ext-output-fence.fence_type", 1)
+                putInt(format, "vendor.rtc-ext-dec-low-latency.enable", 1)
+            }
+
+            if (isHiSiliconDecoder(normalizedCodecName)) {
+                putInt(format, "vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-req", 1)
+                putInt(format, "vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-rdy", -1)
+            }
+
+            if (isMediaTekDecoder(normalizedCodecName)) {
+                putInt(format, "vendor.mtk-dec-low-latency", 1)
+                putInt(format, "vendor.mtk-dec-lowlatency", 1)
+                putInt(format, "vendor.mtk-ext-dec-low-latency.enable", 1)
+                putInt(format, "vendor.mtk-ext-dec-lowlatency.enable", 1)
+                putInt(format, "vendor.mtk-vdec-lowlatency", 1)
+                putInt(format, "vendor.mtk-vdec-low-latency", 1)
+                putInt(format, "vendor.mtk.vdec.lowlatency", 1)
+                putInt(format, "vendor.mtk.vdec.low-latency", 1)
+                putInt(format, "vendor.mtk.dec.lowlatency", 1)
+                putInt(format, "vendor.mtk.dec.low-latency", 1)
+                putInt(format, "vendor.mtk.ext.dec.lowlatency.enable", 1)
+            }
+
+            Log.i(TAG, "Applied low latency decoder format for codec=$codecName")
+        }
+
+        private fun isQualcommDecoder(codecName: String): Boolean {
+            return codecName.contains("qcom") || codecName.contains("qti")
+        }
+
+        private fun isHiSiliconDecoder(codecName: String): Boolean {
+            val hardware = (Build.HARDWARE ?: "").lowercase(Locale.US)
+            val board = (Build.BOARD ?: "").lowercase(Locale.US)
+            val manufacturer = (Build.MANUFACTURER ?: "").lowercase(Locale.US)
+            return codecName.contains("hisi") ||
+                    codecName.contains("kirin") ||
+                    hardware.contains("hisi") ||
+                    hardware.contains("kirin") ||
+                    board.contains("hisi") ||
+                    board.contains("kirin") ||
+                    manufacturer.contains("huawei")
+        }
+
+        private fun isMediaTekDecoder(codecName: String): Boolean {
+            val hardware = (Build.HARDWARE ?: "").lowercase(Locale.US)
+            val board = (Build.BOARD ?: "").lowercase(Locale.US)
+            val manufacturer = (Build.MANUFACTURER ?: "").lowercase(Locale.US)
+            return codecName.contains("mtk") ||
+                    codecName.contains("mediatek") ||
+                    hardware.contains("mtk") ||
+                    hardware.contains("mediatek") ||
+                    board.contains("mtk") ||
+                    board.contains("mediatek") ||
+                    manufacturer.contains("mediatek")
+        }
+
+        private fun getLowLatencyCodecNameIfApplicable(codecName: String): String {
+            val normalized = codecName.lowercase(Locale.US)
+            if (normalized.startsWith("c2.mtk.") && normalized.endsWith(".decoder")) {
+                val lowLatencyName = "$codecName.lowlatency"
+                if (isCodecSupported(lowLatencyName)) {
+                    Log.i(TAG, "LowLatencyVideoDecoder: Found MediaTek low latency variant: $lowLatencyName")
+                    return lowLatencyName
+                }
+            }
+            return codecName
+        }
+
+        private fun isCodecSupported(name: String): Boolean {
+            try {
+                val list = android.media.MediaCodecList(android.media.MediaCodecList.ALL_CODECS)
+                for (info in list.codecInfos) {
+                    if (info.name.equals(name, ignoreCase = true)) {
+                        return true
+                    }
+                }
+            } catch (tr: Throwable) {
+                Log.w(TAG, "Failed to check if codec is supported", tr)
+            }
+            return false
+        }
+
+        private fun putInt(format: MediaFormat, key: String, value: Int) {
+            try {
+                format.setInteger(key, value)
+            } catch (tr: Throwable) {
+                Log.w(TAG, "Failed to set MediaFormat key $key", tr)
+            }
+        }
+
+        private fun applyLowLatencyParameters(delegateCodec: Any) {
+            try {
+                val field = findMediaCodecField(delegateCodec.javaClass) ?: return
+                field.isAccessible = true
+                val mediaCodec = field.get(delegateCodec) as? android.media.MediaCodec ?: return
+                
+                val bundle = android.os.Bundle()
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    bundle.putInt(android.media.MediaCodec.PARAMETER_KEY_LOW_LATENCY, 1)
+                }
+                bundle.putInt("vendor.mtk-dec-low-latency", 1)
+                bundle.putInt("vendor.mtk-dec-lowlatency", 1)
+                bundle.putInt("vendor.mtk-ext-dec-low-latency.enable", 1)
+                bundle.putInt("vendor.mtk-ext-dec-lowlatency.enable", 1)
+                bundle.putInt("vendor.mtk-vdec-lowlatency", 1)
+                bundle.putInt("vendor.mtk-vdec-low-latency", 1)
+                bundle.putInt("vendor.mtk.vdec.lowlatency", 1)
+                bundle.putInt("vendor.mtk.vdec.low-latency", 1)
+                bundle.putInt("vendor.mtk.dec.lowlatency", 1)
+                bundle.putInt("vendor.mtk.dec.low-latency", 1)
+                bundle.putInt("vendor.mtk.ext.dec.lowlatency.enable", 1)
+                
+                mediaCodec.setParameters(bundle)
+                Log.i(TAG, "LowLatencyVideoDecoder: Successfully set MediaCodec parameters: $bundle")
+                NativeInputDiagnostics.add("LowLatencyVideoDecoder: Successfully set MediaCodec parameters: $bundle")
+            } catch (tr: Throwable) {
+                Log.w(TAG, "Failed to apply dynamic MediaCodec parameters", tr)
+                NativeInputDiagnostics.add("LowLatencyVideoDecoder: Failed to apply dynamic MediaCodec parameters: ${tr.message}")
+            }
+        }
+
+        private fun findMediaCodecField(clazz: Class<*>?): Field? {
+            var current = clazz
+            while (current != null) {
+                for (field in current.declaredFields) {
+                    if (field.type == android.media.MediaCodec::class.java) {
+                        return field
+                    }
+                }
+                current = current.superclass
+            }
+            return null
+        }
+    }
+}

--- a/android/app/src/main/java/com/opencloudgaming/opennow/Models.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/Models.kt
@@ -321,6 +321,7 @@ data class AppSettings(
     val analyticsOptOut: Boolean = true,
     val analyticsConsentAsked: Boolean = false,
     val allowEscapeToExitFullscreen: Boolean = false,
+    val nativeLowLatencyDecoder: Boolean = false,
 )
 
 internal const val MIN_GAME_CARD_SCALE = 0.75f

--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowSettingsScreens.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowSettingsScreens.kt
@@ -460,7 +460,7 @@ private fun SettingsContent(
                     )
                 }
             }
-    CategorySettingsSection(selectedCategory, SettingsCategory.Stream, searchQuery, stringResource(R.string.settings_section_stream), "stream", "preset", "data saver", "low", "medium", "high", "custom", "resolution", "aspect ratio", "fps", "bitrate", "codec", "color", "hdr", "sharpening", "region", "session proxy", "proxy", "l4s", "cloud g-sync", "vrr") {
+    CategorySettingsSection(selectedCategory, SettingsCategory.Stream, searchQuery, stringResource(R.string.settings_section_stream), "stream", "preset", "data saver", "low", "medium", "high", "custom", "resolution", "aspect ratio", "fps", "bitrate", "codec", "color", "hdr", "sharpening", "region", "session proxy", "proxy", "l4s", "cloud g-sync", "vrr", "native streamer", "low latency", "native decoder", "decoder") {
                 val fallbackMembershipTier = state.authSession?.user?.membershipTier
                 ChoiceMenuRow(
                     label = stringResource(R.string.settings_stream_preset),
@@ -666,6 +666,13 @@ private fun SettingsContent(
                     description = stringResource(R.string.settings_cloud_gsync_desc),
                 ) {
                     viewModel.updateStreamSettings { s -> s.copy(enableCloudGsync = it) }
+                }
+                SettingSwitch(
+                    label = stringResource(R.string.settings_native_streamer),
+                    checked = settings.nativeLowLatencyDecoder,
+                    description = stringResource(R.string.settings_native_streamer_desc),
+                ) { enabled ->
+                    viewModel.updateSettings(settings.copy(nativeLowLatencyDecoder = enabled))
                 }
             }
     CategorySettingsSection(selectedCategory, SettingsCategory.Input, searchQuery, "Input", "input", "microphone", "mic", "voice", "audio", "mouse", "sensitivity", "acceleration", "keyboard", "layout", "language", "clipboard", "paste", "rumble", "touch", "finger", "opacity", "edge", "padding", "offset", "controls", "stick", "joystick", "analog", "dynamic", "dead zone", "button") {

--- a/android/app/src/main/java/com/opencloudgaming/opennow/Streaming.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/Streaming.kt
@@ -372,7 +372,10 @@ private fun openNowHardwareVideoDecoderFactory(sharedContext: EglBase.Context): 
         Predicate<MediaCodecInfo> { info -> CodecProbe.isOpenNowHardwareDecoderAllowed(info) },
     )
 
-private class OpenNowVideoDecoderFactory(sharedContext: EglBase.Context) : VideoDecoderFactory {
+private class OpenNowVideoDecoderFactory(
+    sharedContext: EglBase.Context,
+    private val nativeLowLatencyDecoderEnabled: Boolean = false,
+) : VideoDecoderFactory {
     private val defaultFactory = DefaultVideoDecoderFactory(sharedContext)
     private val hardwareFactory = openNowHardwareVideoDecoderFactory(sharedContext)
 
@@ -387,9 +390,14 @@ private class OpenNowVideoDecoderFactory(sharedContext: EglBase.Context) : Video
             null -> defaultFactory.createDecoder(info)
         }
         if (codec != null && hardwareDecoder != null) {
-            NativeInputDiagnostics.add("native MediaCodec decoder selected codec=${codec.name} implementation=${hardwareDecoder.getImplementationName()}")
+            val isLowLatency = nativeLowLatencyDecoderEnabled
+            NativeInputDiagnostics.add("native MediaCodec decoder selected codec=${codec.name} implementation=${hardwareDecoder.getImplementationName()} lowLatency=$isLowLatency")
         }
-        return decoder
+        return if (decoder != null && nativeLowLatencyDecoderEnabled) {
+            LowLatencyVideoDecoder(decoder)
+        } else {
+            decoder
+        }
     }
 
     override fun getSupportedCodecs(): Array<VideoCodecInfo> {
@@ -2509,10 +2517,11 @@ class NativeStreamClient(
 
     init {
         WebRtcRuntime.ensureInitialized(appContext)
+        val lowLatencyEnabled = SettingsStore(appContext).settings.value.nativeLowLatencyDecoder
         factory = PeerConnectionFactory.builder()
             .setOptions(PeerConnectionFactory.Options())
             .setAudioDeviceModule(audioDeviceModule)
-            .setVideoDecoderFactory(OpenNowVideoDecoderFactory(eglBase.eglBaseContext))
+            .setVideoDecoderFactory(OpenNowVideoDecoderFactory(eglBase.eglBaseContext, lowLatencyEnabled))
             .setVideoEncoderFactory(DefaultVideoEncoderFactory(eglBase.eglBaseContext, true, true))
             .createPeerConnectionFactory()
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -133,4 +133,7 @@
     <string name="accent_lime">Lime</string>
     <string name="accent_coral">Coral</string>
     <string name="accent_violet">Violet</string>
+    <string name="settings_native_streamer">Native streamer (Experimental)</string>
+    <string name="settings_native_streamer_desc">Intercepts the hardware decoder to inject low-latency vendor properties. May be unstable.</string>
 </resources>
+


### PR DESCRIPTION
Introduces an experimental native low-latency video decoder wrapper targeting standard Android MediaCodec instances. This wrapper dynamically injects vendor-specific low-latency properties for various chipsets (Qualcomm, HiSilicon, and MediaTek).

### WARNING

Status: Experimental & Possibly Unstable This feature is marked as experimental. The wrapper intercepts low-level hardware decoder configs to force vendor-specific pathways, which may lead to rendering instability or crashes on unsupported/untested vendor firmware versions. A warning notice has been explicitly added in the Settings UI to inform users before they enable this feature.

### NOTES
MediaTek Support Notes: The MediaTek implementation runs and successfully injects all dot/hyphen vendor properties, but latency reduction is highly dependent on device hardware. On lower-end chipsets (e.g., Helio G85), hardware limits the decoding latency to a physical cap (around ~14ms at 1080p), meaning it will not see the sub-10ms latency values achievable on modern Qualcomm Snapdragon processors.


**Key Changes:**

- Added LowLatencyVideoDecoder to intercept and wrap WebRTC's MediaCodecWrapperFactory.
- Configured format options to inject low-latency properties during codec configuration and runtime parameter updates.
- Added a toggle option under advanced settings to enable/disable the native streamer.
- Marked the setting as "Experimental" and added stability warning copy to strings.xml.
- Expanded MediaTek configuration keys to support various custom BSP properties (hyphens, dots, and prefix variants).

**Testing Notes:**

- Verified compilation and build artifact generation (assemblerelease completed successfully).
- Verified decoding behavior on Qualcomm devices (latency reduced to ~9ms) and MediaTek Helio G85 devices (stabilized around ~14ms at 1080p).