### PR TITLE
Add Exit button to the desktop account menu

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -16,6 +16,7 @@
       "continue": "Continue",
       "delete": "Delete",
       "done": "Done",
+      "exit": "Exit OpenNOW",
       "open": "Open",
       "play": "Play",
       "buy": "Buy",

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -2663,6 +2663,7 @@ export function App(): JSX.Element {
           accountConfirmRestoreFocusRef.current = restoreFocusTarget ?? null;
           handleLogout();
         }}
+        onExitApp={handleExitApp}
         onOpenFeedback={() => setFeedbackOpen(true)}
         onBlockingOverlayChange={setNavbarOverlayBlocking}
         controllerMode={effectiveControllerMode}

--- a/opennow-stable/src/renderer/src/components/Navbar.tsx
+++ b/opennow-stable/src/renderer/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import type { ActiveSessionInfo, AuthUser, SavedAccount, SubscriptionInfo } from "@shared/gfn";
-import { House, Library, Settings, User, Timer, HardDrive, X, PlayCircle, Square, ChevronDown, Check, Plus, Store as StoreIcon, MessageSquareText } from "lucide-react";
+import { House, Library, Settings, User, Timer, HardDrive, X, PlayCircle, Square, ChevronDown, Check, Plus, Store as StoreIcon, MessageSquareText, Power } from "lucide-react";
 import { useEffect, useRef, useState, type JSX } from "react";
 import { useTranslation } from "../i18n";
 import { OpenNowLogoMark } from "./OpenNowLogoMark";
@@ -22,6 +22,7 @@ interface NavbarProps {
   onRemoveAccount: (userId: string, restoreFocusTarget?: HTMLElement) => void;
   onAddAccount: () => void;
   onLogoutAll: (restoreFocusTarget?: HTMLElement) => void;
+  onExitApp: () => void;
   onOpenFeedback?: () => void;
   onBlockingOverlayChange?: (blocking: boolean) => void;
   controllerMode?: boolean;
@@ -52,6 +53,7 @@ export function Navbar({
   onRemoveAccount,
   onAddAccount,
   onLogoutAll,
+  onExitApp,
   onOpenFeedback,
   onBlockingOverlayChange,
   controllerMode = false,
@@ -534,6 +536,19 @@ export function Navbar({
                     }}
                   >
                     {t("auth.accounts.signOutAllAccounts")}
+                  </button>
+                  <div className="navbar-account-divider" aria-hidden="true" />
+                  <button
+                    type="button"
+                    className="navbar-account-exit"
+                    role="menuitem"
+                    onClick={() => {
+                      setAccountDropdownOpen(false);
+                      onExitApp();
+                    }}
+                  >
+                    <Power size={14} />
+                    <span>{t("app.actions.exit")}</span>
                   </button>
                 </div>
               )}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -804,7 +804,8 @@ body,
 }
 
 .navbar-account-add,
-.navbar-account-signout-all {
+.navbar-account-signout-all,
+.navbar-account-exit {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -827,12 +828,17 @@ body,
 }
 
 .navbar-account-signout-all {
-  margin-bottom: 8px;
+  margin-bottom: 2px;
 }
 
-.navbar-account-signout-all:hover {
+.navbar-account-signout-all:hover,
+.navbar-account-exit:hover {
   background: color-mix(in srgb, var(--error) 14%, transparent);
   color: var(--error);
+}
+
+.navbar-account-exit {
+  margin-bottom: 8px;
 }
 
 .navbar-logout {


### PR DESCRIPTION
Closes #706.

- Adds a clearly separated **Exit OpenNOW** action with a power icon to the account dropdown.
- Routes the action through the existing renderer shutdown handler so runtime state is persisted before Electron performs its normal cleanup and quit flow.
- Adds the English source localization key and matching hover styling.

Verification:
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable run lint`
- `npm --prefix opennow-stable run locales:check`
- `npm --prefix opennow-stable test` (449 passed)
- `npm --prefix opennow-stable run build`
- Visually inspected the account dropdown in the running Electron app.