### PR TITLE
fix(controller): make bottom hint overlay clickable with mouse (#620)

### DIFF
--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -691,11 +691,23 @@ export const HomePage = memo(function HomePage({
               ))}
             </div>
 
-            <div className="controller-bottom-hints" aria-hidden="true">
-              <div className="controller-hint"><span className="controller-button controller-button--a">A</span><span>{t("app.actions.select")}</span></div>
-              <div className="controller-hint"><span className="controller-button controller-button--b">B</span><span>{t("app.actions.back")}</span></div>
-              <div className="controller-hint"><span className="controller-button controller-button--x">X</span><span>{t("app.actions.search")}</span></div>
-              <div className="controller-hint controller-hint--more"><span className="controller-menu-button"><Menu size={22} /></span><span>{t("library.moreOptions")}</span></div>
+            <div className="controller-bottom-hints" role="toolbar">
+              <button type="button" className="controller-hint" onClick={launchFocusedTile}>
+                <span className="controller-button controller-button--a" aria-hidden="true">A</span>
+                <span>{t("app.actions.select")}</span>
+              </button>
+              <button type="button" className="controller-hint" onClick={() => onPreviousControllerPage?.()}>
+                <span className="controller-button controller-button--b" aria-hidden="true">B</span>
+                <span>{t("app.actions.back")}</span>
+              </button>
+              <button type="button" className="controller-hint" onClick={() => setControllerSearchOpen(true)}>
+                <span className="controller-button controller-button--x" aria-hidden="true">X</span>
+                <span>{t("app.actions.search")}</span>
+              </button>
+              <button type="button" className="controller-hint controller-hint--more" onClick={() => { cycleFocusedVariant(); }}>
+                <span className="controller-menu-button" aria-hidden="true"><Menu size={22} /></span>
+                <span>{t("library.moreOptions")}</span>
+              </button>
             </div>
 
             <AnimatePresence initial={false}>
@@ -726,7 +738,15 @@ export const HomePage = memo(function HomePage({
                     placeholder={t("home.searchPlaceholder")}
                     className="controller-search-input"
                   />
-                  <p>{t("app.actions.back")}</p>
+                  <div className="controller-search-actions">
+                    <button
+                      type="button"
+                      className="controller-secondary-action"
+                      onClick={() => setControllerSearchOpen(false)}
+                    >
+                      {t("app.actions.back")}
+                    </button>
+                  </div>
                   </m.div>
                 </m.div>
               )}

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -562,6 +562,16 @@ export const LibraryPage = memo(function LibraryPage({
         detailsGame={detailsGame}
         onCloseDetails={() => setDetailsGame(null)}
         onCycleGameVariant={cycleGameVariant}
+        onSelectHint={() => {
+          if (selectedControllerGame) onPlayGame(selectedControllerGame);
+        }}
+        onBackHint={() => onPreviousControllerPage?.()}
+        onFilterHint={showControllerStoreFilterOverlay}
+        onSearchHint={() => setControllerSearchOpen(true)}
+        onMoreOptionsHint={() => {
+          if (selectedControllerGame) setDetailsGame(selectedControllerGame);
+        }}
+        onCloseSearchHint={() => setControllerSearchOpen(false)}
       />
     );
   }

--- a/opennow-stable/src/renderer/src/components/library/LibraryControllerView.tsx
+++ b/opennow-stable/src/renderer/src/components/library/LibraryControllerView.tsx
@@ -40,6 +40,12 @@ export interface LibraryControllerViewProps {
   detailsGame: GameInfo | null;
   onCloseDetails: () => void;
   onCycleGameVariant: (game: GameInfo | undefined) => void;
+  onSelectHint?: () => void;
+  onBackHint?: () => void;
+  onFilterHint?: () => void;
+  onSearchHint?: () => void;
+  onMoreOptionsHint?: () => void;
+  onCloseSearchHint?: () => void;
 }
 
 /**
@@ -73,6 +79,12 @@ export function LibraryControllerView({
   detailsGame,
   onCloseDetails,
   onCycleGameVariant,
+  onSelectHint,
+  onBackHint,
+  onFilterHint,
+  onSearchHint,
+  onMoreOptionsHint,
+  onCloseSearchHint,
 }: LibraryControllerViewProps): JSX.Element {
   const { t } = useTranslation();
   const heroImageUrl = featuredGame ? getControllerHeroBackgroundCandidates(featuredGame)[0] : undefined;
@@ -174,12 +186,27 @@ export function LibraryControllerView({
             )}
           </section>
 
-          <div className="controller-bottom-hints" aria-hidden="true">
-            <div className="controller-hint"><span className="controller-button controller-button--a">A</span><span>{t("app.actions.select")}</span></div>
-            <div className="controller-hint"><span className="controller-button controller-button--b">B</span><span>{t("app.actions.back")}</span></div>
-            <div className="controller-hint"><span className="controller-button controller-button--y">Y</span><span>{t("library.filter")}</span></div>
-            <div className="controller-hint"><span className="controller-button controller-button--x">X</span><span>{t("app.actions.search")}</span></div>
-            <div className="controller-hint controller-hint--more"><span className="controller-menu-button"><Menu size={22} /></span><span>{t("library.moreOptions")}</span></div>
+          <div className="controller-bottom-hints" role="toolbar">
+            <button type="button" className="controller-hint" onClick={() => onSelectHint?.()}>
+              <span className="controller-button controller-button--a" aria-hidden="true">A</span>
+              <span>{t("app.actions.select")}</span>
+            </button>
+            <button type="button" className="controller-hint" onClick={() => onBackHint?.()}>
+              <span className="controller-button controller-button--b" aria-hidden="true">B</span>
+              <span>{t("app.actions.back")}</span>
+            </button>
+            <button type="button" className="controller-hint" onClick={() => onFilterHint?.()}>
+              <span className="controller-button controller-button--y" aria-hidden="true">Y</span>
+              <span>{t("library.filter")}</span>
+            </button>
+            <button type="button" className="controller-hint" onClick={() => onSearchHint?.()}>
+              <span className="controller-button controller-button--x" aria-hidden="true">X</span>
+              <span>{t("app.actions.search")}</span>
+            </button>
+            <button type="button" className="controller-hint controller-hint--more" onClick={() => onMoreOptionsHint?.()}>
+              <span className="controller-menu-button" aria-hidden="true"><Menu size={22} /></span>
+              <span>{t("library.moreOptions")}</span>
+            </button>
           </div>
 
           {controllerStoreFilterOpen && (
@@ -219,7 +246,15 @@ export function LibraryControllerView({
                   placeholder={t("library.searchPlaceholder")}
                   className="controller-search-input"
                 />
-                <p>{t("app.actions.back")}</p>
+                <div className="controller-search-actions">
+                  <button
+                    type="button"
+                    className="controller-secondary-action"
+                    onClick={() => onCloseSearchHint?.()}
+                  >
+                    {t("app.actions.back")}
+                  </button>
+                </div>
               </div>
             </div>
           )}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -1891,8 +1891,7 @@ body,
 
 .controller-store-hero,
 .controller-store-sections,
-.controller-store-empty,
-.controller-store-page .controller-bottom-hints {
+.controller-store-empty {
   position: relative;
   z-index: 1;
 }
@@ -3430,7 +3429,7 @@ body,
   display: flex;
   align-items: center;
   gap: clamp(18px, 2.4vw, 74px);
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .controller-hint {
@@ -3438,13 +3437,46 @@ body,
   align-items: center;
   gap: 10px;
   color: color-mix(in srgb, var(--ink) 74%, transparent);
+  font: inherit;
   font-size: clamp(0.76rem, 0.68vw, 1.05rem);
   font-weight: 850;
   white-space: nowrap;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 6px 10px;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+}
+
+button.controller-hint {
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.controller-hint:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.24);
+  color: color-mix(in srgb, var(--ink) 88%, transparent);
+}
+
+.controller-hint:active {
+  transform: scale(0.97);
+  background: rgba(255, 255, 255, 0.18);
 }
 
 .controller-hint--more {
   margin-left: auto;
+}
+
+.controller-search-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 18px;
+}
+
+.controller-search-actions .controller-secondary-action {
+  min-width: 132px;
 }
 
 .controller-button,


### PR DESCRIPTION
## Summary
- Make controller-mode bottom hint overlays (Select A / Back B / Filter Y / Search X / More Options) clickable with the mouse.
- Root cause: hints used `pointer-events: none` and non-interactive `div`s, so clicks never reached local UI actions.
- Wire hint buttons to the same handlers already used by gamepad/keyboard bindings; gamepad behavior is unchanged.

## Approach
- Enable pointer events and button styling for `.controller-bottom-hints` / `.controller-hint`.
- Keep fixed overlay stacking by not nesting bottom hints under the relative `controller-store-page` z-index rule.
- Convert Home + Library controller hints (and search Back) into buttons calling existing actions.

## Test plan
- [ ] Controller mode: mouse-click Select / Back / Search / More Options on Home; actions match gamepad equivalents
- [ ] Controller mode: mouse-click Select / Back / Filter / Search / More Options on Library; Filter opens store filter, More Options opens details
- [ ] Gamepad navigation/actions still work unchanged on Home and Library
- [ ] Search overlay Back button closes search via mouse
- [ ] F8 pointer-lock toggle still works during a stream
- [ ] Non-controller mode UI unchanged (no bottom hint overlay)

Closes #620