### PR TITLE
fix(native): avoid X11 embedding under Wayland

### DIFF
--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -452,6 +452,8 @@ export class NativeStreamerManager {
       externalRendererEnabled: process.platform === "win32"
         ? this.options.getExternalRendererEnabled()
         : false,
+      linuxOzonePlatform: app.commandLine.getSwitchValue("ozone-platform")
+        || app.commandLine.getSwitchValue("ozone-platform-hint"),
       cloudGsyncMode: this.options.getCloudGsyncMode(),
       d3dFullscreenMode: this.options.getD3dFullscreenMode(),
     });

--- a/opennow-stable/src/main/nativeStreamer/runtime.test.ts
+++ b/opennow-stable/src/main/nativeStreamer/runtime.test.ts
@@ -5,11 +5,69 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  createNativeStreamerRuntimeEnvironment,
+  isNativeWaylandSession,
   isPathInside,
   nativeStreamerExecutableName,
   nativeStreamerPlatformKey,
   normalizePathForComparison,
 } from "./runtime";
+
+function createLinuxRuntimeEnvironment(
+  baseEnv: NodeJS.ProcessEnv,
+  linuxOzonePlatform?: string,
+): NodeJS.ProcessEnv {
+  return createNativeStreamerRuntimeEnvironment({
+    executablePath: "/tmp/opennow-streamer",
+    baseEnv,
+    platform: "linux",
+    arch: "arm64",
+    userDataPath: "/tmp/opennow-test",
+    protocolVersion: 4,
+    backendPreference: "auto",
+    videoBackendPreference: "auto",
+    externalRendererEnabled: false,
+    linuxOzonePlatform,
+    cloudGsyncMode: "auto",
+    d3dFullscreenMode: "auto",
+  }).env;
+}
+
+test("native Wayland sessions use the external renderer", () => {
+  assert.equal(isNativeWaylandSession({ WAYLAND_DISPLAY: "wayland-0" }), true);
+  assert.equal(isNativeWaylandSession({ XDG_SESSION_TYPE: "wayland" }), true);
+  assert.equal(isNativeWaylandSession({}, "wayland"), true);
+});
+
+test("explicit X11 keeps Linux child-surface embedding enabled", () => {
+  const waylandEnvironment = {
+    ELECTRON_OZONE_PLATFORM_HINT: "wayland",
+    WAYLAND_DISPLAY: "wayland-0",
+    XDG_SESSION_TYPE: "wayland",
+  };
+
+  assert.equal(isNativeWaylandSession(waylandEnvironment, "x11"), false);
+  assert.equal(isNativeWaylandSession({ XDG_SESSION_TYPE: "x11" }), false);
+  assert.equal(
+    isNativeWaylandSession({ ELECTRON_OZONE_PLATFORM_HINT: "x11" }),
+    false,
+  );
+});
+
+test("Linux runtime selects the renderer for the Electron windowing backend", () => {
+  assert.equal(
+    createLinuxRuntimeEnvironment({ WAYLAND_DISPLAY: "wayland-0" })
+      .OPENNOW_NATIVE_EXTERNAL_RENDERER,
+    "1",
+  );
+  assert.equal(
+    createLinuxRuntimeEnvironment(
+      { WAYLAND_DISPLAY: "wayland-0" },
+      "x11",
+    ).OPENNOW_NATIVE_EXTERNAL_RENDERER,
+    "0",
+  );
+});
 
 test("normalizes real and symlinked paths to the same comparison path", (t) => {
   const root = mkdtempSync(join(tmpdir(), "opennow-native-path-"));

--- a/opennow-stable/src/main/nativeStreamer/runtime.ts
+++ b/opennow-stable/src/main/nativeStreamer/runtime.ts
@@ -25,6 +25,7 @@ export interface NativeStreamerRuntimeEnvironmentOptions {
   backendPreference: NativeStreamerBackendPreference;
   videoBackendPreference: NativeVideoBackendPreference;
   externalRendererEnabled: boolean;
+  linuxOzonePlatform?: string;
   cloudGsyncMode: NativeStreamerFeatureMode;
   d3dFullscreenMode: NativeStreamerFeatureMode;
 }
@@ -113,6 +114,22 @@ export function linuxInstallInstructions(
   platform = process.platform,
 ): NativeGstreamerInstallInstruction[] | undefined {
   return platform === "linux" ? LINUX_GSTREAMER_INSTALL_INSTRUCTIONS : undefined;
+}
+
+export function isNativeWaylandSession(
+  env: NodeJS.ProcessEnv,
+  ozonePlatform?: string,
+): boolean {
+  const explicitPlatform = ozonePlatform?.trim().toLowerCase();
+  if (explicitPlatform === "x11") return false;
+  if (explicitPlatform === "wayland") return true;
+
+  const environmentHint = env.ELECTRON_OZONE_PLATFORM_HINT?.trim().toLowerCase();
+  if (!explicitPlatform && environmentHint === "x11") return false;
+  if (!explicitPlatform && environmentHint === "wayland") return true;
+
+  return env.XDG_SESSION_TYPE?.trim().toLowerCase() === "wayland"
+    || Boolean(env.WAYLAND_DISPLAY?.trim());
 }
 
 function prependEnvPath(env: NodeJS.ProcessEnv, key: string, directory: string): void {
@@ -211,7 +228,10 @@ export function createNativeStreamerRuntimeEnvironment(
     env.OPENNOW_NATIVE_VIDEO_BACKEND = options.videoBackendPreference;
   }
   if (options.platform === "linux") {
-    env.OPENNOW_NATIVE_EXTERNAL_RENDERER = "0";
+    env.OPENNOW_NATIVE_EXTERNAL_RENDERER = isNativeWaylandSession(
+      options.baseEnv,
+      options.linuxOzonePlatform,
+    ) ? "1" : "0";
     if ((options.arch === "arm64" || options.arch === "arm") && !env.GST_V4L2_ENABLE_PROBE) {
       env.GST_V4L2_ENABLE_PROBE = "1";
     }


### PR DESCRIPTION
Fixes #698.

Native Linux sessions now choose the renderer from Electron's effective Ozone backend instead of always forcing X11 child-surface embedding. Native Wayland uses the existing external GStreamer renderer, preventing Chromium's internal widget ID from being passed to `XCreateWindow`, while explicit X11 sessions retain embedded rendering.

The detection honors Electron's `ozone-platform`/`ozone-platform-hint` switches and the relevant environment/session hints. Windows and macOS behavior is unchanged.

Verification:
- Targeted native runtime tests: 6/6 passed
- Full Electron test suite: 310/310 passed
- Typecheck passed
- Changed-file lint passed
- `cargo check` passed
- Native Rust tests: 67/67 passed
- `cargo fmt --all -- --check` remains blocked by pre-existing formatting differences; this PR changes no Rust files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Linux display compatibility by detecting native Wayland sessions.
  * Automatically configures the native renderer for Wayland or X11 environments.

* **Bug Fixes**
  * Fixed Linux renderer environment selection when using Electron’s Ozone platform settings.

* **Tests**
  * Added coverage for Wayland detection, X11 overrides, and Linux renderer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->