### PR TITLE
Add mute control for queue ads

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -326,7 +326,11 @@
       "advertisementInProgress": "Advertisement in progress",
       "mediaWillAppear": "Ad media will appear here as soon as it is available.",
       "advertisement": "Advertisement",
-      "titledAdvertisement": "{{title}} advertisement"
+      "titledAdvertisement": "{{title}} advertisement",
+      "mute": "Mute",
+      "unmute": "Unmute",
+      "muteAdvertisement": "Mute advertisement",
+      "unmuteAdvertisement": "Unmute advertisement"
     },
     "actions": {
       "cancelLoading": "Cancel loading"

--- a/opennow-stable/src/renderer/src/components/QueueAdPreview.tsx
+++ b/opennow-stable/src/renderer/src/components/QueueAdPreview.tsx
@@ -1,7 +1,8 @@
-import { AlertTriangle, Loader2, PauseCircle, PlayCircle, RefreshCcw, XCircle } from "lucide-react";
+import { AlertTriangle, Loader2, PauseCircle, PlayCircle, RefreshCcw, Volume2, VolumeX, XCircle } from "lucide-react";
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState, type JSX } from "react";
 import { m } from "motion/react";
 import { spinnerTransition } from "./MotionProvider";
+import { useTranslation } from "../i18n";
 
 type QueueAdPlaybackState = "loading" | "playing" | "paused" | "stalled" | "blocked" | "timeout" | "error";
 export type QueueAdPlaybackEvent = "loadstart" | "playing" | "paused" | "ended" | "timeupdate" | "error";
@@ -89,8 +90,10 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
   { mediaUrl, title, onPlaybackEvent }: QueueAdPreviewProps,
   ref,
 ): JSX.Element {
+  const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const playbackStateRef = useRef<QueueAdPlaybackState>("loading");
+  const mutedRef = useRef(false);
   // Guards against firing "ended" twice when the proactive timeupdate path
   // already fired it before the native ended event arrives.
   const finishFiredRef = useRef(false);
@@ -103,6 +106,7 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
     onPlaybackEventRef.current = onPlaybackEvent;
   });
   const [playbackState, setPlaybackState] = useState<QueueAdPlaybackState>("loading");
+  const [muted, setMuted] = useState(false);
 
   const setPlayback = (next: QueueAdPlaybackState): void => {
     playbackStateRef.current = next;
@@ -117,6 +121,21 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
 
     setPlayback("loading");
 
+    if (mutedRef.current) {
+      video.muted = true;
+      try {
+        await video.play();
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "NotAllowedError") {
+          setPlayback("blocked");
+          return;
+        }
+        console.warn("Queue ad playback failed:", error);
+        setPlayback("error");
+      }
+      return;
+    }
+
     // Try audible playback first (matching official client behaviour).
     // Fall back to muted if the autoplay policy blocks audio.
     try {
@@ -129,6 +148,8 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
 
     try {
       video.muted = true;
+      mutedRef.current = true;
+      setMuted(true);
       await video.play();
     } catch (error) {
       if (error instanceof DOMException && error.name === "NotAllowedError") {
@@ -138,6 +159,18 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
       console.warn("Queue ad playback failed:", error);
       setPlayback("error");
     }
+  };
+
+  const toggleMuted = (): void => {
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    const nextMuted = !video.muted;
+    video.muted = nextMuted;
+    mutedRef.current = nextMuted;
+    setMuted(nextMuted);
   };
 
   useImperativeHandle(ref, () => ({
@@ -266,6 +299,10 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
   const presentation = getPlaybackPresentation(playbackState);
   const StatusIcon = presentation.icon;
   const showFrameOverlay = playbackState !== "playing";
+  const muteLabel = muted ? t("streamLoading.ads.unmute") : t("streamLoading.ads.mute");
+  const muteButtonLabel = muted
+    ? t("streamLoading.ads.unmuteAdvertisement")
+    : t("streamLoading.ads.muteAdvertisement");
 
   return (
     <div className={`queue-ad-preview queue-ad-preview--${playbackState}`}>
@@ -277,7 +314,9 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
           autoPlay
           playsInline
           preload="auto"
-          aria-label={title ? `${title} advertisement` : "Advertisement"}
+          aria-label={title
+            ? t("streamLoading.ads.titledAdvertisement", { title })
+            : t("streamLoading.ads.advertisement")}
         />
         {showFrameOverlay && (
           <div className="queue-ad-preview-overlay" aria-hidden="true">
@@ -292,6 +331,17 @@ export const QueueAdPreview = forwardRef<QueueAdPreviewHandle, QueueAdPreviewPro
             </div>
           </div>
         )}
+        <button
+          className={`queue-ad-preview-mute${muted ? " queue-ad-preview-mute--active" : ""}`}
+          type="button"
+          onClick={toggleMuted}
+          aria-label={muteButtonLabel}
+          aria-pressed={muted}
+          title={muteButtonLabel}
+        >
+          {muted ? <VolumeX size={16} /> : <Volume2 size={16} />}
+          <span>{muteLabel}</span>
+        </button>
       </div>
       {presentation.retryLabel && (
         <div className="queue-ad-preview-status" aria-live="polite">

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -9262,6 +9262,51 @@ button.game-card-store-chip.owned.active:hover {
   object-fit: cover;
 }
 
+.queue-ad-preview-mute {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  background: rgba(4, 7, 6, 0.82);
+  color: #fff;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(10px);
+  transition: background var(--t-fast), border-color var(--t-fast), color var(--t-fast), transform var(--t-fast);
+}
+
+.queue-ad-preview-mute:hover {
+  border-color: rgba(var(--accent-rgb), 0.72);
+  background: rgba(8, 15, 11, 0.94);
+  color: #d7ff92;
+  transform: translateY(-1px);
+}
+
+.queue-ad-preview-mute:active {
+  transform: translateY(0);
+}
+
+.queue-ad-preview-mute:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.queue-ad-preview-mute--active {
+  border-color: rgba(var(--accent-rgb), 0.48);
+  background: rgba(10, 24, 15, 0.92);
+  color: #c9ff6a;
+}
+
 .queue-ad-preview-overlay {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
Adds an in-player mute toggle to free-tier queue advertisements. The control reflects autoplay's muted fallback, preserves the viewer's audio choice across ad retries and transitions, and includes localized accessible labels and keyboard focus styling.

Closes #673

Verification:
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable run lint`
- `npm --prefix opennow-stable run locales:check`
- `npm --prefix opennow-stable test` (449 passing)
- `npm --prefix opennow-stable run build`
- Visually verified both mute and unmute states in Electron