### PR TITLE
docs: link the OpenNOW Switch prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
   <a href="https://play.google.com/store/apps/details?id=com.opencloudgaming.opennow">
     <img src="https://img.shields.io/badge/Android-Google%20Play-3DDC84?style=for-the-badge&logo=android&logoColor=white" alt="Download Android from Google Play">
   </a>
-  <a href="https://github.com/OpenCloudGaming/Opennow-homebrew">
-    <img src="https://img.shields.io/badge/Switch-Port%20Coming%20Soon-E60012?style=for-the-badge&logo=nintendoswitch&logoColor=white" alt="Switch port coming soon">
+  <a href="https://github.com/OpenCloudGaming/OpenNOW-Switch">
+    <img src="https://img.shields.io/badge/Nintendo%20Switch-Homebrew%20Prototype-E60012?style=for-the-badge&logo=nintendoswitch&logoColor=white" alt="OpenNOW Nintendo Switch homebrew prototype">
   </a>
   <a href="https://opennow.zortos.me">
     <img src="https://img.shields.io/badge/Docs-opennow.zortos.me-blue?style=for-the-badge" alt="Documentation">
@@ -70,7 +70,7 @@ Grab the latest desktop build from [GitHub Releases](https://github.com/OpenClou
 
 - iOS beta: [join TestFlight](https://testflight.apple.com/join/u1XPJKH2). The SwiftUI prototype currently lives on the [`kief5555/ios` branch](https://github.com/OpenCloudGaming/OpenNOW/tree/kief5555/ios/ios/OpenNOWiOS) under `ios/OpenNOWiOS/`; that folder is not present on this branch.
 - Android: download from [Google Play](https://play.google.com/store/apps/details?id=com.opencloudgaming.opennow).
-- Nintendo Switch: a homebrew port is coming soon in [OpenCloudGaming/Opennow-homebrew](https://github.com/OpenCloudGaming/Opennow-homebrew), built on top of Moonlight.
+- Nintendo Switch: follow the native homebrew prototype in [OpenCloudGaming/OpenNOW-Switch](https://github.com/OpenCloudGaming/OpenNOW-Switch). It currently provides the app scaffold and parts of the GFN protocol flow, but streaming is not implemented yet.
 
 For macOS users looking for a more performant OpenNOW version, Jayian1890 maintains the separate [OpenNOW-Mac](https://github.com/OpenCloudGaming/OpenNOW-Mac) repository.
 


### PR DESCRIPTION
Replace the stale “Switch port coming soon” reference with the active OpenNOW-Switch repository. The README now describes the project as a native homebrew prototype and makes its current streaming limitation clear.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/78e65ba3-a417-4067-9406-a43382658883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-275" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/78e65ba3-a417-4067-9406-a43382658883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-275&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-275"><img alt="OPE-275" src="https://capy.ai/api/badge/thread.svg?label=OPE-275"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nintendo Switch promotion and download information.
  * Added a link to the OpenNOW Nintendo Switch homebrew prototype.
  * Clarified that the prototype includes the app scaffold and parts of the GFN protocol flow, while streaming is not yet available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->