### PR TITLE
fix(input): keep gameplay interactive after Escape unlock

### DIFF
--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -63,6 +63,7 @@ import {
 } from "./lib/gameCatalog";
 import { resolveInstallToPlayStorageRegionUrl } from "./lib/launchOwnership";
 import { hasAnyEligiblePrintedWasteZone, isAllianceStreamingBaseUrl } from "./lib/printedWaste";
+import { getStreamPointerLockTarget, isStreamPointerLocked } from "./lib/pointerLock";
 import { normalizeMembershipTier } from "./lib/queueAds";
 import { clearRuntimeSnapshot, type RuntimeSnapshot } from "./lib/runtimeSnapshot";
 import { getEnabledSessionProxyUrl } from "./lib/sessionProxy";
@@ -996,7 +997,7 @@ export function App(): JSX.Element {
   }, []);
 
   const requestPointerLockCapture = useCallback(async (target: HTMLVideoElement) => {
-    const lockTarget = (target.parentElement as HTMLElement | null) ?? target;
+    const lockTarget = getStreamPointerLockTarget(target);
     const requestPointerLockCompat = async (
       options?: { unadjustedMovement?: boolean },
     ): Promise<void> => {
@@ -2201,7 +2202,7 @@ export function App(): JSX.Element {
         {
           const targetVideo = videoRef.current;
           if (streamStatus === "streaming" && targetVideo) {
-            if (document.pointerLockElement === targetVideo) {
+            if (isStreamPointerLocked(targetVideo)) {
               clientRef.current?.suppressNextSyntheticEscapeOnPointerLockLoss();
               document.exitPointerLock();
             } else {

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -26,6 +26,7 @@ import {
 } from "./stream/StreamEmptyStates";
 import { StreamQuickMenu } from "./stream/quick-menu/StreamQuickMenu";
 import { MotionSpinner } from "./MotionSpinner";
+import { isStreamPointerLocked } from "../lib/pointerLock";
 
 const ANTI_AFK_TOGGLE_ACK_MS = 5000;
 const CONTROLLER_SIDEBAR_SHORTCUT_DISPLAY = "View + Menu";
@@ -490,7 +491,8 @@ export function StreamView({
   useEffect(() => {
     const handlePointerLockChange = () => {
       setIsPointerLocked(
-        document.pointerLockElement === localVideoRef.current || nativeInputCaptureActive,
+        (localVideoRef.current !== null && isStreamPointerLocked(localVideoRef.current))
+          || nativeInputCaptureActive,
       );
     };
     handlePointerLockChange();

--- a/opennow-stable/src/renderer/src/lib/pointerLock.test.ts
+++ b/opennow-stable/src/renderer/src/lib/pointerLock.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canForwardStreamPointerInput,
+  didStreamPointerLockExit,
+  getStreamPointerLockTarget,
+  isStreamPointerLocked,
+} from "./pointerLock";
+
+test("stream pointer lock accepts the video wrapper used by input capture", () => {
+  const wrapper = {} as HTMLElement;
+  const video = { parentElement: wrapper } as HTMLVideoElement;
+
+  assert.equal(getStreamPointerLockTarget(video), wrapper);
+  assert.equal(isStreamPointerLocked(video, wrapper), true);
+  assert.equal(isStreamPointerLocked(video, video), true);
+  assert.equal(isStreamPointerLocked(video, null), false);
+});
+
+test("stream pointer lock falls back to the video without a wrapper", () => {
+  const video = { parentElement: null } as HTMLVideoElement;
+
+  assert.equal(getStreamPointerLockTarget(video), video);
+  assert.equal(isStreamPointerLocked(video, video), true);
+});
+
+test("unlocked pointer input only continues during the Escape fallback", () => {
+  assert.equal(canForwardStreamPointerInput(true, false, false), true);
+  assert.equal(canForwardStreamPointerInput(false, true, true), true);
+  assert.equal(canForwardStreamPointerInput(false, true, false), false);
+  assert.equal(canForwardStreamPointerInput(false, false, true), false);
+});
+
+test("pointer lock loss only fires on an active-to-inactive transition", () => {
+  assert.equal(didStreamPointerLockExit(true, false), true);
+  assert.equal(didStreamPointerLockExit(false, false), false);
+  assert.equal(didStreamPointerLockExit(true, true), false);
+  assert.equal(didStreamPointerLockExit(false, true), false);
+});

--- a/opennow-stable/src/renderer/src/lib/pointerLock.ts
+++ b/opennow-stable/src/renderer/src/lib/pointerLock.ts
@@ -1,0 +1,28 @@
+export function getStreamPointerLockTarget(videoElement: HTMLVideoElement): HTMLElement {
+  return (videoElement.parentElement as HTMLElement | null) ?? videoElement;
+}
+
+export function isStreamPointerLocked(
+  videoElement: HTMLVideoElement,
+  pointerLockElement: Element | null = document.pointerLockElement,
+): boolean {
+  return (
+    pointerLockElement === videoElement
+    || pointerLockElement === getStreamPointerLockTarget(videoElement)
+  );
+}
+
+export function canForwardStreamPointerInput(
+  pointerLocked: boolean,
+  escapeFallbackActive: boolean,
+  pointerInsideStream: boolean,
+): boolean {
+  return pointerLocked || (escapeFallbackActive && pointerInsideStream);
+}
+
+export function didStreamPointerLockExit(
+  pointerLockWasActive: boolean,
+  pointerLockIsActive: boolean,
+): boolean {
+  return pointerLockWasActive && !pointerLockIsActive;
+}

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.ts
@@ -742,7 +742,10 @@ export class DomInputCaptureController {
       }
     };
 
-    const queueUnlockedAbsolutePointer = (event: MouseEvent | PointerEvent): void => {
+    const queueUnlockedAbsolutePointer = (
+      event: MouseEvent | PointerEvent,
+      flushAfterQueue = true,
+    ): void => {
       const rect = pointerLockTarget.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) {
         return;
@@ -756,7 +759,9 @@ export class DomInputCaptureController {
         : { x, y, width: rect.width, height: rect.height };
       this.pendingMouseTimestampUs = timestampUs(event.timeStamp);
       this.mouseCoalescedBatchEntries += 1;
-      afterPointerMovement();
+      if (flushAfterQueue) {
+        afterPointerMovement();
+      }
     };
 
     const tryAutoLock = (): void => {
@@ -1115,7 +1120,7 @@ export class DomInputCaptureController {
       }
       event.preventDefault();
       if (escapePointerFallbackActive && !isPointerLockActive()) {
-        queueUnlockedAbsolutePointer(event);
+        queueUnlockedAbsolutePointer(event, false);
       }
       flushMouse(true);
       const payload = this.dependencies.inputEncoder.encodeMouseButtonDown({
@@ -1140,7 +1145,7 @@ export class DomInputCaptureController {
       }
       event.preventDefault();
       if (escapePointerFallbackActive && !isPointerLockActive()) {
-        queueUnlockedAbsolutePointer(event);
+        queueUnlockedAbsolutePointer(event, false);
       }
       flushMouse(true);
       const payload = this.dependencies.inputEncoder.encodeMouseButtonUp({
@@ -1165,7 +1170,7 @@ export class DomInputCaptureController {
       }
       event.preventDefault();
       if (escapePointerFallbackActive && !isPointerLockActive()) {
-        queueUnlockedAbsolutePointer(event);
+        queueUnlockedAbsolutePointer(event, false);
       }
       flushMouse(true);
       // Official GFN client sends negated raw deltaY as int16 (no quantization to ±120).

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.ts
@@ -14,6 +14,12 @@ import {
 import { FULLSCREEN_KEYBOARD_LOCK_CODES } from "../keyboardLock";
 import { GfnCursorOverlayController } from "../cursorChannel";
 import {
+  canForwardStreamPointerInput,
+  didStreamPointerLockExit,
+  getStreamPointerLockTarget,
+  isStreamPointerLocked,
+} from "../../../lib/pointerLock";
+import {
   MouseDeltaFilter,
   quantizeMouseDeltaWithResidual,
   subsampleCoalescedPointerEvents,
@@ -426,7 +432,7 @@ export class DomInputCaptureController {
   install(videoElement: HTMLVideoElement): void {
     this.detach();
 
-    const pointerLockTarget = (videoElement.parentElement as HTMLElement | null) ?? videoElement;
+    const pointerLockTarget = getStreamPointerLockTarget(videoElement);
     const originalPointerLockTargetTabIndex = pointerLockTarget.getAttribute("tabindex");
     if (this.isNativeCursorOverlayEnabled()) {
       this.cursorOverlay = new GfnCursorOverlayController(videoElement);
@@ -445,10 +451,10 @@ export class DomInputCaptureController {
       }
     };
     const isPointerLockActive = (): boolean => {
-      const lockElement = document.pointerLockElement;
-      return lockElement === pointerLockTarget || lockElement === videoElement;
+      return isStreamPointerLocked(videoElement);
     };
-    this.cursorOverlay?.setPointerLocked(isPointerLockActive());
+    let pointerLockWasActive = isPointerLockActive();
+    this.cursorOverlay?.setPointerLocked(pointerLockWasActive);
 
     // Mirror mode: tracks whether the HW cursor is over the stream viewport.
     // Dual-source: coarse window focus/blur sets the initial state and handles
@@ -460,6 +466,7 @@ export class DomInputCaptureController {
     let lastAbsY: number | null = null;
     // Prevent repeated auto-lock attempts within the same focus session.
     let autoLockPending = false;
+    let escapePointerFallbackActive = false;
 
     // Track an approximate server-side absolute pointer position (in server
     // pixels — the remote stream's resolution) so we can align the server cursor
@@ -735,6 +742,23 @@ export class DomInputCaptureController {
       }
     };
 
+    const queueUnlockedAbsolutePointer = (event: MouseEvent | PointerEvent): void => {
+      const rect = pointerLockTarget.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) {
+        return;
+      }
+
+      const x = Math.max(0, Math.min(rect.width, event.clientX - rect.left));
+      const y = Math.max(0, Math.min(rect.height, event.clientY - rect.top));
+      this.cursorOverlay?.setClientPosition(rect.left + x, rect.top + y);
+      this.pendingMouseAbs = this.cursorOverlay?.isCursorVisible()
+        ? this.cursorOverlay.getAbsolutePosition()
+        : { x, y, width: rect.width, height: rect.height };
+      this.pendingMouseTimestampUs = timestampUs(event.timeStamp);
+      this.mouseCoalescedBatchEntries += 1;
+      afterPointerMovement();
+    };
+
     const tryAutoLock = (): void => {
       try {
         if (document?.body?.dataset?.sidebarOpen === "1") {
@@ -930,13 +954,14 @@ export class DomInputCaptureController {
         }
         processRelativePointerSamples([event]);
       } else if (mouseInStreamView) {
-        // Pointer lock disabled: keep local cursor tracking up to date without
-        // forwarding mouse movement into the stream.
         const rect = pointerLockTarget.getBoundingClientRect();
         const absX = event.clientX - rect.left;
         const absY = event.clientY - rect.top;
         lastAbsX = absX;
         lastAbsY = absY;
+        if (escapePointerFallbackActive) {
+          queueUnlockedAbsolutePointer(event);
+        }
       }
     };
 
@@ -948,13 +973,14 @@ export class DomInputCaptureController {
       if (isPointerLockActive()) {
         processRelativePointerSamples([event]);
       } else if (mouseInStreamView) {
-        // Pointer lock disabled: keep local cursor tracking up to date without
-        // forwarding mouse movement into the stream.
         const rect = pointerLockTarget.getBoundingClientRect();
         const absX = event.clientX - rect.left;
         const absY = event.clientY - rect.top;
         lastAbsX = absX;
         lastAbsY = absY;
+        if (escapePointerFallbackActive) {
+          queueUnlockedAbsolutePointer(event);
+        }
       }
     };
 
@@ -1080,10 +1106,15 @@ export class DomInputCaptureController {
       if (!this.dependencies.isInputReady()) {
         return;
       }
-      if (!isPointerLockActive()) {
+      if (!canForwardStreamPointerInput(
+        isPointerLockActive(),
+        escapePointerFallbackActive,
+        mouseInStreamView,
+      )) {
         return;
       }
       event.preventDefault();
+      flushMouse(true);
       const payload = this.dependencies.inputEncoder.encodeMouseButtonDown({
         button: toMouseButton(event.button),
         timestampUs: timestampUs(event.timeStamp),
@@ -1097,10 +1128,15 @@ export class DomInputCaptureController {
       if (!this.dependencies.isInputReady()) {
         return;
       }
-      if (!isPointerLockActive()) {
+      if (!canForwardStreamPointerInput(
+        isPointerLockActive(),
+        escapePointerFallbackActive,
+        mouseInStreamView,
+      )) {
         return;
       }
       event.preventDefault();
+      flushMouse(true);
       const payload = this.dependencies.inputEncoder.encodeMouseButtonUp({
         button: toMouseButton(event.button),
         timestampUs: timestampUs(event.timeStamp),
@@ -1114,10 +1150,15 @@ export class DomInputCaptureController {
       if (!this.dependencies.isInputReady()) {
         return;
       }
-      if (!isPointerLockActive()) {
+      if (!canForwardStreamPointerInput(
+        isPointerLockActive(),
+        escapePointerFallbackActive,
+        mouseInStreamView,
+      )) {
         return;
       }
       event.preventDefault();
+      flushMouse(true);
       // Official GFN client sends negated raw deltaY as int16 (no quantization to ±120).
       // Clamp to int16 range since browser deltaY can exceed it with fast scrolling.
       const delta = Math.max(-32768, Math.min(32767, Math.round(-event.deltaY)));
@@ -1171,7 +1212,10 @@ export class DomInputCaptureController {
     // Handle pointer lock changes — send synthetic Escape when lock is lost by browser
     // (matches official GFN client's "pointerLockEscape" feature)
     const onPointerLockChange = () => {
-      if (isPointerLockActive()) {
+      const pointerLockIsActive = isPointerLockActive();
+      if (pointerLockIsActive) {
+        pointerLockWasActive = true;
+        escapePointerFallbackActive = false;
         this.cursorOverlay?.setPointerLocked(true);
         // Pointer lock gained — cancel any pending synthetic Escape.
         // Reset absolute position tracking since we switch to relative movement.
@@ -1199,6 +1243,11 @@ export class DomInputCaptureController {
         return;
       }
 
+      if (!didStreamPointerLockExit(pointerLockWasActive, pointerLockIsActive)) {
+        return;
+      }
+      pointerLockWasActive = false;
+
       const suppressEscapeFullscreenGrace = this.suppressNextSyntheticEscape;
       this.cursorOverlay?.setPointerLocked(false);
 
@@ -1215,14 +1264,18 @@ export class DomInputCaptureController {
       if (!this.dependencies.isInputReady()) return;
 
       if (this.consumeSyntheticEscapeSuppression()) {
+        escapePointerFallbackActive = false;
         this.releasePressedKeys("pointer lock intentionally released");
         return;
       }
 
       if (!this.shouldSendSyntheticEscapeOnPointerLockLoss()) {
+        escapePointerFallbackActive = false;
         this.releasePressedKeys("pointer lock lost while unfocused");
         return;
       }
+
+      escapePointerFallbackActive = true;
 
       // VK 0x1B = 27 = Escape
       const escapeWasPressed = this.pressedKeys.has(0x1B);
@@ -1281,6 +1334,7 @@ export class DomInputCaptureController {
         return;
       }
       mouseInStreamView = false;
+      escapePointerFallbackActive = false;
       lastAbsX = null;
       lastAbsY = null;
       this.releasePressedKeys("window blur");
@@ -1294,6 +1348,7 @@ export class DomInputCaptureController {
 
     const onVisibilityChange = () => {
       if (document.visibilityState !== "visible") {
+        escapePointerFallbackActive = false;
         this.releasePressedKeys(`visibility ${document.visibilityState}`);
         this.dependencies.setWindowInputPaused(true);
         return;

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.ts
@@ -1114,6 +1114,9 @@ export class DomInputCaptureController {
         return;
       }
       event.preventDefault();
+      if (escapePointerFallbackActive && !isPointerLockActive()) {
+        queueUnlockedAbsolutePointer(event);
+      }
       flushMouse(true);
       const payload = this.dependencies.inputEncoder.encodeMouseButtonDown({
         button: toMouseButton(event.button),
@@ -1136,6 +1139,9 @@ export class DomInputCaptureController {
         return;
       }
       event.preventDefault();
+      if (escapePointerFallbackActive && !isPointerLockActive()) {
+        queueUnlockedAbsolutePointer(event);
+      }
       flushMouse(true);
       const payload = this.dependencies.inputEncoder.encodeMouseButtonUp({
         button: toMouseButton(event.button),
@@ -1158,6 +1164,9 @@ export class DomInputCaptureController {
         return;
       }
       event.preventDefault();
+      if (escapePointerFallbackActive && !isPointerLockActive()) {
+        queueUnlockedAbsolutePointer(event);
+      }
       flushMouse(true);
       // Official GFN client sends negated raw deltaY as int16 (no quantization to ±120).
       // Clamp to int16 range since browser deltaY can exceed it with fast scrolling.


### PR DESCRIPTION
Escape can release Chromium pointer lock before renderer input receives the key, which left mouse events disabled until the user completed another capture click. This keeps an Escape-specific fallback active while the pointer is unlocked, forwarding absolute movement, buttons, and wheel input so the in-game menu remains immediately interactive.

- Treat only real active-to-inactive pointer-lock transitions as Escape loss, avoiding duplicate synthetic Escape packets after failed re-lock attempts.
- Recognize the stream wrapper as the actual pointer-lock target so F8 and the quick menu correctly report and toggle capture.
- Cover pointer-lock target resolution, loss transitions, and fallback routing with focused tests.

Fixes #677

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/ac986a58-dbac-482d-9ec6-a8bf9eea0848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open OPE-283" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/thread/ac986a58-dbac-482d-9ec6-a8bf9eea0848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-283&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=OPE-283"><img alt="OPE-283" src="https://capy.ai/api/badge/thread.svg?label=OPE-283"></picture></a>
<!-- capy-pr-badge:end -->