### PR TITLE
refactor(stream): decompose StreamView runtime

### DIFF
--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1,41 +1,34 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, m } from "motion/react";
 import type { JSX } from "react";
-import { Maximize, Minimize, LogOut, Clock3, AlertTriangle, Mic, Camera, ChevronLeft, ChevronRight, Save, Trash2, X, Circle, Square, Video, FolderOpen, Gamepad2, Gauge, Images, Keyboard, MousePointer2, SlidersHorizontal } from "lucide-react";
-import SideBar from "./SideBar";
+import { Maximize, Minimize, LogOut, AlertTriangle } from "lucide-react";
 import { SessionStartedSplash } from "./SessionStartedSplash";
 import { StreamStatsHud } from "./StreamStatsHud";
 import type { StreamDiagnosticsStore } from "../utils/streamDiagnosticsStore";
 import { useStreamDiagnosticsSelector } from "../utils/streamDiagnosticsStore";
 import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
-import { RemainingPlaytimeIndicator, SessionElapsedIndicator } from "./ElapsedSessionIndicators";
-import type { MicrophoneMode, ScreenshotEntry, RecordingEntry, SubscriptionInfo, VideoShaderSettings } from "@shared/gfn";
-import { DEFAULT_VIDEO_SHADER_SETTINGS } from "@shared/gfn";
+import { SessionElapsedIndicator } from "./ElapsedSessionIndicators";
+import type { MicrophoneMode, SubscriptionInfo, VideoShaderSettings } from "@shared/gfn";
 import { VideoShaderPipeline } from "../platforms/gfn/videoShaderPipeline";
-import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
-import { addStreamShortcutActionListener } from "../streamShortcutActions";
-import { useMicMeter } from "../hooks/useMicMeter";
-import { formatElapsed } from "../utils/timeFormat";
-import { useTranslation } from "../i18n";
-import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
-import { formatFileSize, formatSessionTimeRemaining, formatWarningSeconds } from "./stream/streamFormatters";
+import { formatShortcutForDisplay } from "../shortcuts";
+import { useScreenshotGallery } from "../hooks/useScreenshotGallery";
+import { useStreamMenuNavigation } from "../hooks/useStreamMenuNavigation";
+import { useStreamRecorder } from "../hooks/useStreamRecorder";
+import { formatSessionTimeRemaining, formatWarningSeconds } from "./stream/streamFormatters";
 import { AntiAfkIndicator, MicrophoneIndicator, RecordingIndicator } from "./stream/StreamIndicators";
 import { StreamTitleBar } from "./stream/StreamTitleBar";
 import {
   hasVisibleStreamVideo,
-  SidebarMicMutedBadge,
   StreamEmptyState,
   StreamWaitingForVideo,
   VideoFocusOnReady,
 } from "./stream/StreamEmptyStates";
+import { StreamQuickMenu } from "./stream/quick-menu/StreamQuickMenu";
 import { MotionSpinner } from "./MotionSpinner";
 
 const ANTI_AFK_TOGGLE_ACK_MS = 5000;
-const CONTROLLER_MENU_REPEAT_MS = 180;
 const CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY = "View + Menu";
-const STREAM_MENU_TABS = ["session", "controls", "media", "shortcuts"] as const;
-type StreamMenuTab = (typeof STREAM_MENU_TABS)[number];
 
 interface StreamViewProps {
   videoRef: React.Ref<HTMLVideoElement>;
@@ -163,38 +156,18 @@ export function StreamView({
   videoShader,
   onVideoShaderChange,
 }: StreamViewProps): JSX.Element {
-  const { t } = useTranslation();
   const [showHints, setShowHints] = useState(true);
   const [showSessionClock, setShowSessionClock] = useState(false);
   const [antiAfkToggleAck, setAntiAfkToggleAck] = useState<"on" | "off" | null>(null);
-  const [showSideBar, setShowSideBar] = useState(false);
   const [isPointerLocked, setIsPointerLocked] = useState(false);
   const [pointerLockHintVisible, setPointerLockHintVisible] = useState(false);
   const pointerLockHintTimerRef = useRef<number | null>(null);
-  const [screenshots, setScreenshots] = useState<ScreenshotEntry[]>([]);
-  const [isSavingScreenshot, setIsSavingScreenshot] = useState(false);
-  const [galleryError, setGalleryError] = useState<string | null>(null);
-  const [selectedScreenshotId, setSelectedScreenshotId] = useState<string | null>(null);
-  const [screenshotShortcutInput, setScreenshotShortcutInput] = useState(shortcuts.screenshot);
-  const [screenshotShortcutError, setScreenshotShortcutError] = useState<string | null>(null);
-  const [activeSidebarTab, setActiveSidebarTab] = useState<StreamMenuTab>("session");
-  const sidebarRef = useRef<HTMLElement | null>(null);
-  const sidebarGamepadFrameRef = useRef<number | null>(null);
-  const sidebarGamepadPreviousButtonsRef = useRef(0);
-  const sidebarGamepadLastMoveAtRef = useRef(0);
-  const exitPromptGamepadFrameRef = useRef<number | null>(null);
-  const exitPromptGamepadPreviousButtonsRef = useRef(0);
-  const suppressVideoFocusOnSidebarCloseRef = useRef(false);
-  const screenshotApiAvailable =
-    typeof window.openNow?.saveScreenshot === "function" &&
-    typeof window.openNow?.listScreenshots === "function" &&
-    typeof window.openNow?.deleteScreenshot === "function" &&
-    typeof window.openNow?.saveScreenshotAs === "function";
   const nativeRendererActive = useStreamDiagnosticsSelector(
     diagnosticsStore,
     (stats) => stats.nativeRendererActive,
   );
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
+  const localAudioRef = useRef<HTMLAudioElement | null>(null);
   const shaderPipelineRef = useRef<VideoShaderPipeline | null>(null);
   const streamHasVideo = useStreamDiagnosticsSelector(
     diagnosticsStore,
@@ -255,37 +228,6 @@ export function StreamView({
   const handleSessionReadySplashFinished = useCallback(() => {
     setSessionReadySplashVisible(false);
   }, []);
-
-  // Recording state
-  const [isRecording, setIsRecording] = useState(false);
-  const [recordings, setRecordings] = useState<RecordingEntry[]>([]);
-  const [recordingDurationMs, setRecordingDurationMs] = useState(0);
-  const [recordingError, setRecordingError] = useState<string | null>(null);
-  const [usedMimeType, setUsedMimeType] = useState<string | null>(null);
-  const [recordingShortcutInput, setRecordingShortcutInput] = useState(shortcuts.recording);
-  const [recordingShortcutError, setRecordingShortcutError] = useState<string | null>(null);
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const recordingIdRef = useRef<string | null>(null);
-  const recordingStartTimeRef = useRef<number>(0);
-  const recordingTimerRef = useRef<number | undefined>(undefined);
-  const thumbnailDataUrlRef = useRef<string | null>(null);
-  const recCarouselRef = useRef<HTMLDivElement | null>(null);
-  const recordingApiAvailable =
-    typeof window.openNow?.beginRecording === "function" &&
-    typeof window.openNow?.sendRecordingChunk === "function" &&
-    typeof window.openNow?.finishRecording === "function" &&
-    typeof window.openNow?.abortRecording === "function" &&
-    typeof window.openNow?.listRecordings === "function" &&
-    typeof window.openNow?.deleteRecording === "function";
-
-  const microphoneModes = useMemo(
-    () => [
-      { value: "disabled" as MicrophoneMode, label: "Disabled", description: "No microphone input" },
-      { value: "push-to-talk" as MicrophoneMode, label: "Push-to-Talk", description: "Hold a key to talk" },
-      { value: "voice-activity" as MicrophoneMode, label: "Voice Activity", description: "Always listen" },
-    ],
-    []
-  );
 
   const handleFullscreenToggle = useCallback(() => {
     onToggleFullscreen();
@@ -388,514 +330,48 @@ export function StreamView({
   const platformName = platformStore ? getStoreDisplayName(platformStore) : "";
   const PlatformIcon = platformStore ? getStoreIconComponent(platformStore) : null;
   const isMacClient = navigator.platform?.toLowerCase().includes("mac") || navigator.userAgent.includes("Macintosh");
+  const sidebarToggleRaw = isMacClient ? "Meta+G" : "Ctrl+G";
+  const sidebarToggleShortcutDisplay = formatShortcutForDisplay(sidebarToggleRaw, isMacClient);
 
-  // Local ref for audio element (game audio stream)
-  const localAudioRef = useRef<HTMLAudioElement | null>(null);
-  // AudioContext used during an active recording (torn down on stop/error)
-  const audioCtxRef = useRef<AudioContext | null>(null);
-
-  // Mic level meter canvas
-  const micMeterRef = useRef<HTMLCanvasElement | null>(null);
-  const galleryStripRef = useRef<HTMLDivElement | null>(null);
-  useMicMeter(micMeterRef, micTrack ?? null, showSideBar && microphoneMode !== "disabled");
-
-  const selectedScreenshot = useMemo(() => {
-    if (!selectedScreenshotId) return null;
-    return screenshots.find((item) => item.id === selectedScreenshotId) ?? null;
-  }, [screenshots, selectedScreenshotId]);
-
-  useEffect(() => {
-    setScreenshotShortcutInput(shortcuts.screenshot);
-    setScreenshotShortcutError(null);
-  }, [shortcuts.screenshot]);
-
-  useEffect(() => {
-    setRecordingShortcutInput(shortcuts.recording);
-    setRecordingShortcutError(null);
-  }, [shortcuts.recording]);
-
-  const getScreenshotShortcutError = useCallback((rawValue: string): string | null => {
-    const trimmed = rawValue.trim();
-    if (!trimmed) {
-      return "Shortcut cannot be empty.";
-    }
-
-    const normalized = normalizeShortcut(trimmed);
-    if (!normalized.valid) {
-      return "Invalid shortcut format.";
-    }
-
-    const reserved = [
-      shortcuts.toggleStats,
-      shortcuts.togglePointerLock,
-      shortcuts.stopStream,
-      shortcuts.toggleAntiAfk,
-      shortcuts.toggleMicrophone,
-      shortcuts.recording,
-      ...(isMacClient ? ["Meta+G"] : ["Ctrl+G", "Ctrl+Shift+G"]),
-    ]
-      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-      .map((value) => normalizeShortcut(value))
-      .filter((parsed) => parsed.valid)
-      .map((parsed) => parsed.canonical);
-
-    if (reserved.includes(normalized.canonical)) {
-      return "Shortcut conflicts with an existing binding.";
-    }
-
-    return null;
-  }, [isMacClient, shortcuts.recording, shortcuts.stopStream, shortcuts.toggleAntiAfk, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
-
-  const getRecordingShortcutError = useCallback((rawValue: string): string | null => {
-    const trimmed = rawValue.trim();
-    if (!trimmed) {
-      return "Shortcut cannot be empty.";
-    }
-
-    const normalized = normalizeShortcut(trimmed);
-    if (!normalized.valid) {
-      return "Invalid shortcut format.";
-    }
-
-    const reserved = [
-      shortcuts.toggleStats,
-      shortcuts.togglePointerLock,
-      shortcuts.stopStream,
-      shortcuts.toggleAntiAfk,
-      shortcuts.toggleMicrophone,
-      shortcuts.screenshot,
-      ...(isMacClient ? ["Meta+G"] : ["Ctrl+G", "Ctrl+Shift+G"]),
-    ]
-      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-      .map((value) => normalizeShortcut(value))
-      .filter((parsed) => parsed.valid)
-      .map((parsed) => parsed.canonical);
-
-    if (reserved.includes(normalized.canonical)) {
-      return "Shortcut conflicts with an existing binding.";
-    }
-
-    return null;
-  }, [isMacClient, shortcuts.screenshot, shortcuts.stopStream, shortcuts.toggleAntiAfk, shortcuts.toggleMicrophone, shortcuts.togglePointerLock, shortcuts.toggleStats]);
-
-  const SIDEBAR_TOGGLE_RAW = isMacClient ? "Meta+G" : "Ctrl+G";
-  const sidebarToggleShortcutDisplay = formatShortcutForDisplay(SIDEBAR_TOGGLE_RAW, isMacClient);
-
-  const applyScreenshotShortcutFromCapture = useCallback(
-    (canonical: string) => {
-      const error = getScreenshotShortcutError(canonical);
-      if (error) {
-        setScreenshotShortcutError(error);
-        return;
+  const screenshotGallery = useScreenshotGallery({
+    videoRef: localVideoRef,
+    gameTitle,
+  });
+  const streamRecorder = useStreamRecorder({
+    videoRef: localVideoRef,
+    audioRef: localAudioRef,
+    gameTitle,
+    micTrack: micTrack ?? null,
+    recordingBitrateMbps,
+  });
+  const releasePointerLockForMenu = useCallback(() => {
+    if (document.pointerLockElement) {
+      if (onReleasePointerLock) {
+        onReleasePointerLock();
+      } else {
+        document.exitPointerLock();
       }
-      const normalized = normalizeShortcut(canonical.trim());
-      if (!normalized.valid) {
-        setScreenshotShortcutError("Invalid shortcut format.");
-        return;
-      }
-      setScreenshotShortcutError(null);
-      setScreenshotShortcutInput(normalized.canonical);
-      if (normalized.canonical !== shortcuts.screenshot) {
-        onScreenshotShortcutChange(normalized.canonical);
-      }
-    },
-    [getScreenshotShortcutError, onScreenshotShortcutChange, shortcuts.screenshot],
-  );
-
-  const applyRecordingShortcutFromCapture = useCallback(
-    (canonical: string) => {
-      const error = getRecordingShortcutError(canonical);
-      if (error) {
-        setRecordingShortcutError(error);
-        return;
-      }
-      const normalized = normalizeShortcut(canonical.trim());
-      if (!normalized.valid) {
-        setRecordingShortcutError("Invalid shortcut format.");
-        return;
-      }
-      setRecordingShortcutError(null);
-      setRecordingShortcutInput(normalized.canonical);
-      if (normalized.canonical !== shortcuts.recording) {
-        onRecordingShortcutChange(normalized.canonical);
-      }
-    },
-    [getRecordingShortcutError, onRecordingShortcutChange, shortcuts.recording],
-  );
-
-  const handleStreamScreenshotShortcutKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      e.currentTarget.blur();
-      return;
     }
-    if (e.key === "Enter" || e.key === "Tab") {
-      return;
-    }
-    const captured = shortcutFromKeyboardEvent(e.nativeEvent);
-    if (!captured) {
-      return;
-    }
-    e.preventDefault();
-    e.stopPropagation();
-    applyScreenshotShortcutFromCapture(captured);
-  };
-
-  const handleStreamRecordingShortcutKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      e.currentTarget.blur();
-      return;
-    }
-    if (e.key === "Enter" || e.key === "Tab") {
-      return;
-    }
-    const captured = shortcutFromKeyboardEvent(e.nativeEvent);
-    if (!captured) {
-      return;
-    }
-    e.preventDefault();
-    e.stopPropagation();
-    applyRecordingShortcutFromCapture(captured);
-  };
-
-  const handleStreamScreenshotShortcutPaste = (e: React.ClipboardEvent<HTMLInputElement>): void => {
-    const text = e.clipboardData.getData("text/plain").trim();
-    if (!text) {
-      return;
-    }
-    e.preventDefault();
-    applyScreenshotShortcutFromCapture(text);
-  };
-
-  const handleStreamRecordingShortcutPaste = (e: React.ClipboardEvent<HTMLInputElement>): void => {
-    const text = e.clipboardData.getData("text/plain").trim();
-    if (!text) {
-      return;
-    }
-    e.preventDefault();
-    applyRecordingShortcutFromCapture(text);
-  };
-
-  const refreshScreenshots = useCallback(async () => {
-    setGalleryError(null);
-    if (!screenshotApiAvailable) {
-      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
-      return;
-    }
-    try {
-      const items = await window.openNow.listScreenshots();
-      setScreenshots(items);
-    } catch (error) {
-      console.error("[StreamView] Failed to load screenshots:", error);
-      setGalleryError("Unable to load screenshot gallery.");
-    }
-  }, [screenshotApiAvailable]);
-
-  const captureScreenshot = useCallback(async () => {
-    setGalleryError(null);
-    if (!screenshotApiAvailable) {
-      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable capture.");
-      return;
-    }
-    if (isSavingScreenshot) {
-      return;
-    }
-
-    const video = localVideoRef.current;
-    if (!video || video.videoWidth <= 0 || video.videoHeight <= 0) {
-      setGalleryError("Stream is not ready for screenshots yet.");
-      return;
-    }
-
-    setIsSavingScreenshot(true);
-    try {
-      const canvas = document.createElement("canvas");
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      const context = canvas.getContext("2d");
-      if (!context) {
-        throw new Error("Could not acquire 2D context");
-      }
-
-      context.drawImage(video, 0, 0, canvas.width, canvas.height);
-      const dataUrl = canvas.toDataURL("image/png");
-      const saved = await window.openNow.saveScreenshot({ dataUrl, gameTitle });
-      setScreenshots((prev) => [saved, ...prev.filter((item) => item.id !== saved.id)].slice(0, 60));
-    } catch (error) {
-      console.error("[StreamView] Failed to capture screenshot:", error);
-      setGalleryError("Screenshot failed. Try again.");
-    } finally {
-      setIsSavingScreenshot(false);
-    }
-  }, [gameTitle, isSavingScreenshot, screenshotApiAvailable]);
-
-  const scrollGallery = useCallback((direction: "left" | "right") => {
-    const strip = galleryStripRef.current;
-    if (!strip) return;
-    const delta = Math.max(180, Math.round(strip.clientWidth * 0.7));
-    strip.scrollBy({ left: direction === "left" ? -delta : delta, behavior: "smooth" });
-  }, []);
-
-  const handleDeleteScreenshot = useCallback(async () => {
-    setGalleryError(null);
-    if (!screenshotApiAvailable) {
-      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
-      return;
-    }
-    if (!selectedScreenshot) return;
-
-    try {
-      await window.openNow.deleteScreenshot({ id: selectedScreenshot.id });
-      setScreenshots((prev) => prev.filter((item) => item.id !== selectedScreenshot.id));
-      setSelectedScreenshotId(null);
-    } catch (error) {
-      console.error("[StreamView] Failed to delete screenshot:", error);
-      setGalleryError("Unable to delete screenshot.");
-    }
-  }, [screenshotApiAvailable, selectedScreenshot]);
-
-  const handleSaveScreenshotAs = useCallback(async () => {
-    setGalleryError(null);
-    if (!screenshotApiAvailable) {
-      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
-      return;
-    }
-    if (!selectedScreenshot) return;
-
-    try {
-      await window.openNow.saveScreenshotAs({ id: selectedScreenshot.id });
-    } catch (error) {
-      console.error("[StreamView] Failed to save screenshot as:", error);
-      setGalleryError("Unable to save screenshot.");
-    }
-  }, [screenshotApiAvailable, selectedScreenshot]);
-
-  const refreshRecordings = useCallback(async () => {
-    setRecordingError(null);
-    if (!recordingApiAvailable) return;
-    try {
-      const items = await window.openNow.listRecordings();
-      setRecordings(items);
-    } catch (error) {
-      console.error("[StreamView] Failed to load recordings:", error);
-      setRecordingError("Unable to load recordings.");
-    }
-  }, [recordingApiAvailable]);
-
-  const handleDeleteRecording = useCallback(async (id: string) => {
-    setRecordingError(null);
-    if (!recordingApiAvailable) return;
-    try {
-      await window.openNow.deleteRecording({ id });
-      setRecordings((prev) => prev.filter((r) => r.id !== id));
-    } catch (error) {
-      console.error("[StreamView] Failed to delete recording:", error);
-      setRecordingError("Unable to delete recording.");
-    }
-  }, [recordingApiAvailable]);
-
-  const scrollRecCarousel = useCallback((direction: "left" | "right") => {
-    const strip = recCarouselRef.current;
-    if (!strip) return;
-    strip.scrollBy({ left: direction === "left" ? -200 : 200, behavior: "smooth" });
-  }, []);
-
-  const toggleRecording = useCallback(async () => {
-    setRecordingError(null);
-
-    if (isRecording) {
-      mediaRecorderRef.current?.stop();
-      return;
-    }
-
-    if (!recordingApiAvailable) {
-      setRecordingError("Recording API unavailable. Restart OpenNOW to enable recording.");
-      return;
-    }
-
-    const video = localVideoRef.current;
-    if (!video || !video.srcObject) {
-      setRecordingError("Stream is not ready for recording yet.");
-      return;
-    }
-
-    const stream = video.srcObject as MediaStream;
-    const mimeTypes = [
-      "video/mp4;codecs=avc1.42E01E,mp4a.40.2",
-      "video/mp4;codecs=avc1",
-      "video/mp4",
-      "video/webm;codecs=h264",
-      "video/webm;codecs=vp8",
-      "video/webm",
-    ];
-    const mimeType = mimeTypes.find((m) => MediaRecorder.isTypeSupported(m)) ?? "video/webm";
-    setUsedMimeType(mimeType);
-
-    // Build a composed MediaStream: video tracks + mixed audio (game + mic)
-    const audioCtx = new AudioContext();
-    audioCtxRef.current = audioCtx;
-    const audioDest = audioCtx.createMediaStreamDestination();
-
-    // Wire game audio (from the <audio> element's srcObject)
-    const audioEl = localAudioRef.current;
-    const gameAudioStream = audioEl?.srcObject instanceof MediaStream ? audioEl.srcObject : null;
-    if (gameAudioStream && gameAudioStream.getAudioTracks().length > 0) {
-      audioCtx.createMediaStreamSource(gameAudioStream).connect(audioDest);
-    }
-
-    // Wire microphone (if active)
-    if (micTrack && micTrack.readyState === "live") {
-      const micStream = new MediaStream([micTrack]);
-      audioCtx.createMediaStreamSource(micStream).connect(audioDest);
-    }
-
-    // Compose: video tracks from the video element + mixed audio destination track
-    const composed = new MediaStream([
-      ...stream.getVideoTracks(),
-      ...audioDest.stream.getAudioTracks(),
-    ]);
-
-    let recordingId: string;
-    try {
-      const result = await window.openNow.beginRecording({ mimeType });
-      recordingId = result.recordingId;
-    } catch (error) {
-      console.error("[StreamView] Failed to begin recording:", error);
-      audioCtx.close().catch(() => undefined);
-      audioCtxRef.current = null;
-      setRecordingError("Could not start recording.");
-      return;
-    }
-
-    recordingIdRef.current = recordingId;
-    thumbnailDataUrlRef.current = null;
-    recordingStartTimeRef.current = Date.now();
-    setRecordingDurationMs(0);
-    setIsRecording(true);
-
-    recordingTimerRef.current = window.setInterval(() => {
-      setRecordingDurationMs(Date.now() - recordingStartTimeRef.current);
-    }, 500);
-
-    let isFirstChunk = true;
-    const recorderOptions: MediaRecorderOptions = { mimeType };
-    if (recordingBitrateMbps !== null) {
-      recorderOptions.videoBitsPerSecond = Math.max(1, Math.min(200, Math.round(recordingBitrateMbps))) * 1_000_000;
-    }
-    const recorder = new MediaRecorder(composed, recorderOptions);
-
-    recorder.ondataavailable = (e: BlobEvent) => {
-      if (!e.data || e.data.size === 0) return;
-
-      // Capture thumbnail from the first chunk (frame ~2 s in)
-      if (isFirstChunk) {
-        isFirstChunk = false;
-        const vid = localVideoRef.current;
-        if (vid && vid.videoWidth > 0 && vid.videoHeight > 0) {
-          // create a canvas sized to preserve the video's aspect ratio, but
-          // capped at roughly 320×180 so we don't generate unnecessarily large
-          // thumbnails when the stream resolution is higher than 16:9.
-          const maxW = 320;
-          const maxH = 180;
-          let w = vid.videoWidth;
-          let h = vid.videoHeight;
-
-          // shrink to fit within bounds while keeping aspect ratio
-          if (w > maxW) {
-            h = Math.round((maxW / w) * h);
-            w = maxW;
-          }
-          if (h > maxH) {
-            w = Math.round((maxH / h) * w);
-            h = maxH;
-          }
-
-          const canvas = document.createElement("canvas");
-          canvas.width = w;
-          canvas.height = h;
-          const ctx2d = canvas.getContext("2d");
-          if (ctx2d) {
-            ctx2d.drawImage(vid, 0, 0, w, h);
-            thumbnailDataUrlRef.current = canvas.toDataURL("image/jpeg", 0.72);
-          }
-        }
-      }
-
-      void e.data.arrayBuffer().then((buf) => {
-        const id = recordingIdRef.current;
-        if (!id) return;
-        window.openNow.sendRecordingChunk({ recordingId: id, chunk: buf }).catch((err: unknown) => {
-          console.error("[StreamView] Failed to send recording chunk:", err);
-        });
-      });
-    };
-
-    recorder.onstop = () => {
-      window.clearInterval(recordingTimerRef.current);
-      recordingTimerRef.current = undefined;
-      audioCtxRef.current?.close().catch(() => undefined);
-      audioCtxRef.current = null;
-      const id = recordingIdRef.current;
-      recordingIdRef.current = null;
-      setIsRecording(false);
-
-      if (!id) return;
-
-      const durationMs = Date.now() - recordingStartTimeRef.current;
-      void window.openNow
-        .finishRecording({
-          recordingId: id,
-          durationMs,
-          gameTitle,
-          thumbnailDataUrl: thumbnailDataUrlRef.current ?? undefined,
-        })
-        .then((entry) => {
-          setRecordings((prev) => [entry, ...prev].slice(0, 20));
-          thumbnailDataUrlRef.current = null;
-        })
-        .catch((err: unknown) => {
-          console.error("[StreamView] Failed to finish recording:", err);
-          setRecordingError("Recording could not be saved.");
-        });
-    };
-
-    recorder.onerror = () => {
-      window.clearInterval(recordingTimerRef.current);
-      recordingTimerRef.current = undefined;
-      audioCtxRef.current?.close().catch(() => undefined);
-      audioCtxRef.current = null;
-      const id = recordingIdRef.current;
-      recordingIdRef.current = null;
-      setIsRecording(false);
-      thumbnailDataUrlRef.current = null;
-      if (id) {
-        window.openNow.abortRecording({ recordingId: id }).catch(() => undefined);
-      }
-      setRecordingError("Recording encountered an error.");
-    };
-
-    mediaRecorderRef.current = recorder;
-    recorder.start(2000);
-  }, [gameTitle, isRecording, micTrack, recordingApiAvailable, recordingBitrateMbps]);
-
-  // Cleanup: abort any active recording on unmount
-  useEffect(() => {
-    return () => {
-      window.clearInterval(recordingTimerRef.current);
-      const recorder = mediaRecorderRef.current;
-      const id = recordingIdRef.current;
-      if (recorder && recorder.state !== "inactive") {
-        recorder.stop();
-      }
-      if (id) {
-        window.openNow.abortRecording({ recordingId: id }).catch(() => undefined);
-        recordingIdRef.current = null;
-      }
-      audioCtxRef.current?.close().catch(() => undefined);
-      audioCtxRef.current = null;
-    };
-  }, []);
+  }, [onReleasePointerLock]);
+  const {
+    showSideBar,
+    setShowSideBar,
+    activeSidebarTab,
+    setActiveSidebarTab,
+    sidebarRef,
+  } = useStreamMenuNavigation({
+    shortcuts,
+    isMacClient,
+    exitPromptOpen: exitPrompt.open,
+    selectedScreenshotId: screenshotGallery.selectedScreenshotId,
+    setSelectedScreenshotId: screenshotGallery.setSelectedScreenshotId,
+    captureScreenshot: screenshotGallery.captureScreenshot,
+    toggleRecording: streamRecorder.toggleRecording,
+    onCancelExit,
+    onConfirmExit,
+    onBeforeOpen: releasePointerLockForMenu,
+  });
+  const suppressVideoFocusOnSidebarCloseRef = useRef(false);
 
   // Video shader post-processing pipeline (embedded WebRTC path only; the
   // native streamer renders outside Chromium so shaders cannot apply there).
@@ -1069,8 +545,8 @@ export function StreamView({
       } else {
         document.exitPointerLock();
       }
-      void refreshScreenshots();
-      void refreshRecordings();
+      void screenshotGallery.refreshScreenshots();
+      void streamRecorder.refreshRecordings();
       return () => {
         try {
           delete (document.body.dataset as DOMStringMap).sidebarOpen;
@@ -1093,289 +569,13 @@ export function StreamView({
       delete (document.body.dataset as DOMStringMap).sidebarOpen;
     } catch {}
     return () => clearTimeout(timer);
-  }, [refreshRecordings, refreshScreenshots, showSideBar]);
-
-  useEffect(() => {
-    if (!selectedScreenshotId) return;
-    if (!screenshots.some((item) => item.id === selectedScreenshotId)) {
-      setSelectedScreenshotId(null);
-    }
-  }, [screenshots, selectedScreenshotId]);
-
-  const handleToggleSideBar = useCallback(() => {
-    setShowSideBar((s) => {
-      if (!s && document.pointerLockElement) {
-        if (onReleasePointerLock) {
-          onReleasePointerLock();
-        } else {
-          document.exitPointerLock();
-        }
-      }
-      return !s;
-    });
-  }, [onReleasePointerLock]);
+  }, [screenshotGallery.refreshScreenshots, showSideBar, streamRecorder.refreshRecordings]);
 
   const handleSidebarExitSession = useCallback(() => {
     suppressVideoFocusOnSidebarCloseRef.current = true;
     setShowSideBar(false);
     onEndSession();
-  }, [onEndSession]);
-
-  const selectAdjacentSidebarTab = useCallback((direction: -1 | 1) => {
-    setActiveSidebarTab((current) => {
-      const index = STREAM_MENU_TABS.indexOf(current);
-      return STREAM_MENU_TABS[(index + direction + STREAM_MENU_TABS.length) % STREAM_MENU_TABS.length];
-    });
-    window.requestAnimationFrame(() => {
-      sidebarRef.current?.querySelector<HTMLElement>(".sidebar-tab--active")?.focus({ preventScroll: true });
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!showSideBar || exitPrompt.open) return;
-
-    const getMenuItems = (): HTMLElement[] => {
-      const scope = selectedScreenshotId
-        ? document.querySelector<HTMLElement>(".sv-shot-modal-card")
-        : sidebarRef.current;
-      if (!scope) return [];
-      return Array.from(scope.querySelectorAll<HTMLElement>(
-        "button:not(:disabled), input:not(:disabled):not([type='checkbox']), label.sidebar-mini-toggle, [tabindex='0']",
-      )).filter((element) => {
-        const style = window.getComputedStyle(element);
-        const isInactiveTab = element.getAttribute("role") === "tab" && element.getAttribute("aria-selected") !== "true";
-        return !isInactiveTab && style.display !== "none" && style.visibility !== "hidden";
-      });
-    };
-
-    const focusItem = (direction: -1 | 1): void => {
-      const items = getMenuItems();
-      if (items.length === 0) return;
-      const currentIndex = items.findIndex((item) => item === document.activeElement);
-      const nextIndex = currentIndex < 0
-        ? 0
-        : (currentIndex + direction + items.length) % items.length;
-      items[nextIndex]?.focus({ preventScroll: true });
-      items[nextIndex]?.scrollIntoView({ block: "nearest" });
-    };
-
-    const changeRange = (input: HTMLInputElement, direction: -1 | 1): void => {
-      const min = Number(input.min || 0);
-      const max = Number(input.max || 100);
-      const step = Number(input.step || 1);
-      const value = Math.max(min, Math.min(max, Number(input.value) + step * direction));
-      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(input, String(value));
-      input.dispatchEvent(new Event("input", { bubbles: true }));
-      input.dispatchEvent(new Event("change", { bubbles: true }));
-    };
-
-    const readButtons = (): number => {
-      const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
-      return readControllerGamepadButtons(pad);
-    };
-
-    const handleGamepadFrame = (): void => {
-      const buttons = readButtons();
-      let pressed = buttons & ~sidebarGamepadPreviousButtonsRef.current;
-      const moveMask = controllerButton.up | controllerButton.down | controllerButton.left | controllerButton.right;
-      const activeMoves = buttons & moveMask;
-      const now = performance.now();
-      if (pressed & moveMask) {
-        sidebarGamepadLastMoveAtRef.current = now;
-      } else if (activeMoves && now - sidebarGamepadLastMoveAtRef.current > CONTROLLER_MENU_REPEAT_MS) {
-        pressed |= activeMoves;
-        sidebarGamepadLastMoveAtRef.current = now;
-      }
-
-      const active = document.activeElement as HTMLElement | null;
-      const range = active instanceof HTMLInputElement && active.type === "range" ? active : null;
-      if (pressed & controllerButton.up) focusItem(-1);
-      if (pressed & controllerButton.down) focusItem(1);
-      if (pressed & controllerButton.left) {
-        if (range) changeRange(range, -1);
-        else if (active?.getAttribute("role") === "tab") selectAdjacentSidebarTab(-1);
-        else focusItem(-1);
-      }
-      if (pressed & controllerButton.right) {
-        if (range) changeRange(range, 1);
-        else if (active?.getAttribute("role") === "tab") selectAdjacentSidebarTab(1);
-        else focusItem(1);
-      }
-      if (pressed & controllerButton.leftShoulder) selectAdjacentSidebarTab(-1);
-      if (pressed & controllerButton.rightShoulder) selectAdjacentSidebarTab(1);
-      if (pressed & controllerButton.south) {
-        if (active && !range) active.click();
-      }
-      if (pressed & controllerButton.east) {
-        if (selectedScreenshotId) setSelectedScreenshotId(null);
-        else setShowSideBar(false);
-      }
-      if (pressed & controllerButton.menu) setShowSideBar(false);
-
-      sidebarGamepadPreviousButtonsRef.current = buttons;
-      sidebarGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
-    };
-
-    const initialFocusTimer = window.setTimeout(() => {
-      const initialFocus = selectedScreenshotId
-        ? document.querySelector<HTMLElement>(".sv-shot-modal-btn:not(:disabled), .sv-shot-modal-close")
-        : sidebarRef.current?.querySelector<HTMLElement>(".sidebar-tab--active");
-      initialFocus?.focus({ preventScroll: true });
-    }, 0);
-    sidebarGamepadPreviousButtonsRef.current = readButtons();
-    sidebarGamepadLastMoveAtRef.current = performance.now();
-    sidebarGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
-
-    return () => {
-      window.clearTimeout(initialFocusTimer);
-      if (sidebarGamepadFrameRef.current !== null) {
-        window.cancelAnimationFrame(sidebarGamepadFrameRef.current);
-        sidebarGamepadFrameRef.current = null;
-      }
-      sidebarGamepadPreviousButtonsRef.current = 0;
-      sidebarGamepadLastMoveAtRef.current = 0;
-    };
-  }, [exitPrompt.open, selectAdjacentSidebarTab, selectedScreenshotId, showSideBar]);
-
-  useEffect(() => {
-    if (!exitPrompt.open) return;
-
-    const focusExitButton = (confirm: boolean): void => {
-      document.querySelector<HTMLButtonElement>(
-        confirm ? ".sv-exit-btn-confirm" : ".sv-exit-btn-cancel",
-      )?.focus({ preventScroll: true });
-    };
-    const readButtons = (): number => {
-      const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
-      return readControllerGamepadButtons(pad);
-    };
-    const handleGamepadFrame = (): void => {
-      const buttons = readButtons();
-      const pressed = buttons & ~exitPromptGamepadPreviousButtonsRef.current;
-      if (pressed & (controllerButton.left | controllerButton.up)) focusExitButton(false);
-      if (pressed & (controllerButton.right | controllerButton.down)) focusExitButton(true);
-      if (pressed & controllerButton.south) {
-        const active = document.activeElement as HTMLElement | null;
-        if (active?.closest(".sv-exit-card")) active.click();
-      }
-      if (pressed & (controllerButton.east | controllerButton.menu)) onCancelExit();
-      exitPromptGamepadPreviousButtonsRef.current = buttons;
-      exitPromptGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
-    };
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onCancelExit();
-      } else if (event.key === "Enter") {
-        event.preventDefault();
-        onConfirmExit();
-      }
-    };
-
-    const focusTimer = window.setTimeout(() => focusExitButton(false), 0);
-    exitPromptGamepadPreviousButtonsRef.current = readButtons();
-    exitPromptGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
-    window.addEventListener("keydown", handleKeyDown, true);
-    return () => {
-      window.clearTimeout(focusTimer);
-      window.removeEventListener("keydown", handleKeyDown, true);
-      if (exitPromptGamepadFrameRef.current !== null) {
-        window.cancelAnimationFrame(exitPromptGamepadFrameRef.current);
-        exitPromptGamepadFrameRef.current = null;
-      }
-      exitPromptGamepadPreviousButtonsRef.current = 0;
-    };
-  }, [exitPrompt.open, onCancelExit, onConfirmExit]);
-
-  useEffect(() => {
-    return addStreamShortcutActionListener((action) => {
-      if (action === "toggleSidebar") {
-        handleToggleSideBar();
-        return;
-      }
-      if (action === "screenshot") {
-        void captureScreenshot();
-        return;
-      }
-      if (action === "toggleRecording") {
-        void toggleRecording();
-      }
-    });
-  }, [captureScreenshot, handleToggleSideBar, toggleRecording]);
-
-  useEffect(() => {
-    const screenshotShortcut = normalizeShortcut(shortcuts.screenshot);
-    const recordingShortcut = normalizeShortcut(shortcuts.recording);
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
-      const isTyping = !!target && (
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable
-      );
-      if (isTyping) {
-        return;
-      }
-
-      const key = event.key.toLowerCase();
-      const isSidebarShortcut = isMacClient
-        ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && key === "g"
-        : event.ctrlKey && !event.altKey && !event.metaKey && key === "g";
-      if (isSidebarShortcut) {
-        return;
-      }
-
-      if (isShortcutMatch(event, screenshotShortcut)) {
-        event.preventDefault();
-        event.stopPropagation();
-        void captureScreenshot();
-        return;
-      }
-
-      if (isShortcutMatch(event, recordingShortcut)) {
-        event.preventDefault();
-        event.stopPropagation();
-        void toggleRecording();
-        return;
-      }
-    };
-
-    window.addEventListener("keydown", onKeyDown, true);
-    return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [captureScreenshot, isMacClient, shortcuts.screenshot, shortcuts.recording, toggleRecording]);
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
-      const isTyping = !!target && (
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable
-      );
-      if (isTyping) {
-        return;
-      }
-
-      const key = event.key.toLowerCase();
-      if (isMacClient) {
-        if (event.metaKey && !event.ctrlKey && !event.shiftKey && key === "g") {
-          event.preventDefault();
-          event.stopPropagation();
-          event.stopImmediatePropagation();
-          handleToggleSideBar();
-        }
-      } else if (event.ctrlKey && !event.altKey && !event.metaKey && key === "g") {
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
-        handleToggleSideBar();
-      }
-    };
-
-    window.addEventListener("keydown", onKeyDown, true);
-    return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [handleToggleSideBar, isMacClient]);
+  }, [onEndSession, setShowSideBar]);
 
   useEffect(() => {
     const blurStreamFocusTarget = (): void => {
@@ -1472,668 +672,48 @@ export function StreamView({
         </div>
       )}
 
-      <AnimatePresence>
-        {showSideBar && (
-          <m.div
-            key="quick-menu-backdrop"
-            className="sv-sidebar-backdrop"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.18 }}
-            onMouseDown={(event) => event.stopPropagation()}
-            onClick={() => setShowSideBar(false)}
-          />
-        )}
-      </AnimatePresence>
-      <AnimatePresence>
-        {showSideBar && (
-          <SideBar
-            key="quick-menu-sidebar"
-            title="Quick menu"
-            className="sv-sidebar"
-            elementRef={sidebarRef}
-            onClose={() => setShowSideBar(false)}
-            footer={(
-              <>
-                <div className="sidebar-controller-hints" aria-hidden="true">
-                  <span><kbd>A</kbd> Select</span>
-                  <span><kbd>B</kbd> Back</span>
-                  <span><kbd>LB</kbd><kbd>RB</kbd> Pages</span>
-                </div>
-                <button
-                  type="button"
-                  className="sidebar-exit-session-button"
-                  onClick={handleSidebarExitSession}
-                >
-                  <LogOut size={16} />
-                  <span>End session</span>
-                </button>
-              </>
-            )}
-          >
-            <div className="sidebar-tabs" role="tablist" aria-label="Quick menu pages">
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeSidebarTab === "session"}
-                className={`sidebar-tab${activeSidebarTab === "session" ? " sidebar-tab--active" : ""}`}
-                onClick={() => setActiveSidebarTab("session")}
-              >
-                <Gauge size={16} />
-                <span>Session</span>
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeSidebarTab === "controls"}
-                className={`sidebar-tab${activeSidebarTab === "controls" ? " sidebar-tab--active" : ""}`}
-                onClick={() => setActiveSidebarTab("controls")}
-              >
-                <SlidersHorizontal size={16} />
-                <span>Controls</span>
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeSidebarTab === "media"}
-                className={`sidebar-tab${activeSidebarTab === "media" ? " sidebar-tab--active" : ""}`}
-                onClick={() => setActiveSidebarTab("media")}
-              >
-                <Images size={16} />
-                <span>Media</span>
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeSidebarTab === "shortcuts"}
-                className={`sidebar-tab${activeSidebarTab === "shortcuts" ? " sidebar-tab--active" : ""}`}
-                onClick={() => setActiveSidebarTab("shortcuts")}
-              >
-                <Keyboard size={16} />
-                <span>Keys</span>
-              </button>
-            </div>
-
-            {activeSidebarTab === "session" && (
-              <div className="sidebar-page sidebar-page--session" role="tabpanel">
-                <section className="sidebar-session-card" aria-label="Current stream session">
-                  <div className="sidebar-session-card-head">
-                    <span className="sidebar-session-kicker">Now streaming</span>
-                    <strong className="sidebar-session-title">{gameTitle}</strong>
-                    {PlatformIcon && platformName && (
-                      <span className="sidebar-session-platform" title={platformName}>
-                        <span className="sidebar-session-platform-icon"><PlatformIcon /></span>
-                        <span>{platformName}</span>
-                      </span>
-                    )}
-                  </div>
-                </section>
-                <section className="sidebar-session-metrics" aria-label="Session time">
-                  <div className="sidebar-metric">
-                    <span>Total playtime left</span>
-                    <RemainingPlaytimeIndicator subscriptionInfo={subscriptionInfo} startedAtMs={sessionStartedAtMs} active={isStreaming} className="sidebar-metric-value" />
-                  </div>
-                  {sessionTimeRemainingText !== null && (
-                    <div className="sidebar-metric">
-                      <span>{t("sidebar.sessionTimeRemaining")}</span>
-                      <strong className="sidebar-metric-value">
-                        <Clock3 size={14} />
-                        {sessionTimeRemainingText}
-                      </strong>
-                    </div>
-                  )}
-                </section>
-                <section className="sidebar-section">
-                  <div className="sidebar-section-header">
-                    <span>Session controls</span>
-                    <span className="sidebar-section-sub">Manage the active stream.</span>
-                  </div>
-                  <div className="sidebar-quick-actions">
-                    <button type="button" className="sidebar-action-card" onClick={handleFullscreenToggle}>
-                      {isFullscreen ? <Minimize size={16} /> : <Maximize size={16} />}
-                      <span>{isFullscreen ? "Windowed" : "Fullscreen"}</span>
-                    </button>
-                    <button type="button" className="sidebar-action-card" onClick={handlePointerLockToggle}>
-                      <MousePointer2 size={16} />
-                      <span>{isPointerLocked ? "Release mouse" : "Capture mouse"}</span>
-                    </button>
-                    {onToggleMicrophone && (
-                      <button type="button" className="sidebar-action-card" onClick={onToggleMicrophone}>
-                        <Mic size={16} />
-                        <span>Toggle mic</span>
-                      </button>
-                    )}
-                    <button
-                      type="button"
-                      className="sidebar-action-card"
-                      onClick={() => { void captureScreenshot(); }}
-                      disabled={isSavingScreenshot || !screenshotApiAvailable}
-                    >
-                      <Camera size={16} />
-                      <span>{isSavingScreenshot ? "Capturing" : "Screenshot"}</span>
-                    </button>
-                  </div>
-                </section>
-                {sessionTimeRemainingText !== null && (
-                  <label className="sidebar-setting-card sidebar-mini-toggle" tabIndex={0}>
-                    <span>
-                      <strong>Show time in stats</strong>
-                      <small>Keep session time visible in the performance overlay.</small>
-                    </span>
-                    <input
-                      type="checkbox"
-                      name="show-session-time-in-stats"
-                      checked={showSessionTimeRemainingInStatsOverlay}
-                      aria-label={t("sidebar.showSessionTimeRemainingInStatsOverlay")}
-                      onChange={(event) => onShowSessionTimeRemainingInStatsOverlayChange(event.target.checked)}
-                    />
-                    <span className="sidebar-mini-toggle-track" />
-                  </label>
-                )}
-                <div className="sidebar-open-shortcuts">
-                  <span><kbd>{sidebarToggleShortcutDisplay}</kbd> Keyboard</span>
-                  <span><Gamepad2 size={14} /> {CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY}</span>
-                </div>
-              </div>
-            )}
-
-            {activeSidebarTab === "controls" && (
-              <div className="sidebar-page" role="tabpanel">
-                <section className="sidebar-section">
-                  <div className="sidebar-section-header">
-                    <span>Mouse Preferences</span>
-                    <span className="sidebar-section-sub">Fine-tune cursor movement.</span>
-                  </div>
-                  <div className="sidebar-row sidebar-row--column">
-                    <div className="sidebar-row-top">
-                      <span className="sidebar-label">Mouse Sensitivity</span>
-                      <span className="settings-value-badge">{mouseSensitivity.toFixed(2)}x</span>
-                    </div>
-                    <input
-                      type="range"
-                      name="mouse-sensitivity"
-                      aria-label="Mouse sensitivity"
-                      className="settings-slider"
-                      min={0.1}
-                      max={4}
-                      step={0.01}
-                      value={mouseSensitivity}
-                      onChange={(event) => {
-                        const next = Number(event.target.value);
-                        if (Number.isFinite(next)) {
-                          onMouseSensitivityChange(Math.max(0.1, Math.min(4, next)));
-                        }
-                      }}
-                    />
-                    <span className="sidebar-hint">Multiplier applied to mouse movement (1.00 = default).</span>
-                  </div>
-                  <div className="sidebar-row sidebar-row--column">
-                    <div className="sidebar-row-top">
-                      <span className="sidebar-label">Mouse Accelerator</span>
-                      <span className="settings-value-badge">{Math.round(mouseAcceleration)}%</span>
-                    </div>
-                    <input
-                      type="range"
-                      name="mouse-acceleration"
-                      aria-label="Mouse accelerator"
-                      className="settings-slider"
-                      min={1}
-                      max={150}
-                      step={1}
-                      value={Math.round(mouseAcceleration)}
-                      onChange={(event) => {
-                        const next = Number(event.target.value);
-                        if (Number.isFinite(next)) {
-                          onMouseAccelerationChange(Math.max(1, Math.min(150, Math.round(next))));
-                        }
-                      }}
-                    />
-                    <span className="sidebar-hint">Dynamic turn boost strength (1% = off-like, 150% = strongest).</span>
-                  </div>
-                </section>
-                <div className="sidebar-separator" aria-hidden="true" />
-                <section className="sidebar-section">
-                  <div className="sidebar-section-header">
-                    <span>Video Filters</span>
-                    <span className="sidebar-section-sub">GPU shaders applied to the stream.</span>
-                  </div>
-                  {gstreamerEnabled ? (
-                    <span className="sidebar-hint">Video filters are unavailable while the native streamer renders the video.</span>
-                  ) : (
-                    <>
-                      <div className="sidebar-row sidebar-row--aligned">
-                        <span className="sidebar-label">Enable Filters</span>
-                        <label className="sidebar-mini-toggle" title="Enable GPU post-processing filters" tabIndex={0}>
-                          <input
-                            type="checkbox"
-                            name="enable-video-filters"
-                            checked={videoShader.enabled}
-                            aria-label="Enable video filters"
-                            onChange={(event) => onVideoShaderChange({ ...videoShader, enabled: event.target.checked })}
-                          />
-                          <span className="sidebar-mini-toggle-track" />
-                        </label>
-                      </div>
-                      {videoShader.enabled && (
-                        <>
-                          {([
-                            { key: "sharpen", label: "Sharpen", min: 0, max: 100, neutral: 0, format: (v: number) => `${v}%`, hint: "Contrast-adaptive sharpening. Counters stream compression blur." },
-                            { key: "saturation", label: "Saturation", min: 0, max: 200, neutral: 100, format: (v: number) => `${v}%` },
-                            { key: "contrast", label: "Contrast", min: 50, max: 150, neutral: 100, format: (v: number) => `${v}%` },
-                            { key: "brightness", label: "Brightness", min: 50, max: 150, neutral: 100, format: (v: number) => `${v}%` },
-                            { key: "vibrance", label: "Vibrance", min: 0, max: 100, neutral: 0, format: (v: number) => `${v}%`, hint: "Boosts muted colors without oversaturating." },
-                            { key: "filmGrain", label: "Film Grain", min: 0, max: 100, neutral: 0, format: (v: number) => `${v}%` },
-                          ] as const).map((control) => (
-                            <div key={control.key} className="sidebar-row sidebar-row--column">
-                              <div className="sidebar-row-top">
-                                <span className="sidebar-label">{control.label}</span>
-                                <span className="settings-value-badge">{control.format(videoShader[control.key])}</span>
-                              </div>
-                              <input
-                                type="range"
-                                name={`video-filter-${control.key}`}
-                                aria-label={`${control.label} video filter`}
-                                className="settings-slider"
-                                min={control.min}
-                                max={control.max}
-                                step={1}
-                                value={videoShader[control.key]}
-                                onChange={(event) => {
-                                  const next = Number(event.target.value);
-                                  if (Number.isFinite(next)) {
-                                    onVideoShaderChange({
-                                      ...videoShader,
-                                      [control.key]: Math.max(control.min, Math.min(control.max, Math.round(next))),
-                                    });
-                                  }
-                                }}
-                                onDoubleClick={() => onVideoShaderChange({ ...videoShader, [control.key]: control.neutral })}
-                              />
-                              {"hint" in control && control.hint && <span className="sidebar-hint">{control.hint}</span>}
-                            </div>
-                          ))}
-                          <div className="sidebar-row sidebar-row--aligned">
-                            <span className="sidebar-label">Reset Filters</span>
-                            <button
-                              type="button"
-                              className="sidebar-button"
-                              onClick={() => onVideoShaderChange({ ...DEFAULT_VIDEO_SHADER_SETTINGS, enabled: true })}
-                            >
-                              <span>Reset</span>
-                            </button>
-                          </div>
-                        </>
-                      )}
-                    </>
-                  )}
-                </section>
-                <div className="sidebar-separator" aria-hidden="true" />
-                <section className="sidebar-section">
-                  <div className="sidebar-section-header">
-                    <span>Audio</span>
-                    <span className="sidebar-section-sub">Configure microphone handling.</span>
-                  </div>
-                  <div className="sidebar-row sidebar-row--column">
-                    <div className="sidebar-row-top">
-                      <span className="sidebar-label">Microphone Mode</span>
-                      <span className="settings-value-badge">
-                        {microphoneModes.find((option) => option.value === microphoneMode)?.label ?? microphoneMode}
-                      </span>
-                    </div>
-                    <div className="sidebar-chip-row">
-                      {microphoneModes.map((option) => (
-                        <button
-                          key={option.value}
-                          type="button"
-                          className={`sidebar-chip${microphoneMode === option.value ? " sidebar-chip--active" : ""}`}
-                          onClick={() => onMicrophoneModeChange(option.value)}
-                        >
-                          <span>{option.label}</span>
-                        </button>
-                      ))}
-                    </div>
-                    <span className="sidebar-hint">
-                      {microphoneModes.find((option) => option.value === microphoneMode)?.description ?? ""}
-                    </span>
-                  </div>
-                  {microphoneMode !== "disabled" && (
-                    <div className="sidebar-row sidebar-row--column">
-                      <div className="sidebar-row-top">
-                        <span className="sidebar-label">Send level</span>
-                        <SidebarMicMutedBadge diagnosticsStore={diagnosticsStore} micTrack={micTrack} />
-                      </div>
-                      <canvas
-                        ref={micMeterRef}
-                        className="mic-meter-canvas"
-                        aria-label="Microphone send level (what others hear)"
-                      />
-                      {!micTrack && <span className="sidebar-hint">Mic not active — check mode and permissions.</span>}
-                    </div>
-                  )}
-                </section>
-              </div>
-            )}
-
-            {activeSidebarTab === "media" && (
-              <div className="sidebar-page" role="tabpanel">
-                <section className="sidebar-section">
-                  <div className="sidebar-section-header">
-                    <span>Gallery</span>
-                    <span className="sidebar-section-sub">Screenshot key: {shortcuts.screenshot}</span>
-                  </div>
-                  <div className="sidebar-row sidebar-row--aligned">
-                    <span className="sidebar-label">Screenshots</span>
-                    <button
-                      type="button"
-                      className="sidebar-button sidebar-screenshot-button"
-                      onClick={() => {
-                        void captureScreenshot();
-                      }}
-                      disabled={isSavingScreenshot || !screenshotApiAvailable}
-                    >
-                      <Camera size={14} />
-                      <span>{isSavingScreenshot ? "Capturing..." : "Capture"}</span>
-                    </button>
-                  </div>
-                  <div className="sidebar-gallery-row">
-                    <button
-                      type="button"
-                      className="sidebar-gallery-arrow"
-                      onClick={() => scrollGallery("left")}
-                      aria-label="Scroll gallery left"
-                    >
-                      <ChevronLeft size={16} />
-                    </button>
-                    <div className="sidebar-gallery-strip" ref={galleryStripRef}>
-                      {screenshots.map((shot) => (
-                        <button
-                          key={shot.id}
-                          type="button"
-                          className="sidebar-gallery-item"
-                          onClick={() => setSelectedScreenshotId(shot.id)}
-                          title={new Date(shot.createdAtMs).toLocaleString()}
-                        >
-                          <img src={shot.dataUrl} alt={`Screenshot ${shot.fileName}`} />
-                        </button>
-                      ))}
-                    </div>
-                    <button
-                      type="button"
-                      className="sidebar-gallery-arrow"
-                      onClick={() => scrollGallery("right")}
-                      aria-label="Scroll gallery right"
-                    >
-                      <ChevronRight size={16} />
-                    </button>
-                  </div>
-                  {screenshots.length === 0 && (
-                    <span className="sidebar-hint">No screenshots yet. Press {shortcuts.screenshot} to capture one.</span>
-                  )}
-                  {galleryError && <span className="sidebar-hint sidebar-hint--error">{galleryError}</span>}
-                </section>
-                <div className="sidebar-separator" aria-hidden="true" />
-                <section className="sidebar-section">
-                  <div className="sidebar-section-header">
-                    <span>Recordings</span>
-                    <span className="sidebar-section-sub">Record key: {shortcuts.recording}</span>
-                  </div>
-                  {usedMimeType && (
-                    <span className="sidebar-hint sidebar-hint--codec">Codec: {usedMimeType}</span>
-                  )}
-                  <span className="sidebar-hint sidebar-hint--codec">
-                    Recording bitrate: {recordingBitrateMbps === null ? "Auto" : `${recordingBitrateMbps} Mbps`}
-                  </span>
-                  <div className="sidebar-row sidebar-row--aligned">
-                    <span className="sidebar-label">
-                      {isRecording ? `Recording ${formatElapsed(Math.round(recordingDurationMs / 1000))}` : "Record"}
-                    </span>
-                    <button
-                      type="button"
-                      className="sidebar-button sidebar-screenshot-button"
-                      onClick={() => { void toggleRecording(); }}
-                      disabled={!recordingApiAvailable}
-                    >
-                      {isRecording ? <Square size={14} /> : <Circle size={14} />}
-                      <span>{isRecording ? "Stop" : "Start"}</span>
-                    </button>
-                  </div>
-                  {recordingError && (
-                    <span className="sidebar-hint sidebar-hint--error">{recordingError}</span>
-                  )}
-                  {recordings.length === 0 ? (
-                    <span className="sidebar-hint">No recordings yet. Press {shortcuts.recording} to record.</span>
-                  ) : (
-                    <div className="sidebar-gallery-row">
-                      <button
-                        type="button"
-                        className="sidebar-gallery-arrow"
-                        onClick={() => scrollRecCarousel("left")}
-                        aria-label="Scroll recordings left"
-                      >
-                        <ChevronLeft size={16} />
-                      </button>
-                      <div className="sidebar-rec-strip" ref={recCarouselRef}>
-                        {recordings.map((rec) => (
-                          <div key={rec.id} className="sidebar-rec-card">
-                            {rec.thumbnailDataUrl ? (
-                              <img
-                                className="sidebar-rec-card-thumb"
-                                src={rec.thumbnailDataUrl}
-                                alt=""
-                              />
-                            ) : (
-                              <div className="sidebar-rec-card-thumb sidebar-rec-card-thumb--placeholder">
-                                <Video size={20} />
-                              </div>
-                            )}
-                            <div className="sidebar-rec-card-meta">
-                              <span className="sidebar-rec-card-title">{rec.gameTitle ?? "Untitled"}</span>
-                              <span className="sidebar-rec-card-detail">
-                                {formatElapsed(Math.round(rec.durationMs / 1000))} · {formatFileSize(rec.sizeBytes)}
-                              </span>
-                            </div>
-                            <div className="sidebar-rec-card-actions">
-                              <button
-                                type="button"
-                                className="sidebar-rec-card-action"
-                                aria-label="Show in folder"
-                                title="Show in folder"
-                                onClick={() => { void window.openNow.showRecordingInFolder(rec.id); }}
-                                disabled={typeof window.openNow?.showRecordingInFolder !== "function"}
-                              >
-                                <FolderOpen size={11} />
-                              </button>
-                              <button
-                                type="button"
-                                className="sidebar-rec-card-action sidebar-rec-card-action--danger"
-                                aria-label="Delete recording"
-                                title="Delete"
-                                onClick={() => { void handleDeleteRecording(rec.id); }}
-                              >
-                                <Trash2 size={11} />
-                              </button>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                      <button
-                        type="button"
-                        className="sidebar-gallery-arrow"
-                        onClick={() => scrollRecCarousel("right")}
-                        aria-label="Scroll recordings right"
-                      >
-                        <ChevronRight size={16} />
-                      </button>
-                    </div>
-                  )}
-                </section>
-              </div>
-            )}
-
-            {activeSidebarTab === "shortcuts" && (
-              <div className="sidebar-page" role="tabpanel">
-                <section className="sidebar-section">
-                  <div className="sidebar-section-header">
-                    <span>Shortcut Bindings</span>
-                    <span className="sidebar-section-sub">Edit screenshot keybind here</span>
-                  </div>
-                  <div className="sidebar-row sidebar-row--column">
-                    <div className="sidebar-row-top">
-                      <span className="sidebar-label">Screenshot Shortcut</span>
-                    </div>
-                    <input
-                      type="text"
-                      name="screenshot-shortcut"
-                      aria-label="Screenshot shortcut"
-                      className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${screenshotShortcutError ? "error" : ""}`}
-                      value={screenshotShortcutInput}
-                      readOnly
-                      onFocus={(event) => event.target.select()}
-                      onPaste={handleStreamScreenshotShortcutPaste}
-                      onBlur={() => {
-                        const error = getScreenshotShortcutError(screenshotShortcutInput);
-                        if (error) {
-                          setScreenshotShortcutError(error);
-                          return;
-                        }
-                        const normalized = normalizeShortcut(screenshotShortcutInput.trim());
-                        if (!normalized.valid) {
-                          setScreenshotShortcutError("Invalid shortcut format.");
-                          return;
-                        }
-                        setScreenshotShortcutError(null);
-                        setScreenshotShortcutInput(normalized.canonical);
-                        if (normalized.canonical !== shortcuts.screenshot) {
-                          onScreenshotShortcutChange(normalized.canonical);
-                        }
-                      }}
-                      onKeyDown={handleStreamScreenshotShortcutKeyDown}
-                      placeholder="Click, then press a key"
-                      title="Focus and press the key combination to bind"
-                      spellCheck={false}
-                    />
-                  </div>
-                  {screenshotShortcutError && <span className="sidebar-hint sidebar-hint--error">{screenshotShortcutError}</span>}
-                  <div className="sidebar-row sidebar-row--column">
-                    <div className="sidebar-row-top">
-                      <span className="sidebar-label">Recording Shortcut</span>
-                    </div>
-                    <input
-                      type="text"
-                      name="recording-shortcut"
-                      aria-label="Recording shortcut"
-                      className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${recordingShortcutError ? "error" : ""}`}
-                      value={recordingShortcutInput}
-                      readOnly
-                      onFocus={(event) => event.target.select()}
-                      onPaste={handleStreamRecordingShortcutPaste}
-                      onBlur={() => {
-                        const error = getRecordingShortcutError(recordingShortcutInput);
-                        if (error) {
-                          setRecordingShortcutError(error);
-                          return;
-                        }
-                        const normalized = normalizeShortcut(recordingShortcutInput.trim());
-                        if (!normalized.valid) {
-                          setRecordingShortcutError("Invalid shortcut format.");
-                          return;
-                        }
-                        setRecordingShortcutError(null);
-                        setRecordingShortcutInput(normalized.canonical);
-                        if (normalized.canonical !== shortcuts.recording) {
-                          onRecordingShortcutChange(normalized.canonical);
-                        }
-                      }}
-                      onKeyDown={handleStreamRecordingShortcutKeyDown}
-                      placeholder="Click, then press a key"
-                      title="Focus and press the key combination to bind"
-                      spellCheck={false}
-                    />
-                  </div>
-                  {recordingShortcutError && <span className="sidebar-hint sidebar-hint--error">{recordingShortcutError}</span>}
-                  <div className="sidebar-row sidebar-row--aligned">
-                    <span className="sidebar-label">Toggle Stats</span>
-                    <span className="settings-value-badge">{shortcuts.toggleStats}</span>
-                  </div>
-                  <div className="sidebar-row sidebar-row--aligned">
-                    <span className="sidebar-label">Mouse Lock</span>
-                    <span className="settings-value-badge">{shortcuts.togglePointerLock}</span>
-                  </div>
-                  <div className="sidebar-row sidebar-row--aligned">
-                    <span className="sidebar-label">Stop Stream</span>
-                    <span className="settings-value-badge">{shortcuts.stopStream}</span>
-                  </div>
-                  {shortcuts.toggleMicrophone && (
-                    <div className="sidebar-row sidebar-row--aligned">
-                      <span className="sidebar-label">Toggle Microphone</span>
-                      <span className="settings-value-badge">{shortcuts.toggleMicrophone}</span>
-                    </div>
-                  )}
-                  <div className="sidebar-row sidebar-row--aligned">
-                    <span className="sidebar-label">Toggle Sidebar</span>
-                    <span className="sidebar-shortcut-stack">
-                      <span className="settings-value-badge">{sidebarToggleShortcutDisplay}</span>
-                      <span className="settings-value-badge">{CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY}</span>
-                    </span>
-                  </div>
-                </section>
-              </div>
-            )}
-          </SideBar>
-        )}
-      </AnimatePresence>
-
-      {selectedScreenshot && (
-        <div className="sv-shot-modal" role="dialog" aria-modal="true" aria-label="Screenshot preview">
-          <button
-            type="button"
-            className="sv-shot-modal-backdrop"
-            onClick={() => setSelectedScreenshotId(null)}
-            aria-label="Close screenshot preview"
-          />
-          <div className="sv-shot-modal-card">
-            <div className="sv-shot-modal-head">
-              <h4>Screenshot</h4>
-              <button
-                type="button"
-                className="sv-shot-modal-close"
-                onClick={() => setSelectedScreenshotId(null)}
-                aria-label="Close screenshot preview"
-              >
-                <X size={16} />
-              </button>
-            </div>
-            <img
-              className="sv-shot-modal-image"
-              src={selectedScreenshot.dataUrl}
-              alt={`Screenshot ${selectedScreenshot.fileName}`}
-            />
-            <div className="sv-shot-modal-actions">
-              <button
-                type="button"
-                className="sv-shot-modal-btn"
-                onClick={() => {
-                  void handleSaveScreenshotAs();
-                }}
-              >
-                <Save size={14} />
-                <span>Save</span>
-              </button>
-              <button
-                type="button"
-                className="sv-shot-modal-btn sv-shot-modal-btn--danger"
-                onClick={() => {
-                  void handleDeleteScreenshot();
-                }}
-              >
-                <Trash2 size={14} />
-                <span>Delete</span>
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <StreamQuickMenu
+        open={showSideBar}
+        onClose={() => setShowSideBar(false)}
+        sidebarRef={sidebarRef}
+        activeTab={activeSidebarTab}
+        setActiveTab={setActiveSidebarTab}
+        onEndSession={handleSidebarExitSession}
+        gameTitle={gameTitle}
+        platformName={platformName}
+        PlatformIcon={PlatformIcon}
+        subscriptionInfo={subscriptionInfo}
+        sessionStartedAtMs={sessionStartedAtMs}
+        isStreaming={isStreaming}
+        sessionTimeRemainingText={sessionTimeRemainingText}
+        isFullscreen={isFullscreen}
+        isPointerLocked={isPointerLocked}
+        onToggleFullscreen={handleFullscreenToggle}
+        onTogglePointerLock={handlePointerLockToggle}
+        onToggleMicrophone={onToggleMicrophone}
+        showSessionTimeRemainingInStatsOverlay={showSessionTimeRemainingInStatsOverlay}
+        onShowSessionTimeRemainingInStatsOverlayChange={onShowSessionTimeRemainingInStatsOverlayChange}
+        sidebarToggleShortcutDisplay={sidebarToggleShortcutDisplay}
+        controllerSidebarShortcutDisplay={CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY}
+        mouseSensitivity={mouseSensitivity}
+        onMouseSensitivityChange={onMouseSensitivityChange}
+        mouseAcceleration={mouseAcceleration}
+        onMouseAccelerationChange={onMouseAccelerationChange}
+        gstreamerEnabled={gstreamerEnabled}
+        videoShader={videoShader}
+        onVideoShaderChange={onVideoShaderChange}
+        microphoneMode={microphoneMode}
+        onMicrophoneModeChange={onMicrophoneModeChange}
+        diagnosticsStore={diagnosticsStore}
+        micTrack={micTrack ?? null}
+        shortcuts={shortcuts}
+        isMacClient={isMacClient}
+        onScreenshotShortcutChange={onScreenshotShortcutChange}
+        onRecordingShortcutChange={onRecordingShortcutChange}
+        screenshotGallery={screenshotGallery}
+        streamRecorder={streamRecorder}
+        recordingBitrateMbps={recordingBitrateMbps}
+      />
 
       {/* Gradient background when no video */}
       <StreamEmptyState diagnosticsStore={diagnosticsStore} />
@@ -2230,9 +810,9 @@ export function StreamView({
         showAntiAfkIndicator={antiAfkEnabled && showAntiAfkIndicator}
         hideStreamButtons={hideStreamButtons}
         isConnecting={isConnecting}
-        isRecording={isRecording}
+        isRecording={streamRecorder.isRecording}
         onToggleMicrophone={onToggleMicrophone}
-        recordingDurationMs={recordingDurationMs}
+        recordingDurationMs={streamRecorder.recordingDurationMs}
       />
 
       {exitPrompt.open && !isConnecting && typeof document !== "undefined" && createPortal(

--- a/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenu.tsx
+++ b/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenu.tsx
@@ -1,0 +1,330 @@
+import { useRef } from "react";
+import type { Dispatch, JSX, RefObject, SetStateAction } from "react";
+import { AnimatePresence, m } from "motion/react";
+import { Gauge, Images, Keyboard, LogOut, Save, SlidersHorizontal, Trash2, X } from "lucide-react";
+import type { MicrophoneMode, SubscriptionInfo, VideoShaderSettings } from "@shared/gfn";
+import SideBar from "../../SideBar";
+import type { StreamDiagnosticsStore } from "../../../utils/streamDiagnosticsStore";
+import { useMicMeter } from "../../../hooks/useMicMeter";
+import type { useScreenshotGallery } from "../../../hooks/useScreenshotGallery";
+import type { useStreamRecorder } from "../../../hooks/useStreamRecorder";
+import type { StreamMenuTab } from "../../../hooks/useStreamMenuNavigation";
+import { StreamQuickMenuControlsPage } from "./StreamQuickMenuControlsPage";
+import { StreamQuickMenuMediaPage } from "./StreamQuickMenuMediaPage";
+import { StreamQuickMenuSessionPage } from "./StreamQuickMenuSessionPage";
+import {
+  StreamQuickMenuShortcutsPage,
+  type StreamShortcutBindings,
+  useStreamQuickMenuShortcuts,
+} from "./StreamQuickMenuShortcutsPage";
+
+interface StreamQuickMenuProps {
+  open: boolean;
+  onClose: () => void;
+  sidebarRef: RefObject<HTMLElement | null>;
+  activeTab: StreamMenuTab;
+  setActiveTab: Dispatch<SetStateAction<StreamMenuTab>>;
+  onEndSession: () => void;
+  gameTitle: string;
+  platformName: string;
+  PlatformIcon: (() => JSX.Element) | null;
+  subscriptionInfo: SubscriptionInfo | null;
+  sessionStartedAtMs: number | null;
+  isStreaming: boolean;
+  sessionTimeRemainingText: string | null;
+  isFullscreen: boolean;
+  isPointerLocked: boolean;
+  onToggleFullscreen: () => void;
+  onTogglePointerLock: () => void;
+  onToggleMicrophone?: () => void;
+  showSessionTimeRemainingInStatsOverlay: boolean;
+  onShowSessionTimeRemainingInStatsOverlayChange: (value: boolean) => void;
+  sidebarToggleShortcutDisplay: string;
+  controllerSidebarShortcutDisplay: string;
+  mouseSensitivity: number;
+  onMouseSensitivityChange: (value: number) => void;
+  mouseAcceleration: number;
+  onMouseAccelerationChange: (value: number) => void;
+  gstreamerEnabled: boolean;
+  videoShader: VideoShaderSettings;
+  onVideoShaderChange: (value: VideoShaderSettings) => void;
+  microphoneMode: MicrophoneMode;
+  onMicrophoneModeChange: (value: MicrophoneMode) => void;
+  diagnosticsStore: StreamDiagnosticsStore;
+  micTrack: MediaStreamTrack | null;
+  shortcuts: StreamShortcutBindings;
+  isMacClient: boolean;
+  onScreenshotShortcutChange: (value: string) => void;
+  onRecordingShortcutChange: (value: string) => void;
+  screenshotGallery: ReturnType<typeof useScreenshotGallery>;
+  streamRecorder: ReturnType<typeof useStreamRecorder>;
+  recordingBitrateMbps: number | null;
+}
+
+export function StreamQuickMenu({
+  open,
+  onClose,
+  sidebarRef,
+  activeTab,
+  setActiveTab,
+  onEndSession,
+  gameTitle,
+  platformName,
+  PlatformIcon,
+  subscriptionInfo,
+  sessionStartedAtMs,
+  isStreaming,
+  sessionTimeRemainingText,
+  isFullscreen,
+  isPointerLocked,
+  onToggleFullscreen,
+  onTogglePointerLock,
+  onToggleMicrophone,
+  showSessionTimeRemainingInStatsOverlay,
+  onShowSessionTimeRemainingInStatsOverlayChange,
+  sidebarToggleShortcutDisplay,
+  controllerSidebarShortcutDisplay,
+  mouseSensitivity,
+  onMouseSensitivityChange,
+  mouseAcceleration,
+  onMouseAccelerationChange,
+  gstreamerEnabled,
+  videoShader,
+  onVideoShaderChange,
+  microphoneMode,
+  onMicrophoneModeChange,
+  diagnosticsStore,
+  micTrack,
+  shortcuts,
+  isMacClient,
+  onScreenshotShortcutChange,
+  onRecordingShortcutChange,
+  screenshotGallery,
+  streamRecorder,
+  recordingBitrateMbps,
+}: StreamQuickMenuProps): JSX.Element {
+  const micMeterRef = useRef<HTMLCanvasElement | null>(null);
+  useMicMeter(micMeterRef, micTrack, open && microphoneMode !== "disabled");
+  const shortcutEditor = useStreamQuickMenuShortcuts({
+    shortcuts,
+    isMacClient,
+    onScreenshotShortcutChange,
+    onRecordingShortcutChange,
+  });
+
+  return (
+    <>
+      <AnimatePresence>
+        {open && (
+          <m.div
+            key="quick-menu-backdrop"
+            className="sv-sidebar-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={onClose}
+          />
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {open && (
+          <SideBar
+            key="quick-menu-sidebar"
+            title="Quick menu"
+            className="sv-sidebar"
+            elementRef={sidebarRef}
+            onClose={onClose}
+            footer={(
+              <>
+                <div className="sidebar-controller-hints" aria-hidden="true">
+                  <span><kbd>A</kbd> Select</span>
+                  <span><kbd>B</kbd> Back</span>
+                  <span><kbd>LB</kbd><kbd>RB</kbd> Pages</span>
+                </div>
+                <button
+                  type="button"
+                  className="sidebar-exit-session-button"
+                  onClick={onEndSession}
+                >
+                  <LogOut size={16} />
+                  <span>End session</span>
+                </button>
+              </>
+            )}
+          >
+            <div className="sidebar-tabs" role="tablist" aria-label="Quick menu pages">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === "session"}
+                className={`sidebar-tab${activeTab === "session" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveTab("session")}
+              >
+                <Gauge size={16} />
+                <span>Session</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === "controls"}
+                className={`sidebar-tab${activeTab === "controls" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveTab("controls")}
+              >
+                <SlidersHorizontal size={16} />
+                <span>Controls</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === "media"}
+                className={`sidebar-tab${activeTab === "media" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveTab("media")}
+              >
+                <Images size={16} />
+                <span>Media</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === "shortcuts"}
+                className={`sidebar-tab${activeTab === "shortcuts" ? " sidebar-tab--active" : ""}`}
+                onClick={() => setActiveTab("shortcuts")}
+              >
+                <Keyboard size={16} />
+                <span>Keys</span>
+              </button>
+            </div>
+
+            {activeTab === "session" && (
+              <StreamQuickMenuSessionPage
+                gameTitle={gameTitle}
+                platformName={platformName}
+                PlatformIcon={PlatformIcon}
+                subscriptionInfo={subscriptionInfo}
+                sessionStartedAtMs={sessionStartedAtMs}
+                isStreaming={isStreaming}
+                sessionTimeRemainingText={sessionTimeRemainingText}
+                isFullscreen={isFullscreen}
+                isPointerLocked={isPointerLocked}
+                onToggleFullscreen={onToggleFullscreen}
+                onTogglePointerLock={onTogglePointerLock}
+                onToggleMicrophone={onToggleMicrophone}
+                onCaptureScreenshot={() => { void screenshotGallery.captureScreenshot(); }}
+                isSavingScreenshot={screenshotGallery.isSavingScreenshot}
+                screenshotApiAvailable={screenshotGallery.screenshotApiAvailable}
+                showSessionTimeRemainingInStatsOverlay={showSessionTimeRemainingInStatsOverlay}
+                onShowSessionTimeRemainingInStatsOverlayChange={onShowSessionTimeRemainingInStatsOverlayChange}
+                sidebarToggleShortcutDisplay={sidebarToggleShortcutDisplay}
+                controllerSidebarShortcutDisplay={controllerSidebarShortcutDisplay}
+              />
+            )}
+
+            {activeTab === "controls" && (
+              <StreamQuickMenuControlsPage
+                mouseSensitivity={mouseSensitivity}
+                onMouseSensitivityChange={onMouseSensitivityChange}
+                mouseAcceleration={mouseAcceleration}
+                onMouseAccelerationChange={onMouseAccelerationChange}
+                gstreamerEnabled={gstreamerEnabled}
+                videoShader={videoShader}
+                onVideoShaderChange={onVideoShaderChange}
+                microphoneMode={microphoneMode}
+                onMicrophoneModeChange={onMicrophoneModeChange}
+                diagnosticsStore={diagnosticsStore}
+                micTrack={micTrack}
+                micMeterRef={micMeterRef}
+              />
+            )}
+
+            {activeTab === "media" && (
+              <StreamQuickMenuMediaPage
+                screenshotShortcut={shortcuts.screenshot}
+                screenshots={screenshotGallery.screenshots}
+                isSavingScreenshot={screenshotGallery.isSavingScreenshot}
+                screenshotApiAvailable={screenshotGallery.screenshotApiAvailable}
+                galleryError={screenshotGallery.galleryError}
+                galleryStripRef={screenshotGallery.galleryStripRef}
+                onCaptureScreenshot={() => { void screenshotGallery.captureScreenshot(); }}
+                onSelectScreenshot={screenshotGallery.setSelectedScreenshotId}
+                onScrollGallery={screenshotGallery.scrollGallery}
+                recordingShortcut={shortcuts.recording}
+                recordings={streamRecorder.recordings}
+                isRecording={streamRecorder.isRecording}
+                recordingDurationMs={streamRecorder.recordingDurationMs}
+                recordingError={streamRecorder.recordingError}
+                recordingApiAvailable={streamRecorder.recordingApiAvailable}
+                usedMimeType={streamRecorder.usedMimeType}
+                recordingBitrateMbps={recordingBitrateMbps}
+                recCarouselRef={streamRecorder.recCarouselRef}
+                onToggleRecording={() => { void streamRecorder.toggleRecording(); }}
+                onDeleteRecording={(id) => { void streamRecorder.deleteRecording(id); }}
+                onScrollRecordings={streamRecorder.scrollRecordings}
+              />
+            )}
+
+            {activeTab === "shortcuts" && (
+              <StreamQuickMenuShortcutsPage
+                shortcuts={shortcuts}
+                isMacClient={isMacClient}
+                sidebarToggleShortcutDisplay={sidebarToggleShortcutDisplay}
+                controllerSidebarShortcutDisplay={controllerSidebarShortcutDisplay}
+                onScreenshotShortcutChange={onScreenshotShortcutChange}
+                onRecordingShortcutChange={onRecordingShortcutChange}
+                editor={shortcutEditor}
+              />
+            )}
+          </SideBar>
+        )}
+      </AnimatePresence>
+
+      {screenshotGallery.selectedScreenshot && (
+        <div className="sv-shot-modal" role="dialog" aria-modal="true" aria-label="Screenshot preview">
+          <button
+            type="button"
+            className="sv-shot-modal-backdrop"
+            onClick={() => screenshotGallery.setSelectedScreenshotId(null)}
+            aria-label="Close screenshot preview"
+          />
+          <div className="sv-shot-modal-card">
+            <div className="sv-shot-modal-head">
+              <h4>Screenshot</h4>
+              <button
+                type="button"
+                className="sv-shot-modal-close"
+                onClick={() => screenshotGallery.setSelectedScreenshotId(null)}
+                aria-label="Close screenshot preview"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <img
+              className="sv-shot-modal-image"
+              src={screenshotGallery.selectedScreenshot.dataUrl}
+              alt={`Screenshot ${screenshotGallery.selectedScreenshot.fileName}`}
+            />
+            <div className="sv-shot-modal-actions">
+              <button
+                type="button"
+                className="sv-shot-modal-btn"
+                onClick={() => { void screenshotGallery.saveSelectedScreenshotAs(); }}
+              >
+                <Save size={14} />
+                <span>Save</span>
+              </button>
+              <button
+                type="button"
+                className="sv-shot-modal-btn sv-shot-modal-btn--danger"
+                onClick={() => { void screenshotGallery.deleteSelectedScreenshot(); }}
+              >
+                <Trash2 size={14} />
+                <span>Delete</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenuControlsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenuControlsPage.tsx
@@ -1,0 +1,220 @@
+import type { JSX, RefObject } from "react";
+import type { MicrophoneMode, VideoShaderSettings } from "@shared/gfn";
+import { DEFAULT_VIDEO_SHADER_SETTINGS } from "@shared/gfn";
+import type { StreamDiagnosticsStore } from "../../../utils/streamDiagnosticsStore";
+import { SidebarMicMutedBadge } from "../StreamEmptyStates";
+
+const MICROPHONE_MODES = [
+  { value: "disabled" as MicrophoneMode, label: "Disabled", description: "No microphone input" },
+  { value: "push-to-talk" as MicrophoneMode, label: "Push-to-Talk", description: "Hold a key to talk" },
+  { value: "voice-activity" as MicrophoneMode, label: "Voice Activity", description: "Always listen" },
+];
+
+const VIDEO_FILTER_CONTROLS = [
+  { key: "sharpen", label: "Sharpen", min: 0, max: 100, neutral: 0, format: (value: number) => `${value}%`, hint: "Contrast-adaptive sharpening. Counters stream compression blur." },
+  { key: "saturation", label: "Saturation", min: 0, max: 200, neutral: 100, format: (value: number) => `${value}%` },
+  { key: "contrast", label: "Contrast", min: 50, max: 150, neutral: 100, format: (value: number) => `${value}%` },
+  { key: "brightness", label: "Brightness", min: 50, max: 150, neutral: 100, format: (value: number) => `${value}%` },
+  { key: "vibrance", label: "Vibrance", min: 0, max: 100, neutral: 0, format: (value: number) => `${value}%`, hint: "Boosts muted colors without oversaturating." },
+  { key: "filmGrain", label: "Film Grain", min: 0, max: 100, neutral: 0, format: (value: number) => `${value}%` },
+] as const;
+
+interface StreamQuickMenuControlsPageProps {
+  mouseSensitivity: number;
+  onMouseSensitivityChange: (value: number) => void;
+  mouseAcceleration: number;
+  onMouseAccelerationChange: (value: number) => void;
+  gstreamerEnabled: boolean;
+  videoShader: VideoShaderSettings;
+  onVideoShaderChange: (value: VideoShaderSettings) => void;
+  microphoneMode: MicrophoneMode;
+  onMicrophoneModeChange: (value: MicrophoneMode) => void;
+  diagnosticsStore: StreamDiagnosticsStore;
+  micTrack: MediaStreamTrack | null;
+  micMeterRef: RefObject<HTMLCanvasElement | null>;
+}
+
+export function StreamQuickMenuControlsPage({
+  mouseSensitivity,
+  onMouseSensitivityChange,
+  mouseAcceleration,
+  onMouseAccelerationChange,
+  gstreamerEnabled,
+  videoShader,
+  onVideoShaderChange,
+  microphoneMode,
+  onMicrophoneModeChange,
+  diagnosticsStore,
+  micTrack,
+  micMeterRef,
+}: StreamQuickMenuControlsPageProps): JSX.Element {
+  return (
+    <div className="sidebar-page" role="tabpanel">
+      <section className="sidebar-section">
+        <div className="sidebar-section-header">
+          <span>Mouse Preferences</span>
+          <span className="sidebar-section-sub">Fine-tune cursor movement.</span>
+        </div>
+        <div className="sidebar-row sidebar-row--column">
+          <div className="sidebar-row-top">
+            <span className="sidebar-label">Mouse Sensitivity</span>
+            <span className="settings-value-badge">{mouseSensitivity.toFixed(2)}x</span>
+          </div>
+          <input
+            type="range"
+            name="mouse-sensitivity"
+            aria-label="Mouse sensitivity"
+            className="settings-slider"
+            min={0.1}
+            max={4}
+            step={0.01}
+            value={mouseSensitivity}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              if (Number.isFinite(next)) {
+                onMouseSensitivityChange(Math.max(0.1, Math.min(4, next)));
+              }
+            }}
+          />
+          <span className="sidebar-hint">Multiplier applied to mouse movement (1.00 = default).</span>
+        </div>
+        <div className="sidebar-row sidebar-row--column">
+          <div className="sidebar-row-top">
+            <span className="sidebar-label">Mouse Accelerator</span>
+            <span className="settings-value-badge">{Math.round(mouseAcceleration)}%</span>
+          </div>
+          <input
+            type="range"
+            name="mouse-acceleration"
+            aria-label="Mouse accelerator"
+            className="settings-slider"
+            min={1}
+            max={150}
+            step={1}
+            value={Math.round(mouseAcceleration)}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              if (Number.isFinite(next)) {
+                onMouseAccelerationChange(Math.max(1, Math.min(150, Math.round(next))));
+              }
+            }}
+          />
+          <span className="sidebar-hint">Dynamic turn boost strength (1% = off-like, 150% = strongest).</span>
+        </div>
+      </section>
+      <div className="sidebar-separator" aria-hidden="true" />
+      <section className="sidebar-section">
+        <div className="sidebar-section-header">
+          <span>Video Filters</span>
+          <span className="sidebar-section-sub">GPU shaders applied to the stream.</span>
+        </div>
+        {gstreamerEnabled ? (
+          <span className="sidebar-hint">Video filters are unavailable while the native streamer renders the video.</span>
+        ) : (
+          <>
+            <div className="sidebar-row sidebar-row--aligned">
+              <span className="sidebar-label">Enable Filters</span>
+              <label className="sidebar-mini-toggle" title="Enable GPU post-processing filters" tabIndex={0}>
+                <input
+                  type="checkbox"
+                  name="enable-video-filters"
+                  checked={videoShader.enabled}
+                  aria-label="Enable video filters"
+                  onChange={(event) => onVideoShaderChange({ ...videoShader, enabled: event.target.checked })}
+                />
+                <span className="sidebar-mini-toggle-track" />
+              </label>
+            </div>
+            {videoShader.enabled && (
+              <>
+                {VIDEO_FILTER_CONTROLS.map((control) => (
+                  <div key={control.key} className="sidebar-row sidebar-row--column">
+                    <div className="sidebar-row-top">
+                      <span className="sidebar-label">{control.label}</span>
+                      <span className="settings-value-badge">{control.format(videoShader[control.key])}</span>
+                    </div>
+                    <input
+                      type="range"
+                      name={`video-filter-${control.key}`}
+                      aria-label={`${control.label} video filter`}
+                      className="settings-slider"
+                      min={control.min}
+                      max={control.max}
+                      step={1}
+                      value={videoShader[control.key]}
+                      onChange={(event) => {
+                        const next = Number(event.target.value);
+                        if (Number.isFinite(next)) {
+                          onVideoShaderChange({
+                            ...videoShader,
+                            [control.key]: Math.max(control.min, Math.min(control.max, Math.round(next))),
+                          });
+                        }
+                      }}
+                      onDoubleClick={() => onVideoShaderChange({ ...videoShader, [control.key]: control.neutral })}
+                    />
+                    {"hint" in control && control.hint && <span className="sidebar-hint">{control.hint}</span>}
+                  </div>
+                ))}
+                <div className="sidebar-row sidebar-row--aligned">
+                  <span className="sidebar-label">Reset Filters</span>
+                  <button
+                    type="button"
+                    className="sidebar-button"
+                    onClick={() => onVideoShaderChange({ ...DEFAULT_VIDEO_SHADER_SETTINGS, enabled: true })}
+                  >
+                    <span>Reset</span>
+                  </button>
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </section>
+      <div className="sidebar-separator" aria-hidden="true" />
+      <section className="sidebar-section">
+        <div className="sidebar-section-header">
+          <span>Audio</span>
+          <span className="sidebar-section-sub">Configure microphone handling.</span>
+        </div>
+        <div className="sidebar-row sidebar-row--column">
+          <div className="sidebar-row-top">
+            <span className="sidebar-label">Microphone Mode</span>
+            <span className="settings-value-badge">
+              {MICROPHONE_MODES.find((option) => option.value === microphoneMode)?.label ?? microphoneMode}
+            </span>
+          </div>
+          <div className="sidebar-chip-row">
+            {MICROPHONE_MODES.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={`sidebar-chip${microphoneMode === option.value ? " sidebar-chip--active" : ""}`}
+                onClick={() => onMicrophoneModeChange(option.value)}
+              >
+                <span>{option.label}</span>
+              </button>
+            ))}
+          </div>
+          <span className="sidebar-hint">
+            {MICROPHONE_MODES.find((option) => option.value === microphoneMode)?.description ?? ""}
+          </span>
+        </div>
+        {microphoneMode !== "disabled" && (
+          <div className="sidebar-row sidebar-row--column">
+            <div className="sidebar-row-top">
+              <span className="sidebar-label">Send level</span>
+              <SidebarMicMutedBadge diagnosticsStore={diagnosticsStore} micTrack={micTrack} />
+            </div>
+            <canvas
+              ref={micMeterRef}
+              className="mic-meter-canvas"
+              aria-label="Microphone send level (what others hear)"
+            />
+            {!micTrack && <span className="sidebar-hint">Mic not active — check mode and permissions.</span>}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenuMediaPage.tsx
+++ b/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenuMediaPage.tsx
@@ -1,0 +1,216 @@
+import type { JSX, RefObject } from "react";
+import {
+  Camera,
+  ChevronLeft,
+  ChevronRight,
+  Circle,
+  FolderOpen,
+  Square,
+  Trash2,
+  Video,
+} from "lucide-react";
+import type { RecordingEntry, ScreenshotEntry } from "@shared/gfn";
+import { formatElapsed } from "../../../utils/timeFormat";
+import { formatFileSize } from "../streamFormatters";
+
+interface StreamQuickMenuMediaPageProps {
+  screenshotShortcut: string;
+  screenshots: ScreenshotEntry[];
+  isSavingScreenshot: boolean;
+  screenshotApiAvailable: boolean;
+  galleryError: string | null;
+  galleryStripRef: RefObject<HTMLDivElement | null>;
+  onCaptureScreenshot: () => void;
+  onSelectScreenshot: (id: string) => void;
+  onScrollGallery: (direction: "left" | "right") => void;
+  recordingShortcut: string;
+  recordings: RecordingEntry[];
+  isRecording: boolean;
+  recordingDurationMs: number;
+  recordingError: string | null;
+  recordingApiAvailable: boolean;
+  usedMimeType: string | null;
+  recordingBitrateMbps: number | null;
+  recCarouselRef: RefObject<HTMLDivElement | null>;
+  onToggleRecording: () => void;
+  onDeleteRecording: (id: string) => void;
+  onScrollRecordings: (direction: "left" | "right") => void;
+}
+
+export function StreamQuickMenuMediaPage({
+  screenshotShortcut,
+  screenshots,
+  isSavingScreenshot,
+  screenshotApiAvailable,
+  galleryError,
+  galleryStripRef,
+  onCaptureScreenshot,
+  onSelectScreenshot,
+  onScrollGallery,
+  recordingShortcut,
+  recordings,
+  isRecording,
+  recordingDurationMs,
+  recordingError,
+  recordingApiAvailable,
+  usedMimeType,
+  recordingBitrateMbps,
+  recCarouselRef,
+  onToggleRecording,
+  onDeleteRecording,
+  onScrollRecordings,
+}: StreamQuickMenuMediaPageProps): JSX.Element {
+  return (
+    <div className="sidebar-page" role="tabpanel">
+      <section className="sidebar-section">
+        <div className="sidebar-section-header">
+          <span>Gallery</span>
+          <span className="sidebar-section-sub">Screenshot key: {screenshotShortcut}</span>
+        </div>
+        <div className="sidebar-row sidebar-row--aligned">
+          <span className="sidebar-label">Screenshots</span>
+          <button
+            type="button"
+            className="sidebar-button sidebar-screenshot-button"
+            onClick={onCaptureScreenshot}
+            disabled={isSavingScreenshot || !screenshotApiAvailable}
+          >
+            <Camera size={14} />
+            <span>{isSavingScreenshot ? "Capturing..." : "Capture"}</span>
+          </button>
+        </div>
+        <div className="sidebar-gallery-row">
+          <button
+            type="button"
+            className="sidebar-gallery-arrow"
+            onClick={() => onScrollGallery("left")}
+            aria-label="Scroll gallery left"
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <div className="sidebar-gallery-strip" ref={galleryStripRef}>
+            {screenshots.map((shot) => (
+              <button
+                key={shot.id}
+                type="button"
+                className="sidebar-gallery-item"
+                onClick={() => onSelectScreenshot(shot.id)}
+                title={new Date(shot.createdAtMs).toLocaleString()}
+              >
+                <img src={shot.dataUrl} alt={`Screenshot ${shot.fileName}`} />
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="sidebar-gallery-arrow"
+            onClick={() => onScrollGallery("right")}
+            aria-label="Scroll gallery right"
+          >
+            <ChevronRight size={16} />
+          </button>
+        </div>
+        {screenshots.length === 0 && (
+          <span className="sidebar-hint">No screenshots yet. Press {screenshotShortcut} to capture one.</span>
+        )}
+        {galleryError && <span className="sidebar-hint sidebar-hint--error">{galleryError}</span>}
+      </section>
+      <div className="sidebar-separator" aria-hidden="true" />
+      <section className="sidebar-section">
+        <div className="sidebar-section-header">
+          <span>Recordings</span>
+          <span className="sidebar-section-sub">Record key: {recordingShortcut}</span>
+        </div>
+        {usedMimeType && (
+          <span className="sidebar-hint sidebar-hint--codec">Codec: {usedMimeType}</span>
+        )}
+        <span className="sidebar-hint sidebar-hint--codec">
+          Recording bitrate: {recordingBitrateMbps === null ? "Auto" : `${recordingBitrateMbps} Mbps`}
+        </span>
+        <div className="sidebar-row sidebar-row--aligned">
+          <span className="sidebar-label">
+            {isRecording ? `Recording ${formatElapsed(Math.round(recordingDurationMs / 1000))}` : "Record"}
+          </span>
+          <button
+            type="button"
+            className="sidebar-button sidebar-screenshot-button"
+            onClick={onToggleRecording}
+            disabled={!recordingApiAvailable}
+          >
+            {isRecording ? <Square size={14} /> : <Circle size={14} />}
+            <span>{isRecording ? "Stop" : "Start"}</span>
+          </button>
+        </div>
+        {recordingError && (
+          <span className="sidebar-hint sidebar-hint--error">{recordingError}</span>
+        )}
+        {recordings.length === 0 ? (
+          <span className="sidebar-hint">No recordings yet. Press {recordingShortcut} to record.</span>
+        ) : (
+          <div className="sidebar-gallery-row">
+            <button
+              type="button"
+              className="sidebar-gallery-arrow"
+              onClick={() => onScrollRecordings("left")}
+              aria-label="Scroll recordings left"
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <div className="sidebar-rec-strip" ref={recCarouselRef}>
+              {recordings.map((recording) => (
+                <div key={recording.id} className="sidebar-rec-card">
+                  {recording.thumbnailDataUrl ? (
+                    <img
+                      className="sidebar-rec-card-thumb"
+                      src={recording.thumbnailDataUrl}
+                      alt=""
+                    />
+                  ) : (
+                    <div className="sidebar-rec-card-thumb sidebar-rec-card-thumb--placeholder">
+                      <Video size={20} />
+                    </div>
+                  )}
+                  <div className="sidebar-rec-card-meta">
+                    <span className="sidebar-rec-card-title">{recording.gameTitle ?? "Untitled"}</span>
+                    <span className="sidebar-rec-card-detail">
+                      {formatElapsed(Math.round(recording.durationMs / 1000))} · {formatFileSize(recording.sizeBytes)}
+                    </span>
+                  </div>
+                  <div className="sidebar-rec-card-actions">
+                    <button
+                      type="button"
+                      className="sidebar-rec-card-action"
+                      aria-label="Show in folder"
+                      title="Show in folder"
+                      onClick={() => { void window.openNow.showRecordingInFolder(recording.id); }}
+                      disabled={typeof window.openNow?.showRecordingInFolder !== "function"}
+                    >
+                      <FolderOpen size={11} />
+                    </button>
+                    <button
+                      type="button"
+                      className="sidebar-rec-card-action sidebar-rec-card-action--danger"
+                      aria-label="Delete recording"
+                      title="Delete"
+                      onClick={() => onDeleteRecording(recording.id)}
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="sidebar-gallery-arrow"
+              onClick={() => onScrollRecordings("right")}
+              aria-label="Scroll recordings right"
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenuSessionPage.tsx
+++ b/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenuSessionPage.tsx
@@ -1,0 +1,147 @@
+import type { JSX } from "react";
+import {
+  Camera,
+  Clock3,
+  Gamepad2,
+  Maximize,
+  Mic,
+  Minimize,
+  MousePointer2,
+} from "lucide-react";
+import type { SubscriptionInfo } from "@shared/gfn";
+import { RemainingPlaytimeIndicator } from "../../ElapsedSessionIndicators";
+import { useTranslation } from "../../../i18n";
+
+interface StreamQuickMenuSessionPageProps {
+  gameTitle: string;
+  platformName: string;
+  PlatformIcon: (() => JSX.Element) | null;
+  subscriptionInfo: SubscriptionInfo | null;
+  sessionStartedAtMs: number | null;
+  isStreaming: boolean;
+  sessionTimeRemainingText: string | null;
+  isFullscreen: boolean;
+  isPointerLocked: boolean;
+  onToggleFullscreen: () => void;
+  onTogglePointerLock: () => void;
+  onToggleMicrophone?: () => void;
+  onCaptureScreenshot: () => void;
+  isSavingScreenshot: boolean;
+  screenshotApiAvailable: boolean;
+  showSessionTimeRemainingInStatsOverlay: boolean;
+  onShowSessionTimeRemainingInStatsOverlayChange: (value: boolean) => void;
+  sidebarToggleShortcutDisplay: string;
+  controllerSidebarShortcutDisplay: string;
+}
+
+export function StreamQuickMenuSessionPage({
+  gameTitle,
+  platformName,
+  PlatformIcon,
+  subscriptionInfo,
+  sessionStartedAtMs,
+  isStreaming,
+  sessionTimeRemainingText,
+  isFullscreen,
+  isPointerLocked,
+  onToggleFullscreen,
+  onTogglePointerLock,
+  onToggleMicrophone,
+  onCaptureScreenshot,
+  isSavingScreenshot,
+  screenshotApiAvailable,
+  showSessionTimeRemainingInStatsOverlay,
+  onShowSessionTimeRemainingInStatsOverlayChange,
+  sidebarToggleShortcutDisplay,
+  controllerSidebarShortcutDisplay,
+}: StreamQuickMenuSessionPageProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="sidebar-page sidebar-page--session" role="tabpanel">
+      <section className="sidebar-session-card" aria-label="Current stream session">
+        <div className="sidebar-session-card-head">
+          <span className="sidebar-session-kicker">Now streaming</span>
+          <strong className="sidebar-session-title">{gameTitle}</strong>
+          {PlatformIcon && platformName && (
+            <span className="sidebar-session-platform" title={platformName}>
+              <span className="sidebar-session-platform-icon"><PlatformIcon /></span>
+              <span>{platformName}</span>
+            </span>
+          )}
+        </div>
+      </section>
+      <section className="sidebar-session-metrics" aria-label="Session time">
+        <div className="sidebar-metric">
+          <span>Total playtime left</span>
+          <RemainingPlaytimeIndicator
+            subscriptionInfo={subscriptionInfo}
+            startedAtMs={sessionStartedAtMs}
+            active={isStreaming}
+            className="sidebar-metric-value"
+          />
+        </div>
+        {sessionTimeRemainingText !== null && (
+          <div className="sidebar-metric">
+            <span>{t("sidebar.sessionTimeRemaining")}</span>
+            <strong className="sidebar-metric-value">
+              <Clock3 size={14} />
+              {sessionTimeRemainingText}
+            </strong>
+          </div>
+        )}
+      </section>
+      <section className="sidebar-section">
+        <div className="sidebar-section-header">
+          <span>Session controls</span>
+          <span className="sidebar-section-sub">Manage the active stream.</span>
+        </div>
+        <div className="sidebar-quick-actions">
+          <button type="button" className="sidebar-action-card" onClick={onToggleFullscreen}>
+            {isFullscreen ? <Minimize size={16} /> : <Maximize size={16} />}
+            <span>{isFullscreen ? "Windowed" : "Fullscreen"}</span>
+          </button>
+          <button type="button" className="sidebar-action-card" onClick={onTogglePointerLock}>
+            <MousePointer2 size={16} />
+            <span>{isPointerLocked ? "Release mouse" : "Capture mouse"}</span>
+          </button>
+          {onToggleMicrophone && (
+            <button type="button" className="sidebar-action-card" onClick={onToggleMicrophone}>
+              <Mic size={16} />
+              <span>Toggle mic</span>
+            </button>
+          )}
+          <button
+            type="button"
+            className="sidebar-action-card"
+            onClick={onCaptureScreenshot}
+            disabled={isSavingScreenshot || !screenshotApiAvailable}
+          >
+            <Camera size={16} />
+            <span>{isSavingScreenshot ? "Capturing" : "Screenshot"}</span>
+          </button>
+        </div>
+      </section>
+      {sessionTimeRemainingText !== null && (
+        <label className="sidebar-setting-card sidebar-mini-toggle" tabIndex={0}>
+          <span>
+            <strong>Show time in stats</strong>
+            <small>Keep session time visible in the performance overlay.</small>
+          </span>
+          <input
+            type="checkbox"
+            name="show-session-time-in-stats"
+            checked={showSessionTimeRemainingInStatsOverlay}
+            aria-label={t("sidebar.showSessionTimeRemainingInStatsOverlay")}
+            onChange={(event) => onShowSessionTimeRemainingInStatsOverlayChange(event.target.checked)}
+          />
+          <span className="sidebar-mini-toggle-track" />
+        </label>
+      )}
+      <div className="sidebar-open-shortcuts">
+        <span><kbd>{sidebarToggleShortcutDisplay}</kbd> Keyboard</span>
+        <span><Gamepad2 size={14} /> {controllerSidebarShortcutDisplay}</span>
+      </div>
+    </div>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenuShortcutsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/stream/quick-menu/StreamQuickMenuShortcutsPage.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ClipboardEvent, JSX, KeyboardEvent } from "react";
+import { normalizeShortcut, shortcutFromKeyboardEvent } from "../../../shortcuts";
+import { getShortcutConflictError } from "../streamRuntimeHelpers";
+
+export interface StreamShortcutBindings {
+  toggleStats: string;
+  togglePointerLock: string;
+  toggleFullscreen: string;
+  stopStream: string;
+  toggleAntiAfk: string;
+  toggleMicrophone?: string;
+  screenshot: string;
+  recording: string;
+}
+
+interface UseStreamQuickMenuShortcutsOptions {
+  shortcuts: StreamShortcutBindings;
+  isMacClient: boolean;
+  onScreenshotShortcutChange: (value: string) => void;
+  onRecordingShortcutChange: (value: string) => void;
+}
+
+export function useStreamQuickMenuShortcuts({
+  shortcuts,
+  isMacClient,
+  onScreenshotShortcutChange,
+  onRecordingShortcutChange,
+}: UseStreamQuickMenuShortcutsOptions) {
+  const [screenshotShortcutInput, setScreenshotShortcutInput] = useState(shortcuts.screenshot);
+  const [screenshotShortcutError, setScreenshotShortcutError] = useState<string | null>(null);
+  const [recordingShortcutInput, setRecordingShortcutInput] = useState(shortcuts.recording);
+  const [recordingShortcutError, setRecordingShortcutError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setScreenshotShortcutInput(shortcuts.screenshot);
+    setScreenshotShortcutError(null);
+  }, [shortcuts.screenshot]);
+
+  useEffect(() => {
+    setRecordingShortcutInput(shortcuts.recording);
+    setRecordingShortcutError(null);
+  }, [shortcuts.recording]);
+
+  const getScreenshotShortcutError = useCallback((rawValue: string): string | null => {
+    return getShortcutConflictError(rawValue, [
+      shortcuts.toggleStats,
+      shortcuts.togglePointerLock,
+      shortcuts.stopStream,
+      shortcuts.toggleAntiAfk,
+      shortcuts.toggleMicrophone,
+      shortcuts.recording,
+      ...(isMacClient ? ["Meta+G"] : ["Ctrl+G", "Ctrl+Shift+G"]),
+    ]);
+  }, [
+    isMacClient,
+    shortcuts.recording,
+    shortcuts.stopStream,
+    shortcuts.toggleAntiAfk,
+    shortcuts.toggleMicrophone,
+    shortcuts.togglePointerLock,
+    shortcuts.toggleStats,
+  ]);
+
+  const getRecordingShortcutError = useCallback((rawValue: string): string | null => {
+    return getShortcutConflictError(rawValue, [
+      shortcuts.toggleStats,
+      shortcuts.togglePointerLock,
+      shortcuts.stopStream,
+      shortcuts.toggleAntiAfk,
+      shortcuts.toggleMicrophone,
+      shortcuts.screenshot,
+      ...(isMacClient ? ["Meta+G"] : ["Ctrl+G", "Ctrl+Shift+G"]),
+    ]);
+  }, [
+    isMacClient,
+    shortcuts.screenshot,
+    shortcuts.stopStream,
+    shortcuts.toggleAntiAfk,
+    shortcuts.toggleMicrophone,
+    shortcuts.togglePointerLock,
+    shortcuts.toggleStats,
+  ]);
+
+  const applyScreenshotShortcutFromCapture = useCallback((canonical: string) => {
+    const error = getScreenshotShortcutError(canonical);
+    if (error) {
+      setScreenshotShortcutError(error);
+      return;
+    }
+    const normalized = normalizeShortcut(canonical.trim());
+    if (!normalized.valid) {
+      setScreenshotShortcutError("Invalid shortcut format.");
+      return;
+    }
+    setScreenshotShortcutError(null);
+    setScreenshotShortcutInput(normalized.canonical);
+    if (normalized.canonical !== shortcuts.screenshot) {
+      onScreenshotShortcutChange(normalized.canonical);
+    }
+  }, [getScreenshotShortcutError, onScreenshotShortcutChange, shortcuts.screenshot]);
+
+  const applyRecordingShortcutFromCapture = useCallback((canonical: string) => {
+    const error = getRecordingShortcutError(canonical);
+    if (error) {
+      setRecordingShortcutError(error);
+      return;
+    }
+    const normalized = normalizeShortcut(canonical.trim());
+    if (!normalized.valid) {
+      setRecordingShortcutError("Invalid shortcut format.");
+      return;
+    }
+    setRecordingShortcutError(null);
+    setRecordingShortcutInput(normalized.canonical);
+    if (normalized.canonical !== shortcuts.recording) {
+      onRecordingShortcutChange(normalized.canonical);
+    }
+  }, [getRecordingShortcutError, onRecordingShortcutChange, shortcuts.recording]);
+
+  const handleScreenshotShortcutKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.currentTarget.blur();
+      return;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      return;
+    }
+    const captured = shortcutFromKeyboardEvent(event.nativeEvent);
+    if (!captured) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    applyScreenshotShortcutFromCapture(captured);
+  };
+
+  const handleRecordingShortcutKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.currentTarget.blur();
+      return;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      return;
+    }
+    const captured = shortcutFromKeyboardEvent(event.nativeEvent);
+    if (!captured) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    applyRecordingShortcutFromCapture(captured);
+  };
+
+  const handleScreenshotShortcutPaste = (event: ClipboardEvent<HTMLInputElement>): void => {
+    const text = event.clipboardData.getData("text/plain").trim();
+    if (!text) {
+      return;
+    }
+    event.preventDefault();
+    applyScreenshotShortcutFromCapture(text);
+  };
+
+  const handleRecordingShortcutPaste = (event: ClipboardEvent<HTMLInputElement>): void => {
+    const text = event.clipboardData.getData("text/plain").trim();
+    if (!text) {
+      return;
+    }
+    event.preventDefault();
+    applyRecordingShortcutFromCapture(text);
+  };
+
+  return {
+    screenshotShortcutInput,
+    setScreenshotShortcutInput,
+    screenshotShortcutError,
+    setScreenshotShortcutError,
+    recordingShortcutInput,
+    setRecordingShortcutInput,
+    recordingShortcutError,
+    setRecordingShortcutError,
+    getScreenshotShortcutError,
+    getRecordingShortcutError,
+    handleScreenshotShortcutKeyDown,
+    handleRecordingShortcutKeyDown,
+    handleScreenshotShortcutPaste,
+    handleRecordingShortcutPaste,
+  };
+}
+
+interface StreamQuickMenuShortcutsPageProps extends UseStreamQuickMenuShortcutsOptions {
+  sidebarToggleShortcutDisplay: string;
+  controllerSidebarShortcutDisplay: string;
+  editor: ReturnType<typeof useStreamQuickMenuShortcuts>;
+}
+
+export function StreamQuickMenuShortcutsPage({
+  shortcuts,
+  sidebarToggleShortcutDisplay,
+  controllerSidebarShortcutDisplay,
+  onScreenshotShortcutChange,
+  onRecordingShortcutChange,
+  editor,
+}: StreamQuickMenuShortcutsPageProps): JSX.Element {
+  const {
+    screenshotShortcutInput,
+    setScreenshotShortcutInput,
+    screenshotShortcutError,
+    setScreenshotShortcutError,
+    recordingShortcutInput,
+    setRecordingShortcutInput,
+    recordingShortcutError,
+    setRecordingShortcutError,
+    getScreenshotShortcutError,
+    getRecordingShortcutError,
+    handleScreenshotShortcutKeyDown,
+    handleRecordingShortcutKeyDown,
+    handleScreenshotShortcutPaste,
+    handleRecordingShortcutPaste,
+  } = editor;
+
+  return (
+    <div className="sidebar-page" role="tabpanel">
+      <section className="sidebar-section">
+        <div className="sidebar-section-header">
+          <span>Shortcut Bindings</span>
+          <span className="sidebar-section-sub">Edit screenshot keybind here</span>
+        </div>
+        <div className="sidebar-row sidebar-row--column">
+          <div className="sidebar-row-top">
+            <span className="sidebar-label">Screenshot Shortcut</span>
+          </div>
+          <input
+            type="text"
+            name="screenshot-shortcut"
+            aria-label="Screenshot shortcut"
+            className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${screenshotShortcutError ? "error" : ""}`}
+            value={screenshotShortcutInput}
+            readOnly
+            onFocus={(event) => event.target.select()}
+            onPaste={handleScreenshotShortcutPaste}
+            onBlur={() => {
+              const error = getScreenshotShortcutError(screenshotShortcutInput);
+              if (error) {
+                setScreenshotShortcutError(error);
+                return;
+              }
+              const normalized = normalizeShortcut(screenshotShortcutInput.trim());
+              if (!normalized.valid) {
+                setScreenshotShortcutError("Invalid shortcut format.");
+                return;
+              }
+              setScreenshotShortcutError(null);
+              setScreenshotShortcutInput(normalized.canonical);
+              if (normalized.canonical !== shortcuts.screenshot) {
+                onScreenshotShortcutChange(normalized.canonical);
+              }
+            }}
+            onKeyDown={handleScreenshotShortcutKeyDown}
+            placeholder="Click, then press a key"
+            title="Focus and press the key combination to bind"
+            spellCheck={false}
+          />
+        </div>
+        {screenshotShortcutError && (
+          <span className="sidebar-hint sidebar-hint--error">{screenshotShortcutError}</span>
+        )}
+        <div className="sidebar-row sidebar-row--column">
+          <div className="sidebar-row-top">
+            <span className="sidebar-label">Recording Shortcut</span>
+          </div>
+          <input
+            type="text"
+            name="recording-shortcut"
+            aria-label="Recording shortcut"
+            className={`settings-text-input settings-shortcut-input sidebar-shortcut-input ${recordingShortcutError ? "error" : ""}`}
+            value={recordingShortcutInput}
+            readOnly
+            onFocus={(event) => event.target.select()}
+            onPaste={handleRecordingShortcutPaste}
+            onBlur={() => {
+              const error = getRecordingShortcutError(recordingShortcutInput);
+              if (error) {
+                setRecordingShortcutError(error);
+                return;
+              }
+              const normalized = normalizeShortcut(recordingShortcutInput.trim());
+              if (!normalized.valid) {
+                setRecordingShortcutError("Invalid shortcut format.");
+                return;
+              }
+              setRecordingShortcutError(null);
+              setRecordingShortcutInput(normalized.canonical);
+              if (normalized.canonical !== shortcuts.recording) {
+                onRecordingShortcutChange(normalized.canonical);
+              }
+            }}
+            onKeyDown={handleRecordingShortcutKeyDown}
+            placeholder="Click, then press a key"
+            title="Focus and press the key combination to bind"
+            spellCheck={false}
+          />
+        </div>
+        {recordingShortcutError && (
+          <span className="sidebar-hint sidebar-hint--error">{recordingShortcutError}</span>
+        )}
+        <div className="sidebar-row sidebar-row--aligned">
+          <span className="sidebar-label">Toggle Stats</span>
+          <span className="settings-value-badge">{shortcuts.toggleStats}</span>
+        </div>
+        <div className="sidebar-row sidebar-row--aligned">
+          <span className="sidebar-label">Mouse Lock</span>
+          <span className="settings-value-badge">{shortcuts.togglePointerLock}</span>
+        </div>
+        <div className="sidebar-row sidebar-row--aligned">
+          <span className="sidebar-label">Stop Stream</span>
+          <span className="settings-value-badge">{shortcuts.stopStream}</span>
+        </div>
+        {shortcuts.toggleMicrophone && (
+          <div className="sidebar-row sidebar-row--aligned">
+            <span className="sidebar-label">Toggle Microphone</span>
+            <span className="settings-value-badge">{shortcuts.toggleMicrophone}</span>
+          </div>
+        )}
+        <div className="sidebar-row sidebar-row--aligned">
+          <span className="sidebar-label">Toggle Sidebar</span>
+          <span className="sidebar-shortcut-stack">
+            <span className="settings-value-badge">{sidebarToggleShortcutDisplay}</span>
+            <span className="settings-value-badge">{controllerSidebarShortcutDisplay}</span>
+          </span>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/stream/streamRuntimeHelpers.test.ts
+++ b/opennow-stable/src/renderer/src/components/stream/streamRuntimeHelpers.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  fitThumbnailSize,
+  getShortcutConflictError,
+  selectRecordingMimeType,
+} from "./streamRuntimeHelpers";
+
+test("shortcut conflict validation preserves empty, invalid, and conflict errors", () => {
+  assert.equal(getShortcutConflictError("", []), "Shortcut cannot be empty.");
+  assert.equal(getShortcutConflictError("Ctrl+UnknownNamedKey", []), "Invalid shortcut format.");
+  assert.equal(
+    getShortcutConflictError("shift+ctrl+s", ["Ctrl+Shift+S"]),
+    "Shortcut conflicts with an existing binding.",
+  );
+  assert.equal(getShortcutConflictError("Ctrl+Shift+S", ["Ctrl+R", undefined]), null);
+});
+
+test("recording MIME selection uses the first supported preference", () => {
+  assert.equal(
+    selectRecordingMimeType((mimeType) => mimeType === "video/webm;codecs=h264"),
+    "video/webm;codecs=h264",
+  );
+  assert.equal(selectRecordingMimeType(() => false), "video/webm");
+});
+
+test("thumbnail sizing preserves aspect ratio within recording bounds", () => {
+  assert.deepEqual(fitThumbnailSize(1920, 1080), { width: 320, height: 180 });
+  assert.deepEqual(fitThumbnailSize(1024, 768), { width: 240, height: 180 });
+  assert.deepEqual(fitThumbnailSize(1080, 1920), { width: 101, height: 180 });
+  assert.deepEqual(fitThumbnailSize(160, 90), { width: 160, height: 90 });
+});

--- a/opennow-stable/src/renderer/src/components/stream/streamRuntimeHelpers.ts
+++ b/opennow-stable/src/renderer/src/components/stream/streamRuntimeHelpers.ts
@@ -1,0 +1,67 @@
+import { normalizeShortcut } from "../../shortcuts";
+
+export const RECORDING_MIME_TYPES = [
+  "video/mp4;codecs=avc1.42E01E,mp4a.40.2",
+  "video/mp4;codecs=avc1",
+  "video/mp4",
+  "video/webm;codecs=h264",
+  "video/webm;codecs=vp8",
+  "video/webm",
+] as const;
+
+export function getShortcutConflictError(
+  rawValue: string,
+  reservedShortcuts: readonly (string | undefined)[],
+): string | null {
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return "Shortcut cannot be empty.";
+  }
+
+  const normalized = normalizeShortcut(trimmed);
+  if (!normalized.valid) {
+    return "Invalid shortcut format.";
+  }
+
+  const reserved = reservedShortcuts
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .map((value) => normalizeShortcut(value))
+    .filter((parsed) => parsed.valid)
+    .map((parsed) => parsed.canonical);
+
+  return reserved.includes(normalized.canonical)
+    ? "Shortcut conflicts with an existing binding."
+    : null;
+}
+
+export function selectRecordingMimeType(
+  isTypeSupported: (mimeType: string) => boolean,
+): string {
+  return RECORDING_MIME_TYPES.find(isTypeSupported) ?? "video/webm";
+}
+
+export interface ThumbnailSize {
+  width: number;
+  height: number;
+}
+
+export function fitThumbnailSize(
+  width: number,
+  height: number,
+  maxWidth = 320,
+  maxHeight = 180,
+): ThumbnailSize {
+  let fittedWidth = width;
+  let fittedHeight = height;
+
+  if (fittedWidth > maxWidth) {
+    fittedHeight = Math.round((maxWidth / fittedWidth) * fittedHeight);
+    fittedWidth = maxWidth;
+  }
+  if (fittedHeight > maxHeight) {
+    fittedWidth = Math.round((maxHeight / fittedHeight) * fittedWidth);
+    fittedHeight = maxHeight;
+  }
+
+  return { width: fittedWidth, height: fittedHeight };
+}

--- a/opennow-stable/src/renderer/src/hooks/useScreenshotGallery.ts
+++ b/opennow-stable/src/renderer/src/hooks/useScreenshotGallery.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
+import type { ScreenshotEntry } from "@shared/gfn";
+
+interface UseScreenshotGalleryOptions {
+  videoRef: RefObject<HTMLVideoElement | null>;
+  gameTitle: string;
+}
+
+export function useScreenshotGallery({
+  videoRef,
+  gameTitle,
+}: UseScreenshotGalleryOptions) {
+  const [screenshots, setScreenshots] = useState<ScreenshotEntry[]>([]);
+  const [isSavingScreenshot, setIsSavingScreenshot] = useState(false);
+  const [galleryError, setGalleryError] = useState<string | null>(null);
+  const [selectedScreenshotId, setSelectedScreenshotId] = useState<string | null>(null);
+  const galleryStripRef = useRef<HTMLDivElement | null>(null);
+  const screenshotApiAvailable =
+    typeof window.openNow?.saveScreenshot === "function" &&
+    typeof window.openNow?.listScreenshots === "function" &&
+    typeof window.openNow?.deleteScreenshot === "function" &&
+    typeof window.openNow?.saveScreenshotAs === "function";
+
+  const selectedScreenshot = useMemo(() => {
+    if (!selectedScreenshotId) return null;
+    return screenshots.find((item) => item.id === selectedScreenshotId) ?? null;
+  }, [screenshots, selectedScreenshotId]);
+
+  const refreshScreenshots = useCallback(async () => {
+    setGalleryError(null);
+    if (!screenshotApiAvailable) {
+      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
+      return;
+    }
+    try {
+      const items = await window.openNow.listScreenshots();
+      setScreenshots(items);
+    } catch (error) {
+      console.error("[StreamView] Failed to load screenshots:", error);
+      setGalleryError("Unable to load screenshot gallery.");
+    }
+  }, [screenshotApiAvailable]);
+
+  const captureScreenshot = useCallback(async () => {
+    setGalleryError(null);
+    if (!screenshotApiAvailable) {
+      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable capture.");
+      return;
+    }
+    if (isSavingScreenshot) {
+      return;
+    }
+
+    const video = videoRef.current;
+    if (!video || video.videoWidth <= 0 || video.videoHeight <= 0) {
+      setGalleryError("Stream is not ready for screenshots yet.");
+      return;
+    }
+
+    setIsSavingScreenshot(true);
+    try {
+      const canvas = document.createElement("canvas");
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const context = canvas.getContext("2d");
+      if (!context) {
+        throw new Error("Could not acquire 2D context");
+      }
+
+      context.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const dataUrl = canvas.toDataURL("image/png");
+      const saved = await window.openNow.saveScreenshot({ dataUrl, gameTitle });
+      setScreenshots((prev) => [saved, ...prev.filter((item) => item.id !== saved.id)].slice(0, 60));
+    } catch (error) {
+      console.error("[StreamView] Failed to capture screenshot:", error);
+      setGalleryError("Screenshot failed. Try again.");
+    } finally {
+      setIsSavingScreenshot(false);
+    }
+  }, [gameTitle, isSavingScreenshot, screenshotApiAvailable, videoRef]);
+
+  const scrollGallery = useCallback((direction: "left" | "right") => {
+    const strip = galleryStripRef.current;
+    if (!strip) return;
+    const delta = Math.max(180, Math.round(strip.clientWidth * 0.7));
+    strip.scrollBy({ left: direction === "left" ? -delta : delta, behavior: "smooth" });
+  }, []);
+
+  const deleteSelectedScreenshot = useCallback(async () => {
+    setGalleryError(null);
+    if (!screenshotApiAvailable) {
+      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
+      return;
+    }
+    if (!selectedScreenshot) return;
+
+    try {
+      await window.openNow.deleteScreenshot({ id: selectedScreenshot.id });
+      setScreenshots((prev) => prev.filter((item) => item.id !== selectedScreenshot.id));
+      setSelectedScreenshotId(null);
+    } catch (error) {
+      console.error("[StreamView] Failed to delete screenshot:", error);
+      setGalleryError("Unable to delete screenshot.");
+    }
+  }, [screenshotApiAvailable, selectedScreenshot]);
+
+  const saveSelectedScreenshotAs = useCallback(async () => {
+    setGalleryError(null);
+    if (!screenshotApiAvailable) {
+      setGalleryError("Screenshot API unavailable. Restart OpenNOW to enable gallery.");
+      return;
+    }
+    if (!selectedScreenshot) return;
+
+    try {
+      await window.openNow.saveScreenshotAs({ id: selectedScreenshot.id });
+    } catch (error) {
+      console.error("[StreamView] Failed to save screenshot as:", error);
+      setGalleryError("Unable to save screenshot.");
+    }
+  }, [screenshotApiAvailable, selectedScreenshot]);
+
+  useEffect(() => {
+    if (!selectedScreenshotId) return;
+    if (!screenshots.some((item) => item.id === selectedScreenshotId)) {
+      setSelectedScreenshotId(null);
+    }
+  }, [screenshots, selectedScreenshotId]);
+
+  return {
+    screenshots,
+    isSavingScreenshot,
+    galleryError,
+    selectedScreenshot,
+    selectedScreenshotId,
+    setSelectedScreenshotId,
+    galleryStripRef,
+    screenshotApiAvailable,
+    refreshScreenshots,
+    captureScreenshot,
+    scrollGallery,
+    deleteSelectedScreenshot,
+    saveSelectedScreenshotAs,
+  };
+}

--- a/opennow-stable/src/renderer/src/hooks/useStreamMenuNavigation.ts
+++ b/opennow-stable/src/renderer/src/hooks/useStreamMenuNavigation.ts
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import { isShortcutMatch, normalizeShortcut } from "../shortcuts";
+import { addStreamShortcutActionListener } from "../streamShortcutActions";
+import { controllerButton, readControllerGamepadButtons } from "../utils/controllerGamepad";
+
+const CONTROLLER_MENU_REPEAT_MS = 180;
+
+export const STREAM_MENU_TABS = ["session", "controls", "media", "shortcuts"] as const;
+export type StreamMenuTab = (typeof STREAM_MENU_TABS)[number];
+
+interface UseStreamMenuNavigationOptions {
+  shortcuts: {
+    screenshot: string;
+    recording: string;
+  };
+  isMacClient: boolean;
+  exitPromptOpen: boolean;
+  selectedScreenshotId: string | null;
+  setSelectedScreenshotId: Dispatch<SetStateAction<string | null>>;
+  captureScreenshot: () => Promise<void>;
+  toggleRecording: () => Promise<void>;
+  onCancelExit: () => void;
+  onConfirmExit: () => void;
+  onBeforeOpen: () => void;
+}
+
+interface StreamMenuNavigation {
+  showSideBar: boolean;
+  setShowSideBar: Dispatch<SetStateAction<boolean>>;
+  activeSidebarTab: StreamMenuTab;
+  setActiveSidebarTab: Dispatch<SetStateAction<StreamMenuTab>>;
+  sidebarRef: RefObject<HTMLElement | null>;
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  return !!element && (
+    element.tagName === "INPUT" ||
+    element.tagName === "TEXTAREA" ||
+    element.isContentEditable
+  );
+}
+
+function readButtons(): number {
+  const pad = navigator.getGamepads?.().find((gamepad): gamepad is Gamepad => Boolean(gamepad));
+  return readControllerGamepadButtons(pad);
+}
+
+export function useStreamMenuNavigation({
+  shortcuts,
+  isMacClient,
+  exitPromptOpen,
+  selectedScreenshotId,
+  setSelectedScreenshotId,
+  captureScreenshot,
+  toggleRecording,
+  onCancelExit,
+  onConfirmExit,
+  onBeforeOpen,
+}: UseStreamMenuNavigationOptions): StreamMenuNavigation {
+  const [showSideBar, setShowSideBar] = useState(false);
+  const [activeSidebarTab, setActiveSidebarTab] = useState<StreamMenuTab>("session");
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  const sidebarGamepadFrameRef = useRef<number | null>(null);
+  const sidebarGamepadPreviousButtonsRef = useRef(0);
+  const sidebarGamepadLastMoveAtRef = useRef(0);
+  const exitPromptGamepadFrameRef = useRef<number | null>(null);
+  const exitPromptGamepadPreviousButtonsRef = useRef(0);
+
+  const handleToggleSideBar = useCallback(() => {
+    setShowSideBar((open) => {
+      if (!open) {
+        onBeforeOpen();
+      }
+      return !open;
+    });
+  }, [onBeforeOpen]);
+
+  const selectAdjacentSidebarTab = useCallback((direction: -1 | 1) => {
+    setActiveSidebarTab((current) => {
+      const index = STREAM_MENU_TABS.indexOf(current);
+      return STREAM_MENU_TABS[(index + direction + STREAM_MENU_TABS.length) % STREAM_MENU_TABS.length];
+    });
+    window.requestAnimationFrame(() => {
+      sidebarRef.current?.querySelector<HTMLElement>(".sidebar-tab--active")?.focus({ preventScroll: true });
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!showSideBar || exitPromptOpen) return;
+
+    const getMenuItems = (): HTMLElement[] => {
+      const scope = selectedScreenshotId
+        ? document.querySelector<HTMLElement>(".sv-shot-modal-card")
+        : sidebarRef.current;
+      if (!scope) return [];
+      return Array.from(scope.querySelectorAll<HTMLElement>(
+        "button:not(:disabled), input:not(:disabled):not([type='checkbox']), label.sidebar-mini-toggle, [tabindex='0']",
+      )).filter((element) => {
+        const style = window.getComputedStyle(element);
+        const isInactiveTab =
+          element.getAttribute("role") === "tab" &&
+          element.getAttribute("aria-selected") !== "true";
+        return !isInactiveTab && style.display !== "none" && style.visibility !== "hidden";
+      });
+    };
+
+    const focusItem = (direction: -1 | 1): void => {
+      const items = getMenuItems();
+      if (items.length === 0) return;
+      const currentIndex = items.findIndex((item) => item === document.activeElement);
+      const nextIndex = currentIndex < 0
+        ? 0
+        : (currentIndex + direction + items.length) % items.length;
+      items[nextIndex]?.focus({ preventScroll: true });
+      items[nextIndex]?.scrollIntoView({ block: "nearest" });
+    };
+
+    const changeRange = (input: HTMLInputElement, direction: -1 | 1): void => {
+      const min = Number(input.min || 0);
+      const max = Number(input.max || 100);
+      const step = Number(input.step || 1);
+      const value = Math.max(min, Math.min(max, Number(input.value) + step * direction));
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(input, String(value));
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    };
+
+    const handleGamepadFrame = (): void => {
+      const buttons = readButtons();
+      let pressed = buttons & ~sidebarGamepadPreviousButtonsRef.current;
+      const moveMask = controllerButton.up |
+        controllerButton.down |
+        controllerButton.left |
+        controllerButton.right;
+      const activeMoves = buttons & moveMask;
+      const now = performance.now();
+      if (pressed & moveMask) {
+        sidebarGamepadLastMoveAtRef.current = now;
+      } else if (
+        activeMoves &&
+        now - sidebarGamepadLastMoveAtRef.current > CONTROLLER_MENU_REPEAT_MS
+      ) {
+        pressed |= activeMoves;
+        sidebarGamepadLastMoveAtRef.current = now;
+      }
+
+      const active = document.activeElement as HTMLElement | null;
+      const range = active instanceof HTMLInputElement && active.type === "range" ? active : null;
+      if (pressed & controllerButton.up) focusItem(-1);
+      if (pressed & controllerButton.down) focusItem(1);
+      if (pressed & controllerButton.left) {
+        if (range) changeRange(range, -1);
+        else if (active?.getAttribute("role") === "tab") selectAdjacentSidebarTab(-1);
+        else focusItem(-1);
+      }
+      if (pressed & controllerButton.right) {
+        if (range) changeRange(range, 1);
+        else if (active?.getAttribute("role") === "tab") selectAdjacentSidebarTab(1);
+        else focusItem(1);
+      }
+      if (pressed & controllerButton.leftShoulder) selectAdjacentSidebarTab(-1);
+      if (pressed & controllerButton.rightShoulder) selectAdjacentSidebarTab(1);
+      if (pressed & controllerButton.south) {
+        if (active && !range) active.click();
+      }
+      if (pressed & controllerButton.east) {
+        if (selectedScreenshotId) setSelectedScreenshotId(null);
+        else setShowSideBar(false);
+      }
+      if (pressed & controllerButton.menu) setShowSideBar(false);
+
+      sidebarGamepadPreviousButtonsRef.current = buttons;
+      sidebarGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+    };
+
+    const initialFocusTimer = window.setTimeout(() => {
+      const initialFocus = selectedScreenshotId
+        ? document.querySelector<HTMLElement>(".sv-shot-modal-btn:not(:disabled), .sv-shot-modal-close")
+        : sidebarRef.current?.querySelector<HTMLElement>(".sidebar-tab--active");
+      initialFocus?.focus({ preventScroll: true });
+    }, 0);
+    sidebarGamepadPreviousButtonsRef.current = readButtons();
+    sidebarGamepadLastMoveAtRef.current = performance.now();
+    sidebarGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+
+    return () => {
+      window.clearTimeout(initialFocusTimer);
+      if (sidebarGamepadFrameRef.current !== null) {
+        window.cancelAnimationFrame(sidebarGamepadFrameRef.current);
+        sidebarGamepadFrameRef.current = null;
+      }
+      sidebarGamepadPreviousButtonsRef.current = 0;
+      sidebarGamepadLastMoveAtRef.current = 0;
+    };
+  }, [
+    exitPromptOpen,
+    selectAdjacentSidebarTab,
+    selectedScreenshotId,
+    setSelectedScreenshotId,
+    showSideBar,
+  ]);
+
+  useEffect(() => {
+    if (!exitPromptOpen) return;
+
+    const focusExitButton = (confirm: boolean): void => {
+      document.querySelector<HTMLButtonElement>(
+        confirm ? ".sv-exit-btn-confirm" : ".sv-exit-btn-cancel",
+      )?.focus({ preventScroll: true });
+    };
+    const handleGamepadFrame = (): void => {
+      const buttons = readButtons();
+      const pressed = buttons & ~exitPromptGamepadPreviousButtonsRef.current;
+      if (pressed & (controllerButton.left | controllerButton.up)) focusExitButton(false);
+      if (pressed & (controllerButton.right | controllerButton.down)) focusExitButton(true);
+      if (pressed & controllerButton.south) {
+        const active = document.activeElement as HTMLElement | null;
+        if (active?.closest(".sv-exit-card")) active.click();
+      }
+      if (pressed & (controllerButton.east | controllerButton.menu)) onCancelExit();
+      exitPromptGamepadPreviousButtonsRef.current = buttons;
+      exitPromptGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+    };
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancelExit();
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        onConfirmExit();
+      }
+    };
+
+    const focusTimer = window.setTimeout(() => focusExitButton(false), 0);
+    exitPromptGamepadPreviousButtonsRef.current = readButtons();
+    exitPromptGamepadFrameRef.current = window.requestAnimationFrame(handleGamepadFrame);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.clearTimeout(focusTimer);
+      window.removeEventListener("keydown", handleKeyDown, true);
+      if (exitPromptGamepadFrameRef.current !== null) {
+        window.cancelAnimationFrame(exitPromptGamepadFrameRef.current);
+        exitPromptGamepadFrameRef.current = null;
+      }
+      exitPromptGamepadPreviousButtonsRef.current = 0;
+    };
+  }, [exitPromptOpen, onCancelExit, onConfirmExit]);
+
+  useEffect(() => {
+    return addStreamShortcutActionListener((action) => {
+      if (action === "toggleSidebar") {
+        handleToggleSideBar();
+        return;
+      }
+      if (action === "screenshot") {
+        void captureScreenshot();
+        return;
+      }
+      if (action === "toggleRecording") {
+        void toggleRecording();
+      }
+    });
+  }, [captureScreenshot, handleToggleSideBar, toggleRecording]);
+
+  useEffect(() => {
+    const screenshotShortcut = normalizeShortcut(shortcuts.screenshot);
+    const recordingShortcut = normalizeShortcut(shortcuts.recording);
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      const isSidebarShortcut = isMacClient
+        ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && key === "g"
+        : event.ctrlKey && !event.altKey && !event.metaKey && key === "g";
+      if (isSidebarShortcut) {
+        return;
+      }
+
+      if (isShortcutMatch(event, screenshotShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void captureScreenshot();
+        return;
+      }
+
+      if (isShortcutMatch(event, recordingShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void toggleRecording();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [
+    captureScreenshot,
+    isMacClient,
+    shortcuts.recording,
+    shortcuts.screenshot,
+    toggleRecording,
+  ]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (isMacClient) {
+        if (event.metaKey && !event.ctrlKey && !event.shiftKey && key === "g") {
+          event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation();
+          handleToggleSideBar();
+        }
+      } else if (event.ctrlKey && !event.altKey && !event.metaKey && key === "g") {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        handleToggleSideBar();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [handleToggleSideBar, isMacClient]);
+
+  return {
+    showSideBar,
+    setShowSideBar,
+    activeSidebarTab,
+    setActiveSidebarTab,
+    sidebarRef,
+  };
+}

--- a/opennow-stable/src/renderer/src/hooks/useStreamRecorder.ts
+++ b/opennow-stable/src/renderer/src/hooks/useStreamRecorder.ts
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import type { RecordingEntry } from "@shared/gfn";
+import { fitThumbnailSize, selectRecordingMimeType } from "../components/stream/streamRuntimeHelpers";
+
+interface UseStreamRecorderOptions {
+  videoRef: RefObject<HTMLVideoElement | null>;
+  audioRef: RefObject<HTMLAudioElement | null>;
+  gameTitle: string;
+  micTrack: MediaStreamTrack | null;
+  recordingBitrateMbps: number | null;
+}
+
+export function useStreamRecorder({
+  videoRef,
+  audioRef,
+  gameTitle,
+  micTrack,
+  recordingBitrateMbps,
+}: UseStreamRecorderOptions) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordings, setRecordings] = useState<RecordingEntry[]>([]);
+  const [recordingDurationMs, setRecordingDurationMs] = useState(0);
+  const [recordingError, setRecordingError] = useState<string | null>(null);
+  const [usedMimeType, setUsedMimeType] = useState<string | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const recordingIdRef = useRef<string | null>(null);
+  const recordingStartTimeRef = useRef(0);
+  const recordingTimerRef = useRef<number | undefined>(undefined);
+  const thumbnailDataUrlRef = useRef<string | null>(null);
+  const recCarouselRef = useRef<HTMLDivElement | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const recordingApiAvailable =
+    typeof window.openNow?.beginRecording === "function" &&
+    typeof window.openNow?.sendRecordingChunk === "function" &&
+    typeof window.openNow?.finishRecording === "function" &&
+    typeof window.openNow?.abortRecording === "function" &&
+    typeof window.openNow?.listRecordings === "function" &&
+    typeof window.openNow?.deleteRecording === "function";
+
+  const refreshRecordings = useCallback(async () => {
+    setRecordingError(null);
+    if (!recordingApiAvailable) return;
+    try {
+      const items = await window.openNow.listRecordings();
+      setRecordings(items);
+    } catch (error) {
+      console.error("[StreamView] Failed to load recordings:", error);
+      setRecordingError("Unable to load recordings.");
+    }
+  }, [recordingApiAvailable]);
+
+  const deleteRecording = useCallback(async (id: string) => {
+    setRecordingError(null);
+    if (!recordingApiAvailable) return;
+    try {
+      await window.openNow.deleteRecording({ id });
+      setRecordings((prev) => prev.filter((recording) => recording.id !== id));
+    } catch (error) {
+      console.error("[StreamView] Failed to delete recording:", error);
+      setRecordingError("Unable to delete recording.");
+    }
+  }, [recordingApiAvailable]);
+
+  const scrollRecordings = useCallback((direction: "left" | "right") => {
+    const strip = recCarouselRef.current;
+    if (!strip) return;
+    strip.scrollBy({ left: direction === "left" ? -200 : 200, behavior: "smooth" });
+  }, []);
+
+  const toggleRecording = useCallback(async () => {
+    setRecordingError(null);
+
+    if (isRecording) {
+      mediaRecorderRef.current?.stop();
+      return;
+    }
+
+    if (!recordingApiAvailable) {
+      setRecordingError("Recording API unavailable. Restart OpenNOW to enable recording.");
+      return;
+    }
+
+    const video = videoRef.current;
+    if (!video || !video.srcObject) {
+      setRecordingError("Stream is not ready for recording yet.");
+      return;
+    }
+
+    const stream = video.srcObject as MediaStream;
+    const mimeType = selectRecordingMimeType((candidate) => MediaRecorder.isTypeSupported(candidate));
+    setUsedMimeType(mimeType);
+
+    const audioCtx = new AudioContext();
+    audioCtxRef.current = audioCtx;
+    const audioDest = audioCtx.createMediaStreamDestination();
+
+    const audioElement = audioRef.current;
+    const gameAudioStream = audioElement?.srcObject instanceof MediaStream ? audioElement.srcObject : null;
+    if (gameAudioStream && gameAudioStream.getAudioTracks().length > 0) {
+      audioCtx.createMediaStreamSource(gameAudioStream).connect(audioDest);
+    }
+
+    if (micTrack && micTrack.readyState === "live") {
+      const micStream = new MediaStream([micTrack]);
+      audioCtx.createMediaStreamSource(micStream).connect(audioDest);
+    }
+
+    const composed = new MediaStream([
+      ...stream.getVideoTracks(),
+      ...audioDest.stream.getAudioTracks(),
+    ]);
+
+    let recordingId: string;
+    try {
+      const result = await window.openNow.beginRecording({ mimeType });
+      recordingId = result.recordingId;
+    } catch (error) {
+      console.error("[StreamView] Failed to begin recording:", error);
+      audioCtx.close().catch(() => undefined);
+      audioCtxRef.current = null;
+      setRecordingError("Could not start recording.");
+      return;
+    }
+
+    recordingIdRef.current = recordingId;
+    thumbnailDataUrlRef.current = null;
+    recordingStartTimeRef.current = Date.now();
+    setRecordingDurationMs(0);
+    setIsRecording(true);
+
+    recordingTimerRef.current = window.setInterval(() => {
+      setRecordingDurationMs(Date.now() - recordingStartTimeRef.current);
+    }, 500);
+
+    let isFirstChunk = true;
+    const recorderOptions: MediaRecorderOptions = { mimeType };
+    if (recordingBitrateMbps !== null) {
+      recorderOptions.videoBitsPerSecond =
+        Math.max(1, Math.min(200, Math.round(recordingBitrateMbps))) * 1_000_000;
+    }
+    const recorder = new MediaRecorder(composed, recorderOptions);
+
+    recorder.ondataavailable = (event: BlobEvent) => {
+      if (!event.data || event.data.size === 0) return;
+
+      if (isFirstChunk) {
+        isFirstChunk = false;
+        const currentVideo = videoRef.current;
+        if (currentVideo && currentVideo.videoWidth > 0 && currentVideo.videoHeight > 0) {
+          const { width, height } = fitThumbnailSize(
+            currentVideo.videoWidth,
+            currentVideo.videoHeight,
+          );
+          const canvas = document.createElement("canvas");
+          canvas.width = width;
+          canvas.height = height;
+          const context = canvas.getContext("2d");
+          if (context) {
+            context.drawImage(currentVideo, 0, 0, width, height);
+            thumbnailDataUrlRef.current = canvas.toDataURL("image/jpeg", 0.72);
+          }
+        }
+      }
+
+      void event.data.arrayBuffer().then((buffer) => {
+        const id = recordingIdRef.current;
+        if (!id) return;
+        window.openNow.sendRecordingChunk({ recordingId: id, chunk: buffer }).catch((error: unknown) => {
+          console.error("[StreamView] Failed to send recording chunk:", error);
+        });
+      });
+    };
+
+    recorder.onstop = () => {
+      window.clearInterval(recordingTimerRef.current);
+      recordingTimerRef.current = undefined;
+      audioCtxRef.current?.close().catch(() => undefined);
+      audioCtxRef.current = null;
+      const id = recordingIdRef.current;
+      recordingIdRef.current = null;
+      setIsRecording(false);
+
+      if (!id) return;
+
+      const durationMs = Date.now() - recordingStartTimeRef.current;
+      void window.openNow
+        .finishRecording({
+          recordingId: id,
+          durationMs,
+          gameTitle,
+          thumbnailDataUrl: thumbnailDataUrlRef.current ?? undefined,
+        })
+        .then((entry) => {
+          setRecordings((prev) => [entry, ...prev].slice(0, 20));
+          thumbnailDataUrlRef.current = null;
+        })
+        .catch((error: unknown) => {
+          console.error("[StreamView] Failed to finish recording:", error);
+          setRecordingError("Recording could not be saved.");
+        });
+    };
+
+    recorder.onerror = () => {
+      window.clearInterval(recordingTimerRef.current);
+      recordingTimerRef.current = undefined;
+      audioCtxRef.current?.close().catch(() => undefined);
+      audioCtxRef.current = null;
+      const id = recordingIdRef.current;
+      recordingIdRef.current = null;
+      setIsRecording(false);
+      thumbnailDataUrlRef.current = null;
+      if (id) {
+        window.openNow.abortRecording({ recordingId: id }).catch(() => undefined);
+      }
+      setRecordingError("Recording encountered an error.");
+    };
+
+    mediaRecorderRef.current = recorder;
+    recorder.start(2000);
+  }, [
+    audioRef,
+    gameTitle,
+    isRecording,
+    micTrack,
+    recordingApiAvailable,
+    recordingBitrateMbps,
+    videoRef,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      window.clearInterval(recordingTimerRef.current);
+      const recorder = mediaRecorderRef.current;
+      const id = recordingIdRef.current;
+      if (recorder && recorder.state !== "inactive") {
+        recorder.stop();
+      }
+      if (id) {
+        window.openNow.abortRecording({ recordingId: id }).catch(() => undefined);
+        recordingIdRef.current = null;
+      }
+      audioCtxRef.current?.close().catch(() => undefined);
+      audioCtxRef.current = null;
+    };
+  }, []);
+
+  return {
+    isRecording,
+    recordings,
+    recordingDurationMs,
+    recordingError,
+    usedMimeType,
+    recCarouselRef,
+    recordingApiAvailable,
+    refreshRecordings,
+    deleteRecording,
+    scrollRecordings,
+    toggleRecording,
+  };
+}


### PR DESCRIPTION
Split `StreamView` into focused media hooks and quick-menu components while keeping the video/audio, pointer-lock, native-surface, and shader boundaries in the parent.

- Extract screenshot gallery, recording lifecycle, and controller/keyboard menu navigation hooks.
- Separate the quick menu into session, controls, media, and shortcut pages without changing its class names or behavior.
- Add focused coverage for shortcut conflicts, recorder format selection, and thumbnail sizing.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->