### PR TITLE
fix(main): harden auth and external lifecycle

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -427,6 +427,7 @@ function createMainWindowDeps() {
     setNativeRawInputOwnsEscape: (ownsEscape: boolean) => {
       nativeRawInputOwnsEscapeRuntime = ownsEscape;
     },
+    isAppShutdownRequested: () => isShutdownRequested,
   };
 }
 

--- a/opennow-stable/src/main/ipc/coreHandlers.ts
+++ b/opennow-stable/src/main/ipc/coreHandlers.ts
@@ -41,7 +41,7 @@ import type { AppUpdaterController } from "../updater";
 import type { SignalingCoordinator } from "../signaling/signalingCoordinator";
 import { fetchThanksData } from "../thanks/fetchThanksData";
 import { applyTelemetrySettingsChange, syncMainTelemetry } from "../telemetry/posthog";
-import { openExternalHttpUrl } from "../window/externalUrl";
+import { openExplicitExternalUrl } from "../window/externalUrl";
 
 type DiscordMonitor = {
   start(): void;
@@ -165,7 +165,7 @@ export function registerCoreIpcHandlers(deps: CoreIpcHandlerDeps): void {
   ipcMain.handle(
     IPC_CHANNELS.OPEN_EXTERNAL_URL,
     async (_event, url: string): Promise<void> => {
-      await openExternalHttpUrl(url);
+      await openExplicitExternalUrl(url);
     },
   );
 

--- a/opennow-stable/src/main/platforms/gfn/auth.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth.ts
@@ -26,7 +26,7 @@ import {
   exchangeAuthorizationCode,
   findAvailablePort,
   generatePkce,
-  waitForAuthorizationCode,
+  openAuthorizationUrlAndWaitForCode,
 } from "./auth/oauthFlow";
 import { PersistedAccountState } from "./auth/persistedAccountState";
 import {
@@ -221,9 +221,12 @@ export class AuthService {
     const { verifier, challenge } = generatePkce();
     const port = await findAvailablePort();
     const authUrl = buildAuthUrl(provider, challenge, port);
-    const codePromise = waitForAuthorizationCode(port, 120000);
-    await shell.openExternal(authUrl);
-    const code = await codePromise;
+    const code = await openAuthorizationUrlAndWaitForCode(
+      authUrl,
+      port,
+      120000,
+      (url) => shell.openExternal(url),
+    );
     const initialTokens = await exchangeAuthorizationCode(code, verifier, port);
     const session = await this.buildLoginSession(initialTokens, provider);
     return this.saveLoginSession(session);

--- a/opennow-stable/src/main/platforms/gfn/auth/oauthFlow.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/oauthFlow.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+
+import {
+  openAuthorizationUrlAndWaitForCode,
+  waitForAuthorizationCode,
+} from "./oauthFlow";
+
+async function getAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Unable to allocate test port"));
+        return;
+      }
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(address.port);
+      });
+    });
+  });
+}
+
+async function assertPortCanBeReused(port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  });
+}
+
+test("browser launch failure cancels and closes the OAuth callback waiter", async () => {
+  const port = await getAvailablePort();
+  const browserError = new Error("No default browser is available");
+
+  await assert.rejects(
+    openAuthorizationUrlAndWaitForCode(
+      "https://login.example/authorize",
+      port,
+      10_000,
+      async () => {
+        throw browserError;
+      },
+    ),
+    (error) => error === browserError,
+  );
+
+  await assertPortCanBeReused(port);
+});
+
+test("OAuth callback timeout closes the server and reports a useful error", async () => {
+  const port = await getAvailablePort();
+
+  await assert.rejects(
+    waitForAuthorizationCode(port, 20),
+    /Timed out waiting for OAuth callback/,
+  );
+
+  await assertPortCanBeReused(port);
+});
+
+test("aborting OAuth callback waiting closes the server", async () => {
+  const port = await getAvailablePort();
+  const abortController = new AbortController();
+  const codePromise = waitForAuthorizationCode(
+    port,
+    10_000,
+    abortController.signal,
+  );
+  abortController.abort();
+
+  await assert.rejects(codePromise, /OAuth login was cancelled/);
+  await assertPortCanBeReused(port);
+});

--- a/opennow-stable/src/main/platforms/gfn/auth/oauthFlow.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/oauthFlow.ts
@@ -79,8 +79,16 @@ export async function findAvailablePort(): Promise<number> {
   throw new Error("No available OAuth callback ports");
 }
 
-export async function waitForAuthorizationCode(port: number, timeoutMs: number): Promise<string> {
+export async function waitForAuthorizationCode(
+  port: number,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<string> {
   return new Promise((resolve, reject) => {
+    let timer: NodeJS.Timeout | null = null;
+    let listenPending = true;
+    let pendingResult: string | Error | undefined;
+    let settlementStarted = false;
     const server = createServer((request, response) => {
       const url = new URL(request.url ?? "/", `http://localhost:${port}`);
       const code = url.searchParams.get("code");
@@ -94,25 +102,107 @@ export async function waitForAuthorizationCode(port: number, timeoutMs: number):
 
       response.statusCode = 200;
       response.setHeader("Content-Type", "text/html; charset=utf-8");
-      response.end(html);
-
-      server.close(() => {
-        if (code) {
-          resolve(code);
-          return;
-        }
-        reject(new Error(error ?? "Authorization failed"));
+      response.setHeader("Connection", "close");
+      response.end(html, () => {
+        finish(code ?? new Error(error ?? "Authorization failed"));
       });
     });
 
-    server.listen(port, "127.0.0.1", () => {
-      const timer = setTimeout(() => {
-        server.close(() => reject(new Error("Timed out waiting for OAuth callback")));
-      }, timeoutMs);
+    const settle = (result: string | Error): void => {
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(result);
+      }
+    };
 
-      server.once("close", () => clearTimeout(timer));
+    const closeAndSettle = (): void => {
+      if (settlementStarted || pendingResult === undefined) return;
+      settlementStarted = true;
+      const result = pendingResult;
+      if (!server.listening) {
+        settle(result);
+        return;
+      }
+
+      try {
+        server.close(() => settle(result));
+        server.closeAllConnections();
+      } catch {
+        settle(result);
+      }
+    };
+
+    const finish = (result: string | Error): void => {
+      if (pendingResult !== undefined) return;
+      pendingResult = result;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      signal?.removeEventListener("abort", handleAbort);
+      if (!listenPending) {
+        closeAndSettle();
+      }
+    };
+
+    const handleAbort = (): void => {
+      finish(new Error("OAuth login was cancelled."));
+    };
+
+    server.once("error", (error) => {
+      listenPending = false;
+      finish(error);
+      closeAndSettle();
     });
+    server.listen(port, "127.0.0.1", () => {
+      listenPending = false;
+      if (pendingResult !== undefined) {
+        closeAndSettle();
+        return;
+      }
+      timer = setTimeout(() => {
+        finish(new Error("Timed out waiting for OAuth callback"));
+      }, timeoutMs);
+    });
+
+    if (signal?.aborted) {
+      handleAbort();
+    } else {
+      signal?.addEventListener("abort", handleAbort, { once: true });
+    }
   });
+}
+
+export async function openAuthorizationUrlAndWaitForCode(
+  authUrl: string,
+  port: number,
+  timeoutMs: number,
+  openExternal: (url: string) => Promise<void>,
+): Promise<string> {
+  const abortController = new AbortController();
+  const resultPromise = waitForAuthorizationCode(
+    port,
+    timeoutMs,
+    abortController.signal,
+  ).then(
+    (code) => ({ code }),
+    (error: unknown) => ({ error }),
+  );
+
+  try {
+    await openExternal(authUrl);
+  } catch (error) {
+    abortController.abort();
+    await resultPromise;
+    throw error;
+  }
+
+  const result = await resultPromise;
+  if ("error" in result) {
+    throw result.error;
+  }
+  return result.code;
 }
 
 export async function exchangeAuthorizationCode(

--- a/opennow-stable/src/main/window/externalUrl.test.ts
+++ b/opennow-stable/src/main/window/externalUrl.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseExplicitExternalUrl,
+  parseExternalHttpUrl,
+} from "./externalUrlPolicy";
+
+test("automatic external URLs remain limited to HTTP(S)", () => {
+  assert.equal(parseExternalHttpUrl("https://store.steampowered.com/app/1").protocol, "https:");
+  assert.throws(() => parseExternalHttpUrl("steam://store/1"));
+  assert.throws(() => parseExternalHttpUrl("file:///tmp/example"));
+  assert.throws(() => parseExternalHttpUrl("javascript:alert(1)"));
+});
+
+test("explicit external URLs allow only known launchers for Windows", () => {
+  assert.equal(parseExplicitExternalUrl("steam://store/1", "win32").protocol, "steam:");
+  assert.equal(
+    parseExplicitExternalUrl("com.epicgames.launcher://store/product/example", "win32").protocol,
+    "com.epicgames.launcher:",
+  );
+  assert.equal(
+    parseExplicitExternalUrl("ms-windows-store://pdp/?productid=example", "win32").protocol,
+    "ms-windows-store:",
+  );
+  assert.throws(() => parseExplicitExternalUrl("macappstore://itunes.apple.com/app/id1", "win32"));
+});
+
+test("explicit external URLs allow only known launchers for macOS", () => {
+  assert.equal(parseExplicitExternalUrl("steam://store/1", "darwin").protocol, "steam:");
+  assert.equal(
+    parseExplicitExternalUrl("itms-apps://itunes.apple.com/app/id1", "darwin").protocol,
+    "itms-apps:",
+  );
+  assert.equal(
+    parseExplicitExternalUrl("macappstore://itunes.apple.com/app/id1", "darwin").protocol,
+    "macappstore:",
+  );
+  assert.throws(() => parseExplicitExternalUrl("ms-windows-store://pdp/", "darwin"));
+});
+
+test("explicit external URLs reject arbitrary and dangerous schemes", () => {
+  for (const url of [
+    "file:///tmp/example",
+    "javascript:alert(1)",
+    "data:text/html,example",
+    "arbitrary-launcher://store/example",
+  ]) {
+    assert.throws(() => parseExplicitExternalUrl(url, "win32"));
+    assert.throws(() => parseExplicitExternalUrl(url, "darwin"));
+  }
+  assert.throws(() => parseExplicitExternalUrl("steam://store/1", "linux"));
+});

--- a/opennow-stable/src/main/window/externalUrl.ts
+++ b/opennow-stable/src/main/window/externalUrl.ts
@@ -1,14 +1,10 @@
 import { shell } from "electron";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-
-export function parseExternalHttpUrl(url: string): URL {
-  const parsed = new URL(url);
-  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-    throw new Error("Only HTTP(S) external URLs can be opened.");
-  }
-  return parsed;
-}
+import {
+  parseExplicitExternalUrl,
+  parseExternalHttpUrl,
+} from "./externalUrlPolicy";
 
 export function isAppNavigationUrl(url: string, mainDir: string): boolean {
   try {
@@ -27,4 +23,8 @@ export function isAppNavigationUrl(url: string, mainDir: string): boolean {
 
 export async function openExternalHttpUrl(url: string): Promise<void> {
   await shell.openExternal(parseExternalHttpUrl(url).toString());
+}
+
+export async function openExplicitExternalUrl(url: string): Promise<void> {
+  await shell.openExternal(parseExplicitExternalUrl(url).toString());
 }

--- a/opennow-stable/src/main/window/externalUrlPolicy.ts
+++ b/opennow-stable/src/main/window/externalUrlPolicy.ts
@@ -1,0 +1,35 @@
+export function parseExternalHttpUrl(url: string): URL {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("Only HTTP(S) external URLs can be opened.");
+  }
+  return parsed;
+}
+
+const LAUNCHER_PROTOCOLS: Partial<Record<NodeJS.Platform, ReadonlySet<string>>> = {
+  darwin: new Set([
+    "com.epicgames.launcher:",
+    "itms-apps:",
+    "macappstore:",
+    "steam:",
+  ]),
+  win32: new Set([
+    "com.epicgames.launcher:",
+    "ms-windows-store:",
+    "steam:",
+  ]),
+};
+
+export function parseExplicitExternalUrl(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): URL {
+  const parsed = new URL(url);
+  if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+    return parsed;
+  }
+  if (LAUNCHER_PROTOCOLS[platform]?.has(parsed.protocol)) {
+    return parsed;
+  }
+  throw new Error("Only HTTP(S) and supported store launcher URLs can be opened.");
+}

--- a/opennow-stable/src/main/window/mainWindow.ts
+++ b/opennow-stable/src/main/window/mainWindow.ts
@@ -13,6 +13,7 @@ import {
 } from "../escapeFullscreenGuard";
 import { captureMainException } from "../telemetry/posthog";
 import { isAppNavigationUrl, openExternalHttpUrl } from "./externalUrl";
+import { shouldReportRendererTermination } from "./rendererLifecycle";
 
 export interface CreateMainWindowDeps {
   mainDir: string;
@@ -31,6 +32,7 @@ export interface CreateMainWindowDeps {
   setStreamInputActive(active: boolean): void;
   getNativeRawInputOwnsEscape(): boolean;
   setNativeRawInputOwnsEscape(ownsEscape: boolean): void;
+  isAppShutdownRequested(): boolean;
 }
 
 export async function createMainWindow(
@@ -82,6 +84,15 @@ export async function createMainWindow(
   deps.setMainWindow(window);
 
   window.webContents.on("render-process-gone", (_event, details) => {
+    if (
+      !shouldReportRendererTermination(
+        details.reason,
+        deps.isAppShutdownRequested(),
+      )
+    ) {
+      console.log("[Main] Renderer process exited during shutdown:", details);
+      return;
+    }
     console.error("[Main] Renderer process gone:", details);
     captureMainException(new Error(`Renderer process gone: ${details.reason}`), {
       reason: details.reason,

--- a/opennow-stable/src/main/window/rendererLifecycle.test.ts
+++ b/opennow-stable/src/main/window/rendererLifecycle.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldReportRendererTermination } from "./rendererLifecycle";
+
+test("suppresses renderer termination after app shutdown is requested", () => {
+  for (const reason of ["clean-exit", "killed", "crashed", "oom"] as const) {
+    assert.equal(shouldReportRendererTermination(reason, true), false);
+  }
+});
+
+test("reports unexpected killed, crashed, and OOM renderers", () => {
+  for (const reason of ["killed", "crashed", "oom"] as const) {
+    assert.equal(shouldReportRendererTermination(reason, false), true);
+  }
+});
+
+test("preserves reporting for renderer exits when shutdown was not requested", () => {
+  assert.equal(shouldReportRendererTermination("clean-exit", false), true);
+  assert.equal(shouldReportRendererTermination("abnormal-exit", false), true);
+});

--- a/opennow-stable/src/main/window/rendererLifecycle.ts
+++ b/opennow-stable/src/main/window/rendererLifecycle.ts
@@ -1,0 +1,8 @@
+import type { RenderProcessGoneDetails } from "electron";
+
+export function shouldReportRendererTermination(
+  _reason: RenderProcessGoneDetails["reason"],
+  appShutdownRequested: boolean,
+): boolean {
+  return !appShutdownRequested;
+}


### PR DESCRIPTION
OAuth and external-link lifecycle failures could leave callback work unobserved, produce misleading shutdown telemetry, or block legitimate user-selected store launcher URLs.

- Make browser OAuth startup and callback waiting one coordinated operation that always clears timers, closes the loopback server, and observes cancellation or launch failures.
- Suppress renderer-termination exceptions only after an app shutdown has already been requested; unexpected crashes, kills, and OOM exits remain reportable.
- Permit a narrow platform-specific allowlist of store launcher schemes for explicit IPC requests while keeping automatic navigation restricted to HTTP(S) and rejecting dangerous or arbitrary protocols.

Focused tests cover OAuth success/failure/timeout cleanup, renderer lifecycle classification, and external URL policy boundaries.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->