### PR TITLE
fix(media): recover shader and audio playback

### DIFF
--- a/opennow-stable/src/renderer/src/platforms/gfn/videoShaderPipeline.test.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/videoShaderPipeline.test.ts
@@ -1,0 +1,243 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { VideoShaderPipeline } from "./videoShaderPipeline";
+
+class FakeWebGlContext {
+  readonly VERTEX_SHADER = 1;
+  readonly FRAGMENT_SHADER = 2;
+  readonly COMPILE_STATUS = 3;
+  readonly LINK_STATUS = 4;
+  readonly TEXTURE_2D = 5;
+  readonly TEXTURE_MIN_FILTER = 6;
+  readonly TEXTURE_MAG_FILTER = 7;
+  readonly LINEAR = 8;
+  readonly TEXTURE_WRAP_S = 9;
+  readonly TEXTURE_WRAP_T = 10;
+  readonly CLAMP_TO_EDGE = 11;
+  readonly TEXTURE0 = 12;
+  readonly RGBA = 13;
+  readonly UNSIGNED_BYTE = 14;
+  readonly SCISSOR_TEST = 15;
+  readonly COLOR_BUFFER_BIT = 16;
+  readonly TRIANGLES = 17;
+
+  lost = false;
+  programCreations = 0;
+  textureCreations = 0;
+  drawCalls = 0;
+
+  createShader(): WebGLShader {
+    return {} as WebGLShader;
+  }
+
+  shaderSource(): void {}
+  compileShader(): void {}
+  getShaderParameter(): boolean {
+    return true;
+  }
+  getShaderInfoLog(): string {
+    return "";
+  }
+  deleteShader(): void {}
+
+  createProgram(): WebGLProgram {
+    this.programCreations++;
+    return {} as WebGLProgram;
+  }
+
+  attachShader(): void {}
+  linkProgram(): void {}
+  getProgramParameter(): boolean {
+    return true;
+  }
+  getProgramInfoLog(): string {
+    return "";
+  }
+  deleteProgram(): void {}
+
+  createTexture(): WebGLTexture {
+    this.textureCreations++;
+    return {} as WebGLTexture;
+  }
+
+  bindTexture(): void {}
+  texParameteri(): void {}
+  useProgram(): void {}
+  getUniformLocation(): WebGLUniformLocation {
+    return {} as WebGLUniformLocation;
+  }
+  uniform1i(): void {}
+  activeTexture(): void {}
+  texImage2D(): void {}
+  viewport(): void {}
+  disable(): void {}
+  clearColor(): void {}
+  clear(): void {}
+  uniform2f(): void {}
+  uniform1f(): void {}
+
+  drawArrays(): void {
+    this.drawCalls++;
+  }
+
+  deleteTexture(): void {}
+  getExtension(): null {
+    return null;
+  }
+  isContextLost(): boolean {
+    return this.lost;
+  }
+}
+
+class FakeCanvas {
+  readonly style: Record<string, string> = {};
+  className = "";
+  width = 0;
+  height = 0;
+  removed = false;
+  private readonly listeners = new Map<string, Set<(event: Event) => void>>();
+
+  constructor(private readonly gl: FakeWebGlContext) {}
+
+  getContext(): WebGL2RenderingContext {
+    return this.gl as unknown as WebGL2RenderingContext;
+  }
+
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: Event) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatch(type: string): Event {
+    const event = new Event(type, { cancelable: true });
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+    return event;
+  }
+
+  remove(): void {
+    this.removed = true;
+  }
+}
+
+class FakeVideo {
+  videoWidth = 1920;
+  videoHeight = 1080;
+  readyState = 4;
+  insertedCanvas: FakeCanvas | null = null;
+  requestCount = 0;
+  private nextCallbackId = 1;
+  private readonly callbacks = new Map<number, VideoFrameRequestCallback>();
+
+  insertAdjacentElement(_position: string, canvas: Element): void {
+    this.insertedCanvas = canvas as unknown as FakeCanvas;
+  }
+
+  getBoundingClientRect(): DOMRect {
+    return { width: 1280, height: 720 } as DOMRect;
+  }
+
+  requestVideoFrameCallback(callback: VideoFrameRequestCallback): number {
+    const id = this.nextCallbackId++;
+    this.requestCount++;
+    this.callbacks.set(id, callback);
+    return id;
+  }
+
+  cancelVideoFrameCallback(): void {}
+
+  invokeCallback(id: number): void {
+    this.callbacks.get(id)?.(0, {} as VideoFrameCallbackMetadata);
+  }
+}
+
+function replaceGlobal(name: "document" | "window" | "ResizeObserver", value: unknown): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(globalThis, name, descriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, name);
+    }
+  };
+}
+
+test("shader context loss immediately reveals video and restores with a fresh render loop", () => {
+  const gl = new FakeWebGlContext();
+  const canvas = new FakeCanvas(gl);
+  const video = new FakeVideo();
+  const restoreGlobals = [
+    replaceGlobal("document", {
+      createElement: () => canvas,
+    }),
+    replaceGlobal("window", { devicePixelRatio: 1 }),
+    replaceGlobal("ResizeObserver", undefined),
+  ];
+
+  try {
+    const pipeline = new VideoShaderPipeline(video as unknown as HTMLVideoElement, {
+      enabled: true,
+      sharpen: 40,
+      saturation: 100,
+      contrast: 100,
+      brightness: 100,
+      vibrance: 0,
+      filmGrain: 0,
+    });
+
+    assert.equal(canvas.style.display, "none");
+    assert.equal(video.requestCount, 1);
+    video.invokeCallback(1);
+    assert.equal(canvas.style.display, "block");
+    assert.equal(pipeline.getCanvas(), canvas as unknown as HTMLCanvasElement);
+    assert.equal(gl.drawCalls, 1);
+
+    gl.lost = true;
+    const lostEvent = canvas.dispatch("webglcontextlost");
+    assert.equal(lostEvent.defaultPrevented, true);
+    assert.equal(canvas.style.display, "none");
+    assert.equal(pipeline.getCanvas(), null);
+    assert.equal(pipeline.isActive(), false);
+
+    gl.lost = false;
+    canvas.dispatch("webglcontextrestored");
+    assert.equal(gl.programCreations, 2);
+    assert.equal(gl.textureCreations, 2);
+    assert.equal(video.requestCount, 3);
+    assert.equal(canvas.style.display, "none");
+
+    video.invokeCallback(2);
+    assert.equal(video.requestCount, 3);
+    assert.equal(canvas.style.display, "none");
+
+    video.invokeCallback(3);
+    assert.equal(gl.drawCalls, 2);
+    assert.equal(video.requestCount, 4);
+    assert.equal(canvas.style.display, "block");
+
+    pipeline.dispose();
+    canvas.dispatch("webglcontextlost");
+    canvas.dispatch("webglcontextrestored");
+    assert.equal(canvas.removed, true);
+    assert.equal(gl.programCreations, 2);
+    assert.equal(video.requestCount, 4);
+  } finally {
+    for (const restore of restoreGlobals.reverse()) {
+      restore();
+    }
+  }
+});

--- a/opennow-stable/src/renderer/src/platforms/gfn/videoShaderPipeline.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/videoShaderPipeline.ts
@@ -131,8 +131,10 @@ export class VideoShaderPipeline {
   private active = false;
   private disposed = false;
   private contextFailed = false;
+  private contextLost = false;
   private frameCallbackId: number | null = null;
   private rafId: number | null = null;
+  private renderLoopGeneration = 0;
   private hasRenderedFrame = false;
   private readonly startTimeMs = performance.now();
 
@@ -151,6 +153,8 @@ export class VideoShaderPipeline {
     this.canvas.style.zIndex = "5";
     this.canvas.style.pointerEvents = "none";
     this.canvas.style.display = "none";
+    this.canvas.addEventListener("webglcontextlost", this.onContextLost);
+    this.canvas.addEventListener("webglcontextrestored", this.onContextRestored);
     videoElement.insertAdjacentElement("afterend", this.canvas);
 
     if (typeof ResizeObserver !== "undefined") {
@@ -180,6 +184,8 @@ export class VideoShaderPipeline {
     this.stopRenderLoop();
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    this.canvas.removeEventListener("webglcontextlost", this.onContextLost);
+    this.canvas.removeEventListener("webglcontextrestored", this.onContextRestored);
     if (this.gl) {
       if (this.texture) this.gl.deleteTexture(this.texture);
       if (this.program) this.gl.deleteProgram(this.program);
@@ -188,11 +194,16 @@ export class VideoShaderPipeline {
     this.gl = null;
     this.program = null;
     this.texture = null;
+    this.uniforms = null;
     this.canvas.remove();
   }
 
   private applyActivation(): void {
-    const shouldRun = !this.disposed && !this.contextFailed && videoShaderHasVisibleEffect(this.settings);
+    const shouldRun =
+      !this.disposed &&
+      !this.contextFailed &&
+      !this.contextLost &&
+      videoShaderHasVisibleEffect(this.settings);
     if (shouldRun === this.active) {
       return;
     }
@@ -243,12 +254,16 @@ export class VideoShaderPipeline {
     const vs = compile(gl.VERTEX_SHADER, VERTEX_SHADER);
     const fs = compile(gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
     if (!vs || !fs) {
+      if (vs) gl.deleteShader(vs);
+      if (fs) gl.deleteShader(fs);
       this.contextFailed = true;
       return false;
     }
 
     const program = gl.createProgram();
     if (!program) {
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
       this.contextFailed = true;
       return false;
     }
@@ -265,6 +280,11 @@ export class VideoShaderPipeline {
     }
 
     const texture = gl.createTexture();
+    if (!texture) {
+      gl.deleteProgram(program);
+      this.contextFailed = true;
+      return false;
+    }
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
@@ -285,21 +305,33 @@ export class VideoShaderPipeline {
     };
     gl.uniform1i(this.uniforms.frame, 0);
 
-    this.canvas.addEventListener("webglcontextlost", this.onContextLost);
-
     this.gl = gl;
     this.program = program;
     this.texture = texture;
+    this.contextFailed = false;
     return true;
   }
 
   private readonly onContextLost = (event: Event): void => {
     event.preventDefault();
-    console.warn("[VideoShader] WebGL context lost; shader pipeline disabled");
-    this.contextFailed = true;
+    this.canvas.style.display = "none";
+    this.hasRenderedFrame = false;
+    this.contextLost = true;
     this.gl = null;
     this.program = null;
     this.texture = null;
+    this.uniforms = null;
+    this.applyActivation();
+    console.warn("[VideoShader] WebGL context lost; showing unprocessed video");
+  };
+
+  private readonly onContextRestored = (): void => {
+    if (this.disposed || !this.contextLost) {
+      return;
+    }
+    this.contextLost = false;
+    this.contextFailed = false;
+    console.info("[VideoShader] WebGL context restored; reinitializing shader pipeline");
     this.applyActivation();
   };
 
@@ -317,18 +349,31 @@ export class VideoShaderPipeline {
 
   private startRenderLoop(): void {
     this.stopRenderLoop();
+    const generation = this.renderLoopGeneration;
     const video = this.videoElement;
     if (typeof video.requestVideoFrameCallback === "function") {
       const onFrame = (): void => {
-        if (!this.active || this.disposed) return;
+        if (generation !== this.renderLoopGeneration || !this.active || this.disposed) {
+          return;
+        }
+        this.frameCallbackId = null;
         this.renderFrame();
+        if (generation !== this.renderLoopGeneration || !this.active || this.disposed) {
+          return;
+        }
         this.frameCallbackId = video.requestVideoFrameCallback(onFrame);
       };
       this.frameCallbackId = video.requestVideoFrameCallback(onFrame);
     } else {
       const onRaf = (): void => {
-        if (!this.active || this.disposed) return;
+        if (generation !== this.renderLoopGeneration || !this.active || this.disposed) {
+          return;
+        }
+        this.rafId = null;
         this.renderFrame();
+        if (generation !== this.renderLoopGeneration || !this.active || this.disposed) {
+          return;
+        }
         this.rafId = requestAnimationFrame(onRaf);
       };
       this.rafId = requestAnimationFrame(onRaf);
@@ -336,6 +381,7 @@ export class VideoShaderPipeline {
   }
 
   private stopRenderLoop(): void {
+    this.renderLoopGeneration++;
     if (this.frameCallbackId !== null) {
       this.videoElement.cancelVideoFrameCallback?.(this.frameCallbackId);
       this.frameCallbackId = null;
@@ -349,7 +395,7 @@ export class VideoShaderPipeline {
   private renderFrame(): void {
     const gl = this.gl;
     const video = this.videoElement;
-    if (!gl || !this.program || !this.texture || !this.uniforms) return;
+    if (!gl || !this.program || !this.texture || !this.uniforms || gl.isContextLost()) return;
 
     const videoWidth = video.videoWidth;
     const videoHeight = video.videoHeight;
@@ -398,7 +444,7 @@ export class VideoShaderPipeline {
 
     gl.drawArrays(gl.TRIANGLES, 0, 3);
 
-    if (!this.hasRenderedFrame) {
+    if (!gl.isContextLost() && !this.hasRenderedFrame) {
       this.hasRenderedFrame = true;
       this.canvas.style.display = "block";
     }

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/peerMediaLifecycleController.test.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/peerMediaLifecycleController.test.ts
@@ -1,0 +1,266 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PeerMediaLifecycleController } from "./peerMediaLifecycleController";
+
+class FakeMediaStream {
+  private readonly tracks: MediaStreamTrack[] = [];
+
+  get active(): boolean {
+    return this.tracks.length > 0;
+  }
+
+  addTrack(track: MediaStreamTrack): void {
+    this.tracks.push(track);
+  }
+
+  removeTrack(track: MediaStreamTrack): void {
+    const index = this.tracks.indexOf(track);
+    if (index >= 0) {
+      this.tracks.splice(index, 1);
+    }
+  }
+
+  getTracks(): MediaStreamTrack[] {
+    return [...this.tracks];
+  }
+
+  getAudioTracks(): MediaStreamTrack[] {
+    return this.tracks.filter((track) => track.kind === "audio");
+  }
+
+  getVideoTracks(): MediaStreamTrack[] {
+    return this.tracks.filter((track) => track.kind === "video");
+  }
+}
+
+class FakeAudioNode {
+  disconnectCalls = 0;
+  connectedTo: unknown = null;
+
+  connect(destination: unknown): void {
+    this.connectedTo = destination;
+  }
+
+  disconnect(): void {
+    this.disconnectCalls++;
+    this.connectedTo = null;
+  }
+}
+
+class FakeGainNode extends FakeAudioNode {
+  readonly gain = { value: 1 };
+}
+
+class FakeAudioContext {
+  readonly source = new FakeAudioNode();
+  readonly gain = new FakeGainNode();
+  readonly destination = {};
+  readonly baseLatency = 0.004;
+  readonly sampleRate = 48000;
+  closeCalls = 0;
+  resumeCalls = 0;
+
+  constructor(
+    public state: AudioContextState,
+    private readonly resumeResult: () => Promise<void> = async () => {},
+  ) {}
+
+  createMediaStreamSource(): MediaStreamAudioSourceNode {
+    return this.source as unknown as MediaStreamAudioSourceNode;
+  }
+
+  createGain(): GainNode {
+    return this.gain as unknown as GainNode;
+  }
+
+  async resume(): Promise<void> {
+    this.resumeCalls++;
+    await this.resumeResult();
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls++;
+    this.state = "closed";
+  }
+}
+
+interface AudioElementFake {
+  muted: boolean;
+  volume: number;
+  srcObject: MediaProvider | null;
+  playCalls: number;
+  pauseCalls: number;
+  play: () => Promise<void>;
+  pause: () => void;
+}
+
+function createHarness(contexts: FakeAudioContext[]) {
+  const logs: string[] = [];
+  const audioElement: AudioElementFake = {
+    muted: false,
+    volume: 0,
+    srcObject: null,
+    playCalls: 0,
+    pauseCalls: 0,
+    play: async () => {
+      audioElement.playCalls++;
+    },
+    pause: () => {
+      audioElement.pauseCalls++;
+    },
+  };
+  const videoElement = { srcObject: null };
+  let contextIndex = 0;
+  const controller = new PeerMediaLifecycleController({
+    videoElement: videoElement as unknown as HTMLVideoElement,
+    audioElement: audioElement as unknown as HTMLAudioElement,
+    onRenderFrame: () => {},
+    log: (message) => logs.push(message),
+    createAudioContext: () => contexts[contextIndex++] as unknown as AudioContext,
+  });
+  return { audioElement, controller, logs };
+}
+
+function audioTrack(id: string): MediaStreamTrack {
+  return { id, kind: "audio" } as MediaStreamTrack;
+}
+
+function installMediaStreamFake(): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "MediaStream");
+  Object.defineProperty(globalThis, "MediaStream", {
+    configurable: true,
+    writable: true,
+    value: FakeMediaStream,
+  });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "MediaStream", descriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, "MediaStream");
+    }
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason: unknown) => void;
+} {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((_resolve, rejectPromise) => {
+    reject = rejectPromise;
+  });
+  return { promise, reject };
+}
+
+test("running Web Audio stays on the low-latency route without direct playback", () => {
+  const restoreMediaStream = installMediaStreamFake();
+  try {
+    const context = new FakeAudioContext("running");
+    const { audioElement, controller, logs } = createHarness([context]);
+
+    controller.attachTrack(audioTrack("running"));
+
+    assert.equal(context.resumeCalls, 0);
+    assert.equal(audioElement.muted, true);
+    assert.equal(audioElement.playCalls, 0);
+    assert.equal(context.source.connectedTo, context.gain);
+    assert.equal(context.gain.connectedTo, context.destination);
+    assert.ok(logs.some((message) => message.includes("Audio routed through AudioContext")));
+  } finally {
+    restoreMediaStream();
+  }
+});
+
+test("rejected AudioContext resume falls back after disconnecting Web Audio", async () => {
+  const restoreMediaStream = installMediaStreamFake();
+  try {
+    const context = new FakeAudioContext(
+      "suspended",
+      async () => Promise.reject(new Error("resume denied")),
+    );
+    const { audioElement, controller, logs } = createHarness([context]);
+
+    controller.attachTrack(audioTrack("rejected"));
+    assert.equal(audioElement.muted, true);
+    await flushPromises();
+
+    assert.equal(context.resumeCalls, 1);
+    assert.equal(context.source.disconnectCalls, 1);
+    assert.equal(context.gain.disconnectCalls, 1);
+    assert.equal(context.closeCalls, 1);
+    assert.equal(audioElement.muted, false);
+    assert.equal(audioElement.playCalls, 1);
+    assert.ok(logs.some((message) => message.includes("AudioContext resume failed")));
+  } finally {
+    restoreMediaStream();
+  }
+});
+
+test("AudioContext that remains suspended after resume falls back to direct playback", async () => {
+  const restoreMediaStream = installMediaStreamFake();
+  try {
+    const context = new FakeAudioContext("suspended");
+    const { audioElement, controller, logs } = createHarness([context]);
+
+    controller.attachTrack(audioTrack("suspended"));
+    await flushPromises();
+
+    assert.equal(context.resumeCalls, 1);
+    assert.equal(context.closeCalls, 1);
+    assert.equal(audioElement.muted, false);
+    assert.equal(audioElement.playCalls, 1);
+    assert.ok(logs.some((message) => message.includes("remained suspended after resume")));
+  } finally {
+    restoreMediaStream();
+  }
+});
+
+test("stale resume failure cannot override a replacement Web Audio route", async () => {
+  const restoreMediaStream = installMediaStreamFake();
+  try {
+    const pendingResume = deferred<void>();
+    const oldContext = new FakeAudioContext("suspended", () => pendingResume.promise);
+    const newContext = new FakeAudioContext("running");
+    const { audioElement, controller } = createHarness([oldContext, newContext]);
+
+    controller.attachTrack(audioTrack("old"));
+    controller.attachTrack(audioTrack("new"));
+    pendingResume.reject(new Error("late rejection"));
+    await flushPromises();
+
+    assert.equal(oldContext.closeCalls, 1);
+    assert.equal(newContext.closeCalls, 0);
+    assert.equal(audioElement.muted, true);
+    assert.equal(audioElement.playCalls, 0);
+    assert.equal(newContext.source.connectedTo, newContext.gain);
+  } finally {
+    restoreMediaStream();
+  }
+});
+
+test("reset invalidates pending resume fallback and leaves direct audio stopped", async () => {
+  const restoreMediaStream = installMediaStreamFake();
+  try {
+    const pendingResume = deferred<void>();
+    const context = new FakeAudioContext("suspended", () => pendingResume.promise);
+    const { audioElement, controller } = createHarness([context]);
+
+    controller.attachTrack(audioTrack("pending"));
+    controller.reset();
+    pendingResume.reject(new Error("late rejection"));
+    await flushPromises();
+
+    assert.equal(context.closeCalls, 1);
+    assert.equal(audioElement.muted, true);
+    assert.equal(audioElement.playCalls, 0);
+  } finally {
+    restoreMediaStream();
+  }
+});

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/peerMediaLifecycleController.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/peerMediaLifecycleController.ts
@@ -3,6 +3,7 @@ interface PeerMediaLifecycleDependencies {
   audioElement: HTMLAudioElement;
   onRenderFrame: () => void;
   log: (message: string) => void;
+  createAudioContext?: () => AudioContext;
 }
 
 export class PeerMediaLifecycleController {
@@ -11,6 +12,7 @@ export class PeerMediaLifecycleController {
   private audioContext: AudioContext | null = null;
   private audioSourceNode: MediaStreamAudioSourceNode | null = null;
   private audioGainNode: GainNode | null = null;
+  private audioRoutingGeneration = 0;
   private outputVolume = 1;
 
   constructor(private readonly dependencies: PeerMediaLifecycleDependencies) {
@@ -67,14 +69,15 @@ export class PeerMediaLifecycleController {
     }
 
     if (track.kind === "audio") {
-      this.replaceTrackInStream(this.audioStream, track);
       this.cleanupAudioRouting();
+      this.replaceTrackInStream(this.audioStream, track);
+      const generation = this.audioRoutingGeneration;
 
       let audioContext: AudioContext | null = null;
       let audioSourceNode: MediaStreamAudioSourceNode | null = null;
       let audioGainNode: GainNode | null = null;
       try {
-        audioContext = new AudioContext({
+        audioContext = this.dependencies.createAudioContext?.() ?? new AudioContext({
           latencyHint: "interactive",
           sampleRate: 48000,
         });
@@ -83,36 +86,34 @@ export class PeerMediaLifecycleController {
         audioGainNode.gain.value = this.outputVolume;
         audioSourceNode.connect(audioGainNode);
         audioGainNode.connect(audioContext.destination);
-        if (audioContext.state === "suspended") {
-          void audioContext.resume();
-        }
         this.audioContext = audioContext;
         this.audioSourceNode = audioSourceNode;
         this.audioGainNode = audioGainNode;
-        this.dependencies.log(
-          `Audio routed through AudioContext (latency: ${(audioContext.baseLatency * 1000).toFixed(1)}ms, sampleRate: ${audioContext.sampleRate}Hz)`,
-        );
+        if (audioContext.state === "running") {
+          this.logAudioContextRouting(audioContext);
+        } else {
+          void this.resumeAudioContext(
+            audioContext,
+            audioSourceNode,
+            audioGainNode,
+            track,
+            generation,
+          );
+        }
       } catch (error) {
-        if (audioSourceNode) {
-          try {
-            audioSourceNode.disconnect();
-          } catch {
-            // Ignore cleanup errors from a partially-created node.
-          }
+        if (this.audioContext === audioContext) {
+          this.audioContext = null;
+          this.audioSourceNode = null;
+          this.audioGainNode = null;
         }
-        if (audioGainNode) {
-          try {
-            audioGainNode.disconnect();
-          } catch {
-            // Ignore cleanup errors from a partially-created node.
-          }
+        this.releaseAudioGraph(audioContext, audioSourceNode, audioGainNode);
+        if (this.isCurrentAudioTrack(track, generation)) {
+          this.startDirectAudioPlayback(
+            `AudioContext creation failed, falling back to audio element: ${String(error)}`,
+            track,
+            generation,
+          );
         }
-        if (audioContext) {
-          void audioContext.close().catch(() => {});
-        }
-        this.startDirectAudioPlayback(
-          `AudioContext creation failed, falling back to audio element: ${String(error)}`,
-        );
       }
     }
   }
@@ -129,7 +130,6 @@ export class PeerMediaLifecycleController {
   }
 
   reset(): void {
-    this.cleanupAudioRouting();
     this.clearTracks();
   }
 
@@ -138,6 +138,7 @@ export class PeerMediaLifecycleController {
   }
 
   clearTracks(): void {
+    this.cleanupAudioRouting();
     for (const track of this.videoStream.getTracks()) {
       this.videoStream.removeTrack(track);
     }
@@ -160,41 +161,120 @@ export class PeerMediaLifecycleController {
   }
 
   private cleanupAudioRouting(): void {
-    if (this.audioSourceNode) {
-      try {
-        this.audioSourceNode.disconnect();
-      } catch {
-        // Ignore cleanup errors from an already-disconnected node.
-      }
-      this.audioSourceNode = null;
-    }
-    if (this.audioGainNode) {
-      try {
-        this.audioGainNode.disconnect();
-      } catch {
-        // Ignore cleanup errors from an already-disconnected node.
-      }
-      this.audioGainNode = null;
-    }
-    if (this.audioContext) {
-      void this.audioContext.close().catch(() => {});
-      this.audioContext = null;
-    }
+    this.audioRoutingGeneration++;
+    const audioContext = this.audioContext;
+    const audioSourceNode = this.audioSourceNode;
+    const audioGainNode = this.audioGainNode;
+    this.audioContext = null;
+    this.audioSourceNode = null;
+    this.audioGainNode = null;
+    this.releaseAudioGraph(audioContext, audioSourceNode, audioGainNode);
     this.dependencies.audioElement.pause();
     this.dependencies.audioElement.muted = true;
   }
 
-  private startDirectAudioPlayback(reason: string): void {
+  private releaseAudioGraph(
+    audioContext: AudioContext | null,
+    audioSourceNode: MediaStreamAudioSourceNode | null,
+    audioGainNode: GainNode | null,
+  ): void {
+    if (audioSourceNode) {
+      try {
+        audioSourceNode.disconnect();
+      } catch {
+        // Ignore cleanup errors from an already-disconnected node.
+      }
+    }
+    if (audioGainNode) {
+      try {
+        audioGainNode.disconnect();
+      } catch {
+        // Ignore cleanup errors from an already-disconnected node.
+      }
+    }
+    if (audioContext) {
+      try {
+        void audioContext.close().catch(() => {});
+      } catch {
+        // Ignore cleanup errors from a partially-created context.
+      }
+    }
+  }
+
+  private async resumeAudioContext(
+    audioContext: AudioContext,
+    audioSourceNode: MediaStreamAudioSourceNode,
+    audioGainNode: GainNode,
+    track: MediaStreamTrack,
+    generation: number,
+  ): Promise<void> {
+    let resumeError: unknown = null;
+    try {
+      await audioContext.resume();
+    } catch (error) {
+      resumeError = error;
+    }
+
+    if (
+      !this.isCurrentAudioTrack(track, generation) ||
+      this.audioContext !== audioContext ||
+      this.audioSourceNode !== audioSourceNode ||
+      this.audioGainNode !== audioGainNode
+    ) {
+      return;
+    }
+
+    if (audioContext.state === "running") {
+      this.logAudioContextRouting(audioContext);
+      return;
+    }
+
+    this.audioContext = null;
+    this.audioSourceNode = null;
+    this.audioGainNode = null;
+    const failedState = audioContext.state;
+    this.releaseAudioGraph(audioContext, audioSourceNode, audioGainNode);
+    const reason = resumeError
+      ? `AudioContext resume failed, falling back to audio element: ${String(resumeError)}`
+      : `AudioContext remained ${failedState} after resume, falling back to audio element`;
+    this.startDirectAudioPlayback(reason, track, generation);
+  }
+
+  private logAudioContextRouting(audioContext: AudioContext): void {
+    this.dependencies.log(
+      `Audio routed through AudioContext (latency: ${(audioContext.baseLatency * 1000).toFixed(1)}ms, sampleRate: ${audioContext.sampleRate}Hz)`,
+    );
+  }
+
+  private isCurrentAudioTrack(track: MediaStreamTrack, generation: number): boolean {
+    return (
+      generation === this.audioRoutingGeneration &&
+      this.audioStream.getAudioTracks()[0] === track
+    );
+  }
+
+  private startDirectAudioPlayback(
+    reason: string,
+    track: MediaStreamTrack,
+    generation: number,
+  ): void {
+    if (!this.isCurrentAudioTrack(track, generation)) {
+      return;
+    }
     this.dependencies.log(reason);
     this.dependencies.audioElement.muted = false;
     this.dependencies.audioElement.volume = this.outputVolume;
     this.dependencies.audioElement
       .play()
       .then(() => {
-        this.dependencies.log("Audio track attached (fallback)");
+        if (this.isCurrentAudioTrack(track, generation)) {
+          this.dependencies.log("Audio track attached (fallback)");
+        }
       })
       .catch((playError) => {
-        this.dependencies.log(`Audio autoplay blocked: ${String(playError)}`);
+        if (this.isCurrentAudioTrack(track, generation)) {
+          this.dependencies.log(`Audio autoplay blocked: ${String(playError)}`);
+        }
       });
   }
 }


### PR DESCRIPTION
Video-filter context loss could leave users with a black transition and permanently disable post-processing, while a suspended Web Audio context could keep game audio muted without reaching the direct-playback fallback.

- Reveal the underlying video immediately on WebGL context loss and safely rebuild shader resources after restoration.
- Guard render callbacks against stale context generations so a blank canvas is never promoted over live video.
- Verify `AudioContext.resume()` reaches a running state, otherwise tear down the graph and use direct audio playback.
- Protect asynchronous audio setup from track replacement and reset races.

Deterministic regression tests cover context loss/restoration, rejected or ineffective audio resumes, successful low-latency routing, and stale setup cleanup.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->