### PR TITLE
feat(input): Scandinavian keyboard layouts (#624)

### DIFF
--- a/opennow-stable/src/shared/gfn/keyboard.test.ts
+++ b/opennow-stable/src/shared/gfn/keyboard.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  keyboardLayoutOptions,
+  resolveGfnKeyboardLayout,
+} from "./keyboard";
+
+describe("resolveGfnKeyboardLayout", () => {
+  const scandinavianLayouts = [
+    { value: "da-DK", macValue: "m-da" },
+    { value: "nb-NO", macValue: "m-no" },
+    { value: "sv-SE", macValue: "m-sv" },
+    { value: "fi-FI", macValue: "m-fi" },
+  ] as const;
+
+  it("exposes Scandinavian layouts matching official GFN key codes", () => {
+    for (const expected of scandinavianLayouts) {
+      const option = keyboardLayoutOptions.find((candidate) => candidate.value === expected.value);
+      assert.ok(option, `missing layout option ${expected.value}`);
+      assert.equal(option.macValue, expected.macValue);
+    }
+  });
+
+  it("sends Windows layout IDs unchanged", () => {
+    for (const { value } of scandinavianLayouts) {
+      assert.equal(resolveGfnKeyboardLayout(value, "win32"), value);
+      assert.equal(resolveGfnKeyboardLayout(value, "linux"), value);
+    }
+  });
+
+  it("maps Scandinavian layouts to official mac key codes on darwin", () => {
+    for (const { value, macValue } of scandinavianLayouts) {
+      assert.equal(resolveGfnKeyboardLayout(value, "darwin"), macValue);
+    }
+  });
+});

--- a/opennow-stable/src/shared/gfn/keyboard.ts
+++ b/opennow-stable/src/shared/gfn/keyboard.ts
@@ -9,7 +9,8 @@ export type GameLanguage =
 /** Keyboard layout codes for physical key mapping in remote sessions */
 export type KeyboardLayout =
   | "en-US" | "en-GB" | "tr-TR" | "de-DE" | "fr-FR" | "es-ES" | "es-MX" | "it-IT"
-  | "pt-PT" | "pt-BR" | "pl-PL" | "ru-RU" | "ja-JP" | "ko-KR" | "zh-CN" | "zh-TW";
+  | "pt-PT" | "pt-BR" | "pl-PL" | "da-DK" | "nb-NO" | "sv-SE" | "fi-FI"
+  | "ru-RU" | "ja-JP" | "ko-KR" | "zh-CN" | "zh-TW";
 
 export interface KeyboardLayoutOption {
   value: KeyboardLayout;
@@ -31,6 +32,10 @@ export const keyboardLayoutOptions: readonly KeyboardLayoutOption[] = [
   { value: "pt-PT", label: "Portuguese (Portugal)" },
   { value: "pt-BR", label: "Portuguese (Brazil)" },
   { value: "pl-PL", label: "Polish" },
+  { value: "da-DK", label: "Danish", macValue: "m-da" },
+  { value: "nb-NO", label: "Norwegian", macValue: "m-no" },
+  { value: "sv-SE", label: "Swedish", macValue: "m-sv" },
+  { value: "fi-FI", label: "Finnish", macValue: "m-fi" },
   { value: "ru-RU", label: "Russian" },
   { value: "ja-JP", label: "Japanese" },
   { value: "ko-KR", label: "Korean" },


### PR DESCRIPTION
﻿## Summary
- Official GFN maps keyboards by **layout ID** sent on session create/claim (`keyboardLayout` query param) and optionally mid-session via `setKeyboardLayout`. Physical VK events are forwarded; the server remaps OEM keys from that layout ID (not a client-side character lookup table).
- OpenNOW already used this path (`resolveGfnKeyboardLayout` → CloudMatch session URL + settings dropdown). Scandinavian layouts were simply missing from the selectable ID list.
- Adds official layout IDs: **Danish `da-DK` (`m-da` on macOS)**, **Norwegian `nb-NO` (`m-no`)**, **Swedish `sv-SE` (`m-sv`)**, **Finnish `fi-FI` (`m-fi`)** — matching NVIDIA's `default_keyCode` / `mac_keyCode` tables from the GFN web JS runtime.
- Settings → Input → Keyboard layout now lists these options; selecting one configures the remote Windows session layout so in-game chat and other text input get the correct Scandinavian keys.

Fixes #624

## Test plan
- [ ] `npm --prefix opennow-stable run typecheck`
- [ ] `npm --prefix opennow-stable test -- --test-name-pattern resolveGfnKeyboardLayout`
- [ ] Open Settings → Input and confirm Danish / Norwegian / Swedish / Finnish appear in Keyboard layout
- [ ] Start a stream with Danish selected; verify Æ Ø Å produce the expected characters in in-game chat
- [ ] Repeat for Norwegian, Swedish (ä ö å), and Finnish
- [ ] On macOS, confirm session request uses `m-da` / `m-no` / `m-sv` / `m-fi` (optional)
