### PR TITLE
fix(input): prevent recursive mouse flush scheduling

### DIFF
--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.test.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.test.ts
@@ -1,0 +1,222 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { INPUT_MOUSE_REL, InputEncoder } from "../inputProtocol";
+import { DomInputCaptureController } from "./domInputCaptureController";
+
+type Listener = (event: Record<string, unknown>) => void;
+
+class FakeEventTarget {
+  readonly listeners = new Map<string, Set<Listener>>();
+  parentElement: FakeEventTarget | null = null;
+  tabIndex = 0;
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject | Listener): void {
+    if (typeof listener !== "function") {
+      return;
+    }
+    let listeners = this.listeners.get(type);
+    if (!listeners) {
+      listeners = new Set();
+      this.listeners.set(type, listeners);
+    }
+    listeners.add(listener as Listener);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject | Listener): void {
+    if (typeof listener === "function") {
+      this.listeners.get(type)?.delete(listener as Listener);
+    }
+  }
+
+  dispatch(type: string, event: Record<string, unknown>): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  getAttribute(): string | null {
+    return null;
+  }
+
+  setAttribute(): void {}
+
+  removeAttribute(): void {}
+
+  focus(): void {}
+
+  getBoundingClientRect(): DOMRect {
+    return {
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 4,
+      bottom: 4,
+      width: 4,
+      height: 4,
+      toJSON: () => ({}),
+    };
+  }
+}
+
+function installMouseHarness(options: {
+  mouseSensitivity: number;
+  resolution: string;
+}): {
+  controller: DomInputCaptureController;
+  dispatchMouseMove: (movementX: number, timeStamp: number) => void;
+  pendingTimerCount: () => number;
+  runNextTimer: (nowMs: number) => void;
+  sentInputTypes: number[];
+  restoreGlobals: () => void;
+} {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalPointerEvent = Object.getOwnPropertyDescriptor(globalThis, "PointerEvent");
+  const originalPerformance = Object.getOwnPropertyDescriptor(globalThis, "performance");
+  const windowTarget = new FakeEventTarget();
+  const documentTarget = new FakeEventTarget();
+  const videoElement = new FakeEventTarget();
+  const pointerLockTarget = new FakeEventTarget();
+  videoElement.parentElement = pointerLockTarget;
+
+  let nowMs = 0;
+  let nextTimerId = 1;
+  const timers = new Map<number, () => void>();
+  const fakeWindow = Object.assign(windowTarget, {
+    setTimeout(callback: () => void): number {
+      const id = nextTimerId++;
+      timers.set(id, callback);
+      return id;
+    },
+    clearTimeout(id: number): void {
+      timers.delete(id);
+    },
+  });
+  const fakeDocument = Object.assign(documentTarget, {
+    body: { dataset: {} },
+    documentElement: new FakeEventTarget(),
+    fullscreenElement: null,
+    pointerLockElement: pointerLockTarget,
+    visibilityState: "visible",
+    hasFocus: () => true,
+    contains: () => false,
+  });
+
+  Object.defineProperty(globalThis, "window", { configurable: true, value: fakeWindow });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: fakeDocument });
+  Object.defineProperty(globalThis, "PointerEvent", { configurable: true, value: undefined });
+  Object.defineProperty(globalThis, "performance", {
+    configurable: true,
+    value: { now: () => nowMs },
+  });
+
+  const sentInputTypes: number[] = [];
+  const controller = new DomInputCaptureController(
+    {
+      videoElement: videoElement as unknown as HTMLVideoElement,
+      inputEncoder: new InputEncoder(),
+      isInputReady: () => true,
+      isInputBlocked: () => false,
+      isNativeInputActive: () => false,
+      isNativeElectronInputBridge: () => false,
+      shouldAutoFullscreen: () => false,
+      getCurrentResolution: () => options.resolution,
+      getKeyboardLayout: () => undefined,
+      getMicState: () => "disabled",
+      setWindowInputPaused: () => {},
+      recordSchedulingDelay: () => {},
+      refreshClipboardAvailability: async () => false,
+      sendReliableSingleInput: () => {},
+      sendReliable: () => {},
+      sendInputPacket: (_payload, inputType) => {
+        sentInputTypes.push(inputType);
+      },
+      onGamepadConnected: () => {},
+      onGamepadDisconnected: () => {},
+      log: () => {},
+    },
+    {
+      mouseSensitivity: options.mouseSensitivity,
+      mouseAccelerationPercent: 1,
+      nativeCursorOverlay: false,
+    },
+  );
+  controller.install(videoElement as unknown as HTMLVideoElement);
+
+  return {
+    controller,
+    dispatchMouseMove: (movementX, timeStamp) => {
+      windowTarget.dispatch("mousemove", {
+        movementX,
+        movementY: 0,
+        clientX: 0,
+        clientY: 0,
+        timeStamp,
+      });
+    },
+    pendingTimerCount: () => timers.size,
+    runNextTimer: (timerNowMs) => {
+      const entry = timers.entries().next().value;
+      assert.ok(entry);
+      const [id, callback] = entry;
+      timers.delete(id);
+      nowMs = timerNowMs;
+      callback();
+    },
+    sentInputTypes,
+    restoreGlobals: () => {
+      for (const [key, descriptor] of [
+        ["window", originalWindow],
+        ["document", originalDocument],
+        ["PointerEvent", originalPointerEvent],
+        ["performance", originalPerformance],
+      ] as const) {
+        if (descriptor) {
+          Object.defineProperty(globalThis, key, descriptor);
+        } else {
+          Reflect.deleteProperty(globalThis, key);
+        }
+      }
+    },
+  };
+}
+
+test("negative half-pixel residual parks without synchronous recursion and resumes on input", () => {
+  const harness = installMouseHarness({ mouseSensitivity: 0.5, resolution: "4x4" });
+  try {
+    harness.dispatchMouseMove(-1, 1);
+    assert.equal(harness.pendingTimerCount(), 1);
+    assert.doesNotThrow(() => harness.runNextTimer(16));
+    assert.deepEqual(harness.sentInputTypes, []);
+    assert.equal(harness.pendingTimerCount(), 0);
+    assert.equal(harness.controller.getMouseDiagnostics().residualMagnitude, 0.5);
+
+    harness.dispatchMouseMove(-1, 2);
+    assert.deepEqual(harness.sentInputTypes, [INPUT_MOUSE_REL]);
+    assert.equal(harness.controller.getMouseDiagnostics().residualMagnitude, 0);
+  } finally {
+    harness.restoreGlobals();
+  }
+});
+
+test("scaled-to-zero residual parks without synchronous recursion and resumes on input", () => {
+  const harness = installMouseHarness({ mouseSensitivity: 1, resolution: "1x1" });
+  try {
+    harness.dispatchMouseMove(1, 1);
+    assert.equal(harness.pendingTimerCount(), 1);
+    assert.doesNotThrow(() => harness.runNextTimer(16));
+    assert.deepEqual(harness.sentInputTypes, []);
+    assert.equal(harness.pendingTimerCount(), 0);
+    assert.equal(harness.controller.getMouseDiagnostics().residualMagnitude, 1);
+
+    harness.dispatchMouseMove(3, 2);
+    assert.deepEqual(harness.sentInputTypes, [INPUT_MOUSE_REL]);
+    assert.equal(harness.controller.getMouseDiagnostics().residualMagnitude, 0);
+  } finally {
+    harness.restoreGlobals();
+  }
+});

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/domInputCaptureController.ts
@@ -706,9 +706,6 @@ export class DomInputCaptureController {
       const elapsed = now - this.mouseFlushLastSendMs;
       if (this.mouseFlushIntervalMs <= 0 || elapsed >= this.mouseFlushIntervalMs) {
         flushMouse();
-        if (hasPendingMouseMovement()) {
-          scheduleMouseBatchFlush();
-        }
         return;
       }
 
@@ -718,15 +715,11 @@ export class DomInputCaptureController {
           flushMouse();
         } catch (err) {
           this.dependencies.log(`Mouse flush tick failed (non-fatal): ${String(err)}`);
-        } finally {
-          if (hasPendingMouseMovement()) {
-            scheduleMouseBatchFlush();
-          }
         }
       }, Math.max(0, this.mouseFlushIntervalMs - elapsed));
     };
 
-    /** Official GFN Cp(): after wm(), flush when the mouse batch transitions empty -> non-empty. */
+    /** Official GFN Cp(): flush on empty -> non-empty, or when new input makes a parked residual sendable. */
     const afterPointerMovement = (): void => {
       if (!hasPendingMouseMovement()) {
         return;
@@ -734,9 +727,6 @@ export class DomInputCaptureController {
       const elapsed = performance.now() - this.mouseFlushLastSendMs;
       if (this.mouseFlushIntervalMs <= 0 || elapsed >= this.mouseFlushIntervalMs) {
         flushMouse();
-        if (hasPendingMouseMovement()) {
-          scheduleMouseBatchFlush();
-        }
       } else {
         scheduleMouseBatchFlush();
       }
@@ -921,7 +911,10 @@ export class DomInputCaptureController {
       for (const sample of events) {
         queueMouseMovement(sample.movementX, sample.movementY, sample.timeStamp);
       }
-      if (!hadBatch && hasPendingMouseMovement()) {
+      if (
+        hasPendingMouseMovement()
+        && (!hadBatch || this.mouseFlushTimer === null)
+      ) {
         afterPointerMovement();
       }
     };


### PR DESCRIPTION
Mouse batching could synchronously reschedule an unsendable sub-pixel residual until the renderer exhausted its call stack. This change parks residual movement that cannot yet produce a packet and retries it when new pointer input makes it sendable, preserving coalescing precision without recursive timers.

Regression coverage exercises both negative half-pixel and resolution-scaled zero-delta cases, including their eventual delivery after additional movement.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->