### PR TITLE
fix(main): tolerate closed output and streamer pipes

### DIFF
--- a/opennow-stable/src/main/nativeStreamer/manager.test.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import type {
+  NativeStreamerCapabilities,
+  NativeStreamerResponse,
+} from "@shared/nativeStreamer";
+import { NativeStreamerManager } from "./manager";
+import type { NativeStreamerCommandInput } from "./protocol";
+
+type WriteCallback = (error?: Error | null) => void;
+
+class FakeStdin extends EventEmitter {
+  destroyed = false;
+  writable = true;
+  writableEnded = false;
+  writableLength = 0;
+  writeImpl: (
+    chunk: string,
+    encoding: string,
+    callback: WriteCallback,
+  ) => boolean = () => true;
+
+  write(chunk: string, encoding: string, callback: WriteCallback): boolean {
+    return this.writeImpl(chunk, encoding, callback);
+  }
+}
+
+interface FakeChild {
+  child: ChildProcessWithoutNullStreams;
+  stdin: FakeStdin;
+  wasKilled(): boolean;
+}
+
+interface ManagerInternals {
+  child: ChildProcessWithoutNullStreams | null;
+  activeSessionId: string | null;
+  capabilities: NativeStreamerCapabilities | null;
+  pending: Map<string, unknown>;
+  request(
+    input: NativeStreamerCommandInput,
+    timeoutMs: number,
+  ): Promise<NativeStreamerResponse>;
+  installStdinErrorHandler(child: ChildProcessWithoutNullStreams): void;
+}
+
+function createFakeChild(): FakeChild {
+  const stdin = new FakeStdin();
+  let killed = false;
+  const child = {
+    stdin,
+    get killed() {
+      return killed;
+    },
+    kill() {
+      killed = true;
+      return true;
+    },
+  } as unknown as ChildProcessWithoutNullStreams;
+  return {
+    child,
+    stdin,
+    wasKilled: () => killed,
+  };
+}
+
+function createManager(): {
+  manager: NativeStreamerManager;
+  internals: ManagerInternals;
+} {
+  const manager = new NativeStreamerManager({
+    mainDir: "",
+    getBackendPreference: () => "auto",
+    getVideoBackendPreference: () => "auto",
+    getExecutablePathOverride: () => "",
+    getCloudGsyncMode: () => "auto",
+    getD3dFullscreenMode: () => "auto",
+    getExternalRendererEnabled: () => false,
+    sendAnswer: async () => undefined,
+    sendIceCandidate: async () => undefined,
+    requestKeyframe: async () => undefined,
+    emit: () => undefined,
+  });
+  return {
+    manager,
+    internals: manager as unknown as ManagerInternals,
+  };
+}
+
+function writeError(code: string): NodeJS.ErrnoException {
+  const error = new Error(`${code}: write failed`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+test("command writes reject and clear pending state after a synchronous broken pipe", async () => {
+  const { internals } = createManager();
+  const fake = createFakeChild();
+  const failure = writeError("EPIPE");
+  fake.stdin.writeImpl = () => {
+    throw failure;
+  };
+  internals.child = fake.child;
+
+  await assert.rejects(
+    internals.request({ type: "stop", reason: "test" }, 1_000),
+    (error) => error === failure,
+  );
+  assert.equal(internals.pending.size, 0);
+  assert.equal(internals.child, null);
+  assert.equal(fake.wasKilled(), true);
+});
+
+test("stdin error events reject every pending request and remain handled after exit", async () => {
+  const { internals } = createManager();
+  const fake = createFakeChild();
+  internals.child = fake.child;
+  internals.installStdinErrorHandler(fake.child);
+
+  const first = internals.request({ type: "stop", reason: "first" }, 1_000);
+  const second = internals.request({ type: "stop", reason: "second" }, 1_000);
+  assert.equal(internals.pending.size, 2);
+
+  const failure = writeError("EIO");
+  fake.stdin.emit("error", failure);
+
+  await Promise.all([
+    assert.rejects(first, (error) => error === failure),
+    assert.rejects(second, (error) => error === failure),
+  ]);
+  assert.equal(internals.pending.size, 0);
+  assert.equal(internals.child, null);
+  assert.doesNotThrow(() => fake.stdin.emit("error", writeError("EPIPE")));
+});
+
+test("input writes tolerate a child exit race but still throw unrelated failures", () => {
+  const { manager, internals } = createManager();
+  const fake = createFakeChild();
+  internals.child = fake.child;
+  internals.activeSessionId = "session";
+  internals.capabilities = {
+    protocolVersion: 4,
+    backend: "gstreamer",
+    supportsOfferAnswer: true,
+    supportsRemoteIce: true,
+    supportsLocalIce: true,
+    supportsInput: true,
+  };
+  fake.stdin.writeImpl = () => {
+    throw writeError("ERR_STREAM_DESTROYED");
+  };
+
+  assert.doesNotThrow(() => manager.sendInput({
+    payloadBase64: "AQ==",
+    partiallyReliable: true,
+  }));
+  assert.equal(internals.child, null);
+
+  const programmingFailure = new Error("bad writable implementation");
+  const secondFake = createFakeChild();
+  secondFake.stdin.writeImpl = () => {
+    throw programmingFailure;
+  };
+  internals.child = secondFake.child;
+  internals.activeSessionId = "session";
+  internals.capabilities = {
+    protocolVersion: 4,
+    backend: "gstreamer",
+    supportsOfferAnswer: true,
+    supportsRemoteIce: true,
+    supportsLocalIce: true,
+    supportsInput: true,
+  };
+
+  assert.throws(
+    () => manager.sendInput({ payloadBase64: "AQ==" }),
+    (error) => error === programmingFailure,
+  );
+  assert.equal(internals.child, secondFake.child);
+});
+
+test("unrelated synchronous command write failures reject only their request", async () => {
+  const { internals } = createManager();
+  const fake = createFakeChild();
+  const failure = new Error("bad writable implementation");
+  fake.stdin.writeImpl = () => {
+    throw failure;
+  };
+  internals.child = fake.child;
+
+  await assert.rejects(
+    internals.request({ type: "stop", reason: "test" }, 1_000),
+    (error) => error === failure,
+  );
+  assert.equal(internals.pending.size, 0);
+  assert.equal(internals.child, fake.child);
+});

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -1,4 +1,4 @@
-import { app } from "electron";
+import electron from "electron";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
@@ -28,6 +28,7 @@ import {
   type NativeStreamerMessage,
   type NativeStreamerResponse,
 } from "@shared/nativeStreamer";
+import { isTerminalBrokenWriteError } from "@shared/logger";
 import type { NativeStreamerShortcutBindings } from "@shared/gfn";
 import {
   createNativeStreamerDetectionFailureStatus,
@@ -42,6 +43,8 @@ import {
 } from "./protocol";
 import { createNativeStreamerRuntimeEnvironment } from "./runtime";
 import { NativeSurfaceUpdateQueue } from "./surfaceUpdateQueue";
+
+const { app } = electron;
 
 interface NativeStreamerCallbacks {
   sendAnswer(payload: SendAnswerRequest): Promise<void>;
@@ -76,6 +79,10 @@ const STOP_TIMEOUT_MS = 1200;
 const MAX_INPUT_STDIN_BUFFER_BYTES = 64 * 1024;
 const MIN_NATIVE_BITRATE_KBPS = 5_000;
 const MAX_NATIVE_BITRATE_KBPS = 150_000;
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
 
 function normalizeBitrateKbps(value: number): number {
   if (!Number.isFinite(value)) {
@@ -248,6 +255,8 @@ export class NativeStreamerManager {
       !child
       || child.killed
       || !child.stdin.writable
+      || child.stdin.destroyed
+      || child.stdin.writableEnded
       || !this.activeSessionId
       || !this.capabilities?.supportsInput
     ) {
@@ -268,12 +277,28 @@ export class NativeStreamerManager {
       input,
     } satisfies NativeStreamerCommand;
 
-    const flushed = child.stdin.write(`${JSON.stringify(payload)}\n`, "utf8", (error) => {
-      if (error && !this.inputBackpressureWarned) {
-        this.inputBackpressureWarned = true;
-        console.warn("[NativeStreamer] Failed to write native input:", error);
+    let writeFailed = false;
+    let flushed: boolean;
+    try {
+      flushed = child.stdin.write(`${JSON.stringify(payload)}\n`, "utf8", (error) => {
+        if (!error) {
+          return;
+        }
+        writeFailed = true;
+        this.handleStdinFailure(child, error);
+      });
+    } catch (error) {
+      const writeError = toError(error);
+      if (!isTerminalBrokenWriteError(writeError, child.stdin)) {
+        throw error;
       }
-    });
+      this.handleStdinFailure(child, writeError);
+      return;
+    }
+
+    if (writeFailed) {
+      return;
+    }
 
     if (!flushed && !this.inputBackpressureWarned) {
       this.inputBackpressureWarned = true;
@@ -474,6 +499,7 @@ export class NativeStreamerManager {
     this.child = child;
     this.stdoutBuffer = "";
     this.stderrTail = [];
+    this.inputBackpressureWarned = false;
 
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => this.handleStdout(chunk));
@@ -486,15 +512,16 @@ export class NativeStreamerManager {
         }
       }
     });
+    this.installStdinErrorHandler(child);
 
     child.once("error", (error) => {
       this.options.emit({ type: "error", message: `Native streamer failed to start: ${formatError(error)}` });
-      this.handleProcessExit(`spawn error: ${formatError(error)}`);
+      this.handleProcessExit(child, `spawn error: ${formatError(error)}`);
     });
 
     child.once("exit", (code, signal) => {
       const reason = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
-      this.handleProcessExit(reason);
+      this.handleProcessExit(child, reason);
     });
 
     const helloTimeoutMs = runtimeStatus.bundled ? BUNDLED_GSTREAMER_HELLO_TIMEOUT_MS : HELLO_TIMEOUT_MS;
@@ -534,7 +561,13 @@ export class NativeStreamerManager {
 
   private request(input: NativeStreamerCommandInput, timeoutMs: number): Promise<NativeStreamerResponse> {
     const child = this.child;
-    if (!child || child.killed || !child.stdin.writable) {
+    if (
+      !child
+      || child.killed
+      || !child.stdin.writable
+      || child.stdin.destroyed
+      || child.stdin.writableEnded
+    ) {
       return Promise.reject(new Error("Native streamer process is not running."));
     }
 
@@ -560,16 +593,20 @@ export class NativeStreamerManager {
         timeout,
       });
 
-      child.stdin.write(`${JSON.stringify(payload)}\n`, "utf8", (error) => {
-        if (!error) {
+      try {
+        child.stdin.write(`${JSON.stringify(payload)}\n`, "utf8", (error) => {
+          if (error) {
+            this.handleStdinFailure(child, error);
+          }
+        });
+      } catch (error) {
+        const writeError = toError(error);
+        if (isTerminalBrokenWriteError(writeError, child.stdin)) {
+          this.handleStdinFailure(child, writeError);
           return;
         }
-        const pending = this.pending.get(id);
-        if (pending) {
-          this.pending.delete(id);
-          pending.reject(error);
-        }
-      });
+        this.rejectPendingRequest(id, writeError);
+      }
     });
   }
 
@@ -742,8 +779,40 @@ export class NativeStreamerManager {
     }
   }
 
-  private handleProcessExit(reason: string): void {
-    if (!this.child) {
+  private handleStdinFailure(
+    child: ChildProcessWithoutNullStreams,
+    error: Error,
+  ): void {
+    if (this.child !== child) {
+      return;
+    }
+
+    if (!isTerminalBrokenWriteError(error, child.stdin)) {
+      console.error("[NativeStreamer] Streamer stdin failed:", error);
+    }
+
+    this.rejectPending(error);
+    this.handleProcessExit(child, `stdin error: ${formatError(error)}`);
+    if (!child.killed) {
+      try {
+        child.kill();
+      } catch (killError) {
+        console.warn("[NativeStreamer] Failed to terminate process after stdin failure:", killError);
+      }
+    }
+  }
+
+  private installStdinErrorHandler(child: ChildProcessWithoutNullStreams): void {
+    child.stdin.on("error", (error) => {
+      this.handleStdinFailure(child, error);
+    });
+  }
+
+  private handleProcessExit(
+    child: ChildProcessWithoutNullStreams,
+    reason: string,
+  ): void {
+    if (this.child !== child) {
       return;
     }
 
@@ -756,6 +825,7 @@ export class NativeStreamerManager {
     this.stderrTail = [];
     this.activeSessionId = null;
     this.capabilities = null;
+    this.inputBackpressureWarned = false;
     this.surfaceUpdates.markNotReady();
     this.clearQueuedRemoteIce();
     this.rejectPending(new Error(`Native streamer process ended (${reason}).${tail}`));
@@ -776,11 +846,21 @@ export class NativeStreamerManager {
   }
 
   private rejectPending(error: Error): void {
-    for (const [id, pending] of this.pending.entries()) {
+    const pendingRequests = [...this.pending.values()];
+    this.pending.clear();
+    for (const pending of pendingRequests) {
       clearTimeout(pending.timeout);
       pending.reject(error);
-      this.pending.delete(id);
     }
+  }
+
+  private rejectPendingRequest(id: string, error: Error): void {
+    const pending = this.pending.get(id);
+    if (!pending) {
+      return;
+    }
+    this.pending.delete(id);
+    pending.reject(error);
   }
 
   private async flushQueuedLocalIce(): Promise<void> {

--- a/opennow-stable/src/shared/logger.test.ts
+++ b/opennow-stable/src/shared/logger.test.ts
@@ -1,0 +1,118 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { LogCapture } from "./logger";
+
+type ConsoleOutputStreams = NonNullable<ConstructorParameters<typeof LogCapture>[1]>;
+
+class FakeOutputStream extends EventEmitter {
+  destroyed = false;
+  writable = true;
+  writableEnded = false;
+}
+
+function writeError(code: string, message = "write failed"): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+function streams(): {
+  outputStreams: ConsoleOutputStreams;
+  stdout: FakeOutputStream;
+  stderr: FakeOutputStream;
+} {
+  const stdout = new FakeOutputStream();
+  const stderr = new FakeOutputStream();
+  return {
+    outputStreams: { stdout, stderr },
+    stdout,
+    stderr,
+  };
+}
+
+test("captures logs when the original console method synchronously hits a broken pipe", () => {
+  const originalLog = console.log;
+  const { outputStreams } = streams();
+  const capture = new LogCapture("test", outputStreams);
+  console.log = () => {
+    throw writeError("EPIPE");
+  };
+
+  try {
+    capture.interceptConsole();
+    assert.doesNotThrow(() => console.log("[PostHog] still captured"));
+    assert.equal(capture.getCount(), 1);
+    assert.equal(capture.getEntries()[0]?.message, "still captured");
+  } finally {
+    capture.restoreConsole();
+    console.log = originalLog;
+  }
+});
+
+test("captures logs when a console stream asynchronously reports an I/O write error", async () => {
+  const originalLog = console.log;
+  const { outputStreams, stdout } = streams();
+  const capture = new LogCapture("test", outputStreams);
+  console.log = () => {
+    setImmediate(() => stdout.emit("error", writeError("EIO", "EIO: i/o error, write")));
+  };
+
+  try {
+    capture.interceptConsole();
+    console.log("[PostHog] async failure");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(capture.getCount(), 1);
+    assert.equal(capture.getEntries()[0]?.message, "async failure");
+  } finally {
+    capture.restoreConsole();
+    console.log = originalLog;
+  }
+});
+
+test("does not suppress unrelated synchronous console failures", () => {
+  const originalError = console.error;
+  const { outputStreams } = streams();
+  const capture = new LogCapture("test", outputStreams);
+  const failure = new Error("console formatter failed");
+  console.error = () => {
+    throw failure;
+  };
+
+  try {
+    capture.interceptConsole();
+    assert.throws(() => console.error("bad log"), (error) => error === failure);
+    assert.equal(capture.getCount(), 1);
+  } finally {
+    capture.restoreConsole();
+    console.error = originalError;
+  }
+});
+
+test("leaves unrelated asynchronous stream errors to existing reporters", async () => {
+  const originalWarn = console.warn;
+  const { outputStreams, stderr } = streams();
+  const capture = new LogCapture("test", outputStreams);
+  const failure = new Error("unexpected stream implementation failure");
+  let reported: unknown;
+  stderr.on("error", (error) => {
+    reported = error;
+  });
+  console.warn = () => {
+    setImmediate(() => stderr.emit("error", failure));
+  };
+
+  try {
+    capture.interceptConsole();
+    console.warn("bad log");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(reported, failure);
+    assert.equal(capture.getCount(), 1);
+  } finally {
+    capture.restoreConsole();
+    console.warn = originalWarn;
+  }
+});

--- a/opennow-stable/src/shared/logger.ts
+++ b/opennow-stable/src/shared/logger.ts
@@ -11,6 +11,28 @@ export interface LogEntry {
   args: unknown[];
 }
 
+interface ConsoleOutputStream {
+  destroyed?: boolean;
+  writable?: boolean;
+  writableEnded?: boolean;
+  on?(event: "error", listener: (error: unknown) => void): unknown;
+  removeListener?(event: "error", listener: (error: unknown) => void): unknown;
+  listeners?(event: "error"): unknown[];
+}
+
+interface ConsoleOutputStreams {
+  stdout?: ConsoleOutputStream;
+  stderr?: ConsoleOutputStream;
+}
+
+const BROKEN_WRITE_ERROR_CODES = new Set([
+  "EIO",
+  "EPIPE",
+  "ERR_STREAM_DESTROYED",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ERR_STREAM_WRITE_AFTER_END",
+]);
+
 /** Maximum number of log entries to keep in memory */
 const MAX_LOG_ENTRIES = 5000;
 
@@ -95,15 +117,53 @@ export function createRedactedLogExport(entries: LogEntry[]): string {
   return lines.join("\n");
 }
 
+export function isTerminalBrokenWriteError(
+  error: unknown,
+  stream?: Pick<ConsoleOutputStream, "destroyed" | "writable" | "writableEnded">,
+): boolean {
+  if (!error || (typeof error !== "object" && typeof error !== "function")) {
+    return false;
+  }
+
+  const code = "code" in error && typeof error.code === "string" ? error.code : "";
+  if (BROKEN_WRITE_ERROR_CODES.has(code)) {
+    return true;
+  }
+
+  if (!stream?.destroyed && stream?.writable !== false && !stream?.writableEnded) {
+    return false;
+  }
+
+  const message = "message" in error && typeof error.message === "string" ? error.message : "";
+  return /broken pipe|destroyed stream|stream (?:was )?destroyed|write after end|write.*(?:closed|ended|stream)/i.test(message);
+}
+
+function getProcessOutputStreams(): ConsoleOutputStreams {
+  const runtimeProcess = (globalThis as {
+    process?: ConsoleOutputStreams;
+  }).process;
+  return {
+    stdout: runtimeProcess?.stdout,
+    stderr: runtimeProcess?.stderr,
+  };
+}
+
 /**
  * Logger class that captures console output
  */
 export class LogCapture {
   private entries: LogEntry[] = [];
   private originalConsole: Partial<typeof console> | null = null;
+  private streamErrorListeners: Array<{
+    stream: ConsoleOutputStream;
+    listener: (error: unknown) => void;
+  }> = [];
   private processName: string;
 
-  constructor(processName: string) {
+  constructor(
+    processName: string,
+    private readonly outputStreams: ConsoleOutputStreams = getProcessOutputStreams(),
+  ) {
     this.processName = processName;
   }
 
@@ -163,6 +223,7 @@ export class LogCapture {
       info: console.info,
       debug: console.debug,
     };
+    this.installStreamErrorHandlers();
 
     // Extract prefix from first argument if it's a string like "[Module] message"
     const extractPrefix = (args: unknown[]): { prefix: string; message: string; rest: unknown[] } => {
@@ -183,35 +244,82 @@ export class LogCapture {
       };
     };
 
+    const forward = (level: LogEntry["level"], args: unknown[]): void => {
+      const method = this.originalConsole?.[level];
+      if (!method) {
+        return;
+      }
+
+      const stream = level === "error" || level === "warn"
+        ? this.outputStreams.stderr
+        : this.outputStreams.stdout;
+      try {
+        method.apply(console, args);
+      } catch (error) {
+        if (!isTerminalBrokenWriteError(error, stream)) {
+          throw error;
+        }
+      }
+    };
+
     console.log = (...args: unknown[]) => {
       const { prefix, message, rest } = extractPrefix(args);
       this.addEntry("log", prefix, message, rest);
-      this.originalConsole?.log?.apply(console, args);
+      forward("log", args);
     };
 
     console.error = (...args: unknown[]) => {
       const { prefix, message, rest } = extractPrefix(args);
       this.addEntry("error", prefix, message, rest);
-      this.originalConsole?.error?.apply(console, args);
+      forward("error", args);
     };
 
     console.warn = (...args: unknown[]) => {
       const { prefix, message, rest } = extractPrefix(args);
       this.addEntry("warn", prefix, message, rest);
-      this.originalConsole?.warn?.apply(console, args);
+      forward("warn", args);
     };
 
     console.info = (...args: unknown[]) => {
       const { prefix, message, rest } = extractPrefix(args);
       this.addEntry("info", prefix, message, rest);
-      this.originalConsole?.info?.apply(console, args);
+      forward("info", args);
     };
 
     console.debug = (...args: unknown[]) => {
       const { prefix, message, rest } = extractPrefix(args);
       this.addEntry("debug", prefix, message, rest);
-      this.originalConsole?.debug?.apply(console, args);
+      forward("debug", args);
     };
+  }
+
+  private installStreamErrorHandlers(): void {
+    const streams = new Set(
+      [this.outputStreams.stdout, this.outputStreams.stderr].filter(
+        (stream): stream is ConsoleOutputStream => Boolean(stream),
+      ),
+    );
+
+    for (const stream of streams) {
+      if (!stream.on) {
+        continue;
+      }
+
+      const listener = (error: unknown): void => {
+        if (isTerminalBrokenWriteError(error, stream)) {
+          return;
+        }
+
+        const otherErrorListeners = stream.listeners?.("error").filter(
+          (candidate) => candidate !== listener,
+        );
+        if (!otherErrorListeners || otherErrorListeners.length === 0) {
+          throw error;
+        }
+      };
+      stream.on("error", listener);
+      this.streamErrorListeners.push({ stream, listener });
+    }
   }
 
   /**
@@ -224,6 +332,10 @@ export class LogCapture {
       if (this.originalConsole.warn) console.warn = this.originalConsole.warn;
       if (this.originalConsole.info) console.info = this.originalConsole.info;
       if (this.originalConsole.debug) console.debug = this.originalConsole.debug;
+      for (const { stream, listener } of this.streamErrorListeners) {
+        stream.removeListener?.("error", listener);
+      }
+      this.streamErrorListeners = [];
       this.originalConsole = null;
     }
   }


### PR DESCRIPTION
Closed stdout/stderr and native-streamer stdin races were surfacing as uncaught `EPIPE` and `EIO` exceptions in production.

- Keep capturing console entries in memory while suppressing only terminal broken-stream write failures; unrelated output errors still propagate.
- Guard native input and command writes against destroyed/ended stdin and handle asynchronous stream errors.
- Reject and clear pending native requests deterministically when the child pipe fails, while ignoring stale errors from replaced child processes.

Focused tests cover synchronous and asynchronous pipe failures, normal error propagation, pending cleanup, and stale-child behavior.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->