### PR TITLE
fix(streaming): stop synthesizing 90 FPS from entitlements

### DIFF
--- a/opennow-stable/src/shared/entitlements.test.ts
+++ b/opennow-stable/src/shared/entitlements.test.ts
@@ -103,12 +103,40 @@ test("does not derive modes that exceed entitlement dimensions", () => {
   );
 });
 
-test("derives 90 FPS modes only from entitlements that cover 90 FPS", () => {
+test("does not synthesize 90 FPS from higher FPS entitlement envelopes", () => {
   const highFpsEntitlements = [{ width: 1920, height: 1080, fps: 120 }];
   const highFpsExpanded = expandEntitledStreamResolutions(highFpsEntitlements);
 
   assert.equal(
+    highFpsExpanded.some((resolution) => resolution.fps === 90),
+    false,
+  );
+  // Envelope coverage still allows lower catalog FPS at covered resolutions.
+  assert.equal(
     highFpsExpanded.some(
+      (resolution) =>
+        resolution.width === 1280 &&
+        resolution.height === 800 &&
+        resolution.fps === 60,
+    ),
+    true,
+  );
+  // Without an exact MES 90 tuple, request 90 and clamp to the nearest entitled FPS.
+  assert.deepEqual(
+    resolveEntitledStreamProfile(highFpsEntitlements, { resolution: "1280x800", fps: 90 }),
+    { resolution: "1280x800", fps: 60 },
+  );
+});
+
+test("preserves exact 90 FPS modes returned by MES entitlements", () => {
+  const mesNinety = [
+    { width: 1920, height: 1080, fps: 120 },
+    { width: 1280, height: 800, fps: 90 },
+  ];
+  const expanded = expandEntitledStreamResolutions(mesNinety);
+
+  assert.equal(
+    expanded.some(
       (resolution) =>
         resolution.width === 1280 &&
         resolution.height === 800 &&
@@ -117,15 +145,7 @@ test("derives 90 FPS modes only from entitlements that cover 90 FPS", () => {
     true,
   );
   assert.deepEqual(
-    resolveEntitledStreamProfile(highFpsEntitlements, { resolution: "1280x800", fps: 90 }),
+    resolveEntitledStreamProfile(mesNinety, { resolution: "1280x800", fps: 90 }),
     { resolution: "1280x800", fps: 90 },
-  );
-
-  const sixtyFpsExpanded = expandEntitledStreamResolutions([
-    { width: 1920, height: 1080, fps: 60 },
-  ]);
-  assert.equal(
-    sixtyFpsExpanded.some((resolution) => resolution.fps === 90),
-    false,
   );
 });

--- a/opennow-stable/src/shared/gfn/entitlements.ts
+++ b/opennow-stable/src/shared/gfn/entitlements.ts
@@ -9,33 +9,36 @@ export interface EntitledStreamProfile {
   fps: number;
 }
 
+// Official GFN web/Steam Deck mode catalog. Omit 90 FPS: official clients only
+// expose exact MES entitlement tuples, and synthesizing 90 from a 120 FPS
+// envelope is rejected or ignored by CloudMatch.
 const STREAM_MODE_PRESETS: ReadonlyArray<Readonly<{
   width: number;
   height: number;
   fps: readonly number[];
 }>> = Object.freeze([
-  { width: 3840, height: 2160, fps: [120, 90, 60, 30] },
-  { width: 3456, height: 2160, fps: [120, 90, 60, 30] },
-  { width: 3840, height: 1600, fps: [120, 90, 60, 30] },
-  { width: 3440, height: 1440, fps: [120, 90, 60, 30] },
-  { width: 3840, height: 1080, fps: [120, 90, 60, 30] },
-  { width: 2560, height: 1600, fps: [120, 90, 60, 30] },
-  { width: 2560, height: 1440, fps: [120, 90, 60, 30] },
-  { width: 2560, height: 1080, fps: [120, 90, 60, 30] },
-  { width: 1920, height: 1200, fps: [240, 120, 90, 60, 30] },
-  { width: 1920, height: 1080, fps: [240, 120, 90, 60, 30] },
-  { width: 1600, height: 1200, fps: [120, 90, 60, 30] },
-  { width: 1680, height: 1050, fps: [120, 90, 60, 30] },
-  { width: 1600, height: 900, fps: [120, 90, 60, 30] },
-  { width: 1280, height: 1024, fps: [120, 90, 60, 30] },
-  { width: 1440, height: 900, fps: [120, 90, 60, 30] },
-  { width: 1680, height: 720, fps: [120, 90, 60, 30] },
-  { width: 1366, height: 768, fps: [120, 90, 60, 30] },
-  { width: 1280, height: 800, fps: [120, 90, 60, 30] },
-  { width: 1112, height: 834, fps: [120, 90, 60, 30] },
-  { width: 1280, height: 720, fps: [120, 90, 60, 30] },
-  { width: 1376, height: 640, fps: [120, 90, 60, 30] },
-  { width: 1024, height: 768, fps: [120, 90, 60, 30] },
+  { width: 3840, height: 2160, fps: [120, 60, 30] },
+  { width: 3456, height: 2160, fps: [120, 60, 30] },
+  { width: 3840, height: 1600, fps: [120, 60, 30] },
+  { width: 3440, height: 1440, fps: [120, 60, 30] },
+  { width: 3840, height: 1080, fps: [120, 60, 30] },
+  { width: 2560, height: 1600, fps: [120, 60, 30] },
+  { width: 2560, height: 1440, fps: [120, 60, 30] },
+  { width: 2560, height: 1080, fps: [120, 60, 30] },
+  { width: 1920, height: 1200, fps: [240, 120, 60, 30] },
+  { width: 1920, height: 1080, fps: [240, 120, 60, 30] },
+  { width: 1600, height: 1200, fps: [120, 60, 30] },
+  { width: 1680, height: 1050, fps: [120, 60, 30] },
+  { width: 1600, height: 900, fps: [120, 60, 30] },
+  { width: 1280, height: 1024, fps: [120, 60, 30] },
+  { width: 1440, height: 900, fps: [120, 60, 30] },
+  { width: 1680, height: 720, fps: [120, 60, 30] },
+  { width: 1366, height: 768, fps: [120, 60, 30] },
+  { width: 1280, height: 800, fps: [120, 60, 30] },
+  { width: 1112, height: 834, fps: [120, 60, 30] },
+  { width: 1280, height: 720, fps: [120, 60, 30] },
+  { width: 1376, height: 640, fps: [120, 60, 30] },
+  { width: 1024, height: 768, fps: [120, 60, 30] },
 ]);
 
 export const SAFE_FALLBACK_STREAM_PROFILE: Readonly<EntitledStreamProfile> = Object.freeze({


### PR DESCRIPTION
## Summary
- OpenNOW was inventing 90 FPS stream modes from any 120 FPS MES entitlement envelope (`STREAM_MODE_PRESETS`), then sending `framesPerSecond: 90` in CloudMatch/network-test requests.
- Official GFN web and Steam Deck clients do **not** include 90 in their device mode catalogs; they only expose FPS values returned as exact MES `(width, height, framesPerSecond)` tuples via `getFpsOption()`.
- Align OpenNOW with that behavior: keep exact MES 90 FPS modes, stop synthesizing 90 from higher FPS envelopes. Official 90 FPS SDP capture timing remains in place for real MES-backed 90 sessions.

## What changed
- Restore official `STREAM_MODE_PRESETS` FPS lists (no synthesized 90).
- Update entitlement tests to assert non-synthesis + MES-exact 90 preservation.

## Test plan
- [x] `npm --prefix opennow-stable test` (232 passed)
- [x] `npm --prefix opennow-stable run typecheck`
- [ ] Sign in with an account whose MES returns an exact 90 FPS entitlement; confirm 90 appears and session starts at 90
- [ ] Sign in with a 120-only entitlement; confirm 90 is not offered and requests never send `framesPerSecond: 90`
- [ ] Confirm existing 60/120/240 options and SDP 90 profile tests still pass