### PR TITLE
Align web stream SDP and BWE with official GFN

### DIFF
--- a/opennow-stable/src/main/platforms/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/cloudmatch.test.ts
@@ -118,6 +118,11 @@ test("CloudMatch uses official streaming feature enum values", () => {
     prefilterSharpness: 0,
     prefilterNoiseReduction: 0,
     hudStreamingMode: 0,
+    maxBitrateKbps: 75000,
+    codec: 2,
+    vsync: false,
+    dynamicStreamingMode: 3,
+    audioChannelCount: 2,
   });
 });
 
@@ -143,13 +148,6 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
   const originalFetch = globalThis.fetch;
   const originalWarn = console.warn;
   const calls: string[] = [];
-  type CapturedNetworkTestRequestBody = {
-    netTestRequestData: {
-      netTestProfile: {
-        framesPerSecond: number;
-      };
-    };
-  };
   type CapturedSessionRequestBody = {
     sessionRequestData: {
       networkTestSessionId?: string | null;
@@ -161,10 +159,14 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
       requestedStreamingFeatures: {
         bitDepth?: number;
         chromaFormat?: number;
+        maxBitrateKbps?: number;
+        codec?: number;
+        vsync?: boolean;
+        dynamicStreamingMode?: number;
+        audioChannelCount?: number;
       };
     };
   };
-  let networkTestRequestBody: CapturedNetworkTestRequestBody | null = null;
   let requestBody: CapturedSessionRequestBody | null = null;
   const expectedSessionUrl = `https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?${new URLSearchParams({
     keyboardLayout: resolveGfnKeyboardLayout(DEFAULT_KEYBOARD_LAYOUT, process.platform),
@@ -185,18 +187,6 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
           { key: "US West", value: "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/" },
           { key: "US East", value: "https://np-ash-01.cloudmatchbeta.nvidiagrid.net/" },
         ],
-      }), { status: 200 });
-    }
-
-    if (url === "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession") {
-      networkTestRequestBody = JSON.parse(String(init?.body));
-      return new Response(JSON.stringify({
-        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
-        netTestSession: {
-          sessionId: "nettest-1",
-          connectionInfo: [{ ip: "127.0.0.1", port: 443, appLevelProtocol: 5 }],
-          netTestThresholds: {},
-        },
       }), { status: 200 });
     }
 
@@ -244,20 +234,21 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
     assert.equal(session.enablePersistingInGameSettings, false);
     assert.deepEqual(calls, [
       "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
-      "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession",
       expectedSessionUrl,
     ]);
-    const capturedNetworkTestRequestBody = networkTestRequestBody as CapturedNetworkTestRequestBody | null;
-    assert.ok(capturedNetworkTestRequestBody);
-    assert.equal(capturedNetworkTestRequestBody.netTestRequestData.netTestProfile.framesPerSecond, 90);
     const capturedRequestBody = requestBody as CapturedSessionRequestBody | null;
     assert.ok(capturedRequestBody);
     assert.equal(capturedRequestBody.sessionRequestData.clientRequestMonitorSettings[0]?.framesPerSecond, 90);
     assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.bitDepth, 1);
     assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.chromaFormat, 1);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.maxBitrateKbps, 75000);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.codec, 2);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.vsync, false);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.dynamicStreamingMode, 3);
+    assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.audioChannelCount, 2);
     assert.equal(capturedRequestBody.sessionRequestData.appLaunchMode, 2);
     assert.equal(capturedRequestBody.sessionRequestData.enablePersistingInGameSettings, false);
-    assert.equal(capturedRequestBody.sessionRequestData.networkTestSessionId, "nettest-1");
+    assert.equal(capturedRequestBody.sessionRequestData.networkTestSessionId, null);
   } finally {
     globalThis.fetch = originalFetch;
     console.warn = originalWarn;
@@ -292,17 +283,6 @@ test("CloudMatch retries transient serverInfo failures before creating a session
           { key: "gfn-regions", value: "US West" },
           { key: "US West", value: "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/" },
         ],
-      }), { status: 200 });
-    }
-
-    if (url === "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession") {
-      return new Response(JSON.stringify({
-        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
-        netTestSession: {
-          sessionId: "nettest-retry",
-          connectionInfo: [{ ip: "127.0.0.1", port: 443, appLevelProtocol: 5 }],
-          netTestThresholds: {},
-        },
       }), { status: 200 });
     }
 
@@ -348,7 +328,6 @@ test("CloudMatch retries transient serverInfo failures before creating a session
     assert.deepEqual(calls, [
       "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
       "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
-      "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession",
       expectedSessionUrl,
     ]);
   } finally {
@@ -376,17 +355,6 @@ test("CloudMatch only sends in-game settings persistence when user opt-in and ga
 
   globalThis.fetch = (async (input, init) => {
     const url = String(input);
-    if (url === "https://np-test.example.test/v2/nettestsession") {
-      return new Response(JSON.stringify({
-        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-TEST" },
-        netTestSession: {
-          sessionId: "nettest-persistence",
-          connectionInfo: [{ ip: "127.0.0.1", port: 443, appLevelProtocol: 5 }],
-          netTestThresholds: {},
-        },
-      }), { status: 200 });
-    }
-
     if (url !== expectedSessionUrl) {
       throw new Error(`Unexpected fetch: ${url}`);
     }

--- a/opennow-stable/src/main/platforms/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/platforms/gfn/cloudmatch.ts
@@ -48,7 +48,6 @@ import {
 import {
   buildClaimRequestBody,
   buildSessionRequestBody,
-  createNetworkTestSession,
 } from "./cloudmatchSessionRequest";
 import {
   echoedSessionAppLaunchMode,
@@ -100,20 +99,12 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
     deviceId,
     input.proxyUrl,
   );
-  const networkTestSessionId = await createNetworkTestSession({
-    base,
-    token: input.token,
-    clientId,
-    deviceId,
-    settings: input.settings,
-    proxyUrl: input.proxyUrl,
-  });
-  const body = buildSessionRequestBody(input, deviceId, networkTestSessionId);
+  const body = buildSessionRequestBody(input, deviceId, null);
   console.log(
     `[CloudMatch] createSession in-game settings persistence: user=${input.enablePersistingInGameSettings === true}, ` +
     `gameSupport=${input.supportsInGameSettingsPersistence === true}, ` +
     `sent=${body.sessionRequestData.enablePersistingInGameSettings}, ` +
-    `networkTestSessionId=${networkTestSessionId ?? "none"}`,
+    "networkTestSessionId=none",
   );
 
   const keyboardLayout = resolveGfnKeyboardLayout(input.settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);

--- a/opennow-stable/src/main/platforms/gfn/cloudmatchFeatures.ts
+++ b/opennow-stable/src/main/platforms/gfn/cloudmatchFeatures.ts
@@ -1,4 +1,9 @@
-import type { AppLaunchMode, SessionCreateRequest, StreamSettings } from "@shared/gfn";
+import type {
+  AppLaunchMode,
+  SessionCreateRequest,
+  StreamSettings,
+  VideoCodec,
+} from "@shared/gfn";
 import { DEFAULT_MINIMUM_FPS_FOR_REFLEX_WITHOUT_VRR } from "@shared/cloudGsync";
 
 import type { CloudMatchRequest } from "./types";
@@ -36,7 +41,25 @@ export function buildRequestedStreamingFeatures(
     prefilterSharpness: 0,
     prefilterNoiseReduction: 0,
     hudStreamingMode: 0,
+    maxBitrateKbps: Math.round(settings.maxBitrateMbps * 1000),
+    codec: codecWireValue(settings.codec),
+    vsync: false,
+    dynamicStreamingMode: 3,
+    audioChannelCount: 2,
   };
+}
+
+export function codecWireValue(codec: VideoCodec): number {
+  switch (codec) {
+    case "H264":
+      return 1;
+    case "H265":
+      return 2;
+    case "AV1":
+      return 3;
+    default:
+      return 0;
+  }
 }
 
 export function shouldRequestReflex(settings: StreamSettings): boolean {

--- a/opennow-stable/src/main/platforms/gfn/cloudmatchSessionRequest.ts
+++ b/opennow-stable/src/main/platforms/gfn/cloudmatchSessionRequest.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { createHash } from "node:crypto";
 
 import type { SessionCreateRequest, StreamSettings } from "@shared/gfn";
 import {
@@ -8,7 +7,6 @@ import {
 } from "@shared/gfn";
 
 import type { CloudMatchRequest } from "./types";
-import { buildGfnCloudMatchHeaders } from "./clientHeaders";
 import { resolveGfnDeviceIdentity } from "./deviceIdentity";
 import { getStableDeviceId } from "./deviceId";
 import {
@@ -16,40 +14,6 @@ import {
   buildRequestedStreamingFeatures,
   shouldEnableInGameSettingsPersistence,
 } from "./cloudmatchFeatures";
-import {
-  fetchCloudMatch,
-  formatErrorForLog,
-} from "./cloudmatchTransport";
-
-const NETWORK_TEST_SESSION_TIMEOUT_MS = 8_000;
-const NETWORK_TEST_SESSION_CACHE_TTL_MS = 30 * 60 * 1000;
-
-const networkTestSessionCache = new Map<string, { sessionId: string; expiresAt: number }>();
-
-interface NetworkTestSessionResponse {
-  requestStatus?: {
-    statusCode?: number;
-    statusDescription?: string;
-    serverId?: string;
-  };
-  netTestSession?: {
-    sessionId?: string;
-    connectionInfo?: Array<{
-      ip?: string;
-      port?: number;
-      appLevelProtocol?: number;
-    }>;
-    netTestThresholds?: {
-      recommendedBandwidthMBPS?: number;
-      requiredBandwidthMBPS?: number;
-      recommendedLatencyMS?: number;
-      requiredLatencyMS?: number;
-      recommendedPacketLossPct?: number;
-      requiredPacketLossPct?: number;
-    };
-    serverId?: string;
-  };
-}
 
 export function parseResolution(input: string): { width: number; height: number } {
   const [rawWidth, rawHeight] = input.split("x");
@@ -61,115 +25,6 @@ export function parseResolution(input: string): { width: number; height: number 
   }
 
   return { width, height };
-}
-
-function networkTestSessionCacheKey(base: string, settings: StreamSettings, token: string, proxyUrl?: string): string {
-  const { width, height } = parseResolution(settings.resolution);
-  const identityHash = createHash("sha256")
-    .update(token)
-    .update("\0")
-    .update(proxyUrl ?? "")
-    .digest("hex")
-    .slice(0, 16);
-  return `${base}\0${width}x${height}@${settings.fps}\0${identityHash}`;
-}
-
-export function getCachedNetworkTestSessionId(base: string, settings: StreamSettings, token: string, proxyUrl?: string): string | null {
-  const cacheKey = networkTestSessionCacheKey(base, settings, token, proxyUrl);
-  const cached = networkTestSessionCache.get(cacheKey);
-  if (!cached) {
-    return null;
-  }
-
-  if (cached.expiresAt <= Date.now()) {
-    networkTestSessionCache.delete(cacheKey);
-    return null;
-  }
-
-  return cached.sessionId;
-}
-
-export function cacheNetworkTestSessionId(
-  base: string,
-  settings: StreamSettings,
-  token: string,
-  sessionId: string,
-  proxyUrl?: string,
-): void {
-  networkTestSessionCache.set(networkTestSessionCacheKey(base, settings, token, proxyUrl), {
-    sessionId,
-    expiresAt: Date.now() + NETWORK_TEST_SESSION_CACHE_TTL_MS,
-  });
-}
-
-export async function createNetworkTestSession(input: {
-  base: string;
-  token: string;
-  clientId: string;
-  deviceId: string;
-  settings: StreamSettings;
-  proxyUrl?: string;
-}): Promise<string | null> {
-  const cached = getCachedNetworkTestSessionId(input.base, input.settings, input.token, input.proxyUrl);
-  if (cached) {
-    return cached;
-  }
-
-  const { width, height } = parseResolution(input.settings.resolution);
-  const { clientPlatformName } = resolveGfnDeviceIdentity();
-  const body = {
-    netTestRequestData: {
-      clientPlatformName,
-      netTestProfile: {
-        widthInPixels: width,
-        heightInPixels: height,
-        framesPerSecond: input.settings.fps,
-      },
-    },
-  };
-
-  try {
-    const response = await fetchCloudMatch(`${input.base}/v2/nettestsession`, {
-      method: "POST",
-      headers: buildGfnCloudMatchHeaders({
-        token: input.token,
-        clientId: input.clientId,
-        deviceId: input.deviceId,
-        includeOrigin: true,
-      }),
-      body: JSON.stringify(body),
-    }, {
-      proxyUrl: input.proxyUrl,
-      timeoutMs: NETWORK_TEST_SESSION_TIMEOUT_MS,
-      retries: 0,
-    });
-
-    if (!response.ok) {
-      console.warn(`[CloudMatch] nettestsession failed HTTP ${response.status}: ${(await response.text()).slice(0, 200)}`);
-      return null;
-    }
-
-    const payload = (await response.json()) as NetworkTestSessionResponse;
-    if (payload.requestStatus?.statusCode !== 1) {
-      console.warn(
-        `[CloudMatch] nettestsession API error: ${payload.requestStatus?.statusCode ?? "unknown"} ` +
-        `${payload.requestStatus?.statusDescription ?? ""}`.trim(),
-      );
-      return null;
-    }
-
-    const sessionId = payload.netTestSession?.sessionId?.trim();
-    if (!sessionId) {
-      console.warn("[CloudMatch] nettestsession response did not include a sessionId");
-      return null;
-    }
-
-    cacheNetworkTestSessionId(input.base, input.settings, input.token, sessionId, input.proxyUrl);
-    return sessionId;
-  } catch (error) {
-    console.warn(`[CloudMatch] nettestsession creation failed: ${formatErrorForLog(error)}`);
-    return null;
-  }
 }
 
 export function timezoneOffsetMs(): number {

--- a/opennow-stable/src/main/platforms/gfn/types.ts
+++ b/opennow-stable/src/main/platforms/gfn/types.ts
@@ -67,6 +67,11 @@ export interface CloudMatchRequest {
       hudStreamingMode?: number;
       sdrColorSpace?: number;
       hdrColorSpace?: number;
+      maxBitrateKbps?: number;
+      codec?: number;
+      vsync?: boolean;
+      dynamicStreamingMode?: number;
+      audioChannelCount?: number;
     };
   };
 }

--- a/opennow-stable/src/renderer/src/platforms/gfn/sdp/nvstOffer.test.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/sdp/nvstOffer.test.ts
@@ -28,31 +28,27 @@ test("buildNvstSdp includes stream quality and partially reliable input paramete
     "a=video.clientViewportWd:2560",
     "a=video.clientViewportHt:1440",
     "a=video.maxFPS:120",
-    "a=video.initialBitrateKbps:20000",
-    "a=video.initialPeakBitrateKbps:20000",
+    "a=video.initialBitrateKbps:20000", // startup = max(4000, max/4), official web formula
+    "a=video.initialPeakBitrateKbps:20000", // initialPeak mirrors initial (official web client)
     "a=vqos.bw.maximumBitrateKbps:80000",
-    "a=vqos.bw.minimumBitrateKbps:4000",
-    "a=vqos.bw.peakBitrateKbps:80000",
+    "a=vqos.bw.minimumBitrateKbps:4000", // official web client keeps the floor at 4000
     "a=vqos.drc.minRequiredBitrateCheckEnabled:1",
     "a=vqos.fec.repairPercent:5",
     "a=vqos.fec.repairMaxPercent:35",
-    "a=packetPacing.enableAccurateSleep:1",
     "a=packetPacing.minNumPacketsPerGroup:15",
-    "a=video.framePacing.mode:2",
-    "a=video.framePacing.pid.minTargetFrameTimeUs:7916",
-    "a=video.adaptiveQuantization.spatialAQSetting:7",
+    "a=packetPacing.maxDelayUs:1000",
     "a=video.rtpNackQueueLength:1024",
     "a=video.rtpNackQueueMaxPackets:512",
     "a=video.rtpNackMaxPacketCount:25",
-    "a=aqos.enableRedundancy:1",
-    "a=aqos.redundancyLevel:2",
-    "a=ri.timestampsEnabled:1",
     "a=video.bitDepth:10",
+    "a=video.encoderCscMode:3", // desktop web always 3 (official: TIZEN ? 2 : 3)
+    "a=video.encoderHdrCscMode:4",
+    "a=video.dynamicRangeMode:1",
     "a=vqos.drc.enable:0",
     "a=vqos.dfc.enable:1",
+    "a=vqos.dfc.adjustResAndFps:1", // official mode-3 high-FPS case
     "a=vqos.dfc.qpMaxResThresholdAdj:20",
     "a=vqos.grc.qpMaxResThresholdAdj:20",
-    "a=vqos.resControl.cpmRtc.enable:0",
     "a=ri.partialReliableThresholdMs:16",
     "a=ri.hidDeviceMask:128",
     "a=ri.enablePartiallyReliableTransferGamepad:15",
@@ -79,12 +75,13 @@ test("buildNvstSdp applies the official 90 FPS capture profile", () => {
   });
 
   const lines = new Set(sdp.split(/\r?\n/));
+  // The 90 FPS capture profile quirks below stay active; maxFPS mirrors the
+  // requested FPS like the official web client.
   for (const line of [
     "a=video.maxFPS:90",
-    "a=video.framePacing.pid.minTargetFrameTimeUs:10555",
     "a=vqos.dfc.enable:1",
     "a=vqos.dfc.dfcAlgoVersion:1",
-    "a=vqos.dfc.minTargetFps:60",
+    "a=vqos.dfc.minTargetFps:60", // official web: 60 target for 90 FPS sessions
     "a=video.fbcDynamicFpsGrabTimeoutMs:9",
     "a=vqos.resControl.cpmRtc.decodeTimeThresholdMs:11",
   ]) {
@@ -126,7 +123,7 @@ test("buildNvstSdp keeps dynamic split encode updates enabled for 240 FPS by def
 
   assert.match(defaultSdp, /a=video\.updateSplitEncodeStateDynamically:1/);
   assert.match(defaultSdp, /a=video\.videoSplitEncodeStripsPerFrame:63/);
-  assert.match(defaultSdp, /a=vqos\.relaxMaxBitrate\.iirFilterFactor:120/);
+  assert.match(defaultSdp, /a=video\.fakeEncodeFps:120/); // official 120 FPS encoder hint
   assert.match(diagnosticOffSdp, /a=video\.updateSplitEncodeStateDynamically:0/);
 });
 
@@ -149,6 +146,55 @@ test("buildNvstSdp floors low bitrate and applies protocol input defaults", () =
   const lines = new Set(sdp.split("\n"));
   assert.equal(lines.has("a=video.initialBitrateKbps:4000"), true);
   assert.equal(lines.has("a=vqos.bw.maximumBitrateKbps:4000"), true);
+  assert.equal(lines.has("a=vqos.bw.minimumBitrateKbps:4000"), true);
+  assert.equal(lines.has("a=video.maxFPS:60"), true);
+  assert.equal(lines.has("a=video.encoderCscMode:3"), true);
+  // Official web client, 60 FPS + dynamicStreamingMode=3: mode 3 + drc.enable:1.
+  assert.equal(lines.has("a=vqos.dynamicStreamingMode:3"), true);
+  assert.equal(lines.has("a=vqos.drc.enable:1"), true);
+  // Official web client sends featureMask:3 (CPM enabled); the old fork-only
+  // cpmRtc.enable:0 / minResolutionPercent:100 / resolutionChangeHoldonMs:999999
+  // lock attrs are gone (zero hits in the play.geforcenow.com bundle).
+  assert.equal(lines.has("a=vqos.resControl.cpmRtc.featureMask:3"), true);
+  // Fork-only attributes the official web client never sends — guard against
+  // regressions (the BWE ones made the server throttle to the bitrate floor).
+  // Prefix match on the full line so "a=foo" also catches "a=foo:123".
+  for (const absent of [
+    "a=vqos.bw.enableBandwidthEstimation",
+    "a=vqos.bw.disableBitrateLimit",
+    "a=vqos.bw.serverPeakBitrateKbps",
+    "a=vqos.bw.peakBitrateKbps",
+    "a=vqos.grc.maximumBitrateKbps",
+    "a=vqos.grc.enable",
+    "a=vqos.resControl.cpmRtc.enable",
+    "a=vqos.resControl.cpmRtc.minResolutionPercent",
+    "a=vqos.resControl.cpmRtc.resolutionChangeHoldonMs",
+    "a=vqos.calculateAvgVideoStreamingBitrate",
+    "a=vqos.dfc.adjustResAndFps",
+    "a=vqos.drc.enable:0", // 60 FPS sessions send no drc/dfc (high-FPS only)
+    "a=vqos.dfc.enable:0",
+    "a=video.framePacing.mode",
+    "a=video.adaptiveQuantization.spatialAQSetting",
+    "a=vqos.relaxMaxBitrate.overrideAvgBitrateThresholdPercent",
+    "a=vqos.qpDelta.qpDeltaMaxPercent",
+    "a=packetPacing.version",
+    "a=packetPacing.enableAccurateSleep",
+    "a=vqos.rtcPreemptiveIdrSettings.minBurstNackSize",
+    "a=video.minQp", // H264 does not get the H265 minQp:14 pin
+    "a=video.fakeEncodeFps", // 60 FPS is below the 120 FPS hint threshold
+    // Audio/input extras the official web client never sends.
+    "a=aqos.enableRedundancy",
+    "a=aqos.redundancyLevel",
+    "a=aqos.enableRedundancyForMic",
+    "a=aqos.redundancyLevelForMic",
+    "a=audio.enableDynamicAudioConfig",
+    "a=audio.enableTimestampAudioBuffer",
+    "a=ri.timestampsEnabled",
+    "a=ri.useMultipleGamepads",
+  ]) {
+    const leaked = [...lines].some((line) => line.startsWith(absent));
+    assert.equal(leaked, false, `fork-only attribute still sent: ${absent}`);
+  }
   assert.equal(lines.has("a=video.bitDepth:8"), true);
   assert.equal(lines.has("a=ri.hidDeviceMask:4294967295"), true);
   assert.equal(lines.has("a=ri.enablePartiallyReliableTransferGamepad:15"), true);

--- a/opennow-stable/src/renderer/src/platforms/gfn/sdp/nvstOffer.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/sdp/nvstOffer.ts
@@ -9,7 +9,7 @@ import {
 // repair and frame-state assumptions no longer line up.
 const ENABLE_240_FPS_SPLIT_ENCODE = true;
 const ENABLE_DYNAMIC_SPLIT_ENCODE_UPDATES = true;
-const OFFICIAL_MIN_BITRATE_KBPS = 4000;
+export const OFFICIAL_MIN_BITRATE_KBPS = 4000;
 const HIGH_RESOLUTION_PIXEL_COUNT = 2764800; // 2560x1080 / 1920x1440 class
 const HIGH_BITRATE_PACING_THRESHOLD_KBPS = 42000;
 
@@ -34,6 +34,11 @@ interface NvstParams {
   dynamicSplitEncodeUpdatesEnabled?: boolean;
 }
 
+// This builder targets the WEB (Chromium WebRTC) transport and is aligned
+// byte-for-byte with the official play.geforcenow.com SDP where it matters.
+// The NATIVE streamer (native/opennow-streamer/src/sdp.rs) intentionally keeps
+// its own (native-client) attribute set — do NOT sync this file's removals
+// into sdp.rs; native mode works with its current profile.
 export function buildNvstSdp(params: NvstParams): string {
   console.log(`[SDP] buildNvstSdp: ${params.width}x${params.height}@${params.fps}fps, codec=${params.codec}, colorQuality=${params.colorQuality}, maxBitrate=${params.maxBitrateKbps}kbps`);
   console.log(`[SDP] buildNvstSdp: ICE ufrag=${params.credentials.ufrag}, pwd=${params.credentials.pwd.slice(0, 8)}..., fingerprint=${params.credentials.fingerprint.slice(0, 20)}...`);
@@ -73,34 +78,43 @@ export function buildNvstSdp(params: NvstParams): string {
     "a=vqos.fec.repairMinPercent:5",
     "a=vqos.fec.repairPercent:5",
     "a=vqos.fec.repairMaxPercent:35",
-    // Official dynamicStreamingMode=0 path disables server resolution/FPS switching.
-    "a=vqos.dynamicStreamingMode:0",
-    "a=vqos.drc.enable:0",
-    "a=vqos.calculateAvgVideoStreamingBitrate:1",
+    // Official web client defaults to dynamicStreamingMode=3 (full dynamic
+    // streaming: DRC + DFC + bitrate envelope). The fork previously locked 0
+    // to prevent mid-session SSRC switches, but the renderer now handles track
+    // replacement (peerMediaLifecycleController), so align with the official
+    // default and let the server's BWE drive the bitrate like the web app.
+    "a=vqos.dynamicStreamingMode:3",
+    // Official web client always sends vqos.bllFec.enable:0 (backward-lossless
+    // FEC off). drc.enable / dfc.enable are NOT emitted for 60 FPS sessions —
+    // the official DFC/DRC helper only writes them for high-FPS (see below).
+    // vqos.calculateAvgVideoStreamingBitrate was a fork-only extra (zero hits
+    // in the play.geforcenow.com bundle) and is dropped for parity.
+    "a=vqos.bllFec.enable:0",
   ];
 
   if (isHighFps) {
     lines.push(
+      // Official web client, dynamicStreamingMode=3 + high FPS: drc.enable:0,
+      // dfc.enable:1, decodeFpsAdjPercent:85, targetDownCooldownMs:250,
+      // dfcAlgoVersion 2 (120/240) / 1 (90), minTargetFps 100 (120/240) / 60
+      // (90), resControl.dfc.useClientFpsPerf:0, and dfc.adjustResAndFps:1
+      // (the mode-3 case sets it for high-FPS sessions).
+      "a=vqos.drc.enable:0",
       "a=vqos.dfc.enable:1",
       "a=vqos.dfc.decodeFpsAdjPercent:85",
       "a=vqos.dfc.targetDownCooldownMs:250",
       `a=vqos.dfc.dfcAlgoVersion:${is120Fps || is240Fps ? 2 : 1}`,
-      `a=vqos.dfc.minTargetFps:${is120Fps || is240Fps ? 100 : 60}`,
+      `a=vqos.dfc.minTargetFps:${is90Fps ? 60 : 100}`,
       "a=vqos.resControl.dfc.useClientFpsPerf:0",
-      "a=vqos.dfc.adjustResAndFps:0",
+      "a=vqos.dfc.adjustResAndFps:1",
     );
   } else {
+    // Official web client, 60 FPS + dynamicStreamingMode=3: only drc.enable:1
+    // is emitted (the mode-3 case enables DRC for non-high-FPS sessions).
     lines.push(
-      "a=vqos.dfc.enable:0",
-      "a=vqos.dfc.adjustResAndFps:0",
+      "a=vqos.drc.enable:1",
     );
   }
-
-  // Frame pacing target: ~1/fps with a small headroom (official 240 FPS DESCRIBE used 7936 µs).
-  const minTargetFrameTimeUs = Math.max(
-    1000,
-    Math.floor((1_000_000 * 95) / (Math.max(1, params.fps) * 100)),
-  );
 
   // Video encoder settings
   lines.push(
@@ -108,43 +122,19 @@ export function buildNvstSdp(params: NvstParams): string {
     "a=video.dx9EnableHdr:1",
     "a=vqos.qpg.enable:1",
     "a=vqos.resControl.qp.qpg.featureSetting:7",
-    // Official DESCRIBE adaptive quantization block (HEVC/AV1 sessions).
-    "a=video.adaptiveQuantization.spatialAQSetting:7",
-    "a=video.adaptiveQuantization.temporalAQSetting:0",
-    "a=video.adaptiveQuantization.spatialAQStrength:12",
-    "a=video.adaptiveQuantization.qpThresholdAdjPercent:2",
-    "a=video.adaptiveQuantization.saqAdaptMinQpThresholdPercent:40",
-    "a=video.adaptiveQuantization.saqAdaptMaxQpThresholdPercent:100",
-    "a=video.adaptiveQuantization.saqAdaptDecayStrengthX100:250",
-    "a=video.adaptiveQuantization.perfAdjEnablement:1",
-    "a=video.framePacing.mode:2",
-    `a=video.framePacing.pid.minTargetFrameTimeUs:${minTargetFrameTimeUs}`,
+    // NOTE: the official web client does NOT send video.framePacing.* or
+    // video.adaptiveQuantization.* — those fork additions came from native
+    // client dumps. Dropped to match play.geforcenow.com byte-for-byte.
     "a=bwe.useOwdCongestionControl:1",
     "a=video.enableRtpNack:1",
     "a=vqos.bw.txRxLag.minFeedbackTxDeltaMs:200",
     "a=vqos.drc.bitrateIirFilterFactor:18",
     "a=video.packetSize:1140",
-    // Official packet pacing profile (Nvsc dumps + DESCRIBE enableAccurateSleep).
-    "a=packetPacing.version:3",
-    "a=packetPacing.mode:1",
+    // The official web client only sends packetPacing.minNumPacketsPerGroup
+    // here (version/mode/enableAccurateSleep/etc. are native-client extras,
+    // and vqos.relaxMaxBitrate.* / vqos.qpDelta.* detail attrs are not sent
+    // by play.geforcenow.com at all — dropped to match it byte-for-byte).
     "a=packetPacing.minNumPacketsPerGroup:15",
-    "a=packetPacing.enableAccurateSleep:1",
-    "a=packetPacing.enableSmoothTransition:1",
-    "a=packetPacing.allowFpsBasedToggle:1",
-    // Bitrate headroom / QP delta — present on official DESCRIBE ANNOUNCE path.
-    "a=vqos.relaxMaxBitrate.overrideAvgBitrateThresholdPercent:4",
-    "a=vqos.relaxMaxBitrate.customAvgBitrateThresholdPercent:65",
-    "a=vqos.relaxMaxBitrate.overrideAvgQpThresholdPercent:7",
-    "a=vqos.relaxMaxBitrate.customAvgQpThresholdPercent:51",
-    "a=vqos.relaxMaxBitrate.iirFilterFactor:120",
-    "a=vqos.qpDelta.qpDeltaMaxPercent:10",
-    "a=vqos.qpDelta.qpDeltaSurfaceAdjustmentStrengthPercent:70",
-    "a=vqos.qpDelta.qpDeltaVbvUsageFactorPercentH264:100",
-    "a=vqos.qpDelta.qpDeltaVbvUsageFactorPercentH265:100",
-    "a=vqos.qpDelta.qpDeltaVbvUsageFactorPercentAv1:100",
-    "a=vqos.qpDelta.qpDeltaMinPercent:60",
-    "a=vqos.qpDelta.qpDeltaIirFactor:60",
-    "a=vqos.qpDelta.qpDeltaThrottlePercent:100",
   );
 
   // High FPS optimizations
@@ -157,10 +147,14 @@ export function buildNvstSdp(params: NvstParams): string {
       `a=vqos.resControl.cpmRtc.decodeTimeThresholdMs:${is90Fps ? 11 : 9}`,
       `a=video.fbcDynamicFpsGrabTimeoutMs:${is90Fps ? 9 : is120Fps ? 6 : 18}`,
       `a=vqos.resControl.cpmRtc.serverResolutionUpdateCoolDownCount:${is120Fps ? 6000 : 12000}`,
+      // Official client sends the 120 FPS encoder-rate hint for 120/240 sessions.
+      ...(is120Fps || is240Fps ? ["a=video.fakeEncodeFps:120"] : []),
     );
   }
 
   // 240+ FPS optimizations
+  // NOTE: vqos.rtcPreemptiveIdrSettings.* (older web-client extras) are not
+  // sent — the official play.geforcenow.com bundle doesn't include them.
   if (is240Fps) {
     lines.push(
       "a=video.enableNextCaptureMode:1",
@@ -171,24 +165,21 @@ export function buildNvstSdp(params: NvstParams): string {
       lines.push(
         "a=video.videoSplitEncodeStripsPerFrame:63",
         `a=video.updateSplitEncodeStateDynamically:${dynamicSplitEncodeUpdatesEnabled ? 1 : 0}`,
-        "a=vqos.rtcPreemptiveIdrSettings.minBurstNackSize:65535",
-        "a=vqos.rtcPreemptiveIdrSettings.minNackPacketCaptureAgeMs:65535",
       );
     }
   }
 
-  // Out-of-focus handling + disable CPM-based resolution changes
+  // Out-of-focus handling + CPM resolution control (official web client).
+  // The official bundle emits cpmRtc.featureMask:3 when the CPM path is
+  // enabled (web default) and never sends cpmRtc.enable / minResolutionPercent
+  // / resolutionChangeHoldonMs — those fork-only locks disabled the server's
+  // CPM resolution control, which fights dynamicStreamingMode:3 and pins the
+  // BWE to the 4000 kbps floor (~5 Mbps) instead of ramping to the ceiling.
   lines.push(
     "a=vqos.adjustStreamingFpsDuringOutOfFocus:1",
     "a=vqos.resControl.cpmRtc.ignoreOutOfFocusWindowState:1",
     "a=vqos.resControl.perfHistory.rtcIgnoreOutOfFocusWindowState:1",
-    // Disable CPM-based resolution changes (prevents SSRC switches)
-    "a=vqos.resControl.cpmRtc.featureMask:0",
-    "a=vqos.resControl.cpmRtc.enable:0",
-    // Never scale down resolution
-    "a=vqos.resControl.cpmRtc.minResolutionPercent:100",
-    // Infinite cooldown to prevent resolution changes
-    "a=vqos.resControl.cpmRtc.resolutionChangeHoldonMs:999999",
+    "a=vqos.resControl.cpmRtc.featureMask:3",
   );
 
   // Packet pacing group/delay + NACK queues (official Nvsc defaults).
@@ -250,50 +241,65 @@ export function buildNvstSdp(params: NvstParams): string {
   lines.push(
     `a=video.clientViewportWd:${params.width}`,
     `a=video.clientViewportHt:${params.height}`,
+    // Official web client sends the session FPS from settings (previously the
+    // fork forced maxFPS:120 — reverted as part of full alignment with the
+    // official bundle dump; revert this line again if GFN ignores low FPS).
     `a=video.maxFPS:${params.fps}`,
+    // Bitrate attributes mirror the official GFN web client exactly (verified
+    // against a dump of play.geforcenow.com's vendor bundle): initial =
+    // initialPeak = max(4000, max/4), minimum fixed at 4000. The official
+    // client does NOT send enableBandwidthEstimation / disableBitrateLimit /
+    // peakBitrateKbps / serverPeakBitrateKbps / grc.maximumBitrateKbps — those
+    // fork additions made the server enable its own throttling BWE, which read
+    // Chromium WebRTC feedback and sat around the 4000 kbps floor (~5 Mbps at
+    // a 35 Mbps cap) instead of ramping to the ceiling.
     `a=video.initialBitrateKbps:${startupBitrate}`,
     `a=video.initialPeakBitrateKbps:${startupBitrate}`,
     `a=vqos.bw.maximumBitrateKbps:${maxBitrate}`,
     `a=vqos.bw.minimumBitrateKbps:${OFFICIAL_MIN_BITRATE_KBPS}`,
-    `a=vqos.bw.peakBitrateKbps:${maxBitrate}`,
-    `a=vqos.bw.serverPeakBitrateKbps:${maxBitrate}`,
-    "a=vqos.bw.enableBandwidthEstimation:1",
-    "a=vqos.bw.disableBitrateLimit:0",
-    // GRC — disabled
-    `a=vqos.grc.maximumBitrateKbps:${maxBitrate}`,
-    "a=vqos.grc.enable:0",
-    // Encoder settings
+    // Encoder settings — encoderCscMode is always 3 on desktop web (the official
+    // bundle computes it as `TIZEN ? 2 : 3`; the fork's old 4 for 10-bit was a
+    // fork-only value the server does not expect). encoderHdrCscMode:4 and
+    // dynamicRangeMode mirror the official client for HDR content.
     "a=video.maxNumReferenceFrames:4",
     "a=video.mapRtpTimestampsToFrames:1",
     "a=video.encoderCscMode:3",
-    "a=video.dynamicRangeMode:0",
+    "a=video.encoderHdrCscMode:4",
+    `a=video.dynamicRangeMode:${bitDepth === 10 ? 1 : 0}`,
     `a=video.bitDepth:${bitDepth}`,
-    // Disable server-side scaling and prefilter (prevents resolution downgrade)
+    // Official web client sets video.minQp:14 only for 10-bit H265 (verified
+    // against the vendor bundle: `10===To && "H265"===tn`); 8-bit H265 sends
+    // no minQp. AV1 pins minQp:25 in its block above.
+    ...(params.codec === "H265" && bitDepth === 10 ? ["a=video.minQp:14"] : []),
+    // Disable server-side scaling and prefilter (prevents resolution downgrade).
+    // Official web client sends the full prefilterParams set — mode OFF,
+    // model 0, denoise 0, sharpness 0 — the fork previously sent only model.
     `a=video.scalingFeature1:${isAv1 ? 1 : 0}`,
+    "a=video.prefilterParams.prefilterMode:0",
     "a=video.prefilterParams.prefilterModel:0",
+    "a=video.prefilterParams.denoiseLevel:0",
+    "a=video.prefilterParams.sharpnessLevel:0",
     // Audio track (receive-only from server)
+    // NOTE: the official web client sends NO aqos.* / audio.* attributes here
+    // (verified against the play.geforcenow.com bundle dump) — the fork's
+    // aqos redundancy + dynamic audio config lines were native-client extras
+    // and are dropped for byte-for-byte alignment.
     "m=audio 0 RTP/AVP",
     "a=msid:audio",
-    // Official aqos redundancy + dynamic audio config (DESCRIBE / Nvsc dumps).
-    "a=aqos.enableRedundancy:1",
-    "a=aqos.redundancyLevel:2",
-    "a=aqos.enableRedundancyForMic:1",
-    "a=aqos.redundancyLevelForMic:3",
-    "a=audio.enableDynamicAudioConfig:1",
-    "a=audio.enableTimestampAudioBuffer:1",
     // Mic track (send to server)
     "m=mic 0 RTP/AVP",
     "a=msid:mic",
     "a=rtpmap:0 PCMU/8000",
     // Input/application track
+    // ri.* values echo the server's offer (partial reliability for input) —
+    // matches the official client, which echoes them from the DESCRIBE
+    // response instead of sending fixed values.
     "m=application 0 RTP/AVP",
     "a=msid:input_1",
     `a=ri.partialReliableThresholdMs:${params.partialReliableThresholdMs}`,
     `a=ri.hidDeviceMask:${hidDeviceMask}`,
     `a=ri.enablePartiallyReliableTransferGamepad:${enablePartiallyReliableTransferGamepad}`,
     `a=ri.enablePartiallyReliableTransferHid:${enablePartiallyReliableTransferHid}`,
-    "a=ri.timestampsEnabled:1",
-    "a=ri.useMultipleGamepads:1",
     "",
   );
 

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/controllers.test.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/controllers.test.ts
@@ -31,7 +31,7 @@ test("decoder recovery waits for three pressure polls and clears after six stabl
     requestSignalingKeyframe: async () => {
       keyframeRequests++;
     },
-    setMaxBitrateKbps: async () => {},
+    setMaxBitrateKbps: async () => true,
     onStateChange: (state) => states.push(state),
     now: () => 2_000,
   });
@@ -60,6 +60,60 @@ test("decoder recovery waits for three pressure polls and clears after six stabl
     recoveryAttempts: 0,
     recoveryAction: "none",
   });
+});
+
+test("decoder recovery preserves bitrate state when no wire update is applied", async () => {
+  const states: DecoderPressureState[] = [];
+  const logs: string[] = [];
+  const requestedBitrates: number[] = [];
+  let updateApplied = false;
+  let now = 2_000;
+  const peerConnection = {
+    localDescription: { type: "answer", sdp: "v=0\r\n" },
+    getSenders: () => [],
+  } as unknown as RTCPeerConnection;
+  const controller = new DecoderPressureController({
+    log: (message) => logs.push(message),
+    getPeerConnection: () => peerConnection,
+    getControlChannel: () => null,
+    requestSignalingKeyframe: async () => {
+      throw new Error("unavailable");
+    },
+    setMaxBitrateKbps: async (kbps) => {
+      requestedBitrates.push(kbps);
+      return updateApplied;
+    },
+    onStateChange: (state) => states.push(state),
+    now: () => now,
+  });
+  controller.initializeBitrate(10_000);
+
+  await controller.recover(pressureSignal);
+  await controller.recover(pressureSignal);
+  await controller.recover(pressureSignal);
+
+  assert.deepEqual(requestedBitrates, [8_500]);
+  assert.deepEqual(states.at(-1), {
+    active: true,
+    recoveryAttempts: 0,
+    recoveryAction: "none",
+  });
+  assert.equal(logs.some((message) => message.includes("bitrate ceiling stepped down")), false);
+
+  updateApplied = true;
+  now = 4_000;
+  await controller.recover(pressureSignal);
+
+  assert.deepEqual(requestedBitrates, [8_500, 8_500]);
+  assert.deepEqual(states.at(-1), {
+    active: true,
+    recoveryAttempts: 1,
+    recoveryAction: "bitrate_step_down",
+  });
+  assert.equal(
+    logs.some((message) => message.includes("bitrate ceiling stepped down 10000 -> 8500 kbps")),
+    true,
+  );
 });
 
 test("input policy preserves native, partially-reliable, and fallback routes", () => {

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/decoderPressureController.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/decoderPressureController.ts
@@ -40,7 +40,7 @@ interface DecoderPressureControllerDependencies {
     backlogFrames: number;
     attempt: number;
   }) => Promise<unknown>;
-  setMaxBitrateKbps: (kbps: number) => Promise<void>;
+  setMaxBitrateKbps: (kbps: number) => Promise<boolean>;
   onStateChange: (state: DecoderPressureState) => void;
   now?: () => number;
 }
@@ -354,7 +354,10 @@ export class DecoderPressureController {
     if (next >= current) {
       return false;
     }
-    await this.dependencies.setMaxBitrateKbps(next);
+    const updated = await this.dependencies.setMaxBitrateKbps(next);
+    if (!updated) {
+      return false;
+    }
     this.currentBitrateCeilingKbps = next;
     this.recoveryAction = "bitrate_step_down";
     this.dependencies.log(

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/senderBitrate.test.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/senderBitrate.test.ts
@@ -1,0 +1,95 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { updateVideoSenderBitrate } from "./senderBitrate";
+
+function makePeerConnection(options: {
+  senders?: RTCRtpSender[];
+  transceivers?: RTCRtpTransceiver[];
+}): RTCPeerConnection {
+  return {
+    getSenders: () => options.senders ?? [],
+    getTransceivers: () => options.transceivers ?? [],
+  } as unknown as RTCPeerConnection;
+}
+
+function makeSender(options: {
+  kind?: "audio" | "video" | null;
+  encodings?: RTCRtpEncodingParameters[];
+  setParameters?: (parameters: RTCRtpSendParameters) => Promise<void>;
+}): RTCRtpSender {
+  return {
+    track: options.kind === null
+      ? null
+      : { kind: options.kind ?? "video" } as MediaStreamTrack,
+    getParameters: () => ({
+      codecs: [],
+      headerExtensions: [],
+      rtcp: {},
+      encodings: options.encodings ?? [],
+      transactionId: "test",
+    }),
+    setParameters: options.setParameters ?? (async () => {}),
+  } as unknown as RTCRtpSender;
+}
+
+test("live bitrate update sets maxBitrate on a sending video encoding", async () => {
+  const applied: RTCRtpSendParameters[] = [];
+  const sender = makeSender({
+    encodings: [{ active: true }],
+    setParameters: async (parameters) => {
+      applied.push(parameters);
+    },
+  });
+
+  const result = await updateVideoSenderBitrate(
+    makePeerConnection({ senders: [sender] }),
+    75000,
+  );
+
+  assert.deepEqual(result, { status: "updated" });
+  assert.equal(applied[0]?.encodings[0]?.maxBitrate, 75000000);
+  assert.equal(applied[0]?.encodings[0]?.active, true);
+});
+
+test("live bitrate update treats a recv-only video transceiver as unavailable", async () => {
+  let setParametersCalled = false;
+  const sender = makeSender({
+    kind: null,
+    setParameters: async () => {
+      setParametersCalled = true;
+    },
+  });
+  const transceiver = {
+    receiver: { track: { kind: "video" } },
+    sender,
+  } as unknown as RTCRtpTransceiver;
+
+  const result = await updateVideoSenderBitrate(
+    makePeerConnection({ senders: [sender], transceivers: [transceiver] }),
+    4000,
+  );
+
+  assert.deepEqual(result, { status: "unavailable" });
+  assert.equal(setParametersCalled, false);
+});
+
+test("live bitrate update reports unavailable and rejected fallbacks", async () => {
+  assert.deepEqual(
+    await updateVideoSenderBitrate(makePeerConnection({}), 75000),
+    { status: "unavailable" },
+  );
+
+  const error = new Error("setParameters unsupported");
+  const sender = makeSender({
+    setParameters: async () => {
+      throw error;
+    },
+  });
+  assert.deepEqual(
+    await updateVideoSenderBitrate(makePeerConnection({ senders: [sender] }), 75000),
+    { status: "unsupported", error },
+  );
+});

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtc/senderBitrate.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtc/senderBitrate.ts
@@ -1,0 +1,30 @@
+export type SenderBitrateUpdateResult =
+  | { status: "updated" }
+  | { status: "unavailable" }
+  | { status: "unsupported"; error: unknown };
+
+function findVideoSender(pc: RTCPeerConnection): RTCRtpSender | null {
+  return pc.getSenders().find((sender) => sender.track?.kind === "video") ?? null;
+}
+
+export async function updateVideoSenderBitrate(
+  pc: RTCPeerConnection,
+  maxBitrateKbps: number,
+): Promise<SenderBitrateUpdateResult> {
+  const sender = findVideoSender(pc);
+  if (!sender) {
+    return { status: "unavailable" };
+  }
+
+  try {
+    const parameters = sender.getParameters();
+    if (parameters.encodings.length === 0) {
+      parameters.encodings = [{}];
+    }
+    parameters.encodings[0].maxBitrate = maxBitrateKbps * 1000;
+    await sender.setParameters(parameters);
+    return { status: "updated" };
+  } catch (error) {
+    return { status: "unsupported", error };
+  }
+}

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtcClient.ts
@@ -711,15 +711,16 @@ export class GfnWebRtcClient {
     this.domInputController.suppressNextSyntheticEscapeOnPointerLockLoss(durationMs);
   }
 
-  public async setMaxBitrateKbps(kbps: number): Promise<void> {
+  public async setMaxBitrateKbps(kbps: number): Promise<boolean> {
     const normalizedKbps = Math.max(OFFICIAL_MIN_BITRATE_KBPS, Math.floor(kbps));
     if (!this.pc) {
-      return;
+      return false;
     }
 
     const result = await updateVideoSenderBitrate(this.pc, normalizedKbps);
     if (result.status === "updated") {
       this.log(`Bitrate ceiling updated to ${normalizedKbps} kbps via sender parameters`);
+      return true;
     } else if (result.status === "unavailable") {
       this.log(
         `No video sender supports a live bitrate update; ${normalizedKbps} kbps applies on the next session`,
@@ -729,6 +730,7 @@ export class GfnWebRtcClient {
         `Video sender rejected the live bitrate update (non-fatal): ${String(result.error)}`,
       );
     }
+    return false;
   }
 
   /**

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtcClient.ts
@@ -63,6 +63,8 @@ import {
 import { GamepadController } from "./webrtc/gamepadController";
 import { DomInputCaptureController } from "./webrtc/domInputCaptureController";
 import { PeerMediaLifecycleController } from "./webrtc/peerMediaLifecycleController";
+import { updateVideoSenderBitrate } from "./webrtc/senderBitrate";
+import { OFFICIAL_MIN_BITRATE_KBPS } from "./sdp/nvstOffer";
 
 export type {
   StreamDiagnostics,
@@ -709,51 +711,23 @@ export class GfnWebRtcClient {
     this.domInputController.suppressNextSyntheticEscapeOnPointerLockLoss(durationMs);
   }
 
-  /**
-   * Replace the b=AS bandwidth line in video sections of an SDP string.
-   * Unlike mungeAnswerSdp, this is safe to call on an already-munged SDP
-   * because it replaces the existing line rather than injecting a new one.
-   */
-  private replaceVideoBitrateInSdp(sdp: string, maxBitrateKbps: number): string {
-    const lines = sdp.split("\r\n");
-    let inVideoSection = false;
-    let bitrateReplaced = false;
-    const result: string[] = [];
-    for (const line of lines) {
-      if (line.startsWith("m=")) {
-        inVideoSection = line.startsWith("m=video");
-        bitrateReplaced = false;
-      }
-      if (inVideoSection && !bitrateReplaced && line.startsWith("b=AS:")) {
-        result.push(`b=AS:${maxBitrateKbps}`);
-        bitrateReplaced = true;
-        continue;
-      }
-      result.push(line);
-    }
-    return result.join("\r\n");
-  }
-
-  /**
-   * Update the maximum receive bitrate ceiling mid-stream by replacing b=AS
-   * in the local SDP and re-applying it. Chrome/Electron honours this change
-   * without requiring a full ICE renegotiation.
-   */
   public async setMaxBitrateKbps(kbps: number): Promise<void> {
-    if (!this.pc || !this.pc.localDescription) {
+    const normalizedKbps = Math.max(OFFICIAL_MIN_BITRATE_KBPS, Math.floor(kbps));
+    if (!this.pc) {
       return;
     }
-    const updatedSdp = this.replaceVideoBitrateInSdp(
-      this.pc.localDescription.sdp,
-      kbps,
-    );
-    try {
-      await this.pc.setLocalDescription(
-        new RTCSessionDescription({ type: this.pc.localDescription.type, sdp: updatedSdp }),
+
+    const result = await updateVideoSenderBitrate(this.pc, normalizedKbps);
+    if (result.status === "updated") {
+      this.log(`Bitrate ceiling updated to ${normalizedKbps} kbps via sender parameters`);
+    } else if (result.status === "unavailable") {
+      this.log(
+        `No video sender supports a live bitrate update; ${normalizedKbps} kbps applies on the next session`,
       );
-      this.log(`Bitrate ceiling updated to ${kbps} kbps via local SDP`);
-    } catch (err) {
-      this.log(`setMaxBitrateKbps failed (non-fatal): ${String(err)}`);
+    } else {
+      this.log(
+        `Video sender rejected the live bitrate update (non-fatal): ${String(result.error)}`,
+      );
     }
   }
 


### PR DESCRIPTION
Aligns web-stream session negotiation with the official GeForce NOW client so server bandwidth estimation can ramp to the configured ceiling instead of being constrained by fork-only SDP controls.

- Sends the official dynamic-streaming, bitrate envelope, codec, audio, and desktop CSC fields while removing nonstandard BWE, pacing, and CPM locks.
- Stops creating and forwarding an unrun network-test session, matching the official web client’s `null` contract.
- Limits live `RTCRtpSender` bitrate updates to actual outgoing video senders; receive-only GFN video safely applies changes on the next session.
- Adds focused wire-contract and sender-capability tests for the negotiated behavior.

Ported from work by [Akamiya Chizui](https://github.com/Chizuui) in `Chizuui/OpenNOW-Modified`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->