### PR TITLE
feat(native): add Linux and Raspberry Pi codec support

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -164,9 +164,11 @@ jobs:
         id: test
         run: npm test
 
-      - name: Test Linux native streamer
+      - name: Test and build Linux native streamer
         if: runner.os == 'Linux'
-        run: cargo test --manifest-path ../native/opennow-streamer/Cargo.toml --features gstreamer
+        run: |
+          cargo test --manifest-path ../native/opennow-streamer/Cargo.toml --features gstreamer
+          npm run native:build
 
       - name: CI summary
         if: always()

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -86,7 +86,8 @@ jobs:
           const isPullRequest = eventName === "pull_request";
           const isDevValidationPullRequest = isPullRequest && baseRef === "dev";
           const include = isDevValidationPullRequest
-            ? builds.filter(({ label }) => label === "windows-x64" || label === "linux-x64")
+            ? builds.filter(({ label }) =>
+                label === "windows-x64" || label === "linux-x64" || label === "linux-arm64")
             : builds;
 
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify({ include })}\n`);
@@ -122,6 +123,32 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Setup Rust
+        if: runner.os == 'Linux'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux native streamer dependencies
+        if: runner.os == 'Linux'
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            pkg-config \
+            libx11-dev \
+            libglib2.0-dev \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            libgstreamer-plugins-bad1.0-dev \
+            gstreamer1.0-libav \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-nice \
+            gstreamer1.0-gl \
+            gstreamer1.0-x
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -136,6 +163,10 @@ jobs:
       - name: Test
         id: test
         run: npm test
+
+      - name: Test Linux native streamer
+        if: runner.os == 'Linux'
+        run: cargo test --manifest-path ../native/opennow-streamer/Cargo.toml --features gstreamer
 
       - name: CI summary
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,7 @@ jobs:
             gstreamer1.0-plugins-good \
             gstreamer1.0-plugins-bad \
             gstreamer1.0-plugins-ugly \
+            gstreamer1.0-nice \
             gstreamer1.0-vaapi \
             gstreamer1.0-gl \
             gstreamer1.0-x \

--- a/native/opennow-streamer/Cargo.lock
+++ b/native/opennow-streamer/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +51,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-expr"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +104,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,12 +159,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -90,6 +207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +222,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
@@ -112,11 +241,44 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+]
+
+[[package]]
+name = "gio"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3e1f669909c326b9413bde5a742097b8c90a7d78f45326db13668984769ded"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "pin-project-lite",
+ "smallvec",
 ]
 
 [[package]]
@@ -187,10 +349,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "gstreamer"
-version = "0.25.2"
+name = "gst-plugin-rtp"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ca0c594cac4e86f5444aaa767c7bb810340c0710667a6467d3ead248e35e84"
+checksum = "94a8636a5d8ab4d590e66c4cd103beac097d4c1f053f5723e47f141f5af67d0e"
+dependencies = [
+ "anyhow",
+ "atomic_refcell",
+ "bitstream-io",
+ "byte-slice-cast",
+ "chrono",
+ "futures",
+ "gio",
+ "glib",
+ "gst-plugin-version-helper",
+ "gstreamer",
+ "gstreamer-audio",
+ "gstreamer-base",
+ "gstreamer-net",
+ "gstreamer-rtp",
+ "gstreamer-video",
+ "hex",
+ "log",
+ "rand",
+ "rtcp-types",
+ "rtp-types",
+ "slab",
+ "smallvec",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "gst-plugin-version-helper"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94668bc2592732b8c2b653668ae41211d45988fb61264888b9c2d545d4bd826d"
+dependencies = [
+ "chrono",
+ "toml_edit",
+]
+
+[[package]]
+name = "gstreamer"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4527e1b9bae8d29ce137bde5b8eec8ae8f78f13ad00fc6e70cbe227d6ad027"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -208,7 +414,36 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gstreamer-audio"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97532c3e21287a6e94563a328cce89367324acf8a4489291b40ede2e39163a0"
+dependencies = [
+ "cfg-if",
+ "glib",
+ "gstreamer",
+ "gstreamer-audio-sys",
+ "gstreamer-base",
+ "libc",
+ "smallvec",
+]
+
+[[package]]
+name = "gstreamer-audio-sys"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2abfb81a073c5c8fb115a3639f47b6430f669ee9fa29123bb0116c9ef59d7d16"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -233,6 +468,56 @@ checksum = "6569606feeb89cfcf95a6476a64a0f0aec83fadcef0e91c24e576f7851ceac3a"
 dependencies = [
  "glib-sys",
  "gobject-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-net"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcad04d471a4f2c859ef1287f22581b07064e357cc89dfa415ffc99b2a3193d"
+dependencies = [
+ "gio",
+ "glib",
+ "gstreamer",
+ "gstreamer-net-sys",
+]
+
+[[package]]
+name = "gstreamer-net-sys"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcefb342a98ffca0b106bc9fea13d5df15879e1613b4dc652a6ec1960c32584c"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-rtp"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea01e76ad8fd2e688a4f8a166060c9f9ba13dd6355ad7e22dbb793325d14411"
+dependencies = [
+ "glib",
+ "gstreamer",
+ "gstreamer-rtp-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-rtp-sys"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf8df32469d863ce4375a978233a40efec206c5256bf0c14ee42bb745d8a793"
+dependencies = [
+ "glib-sys",
+ "gstreamer-base-sys",
  "gstreamer-sys",
  "libc",
  "system-deps",
@@ -287,7 +572,7 @@ dependencies = [
  "gstreamer-base",
  "gstreamer-video-sys",
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -343,6 +628,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -366,6 +681,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kstring"
@@ -383,6 +709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +725,21 @@ name = "muldiv"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -423,10 +770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "opennow-streamer"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "gst-plugin-rtp",
  "gstreamer",
  "gstreamer-sdp",
  "gstreamer-video",
@@ -464,6 +818,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +840,29 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "regex"
@@ -509,6 +892,31 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rtcp-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c081c846edea632bb47332fada9d4ac2fdf54d84beaf547fc947b58489e5f619"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rtp-types"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb90df8268abfe08452ef2dae9e867a54edfdaa71b3127ef47d8b031f77ac73"
+dependencies = [
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
@@ -563,6 +971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,11 +1026,31 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -628,6 +1062,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "pin-project-lite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -652,6 +1127,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -682,10 +1169,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -701,6 +1286,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zmij"

--- a/native/opennow-streamer/Cargo.toml
+++ b/native/opennow-streamer/Cargo.toml
@@ -11,6 +11,7 @@ gstreamer = [
     "dep:gstreamer-sdp",
     "dep:gstreamer-video",
     "dep:gstreamer-webrtc",
+    "dep:gst-plugin-rtp",
     "gstreamer-webrtc/v1_22",
 ]
 
@@ -23,3 +24,6 @@ gstreamer-webrtc = { version = "0.25.0", optional = true }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gst-plugin-rtp = { version = "0.15.3", optional = true }

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -575,7 +575,7 @@ mod tests {
     use crate::gstreamer_pipeline::{
         backend_runs_on_platform, configure_stats_overlay_element,
         default_rtp_video_api_priority, effective_present_max_fps, format_video_chain_selection,
-        preferred_rtp_video_apis_for, resolve_gstreamer_stun_server,
+        init_gstreamer, preferred_rtp_video_apis_for, resolve_gstreamer_stun_server,
         rtp_video_chain_definition, RtpVideoApi, RtpVideoChainRole,
     };
     use crate::gstreamer_transitions::resolve_queue_mode;
@@ -739,6 +739,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
+    fn bundles_av1_rtp_depayloading() {
+        init_gstreamer().expect("GStreamer initializes");
+        assert!(gst::ElementFactory::find("rtpav1depay").is_some());
+    }
+
+    #[test]
     fn parses_input_handshake_versions() {
         assert_eq!(
             parse_input_handshake_version(&[0x0e, 0x02, 0x03, 0x00]),
@@ -808,9 +815,18 @@ mod tests {
         assert!(vaapi.iter().any(|spec| spec.factory == "videoconvert"));
         assert_eq!(vaapi.last().map(|spec| spec.factory), Some("glimagesink"));
 
+        let nvdec = rtp_video_chain_definition("AV1", RtpVideoApi::Nvdec).expect("NVDEC AV1");
+        assert_eq!(nvdec[3].factory, "nvav1dec");
+        assert!(nvdec.iter().any(|spec| spec.factory == "videoconvert"));
+        assert_eq!(nvdec.last().map(|spec| spec.factory), Some("glimagesink"));
+
         let v4l2 = rtp_video_chain_definition("H265", RtpVideoApi::V4L2).expect("V4L2 H265");
         assert_eq!(v4l2[3].factory, "v4l2slh265dec");
-        assert!(v4l2.iter().any(|spec| spec.factory == "videoconvert"));
+        assert!(!v4l2.iter().any(|spec| spec.factory == "videoconvert"));
+
+        let v4l2_av1 =
+            rtp_video_chain_definition("AV1", RtpVideoApi::V4L2).expect("V4L2 AV1");
+        assert_eq!(v4l2_av1[3].factory, "v4l2slav1dec");
 
         let vulkan = rtp_video_chain_definition("H265", RtpVideoApi::Vulkan).expect("Vulkan H265");
         #[cfg(target_os = "windows")]
@@ -835,7 +851,12 @@ mod tests {
                 .any(|spec| spec.factory == "vulkancolorconvert"));
             assert_eq!(vulkan.last().map(|spec| spec.factory), Some("vulkansink"));
         }
-        assert!(rtp_video_chain_definition("AV1", RtpVideoApi::Vulkan).is_none());
+        let vulkan_av1 =
+            rtp_video_chain_definition("AV1", RtpVideoApi::Vulkan).expect("Vulkan AV1");
+        #[cfg(target_os = "windows")]
+        assert_eq!(vulkan_av1[3].factory, "d3d12av1dec");
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(vulkan_av1[3].factory, "vulkanav1dec");
 
         let software =
             rtp_video_chain_definition("H264", RtpVideoApi::Software).expect("software H264");
@@ -856,7 +877,19 @@ mod tests {
     }
 
     #[test]
-    fn explicit_vulkan_selection_does_not_fall_back() {
+    fn explicit_linux_backend_selection_does_not_fall_back() {
+        assert_eq!(
+            preferred_rtp_video_apis_for("nvdec", Some(120)),
+            vec![RtpVideoApi::Nvdec]
+        );
+        assert_eq!(
+            preferred_rtp_video_apis_for("vaapi", Some(120)),
+            vec![RtpVideoApi::Vaapi]
+        );
+        assert_eq!(
+            preferred_rtp_video_apis_for("v4l2", Some(120)),
+            vec![RtpVideoApi::V4L2]
+        );
         assert_eq!(
             preferred_rtp_video_apis_for("vulkan", Some(240)),
             vec![RtpVideoApi::Vulkan]
@@ -884,6 +917,36 @@ mod tests {
                 RtpVideoApi::D3D11,
                 RtpVideoApi::D3D12,
                 RtpVideoApi::Software
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    fn linux_arm64_prefers_v4l2_for_raspberry_pi_and_arm_devices() {
+        assert_eq!(
+            default_rtp_video_api_priority(Some(60)),
+            vec![
+                RtpVideoApi::V4L2,
+                RtpVideoApi::Nvdec,
+                RtpVideoApi::Vaapi,
+                RtpVideoApi::Vulkan,
+                RtpVideoApi::Software,
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
+    fn linux_desktop_prefers_vendor_decoders_before_generic_paths() {
+        assert_eq!(
+            default_rtp_video_api_priority(Some(120)),
+            vec![
+                RtpVideoApi::Nvdec,
+                RtpVideoApi::Vaapi,
+                RtpVideoApi::Vulkan,
+                RtpVideoApi::V4L2,
+                RtpVideoApi::Software,
             ]
         );
     }

--- a/native/opennow-streamer/src/gstreamer_pipeline.rs
+++ b/native/opennow-streamer/src/gstreamer_pipeline.rs
@@ -17,9 +17,11 @@ use crate::gstreamer_liveness::{
     watch_video_sink_caps_transitions, watch_video_sink_rate, VideoLivenessMonitor,
 };
 use crate::gstreamer_platform::{
-    arm_internal_child_input, primary_display_refresh_hz, release_native_input_capture,
-    start_external_renderer_window_guard, update_external_renderer_surface,
+    primary_display_refresh_hz, release_native_input_capture, start_external_renderer_window_guard,
+    update_external_renderer_surface,
 };
+#[cfg(target_os = "windows")]
+use crate::gstreamer_platform::arm_internal_child_input;
 use crate::gstreamer_transitions::DEFAULT_VIDEO_QUEUE_DEPTH;
 use crate::internal_renderer::InternalRenderer;
 use crate::nvst_video::{
@@ -35,11 +37,11 @@ use gst::prelude::*;
 use gstreamer as gst;
 use gstreamer_sdp as gst_sdp;
 use gstreamer_webrtc as gst_webrtc;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 
 const WEBRTC_LATENCY_MS: u32 = 2;
@@ -90,6 +92,7 @@ pub(crate) enum RtpVideoApi {
     D3D11,
     D3D12,
     VideoToolbox,
+    Nvdec,
     Vaapi,
     V4L2,
     Vulkan,
@@ -102,6 +105,7 @@ impl RtpVideoApi {
             Self::D3D11 => "D3D11",
             Self::D3D12 => "D3D12",
             Self::VideoToolbox => "VideoToolbox",
+            Self::Nvdec => "NVIDIA NVDEC",
             Self::Vaapi => "VAAPI",
             Self::V4L2 => "V4L2",
             Self::Vulkan => "Vulkan",
@@ -114,6 +118,7 @@ impl RtpVideoApi {
             Self::D3D11 => "d3d11",
             Self::D3D12 => "d3d12",
             Self::VideoToolbox => "videotoolbox",
+            Self::Nvdec => "nvdec",
             Self::Vaapi => "vaapi",
             Self::V4L2 => "v4l2",
             Self::Vulkan => "vulkan",
@@ -125,7 +130,7 @@ impl RtpVideoApi {
         match self {
             Self::D3D11 | Self::D3D12 => "windows",
             Self::VideoToolbox => "macos",
-            Self::Vaapi | Self::V4L2 => "linux",
+            Self::Nvdec | Self::Vaapi | Self::V4L2 => "linux",
             Self::Vulkan if current_platform_label() == "windows" => "windows",
             Self::Vulkan => "linux",
             Self::Software => "cross-platform",
@@ -159,7 +164,10 @@ impl RtpVideoApi {
             Self::VideoToolbox | Self::Vaapi if zero_copy_requested() => None,
             // Non-D3D hardware decoders are not guaranteed to negotiate directly with every
             // platform sink. Keep these paths reliable with an explicit raw-video conversion stage.
-            Self::VideoToolbox | Self::Vaapi | Self::V4L2 | Self::Software => Some("videoconvert"),
+            Self::VideoToolbox | Self::Nvdec | Self::Vaapi | Self::Software => Some("videoconvert"),
+            // V4L2 stateless decoders expose DMABuf on devices such as Raspberry Pi.
+            // Let glimagesink import it directly instead of forcing a CPU copy.
+            Self::V4L2 => None,
         }
     }
 
@@ -175,6 +183,7 @@ impl RtpVideoApi {
             Self::D3D11 => "d3d11videosink",
             Self::D3D12 => "d3d12videosink",
             Self::VideoToolbox => "glimagesink",
+            Self::Nvdec => "glimagesink",
             Self::Vaapi => "glimagesink",
             Self::V4L2 => "glimagesink",
             Self::Vulkan => "vulkansink",
@@ -191,18 +200,24 @@ impl RtpVideoApi {
             (Self::D3D12, "H264") => Some("d3d12h264dec"),
             (Self::D3D12, "AV1") => Some("d3d12av1dec"),
             (Self::VideoToolbox, "H265" | "HEVC" | "H264") => Some("vtdec_hw"),
+            (Self::Nvdec, "H265" | "HEVC") => Some("nvh265dec"),
+            (Self::Nvdec, "H264") => Some("nvh264dec"),
+            (Self::Nvdec, "AV1") => Some("nvav1dec"),
             (Self::Vaapi, "H265" | "HEVC") => Some("vah265dec"),
             (Self::Vaapi, "H264") => Some("vah264dec"),
             (Self::Vaapi, "AV1") => Some("vaav1dec"),
             (Self::V4L2, "H265" | "HEVC") => Some("v4l2slh265dec"),
             (Self::V4L2, "H264") => Some("v4l2slh264dec"),
+            (Self::V4L2, "AV1") => Some("v4l2slav1dec"),
             // vulkanh264dec/vulkanh265dec SIGSEGV on current NVIDIA Windows drivers;
             // use DXVA decode (prefer D3D12) and either D3D present (Internal) or
             // upload into Vulkan (External).
             (Self::Vulkan, "H265" | "HEVC") if cfg!(target_os = "windows") => Some("d3d12h265dec"),
             (Self::Vulkan, "H264") if cfg!(target_os = "windows") => Some("d3d12h264dec"),
+            (Self::Vulkan, "AV1") if cfg!(target_os = "windows") => Some("d3d12av1dec"),
             (Self::Vulkan, "H265" | "HEVC") => Some("vulkanh265dec"),
             (Self::Vulkan, "H264") => Some("vulkanh264dec"),
+            (Self::Vulkan, "AV1") => Some("vulkanav1dec"),
             (Self::Software, "H265" | "HEVC") => Some("avdec_h265"),
             (Self::Software, "H264") => Some("avdec_h264"),
             (Self::Software, "AV1") => Some("avdec_av1"),
@@ -217,6 +232,7 @@ impl RtpVideoApi {
             (Self::Vaapi, "AV1") => &["vaapiav1dec"],
             (Self::V4L2, "H265" | "HEVC") => &["v4l2h265dec"],
             (Self::V4L2, "H264") => &["v4l2h264dec"],
+            (Self::V4L2, "AV1") => &["v4l2av1dec"],
             (Self::VideoToolbox, "H265" | "HEVC" | "H264") => &["vtdec"],
             (Self::Vulkan, "H265" | "HEVC") if cfg!(target_os = "windows") => {
                 &["d3d11h265dec", "nvh265dec"]
@@ -224,6 +240,10 @@ impl RtpVideoApi {
             (Self::Vulkan, "H264") if cfg!(target_os = "windows") => {
                 &["d3d11h264dec", "nvh264dec"]
             }
+            (Self::Vulkan, "AV1") if cfg!(target_os = "windows") => {
+                &["d3d11av1dec", "nvav1dec"]
+            }
+            (Self::Software, "AV1") => &["dav1ddec", "av1dec"],
             _ => &[],
         }
     }
@@ -233,7 +253,7 @@ impl RtpVideoApi {
             Self::VideoToolbox => &["osxvideosink", "autovideosink"],
             // Prefer X11-capable sinks first: Internal Linux embeds via GstVideoOverlay
             // into an X11 child. waylandsink cannot paint into that handle.
-            Self::Vaapi | Self::V4L2 => {
+            Self::Nvdec | Self::Vaapi | Self::V4L2 => {
                 &["ximagesink", "xvimagesink", "glimagesink", "waylandsink", "autovideosink"]
             }
             Self::Software => &["ximagesink", "xvimagesink", "glimagesink", "waylandsink"],
@@ -244,9 +264,12 @@ impl RtpVideoApi {
     /// Sinks that can bind to the Internal X11 child via GstVideoOverlay.
     fn internal_x11_sink_candidates(self) -> &'static [&'static str] {
         match self {
-            Self::Vaapi | Self::V4L2 | Self::Software | Self::Vulkan => {
+            Self::Nvdec | Self::Vaapi | Self::V4L2 | Self::Software => {
                 &["glimagesink", "ximagesink", "xvimagesink"]
             }
+            // vulkansink implements GstVideoOverlay on Linux, so it can bind
+            // directly to the X11 child while retaining VulkanImage memory.
+            Self::Vulkan => &["vulkansink"],
             _ => &[],
         }
     }
@@ -1168,7 +1191,25 @@ fn nice_stream_from_ice_transport(
 }
 
 pub(crate) fn init_gstreamer() -> Result<(), String> {
-    gst::init().map_err(|error| format!("Failed to initialize GStreamer: {error}"))
+    gst::init().map_err(|error| format!("Failed to initialize GStreamer: {error}"))?;
+    #[cfg(target_os = "linux")]
+    {
+        static RTP_PLUGIN_REGISTRATION: OnceLock<Result<(), String>> = OnceLock::new();
+        RTP_PLUGIN_REGISTRATION
+            .get_or_init(|| {
+                if gst::ElementFactory::find("rtpav1depay").is_some() {
+                    return Ok(());
+                }
+                gstrsrtp::plugin_register_static().map_err(|error| {
+                    format!("Failed to register the bundled AV1 RTP plugin: {error}")
+                })
+            })
+            .clone()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(())
+    }
 }
 
 pub(crate) fn set_property_if_supported<T: Into<glib::Value>>(
@@ -1915,6 +1956,7 @@ pub(crate) fn preferred_rtp_video_apis_for(
         "d3d11" => vec![RtpVideoApi::D3D11],
         "d3d12" => vec![RtpVideoApi::D3D12],
         "videotoolbox" | "vt" => vec![RtpVideoApi::VideoToolbox],
+        "nvdec" | "nvcodec" | "nvidia" => vec![RtpVideoApi::Nvdec],
         "vaapi" | "va" => vec![RtpVideoApi::Vaapi],
         "v4l2" | "v4l2stateless" => vec![RtpVideoApi::V4L2],
         "vulkan" | "vk" => vec![RtpVideoApi::Vulkan],
@@ -1985,6 +2027,7 @@ pub(crate) fn default_rtp_video_api_priority(requested_fps: Option<u32>) -> Vec<
         let _ = requested_fps;
         vec![
             RtpVideoApi::V4L2,
+            RtpVideoApi::Nvdec,
             RtpVideoApi::Vaapi,
             RtpVideoApi::Vulkan,
             RtpVideoApi::Software,
@@ -1994,6 +2037,7 @@ pub(crate) fn default_rtp_video_api_priority(requested_fps: Option<u32>) -> Vec<
     {
         let _ = requested_fps;
         vec![
+            RtpVideoApi::Nvdec,
             RtpVideoApi::Vaapi,
             RtpVideoApi::Vulkan,
             RtpVideoApi::V4L2,
@@ -2170,7 +2214,30 @@ fn select_decoder_factory(video_api: RtpVideoApi, codec: &str) -> Option<&'stati
     let primary = video_api.decoder_factory(codec)?;
     std::iter::once(primary)
         .chain(video_api.fallback_decoder_factories(codec).iter().copied())
-        .find(|factory| gst::ElementFactory::find(factory).is_some())
+        .find(|factory| decoder_factory_usable(factory))
+}
+
+fn decoder_factory_usable(factory: &'static str) -> bool {
+    static DECODER_PROBES: OnceLock<Mutex<HashMap<&'static str, bool>>> = OnceLock::new();
+    let probes = DECODER_PROBES.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(probes) = probes.lock() {
+        if let Some(usable) = probes.get(factory) {
+            return *usable;
+        }
+    }
+
+    let usable = gst::ElementFactory::make(factory)
+        .build()
+        .ok()
+        .is_some_and(|decoder| {
+            let usable = decoder.set_state(gst::State::Ready).is_ok();
+            let _ = decoder.set_state(gst::State::Null);
+            usable
+        });
+    if let Ok(mut probes) = probes.lock() {
+        probes.insert(factory, usable);
+    }
+    usable
 }
 
 fn select_sink_factory(video_api: RtpVideoApi) -> Option<&'static str> {
@@ -2217,6 +2284,7 @@ fn all_rtp_video_apis() -> &'static [RtpVideoApi] {
         RtpVideoApi::D3D12,
         RtpVideoApi::D3D11,
         RtpVideoApi::VideoToolbox,
+        RtpVideoApi::Nvdec,
         RtpVideoApi::Vaapi,
         RtpVideoApi::V4L2,
         RtpVideoApi::Vulkan,
@@ -2255,7 +2323,7 @@ pub(crate) fn backend_runs_on_platform(video_api: RtpVideoApi, platform: &str) -
     match video_api {
         RtpVideoApi::D3D11 | RtpVideoApi::D3D12 => platform == "windows",
         RtpVideoApi::VideoToolbox => platform == "macos",
-        RtpVideoApi::Vaapi | RtpVideoApi::V4L2 => platform == "linux",
+        RtpVideoApi::Nvdec | RtpVideoApi::Vaapi | RtpVideoApi::V4L2 => platform == "linux",
         RtpVideoApi::Vulkan => matches!(platform, "windows" | "linux"),
         RtpVideoApi::Software => true,
     }
@@ -2402,12 +2470,14 @@ fn zero_copy_modes_for_backend(video_api: RtpVideoApi) -> Vec<String> {
         RtpVideoApi::D3D11 => vec!["D3D11Memory".to_owned()],
         RtpVideoApi::D3D12 => vec!["D3D12Memory".to_owned()],
         RtpVideoApi::VideoToolbox => vec!["GLMemory".to_owned()],
+        RtpVideoApi::Nvdec => Vec::new(),
         RtpVideoApi::Vaapi => vec!["VAMemory".to_owned()],
         // Linux keeps decoded frames as VulkanImage. Windows uses DXVA→upload,
         // so there is no end-to-end VulkanImage zero-copy path yet.
         RtpVideoApi::Vulkan if cfg!(target_os = "windows") => Vec::new(),
         RtpVideoApi::Vulkan => vec!["VulkanImage".to_owned()],
-        RtpVideoApi::V4L2 | RtpVideoApi::Software => Vec::new(),
+        RtpVideoApi::V4L2 => vec!["DMABuf".to_owned()],
+        RtpVideoApi::Software => Vec::new(),
     }
 }
 

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -127,11 +127,6 @@ pub(crate) fn arm_internal_child_input(hwnd: usize) -> bool {
     unsafe { win32_renderer_window::arm_internal_child_input(hwnd) }
 }
 
-#[cfg(not(target_os = "windows"))]
-pub(crate) fn arm_internal_child_input(_hwnd: usize) -> bool {
-    false
-}
-
 #[cfg(target_os = "windows")]
 pub(crate) fn update_external_renderer_surface(surface: &NativeRenderSurface) {
     let target = surface

--- a/native/opennow-streamer/src/internal_renderer.rs
+++ b/native/opennow-streamer/src/internal_renderer.rs
@@ -99,6 +99,7 @@ impl InternalRenderer {
         self.child_height.store(2, Ordering::SeqCst);
     }
 
+    #[cfg(target_os = "windows")]
     pub(crate) fn child_handle(&self) -> usize {
         self.child_handle.load(Ordering::SeqCst)
     }

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -155,6 +155,7 @@
         "gstreamer1.0-plugins-good",
         "gstreamer1.0-plugins-bad",
         "gstreamer1.0-plugins-ugly",
+        "gstreamer1.0-nice",
         "gstreamer1.0-vaapi",
         "gstreamer1.0-gl",
         "gstreamer1.0-x",

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -151,21 +151,21 @@ function prependProcessPath(env: NodeJS.ProcessEnv, directory: string): void {
 const LINUX_GSTREAMER_INSTALL_INSTRUCTIONS: NativeGstreamerInstallInstruction[] = [
   {
     distro: "Debian / Ubuntu / Mint / Pop!_OS / KDE neon",
-    command: "sudo apt update && sudo apt install libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-gl gstreamer1.0-vaapi gstreamer1.0-x gstreamer1.0-alsa libva2 libva-drm2 libvulkan1 mesa-vulkan-drivers",
+    command: "sudo apt update && sudo apt install libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 gstreamer1.0-tools gstreamer1.0-libav gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-nice gstreamer1.0-gl gstreamer1.0-vaapi gstreamer1.0-x gstreamer1.0-alsa libva2 libva-drm2 libvulkan1 mesa-vulkan-drivers",
   },
   {
     distro: "Fedora / RHEL / Nobara / Bazzite",
-    command: "sudo dnf install gstreamer1 gstreamer1-plugins-base gstreamer1-plugins-good gstreamer1-plugins-bad-free gstreamer1-plugins-bad-freeworld gstreamer1-plugins-ugly gstreamer1-libav gstreamer1-vaapi gstreamer1-plugin-openh264 mesa-vulkan-drivers libva",
+    command: "sudo dnf install gstreamer1 gstreamer1-plugins-base gstreamer1-plugins-good gstreamer1-plugins-bad-free gstreamer1-plugins-bad-freeworld gstreamer1-plugins-ugly gstreamer1-libav gstreamer1-vaapi gstreamer1-plugin-openh264 libnice-gstreamer1 mesa-vulkan-drivers libva",
     note: "RPM Fusion may be required for libav, ugly, or bad-freeworld packages.",
   },
   {
     distro: "Arch / Manjaro / EndeavourOS / SteamOS",
-    command: "sudo pacman -S --needed gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav gst-plugin-va libva mesa vulkan-radeon",
+    command: "sudo pacman -S --needed gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav gst-plugin-va libnice libva mesa vulkan-radeon",
     note: "NVIDIA users should use their distro NVIDIA/Vulkan driver packages instead of vulkan-radeon.",
   },
   {
     distro: "openSUSE Tumbleweed / Leap",
-    command: "sudo zypper install gstreamer gstreamer-plugins-base gstreamer-plugins-good gstreamer-plugins-bad gstreamer-plugins-ugly gstreamer-plugins-libav gstreamer-plugins-vaapi libva2 Mesa-vulkan-device-select",
+    command: "sudo zypper install gstreamer gstreamer-plugins-base gstreamer-plugins-good gstreamer-plugins-bad gstreamer-plugins-ugly gstreamer-plugins-libav gstreamer-plugins-vaapi gstreamer-libnice libva2 Mesa-vulkan-device-select",
   },
 ];
 
@@ -883,6 +883,10 @@ export class NativeStreamerManager {
     if (process.platform === "linux") {
       // Linux ships Internal-only; never spawn the floating external renderer.
       childEnv.OPENNOW_NATIVE_EXTERNAL_RENDERER = "0";
+      if ((process.arch === "arm64" || process.arch === "arm") && !childEnv.GST_V4L2_ENABLE_PROBE) {
+        // Raspberry Pi's stateful H.264 decoder is hidden unless V4L2 probing is enabled.
+        childEnv.GST_V4L2_ENABLE_PROBE = "1";
+      }
     } else if (process.platform === "win32") {
       childEnv.OPENNOW_NATIVE_EXTERNAL_RENDERER = this.options.getExternalRendererEnabled() ? "1" : "0";
       childEnv.OPENNOW_NATIVE_D3D_ALLOW_TEARING = "1";

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -192,7 +192,11 @@ const NATIVE_VIDEO_BACKEND_PREFERENCES = new Set<NativeVideoBackendPreference>([
   "auto",
   "d3d11",
   "d3d12",
+  "nvdec",
+  "vaapi",
+  "v4l2",
   "vulkan",
+  "software",
 ]);
 const APP_ACCENT_COLORS = new Set<AppAccentColor>(["green", "blue", "violet", "amber", "rose"]);
 const APP_THEMES = new Set<AppTheme>(["light", "dark", "auto"]);

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import type { NativeStreamerStatus, NativeVideoBackendCapability, Settings } from "@shared/gfn";
 import {
   createUnsupportedNativeStreamerStatus,
-  isNativeDirectXBackendSupported,
   isNativeExternalRendererSupported,
   isNativeStreamerSupportedPlatform,
   NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE,
@@ -23,7 +22,6 @@ import { ModalSurface } from "../../ui/ModalSurface";
 const nativePlatformHint = `${navigator.platform} ${navigator.userAgent}`;
 const isNativeStreamerPlatform = isNativeStreamerSupportedPlatform(nativePlatformHint);
 const supportsNativeExternalRenderer = isNativeExternalRendererSupported(nativePlatformHint);
-const supportsNativeDirectXBackend = isNativeDirectXBackendSupported(nativePlatformHint);
 
 function getNativeHostPlatform(): "windows" | "macos" | "linux" | "other" {
   const normalized = nativePlatformHint.toLowerCase();
@@ -61,6 +59,10 @@ export function SettingsNativeStreamerSection({
   const [nativeStreamerEnablePromptOpen, setNativeStreamerEnablePromptOpen] = useState(false);
   const nativeStreamerEnablePromptConfirmRef = useRef<HTMLButtonElement | null>(null);
   const hostVideoBackends = getHostVideoBackends(nativeStreamerStatus);
+  const selectableVideoBackendOptions = nativeVideoBackendOptions.filter(
+    (option) => option.value === "auto"
+      || hostVideoBackends.some((backend) => backend.backend === option.value),
+  );
   const readyHardwareBackendCount = hostVideoBackends.filter(
     (backend) => backend.available && backend.backend !== "software",
   ).length;
@@ -385,10 +387,10 @@ export function SettingsNativeStreamerSection({
                 )}
               </div>
 
-              {supportsNativeDirectXBackend && <div className="settings-row settings-row--column">
+              {isNativeStreamerPlatform && selectableVideoBackendOptions.length > 1 && <div className="settings-row settings-row--column">
                 <label className="settings-label">{t("settings.nativeStreamer.directxBackend")}</label>
                 <div className="settings-chip-row">
-                  {nativeVideoBackendOptions.map((option) => {
+                  {selectableVideoBackendOptions.map((option) => {
                     const capability = option.value === "auto"
                       ? undefined
                       : hostVideoBackends.find((backend) => backend.backend === option.value);

--- a/opennow-stable/src/renderer/src/components/settings/settingsFormatters.ts
+++ b/opennow-stable/src/renderer/src/components/settings/settingsFormatters.ts
@@ -45,7 +45,11 @@ export const nativeVideoBackendOptions: { value: NativeVideoBackendPreference; l
   { value: "auto", label: "Auto", description: "Pick the default native path for the session" },
   { value: "d3d12", label: "DirectX 12", description: "Use the D3D12 decoder and renderer" },
   { value: "d3d11", label: "DirectX 11", description: "Use the D3D11 decoder and renderer" },
+  { value: "nvdec", label: "NVIDIA NVDEC", description: "Use NVIDIA's native Linux hardware decoders" },
+  { value: "vaapi", label: "VAAPI", description: "Use Linux VA-API hardware decoding" },
+  { value: "v4l2", label: "V4L2", description: "Use Linux V4L2 hardware decoding, including Raspberry Pi" },
   { value: "vulkan", label: "Vulkan", description: "Use Vulkan presentation where supported; Windows internal mode uses a compatible D3D presentation path" },
+  { value: "software", label: "Software", description: "Decode on the CPU with libav" },
 ];
 
 export const APP_LANGUAGE_LABELS: Record<string, string> = {
@@ -77,6 +81,8 @@ export function formatNativeVideoBackendName(backend: string | undefined): strin
       return "D3D11";
     case "videotoolbox":
       return "VideoToolbox";
+    case "nvdec":
+      return "NVIDIA NVDEC";
     case "vaapi":
       return "VAAPI";
     case "v4l2":

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtcClient.ts
@@ -178,7 +178,7 @@ function describeNativeHardwareAcceleration(): string {
   if (platform.includes("mac")) {
     return "GStreamer VideoToolbox";
   }
-  return "GStreamer VAAPI/V4L2";
+  return "GStreamer NVDEC/VAAPI/V4L2/Vulkan";
 }
 
 interface ClientOptions {

--- a/opennow-stable/src/shared/gfn/nativeStreamer.ts
+++ b/opennow-stable/src/shared/gfn/nativeStreamer.ts
@@ -3,7 +3,15 @@ import type { StreamClientMode } from "./stream";
 export type NativeStreamerBackend = "stub" | "gstreamer";
 export type NativeStreamerBackendPreference = "auto" | NativeStreamerBackend;
 export type NativeStreamerFeatureMode = "auto" | "disabled" | "forced";
-export type NativeVideoBackendPreference = "auto" | "d3d11" | "d3d12" | "vulkan";
+export type NativeVideoBackendPreference =
+  | "auto"
+  | "d3d11"
+  | "d3d12"
+  | "nvdec"
+  | "vaapi"
+  | "v4l2"
+  | "vulkan"
+  | "software";
 export type StreamTransportMode = "webrtc" | "nvst";
 
 export const NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE =


### PR DESCRIPTION
Linux native streaming now selects codecs from hardware that can actually initialize, with complete H.264, H.265, and AV1 receive paths for desktop Linux and ARM64 devices.

- Add NVIDIA NVDEC, Vulkan Video AV1, V4L2 AV1, VAAPI, and software AV1 fallback support, and bundle the missing AV1 RTP depayloader on Linux.
- Keep Vulkan frames in `VulkanImage` memory through the X11 child renderer, and preserve V4L2 `DMABuf` output for Raspberry Pi presentation without a forced CPU conversion.
- Prefer V4L2 on Linux ARM64, enable Raspberry Pi decoder probing, and expose Linux backend selection and capability results in settings.
- Install the required libnice GStreamer plugin in Linux packages and validate the GStreamer streamer on both x64 and ARM64 CI runners.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cad1a2a3-3e84-4cee-8687-f71a71265887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-278" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/cad1a2a3-3e84-4cee-8687-f71a71265887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-278&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-278"><img alt="OPE-278" src="https://capy.ai/api/badge/thread.svg?label=OPE-278"></picture></a>
<!-- capy-pr-badge:end -->