### PR TITLE
refactor(settings): centralize platform defaults

### DIFF
--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -2,29 +2,16 @@ import { app } from "electron";
 import { join } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import type {
-  VideoCodec,
-  ColorQuality,
-  VideoAccelerationPreference,
-  MicrophoneMode,
-  GameLanguage,
-  AspectRatio,
-  KeyboardLayout,
-  StreamClientMode,
-  StreamTransportMode,
-  NativeStreamerBackendPreference,
   NativeVideoBackendPreference,
-  NativeStreamerFeatureMode,
-  NativeTransitionDiagnostics,
   AppAccentColor,
   AppTheme,
   ErrorReportingConsent,
-  VideoShaderSettings,
-  UpdateChannel,
+  Settings,
 } from "@shared/gfn";
 import {
-  DEFAULT_KEYBOARD_LAYOUT,
-  DEFAULT_VIDEO_SHADER_SETTINGS,
-  getDefaultStreamPreferences,
+  createDefaultSettings,
+  createPlatformShortcutDefaults,
+  SHORTCUT_SETTING_KEYS,
   normalizeNativeExternalRendererForPlatform,
   normalizeStreamClientModeForPlatform,
   normalizeStreamPreferences,
@@ -33,160 +20,14 @@ import {
   normalizeUpdateChannel,
 } from "@shared/gfn";
 
-export interface Settings {
-  /** Video resolution (e.g., "1920x1080") */
-  resolution: string;
-  /** Aspect ratio (16:9, 16:10, 21:9, 32:9) */
-  aspectRatio: AspectRatio;
-  /** Game poster size multiplier used by the renderer */
-  posterSizeScale: number;
-  /** Target FPS (30, 60, 120, etc.) */
-  fps: number;
-  /** Maximum bitrate in Mbps (cap at 150) */
-  maxBitrateMbps: number;
-  /** Recording video bitrate in Mbps (null = MediaRecorder auto, cap at 200) */
-  recordingBitrateMbps: number | null;
-  /** Stream client implementation to use for new sessions */
-  streamClientMode: StreamClientMode;
-  /** Native streamer backend preference for new native sessions */
-  nativeStreamerBackend: NativeStreamerBackendPreference;
-  /** Native GStreamer video backend preference for Windows GPU paths */
-  nativeVideoBackend: NativeVideoBackendPreference;
-  /** Optional path to a custom native streamer executable */
-  nativeStreamerExecutablePath: string;
-  /** Native-only override for Cloud G-Sync / VRR display detection */
-  nativeCloudGsyncMode: NativeStreamerFeatureMode;
-  /** Native D3D sink fullscreen presentation override */
-  nativeD3dFullscreenMode: NativeStreamerFeatureMode;
-  /** Use the native GStreamer renderer window instead of Electron HWND embedding */
-  nativeExternalRenderer: boolean;
-  /** Native media transport. Legacy NVST values normalize to WebRTC. */
-  transportMode: StreamTransportMode;
-  /** Show the native streamer's own stats overlay while native streaming */
-  showNativeStreamerStats: boolean;
-  /** Preferred video codec */
-  codec: VideoCodec;
-  /** Preferred video decode acceleration mode */
-  decoderPreference: VideoAccelerationPreference;
-  /** Preferred video encode acceleration mode */
-  encoderPreference: VideoAccelerationPreference;
-  /** Color quality (bit depth + chroma subsampling) */
-  colorQuality: ColorQuality;
-  /** Preferred region URL (empty = auto) */
-  region: string;
-  /** Enable the optional proxy for Nvidia games catalog, session creation, and queue polling */
-  sessionProxyEnabled: boolean;
-  /** Optional proxy used for Nvidia games catalog, session creation, and queue polling */
-  sessionProxyUrl: string;
-  /** Enable clipboard paste into stream */
-  clipboardPaste: boolean;
-  /** Enable experimental gyroscope controller input mapping */
-  enableGyroscopeControls: boolean;
-  /** macOS-only workaround that restores Chromium's older HID path for Steam Controller compatibility */
-  steamControllerCompatibilityMode: boolean;
-  /** Use the WebRTC cursor_channel overlay instead of leaving cursor rendering to the stream */
-  nativeCursorOverlay: boolean;
-  /** Mouse sensitivity multiplier */
-  mouseSensitivity: number;
-  /** Software mouse acceleration strength percentage (1-150) */
-  mouseAcceleration: number;
-  /** Toggle stats overlay shortcut */
-  shortcutToggleStats: string;
-  /** Toggle pointer lock shortcut */
-  shortcutTogglePointerLock: string;
-  /** Toggle fullscreen shortcut */
-  shortcutToggleFullscreen: string;
-  /** Stop stream shortcut */
-  shortcutStopStream: string;
-  /** Toggle anti-AFK shortcut */
-  shortcutToggleAntiAfk: string;
-  /** Toggle microphone shortcut */
-  shortcutToggleMicrophone: string;
-  /** Take screenshot shortcut */
-  shortcutScreenshot: string;
-  /** Toggle stream recording shortcut */
-  shortcutToggleRecording: string;
-  /** How often to re-show the session timer while streaming (0 = off) */
-  sessionClockShowEveryMinutes: number;
-  /** How long the session timer stays visible when it appears */
-  sessionClockShowDurationSeconds: number;
-  /** Microphone mode: disabled, push-to-talk, or voice-activity */
-  microphoneMode: MicrophoneMode;
-  /** Preferred microphone device ID (empty = default) */
-  microphoneDeviceId: string;
-  /** Hide stream buttons (mic/fullscreen/end-session) while streaming */
-  hideStreamButtons: boolean;
-  /** Show the Anti-AFK indicator badge while streaming */
-  showAntiAfkIndicator: boolean;
-  /** Show the stats overlay automatically when a stream launches */
-  showStatsOnLaunch: boolean;
-  /** Skip the free-tier queue server selection modal and launch with default routing */
-  hideServerSelector: boolean;
-  /** Desktop UI accent preset */
-  appAccentColor: AppAccentColor;
-  /** UI Theme */
-  appTheme: AppTheme;
-  /** Use translucent overlays for settings and navbars */
-  translucentUI: boolean;
-  /** Use the large-screen controller-oriented shell and library layout */
-  controllerMode: boolean;
-  /** Launch fullscreen with Controller Mode enabled, like GeForce NOW's TV mode */
-  launchInConsoleMode: boolean;
-  /** Automatically enter fullscreen when launching a stream */
-  autoFullScreen: boolean;
-  favoriteGameIds: string[];
-  /** Enable the live elapsed session counter */
-  sessionCounterEnabled: boolean;
-  /** Also show the session-limit countdown in the stats overlay while streaming */
-  showSessionTimeRemainingInStatsOverlay: boolean;
-  /** Window width */
-  windowWidth: number;
-  /** Window height */
-  windowHeight: number;
-  /** Keyboard layout for mapping physical keys inside the remote session */
-  keyboardLayout: KeyboardLayout;
-  /** In-game language setting (sent to GFN servers via languageCode parameter) */
-  gameLanguage: GameLanguage;
-  /** User opt-in for NVIDIA's per-game in-game graphics/settings persistence */
-  enablePersistingInGameSettings: boolean;
-  /** Experimental request for Low Latency, Low Loss, Scalable throughput on new sessions */
-  enableL4S: boolean;
-  /**
-   * Advertise OpenNOW as the official Steam Deck GFN client via nv-device-* headers
-   * and clientPlatformName (does not switch OAuth client ID).
-   */
-  identifyAsSteamDeck: boolean;
-  /** Request Cloud G-Sync / Variable Refresh Rate on new sessions */
-  enableCloudGsync: boolean;
-  /** Hidden diagnostics for native transition recovery and 240 FPS server-side stream changes */
-  nativeTransitionDiagnostics?: NativeTransitionDiagnostics;
-  /** Show the currently streaming game as Discord Rich Presence activity */
-  discordRichPresence: boolean;
-  /** Automatically check GitHub Releases for app updates in the background */
-  autoCheckForUpdates: boolean;
-  /** Release channel used for application updates */
-  updateChannel: UpdateChannel;
-  /** When true, pressing Escape will exit fullscreen; when false Escape is sent to the game while pointer-locked */
-  allowEscapeToExitFullscreen?: boolean;
-  /** Last version for which the release highlights modal was acknowledged (empty = never) */
-  lastSeenReleaseHighlightsVersion: string;
-  /** Client-side GPU post-processing shaders applied to the stream (web client mode) */
-  videoShader: VideoShaderSettings;
-  /**
-   * First-run consent for anonymous error reporting.
-   * `"unset"` shows the one-time prompt; only `"granted"` enables exception capture.
-   */
-  errorReportingConsent: ErrorReportingConsent;
-  /** Anonymous install UUID used as PostHog distinct ID (empty until first grant or feedback) */
-  telemetryInstallId: string;
-}
+export type { Settings } from "@shared/gfn";
 
-const defaultStopShortcut = "Ctrl+Shift+Q";
-const defaultAntiAfkShortcut = "Ctrl+Shift+K";
-const defaultMicShortcut = "Ctrl+Shift+M";
+const DEFAULT_SHORTCUTS = createPlatformShortcutDefaults(process.platform).bindings;
+const defaultStopShortcut = DEFAULT_SHORTCUTS.shortcutStopStream;
+const defaultAntiAfkShortcut = DEFAULT_SHORTCUTS.shortcutToggleAntiAfk;
+const defaultMicShortcut = DEFAULT_SHORTCUTS.shortcutToggleMicrophone;
 const LEGACY_STOP_SHORTCUTS = new Set(["META+SHIFT+Q", "CMD+SHIFT+Q"]);
 const LEGACY_ANTI_AFK_SHORTCUTS = new Set(["META+SHIFT+F10", "CMD+SHIFT+F10", "CTRL+SHIFT+F10"]);
-const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
 
 const NATIVE_VIDEO_BACKEND_PREFERENCES = new Set<NativeVideoBackendPreference>([
   "auto",
@@ -226,78 +67,6 @@ function normalizeRecordingBitrateMbps(raw: unknown): number | null {
   return Math.max(1, Math.min(200, Math.round(value)));
 }
 
-const DEFAULT_SETTINGS: Settings = {
-  resolution: "1920x1080",
-  aspectRatio: "16:9",
-  posterSizeScale: 1.05,
-  fps: 60,
-  maxBitrateMbps: 75,
-  recordingBitrateMbps: null,
-  streamClientMode: "web",
-  nativeStreamerBackend: "gstreamer",
-  nativeVideoBackend: "auto",
-  nativeStreamerExecutablePath: "",
-  nativeCloudGsyncMode: "auto",
-  nativeD3dFullscreenMode: "auto",
-  nativeExternalRenderer: false,
-  transportMode: "webrtc",
-  showNativeStreamerStats: false,
-  codec: DEFAULT_STREAM_PREFERENCES.codec,
-  decoderPreference: "auto",
-  encoderPreference: "auto",
-  colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
-  region: "",
-  sessionProxyEnabled: false,
-  sessionProxyUrl: "",
-  clipboardPaste: false,
-  enableGyroscopeControls: false,
-  steamControllerCompatibilityMode: false,
-  nativeCursorOverlay: true,
-  mouseSensitivity: 1,
-  mouseAcceleration: 1,
-  shortcutToggleStats: "F3",
-  shortcutTogglePointerLock: "F8",
-  shortcutToggleFullscreen: "F10",
-  shortcutStopStream: defaultStopShortcut,
-  shortcutToggleAntiAfk: defaultAntiAfkShortcut,
-  shortcutToggleMicrophone: defaultMicShortcut,
-  shortcutScreenshot: "F11",
-  shortcutToggleRecording: "F12",
-  microphoneMode: "disabled",
-  microphoneDeviceId: "",
-  hideStreamButtons: false,
-  showAntiAfkIndicator: true,
-  showStatsOnLaunch: false,
-  hideServerSelector: false,
-  appAccentColor: "green",
-  appTheme: "auto",
-  translucentUI: false,
-  controllerMode: false,
-  launchInConsoleMode: false,
-  autoFullScreen: false,
-  favoriteGameIds: [],
-  sessionCounterEnabled: false,
-  showSessionTimeRemainingInStatsOverlay: false,
-  sessionClockShowEveryMinutes: 60,
-  sessionClockShowDurationSeconds: 30,
-  windowWidth: 1400,
-  windowHeight: 900,
-  keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
-  gameLanguage: "en_US",
-  enablePersistingInGameSettings: false,
-  enableL4S: false,
-  identifyAsSteamDeck: false,
-  enableCloudGsync: false,
-  nativeTransitionDiagnostics: undefined,
-  discordRichPresence: false,
-  autoCheckForUpdates: true,
-  updateChannel: "stable",
-  allowEscapeToExitFullscreen: false,
-  lastSeenReleaseHighlightsVersion: "",
-  videoShader: { ...DEFAULT_VIDEO_SHADER_SETTINGS },
-  errorReportingConsent: "unset",
-  telemetryInstallId: "",
-};
 
 const ERROR_REPORTING_CONSENTS = new Set<ErrorReportingConsent>(["unset", "granted", "denied"]);
 
@@ -310,17 +79,6 @@ function normalizeErrorReportingConsent(raw: unknown): ErrorReportingConsent {
 function normalizeTelemetryInstallId(raw: unknown): string {
   return typeof raw === "string" ? raw.trim() : "";
 }
-
-const SHORTCUT_SETTING_KEYS = [
-  "shortcutToggleStats",
-  "shortcutTogglePointerLock",
-  "shortcutToggleFullscreen",
-  "shortcutStopStream",
-  "shortcutToggleAntiAfk",
-  "shortcutToggleMicrophone",
-  "shortcutScreenshot",
-  "shortcutToggleRecording",
-] as const satisfies readonly (keyof Settings)[];
 
 type ShortcutSettingKey = typeof SHORTCUT_SETTING_KEYS[number];
 
@@ -380,7 +138,7 @@ export class SettingsManager {
   private load(): Settings {
     try {
       if (!existsSync(this.settingsPath)) {
-        const defaults = { ...DEFAULT_SETTINGS };
+        const defaults = createDefaultSettings(process.platform);
         this.enforceCompatibility(defaults);
         return defaults;
       }
@@ -397,7 +155,7 @@ export class SettingsManager {
 
       // Merge with defaults to ensure all fields exist
       const merged: Settings = {
-        ...DEFAULT_SETTINGS,
+        ...createDefaultSettings(process.platform),
         ...parsedSettings,
       };
 
@@ -441,7 +199,7 @@ export class SettingsManager {
       return merged;
     } catch (error) {
       console.error("Failed to load settings, using defaults:", error);
-      const defaults = { ...DEFAULT_SETTINGS };
+      const defaults = createDefaultSettings(process.platform);
       this.enforceCompatibility(defaults);
       return defaults;
     }
@@ -575,7 +333,7 @@ export class SettingsManager {
 
       const fallback = SIDEBAR_RESERVED_SHORTCUT_FALLBACKS[key].find((candidate) =>
         isShortcutAvailable(settings, key, candidate),
-      ) ?? DEFAULT_SETTINGS[key];
+      ) ?? DEFAULT_SHORTCUTS[key];
       settings[key] = fallback;
       migrated = true;
     }
@@ -638,7 +396,7 @@ export class SettingsManager {
    * Reset all settings to defaults
    */
   reset(): Settings {
-    this.settings = { ...DEFAULT_SETTINGS };
+    this.settings = createDefaultSettings(process.platform);
     this.enforceCompatibility(this.settings);
     this.save();
     return { ...this.settings };
@@ -648,7 +406,7 @@ export class SettingsManager {
    * Get the default settings
    */
   getDefaults(): Settings {
-    const defaults = { ...DEFAULT_SETTINGS };
+    const defaults = createDefaultSettings(process.platform);
     this.enforceCompatibility(defaults);
     return defaults;
   }
@@ -663,5 +421,3 @@ export function getSettingsManager(): SettingsManager {
   }
   return settingsManager;
 }
-
-export { DEFAULT_SETTINGS };

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -24,11 +24,11 @@ import type {
 } from "@shared/gfn";
 import {
   buildNativeStreamerSessionContext,
-  DEFAULT_KEYBOARD_LAYOUT,
-  DEFAULT_VIDEO_SHADER_SETTINGS,
-  getDefaultStreamPreferences,
+  createDefaultSettings,
+  createPlatformShortcutDefaults,
   isSessionAdsRequired,
   resolveEntitledStreamProfile,
+  resolveRuntimePlatform,
   SAFE_FALLBACK_STREAM_PROFILE,
 } from "@shared/gfn";
 import { GfnWebRtcClient } from "./platforms/gfn/webrtcClient";
@@ -122,8 +122,6 @@ import { overlayMotion, pageTransition, streamRevealTransition } from "./compone
 import { LazyShaderAtmosphere } from "./components/LazyShaderAtmosphere";
 import { syncRendererTelemetry } from "./telemetry/posthog";
 
-const DEFAULT_STREAM_PREFERENCES = getDefaultStreamPreferences();
-
 type AppStyle = CSSProperties & {
   "--game-poster-scale"?: string;
 };
@@ -149,18 +147,9 @@ const STREAM_WARNING_VISIBILITY_MS = 15 * 1000;
 type AppPage = "home" | "library" | "settings";
 type ExitPromptState = { open: boolean; gameTitle: string };
 
-const isMac = navigator.platform.toLowerCase().includes("mac");
-
-const DEFAULT_SHORTCUTS = {
-  shortcutToggleStats: "F3",
-  shortcutTogglePointerLock: "F8",
-  shortcutToggleFullscreen: "F10",
-  shortcutStopStream: "Ctrl+Shift+Q",
-  shortcutToggleAntiAfk: "Ctrl+Shift+K",
-  shortcutToggleMicrophone: "Ctrl+Shift+M",
-  shortcutScreenshot: "F11",
-  shortcutToggleRecording: "F12",
-} as const;
+const RUNTIME_PLATFORM = resolveRuntimePlatform(navigator.platform);
+const isMac = RUNTIME_PLATFORM === "darwin";
+const DEFAULT_SHORTCUTS = createPlatformShortcutDefaults(RUNTIME_PLATFORM).bindings;
 
 export function App(): JSX.Element {
   const { locale, t } = useTranslation();
@@ -174,76 +163,7 @@ export function App(): JSX.Element {
   const [sessionFullscreen, setSessionFullscreenState] = useState(false);
 
   // Settings State
-  const [settings, setSettings] = useState<Settings>({
-    resolution: "1920x1080",
-    aspectRatio: "16:9",
-    posterSizeScale: 1.05,
-    fps: 60,
-    maxBitrateMbps: 75,
-    recordingBitrateMbps: null,
-    streamClientMode: "web",
-    nativeStreamerBackend: "gstreamer",
-    nativeVideoBackend: "auto",
-    nativeStreamerExecutablePath: "",
-    nativeCloudGsyncMode: "auto",
-    nativeD3dFullscreenMode: "auto",
-    nativeExternalRenderer: false,
-    transportMode: "webrtc",
-    showNativeStreamerStats: false,
-    codec: DEFAULT_STREAM_PREFERENCES.codec,
-    decoderPreference: "auto",
-    encoderPreference: "auto",
-    colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
-    region: "",
-    sessionProxyEnabled: false,
-    sessionProxyUrl: "",
-    clipboardPaste: false,
-    enableGyroscopeControls: false,
-    steamControllerCompatibilityMode: false,
-    nativeCursorOverlay: true,
-    mouseSensitivity: 1,
-    mouseAcceleration: 1,
-    shortcutToggleStats: DEFAULT_SHORTCUTS.shortcutToggleStats,
-    shortcutTogglePointerLock: DEFAULT_SHORTCUTS.shortcutTogglePointerLock,
-    shortcutToggleFullscreen: DEFAULT_SHORTCUTS.shortcutToggleFullscreen,
-    shortcutStopStream: DEFAULT_SHORTCUTS.shortcutStopStream,
-    shortcutToggleAntiAfk: DEFAULT_SHORTCUTS.shortcutToggleAntiAfk,
-    shortcutToggleMicrophone: DEFAULT_SHORTCUTS.shortcutToggleMicrophone,
-    shortcutScreenshot: DEFAULT_SHORTCUTS.shortcutScreenshot,
-    shortcutToggleRecording: DEFAULT_SHORTCUTS.shortcutToggleRecording,
-    microphoneMode: "disabled",
-    microphoneDeviceId: "",
-    hideStreamButtons: false,
-    showAntiAfkIndicator: true,
-    showStatsOnLaunch: false,
-    hideServerSelector: false,
-    appAccentColor: "green",
-    appTheme: "auto",
-    translucentUI: false,
-    controllerMode: false,
-    launchInConsoleMode: false,
-    autoFullScreen: false,
-    favoriteGameIds: [],
-    sessionCounterEnabled: false,
-    showSessionTimeRemainingInStatsOverlay: false,
-    sessionClockShowEveryMinutes: 60,
-    sessionClockShowDurationSeconds: 30,
-    windowWidth: 1400,
-    windowHeight: 900,
-    keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
-    gameLanguage: "en_US",
-    enablePersistingInGameSettings: false,
-    enableL4S: false,
-    identifyAsSteamDeck: false,
-    enableCloudGsync: false,
-    discordRichPresence: false,
-    autoCheckForUpdates: true,
-    updateChannel: "stable",
-    lastSeenReleaseHighlightsVersion: "",
-    videoShader: { ...DEFAULT_VIDEO_SHADER_SETTINGS },
-    errorReportingConsent: "unset",
-    telemetryInstallId: "",
-  });
+  const [settings, setSettings] = useState<Settings>(() => createDefaultSettings(RUNTIME_PLATFORM));
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [releaseHighlightsPayload, setReleaseHighlightsPayload] = useState<ReleaseHighlightsPayload | null>(null);
   const [releaseHighlightsIsAuto, setReleaseHighlightsIsAuto] = useState(false);

--- a/opennow-stable/src/renderer/src/components/settings/settingsFormatters.ts
+++ b/opennow-stable/src/renderer/src/components/settings/settingsFormatters.ts
@@ -12,9 +12,12 @@ import type {
   MicrophonePermissionResult,
   GameLanguage,
   Settings,
+  ShortcutSettingKey,
 } from "@shared/gfn";
 import {
-  isNativeStreamerSupportedPlatform,
+  createPlatformShortcutDefaults,
+  resolveRuntimePlatform,
+  SHORTCUT_SETTING_KEYS,
   USER_FACING_VIDEO_CODEC_OPTIONS,
 } from "@shared/gfn";
 import { getAccentColorOptions } from "../../lib/uiCustomization";
@@ -187,23 +190,18 @@ export const STATIC_FPS_PRESETS: FpsPreset[] = [
   { value: 360 },
 ];
 
-export const isMac = navigator.platform.toLowerCase().includes("mac");
-export const isWindows = isNativeStreamerSupportedPlatform(`${navigator.platform} ${navigator.userAgent}`);
+const runtimePlatform = resolveRuntimePlatform(navigator.platform);
+const platformShortcutDefaults = createPlatformShortcutDefaults(runtimePlatform);
+
+export const isMac = runtimePlatform === "darwin";
 export const shortcutExamples = "Examples: F3, Ctrl+Shift+Q, Ctrl+Shift+K";
-export const shortcutDefaults = {
-  shortcutToggleStats: "F3",
-  shortcutTogglePointerLock: "F8",
-  shortcutToggleFullscreen: "F10",
-  shortcutStopStream: "Ctrl+Shift+Q",
-  shortcutToggleAntiAfk: "Ctrl+Shift+K",
-  shortcutToggleMicrophone: "Ctrl+Shift+M",
-  shortcutScreenshot: "F11",
-  shortcutToggleRecording: "F12",
-} as const;
+export const shortcutDefaults = platformShortcutDefaults.bindings;
 
 /** Canonical shortcut for toggling the stream sidebar (must match StreamView key handler). */
-export const SIDEBAR_TOGGLE_SHORTCUT_RAW = isMac ? "Meta+G" : "Ctrl+G";
-export const SIDEBAR_TOGGLE_SHORTCUT_ALIASES = isMac ? [SIDEBAR_TOGGLE_SHORTCUT_RAW] : [SIDEBAR_TOGGLE_SHORTCUT_RAW, "Ctrl+Shift+G"];
+export const SIDEBAR_TOGGLE_SHORTCUT_RAW = platformShortcutDefaults.sidebarToggle;
+export const SIDEBAR_TOGGLE_SHORTCUT_ALIASES = platformShortcutDefaults.sidebarToggleAliases;
+export { SHORTCUT_SETTING_KEYS };
+export type { ShortcutSettingKey };
 
 export function extractRemoteInvokeErrorMessage(error: unknown, fallback: string): string {
   if (!(error instanceof Error) || !error.message.trim()) {
@@ -213,10 +211,6 @@ export function extractRemoteInvokeErrorMessage(error: unknown, fallback: string
   const ipcMatch = error.message.match(/^Error invoking remote method '[^']+': (?:(?:Error|TypeError|RangeError): )?([\s\S]+)$/);
   return ipcMatch?.[1]?.trim() || error.message.trim();
 }
-
-export type ShortcutSettingKey = keyof typeof shortcutDefaults;
-
-export const SHORTCUT_SETTING_KEYS = Object.keys(shortcutDefaults) as ShortcutSettingKey[];
 
 export function getShortcutConflictMessage(
   editingKey: ShortcutSettingKey,

--- a/opennow-stable/src/shared/gfn/settings.test.ts
+++ b/opennow-stable/src/shared/gfn/settings.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_SHORTCUT_SETTINGS,
+  createDefaultSettings,
+  createPlatformShortcutDefaults,
+  resolveRuntimePlatform,
+} from "./settings";
+
+test("preserves Windows, macOS, and Linux shortcut defaults", () => {
+  const windows = createPlatformShortcutDefaults("win32");
+  const macOs = createPlatformShortcutDefaults("darwin");
+  const linux = createPlatformShortcutDefaults("linux");
+
+  assert.deepEqual(windows.bindings, DEFAULT_SHORTCUT_SETTINGS);
+  assert.deepEqual(macOs.bindings, DEFAULT_SHORTCUT_SETTINGS);
+  assert.deepEqual(linux.bindings, DEFAULT_SHORTCUT_SETTINGS);
+  assert.deepEqual(windows.sidebarToggleAliases, ["Ctrl+G", "Ctrl+Shift+G"]);
+  assert.equal(windows.sidebarToggle, "Ctrl+G");
+  assert.deepEqual(linux.sidebarToggleAliases, ["Ctrl+G", "Ctrl+Shift+G"]);
+  assert.equal(linux.sidebarToggle, "Ctrl+G");
+  assert.deepEqual(macOs.sidebarToggleAliases, ["Meta+G"]);
+  assert.equal(macOs.sidebarToggle, "Meta+G");
+});
+
+test("resolves main and renderer platform names without environment globals", () => {
+  assert.equal(resolveRuntimePlatform("win32"), "win32");
+  assert.equal(resolveRuntimePlatform("Win32"), "win32");
+  assert.equal(resolveRuntimePlatform("MacIntel"), "darwin");
+  assert.equal(resolveRuntimePlatform("Linux x86_64"), "linux");
+  assert.equal(resolveRuntimePlatform("plan9"), "unknown");
+});
+
+test("creates fresh mutable nested settings defaults", () => {
+  const first = createDefaultSettings("win32");
+  const second = createDefaultSettings("win32");
+
+  assert.notStrictEqual(first, second);
+  assert.notStrictEqual(first.favoriteGameIds, second.favoriteGameIds);
+  assert.notStrictEqual(first.videoShader, second.videoShader);
+
+  first.favoriteGameIds.push("game-1");
+  first.videoShader.sharpen = 0;
+
+  assert.deepEqual(second.favoriteGameIds, []);
+  assert.equal(second.videoShader.sharpen, 40);
+});
+
+test("creates fresh platform shortcut collections", () => {
+  const first = createPlatformShortcutDefaults("linux");
+  const second = createPlatformShortcutDefaults("linux");
+
+  assert.notStrictEqual(first.bindings, second.bindings);
+  assert.notStrictEqual(first.sidebarToggleAliases, second.sidebarToggleAliases);
+  first.bindings.shortcutToggleStats = "F4";
+  first.sidebarToggleAliases.push("Alt+G");
+
+  assert.equal(second.bindings.shortcutToggleStats, "F3");
+  assert.deepEqual(second.sidebarToggleAliases, ["Ctrl+G", "Ctrl+Shift+G"]);
+});

--- a/opennow-stable/src/shared/gfn/settings.ts
+++ b/opennow-stable/src/shared/gfn/settings.ts
@@ -11,8 +11,8 @@ import type {
   NativeVideoBackendPreference,
   StreamTransportMode,
 } from "./nativeStreamer";
-import type { GameLanguage, KeyboardLayout } from "./keyboard";
-import type { VideoShaderSettings } from "./videoShader";
+import { DEFAULT_KEYBOARD_LAYOUT, type GameLanguage, type KeyboardLayout } from "./keyboard";
+import { DEFAULT_VIDEO_SHADER_SETTINGS, type VideoShaderSettings } from "./videoShader";
 import type { UpdateChannel } from "./updater";
 import { normalizeStreamPreferences } from "./stream";
 
@@ -149,6 +149,140 @@ export interface Settings {
   errorReportingConsent: ErrorReportingConsent;
   /** Anonymous install UUID used as PostHog distinct ID (empty until first grant or feedback) */
   telemetryInstallId: string;
+}
+
+export const SHORTCUT_SETTING_KEYS = [
+  "shortcutToggleStats",
+  "shortcutTogglePointerLock",
+  "shortcutToggleFullscreen",
+  "shortcutStopStream",
+  "shortcutToggleAntiAfk",
+  "shortcutToggleMicrophone",
+  "shortcutScreenshot",
+  "shortcutToggleRecording",
+] as const satisfies readonly (keyof Settings)[];
+
+export type ShortcutSettingKey = typeof SHORTCUT_SETTING_KEYS[number];
+export type ShortcutSettings = Pick<Settings, ShortcutSettingKey>;
+
+export const DEFAULT_SHORTCUT_SETTINGS: Readonly<ShortcutSettings> = Object.freeze({
+  shortcutToggleStats: "F3",
+  shortcutTogglePointerLock: "F8",
+  shortcutToggleFullscreen: "F10",
+  shortcutStopStream: "Ctrl+Shift+Q",
+  shortcutToggleAntiAfk: "Ctrl+Shift+K",
+  shortcutToggleMicrophone: "Ctrl+Shift+M",
+  shortcutScreenshot: "F11",
+  shortcutToggleRecording: "F12",
+});
+
+export interface PlatformShortcutDefaults {
+  bindings: ShortcutSettings;
+  sidebarToggle: string;
+  sidebarToggleAliases: string[];
+}
+
+export function resolveRuntimePlatform(platform: string): RuntimePlatform {
+  const normalized = platform.trim().toLowerCase();
+  const exactPlatforms: readonly RuntimePlatform[] = [
+    "aix",
+    "android",
+    "cygwin",
+    "darwin",
+    "freebsd",
+    "haiku",
+    "linux",
+    "netbsd",
+    "openbsd",
+    "sunos",
+    "win32",
+  ];
+  if (exactPlatforms.includes(normalized as RuntimePlatform)) {
+    return normalized as RuntimePlatform;
+  }
+  if (normalized.includes("mac")) return "darwin";
+  if (normalized.includes("win")) return "win32";
+  if (normalized.includes("linux")) return "linux";
+  return "unknown";
+}
+
+export function createPlatformShortcutDefaults(platform: string): PlatformShortcutDefaults {
+  const isMacOs = resolveRuntimePlatform(platform) === "darwin";
+  const sidebarToggle = isMacOs ? "Meta+G" : "Ctrl+G";
+  return {
+    bindings: { ...DEFAULT_SHORTCUT_SETTINGS },
+    sidebarToggle,
+    sidebarToggleAliases: isMacOs ? [sidebarToggle] : [sidebarToggle, "Ctrl+Shift+G"],
+  };
+}
+
+export function createDefaultSettings(platform: string): Settings {
+  const shortcuts = createPlatformShortcutDefaults(platform);
+  return {
+    resolution: "1920x1080",
+    aspectRatio: "16:9",
+    posterSizeScale: 1.05,
+    fps: 60,
+    maxBitrateMbps: 75,
+    recordingBitrateMbps: null,
+    streamClientMode: "web",
+    nativeStreamerBackend: "gstreamer",
+    nativeVideoBackend: "auto",
+    nativeStreamerExecutablePath: "",
+    nativeCloudGsyncMode: "auto",
+    nativeD3dFullscreenMode: "auto",
+    nativeExternalRenderer: false,
+    transportMode: "webrtc",
+    showNativeStreamerStats: false,
+    codec: DEFAULT_STREAM_PREFERENCES.codec,
+    decoderPreference: "auto",
+    encoderPreference: "auto",
+    colorQuality: DEFAULT_STREAM_PREFERENCES.colorQuality,
+    region: "",
+    sessionProxyEnabled: false,
+    sessionProxyUrl: "",
+    clipboardPaste: false,
+    enableGyroscopeControls: false,
+    steamControllerCompatibilityMode: false,
+    nativeCursorOverlay: true,
+    mouseSensitivity: 1,
+    mouseAcceleration: 1,
+    ...shortcuts.bindings,
+    microphoneMode: "disabled",
+    microphoneDeviceId: "",
+    hideStreamButtons: false,
+    showAntiAfkIndicator: true,
+    showStatsOnLaunch: false,
+    hideServerSelector: false,
+    appAccentColor: "green",
+    appTheme: "auto",
+    translucentUI: false,
+    controllerMode: false,
+    launchInConsoleMode: false,
+    autoFullScreen: false,
+    favoriteGameIds: [],
+    sessionCounterEnabled: false,
+    showSessionTimeRemainingInStatsOverlay: false,
+    sessionClockShowEveryMinutes: 60,
+    sessionClockShowDurationSeconds: 30,
+    windowWidth: 1400,
+    windowHeight: 900,
+    keyboardLayout: DEFAULT_KEYBOARD_LAYOUT,
+    gameLanguage: "en_US",
+    enablePersistingInGameSettings: false,
+    enableL4S: false,
+    identifyAsSteamDeck: false,
+    enableCloudGsync: false,
+    nativeTransitionDiagnostics: undefined,
+    discordRichPresence: false,
+    autoCheckForUpdates: true,
+    updateChannel: "stable",
+    allowEscapeToExitFullscreen: false,
+    lastSeenReleaseHighlightsVersion: "",
+    videoShader: { ...DEFAULT_VIDEO_SHADER_SETTINGS },
+    errorReportingConsent: "unset",
+    telemetryInstallId: "",
+  };
 }
 
 export const DEFAULT_STREAM_PREFERENCES: Readonly<Pick<Settings, "codec" | "colorQuality">> = Object.freeze({


### PR DESCRIPTION
Centralize application and shortcut defaults in the shared GFN settings contract so main and renderer consumers cannot drift.

- Add platform-aware default factories with fresh nested settings values.
- Reuse the shared `Settings` contract and defaults in persistence, renderer startup, and shortcut formatting.
- Cover platform resolution, shortcut aliases, and object isolation with focused tests.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->