### PR TITLE
Add game detail modal and larger catalog cards

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -32,7 +32,9 @@
       "showInFolder": "Show in folder",
       "sort": "Sort",
       "stop": "Stop",
-      "switch": "Switch"
+      "switch": "Switch",
+      "readMore": "Read more",
+      "showLess": "Show less"
     },
     "status": {
       "checking": "Checking",
@@ -251,6 +253,8 @@
   "gameCard": {
     "selectGame": "Select {{title}}",
     "playGame": "Play {{title}}",
+    "viewDetails": "View details",
+    "viewDetailsFor": "View details for {{title}}",
     "store": "{{store}} store",
     "owned": "Owned",
     "available": "Available",
@@ -259,6 +263,13 @@
       "updating": "Updating",
       "unavailable": "Unavailable"
     }
+  },
+  "gameDetails": {
+    "eyebrow": "Game details",
+    "details": "About this game",
+    "notOwned": "Not owned",
+    "playOn": "Play on {{store}}",
+    "storeOption": "{{store}}, {{ownership}}"
   },
   "streamLoading": {
     "labels": {

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -93,6 +93,7 @@ import { SettingsModalHost } from "./components/SettingsModalHost";
 import { StreamLoading } from "./components/StreamLoading";
 import { StreamView } from "./components/StreamView";
 import { QueueServerSelectModal } from "./components/QueueServerSelectModal";
+import { GameDetailModal } from "./components/GameDetailModal";
 import { ReleaseHighlightsModal } from "./components/ReleaseHighlightsModal";
 import { ErrorReportingConsentModal } from "./components/ErrorReportingConsentModal";
 import { FeedbackModal } from "./components/FeedbackModal";
@@ -1866,8 +1867,19 @@ export function App(): JSX.Element {
     variantByGameId,
   ]);
 
+  const [detailsGame, setDetailsGame] = useState<GameInfo | null>(null);
+  const [detailsSurfacePresent, setDetailsSurfacePresent] = useState(false);
+  const queueModalVariantIdRef = useRef<string | undefined>(undefined);
+  const handleOpenDetails = useCallback((game: GameInfo): void => {
+    setDetailsSurfacePresent(true);
+    setDetailsGame(game);
+  }, []);
+  const handleCloseDetails = useCallback((): void => {
+    setDetailsGame(null);
+  }, []);
+
   // Gate handler: shows queue server modal for FREE-tier users before launching
-  const handleInitiatePlay = useCallback(async (game: GameInfo) => {
+  const handleInitiatePlay = useCallback(async (game: GameInfo, variantId?: string) => {
     const effectiveTier = normalizeMembershipTier(
       subscriptionInfo?.membershipTier ?? authSession?.user.membershipTier,
     );
@@ -1877,12 +1889,14 @@ export function App(): JSX.Element {
     const isAllianceServer = isAllianceStreamingBaseUrl(effectiveStreamingBaseUrl);
     if (!isNvidiaAccount || isAllianceServer) {
       setQueueModalData(null);
-      void handlePlayGame(game);
+      queueModalVariantIdRef.current = undefined;
+      void handlePlayGame(game, { variantId });
       return;
     }
     if (settings.hideServerSelector) {
       setQueueModalData(null);
-      void handlePlayGame(game);
+      queueModalVariantIdRef.current = undefined;
+      void handlePlayGame(game, { variantId });
       return;
     }
     if (isFreeUser && streamStatus === "idle" && !launchInFlightRef.current) {
@@ -1901,14 +1915,16 @@ export function App(): JSX.Element {
             },
           );
           setQueueModalData(null);
-          void handlePlayGame(game);
+          queueModalVariantIdRef.current = undefined;
+          void handlePlayGame(game, { variantId });
           return;
         }
 
         const queueData = queueResult.value;
         if (!queueData || Object.keys(queueData).length === 0) {
           setQueueModalData(null);
-          void handlePlayGame(game);
+          queueModalVariantIdRef.current = undefined;
+          void handlePlayGame(game, { variantId });
           return;
         }
 
@@ -1917,32 +1933,39 @@ export function App(): JSX.Element {
             "[QueueServerSelect] No eligible non-nuked PrintedWaste zones available, skipping queue checks.",
           );
           setQueueModalData(null);
-          void handlePlayGame(game);
+          queueModalVariantIdRef.current = undefined;
+          void handlePlayGame(game, { variantId });
           return;
         }
 
         setQueueModalData(queueData);
+        queueModalVariantIdRef.current = variantId;
         setQueueModalGame(game);
       } catch (error) {
         console.warn("[QueueServerSelect] PrintedWaste queue checks failed, launching without modal.", error);
         setQueueModalData(null);
-        void handlePlayGame(game);
+        queueModalVariantIdRef.current = undefined;
+        void handlePlayGame(game, { variantId });
       }
       return;
     }
-    void handlePlayGame(game);
+    queueModalVariantIdRef.current = undefined;
+    void handlePlayGame(game, { variantId });
   }, [subscriptionInfo, authSession, selectedProvider, settings.hideServerSelector, streamStatus, handlePlayGame, effectiveStreamingBaseUrl]);
 
   const handleQueueModalConfirm = useCallback((zoneUrl: string | null) => {
     const game = queueModalGame;
+    const variantId = queueModalVariantIdRef.current;
+    queueModalVariantIdRef.current = undefined;
     setQueueModalGame(null);
     setQueueModalData(null);
     if (game) {
-      void handlePlayGame(game, { streamingBaseUrl: zoneUrl ?? undefined });
+      void handlePlayGame(game, { streamingBaseUrl: zoneUrl ?? undefined, variantId });
     }
   }, [queueModalGame, handlePlayGame]);
 
   const handleQueueModalCancel = useCallback(() => {
+    queueModalVariantIdRef.current = undefined;
     setQueueModalGame(null);
     setQueueModalData(null);
   }, []);
@@ -2509,6 +2532,8 @@ export function App(): JSX.Element {
     || currentPage === "settings"
     || settingsSurfacePresent
     || navbarOverlayBlocking
+    || detailsGame !== null
+    || detailsSurfacePresent
     || queueModalGame !== null
     || releaseHighlightsPayload !== null
     || releaseHighlightsSurfacePresent
@@ -2609,6 +2634,7 @@ export function App(): JSX.Element {
                 isLoading={effectiveControllerMode ? isLoadingStorePanels : isLoadingCatalog}
                 selectedGameId={selectedGameId}
                 onSelectGame={setSelectedGameId}
+                onOpenDetails={handleOpenDetails}
                 selectedVariantByGameId={variantByGameId}
                 onSelectGameVariant={handleSelectGameVariant}
                 filterGroups={catalogFilterGroups}
@@ -2644,6 +2670,7 @@ export function App(): JSX.Element {
                   isLoading={isLoadingLibrary}
                   selectedGameId={selectedGameId}
                   onSelectGame={setSelectedGameId}
+                  onOpenDetails={handleOpenDetails}
                   selectedVariantByGameId={variantByGameId}
                   onSelectGameVariant={handleSelectGameVariant}
                   libraryCount={libraryGames.length}
@@ -2832,6 +2859,20 @@ export function App(): JSX.Element {
       </SettingsModalHost>
       {logoutConfirmModal}
       {removeAccountConfirmModal}
+      <GameDetailModal
+        open={detailsGame !== null}
+        game={detailsGame}
+        selectedVariantId={detailsGame ? variantByGameId[detailsGame.id] : undefined}
+        onSelectVariant={(variantId) => {
+          if (detailsGame) handleSelectGameVariant(detailsGame.id, variantId);
+        }}
+        onPlay={(game, variantId) => {
+          handleCloseDetails();
+          void handleInitiatePlay(game, variantId);
+        }}
+        onClose={handleCloseDetails}
+        onExitComplete={() => setDetailsSurfacePresent(false)}
+      />
       {queueModalGame && streamStatus === "idle" && (
         <QueueServerSelectModal
           game={queueModalGame}

--- a/opennow-stable/src/renderer/src/components/GameCard.test.ts
+++ b/opennow-stable/src/renderer/src/components/GameCard.test.ts
@@ -9,6 +9,25 @@ import { getActiveStoreOption, getStoreOptions } from "../lib/gameCardStores";
 
 const gameCardStyles = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
 
+function getCssDeclarations(selector: string): Record<string, string> {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const rules = [...gameCardStyles.matchAll(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`, "gs"))];
+  assert.ok(rules.length > 0, `Missing CSS rule for ${selector}`);
+  return Object.assign({}, ...rules.map((rule) => Object.fromEntries(
+    rule[1]
+      .split(";")
+      .map((declaration) => declaration.trim())
+      .filter(Boolean)
+      .map((declaration) => {
+        const separatorIndex = declaration.indexOf(":");
+        return [
+          declaration.slice(0, separatorIndex).trim(),
+          declaration.slice(separatorIndex + 1).trim(),
+        ];
+      }),
+  )));
+}
+
 function makeVariant(overrides: Partial<GameVariant> = {}): GameVariant {
   return {
     id: overrides.id ?? "variant-1",
@@ -196,21 +215,21 @@ test("uses the selected store option for store-specific play actions", () => {
   assert.equal(getActiveStoreOption(options)?.storeKey, "EPIC_GAMES_STORE");
 });
 
-test("keeps the full-card details target below Play and store controls", () => {
-  assert.match(
-    gameCardStyles,
-    /\.game-card-details-hit-target\s*\{[^}]*z-index:\s*2;/s,
+test("places the card content stacking context above Details while preserving control hit testing", () => {
+  const detailsTarget = getCssDeclarations(".game-card-details-hit-target");
+  const cardContent = getCssDeclarations(".game-card-image-wrapper");
+  const detailsLabel = getCssDeclarations(".game-card-details-label");
+  const storeControls = getCssDeclarations(".game-card-info .game-card-stores");
+  const hoveredPlay = getCssDeclarations(".game-card:hover .game-card-play-button");
+  const focusedPlay = getCssDeclarations(".game-card:focus-within .game-card-play-button");
+
+  assert.ok(
+    Number(cardContent["z-index"]) > Number(detailsTarget["z-index"]),
+    "card content must establish a stacking context above the full-card Details target",
   );
-  assert.match(
-    gameCardStyles,
-    /\.game-card-info\s*\{[^}]*z-index:\s*4;/s,
-  );
-  assert.match(
-    gameCardStyles,
-    /\.game-card-play-button\s*\{[^}]*z-index:\s*5;/s,
-  );
-  assert.match(
-    gameCardStyles,
-    /\.game-card:focus-within \.game-card-play-button\s*\{[^}]*pointer-events:\s*auto;/s,
-  );
+  assert.equal(cardContent["pointer-events"], "none");
+  assert.equal(detailsLabel["pointer-events"], "none");
+  assert.equal(storeControls["pointer-events"], "auto");
+  assert.equal(hoveredPlay["pointer-events"], "auto");
+  assert.equal(focusedPlay["pointer-events"], "auto");
 });

--- a/opennow-stable/src/renderer/src/components/GameCard.test.ts
+++ b/opennow-stable/src/renderer/src/components/GameCard.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { GameInfo, GameVariant } from "@shared/gfn";
-import { getStoreOptions } from "../lib/gameCardStores";
+import { getActiveStoreOption, getStoreOptions } from "../lib/gameCardStores";
 
 function makeVariant(overrides: Partial<GameVariant> = {}): GameVariant {
   return {
@@ -178,4 +178,17 @@ test("still hides empty and none store placeholders", () => {
       { storeKey: "STEAM", variantId: "steam", isOwned: false },
     ],
   );
+});
+
+test("uses the selected store option for store-specific play actions", () => {
+  const options = getStoreOptions(
+    makeGame([
+      makeVariant({ id: "steam", store: "Steam", libraryStatus: "IN_LIBRARY" }),
+      makeVariant({ id: "epic", store: "Epic", libraryStatus: "NOT_OWNED" }),
+    ]),
+    "epic",
+  );
+
+  assert.equal(getActiveStoreOption(options)?.variantId, "epic");
+  assert.equal(getActiveStoreOption(options)?.storeKey, "EPIC_GAMES_STORE");
 });

--- a/opennow-stable/src/renderer/src/components/GameCard.test.ts
+++ b/opennow-stable/src/renderer/src/components/GameCard.test.ts
@@ -2,9 +2,12 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import type { GameInfo, GameVariant } from "@shared/gfn";
 import { getActiveStoreOption, getStoreOptions } from "../lib/gameCardStores";
+
+const gameCardStyles = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
 
 function makeVariant(overrides: Partial<GameVariant> = {}): GameVariant {
   return {
@@ -191,4 +194,23 @@ test("uses the selected store option for store-specific play actions", () => {
 
   assert.equal(getActiveStoreOption(options)?.variantId, "epic");
   assert.equal(getActiveStoreOption(options)?.storeKey, "EPIC_GAMES_STORE");
+});
+
+test("keeps the full-card details target below Play and store controls", () => {
+  assert.match(
+    gameCardStyles,
+    /\.game-card-details-hit-target\s*\{[^}]*z-index:\s*2;/s,
+  );
+  assert.match(
+    gameCardStyles,
+    /\.game-card-info\s*\{[^}]*z-index:\s*4;/s,
+  );
+  assert.match(
+    gameCardStyles,
+    /\.game-card-play-button\s*\{[^}]*z-index:\s*5;/s,
+  );
+  assert.match(
+    gameCardStyles,
+    /\.game-card:focus-within \.game-card-play-button\s*\{[^}]*pointer-events:\s*auto;/s,
+  );
 });

--- a/opennow-stable/src/renderer/src/components/GameCard.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCard.tsx
@@ -229,12 +229,7 @@ export const GameCard = memo(function GameCard({
         className="game-card-details-hit-target"
         onClick={onSelect}
         aria-label={t("gameCard.viewDetailsFor", { title: game.title })}
-      >
-        <span className="game-card-details-label">
-          <Eye size={15} />
-          {t("gameCard.viewDetails")}
-        </span>
-      </button>
+      />
       <div
         className="game-card-image-wrapper"
         style={
@@ -329,6 +324,10 @@ export const GameCard = memo(function GameCard({
           </h3>
         </div>
       </div>
+      <span className="game-card-details-label" aria-hidden="true">
+        <Eye size={15} />
+        {t("gameCard.viewDetails")}
+      </span>
     </m.article>
   );
 }, gameCardPropsAreEqual);

--- a/opennow-stable/src/renderer/src/components/GameCard.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCard.tsx
@@ -1,11 +1,11 @@
-import { Play, Monitor } from "lucide-react";
+import { Eye, Play, Monitor } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { JSX } from "react";
 import { m } from "motion/react";
 import { normalizeGameStore } from "@shared/gfn";
 import type { GameInfo } from "@shared/gfn";
 import { getActiveGameAvailabilityBadge } from "../lib/gameCardStatus";
-import { getStoreOptions as getGameCardStoreOptions } from "../lib/gameCardStores";
+import { getActiveStoreOption, getStoreOptions as getGameCardStoreOptions } from "../lib/gameCardStores";
 import { useTranslation } from "../i18n";
 
 interface GameCardProps {
@@ -169,7 +169,7 @@ export const GameCard = memo(function GameCard({
     })),
     [game, selectedVariantId],
   );
-  const activeStoreOption = storeOptions.find((option) => option.isActive) ?? storeOptions[0];
+  const activeStoreOption = getActiveStoreOption(storeOptions);
   const availabilityBadge = useMemo(
     () => getActiveGameAvailabilityBadge(game, selectedVariantId),
     [game, selectedVariantId],
@@ -177,16 +177,25 @@ export const GameCard = memo(function GameCard({
 
   const fallbackAspectPct = GAME_CARD_FALLBACK_ASPECT[surface];
   const [aspectPct, setAspectPct] = useState(
-    () => (game.imageUrl ? gameCardAspectByImageUrl.get(game.imageUrl) : undefined) ?? fallbackAspectPct,
+    () => (
+      surface === "library" && game.imageUrl
+        ? gameCardAspectByImageUrl.get(game.imageUrl)
+        : undefined
+    ) ?? fallbackAspectPct,
   );
 
   useEffect(() => {
     setAspectPct(
-      (game.imageUrl ? gameCardAspectByImageUrl.get(game.imageUrl) : undefined) ?? fallbackAspectPct,
+      (
+        surface === "library" && game.imageUrl
+          ? gameCardAspectByImageUrl.get(game.imageUrl)
+          : undefined
+      ) ?? fallbackAspectPct,
     );
-  }, [fallbackAspectPct, game.imageUrl]);
+  }, [fallbackAspectPct, game.imageUrl, surface]);
 
   const handleImageLoad = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
+    if (surface !== "library") return;
     const img = event.currentTarget;
     const w = img.naturalWidth;
     const h = img.naturalHeight;
@@ -197,7 +206,7 @@ export const GameCard = memo(function GameCard({
       }
       setAspectPct(measuredAspectPct);
     }
-  }, [game.imageUrl]);
+  }, [game.imageUrl, surface]);
 
   const handlePlayClick = (event: React.MouseEvent): void => {
     event.stopPropagation();
@@ -210,24 +219,22 @@ export const GameCard = memo(function GameCard({
   };
 
   return (
-    <m.div
+    <m.article
       className={`game-card ${isSelected ? "selected" : ""}`}
       whileHover={{ y: -2, scale: 1.01 }}
       whileTap={{ scale: 0.985 }}
-      onClick={onSelect}
-      onKeyDown={(event) => {
-        if (event.target !== event.currentTarget) {
-          return;
-        }
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          onPlay();
-        }
-      }}
-      role="button"
-      tabIndex={0}
-      aria-label={t("gameCard.selectGame", { title: game.title })}
     >
+      <button
+        type="button"
+        className="game-card-details-hit-target"
+        onClick={onSelect}
+        aria-label={t("gameCard.viewDetailsFor", { title: game.title })}
+      >
+        <span className="game-card-details-label">
+          <Eye size={15} />
+          {t("gameCard.viewDetails")}
+        </span>
+      </button>
       <div
         className="game-card-image-wrapper"
         style={
@@ -256,7 +263,6 @@ export const GameCard = memo(function GameCard({
             className="game-card-play-button"
             onClick={handlePlayClick}
             aria-label={t("gameCard.playGame", { title: game.title })}
-            tabIndex={-1}
           >
             <Play size={24} fill="currentColor" />
           </button>
@@ -323,6 +329,6 @@ export const GameCard = memo(function GameCard({
           </h3>
         </div>
       </div>
-    </m.div>
+    </m.article>
   );
 }, gameCardPropsAreEqual);

--- a/opennow-stable/src/renderer/src/components/GameCardListItem.tsx
+++ b/opennow-stable/src/renderer/src/components/GameCardListItem.tsx
@@ -6,6 +6,7 @@ export interface CatalogCardActions {
   onPlayGame: (game: GameInfo) => void;
   onSelectGame: (gameId: string) => void;
   onSelectGameVariant: (gameId: string, variantId: string) => void;
+  onOpenDetails: (game: GameInfo) => void;
 }
 
 export interface GameCardListItemProps {
@@ -38,7 +39,8 @@ export const GameCardListItem = memo(function GameCardListItem({
 }: GameCardListItemProps) {
   const handleSelect = useCallback(() => {
     actionsRef.current?.onSelectGame(game.id);
-  }, [actionsRef, game.id]);
+    actionsRef.current?.onOpenDetails(game);
+  }, [actionsRef, game]);
 
   const handlePlay = useCallback(() => {
     actionsRef.current?.onPlayGame(game);

--- a/opennow-stable/src/renderer/src/components/GameDetailModal.tsx
+++ b/opennow-stable/src/renderer/src/components/GameDetailModal.tsx
@@ -1,0 +1,252 @@
+import { Check, X } from "lucide-react";
+import {
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type JSX,
+} from "react";
+import type { GameInfo } from "@shared/gfn";
+import { getControllerHeroBackgroundCandidates, getPlayerSummary } from "../lib/controllerCatalogUi";
+import { getActiveStoreOption, getStoreOptions } from "../lib/gameCardStores";
+import { useTranslation } from "../i18n";
+import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
+import { ModalSurface } from "./ui/ModalSurface";
+
+export interface GameDetailModalProps {
+  open: boolean;
+  game: GameInfo | null;
+  selectedVariantId?: string;
+  onClose: () => void;
+  onExitComplete?: () => void;
+  onPlay: (game: GameInfo, variantId?: string) => void;
+  onSelectVariant: (variantId: string) => void;
+}
+
+function GameDetailHero({ game }: { game: GameInfo }): JSX.Element {
+  const candidates = getControllerHeroBackgroundCandidates(game);
+  const [candidateIndex, setCandidateIndex] = useState(0);
+  const imageUrl = candidates[candidateIndex];
+
+  if (!imageUrl) {
+    return <div className="game-detail-hero-image game-detail-hero-image--empty" />;
+  }
+
+  return (
+    <img
+      className="game-detail-hero-image"
+      src={imageUrl}
+      alt=""
+      decoding="async"
+      fetchPriority="high"
+      onError={() => setCandidateIndex((index) => index + 1)}
+    />
+  );
+}
+
+function ExpandableDescription({
+  descriptionId,
+  text,
+}: {
+  descriptionId: string;
+  text: string;
+}): JSX.Element {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const descriptionRef = useRef<HTMLParagraphElement | null>(null);
+
+  useLayoutEffect(() => {
+    const element = descriptionRef.current;
+    if (!element) return undefined;
+
+    const measure = (): void => {
+      setIsClamped(element.scrollHeight - element.clientHeight > 2);
+    };
+    measure();
+
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(measure);
+    observer?.observe(element);
+    return () => observer?.disconnect();
+  }, []);
+
+  return (
+    <div className="game-detail-description-block">
+      <p
+        ref={descriptionRef}
+        id={descriptionId}
+        className={`game-detail-description${expanded ? " is-expanded" : ""}`}
+      >
+        {text}
+      </p>
+      {(isClamped || expanded) && (
+        <button
+          type="button"
+          className="game-detail-readmore"
+          aria-expanded={expanded}
+          aria-controls={descriptionId}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? t("app.actions.showLess") : t("app.actions.readMore")}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function GameDetailModal({
+  open,
+  game,
+  selectedVariantId,
+  onClose,
+  onExitComplete,
+  onPlay,
+  onSelectVariant,
+}: GameDetailModalProps): JSX.Element {
+  const { t } = useTranslation();
+  const generatedId = useId();
+  const titleId = `${generatedId}-title`;
+  const descriptionId = `${generatedId}-description`;
+
+  if (!game) {
+    return (
+      <ModalSurface
+        open={false}
+        onClose={onClose}
+        onExitComplete={onExitComplete}
+        overlayClassName="game-detail-overlay"
+        backdropClassName="game-detail-backdrop"
+        panelClassName="game-detail-panel"
+        motion="large"
+      >
+        <div />
+      </ModalSurface>
+    );
+  }
+
+  const storeOptions = getStoreOptions(game, selectedVariantId);
+  const activeStoreOption = getActiveStoreOption(storeOptions);
+  const playerSummary = getPlayerSummary(game);
+  const description = game.description
+    || game.longDescription
+    || game.featureLabels?.join(" / ")
+    || t("library.loadingGameDetails");
+  const metadata = [
+    game.developerName ? t("library.developer", { developer: game.developerName }) : null,
+    game.publisherName ? t("library.publisher", { publisher: game.publisherName }) : null,
+    playerSummary ? t("library.players", { players: playerSummary }) : null,
+    game.genres?.length ? t("library.genres", { genres: game.genres.slice(0, 4).join(", ") }) : null,
+    game.supportedControls?.length
+      ? t("library.controls", { controls: game.supportedControls.slice(0, 4).join(", ") })
+      : null,
+    game.nvidiaTech?.length ? t("library.nvidiaTech", { tech: game.nvidiaTech.slice(0, 4).join(", ") }) : null,
+    game.contentRatings?.length
+      ? t("library.rating", { rating: game.contentRatings.slice(0, 2).join(", ") })
+      : null,
+  ].filter((value): value is string => Boolean(value));
+
+  const handlePlay = (): void => {
+    onPlay(game, activeStoreOption?.variantId ?? selectedVariantId);
+  };
+
+  return (
+    <ModalSurface
+      open={open}
+      onClose={onClose}
+      onExitComplete={onExitComplete}
+      onConfirm={handlePlay}
+      overlayClassName="game-detail-overlay"
+      backdropClassName="game-detail-backdrop"
+      panelClassName="game-detail-panel"
+      motion="large"
+      ariaLabelledBy={titleId}
+      ariaDescribedBy={descriptionId}
+      backdropLabel={t("app.actions.close")}
+    >
+      <header className="game-detail-hero">
+        <GameDetailHero key={game.id} game={game} />
+        <div className="game-detail-hero-scrim" />
+        <button
+          type="button"
+          className="game-detail-close"
+          onClick={onClose}
+          aria-label={t("app.actions.close")}
+        >
+          <X size={19} />
+        </button>
+        <div className="game-detail-heading">
+          <span className="game-detail-eyebrow">{t("gameDetails.eyebrow")}</span>
+          <h2 id={titleId} className="game-detail-title">{game.title}</h2>
+        </div>
+      </header>
+
+      <div className="game-detail-body">
+        <ExpandableDescription
+          key={game.id}
+          descriptionId={descriptionId}
+          text={description}
+        />
+
+        {metadata.length > 0 && (
+          <section className="game-detail-section" aria-labelledby={`${generatedId}-metadata`}>
+            <h3 id={`${generatedId}-metadata`} className="game-detail-section-title">
+              {t("gameDetails.details")}
+            </h3>
+            <ul className="game-detail-meta">
+              {metadata.map((row) => <li key={row}>{row}</li>)}
+            </ul>
+          </section>
+        )}
+
+        {storeOptions.length > 0 && (
+          <section className="game-detail-section" aria-labelledby={`${generatedId}-stores`}>
+            <h3 id={`${generatedId}-stores`} className="game-detail-section-title">
+              {t("library.chooseStore")}
+            </h3>
+            <div className="game-detail-stores-row">
+              {storeOptions.map((option) => {
+                const StoreIcon = getStoreIconComponent(option.store);
+                const storeName = getStoreDisplayName(option.store);
+                const ownershipLabel = option.isOwned ? t("gameCard.owned") : t("gameDetails.notOwned");
+                const className = [
+                  "game-detail-store-chip",
+                  option.isActive ? "active" : "",
+                  option.isOwned ? "owned" : "not-owned",
+                ].filter(Boolean).join(" ");
+
+                return (
+                  <button
+                    key={option.storeKey}
+                    type="button"
+                    className={className}
+                    aria-label={t("gameDetails.storeOption", { store: storeName, ownership: ownershipLabel })}
+                    aria-pressed={option.isActive}
+                    onClick={() => onSelectVariant(option.variantId)}
+                  >
+                    <StoreIcon />
+                    <span className="game-detail-store-name">{storeName}</span>
+                    <span className="game-detail-store-ownership">
+                      {option.isOwned && <Check size={12} aria-hidden="true" />}
+                      {ownershipLabel}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        )}
+      </div>
+
+      <footer className="game-detail-actions">
+        <button type="button" className="game-detail-play" onClick={handlePlay}>
+          {activeStoreOption
+            ? t("gameDetails.playOn", { store: getStoreDisplayName(activeStoreOption.store) })
+            : t("app.actions.play")}
+        </button>
+        <button type="button" className="game-detail-cancel" onClick={onClose}>
+          {t("app.actions.close")}
+        </button>
+      </footer>
+    </ModalSurface>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -43,6 +43,7 @@ export interface HomePageProps {
   isLoading: boolean;
   selectedGameId: string;
   onSelectGame: (id: string) => void;
+  onOpenDetails: (game: GameInfo) => void;
   selectedVariantByGameId: Record<string, string>;
   onSelectGameVariant: (gameId: string, variantId: string) => void;
   filterGroups: CatalogFilterGroup[];
@@ -235,6 +236,7 @@ export const HomePage = memo(function HomePage({
   isLoading,
   selectedGameId,
   onSelectGame,
+  onOpenDetails,
   selectedVariantByGameId,
   onSelectGameVariant,
   filterGroups,
@@ -261,6 +263,7 @@ export const HomePage = memo(function HomePage({
     onPlayGame,
     onSelectGame,
     onSelectGameVariant,
+    onOpenDetails,
   });
   const [controllerHeroIndex, setControllerHeroIndex] = useState(0);
   const [focusedRowIndex, setFocusedRowIndex] = useState(0);

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -38,6 +38,7 @@ export interface LibraryPageProps {
   isLoading: boolean;
   selectedGameId: string;
   onSelectGame: (id: string) => void;
+  onOpenDetails: (game: GameInfo) => void;
   selectedVariantByGameId: Record<string, string>;
   onSelectGameVariant: (gameId: string, variantId: string) => void;
   libraryCount: number;
@@ -63,6 +64,7 @@ export const LibraryPage = memo(function LibraryPage({
   isLoading,
   selectedGameId,
   onSelectGame,
+  onOpenDetails,
   selectedVariantByGameId,
   onSelectGameVariant,
   libraryCount,
@@ -81,6 +83,7 @@ export const LibraryPage = memo(function LibraryPage({
     onPlayGame,
     onSelectGame,
     onSelectGameVariant,
+    onOpenDetails,
   });
   const [controllerHeroIndex, setControllerHeroIndex] = useState(0);
   const [detailsGame, setDetailsGame] = useState<GameInfo | null>(null);

--- a/opennow-stable/src/renderer/src/lib/gameCardStores.ts
+++ b/opennow-stable/src/renderer/src/lib/gameCardStores.ts
@@ -10,6 +10,10 @@ export interface StoreOption {
   isActive: boolean;
 }
 
+export function getActiveStoreOption<T extends StoreOption>(options: T[]): T | undefined {
+  return options.find((option) => option.isActive) ?? options[0];
+}
+
 function normalizeStoreOptionKey(store: string): string | null {
   const trimmed = store.trim();
   if (!trimmed) {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3782,11 +3782,13 @@ button.controller-hint {
 /* Image wrapper — portrait poster art */
 .game-card-image-wrapper {
   position: relative;
+  z-index: 3;
   width: 100%;
   padding-top: var(--game-aspect);
   overflow: hidden;
   background: var(--bg-c);
   flex: 1;
+  pointer-events: none;
 }
 
 .home-page .game-card-image-wrapper {
@@ -3847,6 +3849,7 @@ button.controller-hint {
 
 .game-card-details-label {
   position: absolute;
+  z-index: 6;
   left: 50%;
   top: 50%;
   display: inline-flex;
@@ -3862,6 +3865,7 @@ button.controller-hint {
   font-size: 0.75rem;
   font-weight: 750;
   white-space: nowrap;
+  pointer-events: none;
   opacity: 0;
   transform: translate(-50%, calc(-50% + 8px));
   transition: opacity var(--t-normal), transform var(--t-normal), background var(--t-fast);

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3722,10 +3722,10 @@ button.controller-hint {
    ====================================================== */
 .game-grid {
   display: grid;
-  --game-poster-width: clamp(150px, calc(200px * var(--game-poster-scale, 1)), 270px);
-  grid-template-columns: repeat(auto-fill, minmax(var(--game-poster-width), var(--game-poster-width)));
-  justify-content: space-between;
-  gap: 12px;
+  --game-poster-width: clamp(200px, calc(260px * var(--game-poster-scale, 1)), 340px);
+  grid-template-columns: repeat(auto-fill, minmax(var(--game-poster-width), 1fr));
+  justify-content: start;
+  gap: 16px;
   padding-bottom: 16px;
 }
 
@@ -3746,9 +3746,9 @@ button.controller-hint {
   contain: layout style;
 }
 
-.home-page .game-card:focus,
-.home-page .game-card:focus-visible {
-  outline: none;
+.game-card:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 74%, var(--panel-border));
+  box-shadow: 0 0 0 2px var(--accent-surface);
 }
 
 .home-page .game-card.selected {
@@ -3790,7 +3790,7 @@ button.controller-hint {
 }
 
 .home-page .game-card-image-wrapper {
-  padding-top: var(--game-aspect, 56.25%);
+  padding-top: 56.25%;
 }
 
 .game-card-image {
@@ -3830,6 +3830,49 @@ button.controller-hint {
   pointer-events: none;
 }
 
+.game-card-details-hit-target {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+}
+
+.game-card-details-hit-target:focus-visible {
+  outline: none;
+}
+
+.game-card-details-label {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 0 13px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(8, 10, 12, 0.78);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.32);
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 750;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translate(-50%, calc(-50% + 8px));
+  transition: opacity var(--t-normal), transform var(--t-normal), background var(--t-fast);
+}
+
+.game-card:hover .game-card-details-label,
+.game-card:focus-within .game-card-details-label {
+  opacity: 1;
+  transform: translate(-50%, -50%);
+}
+
 .game-card:hover .game-card-gradient,
 .game-card:hover .game-card-play-button {
   opacity: 1;
@@ -3837,6 +3880,11 @@ button.controller-hint {
 
 .game-card:hover .game-card-play-button {
   pointer-events: auto;
+}
+
+.game-card:focus-within .game-card-gradient,
+.game-card:focus-within .game-card-play-button {
+  opacity: 1;
 }
 
 .game-card-gradient {
@@ -3849,10 +3897,12 @@ button.controller-hint {
 }
 
 .game-card-play-button {
-  position: relative;
-  z-index: 4;
-  width: 44px;
-  height: 44px;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 5;
+  width: 42px;
+  height: 42px;
   border-radius: 50%;
   background: var(--accent);
   border: none;
@@ -3880,7 +3930,7 @@ button.controller-hint {
   display: flex;
   flex-direction: column;
   gap: 5px;
-  z-index: 2;
+  z-index: 4;
   pointer-events: none;
 }
 
@@ -3936,7 +3986,7 @@ button.controller-hint {
 
 .game-card-title {
   margin: 0;
-  font-size: 0.8rem;
+  font-size: 0.88rem;
   font-weight: 600;
   color: #fff;
   white-space: nowrap;
@@ -4030,6 +4080,382 @@ button.game-card-store-chip.owned.active:hover {
 .store-svg {
   display: block;
   flex-shrink: 0;
+}
+
+/* ======================================================
+   GAME DETAIL MODAL
+   ====================================================== */
+.game-detail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 3150;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 30px;
+}
+
+.game-detail-backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  background: rgba(3, 5, 7, 0.74);
+  cursor: pointer;
+}
+
+[data-translucent="true"] .game-detail-backdrop {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.game-detail-panel {
+  position: relative;
+  z-index: 1;
+  width: min(720px, calc(100vw - 60px));
+  max-height: min(820px, calc(100vh - 60px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--panel-border-solid) 86%, transparent);
+  border-radius: var(--r-lg);
+  background: color-mix(in srgb, var(--panel) 96%, #070a0d);
+  box-shadow: 0 34px 110px rgba(0, 0, 0, 0.68), 0 0 0 1px rgba(255, 255, 255, 0.025);
+}
+
+.game-detail-hero {
+  position: relative;
+  flex: 0 0 auto;
+  min-height: 250px;
+  aspect-ratio: 16 / 6.7;
+  overflow: hidden;
+  background: var(--bg-c);
+}
+
+.game-detail-hero-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 30%;
+}
+
+.game-detail-hero-image--empty {
+  background:
+    radial-gradient(circle at 74% 20%, rgba(var(--accent-rgb), 0.16), transparent 34%),
+    linear-gradient(135deg, var(--bg-c), var(--panel));
+}
+
+.game-detail-hero-scrim {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(4, 6, 8, 0.34), transparent 58%),
+    linear-gradient(to bottom, rgba(4, 6, 8, 0.04) 18%, rgba(4, 6, 8, 0.58) 68%, var(--panel) 100%);
+}
+
+.game-detail-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 2;
+  display: inline-flex;
+  width: 38px;
+  height: 38px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 50%;
+  background: rgba(5, 7, 9, 0.68);
+  color: #fff;
+  cursor: pointer;
+  transition: background var(--t-fast), border-color var(--t-fast), transform var(--t-fast);
+}
+
+.game-detail-close:hover {
+  border-color: rgba(255, 255, 255, 0.38);
+  background: rgba(5, 7, 9, 0.9);
+  transform: scale(1.04);
+}
+
+.game-detail-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.game-detail-heading {
+  position: absolute;
+  left: 26px;
+  right: 70px;
+  bottom: 20px;
+  z-index: 1;
+}
+
+.game-detail-eyebrow {
+  display: block;
+  margin-bottom: 7px;
+  color: color-mix(in srgb, var(--accent) 70%, #fff);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.game-detail-title {
+  margin: 0;
+  color: #fff;
+  font-size: clamp(1.75rem, 3vw, 2.65rem);
+  font-weight: 780;
+  line-height: 1.03;
+  letter-spacing: -0.035em;
+  text-shadow: 0 4px 22px rgba(0, 0, 0, 0.66);
+}
+
+.game-detail-body {
+  min-height: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  overflow-y: auto;
+  padding: 18px 26px 24px;
+}
+
+.game-detail-description-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.game-detail-description {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  color: var(--ink-soft);
+  font-size: var(--text-base);
+  line-height: 1.62;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+}
+
+.game-detail-description.is-expanded {
+  display: block;
+  overflow: visible;
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+}
+
+.game-detail-readmore {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.game-detail-readmore:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.game-detail-readmore:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+.game-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.game-detail-section-title {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.game-detail-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 20px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.game-detail-meta li {
+  color: var(--ink-soft);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+}
+
+.game-detail-stores-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+.game-detail-store-chip {
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-template-areas:
+    "icon name"
+    "icon ownership";
+  column-gap: 9px;
+  align-items: center;
+  min-width: 128px;
+  padding: 9px 13px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--r-sm);
+  background: var(--chip);
+  color: var(--ink-soft);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast), border-color var(--t-fast), box-shadow var(--t-fast);
+}
+
+.game-detail-store-chip > svg {
+  grid-area: icon;
+}
+
+.game-detail-store-name {
+  grid-area: name;
+  font-size: var(--text-sm);
+  font-weight: 750;
+}
+
+.game-detail-store-ownership {
+  grid-area: ownership;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--ink-muted);
+  font-size: 0.67rem;
+  font-weight: 650;
+}
+
+.game-detail-store-chip:hover {
+  border-color: var(--panel-border-solid);
+  background: color-mix(in srgb, var(--chip) 76%, var(--ink) 7%);
+  color: var(--ink);
+}
+
+.game-detail-store-chip.owned:not(.active) {
+  border-color: color-mix(in srgb, var(--warning) 34%, var(--panel-border));
+}
+
+.game-detail-store-chip.owned:not(.active) .game-detail-store-ownership {
+  color: color-mix(in srgb, var(--warning) 76%, #fff);
+}
+
+.game-detail-store-chip.active {
+  border-color: var(--accent);
+  background: var(--accent-surface);
+  color: var(--ink);
+  box-shadow: inset 3px 0 0 var(--accent), 0 0 0 1px rgba(var(--accent-rgb), 0.15);
+}
+
+.game-detail-store-chip.active .game-detail-store-ownership {
+  color: color-mix(in srgb, var(--accent) 66%, var(--ink));
+}
+
+.game-detail-store-chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.game-detail-actions {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 10px;
+  padding: 16px 26px 20px;
+  border-top: 1px solid var(--panel-border);
+  background: color-mix(in srgb, var(--panel) 96%, #000);
+}
+
+.game-detail-play,
+.game-detail-cancel {
+  min-height: 46px;
+  padding: 0 22px;
+  border-radius: var(--r-sm);
+  font-family: inherit;
+  font-size: var(--text-base);
+  font-weight: 780;
+  cursor: pointer;
+  transition: background var(--t-fast), border-color var(--t-fast), color var(--t-fast), transform var(--t-fast);
+}
+
+.game-detail-play {
+  min-width: 210px;
+  flex: 1;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--accent-on);
+}
+
+.game-detail-play:hover {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+}
+
+.game-detail-cancel {
+  border: 1px solid var(--panel-border-solid);
+  background: transparent;
+  color: var(--ink);
+}
+
+.game-detail-cancel:hover {
+  background: color-mix(in srgb, var(--ink) 7%, transparent);
+}
+
+.game-detail-play:focus-visible,
+.game-detail-cancel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 700px) {
+  .game-detail-overlay {
+    align-items: flex-end;
+    padding: 12px;
+  }
+
+  .game-detail-panel {
+    width: 100%;
+    max-height: calc(100vh - 24px);
+  }
+
+  .game-detail-hero {
+    min-height: 190px;
+  }
+
+  .game-detail-body {
+    padding-inline: 20px;
+  }
+
+  .game-detail-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .game-detail-actions {
+    padding-inline: 20px;
+  }
+
+  .game-detail-play {
+    min-width: 0;
+  }
 }
 
 

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3833,7 +3833,7 @@ button.controller-hint {
 .game-card-details-hit-target {
   position: absolute;
   inset: 0;
-  z-index: 3;
+  z-index: 2;
   padding: 0;
   border: 0;
   background: transparent;
@@ -3885,6 +3885,10 @@ button.controller-hint {
 .game-card:focus-within .game-card-gradient,
 .game-card:focus-within .game-card-play-button {
   opacity: 1;
+}
+
+.game-card:focus-within .game-card-play-button {
+  pointer-events: auto;
 }
 
 .game-card-gradient {


### PR DESCRIPTION
Adds a dedicated desktop game-detail experience so users can inspect catalog metadata and choose the exact store variant before launching.

- Opens an accessible, focus-trapped modal from larger responsive Home and Library cards.
- Shows resilient hero artwork, expandable descriptions, game metadata, ownership-aware store choices, and a store-specific Play action.
- Preserves the selected variant through free-tier queue selection so launch cannot fall back to a different storefront.
- Updates only the English source locale and adds focused store-selection coverage.

![Game detail modal](https://d3byvqof4ma6i6.cloudfront.net/public/pr-assets/by-jam/d880d9acf49cf8c33aea20e61269e09645e22e8057667e4f69b5fe30e124e026/content/bcfae1437607b7e37efaa6ccdd6710a2f8f06873d0266adfac97249d0c8d3f59)

Ported from work by [Akamiya Chizui](https://github.com/Chizuui) in `Chizuui/OpenNOW-Modified`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5c4542bf-47d5-4bf8-8897-2cfdea89a59b/pull/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->