### PR TITLE
fix(linux): restore app icon on Wayland

### DIFF
--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -1,5 +1,6 @@
 {
   "name": "opennow-stable",
+  "desktopName": "com.zortos.opennow.stable.desktop",
   "version": "0.5.2",
   "description": "Electron-based OpenNOW stable client",
   "author": {
@@ -111,6 +112,10 @@
     ],
     "extraResources": [
       {
+        "from": "../logo.png",
+        "to": "app-icon.png"
+      },
+      {
         "from": "../native/opennow-streamer/bin",
         "to": "native/opennow-streamer",
         "filter": [
@@ -140,6 +145,7 @@
       "artifactName": "OpenNOW-v${version}-mac-${arch}.${ext}"
     },
     "linux": {
+      "syncDesktopName": true,
       "target": [
         "AppImage",
         "deb"

--- a/opennow-stable/src/main/window/mainWindow.ts
+++ b/opennow-stable/src/main/window/mainWindow.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, globalShortcut, ipcMain } from "electron";
+import { app, BrowserWindow, globalShortcut, ipcMain } from "electron";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { IPC_CHANNELS } from "@shared/ipc";
@@ -86,6 +86,11 @@ export async function createMainWindow(
   const startFullscreen =
     settings.launchInConsoleMode ||
     deps.getPendingDirectLaunchRequest() !== null;
+  const linuxWindowIcon = process.platform === "linux"
+    ? app.isPackaged
+      ? join(process.resourcesPath, "app-icon.png")
+      : join(deps.mainDir, "../../../logo.png")
+    : undefined;
 
   const window = new BrowserWindow({
     width: settings.windowWidth || 1400,
@@ -93,6 +98,7 @@ export async function createMainWindow(
     minWidth: 1024,
     minHeight: 680,
     ...(startFullscreen ? { fullscreen: true } : {}),
+    ...(linuxWindowIcon ? { icon: linuxWindowIcon } : {}),
     autoHideMenuBar: true,
     backgroundColor: "#0f172a",
     webPreferences: {


### PR DESCRIPTION
Fixes #707.

Electron's Linux window identity did not match an installed desktop entry, so KDE/Wayland could not associate the AppImage window with OpenNOW and displayed the generic Wayland icon.

- define a stable reverse-DNS `desktopName` and synchronize the generated desktop filename and `StartupWMClass`
- bundle the OpenNOW logo as a runtime resource and set it explicitly on Linux windows, including direct AppImage launches without desktop integration

Verification:
- `npm run typecheck`
- `npx oxlint src/main/window/mainWindow.ts`
- `npm run build`
- `npm test` (449 passed)
- packaged and extracted the Linux AppImage; verified `com.zortos.opennow.stable.desktop`, matching `StartupWMClass`, and bundled `resources/app-icon.png`
- launched the packaged Linux app and verified its runtime WM class is `com.zortos.opennow.stable`