### PR TITLE
refactor(gfn): decompose AuthService responsibilities

### DIFF
--- a/opennow-stable/src/main/platforms/gfn/auth.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth.ts
@@ -1,34 +1,26 @@
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 
 import { shell } from "electron";
 
 import type {
-  AuthLoginRequest,
   AuthDeviceLoginAttemptRequest,
   AuthDeviceLoginChallenge,
   AuthDeviceLoginPollRequest,
   AuthDeviceLoginPollResult,
   AuthDeviceLoginStartRequest,
+  AuthLoginRequest,
   AuthSession,
   AuthSessionResult,
   AuthTokens,
-  AuthUser,
   LoginProvider,
   SavedAccount,
   StreamRegion,
   SubscriptionInfo,
 } from "@shared/gfn";
-import { buildGfnLcarsHeaders, GFN_USER_AGENT } from "./clientHeaders";
-import { fetchSubscription, fetchDynamicRegions } from "./subscription";
-import {
-  CLIENT_TOKEN_REFRESH_WINDOW_MS,
-  DEFAULT_IDP_ID,
-  SERVICE_URLS_ENDPOINT,
-  TOKEN_REFRESH_WINDOW_MS,
-} from "./auth/constants";
-import { isExpired, isNearExpiry } from "./auth/helpers";
+
+import { AccountManager } from "./auth/accountManager";
+import { exchangeDeviceCode, requestDeviceAuthorization } from "./auth/deviceLogin";
+import { SubscriptionVpcEnrichmentCaches } from "./auth/enrichmentCaches";
 import {
   buildAuthUrl,
   exchangeAuthorizationCode,
@@ -36,40 +28,16 @@ import {
   generatePkce,
   waitForAuthorizationCode,
 } from "./auth/oauthFlow";
-import { exchangeDeviceCode, requestDeviceAuthorization } from "./auth/deviceLogin";
+import { PersistedAccountState } from "./auth/persistedAccountState";
 import {
-  mergeTokenSnapshot,
-  refreshAuthTokens,
-  refreshWithClientToken,
-  requestClientToken,
-} from "./auth/tokenRefresh";
+  normalizeProvider,
+  ProviderDiscovery,
+} from "./auth/providerDiscovery";
+import { SessionValidityCoordinator } from "./auth/sessionValidity";
 import { fetchUserInfo } from "./auth/userInfo";
-
-interface PersistedAuthState {
-  sessions: AuthSession[];
-  activeUserId: string | null;
-  selectedProvider: LoginProvider | null;
-}
-
-interface ServiceUrlsResponse {
-  requestStatus?: {
-    statusCode?: number;
-  };
-  gfnServiceInfo?: {
-    gfnServiceEndpoints?: Array<{
-      idpId: string;
-      loginProviderCode: string;
-      loginProviderDisplayName: string;
-      streamingServiceUrl: string;
-      loginProviderPriority?: number;
-    }>;
-  };
-}
+import { buildGfnLcarsHeaders } from "./clientHeaders";
 
 interface ServerInfoResponse {
-  requestStatus?: {
-    serverId?: string;
-  };
   metaData?: Array<{
     key: string;
     value: string;
@@ -82,312 +50,102 @@ interface DeviceLoginAttempt {
   expiresAt: number;
 }
 
-function defaultProvider(): LoginProvider {
-  return {
-    idpId: DEFAULT_IDP_ID,
-    code: "NVIDIA",
-    displayName: "NVIDIA",
-    streamingServiceUrl: "https://prod.cloudmatchbeta.nvidiagrid.net/",
-    priority: 0,
-  };
-}
-
-function normalizeProvider(provider: LoginProvider): LoginProvider {
-  return {
-    ...provider,
-    streamingServiceUrl: provider.streamingServiceUrl.endsWith("/")
-      ? provider.streamingServiceUrl
-      : `${provider.streamingServiceUrl}/`,
-  };
-}
-
 export class AuthService {
-  private providers: LoginProvider[] = [];
-  private sessions = new Map<string, AuthSession>();
-  private activeUserId: string | null = null;
-  private selectedProvider: LoginProvider = defaultProvider();
-  private cachedSubscription: SubscriptionInfo | null = null;
-  private cachedVpcId: string | null = null;
+  private readonly state: PersistedAccountState;
+  private readonly providerDiscovery: ProviderDiscovery;
+  private readonly enrichmentCaches: SubscriptionVpcEnrichmentCaches;
+  private readonly sessionValidity: SessionValidityCoordinator;
+  private readonly accountManager: AccountManager;
   private deviceLoginAttempts = new Map<string, DeviceLoginAttempt>();
   private pendingDeviceLoginSessions = new Map<string, AuthSession>();
 
-  constructor(private readonly statePath: string) {}
+  constructor(statePath: string) {
+    this.state = new PersistedAccountState(statePath);
+    this.providerDiscovery = new ProviderDiscovery();
+    this.enrichmentCaches = new SubscriptionVpcEnrichmentCaches({
+      getSession: () => this.getSession(),
+      getSelectedProvider: () => this.getSelectedProvider(),
+      ensureValidSession: () => this.ensureValidSession(),
+      updateSession: (session) => this.state.accounts.updateSession(session),
+    });
+    this.sessionValidity = new SessionValidityCoordinator({
+      state: this.state,
+      enrichmentCaches: this.enrichmentCaches,
+      logout: () => this.accountManager.logout(),
+    });
+    this.accountManager = new AccountManager(
+      this.state,
+      () => this.enrichmentCaches.clearAll(),
+    );
+  }
 
   async initialize(): Promise<void> {
-    try {
-      await access(this.statePath);
-    } catch {
-      await mkdir(dirname(this.statePath), { recursive: true });
-      await this.persist();
-      return;
+    const restoredSession = await this.state.initialize();
+    if (restoredSession) {
+      this.state.accounts.setSelectedProvider(restoredSession.provider);
+      await this.enrichmentCaches.enrichUserTier();
+      await this.state.persist();
     }
-
-    try {
-      const raw = await readFile(this.statePath, "utf8");
-      const parsed = JSON.parse(raw) as Partial<PersistedAuthState> & {
-        session?: AuthSession | null;
-      };
-      if (parsed.selectedProvider) {
-        this.selectedProvider = normalizeProvider(parsed.selectedProvider);
-      }
-
-      this.sessions.clear();
-      if (Array.isArray(parsed.sessions)) {
-        for (const persistedSession of parsed.sessions) {
-          if (!persistedSession?.user?.userId) {
-            continue;
-          }
-          this.sessions.set(persistedSession.user.userId, {
-            ...persistedSession,
-            provider: normalizeProvider(persistedSession.provider),
-          });
-        }
-      } else if (parsed.session?.user?.userId) {
-        this.sessions.set(parsed.session.user.userId, {
-          ...parsed.session,
-          provider: normalizeProvider(parsed.session.provider),
-        });
-      }
-
-      if (typeof parsed.activeUserId === "string" && this.sessions.has(parsed.activeUserId)) {
-        this.activeUserId = parsed.activeUserId;
-      } else {
-        this.activeUserId = this.sessions.keys().next().value ?? null;
-      }
-
-      const restoredSession = this.getSession();
-      if (restoredSession) {
-        this.selectedProvider = restoredSession.provider;
-        await this.enrichUserTier();
-        await this.persist();
-      }
-    } catch {
-      this.sessions.clear();
-      this.activeUserId = null;
-      this.selectedProvider = defaultProvider();
-      await this.persist();
-    }
-  }
-
-  private async persist(): Promise<void> {
-    const payload: PersistedAuthState = {
-      sessions: Array.from(this.sessions.values()),
-      activeUserId: this.activeUserId,
-      selectedProvider: this.selectedProvider,
-    };
-
-    await mkdir(dirname(this.statePath), { recursive: true });
-    await writeFile(this.statePath, JSON.stringify(payload, null, 2), "utf8");
-  }
-
-  private async ensureClientToken(tokens: AuthTokens, userId: string): Promise<AuthTokens> {
-    const hasUsableClientToken =
-      Boolean(tokens.clientToken) &&
-      !isNearExpiry(tokens.clientTokenExpiresAt, CLIENT_TOKEN_REFRESH_WINDOW_MS);
-    if (hasUsableClientToken) {
-      return tokens;
-    }
-
-    if (isExpired(tokens.expiresAt)) {
-      return tokens;
-    }
-
-    const clientToken = await requestClientToken(tokens.accessToken, tokens.authClientId);
-    return {
-      ...tokens,
-      clientToken: clientToken.token,
-      clientTokenExpiresAt: clientToken.expiresAt,
-      clientTokenLifetimeMs: clientToken.lifetimeMs,
-    };
   }
 
   async getProviders(): Promise<LoginProvider[]> {
-    if (this.providers.length > 0) {
-      return this.providers;
-    }
-
-    let response: Response;
-    try {
-      response = await fetch(SERVICE_URLS_ENDPOINT, {
-        headers: {
-          Accept: "application/json",
-          "User-Agent": GFN_USER_AGENT,
-        },
-      });
-    } catch (error) {
-      console.warn("Failed to fetch providers, using default:", error);
-      this.providers = [defaultProvider()];
-      return this.providers;
-    }
-
-    if (!response.ok) {
-      console.warn(`Providers fetch failed with status ${response.status}, using default`);
-      this.providers = [defaultProvider()];
-      return this.providers;
-    }
-
-    try {
-      const payload = (await response.json()) as ServiceUrlsResponse;
-      const endpoints = payload.gfnServiceInfo?.gfnServiceEndpoints ?? [];
-
-      const providers = endpoints
-        .map<LoginProvider>((entry) => ({
-          idpId: entry.idpId,
-          code: entry.loginProviderCode,
-          displayName:
-            entry.loginProviderCode === "BPC" ? "bro.game" : entry.loginProviderDisplayName,
-          streamingServiceUrl: entry.streamingServiceUrl,
-          priority: entry.loginProviderPriority ?? 0,
-        }))
-        .sort((a, b) => a.priority - b.priority)
-        .map(normalizeProvider);
-
-      this.providers = providers.length > 0 ? providers : [defaultProvider()];
-      console.log(`Loaded ${this.providers.length} providers`);
-      return this.providers;
-    } catch (error) {
-      console.warn("Failed to parse providers response, using default:", error);
-      this.providers = [defaultProvider()];
-      return this.providers;
-    }
+    return this.providerDiscovery.getProviders();
   }
 
   setSession(session: AuthSession | null): void {
-    if (!session) {
-      this.sessions.clear();
-      this.activeUserId = null;
-      this.selectedProvider = defaultProvider();
-      this.clearSubscriptionCache();
-      this.clearVpcCache();
-      void this.persist();
-      return;
-    }
-
-    const normalized: AuthSession = {
-      ...session,
-      provider: normalizeProvider(session.provider),
-    };
-    this.sessions.set(normalized.user.userId, normalized);
-    this.activeUserId = normalized.user.userId;
-    this.selectedProvider = normalized.provider;
-    this.clearSubscriptionCache();
-    this.clearVpcCache();
-    void this.persist();
+    this.accountManager.setSession(session);
   }
 
   getSession(): AuthSession | null {
-    if (!this.activeUserId) {
-      return null;
-    }
-    return this.sessions.get(this.activeUserId) ?? null;
-  }
-
-  private setActiveAccount(userId: string | null): void {
-    this.activeUserId = userId && this.sessions.has(userId) ? userId : null;
-    this.selectedProvider = this.getSession()?.provider ?? defaultProvider();
-    this.clearSubscriptionCache();
-    this.clearVpcCache();
+    return this.state.accounts.getSession();
   }
 
   getSavedAccounts(): SavedAccount[] {
-    return Array.from(this.sessions.values()).map((session) => ({
-      userId: session.user.userId,
-      displayName: session.user.displayName,
-      email: session.user.email,
-      avatarUrl: session.user.avatarUrl,
-      membershipTier: session.user.membershipTier,
-      providerCode: session.provider.code,
-    }));
+    return this.accountManager.getSavedAccounts();
   }
 
   async switchAccount(userId: string): Promise<AuthSession> {
-    const target = this.sessions.get(userId);
-    if (!target) {
-      throw new Error("Saved account not found");
-    }
-
-    const previousActiveUserId = this.activeUserId;
-    const previousSelectedProvider = this.selectedProvider;
-
-    this.activeUserId = userId;
-    this.selectedProvider = target.provider;
-    this.clearSubscriptionCache();
-    this.clearVpcCache();
-
-    const result = await this.ensureValidSessionWithStatus(true, userId);
-    const missingRefreshToken = result.refresh.outcome === "missing_refresh_token";
-    const refreshFailed = result.refresh.outcome === "failed";
-    const switchedUserMismatch = result.session?.user.userId !== userId;
-    if (!result.session || refreshFailed || missingRefreshToken || switchedUserMismatch) {
-      const fallbackMessage = "Failed to switch account due to an invalid or expired session.";
-
-      if (missingRefreshToken) {
-        await this.removeAccount(userId);
-        this.setActiveAccount(previousActiveUserId);
-        await this.persist();
-        throw new Error("Saved login for this account is incomplete. Please log in to this account again.");
-      }
-
-      this.activeUserId = previousActiveUserId;
-      this.selectedProvider = previousActiveUserId && this.sessions.has(previousActiveUserId)
-        ? previousSelectedProvider
-        : this.getSession()?.provider ?? defaultProvider();
-      this.clearSubscriptionCache();
-      this.clearVpcCache();
-      await this.persist();
-
-      if (switchedUserMismatch) {
-        throw new Error("Switched session did not match the selected account.");
-      }
-      throw new Error(result.refresh.message || fallbackMessage);
-    }
-    return result.session;
+    return this.accountManager.switchAccount(
+      userId,
+      (forceRefresh, expectedUserId) =>
+        this.ensureValidSessionWithStatus(forceRefresh, expectedUserId),
+    );
   }
 
   async removeAccount(userId: string): Promise<void> {
-    const removed = this.sessions.delete(userId);
-    if (!removed) {
-      return;
-    }
-    if (this.activeUserId === userId) {
-      this.setActiveAccount(this.sessions.keys().next().value ?? null);
-    } else {
-      this.clearSubscriptionCache();
-      this.clearVpcCache();
-    }
-    await this.persist();
+    await this.accountManager.removeAccount(userId);
   }
 
   async logoutAll(): Promise<void> {
-    this.sessions.clear();
-    this.activeUserId = null;
-    this.selectedProvider = defaultProvider();
-    this.cachedSubscription = null;
-    this.clearVpcCache();
-    await this.persist();
+    await this.accountManager.logoutAll();
   }
 
   getSelectedProvider(): LoginProvider {
-    return this.getSession()?.provider ?? this.selectedProvider;
+    return this.state.accounts.getSelectedProvider();
   }
 
   private async selectLoginProvider(providerIdpId?: string): Promise<LoginProvider> {
-    const providers = await this.getProviders();
-    const selected =
-      providers.find((provider) => provider.idpId === providerIdpId) ??
-      this.selectedProvider ??
-      providers[0] ??
-      defaultProvider();
-    this.selectedProvider = normalizeProvider(selected);
-    return this.selectedProvider;
+    const selected = await this.providerDiscovery.selectProvider(
+      this.state.accounts.getPersistedSelectedProvider(),
+      providerIdpId,
+    );
+    this.state.accounts.setSelectedProvider(selected);
+    return this.state.accounts.getPersistedSelectedProvider();
   }
 
-  private async buildLoginSession(initialTokens: AuthTokens, provider: LoginProvider): Promise<AuthSession> {
+  private async buildLoginSession(
+    initialTokens: AuthTokens,
+    provider: LoginProvider,
+  ): Promise<AuthSession> {
     const user = await fetchUserInfo(initialTokens);
-    console.debug("auth: fetched user info during login", { userId: user.userId, email: user.email, avatarUrl: user.avatarUrl });
+    console.debug("auth: fetched user info during login", {
+      userId: user.userId,
+      email: user.email,
+      avatarUrl: user.avatarUrl,
+    });
     let tokens = initialTokens;
     try {
-      tokens = await this.ensureClientToken(initialTokens, user.userId);
+      tokens = await this.sessionValidity.ensureClientToken(initialTokens);
     } catch (error) {
       console.warn("Unable to fetch client token after login. Falling back to OAuth token only:", error);
     }
@@ -400,18 +158,10 @@ export class AuthService {
   }
 
   private async saveLoginSession(session: AuthSession): Promise<AuthSession> {
-    this.sessions.set(session.user.userId, session);
-    this.activeUserId = session.user.userId;
-    this.selectedProvider = session.provider;
-    this.clearSubscriptionCache();
-    this.clearVpcCache();
-
-    // Fetch real membership tier from MES subscription API
-    // (JWT does not contain gfn_tier, so fetchUserInfo always falls back to "FREE")
-    await this.enrichUserTier();
-
-    await this.persist();
-    return this.getSession() as AuthSession;
+    return this.accountManager.saveLoginSession(
+      session,
+      () => this.enrichmentCaches.enrichUserTier(),
+    );
   }
 
   private pruneExpiredDeviceLogins(now = Date.now(), skipAttemptId?: string): void {
@@ -447,19 +197,16 @@ export class AuthService {
 
     let response: Response;
     try {
-      response = await fetch(`${base}v2/serverInfo`, {
-        headers,
-      });
+      response = await fetch(`${base}v2/serverInfo`, { headers });
     } catch {
       return [];
     }
-
     if (!response.ok) {
       return [];
     }
 
     const payload = (await response.json()) as ServerInfoResponse;
-    const regions = (payload.metaData ?? [])
+    return (payload.metaData ?? [])
       .filter((entry) => entry.value.startsWith("https://"))
       .filter((entry) => entry.key !== "gfn-regions" && !entry.key.startsWith("gfn-"))
       .map<StreamRegion>((entry) => ({
@@ -467,21 +214,16 @@ export class AuthService {
         url: entry.value.endsWith("/") ? entry.value : `${entry.value}/`,
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
-
-    return regions;
   }
 
   async login(input: AuthLoginRequest): Promise<AuthSession> {
     const provider = await this.selectLoginProvider(input.providerIdpId);
-
     const { verifier, challenge } = generatePkce();
     const port = await findAvailablePort();
     const authUrl = buildAuthUrl(provider, challenge, port);
-
     const codePromise = waitForAuthorizationCode(port, 120000);
     await shell.openExternal(authUrl);
     const code = await codePromise;
-
     const initialTokens = await exchangeAuthorizationCode(code, verifier, port);
     const session = await this.buildLoginSession(initialTokens, provider);
     return this.saveLoginSession(session);
@@ -563,374 +305,45 @@ export class AuthService {
   }
 
   async logout(): Promise<void> {
-    if (!this.activeUserId) {
-      return;
-    }
-    this.sessions.delete(this.activeUserId);
-    this.activeUserId = this.sessions.keys().next().value ?? null;
-    this.selectedProvider = this.getSession()?.provider ?? defaultProvider();
-    this.cachedSubscription = null;
-    this.clearVpcCache();
-    await this.persist();
+    await this.accountManager.logout();
   }
 
-  /**
-   * Fetch subscription info for the current user.
-   * Uses caching - call clearSubscriptionCache() to force refresh.
-   */
   async getSubscription(): Promise<SubscriptionInfo | null> {
-    // Return cached subscription if available
-    if (this.cachedSubscription) {
-      return this.cachedSubscription;
-    }
-
-    const session = await this.ensureValidSession();
-    if (!session) {
-      return null;
-    }
-
-    const token = session.tokens.idToken ?? session.tokens.accessToken;
-    const userId = session.user.userId;
-
-    // Fetch dynamic regions to get the VPC ID (handles Alliance partners correctly)
-    const { vpcId } = await fetchDynamicRegions(token, session.provider.streamingServiceUrl);
-
-    const subscription = await fetchSubscription(token, userId, vpcId ?? undefined);
-    this.cachedSubscription = subscription;
-    return subscription;
+    return this.enrichmentCaches.getSubscription();
   }
 
-  /**
-   * Clear the cached subscription info.
-   * Called automatically on logout.
-   */
   clearSubscriptionCache(): void {
-    this.cachedSubscription = null;
+    this.enrichmentCaches.clearSubscription();
   }
 
-  /**
-   * Get the cached subscription without fetching.
-   * Returns null if not cached.
-   */
   getCachedSubscription(): SubscriptionInfo | null {
-    return this.cachedSubscription;
+    return this.enrichmentCaches.getCachedSubscription();
   }
 
-  /**
-   * Get the VPC ID for the current provider.
-   * Returns cached value if available, otherwise fetches from serverInfo endpoint.
-   * The VPC ID is used for Alliance partner support and routing to correct data center.
-   */
   async getVpcId(explicitToken?: string): Promise<string | null> {
-    // Return cached VPC ID if available
-    if (this.cachedVpcId) {
-      return this.cachedVpcId;
-    }
-
-    const provider = this.getSelectedProvider();
-    const base = provider.streamingServiceUrl.endsWith("/")
-      ? provider.streamingServiceUrl
-      : `${provider.streamingServiceUrl}/`;
-
-    let token = explicitToken;
-    if (!token) {
-      const session = await this.ensureValidSession();
-      token = session ? session.tokens.idToken ?? session.tokens.accessToken : undefined;
-    }
-
-    const headers = buildGfnLcarsHeaders({
-      token,
-      clientType: "BROWSER",
-      clientStreamer: "WEBRTC",
-      includeUserAgent: true,
-    });
-
-    try {
-      const response = await fetch(`${base}v2/serverInfo`, {
-        headers,
-      });
-
-      if (!response.ok) {
-        return null;
-      }
-
-      const payload = (await response.json()) as ServerInfoResponse;
-      const vpcId = payload.requestStatus?.serverId ?? null;
-
-      // Cache the VPC ID
-      if (vpcId) {
-        this.cachedVpcId = vpcId;
-      }
-
-      return vpcId;
-    } catch {
-      return null;
-    }
+    return this.enrichmentCaches.getVpcId(explicitToken);
   }
 
-  /**
-   * Clear the cached VPC ID.
-   * Called automatically on logout.
-   */
   clearVpcCache(): void {
-    this.cachedVpcId = null;
+    this.enrichmentCaches.clearVpc();
   }
 
-  /**
-   * Get the cached VPC ID without fetching.
-   * Returns null if not cached.
-   */
   getCachedVpcId(): string | null {
-    return this.cachedVpcId;
-  }
-
-  /**
-   * Enrich the current session's user with the real membership tier from MES API.
-   * Falls back silently to the existing tier if the fetch fails.
-   */
-  private async enrichUserTier(): Promise<void> {
-    const session = this.getSession();
-    if (!session) return;
-
-    try {
-      const subscription = await this.getSubscription();
-      if (subscription && subscription.membershipTier) {
-        this.sessions.set(session.user.userId, {
-          ...session,
-          user: {
-            ...session.user,
-            membershipTier: subscription.membershipTier,
-          },
-        });
-        console.log(`Resolved membership tier: ${subscription.membershipTier}`);
-      }
-    } catch (error) {
-      console.warn("Failed to fetch subscription tier, keeping fallback:", error);
-    }
-  }
-
-  private shouldRefresh(tokens: AuthTokens): boolean {
-    return isNearExpiry(tokens.expiresAt, TOKEN_REFRESH_WINDOW_MS);
+    return this.enrichmentCaches.getCachedVpcId();
   }
 
   async ensureValidSessionWithStatus(
     forceRefresh = false,
     expectedUserId?: string,
   ): Promise<AuthSessionResult> {
-    const currentSession = this.getSession();
-    if (!currentSession) {
-      return {
-        session: null,
-        refresh: {
-          attempted: false,
-          forced: forceRefresh,
-          outcome: "not_attempted",
-          message: "No saved session found.",
-        },
-      };
-    }
-
-    const userId = currentSession.user.userId;
-    let tokens = currentSession.tokens;
-
-    // Official GFN client flow relies on client_token-based refresh. Bootstrap it
-    // for older sessions that were saved before we persisted client tokens.
-    if (!tokens.clientToken && !isExpired(tokens.expiresAt)) {
-      try {
-        const withClientToken = await this.ensureClientToken(tokens, userId);
-        if (withClientToken.clientToken && withClientToken.clientToken !== tokens.clientToken) {
-          this.sessions.set(userId, {
-            ...currentSession,
-            tokens: withClientToken,
-          });
-          tokens = withClientToken;
-          await this.persist();
-        }
-      } catch (error) {
-        console.warn("Unable to bootstrap client token from saved session:", error);
-      }
-    }
-
-    const shouldRefreshNow = forceRefresh || this.shouldRefresh(tokens);
-    if (!shouldRefreshNow) {
-      return {
-        session: this.getSession(),
-        refresh: {
-          attempted: false,
-          forced: forceRefresh,
-          outcome: "not_attempted",
-          message: "Session token is still valid.",
-        },
-      };
-    }
-
-    const applyRefreshedTokens = async (
-      refreshedTokens: AuthTokens,
-      source: "client_token" | "refresh_token",
-    ): Promise<AuthSessionResult> => {
-      const latestSession = this.getSession() ?? currentSession;
-      const baseSession = latestSession.user.userId === userId ? latestSession : currentSession;
-      const expectedRefreshUserId = expectedUserId ?? userId;
-      let refreshedUser: AuthUser | null = null;
-      let userInfoError: string | undefined;
-      try {
-        refreshedUser = await fetchUserInfo(refreshedTokens);
-        console.debug("auth: fetched user info on token refresh", {
-          userId: refreshedUser.userId,
-          email: refreshedUser.email,
-          avatarUrl: refreshedUser.avatarUrl,
-        });
-      } catch (error) {
-        console.warn("Token refresh succeeded but user info refresh failed. Keeping cached user:", error);
-        userInfoError = error instanceof Error ? error.message : "Unknown error while fetching user info";
-      }
-
-      const resolvedUser = refreshedUser ?? baseSession.user;
-      if (resolvedUser.userId !== expectedRefreshUserId) {
-        return {
-          session: baseSession,
-          refresh: {
-            attempted: true,
-            forced: forceRefresh,
-            outcome: "failed",
-            message: refreshedUser
-              ? "Token refresh returned a different account than expected."
-              : "Token refresh kept a cached account identity that did not match the expected account.",
-            error: refreshedUser
-              ? `expected_user_id:${expectedRefreshUserId} actual_user_id:${refreshedUser.userId}`
-              : userInfoError
-                ? `expected_user_id:${expectedRefreshUserId} cached_user_id:${resolvedUser.userId} user_info_error:${userInfoError}`
-                : `expected_user_id:${expectedRefreshUserId} cached_user_id:${resolvedUser.userId}`,
-          },
-        };
-      }
-
-      const updatedSession: AuthSession = {
-        provider: baseSession.provider,
-        tokens: refreshedTokens,
-        user: resolvedUser,
-      };
-      this.sessions.set(updatedSession.user.userId, updatedSession);
-
-      // Re-fetch real tier after token refresh
-      this.clearSubscriptionCache();
-      await this.enrichUserTier();
-      await this.persist();
-
-      const sourceText = source === "client_token" ? "client token" : "refresh token";
-      return {
-        session: this.getSession(),
-        refresh: {
-          attempted: true,
-          forced: forceRefresh,
-          outcome: "refreshed",
-          message: forceRefresh
-            ? `Saved session token refreshed via ${sourceText}.`
-            : `Session token refreshed via ${sourceText} because it was near expiry.`,
-        },
-      };
-    };
-
-    const refreshErrors: string[] = [];
-
-    if (tokens.clientToken) {
-      try {
-        const refreshedFromClientToken = await refreshWithClientToken(tokens.clientToken, userId, tokens.authClientId);
-        let refreshedTokens = mergeTokenSnapshot(tokens, refreshedFromClientToken);
-        refreshedTokens = await this.ensureClientToken(refreshedTokens, userId);
-        return applyRefreshedTokens(refreshedTokens, "client_token");
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Unknown error while refreshing with client token";
-        refreshErrors.push(`client_token: ${message}`);
-      }
-    }
-
-    if (tokens.refreshToken) {
-      try {
-        const refreshedOAuth = await refreshAuthTokens(tokens.refreshToken, tokens.authClientId);
-        let refreshedTokens: AuthTokens = {
-          ...tokens,
-          ...refreshedOAuth,
-          // OAuth refresh often omits id_token; never drop the prior JWT.
-          idToken: refreshedOAuth.idToken ?? tokens.idToken,
-          // OAuth refresh does not always return a new client token.
-          clientToken: tokens.clientToken,
-          clientTokenExpiresAt: tokens.clientTokenExpiresAt,
-          clientTokenLifetimeMs: tokens.clientTokenLifetimeMs,
-          authClientId: refreshedOAuth.authClientId ?? tokens.authClientId,
-        };
-        refreshedTokens = await this.ensureClientToken(refreshedTokens, userId);
-        return applyRefreshedTokens(refreshedTokens, "refresh_token");
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Unknown error while refreshing token";
-        refreshErrors.push(`refresh_token: ${message}`);
-      }
-    }
-
-    const errorText = refreshErrors.length > 0 ? refreshErrors.join(" | ") : undefined;
-    const expired = isExpired(tokens.expiresAt);
-
-    if (!tokens.clientToken && !tokens.refreshToken) {
-      if (expired) {
-        await this.logout();
-        return {
-          session: null,
-          refresh: {
-            attempted: true,
-            forced: forceRefresh,
-            outcome: "missing_refresh_token",
-            message: "Saved session expired and has no refresh mechanism. Please log in again.",
-          },
-        };
-      }
-
-      return {
-        session: this.getSession(),
-        refresh: {
-          attempted: true,
-          forced: forceRefresh,
-          outcome: "missing_refresh_token",
-          message: "No refresh token available. Using saved session token.",
-        },
-      };
-    }
-
-    if (expired) {
-      await this.logout();
-      return {
-        session: null,
-        refresh: {
-          attempted: true,
-          forced: forceRefresh,
-          outcome: "failed",
-          message: "Token refresh failed and the saved session expired. Please log in again.",
-          error: errorText,
-        },
-      };
-    }
-
-    return {
-      session: this.getSession(),
-      refresh: {
-        attempted: true,
-        forced: forceRefresh,
-        outcome: "failed",
-        message: "Token refresh failed. Using saved session token.",
-        error: errorText,
-      },
-    };
+    return this.sessionValidity.ensureValidSessionWithStatus(forceRefresh, expectedUserId);
   }
 
   async ensureValidSession(): Promise<AuthSession | null> {
-    const result = await this.ensureValidSessionWithStatus(false);
-    return result.session;
+    return this.sessionValidity.ensureValidSession();
   }
 
   async resolveJwtToken(explicitToken?: string): Promise<string> {
-    // Prefer the managed auth session whenever it exists so renderer-side cached
-    // tokens cannot bypass refresh logic.
     if (this.getSession()) {
       const session = await this.ensureValidSession();
       if (!session) {
@@ -947,7 +360,6 @@ export class AuthService {
     if (!session) {
       throw new Error("No authenticated session available");
     }
-
     return session.tokens.idToken ?? session.tokens.accessToken;
   }
 }

--- a/opennow-stable/src/main/platforms/gfn/auth/accountManager.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/accountManager.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import type { AuthSession } from "@shared/gfn";
+
+import { AccountManager } from "./accountManager";
+import { PersistedAccountState } from "./persistedAccountState";
+
+function session(userId: string): AuthSession {
+  return {
+    provider: {
+      idpId: "nvidia",
+      code: "NVIDIA",
+      displayName: "NVIDIA",
+      streamingServiceUrl: "https://provider.example/",
+      priority: 0,
+    },
+    tokens: {
+      accessToken: `${userId}-access`,
+      expiresAt: Date.now() + 60_000,
+    },
+    user: {
+      userId,
+      displayName: userId,
+      membershipTier: "FREE",
+    },
+  };
+}
+
+test("AccountManager removes an incomplete switched account and restores the prior account", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "opennow-auth-account-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const statePath = join(directory, "auth.json");
+  const state = new PersistedAccountState(statePath);
+  const first = session("first");
+  const second = session("second");
+  state.accounts.setSession(first);
+  state.accounts.setSession(second);
+  state.accounts.setActiveAccount("first");
+
+  let cacheClears = 0;
+  const manager = new AccountManager(state, () => {
+    cacheClears += 1;
+  });
+
+  await assert.rejects(
+    () => manager.switchAccount("second", async () => ({
+      session: second,
+      refresh: {
+        attempted: true,
+        forced: true,
+        outcome: "missing_refresh_token",
+        message: "No refresh token available.",
+      },
+    })),
+    /Saved login for this account is incomplete/,
+  );
+
+  assert.equal(state.accounts.getSession()?.user.userId, "first");
+  assert.equal(state.accounts.hasAccount("second"), false);
+  assert.equal(cacheClears, 3);
+
+  const persisted = JSON.parse(await readFile(statePath, "utf8")) as {
+    activeUserId: string | null;
+    sessions: AuthSession[];
+  };
+  assert.equal(persisted.activeUserId, "first");
+  assert.deepEqual(persisted.sessions.map((saved) => saved.user.userId), ["first"]);
+});

--- a/opennow-stable/src/main/platforms/gfn/auth/accountManager.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/accountManager.ts
@@ -1,0 +1,111 @@
+import type { AuthSession, AuthSessionResult, SavedAccount } from "@shared/gfn";
+
+import type { PersistedAccountState } from "./persistedAccountState";
+
+type EnsureSession = (forceRefresh: boolean, expectedUserId?: string) => Promise<AuthSessionResult>;
+
+export class AccountManager {
+  constructor(
+    private readonly state: PersistedAccountState,
+    private readonly clearCaches: () => void,
+  ) {}
+
+  setSession(session: AuthSession | null): void {
+    if (!session) {
+      this.state.accounts.reset();
+      this.clearCaches();
+      void this.state.persist();
+      return;
+    }
+
+    this.state.accounts.setSession(session);
+    this.clearCaches();
+    void this.state.persist();
+  }
+
+  getSavedAccounts(): SavedAccount[] {
+    return this.state.accounts.getSavedAccounts();
+  }
+
+  async saveLoginSession(
+    session: AuthSession,
+    enrichUserTier: () => Promise<void>,
+  ): Promise<AuthSession> {
+    this.state.accounts.setSession(session);
+    this.clearCaches();
+    await enrichUserTier();
+    await this.state.persist();
+    return this.state.accounts.getSession() as AuthSession;
+  }
+
+  async switchAccount(userId: string, ensureSession: EnsureSession): Promise<AuthSession> {
+    const target = this.state.accounts.getSessionForUser(userId);
+    if (!target) {
+      throw new Error("Saved account not found");
+    }
+
+    const previousActiveUserId = this.state.accounts.getActiveUserId();
+    const previousSelectedProvider = this.state.accounts.getPersistedSelectedProvider();
+
+    this.state.accounts.setActiveAccount(userId);
+    this.clearCaches();
+
+    const result = await ensureSession(true, userId);
+    const missingRefreshToken = result.refresh.outcome === "missing_refresh_token";
+    const refreshFailed = result.refresh.outcome === "failed";
+    const switchedUserMismatch = result.session?.user.userId !== userId;
+    if (!result.session || refreshFailed || missingRefreshToken || switchedUserMismatch) {
+      const fallbackMessage = "Failed to switch account due to an invalid or expired session.";
+
+      if (missingRefreshToken) {
+        await this.removeAccount(userId);
+        this.state.accounts.setActiveAccount(previousActiveUserId);
+        this.clearCaches();
+        await this.state.persist();
+        throw new Error("Saved login for this account is incomplete. Please log in to this account again.");
+      }
+
+      this.state.accounts.setActiveAccount(previousActiveUserId);
+      if (previousActiveUserId && this.state.accounts.hasAccount(previousActiveUserId)) {
+        this.state.accounts.setSelectedProvider(previousSelectedProvider);
+      }
+      this.clearCaches();
+      await this.state.persist();
+
+      if (switchedUserMismatch) {
+        throw new Error("Switched session did not match the selected account.");
+      }
+      throw new Error(result.refresh.message || fallbackMessage);
+    }
+    return result.session;
+  }
+
+  async removeAccount(userId: string): Promise<void> {
+    const removed = this.state.accounts.removeAccount(userId);
+    if (!removed) {
+      return;
+    }
+    if (this.state.accounts.getActiveUserId() === userId) {
+      this.state.accounts.setActiveAccount(this.state.accounts.firstUserId());
+    }
+    this.clearCaches();
+    await this.state.persist();
+  }
+
+  async logout(): Promise<void> {
+    const activeUserId = this.state.accounts.getActiveUserId();
+    if (!activeUserId) {
+      return;
+    }
+    this.state.accounts.removeAccount(activeUserId);
+    this.state.accounts.setActiveAccount(this.state.accounts.firstUserId());
+    this.clearCaches();
+    await this.state.persist();
+  }
+
+  async logoutAll(): Promise<void> {
+    this.state.accounts.reset();
+    this.clearCaches();
+    await this.state.persist();
+  }
+}

--- a/opennow-stable/src/main/platforms/gfn/auth/enrichmentCaches.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/enrichmentCaches.ts
@@ -1,0 +1,129 @@
+import type { AuthSession, LoginProvider, SubscriptionInfo } from "@shared/gfn";
+
+import { buildGfnLcarsHeaders } from "../clientHeaders";
+import { fetchDynamicRegions, fetchSubscription } from "../subscription";
+
+interface ServerInfoResponse {
+  requestStatus?: {
+    serverId?: string;
+  };
+}
+
+interface EnrichmentCacheDependencies {
+  getSession: () => AuthSession | null;
+  getSelectedProvider: () => LoginProvider;
+  ensureValidSession: () => Promise<AuthSession | null>;
+  updateSession: (session: AuthSession) => void;
+}
+
+export class SubscriptionVpcEnrichmentCaches {
+  private cachedSubscription: SubscriptionInfo | null = null;
+  private cachedVpcId: string | null = null;
+
+  constructor(private readonly dependencies: EnrichmentCacheDependencies) {}
+
+  async getSubscription(): Promise<SubscriptionInfo | null> {
+    if (this.cachedSubscription) {
+      return this.cachedSubscription;
+    }
+
+    const session = await this.dependencies.ensureValidSession();
+    if (!session) {
+      return null;
+    }
+
+    const token = session.tokens.idToken ?? session.tokens.accessToken;
+    const { vpcId } = await fetchDynamicRegions(token, session.provider.streamingServiceUrl);
+    const subscription = await fetchSubscription(
+      token,
+      session.user.userId,
+      vpcId ?? undefined,
+    );
+    this.cachedSubscription = subscription;
+    return subscription;
+  }
+
+  clearSubscription(): void {
+    this.cachedSubscription = null;
+  }
+
+  getCachedSubscription(): SubscriptionInfo | null {
+    return this.cachedSubscription;
+  }
+
+  async getVpcId(explicitToken?: string): Promise<string | null> {
+    if (this.cachedVpcId) {
+      return this.cachedVpcId;
+    }
+
+    const provider = this.dependencies.getSelectedProvider();
+    const base = provider.streamingServiceUrl.endsWith("/")
+      ? provider.streamingServiceUrl
+      : `${provider.streamingServiceUrl}/`;
+
+    let token = explicitToken;
+    if (!token) {
+      const session = await this.dependencies.ensureValidSession();
+      token = session ? session.tokens.idToken ?? session.tokens.accessToken : undefined;
+    }
+
+    const headers = buildGfnLcarsHeaders({
+      token,
+      clientType: "BROWSER",
+      clientStreamer: "WEBRTC",
+      includeUserAgent: true,
+    });
+
+    try {
+      const response = await fetch(`${base}v2/serverInfo`, { headers });
+      if (!response.ok) {
+        return null;
+      }
+
+      const payload = (await response.json()) as ServerInfoResponse;
+      const vpcId = payload.requestStatus?.serverId ?? null;
+      if (vpcId) {
+        this.cachedVpcId = vpcId;
+      }
+      return vpcId;
+    } catch {
+      return null;
+    }
+  }
+
+  clearVpc(): void {
+    this.cachedVpcId = null;
+  }
+
+  getCachedVpcId(): string | null {
+    return this.cachedVpcId;
+  }
+
+  clearAll(): void {
+    this.clearSubscription();
+    this.clearVpc();
+  }
+
+  async enrichUserTier(): Promise<void> {
+    const session = this.dependencies.getSession();
+    if (!session) {
+      return;
+    }
+
+    try {
+      const subscription = await this.getSubscription();
+      if (subscription?.membershipTier) {
+        this.dependencies.updateSession({
+          ...session,
+          user: {
+            ...session.user,
+            membershipTier: subscription.membershipTier,
+          },
+        });
+        console.log(`Resolved membership tier: ${subscription.membershipTier}`);
+      }
+    } catch (error) {
+      console.warn("Failed to fetch subscription tier, keeping fallback:", error);
+    }
+  }
+}

--- a/opennow-stable/src/main/platforms/gfn/auth/persistedAccountState.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/persistedAccountState.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AuthSession, LoginProvider } from "@shared/gfn";
+
+import { AccountState } from "./persistedAccountState";
+
+function provider(code: string, streamingServiceUrl = `https://${code.toLowerCase()}.example`): LoginProvider {
+  return {
+    idpId: `${code}-idp`,
+    code,
+    displayName: code,
+    streamingServiceUrl,
+    priority: 0,
+  };
+}
+
+function session(userId: string, loginProvider = provider("NVIDIA")): AuthSession {
+  return {
+    provider: loginProvider,
+    tokens: {
+      accessToken: `${userId}-access`,
+      refreshToken: `${userId}-refresh`,
+      expiresAt: Date.now() + 60_000,
+    },
+    user: {
+      userId,
+      displayName: userId,
+      membershipTier: "FREE",
+    },
+  };
+}
+
+test("AccountState restores the legacy single-session format without changing identity", () => {
+  const state = new AccountState();
+  state.restore({ session: session("legacy-user") });
+
+  assert.equal(state.getSession()?.user.userId, "legacy-user");
+  assert.equal(state.getSession()?.provider.streamingServiceUrl, "https://nvidia.example/");
+  assert.equal(state.snapshot().activeUserId, "legacy-user");
+  assert.equal(state.snapshot().sessions.length, 1);
+});
+
+test("AccountState falls back to the first saved account when activeUserId is stale", () => {
+  const state = new AccountState();
+  state.restore({
+    sessions: [session("first"), session("second", provider("BPC"))],
+    activeUserId: "removed-user",
+    selectedProvider: provider("NVIDIA"),
+  });
+
+  assert.equal(state.getSession()?.user.userId, "first");
+  state.setActiveAccount("second");
+  assert.equal(state.getSession()?.user.userId, "second");
+  assert.equal(state.getSelectedProvider().code, "BPC");
+});
+
+test("AccountState preserves insertion order while removing and replacing accounts", () => {
+  const state = new AccountState();
+  state.setSession(session("first"));
+  state.setSession(session("second", provider("BPC")));
+
+  assert.equal(state.firstUserId(), "first");
+  assert.equal(state.removeAccount("second"), true);
+  state.setActiveAccount(state.firstUserId());
+
+  assert.equal(state.getSession()?.user.userId, "first");
+  assert.deepEqual(
+    state.getSavedAccounts().map((account) => account.userId),
+    ["first"],
+  );
+});

--- a/opennow-stable/src/main/platforms/gfn/auth/persistedAccountState.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/persistedAccountState.ts
@@ -1,0 +1,169 @@
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { AuthSession, LoginProvider, SavedAccount } from "@shared/gfn";
+
+import { defaultProvider, normalizeProvider } from "./providerDiscovery";
+
+export interface PersistedAuthState {
+  sessions: AuthSession[];
+  activeUserId: string | null;
+  selectedProvider: LoginProvider | null;
+}
+
+export type RestorableAuthState = Partial<PersistedAuthState> & {
+  session?: AuthSession | null;
+};
+
+export class AccountState {
+  private sessions = new Map<string, AuthSession>();
+  private activeUserId: string | null = null;
+  private selectedProvider: LoginProvider = defaultProvider();
+
+  restore(parsed: RestorableAuthState): void {
+    if (parsed.selectedProvider) {
+      this.selectedProvider = normalizeProvider(parsed.selectedProvider);
+    }
+
+    this.sessions.clear();
+    if (Array.isArray(parsed.sessions)) {
+      for (const persistedSession of parsed.sessions) {
+        if (!persistedSession?.user?.userId) {
+          continue;
+        }
+        this.sessions.set(persistedSession.user.userId, {
+          ...persistedSession,
+          provider: normalizeProvider(persistedSession.provider),
+        });
+      }
+    } else if (parsed.session?.user?.userId) {
+      this.sessions.set(parsed.session.user.userId, {
+        ...parsed.session,
+        provider: normalizeProvider(parsed.session.provider),
+      });
+    }
+
+    this.activeUserId =
+      typeof parsed.activeUserId === "string" && this.sessions.has(parsed.activeUserId)
+        ? parsed.activeUserId
+        : this.sessions.keys().next().value ?? null;
+  }
+
+  snapshot(): PersistedAuthState {
+    return {
+      sessions: Array.from(this.sessions.values()),
+      activeUserId: this.activeUserId,
+      selectedProvider: this.selectedProvider,
+    };
+  }
+
+  reset(): void {
+    this.sessions.clear();
+    this.activeUserId = null;
+    this.selectedProvider = defaultProvider();
+  }
+
+  getSession(): AuthSession | null {
+    if (!this.activeUserId) {
+      return null;
+    }
+    return this.sessions.get(this.activeUserId) ?? null;
+  }
+
+  getSessionForUser(userId: string): AuthSession | null {
+    return this.sessions.get(userId) ?? null;
+  }
+
+  hasAccount(userId: string): boolean {
+    return this.sessions.has(userId);
+  }
+
+  firstUserId(): string | null {
+    return this.sessions.keys().next().value ?? null;
+  }
+
+  getActiveUserId(): string | null {
+    return this.activeUserId;
+  }
+
+  getSelectedProvider(): LoginProvider {
+    return this.getSession()?.provider ?? this.selectedProvider;
+  }
+
+  getPersistedSelectedProvider(): LoginProvider {
+    return this.selectedProvider;
+  }
+
+  setSelectedProvider(provider: LoginProvider): void {
+    this.selectedProvider = normalizeProvider(provider);
+  }
+
+  setSession(session: AuthSession): AuthSession {
+    const normalized: AuthSession = {
+      ...session,
+      provider: normalizeProvider(session.provider),
+    };
+    this.sessions.set(normalized.user.userId, normalized);
+    this.activeUserId = normalized.user.userId;
+    this.selectedProvider = normalized.provider;
+    return normalized;
+  }
+
+  updateSession(session: AuthSession): void {
+    this.sessions.set(session.user.userId, session);
+  }
+
+  setActiveAccount(userId: string | null): void {
+    this.activeUserId = userId && this.sessions.has(userId) ? userId : null;
+    this.selectedProvider = this.getSession()?.provider ?? defaultProvider();
+  }
+
+  removeAccount(userId: string): boolean {
+    return this.sessions.delete(userId);
+  }
+
+  getSavedAccounts(): SavedAccount[] {
+    return Array.from(this.sessions.values()).map((session) => ({
+      userId: session.user.userId,
+      displayName: session.user.displayName,
+      email: session.user.email,
+      avatarUrl: session.user.avatarUrl,
+      membershipTier: session.user.membershipTier,
+      providerCode: session.provider.code,
+    }));
+  }
+}
+
+export class PersistedAccountState {
+  readonly accounts = new AccountState();
+
+  constructor(private readonly statePath: string) {}
+
+  async initialize(): Promise<AuthSession | null> {
+    try {
+      await access(this.statePath);
+    } catch {
+      await this.persist();
+      return null;
+    }
+
+    try {
+      const raw = await readFile(this.statePath, "utf8");
+      this.accounts.restore(JSON.parse(raw) as RestorableAuthState);
+      return this.accounts.getSession();
+    } catch {
+      this.accounts.reset();
+      await this.persist();
+      return null;
+    }
+  }
+
+  async persist(): Promise<void> {
+    await mkdir(dirname(this.statePath), { recursive: true });
+    await writeFile(
+      this.statePath,
+      JSON.stringify(this.accounts.snapshot(), null, 2),
+      "utf8",
+    );
+  }
+}

--- a/opennow-stable/src/main/platforms/gfn/auth/providerDiscovery.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/providerDiscovery.ts
@@ -1,0 +1,102 @@
+import type { LoginProvider } from "@shared/gfn";
+
+import { GFN_USER_AGENT } from "../clientHeaders";
+import { DEFAULT_IDP_ID, SERVICE_URLS_ENDPOINT } from "./constants";
+
+interface ServiceUrlsResponse {
+  gfnServiceInfo?: {
+    gfnServiceEndpoints?: Array<{
+      idpId: string;
+      loginProviderCode: string;
+      loginProviderDisplayName: string;
+      streamingServiceUrl: string;
+      loginProviderPriority?: number;
+    }>;
+  };
+}
+
+export function defaultProvider(): LoginProvider {
+  return {
+    idpId: DEFAULT_IDP_ID,
+    code: "NVIDIA",
+    displayName: "NVIDIA",
+    streamingServiceUrl: "https://prod.cloudmatchbeta.nvidiagrid.net/",
+    priority: 0,
+  };
+}
+
+export function normalizeProvider(provider: LoginProvider): LoginProvider {
+  return {
+    ...provider,
+    streamingServiceUrl: provider.streamingServiceUrl.endsWith("/")
+      ? provider.streamingServiceUrl
+      : `${provider.streamingServiceUrl}/`,
+  };
+}
+
+export class ProviderDiscovery {
+  private providers: LoginProvider[] = [];
+
+  async getProviders(): Promise<LoginProvider[]> {
+    if (this.providers.length > 0) {
+      return this.providers;
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(SERVICE_URLS_ENDPOINT, {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": GFN_USER_AGENT,
+        },
+      });
+    } catch (error) {
+      console.warn("Failed to fetch providers, using default:", error);
+      this.providers = [defaultProvider()];
+      return this.providers;
+    }
+
+    if (!response.ok) {
+      console.warn(`Providers fetch failed with status ${response.status}, using default`);
+      this.providers = [defaultProvider()];
+      return this.providers;
+    }
+
+    try {
+      const payload = (await response.json()) as ServiceUrlsResponse;
+      const endpoints = payload.gfnServiceInfo?.gfnServiceEndpoints ?? [];
+      const providers = endpoints
+        .map<LoginProvider>((entry) => ({
+          idpId: entry.idpId,
+          code: entry.loginProviderCode,
+          displayName:
+            entry.loginProviderCode === "BPC" ? "bro.game" : entry.loginProviderDisplayName,
+          streamingServiceUrl: entry.streamingServiceUrl,
+          priority: entry.loginProviderPriority ?? 0,
+        }))
+        .sort((a, b) => a.priority - b.priority)
+        .map(normalizeProvider);
+
+      this.providers = providers.length > 0 ? providers : [defaultProvider()];
+      console.log(`Loaded ${this.providers.length} providers`);
+      return this.providers;
+    } catch (error) {
+      console.warn("Failed to parse providers response, using default:", error);
+      this.providers = [defaultProvider()];
+      return this.providers;
+    }
+  }
+
+  async selectProvider(
+    selectedProvider: LoginProvider,
+    providerIdpId?: string,
+  ): Promise<LoginProvider> {
+    const providers = await this.getProviders();
+    const selected =
+      providers.find((provider) => provider.idpId === providerIdpId) ??
+      selectedProvider ??
+      providers[0] ??
+      defaultProvider();
+    return normalizeProvider(selected);
+  }
+}

--- a/opennow-stable/src/main/platforms/gfn/auth/sessionValidity.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/sessionValidity.test.ts
@@ -1,0 +1,30 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldRefreshSession } from "./sessionValidity";
+
+test("shouldRefreshSession only coordinates refresh inside the token refresh window", () => {
+  assert.equal(
+    shouldRefreshSession({
+      accessToken: "valid",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldRefreshSession({
+      accessToken: "near-expiry",
+      expiresAt: Date.now() + 30_000,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldRefreshSession({
+      accessToken: "expired",
+      expiresAt: Date.now() - 1,
+    }),
+    true,
+  );
+});

--- a/opennow-stable/src/main/platforms/gfn/auth/sessionValidity.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/sessionValidity.ts
@@ -1,0 +1,259 @@
+import type {
+  AuthSession,
+  AuthSessionResult,
+  AuthTokens,
+  AuthUser,
+} from "@shared/gfn";
+
+import { CLIENT_TOKEN_REFRESH_WINDOW_MS, TOKEN_REFRESH_WINDOW_MS } from "./constants";
+import type { SubscriptionVpcEnrichmentCaches } from "./enrichmentCaches";
+import { isExpired, isNearExpiry } from "./helpers";
+import type { PersistedAccountState } from "./persistedAccountState";
+import {
+  mergeTokenSnapshot,
+  refreshAuthTokens,
+  refreshWithClientToken,
+  requestClientToken,
+} from "./tokenRefresh";
+import { fetchUserInfo } from "./userInfo";
+
+interface SessionValidityDependencies {
+  state: PersistedAccountState;
+  enrichmentCaches: SubscriptionVpcEnrichmentCaches;
+  logout: () => Promise<void>;
+}
+
+export function shouldRefreshSession(tokens: AuthTokens): boolean {
+  return isNearExpiry(tokens.expiresAt, TOKEN_REFRESH_WINDOW_MS);
+}
+
+export class SessionValidityCoordinator {
+  constructor(private readonly dependencies: SessionValidityDependencies) {}
+
+  async ensureClientToken(tokens: AuthTokens): Promise<AuthTokens> {
+    const hasUsableClientToken =
+      Boolean(tokens.clientToken) &&
+      !isNearExpiry(tokens.clientTokenExpiresAt, CLIENT_TOKEN_REFRESH_WINDOW_MS);
+    if (hasUsableClientToken || isExpired(tokens.expiresAt)) {
+      return tokens;
+    }
+
+    const clientToken = await requestClientToken(tokens.accessToken, tokens.authClientId);
+    return {
+      ...tokens,
+      clientToken: clientToken.token,
+      clientTokenExpiresAt: clientToken.expiresAt,
+      clientTokenLifetimeMs: clientToken.lifetimeMs,
+    };
+  }
+
+  async ensureValidSessionWithStatus(
+    forceRefresh = false,
+    expectedUserId?: string,
+  ): Promise<AuthSessionResult> {
+    const { accounts } = this.dependencies.state;
+    const currentSession = accounts.getSession();
+    if (!currentSession) {
+      return {
+        session: null,
+        refresh: {
+          attempted: false,
+          forced: forceRefresh,
+          outcome: "not_attempted",
+          message: "No saved session found.",
+        },
+      };
+    }
+
+    const userId = currentSession.user.userId;
+    let tokens = currentSession.tokens;
+
+    if (!tokens.clientToken && !isExpired(tokens.expiresAt)) {
+      try {
+        const withClientToken = await this.ensureClientToken(tokens);
+        if (withClientToken.clientToken && withClientToken.clientToken !== tokens.clientToken) {
+          accounts.updateSession({
+            ...currentSession,
+            tokens: withClientToken,
+          });
+          tokens = withClientToken;
+          await this.dependencies.state.persist();
+        }
+      } catch (error) {
+        console.warn("Unable to bootstrap client token from saved session:", error);
+      }
+    }
+
+    if (!forceRefresh && !shouldRefreshSession(tokens)) {
+      return {
+        session: accounts.getSession(),
+        refresh: {
+          attempted: false,
+          forced: forceRefresh,
+          outcome: "not_attempted",
+          message: "Session token is still valid.",
+        },
+      };
+    }
+
+    const applyRefreshedTokens = async (
+      refreshedTokens: AuthTokens,
+      source: "client_token" | "refresh_token",
+    ): Promise<AuthSessionResult> => {
+      const latestSession = accounts.getSession() ?? currentSession;
+      const baseSession = latestSession.user.userId === userId ? latestSession : currentSession;
+      const expectedRefreshUserId = expectedUserId ?? userId;
+      let refreshedUser: AuthUser | null = null;
+      let userInfoError: string | undefined;
+      try {
+        refreshedUser = await fetchUserInfo(refreshedTokens);
+        console.debug("auth: fetched user info on token refresh", {
+          userId: refreshedUser.userId,
+          email: refreshedUser.email,
+          avatarUrl: refreshedUser.avatarUrl,
+        });
+      } catch (error) {
+        console.warn("Token refresh succeeded but user info refresh failed. Keeping cached user:", error);
+        userInfoError = error instanceof Error ? error.message : "Unknown error while fetching user info";
+      }
+
+      const resolvedUser = refreshedUser ?? baseSession.user;
+      if (resolvedUser.userId !== expectedRefreshUserId) {
+        return {
+          session: baseSession,
+          refresh: {
+            attempted: true,
+            forced: forceRefresh,
+            outcome: "failed",
+            message: refreshedUser
+              ? "Token refresh returned a different account than expected."
+              : "Token refresh kept a cached account identity that did not match the expected account.",
+            error: refreshedUser
+              ? `expected_user_id:${expectedRefreshUserId} actual_user_id:${refreshedUser.userId}`
+              : userInfoError
+                ? `expected_user_id:${expectedRefreshUserId} cached_user_id:${resolvedUser.userId} user_info_error:${userInfoError}`
+                : `expected_user_id:${expectedRefreshUserId} cached_user_id:${resolvedUser.userId}`,
+          },
+        };
+      }
+
+      accounts.updateSession({
+        provider: baseSession.provider,
+        tokens: refreshedTokens,
+        user: resolvedUser,
+      });
+      this.dependencies.enrichmentCaches.clearSubscription();
+      await this.dependencies.enrichmentCaches.enrichUserTier();
+      await this.dependencies.state.persist();
+
+      const sourceText = source === "client_token" ? "client token" : "refresh token";
+      return {
+        session: accounts.getSession(),
+        refresh: {
+          attempted: true,
+          forced: forceRefresh,
+          outcome: "refreshed",
+          message: forceRefresh
+            ? `Saved session token refreshed via ${sourceText}.`
+            : `Session token refreshed via ${sourceText} because it was near expiry.`,
+        },
+      };
+    };
+
+    const refreshErrors: string[] = [];
+    if (tokens.clientToken) {
+      try {
+        const refreshedFromClientToken = await refreshWithClientToken(
+          tokens.clientToken,
+          userId,
+          tokens.authClientId,
+        );
+        let refreshedTokens = mergeTokenSnapshot(tokens, refreshedFromClientToken);
+        refreshedTokens = await this.ensureClientToken(refreshedTokens);
+        return applyRefreshedTokens(refreshedTokens, "client_token");
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown error while refreshing with client token";
+        refreshErrors.push(`client_token: ${message}`);
+      }
+    }
+
+    if (tokens.refreshToken) {
+      try {
+        const refreshedOAuth = await refreshAuthTokens(tokens.refreshToken, tokens.authClientId);
+        let refreshedTokens: AuthTokens = {
+          ...tokens,
+          ...refreshedOAuth,
+          idToken: refreshedOAuth.idToken ?? tokens.idToken,
+          clientToken: tokens.clientToken,
+          clientTokenExpiresAt: tokens.clientTokenExpiresAt,
+          clientTokenLifetimeMs: tokens.clientTokenLifetimeMs,
+          authClientId: refreshedOAuth.authClientId ?? tokens.authClientId,
+        };
+        refreshedTokens = await this.ensureClientToken(refreshedTokens);
+        return applyRefreshedTokens(refreshedTokens, "refresh_token");
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown error while refreshing token";
+        refreshErrors.push(`refresh_token: ${message}`);
+      }
+    }
+
+    const errorText = refreshErrors.length > 0 ? refreshErrors.join(" | ") : undefined;
+    const expired = isExpired(tokens.expiresAt);
+    if (!tokens.clientToken && !tokens.refreshToken) {
+      if (expired) {
+        await this.dependencies.logout();
+        return {
+          session: null,
+          refresh: {
+            attempted: true,
+            forced: forceRefresh,
+            outcome: "missing_refresh_token",
+            message: "Saved session expired and has no refresh mechanism. Please log in again.",
+          },
+        };
+      }
+
+      return {
+        session: accounts.getSession(),
+        refresh: {
+          attempted: true,
+          forced: forceRefresh,
+          outcome: "missing_refresh_token",
+          message: "No refresh token available. Using saved session token.",
+        },
+      };
+    }
+
+    if (expired) {
+      await this.dependencies.logout();
+      return {
+        session: null,
+        refresh: {
+          attempted: true,
+          forced: forceRefresh,
+          outcome: "failed",
+          message: "Token refresh failed and the saved session expired. Please log in again.",
+          error: errorText,
+        },
+      };
+    }
+
+    return {
+      session: accounts.getSession(),
+      refresh: {
+        attempted: true,
+        forced: forceRefresh,
+        outcome: "failed",
+        message: "Token refresh failed. Using saved session token.",
+        error: errorText,
+      },
+    };
+  }
+
+  async ensureValidSession(): Promise<AuthSession | null> {
+    const result = await this.ensureValidSessionWithStatus(false);
+    return result.session;
+  }
+}


### PR DESCRIPTION
Reduce `AuthService` to a stable orchestration façade by moving its stateful responsibilities into focused GFN auth owners.

- Separate persisted account state, account transitions, provider discovery, subscription/VPC caches, and session-validity refresh coordination.
- Preserve legacy session restoration, provider normalization, account switching, token refresh, and cache behavior.
- Add focused coverage for persisted compatibility, account rollback/removal, and refresh-window decisions.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->