### PR TITLE
fix(native): bundle Windows DLL dependency closure

### DIFF
--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -27,7 +27,7 @@
     "lint": "oxlint src",
     "locales:check": "node scripts/check-translations.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.json",
-    "test": "node scripts/run-tests.mjs && node --test scripts/after-sign-mac.test.mjs"
+    "test": "node scripts/run-tests.mjs && node --test scripts/after-sign-mac.test.mjs scripts/windows-pe-imports.test.mjs"
   },
   "dependencies": {
     "@formkit/auto-animate": "^0.10.0",

--- a/opennow-stable/scripts/build-native-streamer.mjs
+++ b/opennow-stable/scripts/build-native-streamer.mjs
@@ -435,6 +435,27 @@ function verifyGstreamerBinary(binaryPath, env) {
   console.log(`Verified native streamer GStreamer capabilities: ${availableVideoBackends.join(", ")}.`);
 }
 
+function verifyBundledWindowsLoader(binaryPath, baseEnv) {
+  const result = spawnSync(binaryPath, {
+    cwd: dirname(binaryPath),
+    input: `${JSON.stringify({ id: verifyCommandId, type: "hello", protocolVersion: nativeStreamerProtocolVersion })}\n`,
+    encoding: "utf8",
+    env: {
+      SystemRoot: baseEnv.SystemRoot,
+      WINDIR: baseEnv.WINDIR,
+      PATH: dirname(binaryPath),
+      OPENNOW_NATIVE_STREAMER_BACKEND: "gstreamer",
+    },
+  });
+  if (result.status !== 0) {
+    console.error(result.stderr || result.stdout);
+    console.error("Bundled native streamer could not start using only DLLs next to its executable.");
+    process.exit(result.status ?? 1);
+  }
+  parseNativeStreamerResponse(result.stdout);
+  console.log("Verified native streamer Windows loader dependency closure.");
+}
+
 function verifyBundledWindowsVulkanPlugin(binaryPath, env) {
   const gstInspect = join(dirname(binaryPath), "gstreamer", "bin", "gst-inspect-1.0.exe");
   const result = spawnSync(gstInspect, ["vulkanupload"], {
@@ -501,6 +522,7 @@ if (hasFeature(nativeFeatures, "gstreamer")) {
   if (bundleGstreamerRuntime(gstreamerSdkRoot, nativeFeatures)) {
     const bundledEnv = buildBundledGstreamerEnv(buildEnv, packagePlatformBinary);
     if (process.platform === "win32") {
+      verifyBundledWindowsLoader(packagePlatformBinary, buildEnv);
       verifyBundledWindowsVulkanPlugin(packagePlatformBinary, bundledEnv);
     }
     verifyGstreamerBinary(packagePlatformBinary, bundledEnv);

--- a/opennow-stable/scripts/bundle-gstreamer-runtime.mjs
+++ b/opennow-stable/scripts/bundle-gstreamer-runtime.mjs
@@ -10,9 +10,10 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { delimiter, dirname, extname, join, relative, resolve } from "node:path";
+import { basename, delimiter, dirname, extname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { collectBundledPeDependencies } from "./windows-pe-imports.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -149,21 +150,6 @@ function writeMetadata(destination, source, platform) {
   );
 }
 
-const WINDOWS_LOADER_DLLS = [
-  "gstreamer-1.0-0.dll",
-  "glib-2.0-0.dll",
-  "gobject-2.0-0.dll",
-  "gio-2.0-0.dll",
-  "gmodule-2.0-0.dll",
-  "gthread-2.0-0.dll",
-  "intl-8.dll",
-  "ffi-8.dll",
-  "pcre2-8-0.dll",
-  "orc-0.4-0.dll",
-  "winpthread-1.dll",
-  "zlib1.dll",
-];
-
 const WINDOWS_VC_RUNTIME_DLLS = [
   "vcruntime140.dll",
   "vcruntime140_1.dll",
@@ -191,9 +177,11 @@ function copyWindowsLoaderDlls({ sdkRoot, destination, binary }) {
   const copiedLoader = [];
   const copiedVc = [];
 
-  for (const name of WINDOWS_LOADER_DLLS) {
-    const source = join(sdkBin, name);
-    if (!isExistingFile(source)) continue;
+  if (!binary) {
+    throw new Error("A native streamer executable is required to collect its Windows DLL dependencies.");
+  }
+  for (const source of collectBundledPeDependencies(binary, sdkBin)) {
+    const name = basename(source);
     copyFileSync(source, join(executableDir, name));
     copiedLoader.push(name);
   }

--- a/opennow-stable/scripts/windows-pe-imports.mjs
+++ b/opennow-stable/scripts/windows-pe-imports.mjs
@@ -1,0 +1,123 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { basename, join } from "node:path";
+
+function checkedRead(buffer, offset, size, label) {
+  if (!Number.isInteger(offset) || offset < 0 || offset + size > buffer.length) {
+    throw new Error(`Invalid PE ${label} offset: ${offset}`);
+  }
+}
+
+function readUInt16(buffer, offset, label) {
+  checkedRead(buffer, offset, 2, label);
+  return buffer.readUInt16LE(offset);
+}
+
+function readUInt32(buffer, offset, label) {
+  checkedRead(buffer, offset, 4, label);
+  return buffer.readUInt32LE(offset);
+}
+
+function readAsciiString(buffer, offset) {
+  checkedRead(buffer, offset, 1, "string");
+  const end = buffer.indexOf(0, offset);
+  if (end < 0) {
+    throw new Error(`Unterminated PE import name at offset ${offset}`);
+  }
+  return buffer.toString("ascii", offset, end);
+}
+
+export function readPeImportNames(buffer) {
+  if (buffer.length < 64 || buffer.toString("ascii", 0, 2) !== "MZ") {
+    throw new Error("File is not a PE executable");
+  }
+
+  const peOffset = readUInt32(buffer, 0x3c, "header");
+  checkedRead(buffer, peOffset, 24, "signature");
+  if (buffer.toString("ascii", peOffset, peOffset + 4) !== "PE\u0000\u0000") {
+    throw new Error("Invalid PE signature");
+  }
+
+  const sectionCount = readUInt16(buffer, peOffset + 6, "section count");
+  const optionalHeaderSize = readUInt16(buffer, peOffset + 20, "optional header size");
+  const optionalHeaderOffset = peOffset + 24;
+  const optionalHeaderMagic = readUInt16(buffer, optionalHeaderOffset, "optional header");
+  const dataDirectoryOffset = optionalHeaderOffset + (
+    optionalHeaderMagic === 0x10b ? 96 : optionalHeaderMagic === 0x20b ? 112 : 0
+  );
+  if (dataDirectoryOffset === optionalHeaderOffset) {
+    throw new Error(`Unsupported PE optional header: 0x${optionalHeaderMagic.toString(16)}`);
+  }
+
+  checkedRead(buffer, optionalHeaderOffset, optionalHeaderSize, "optional header");
+  const importTableRva = readUInt32(buffer, dataDirectoryOffset + 8, "import table");
+  if (importTableRva === 0) {
+    return [];
+  }
+
+  const sectionTableOffset = optionalHeaderOffset + optionalHeaderSize;
+  const sections = [];
+  for (let index = 0; index < sectionCount; index += 1) {
+    const offset = sectionTableOffset + index * 40;
+    checkedRead(buffer, offset, 40, "section");
+    sections.push({
+      virtualSize: readUInt32(buffer, offset + 8, "section virtual size"),
+      virtualAddress: readUInt32(buffer, offset + 12, "section virtual address"),
+      rawSize: readUInt32(buffer, offset + 16, "section raw size"),
+      rawOffset: readUInt32(buffer, offset + 20, "section raw offset"),
+    });
+  }
+
+  const rvaToOffset = (rva) => {
+    const section = sections.find(({ virtualAddress, virtualSize, rawSize }) =>
+      rva >= virtualAddress && rva < virtualAddress + Math.max(virtualSize, rawSize),
+    );
+    if (!section) {
+      throw new Error(`PE import RVA 0x${rva.toString(16)} is outside every section`);
+    }
+    const offset = section.rawOffset + rva - section.virtualAddress;
+    checkedRead(buffer, offset, 1, "import");
+    return offset;
+  };
+
+  const imports = [];
+  let descriptorOffset = rvaToOffset(importTableRva);
+  for (;;) {
+    checkedRead(buffer, descriptorOffset, 20, "import descriptor");
+    const fields = Array.from({ length: 5 }, (_, index) =>
+      readUInt32(buffer, descriptorOffset + index * 4, "import descriptor"),
+    );
+    if (fields.every((value) => value === 0)) {
+      break;
+    }
+    imports.push(readAsciiString(buffer, rvaToOffset(fields[3])));
+    descriptorOffset += 20;
+  }
+  return imports;
+}
+
+export function collectBundledPeDependencies(binary, dependencyDirectory) {
+  const available = new Map(
+    readdirSync(dependencyDirectory)
+      .filter((name) => name.toLowerCase().endsWith(".dll"))
+      .map((name) => [name.toLowerCase(), join(dependencyDirectory, name)]),
+  );
+  const dependencies = new Map();
+  const pending = [binary];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const importedName of readPeImportNames(readFileSync(current))) {
+      const normalizedName = importedName.toLowerCase();
+      const dependency = available.get(normalizedName);
+      if (!dependency || dependencies.has(normalizedName)) {
+        continue;
+      }
+      dependencies.set(normalizedName, dependency);
+      pending.push(dependency);
+    }
+  }
+
+  return [...dependencies.values()].sort((left, right) =>
+    basename(left).localeCompare(basename(right), "en", { sensitivity: "base" }),
+  );
+}

--- a/opennow-stable/scripts/windows-pe-imports.test.mjs
+++ b/opennow-stable/scripts/windows-pe-imports.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { collectBundledPeDependencies, readPeImportNames } from "./windows-pe-imports.mjs";
+
+function peFixture(importNames) {
+  const buffer = Buffer.alloc(0x800);
+  const peOffset = 0x80;
+  const optionalHeaderOffset = peOffset + 24;
+  const sectionTableOffset = optionalHeaderOffset + 0xf0;
+  const sectionRva = 0x1000;
+  const sectionOffset = 0x200;
+  const importTableOffset = sectionOffset;
+
+  buffer.write("MZ", 0, "ascii");
+  buffer.writeUInt32LE(peOffset, 0x3c);
+  buffer.write("PE\u0000\u0000", peOffset, "ascii");
+  buffer.writeUInt16LE(0x8664, peOffset + 4);
+  buffer.writeUInt16LE(1, peOffset + 6);
+  buffer.writeUInt16LE(0xf0, peOffset + 20);
+  buffer.writeUInt16LE(0x20b, optionalHeaderOffset);
+  buffer.writeUInt32LE(sectionRva, optionalHeaderOffset + 112 + 8);
+  buffer.write(".rdata\u0000\u0000", sectionTableOffset, "ascii");
+  buffer.writeUInt32LE(0x600, sectionTableOffset + 8);
+  buffer.writeUInt32LE(sectionRva, sectionTableOffset + 12);
+  buffer.writeUInt32LE(0x600, sectionTableOffset + 16);
+  buffer.writeUInt32LE(sectionOffset, sectionTableOffset + 20);
+
+  let nameOffset = importTableOffset + (importNames.length + 1) * 20;
+  importNames.forEach((name, index) => {
+    buffer.writeUInt32LE(sectionRva + nameOffset - sectionOffset, importTableOffset + index * 20 + 12);
+    buffer.write(`${name}\u0000`, nameOffset, "ascii");
+    nameOffset += Buffer.byteLength(name) + 1;
+  });
+  return buffer;
+}
+
+test("reads imported DLL names from a 64-bit PE image", () => {
+  assert.deepEqual(
+    readPeImportNames(peFixture(["gstvideo-1.0-0.dll", "KERNEL32.dll"])),
+    ["gstvideo-1.0-0.dll", "KERNEL32.dll"],
+  );
+});
+
+test("collects only the recursive DLL closure available in the runtime", async () => {
+  const root = await mkdtemp(join(tmpdir(), "opennow-pe-imports-"));
+  const runtime = join(root, "runtime");
+  const binary = join(root, "opennow-streamer.exe");
+
+  try {
+    await mkdir(runtime);
+    await writeFile(binary, peFixture(["gstvideo-1.0-0.dll", "KERNEL32.dll"]));
+    await writeFile(
+      join(runtime, "gstvideo-1.0-0.dll"),
+      peFixture(["gstreamer-1.0-0.dll", "ffi-7.dll"]),
+    );
+    await writeFile(join(runtime, "gstreamer-1.0-0.dll"), peFixture(["glib-2.0-0.dll"]));
+    await writeFile(join(runtime, "glib-2.0-0.dll"), peFixture([]));
+    await writeFile(join(runtime, "unused.dll"), peFixture([]));
+
+    assert.deepEqual(
+      collectBundledPeDependencies(binary, runtime).map((path) => path.slice(runtime.length + 1)),
+      ["glib-2.0-0.dll", "gstreamer-1.0-0.dll", "gstvideo-1.0-0.dll"],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Windows releases copied a fixed list of GStreamer DLLs beside `opennow-streamer.exe`, leaving direct and transitive imports such as `gstvideo`, `gstwebrtc`, `gstsdp`, and the installed `ffi` version unresolved. This change derives the executable’s complete bundled DLL closure from its PE import tables so the packaged streamer starts without a system GStreamer installation.

- Recursively collect only imported DLLs available in the bundled GStreamer runtime, avoiding a second copy of the entire runtime.
- Smoke-test the Windows executable with a restricted `PATH` during release builds so missing loader dependencies fail the build.
- Cover PE import parsing and recursive dependency selection with packaging tests.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/31a49b47-c4ad-4af9-beb0-a85a4f7870be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-277" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/31a49b47-c4ad-4af9-beb0-a85a4f7870be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-277&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-277"><img alt="OPE-277" src="https://capy.ai/api/badge/thread.svg?label=OPE-277"></picture></a>
<!-- capy-pr-badge:end -->