### PR TITLE
Improve app performance and repair light theme

### DIFF
--- a/opennow-stable/package-lock.json
+++ b/opennow-stable/package-lock.json
@@ -9,21 +9,14 @@
       "version": "0.5.2",
       "hasInstallScript": true,
       "dependencies": {
-        "@formkit/auto-animate": "^0.10.0",
-        "@react-three/fiber": "^9.7.0",
         "discord-rpc": "^4.0.1",
         "electron-updater": "^6.8.9",
-        "lucide-react": "^1.31.0",
-        "motion": "^12.43.0",
-        "posthog-js": "^1.415.1",
         "posthog-node": "^5.48.1",
-        "qrcode": "^1.5.4",
-        "react": "^19.2.8",
-        "react-dom": "^19.2.8",
-        "three": "^0.185.1",
         "ws": "^8.21.3"
       },
       "devDependencies": {
+        "@formkit/auto-animate": "^0.10.0",
+        "@react-three/fiber": "^9.7.0",
         "@types/discord-rpc": "^4.0.11",
         "@types/node": "^22.20.1",
         "@types/qrcode": "^1.5.6",
@@ -36,8 +29,15 @@
         "electron": "^43.3.0",
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
+        "lucide-react": "^1.31.0",
+        "motion": "^12.43.0",
         "oxlint": "^1.78.0",
+        "posthog-js": "^1.415.1",
+        "qrcode": "^1.5.4",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "react-scan": "^0.5.7",
+        "three": "^0.185.1",
         "tsx": "^4.23.12",
         "typescript": "^6.0.3",
         "vite": "^7.3.6"
@@ -353,6 +353,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1332,6 +1333,7 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@formkit/auto-animate/-/auto-animate-0.10.0.tgz",
       "integrity": "sha512-KGomRttjUfORuPUaR/ZGQw+6xfMrTM+sxnILv7JAd9AmabU9rg9i6gF/iC0Ih+QpKCubJpCA/1DX9UHKE8cX+A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
@@ -2798,6 +2800,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.4.0.tgz",
       "integrity": "sha512-W9DCGVks15docUMPvJ2nd8NS16Gn74bsGWuaeg31beEKFSjdW8wvnQ1ETY6WSql5pYxZb3GdJmEUZVVstKSrBQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@posthog/core": "^1.46.8",
@@ -2908,6 +2911,7 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
       "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
@@ -3671,6 +3675,7 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3690,6 +3695,7 @@
       "version": "0.28.9",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
       "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
@@ -3731,6 +3737,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3738,6 +3745,7 @@
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -3920,6 +3928,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4217,6 +4226,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4346,6 +4356,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4479,6 +4490,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4661,6 +4673,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4673,6 +4686,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4770,6 +4784,7 @@
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
       "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -4830,6 +4845,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debounce-fn": {
@@ -4869,6 +4885,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5020,6 +5037,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dir-compare": {
@@ -5094,6 +5112,7 @@
       "version": "3.4.13",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
       "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5407,6 +5426,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -6043,6 +6063,7 @@
       "version": "12.43.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
       "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "motion-dom": "^12.43.0",
@@ -6126,6 +6147,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -6531,6 +6553,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6617,6 +6640,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6702,6 +6726,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
       "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react-reconciler": "^0.28.9"
@@ -7241,6 +7266,7 @@
       "version": "1.31.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.31.0.tgz",
       "integrity": "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -7479,6 +7505,7 @@
       "version": "12.43.0",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.43.0.tgz",
       "integrity": "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "framer-motion": "^12.43.0",
@@ -7505,6 +7532,7 @@
       "version": "12.43.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
       "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"
@@ -7514,6 +7542,7 @@
       "version": "12.39.0",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
       "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -8020,6 +8049,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8036,6 +8066,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8146,6 +8177,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -8184,6 +8216,7 @@
       "version": "1.415.1",
       "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.415.1.tgz",
       "integrity": "sha512-42kmHsgzxAZ3fM6W/NcbBun6r39Zoc5v0l0RJRZ6O+2BdVGNCQXiZTe/mDG9+7Bf0yz/dKY5BDZXB85Vq0JGFw==",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@posthog/browser-common": "^0.4.0",
@@ -8202,6 +8235,7 @@
       "version": "0.4.9",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
       "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/posthog-node": {
@@ -8258,6 +8292,7 @@
       "version": "10.29.7",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
       "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -8396,6 +8431,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
       "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
@@ -8413,6 +8449,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8422,6 +8459,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -8433,6 +8471,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -8446,6 +8485,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -8458,6 +8498,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -8473,6 +8514,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -8485,6 +8527,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8499,6 +8542,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8511,6 +8555,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -8525,12 +8570,14 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/qrcode/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^6.0.0",
@@ -8553,6 +8600,7 @@
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -8566,6 +8614,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -8606,6 +8655,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9061,6 +9111,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -9151,6 +9202,7 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
       "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.13",
@@ -9206,6 +9258,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9239,6 +9292,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/resedit": {
@@ -9463,6 +9517,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semifies": {
@@ -9525,6 +9580,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -9742,6 +9798,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
       "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=17.0"
@@ -9817,6 +9874,7 @@
       "version": "0.185.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
@@ -9925,6 +9983,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -10644,6 +10703,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -11281,6 +11341,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
       "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/web-vitals-soft-navs": {
@@ -11288,6 +11349,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.0.tgz",
       "integrity": "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/webcrypto-core": {
@@ -11355,6 +11417,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/word-wrap": {
@@ -11622,6 +11685,7 @@
       "version": "5.0.14",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -110,6 +110,15 @@
       "dist-electron/**",
       "package.json"
     ],
+    "extraResources": [
+      {
+        "from": "../native/opennow-streamer/bin",
+        "to": "native/opennow-streamer",
+        "filter": [
+          "**/*"
+        ]
+      }
+    ],
     "electronLanguages": [
       "de",
       "en-GB",
@@ -129,15 +138,6 @@
     ],
     "asar": true,
     "win": {
-      "extraResources": [
-        {
-          "from": "../native/opennow-streamer/bin",
-          "to": "native/opennow-streamer",
-          "filter": [
-            "**/*"
-          ]
-        }
-      ],
       "target": [
         "nsis",
         "portable"

--- a/opennow-stable/package.json
+++ b/opennow-stable/package.json
@@ -34,21 +34,14 @@
     "test": "node scripts/run-tests.mjs"
   },
   "dependencies": {
-    "@formkit/auto-animate": "^0.10.0",
-    "@react-three/fiber": "^9.7.0",
     "discord-rpc": "^4.0.1",
     "electron-updater": "^6.8.9",
-    "lucide-react": "^1.31.0",
-    "motion": "^12.43.0",
-    "posthog-js": "^1.415.1",
     "posthog-node": "^5.48.1",
-    "qrcode": "^1.5.4",
-    "react": "^19.2.8",
-    "react-dom": "^19.2.8",
-    "three": "^0.185.1",
     "ws": "^8.21.3"
   },
   "devDependencies": {
+    "@formkit/auto-animate": "^0.10.0",
+    "@react-three/fiber": "^9.7.0",
     "@types/discord-rpc": "^4.0.11",
     "@types/node": "^22.20.1",
     "@types/qrcode": "^1.5.6",
@@ -61,8 +54,15 @@
     "electron": "^43.3.0",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
+    "lucide-react": "^1.31.0",
+    "motion": "^12.43.0",
     "oxlint": "^1.78.0",
+    "posthog-js": "^1.415.1",
+    "qrcode": "^1.5.4",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "react-scan": "^0.5.7",
+    "three": "^0.185.1",
     "tsx": "^4.23.12",
     "typescript": "^6.0.3",
     "vite": "^7.3.6"
@@ -110,21 +110,34 @@
       "dist-electron/**",
       "package.json"
     ],
-    "extraResources": [
-      {
-        "from": "../logo.png",
-        "to": "app-icon.png"
-      },
-      {
-        "from": "../native/opennow-streamer/bin",
-        "to": "native/opennow-streamer",
-        "filter": [
-          "**/*"
-        ]
-      }
+    "electronLanguages": [
+      "de",
+      "en-GB",
+      "en-US",
+      "es",
+      "es-419",
+      "fr",
+      "ja",
+      "ko",
+      "nl",
+      "pl",
+      "ro",
+      "ru",
+      "tr",
+      "zh-CN",
+      "zh-TW"
     ],
     "asar": true,
     "win": {
+      "extraResources": [
+        {
+          "from": "../native/opennow-streamer/bin",
+          "to": "native/opennow-streamer",
+          "filter": [
+            "**/*"
+          ]
+        }
+      ],
       "target": [
         "nsis",
         "portable"
@@ -146,6 +159,12 @@
     },
     "linux": {
       "syncDesktopName": true,
+      "extraResources": [
+        {
+          "from": "../logo.png",
+          "to": "app-icon.png"
+        }
+      ],
       "target": [
         "AppImage",
         "deb"

--- a/opennow-stable/src/main/ipc/coreHandlers.ts
+++ b/opennow-stable/src/main/ipc/coreHandlers.ts
@@ -7,6 +7,7 @@ import type {
   Shell,
   SystemPreferences,
 } from "electron";
+import { nativeTheme } from "electron";
 import { IPC_CHANNELS } from "@shared/ipc";
 import type { CommunityProxyProvisionResult } from "@shared/communityProxy";
 import type { DiscordActivityUpdate } from "@shared/discord";
@@ -44,6 +45,7 @@ import { fetchThanksData } from "../thanks/fetchThanksData";
 import { applyTelemetrySettingsChange, syncMainTelemetry } from "../telemetry/posthog";
 import { openExplicitExternalUrl } from "../window/externalUrl";
 import { EMPTY_GPU_BACKEND_INFO, getGpuBackendInfo } from "../gpuInfo";
+import { applyNativeAppTheme } from "../window/windowTheme";
 
 type DiscordMonitor = {
   start(): void;
@@ -246,6 +248,10 @@ export function registerCoreIpcHandlers(deps: CoreIpcHandlerDeps): void {
         if (key === "updateChannel") {
           deps.getAppUpdater()?.setUpdateChannel(appliedValue as Settings["updateChannel"]);
         }
+        if (key === "appTheme") {
+          const backgroundColor = applyNativeAppTheme(appliedValue as Settings["appTheme"], nativeTheme);
+          deps.getMainWindow()?.setBackgroundColor(backgroundColor);
+        }
         deps.getSignalingCoordinator()?.applySettingsChange(key, appliedValue);
         if (key === "discordRichPresence") {
           if (appliedValue) {
@@ -264,6 +270,8 @@ export function registerCoreIpcHandlers(deps: CoreIpcHandlerDeps): void {
 
   ipcMain.handle(IPC_CHANNELS.SETTINGS_RESET, async (): Promise<Settings> => {
     const resetSettings = settingsManager.reset();
+    const backgroundColor = applyNativeAppTheme(resetSettings.appTheme, nativeTheme);
+    deps.getMainWindow()?.setBackgroundColor(backgroundColor);
     deps
       .getAppUpdater()
       ?.setAutomaticChecksEnabled(resetSettings.autoCheckForUpdates);

--- a/opennow-stable/src/main/media/recordings.ts
+++ b/opennow-stable/src/main/media/recordings.ts
@@ -49,6 +49,13 @@ export function extFromMimeType(mimeType: string): ".mp4" | ".webm" {
   return mimeType.startsWith("video/mp4") ? ".mp4" : ".webm";
 }
 
+function getRecordingCreatedAtMs(fileName: string, fallbackMs: number): number {
+  const match = /^(\d{4}-\d{2}-\d{2}T)(\d{2})-(\d{2})-(\d{2})-(\d{3})Z-/.exec(fileName);
+  if (!match) return fallbackMs;
+  const parsed = Date.parse(`${match[1]}${match[2]}:${match[3]}:${match[4]}.${match[5]}Z`);
+  return Number.isFinite(parsed) ? parsed : fallbackMs;
+}
+
 async function listRecordingMetadata(dir: string): Promise<RecordingMetadata[]> {
   const entries = await readdir(dir, { withFileTypes: true });
   const webmFiles = entries
@@ -75,7 +82,10 @@ async function listRecordingMetadata(dir: string): Promise<RecordingMetadata[]> 
           id: fileName,
           fileName,
           filePath,
-          createdAtMs: fileStats.birthtimeMs || fileStats.mtimeMs,
+          createdAtMs: getRecordingCreatedAtMs(
+            fileName,
+            fileStats.birthtimeMs || fileStats.mtimeMs,
+          ),
           sizeBytes: fileStats.size,
           durationMs,
           gameTitle,
@@ -185,12 +195,18 @@ export async function finishRecording(
   // Enforce recording limit: delete oldest entries beyond RECORDING_LIMIT
   const all = await listRecordingMetadata(dir);
   if (all.length > RECORDING_LIMIT) {
-    const toDelete = all.slice(RECORDING_LIMIT);
+    const toDelete = all
+      .filter((entry) => entry.filePath !== finalPath)
+      .slice(RECORDING_LIMIT - 1);
     await Promise.all(
       toDelete.map(async (entry) => {
-        await unlink(entry.filePath).catch(() => undefined);
-        const stem = entry.fileName.replace(/\.(mp4|webm)$/i, "");
-        await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
+        try {
+          await unlink(entry.filePath);
+          const stem = entry.fileName.replace(/\.(mp4|webm)$/i, "");
+          await unlink(join(dir, `${stem}-thumb.jpg`)).catch(() => undefined);
+        } catch {
+          return;
+        }
       }),
     );
   }

--- a/opennow-stable/src/main/media/recordings.ts
+++ b/opennow-stable/src/main/media/recordings.ts
@@ -29,6 +29,8 @@ interface ActiveRecording {
 
 const activeRecordings = new Map<string, ActiveRecording>();
 
+type RecordingMetadata = Omit<RecordingEntry, "thumbnailDataUrl">;
+
 export function getRecordingsDirectory(): string {
   return join(app.getPath("pictures"), "OpenNOW", "Recordings");
 }
@@ -47,8 +49,7 @@ export function extFromMimeType(mimeType: string): ".mp4" | ".webm" {
   return mimeType.startsWith("video/mp4") ? ".mp4" : ".webm";
 }
 
-export async function listRecordings(): Promise<RecordingEntry[]> {
-  const dir = await ensureRecordingsDirectory();
+async function listRecordingMetadata(dir: string): Promise<RecordingMetadata[]> {
   const entries = await readdir(dir, { withFileTypes: true });
   const webmFiles = entries
     .filter((e) => e.isFile())
@@ -56,27 +57,12 @@ export async function listRecordings(): Promise<RecordingEntry[]> {
     .filter((name) => /\.(mp4|webm)$/i.test(name));
 
   const loaded = await Promise.all(
-    webmFiles.map(async (fileName): Promise<RecordingEntry | null> => {
+    webmFiles.map(async (fileName): Promise<RecordingMetadata | null> => {
       const filePath = join(dir, fileName);
       try {
         const fileStats = await stat(filePath);
-        const stem = fileName.replace(/\.(mp4|webm)$/i, "");
-        const thumbName = `${stem}-thumb.jpg`;
-        const thumbPath = join(dir, thumbName);
-
-        let thumbnailDataUrl: string | undefined;
-        try {
-          const thumbBuf = await readFile(thumbPath);
-          thumbnailDataUrl = `data:image/jpeg;base64,${thumbBuf.toString("base64")}`;
-        } catch {
-          // No thumbnail for this recording — that's fine
-        }
-
-        // Parse durationMs encoded in filename as last numeric segment before extension
         const durMatch = /-dur(\d+)\.(mp4|webm)$/i.exec(fileName);
         const durationMs = durMatch ? Number(durMatch[1]) : 0;
-
-        // Parse game title from filename: {stamp}-{title}-{rand}[-dur{ms}].{ext}
         const titleMatch =
           /^[^-]+-[^-]+-([^-]+(?:-[^-]+)*?)-[a-f0-9]{6}(?:-dur\d+)?\.(mp4|webm)$/i.exec(
             fileName,
@@ -93,7 +79,6 @@ export async function listRecordings(): Promise<RecordingEntry[]> {
           sizeBytes: fileStats.size,
           durationMs,
           gameTitle,
-          thumbnailDataUrl,
         };
       } catch {
         return null;
@@ -102,9 +87,26 @@ export async function listRecordings(): Promise<RecordingEntry[]> {
   );
 
   return loaded
-    .filter((item): item is RecordingEntry => item !== null)
-    .sort((a, b) => b.createdAtMs - a.createdAtMs)
-    .slice(0, RECORDING_LIMIT);
+    .filter((item): item is RecordingMetadata => item !== null)
+    .sort((a, b) => b.createdAtMs - a.createdAtMs);
+}
+
+export async function listRecordings(): Promise<RecordingEntry[]> {
+  const dir = await ensureRecordingsDirectory();
+  const newest = (await listRecordingMetadata(dir)).slice(0, RECORDING_LIMIT);
+
+  return Promise.all(newest.map(async (entry): Promise<RecordingEntry> => {
+    const stem = entry.fileName.replace(/\.(mp4|webm)$/i, "");
+    try {
+      const thumbBuf = await readFile(join(dir, `${stem}-thumb.jpg`));
+      return {
+        ...entry,
+        thumbnailDataUrl: `data:image/jpeg;base64,${thumbBuf.toString("base64")}`,
+      };
+    } catch {
+      return entry;
+    }
+  }));
 }
 
 export async function beginRecording(
@@ -181,7 +183,7 @@ export async function finishRecording(
   }
 
   // Enforce recording limit: delete oldest entries beyond RECORDING_LIMIT
-  const all = await listRecordings();
+  const all = await listRecordingMetadata(dir);
   if (all.length > RECORDING_LIMIT) {
     const toDelete = all.slice(RECORDING_LIMIT);
     await Promise.all(

--- a/opennow-stable/src/main/media/screenshots.ts
+++ b/opennow-stable/src/main/media/screenshots.ts
@@ -71,26 +71,31 @@ export async function listScreenshots(): Promise<ScreenshotEntry[]> {
 
   const newest = metadata
     .filter((item): item is NonNullable<typeof item> => item !== null)
-    .sort((a, b) => b.createdAtMs - a.createdAtMs)
-    .slice(0, SCREENSHOT_LIMIT);
+    .sort((a, b) => b.createdAtMs - a.createdAtMs);
 
-  const loaded = await Promise.all(newest.map(async (item): Promise<ScreenshotEntry | null> => {
-    try {
-      const fileBuffer = await readFile(item.filePath);
-      return {
-        id: item.fileName,
-        fileName: item.fileName,
-        filePath: item.filePath,
-        createdAtMs: item.createdAtMs,
-        sizeBytes: item.sizeBytes,
-        dataUrl: buildScreenshotDataUrl(item.ext, fileBuffer),
-      };
-    } catch {
-      return null;
-    }
-  }));
+  const loaded: ScreenshotEntry[] = [];
+  for (let offset = 0; offset < newest.length && loaded.length < SCREENSHOT_LIMIT; offset += SCREENSHOT_LIMIT) {
+    const batch = await Promise.all(
+      newest.slice(offset, offset + SCREENSHOT_LIMIT).map(async (item): Promise<ScreenshotEntry | null> => {
+        try {
+          const fileBuffer = await readFile(item.filePath);
+          return {
+            id: item.fileName,
+            fileName: item.fileName,
+            filePath: item.filePath,
+            createdAtMs: item.createdAtMs,
+            sizeBytes: item.sizeBytes,
+            dataUrl: buildScreenshotDataUrl(item.ext, fileBuffer),
+          };
+        } catch {
+          return null;
+        }
+      }),
+    );
+    loaded.push(...batch.filter((item): item is ScreenshotEntry => item !== null));
+  }
 
-  return loaded.filter((item): item is ScreenshotEntry => item !== null);
+  return loaded.slice(0, SCREENSHOT_LIMIT);
 }
 
 export async function saveScreenshot(

--- a/opennow-stable/src/main/media/screenshots.ts
+++ b/opennow-stable/src/main/media/screenshots.ts
@@ -49,22 +49,19 @@ export async function listScreenshots(): Promise<ScreenshotEntry[]> {
     .map((entry) => entry.name)
     .filter((name) => /\.(png|jpg|jpeg|webp)$/i.test(name));
 
-  const loaded = await Promise.all(
-    screenshotFiles.map(async (fileName): Promise<ScreenshotEntry | null> => {
+  const metadata = await Promise.all(
+    screenshotFiles.map(async (fileName) => {
       const filePath = join(dir, fileName);
       try {
         const fileStats = await stat(filePath);
-        const fileBuffer = await readFile(filePath);
         const extMatch = /\.([^.]+)$/.exec(fileName);
         const ext = (extMatch?.[1] ?? "png").toLowerCase();
-
         return {
-          id: fileName,
           fileName,
           filePath,
           createdAtMs: fileStats.birthtimeMs || fileStats.mtimeMs,
           sizeBytes: fileStats.size,
-          dataUrl: buildScreenshotDataUrl(ext, fileBuffer),
+          ext,
         };
       } catch {
         return null;
@@ -72,10 +69,28 @@ export async function listScreenshots(): Promise<ScreenshotEntry[]> {
     }),
   );
 
-  return loaded
-    .filter((item): item is ScreenshotEntry => item !== null)
+  const newest = metadata
+    .filter((item): item is NonNullable<typeof item> => item !== null)
     .sort((a, b) => b.createdAtMs - a.createdAtMs)
     .slice(0, SCREENSHOT_LIMIT);
+
+  const loaded = await Promise.all(newest.map(async (item): Promise<ScreenshotEntry | null> => {
+    try {
+      const fileBuffer = await readFile(item.filePath);
+      return {
+        id: item.fileName,
+        fileName: item.fileName,
+        filePath: item.filePath,
+        createdAtMs: item.createdAtMs,
+        sizeBytes: item.sizeBytes,
+        dataUrl: buildScreenshotDataUrl(item.ext, fileBuffer),
+      };
+    } catch {
+      return null;
+    }
+  }));
+
+  return loaded.filter((item): item is ScreenshotEntry => item !== null);
 }
 
 export async function saveScreenshot(

--- a/opennow-stable/src/main/platforms/gfn/proxyFetch.ts
+++ b/opennow-stable/src/main/platforms/gfn/proxyFetch.ts
@@ -1,5 +1,3 @@
-import { ProxyAgent, fetch as undiciFetch } from "undici";
-
 import {
   normalizeSessionProxyUrl,
   parseSessionProxyForElectron,
@@ -11,16 +9,29 @@ type ElectronSessionWithFetch = Electron.Session & {
   fetch?: typeof fetch;
 };
 
-const httpProxyAgents = new Map<string, ProxyAgent>();
+type UndiciModule = typeof import("undici");
+
+const httpProxyAgents = new Map<string, import("undici").ProxyAgent>();
 const proxyCredentialsByEndpoint = new Map<string, { username: string; password: string }>();
 let proxyLoginHandlerRegistered = false;
+let undiciModulePromise: Promise<UndiciModule> | null = null;
 
-function getHttpProxyAgent(normalizedProxyUrl: string): ProxyAgent {
+function loadUndici(): Promise<UndiciModule> {
+  undiciModulePromise ??= import("undici");
+  return undiciModulePromise;
+}
+
+async function getHttpProxyAgent(normalizedProxyUrl: string): Promise<import("undici").ProxyAgent> {
   const existing = httpProxyAgents.get(normalizedProxyUrl);
   if (existing) {
     return existing;
   }
 
+  const { ProxyAgent } = await loadUndici();
+  const raced = httpProxyAgents.get(normalizedProxyUrl);
+  if (raced) {
+    return raced;
+  }
   const agent = new ProxyAgent(normalizedProxyUrl);
   httpProxyAgents.set(normalizedProxyUrl, agent);
   return agent;
@@ -103,11 +114,14 @@ export async function fetchWithOptionalProxy(
 
   const protocol = new URL(normalizedProxyUrl).protocol;
   if (protocol === "http:" || protocol === "https:") {
-    const agent = getHttpProxyAgent(normalizedProxyUrl);
+    const [{ fetch: undiciFetch }, agent] = await Promise.all([
+      loadUndici(),
+      getHttpProxyAgent(normalizedProxyUrl),
+    ]);
     return undiciFetch(input, {
       ...init,
       dispatcher: agent,
-    } as Parameters<typeof undiciFetch>[1]) as unknown as Response;
+    } as Parameters<UndiciModule["fetch"]>[1]) as unknown as Response;
   }
 
   const proxyConfig = parseSessionProxyForElectron(normalizedProxyUrl);

--- a/opennow-stable/src/main/window/mainWindow.ts
+++ b/opennow-stable/src/main/window/mainWindow.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, globalShortcut, ipcMain } from "electron";
+import { app, BrowserWindow, globalShortcut, ipcMain, nativeTheme } from "electron";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { IPC_CHANNELS } from "@shared/ipc";
@@ -17,6 +17,7 @@ import { shouldReportRendererTermination } from "./rendererLifecycle";
 import type { StreamShortcutInterceptionGate } from "@shared/gfn";
 import { resolveStatsShortcutInterception } from "./streamShortcutInterception";
 import { StreamEscapeShortcutController } from "./streamEscapeShortcut";
+import { applyNativeAppTheme } from "./windowTheme";
 
 export interface CreateMainWindowDeps {
   mainDir: string;
@@ -88,6 +89,7 @@ export async function createMainWindow(
   const startFullscreen =
     settings.launchInConsoleMode ||
     deps.getPendingDirectLaunchRequest() !== null;
+  const windowBackgroundColor = applyNativeAppTheme(settings.appTheme, nativeTheme);
   const linuxWindowIcon = process.platform === "linux"
     ? app.isPackaged
       ? join(process.resourcesPath, "app-icon.png")
@@ -103,7 +105,7 @@ export async function createMainWindow(
     ...(startFullscreen ? { fullscreen: true } : {}),
     ...(linuxWindowIcon ? { icon: linuxWindowIcon } : {}),
     autoHideMenuBar: true,
-    backgroundColor: "#0f172a",
+    backgroundColor: windowBackgroundColor,
     webPreferences: {
       preload: preloadPath,
       contextIsolation: true,

--- a/opennow-stable/src/main/window/mainWindow.ts
+++ b/opennow-stable/src/main/window/mainWindow.ts
@@ -113,6 +113,11 @@ export async function createMainWindow(
       sandbox: false,
     },
   });
+  const syncAutomaticWindowTheme = (): void => {
+    if (deps.settingsManager.get("appTheme") !== "auto" || window.isDestroyed()) return;
+    window.setBackgroundColor(applyNativeAppTheme("auto", nativeTheme));
+  };
+  nativeTheme.on("updated", syncAutomaticWindowTheme);
   deps.setMainWindow(window);
   if (windowTitle) {
     window.on("page-title-updated", (event) => {
@@ -334,6 +339,7 @@ export async function createMainWindow(
   }
 
   window.on("closed", () => {
+    nativeTheme.off("updated", syncAutomaticWindowTheme);
     ipcMain.off(
       IPC_CHANNELS.STREAM_SHORTCUT_INTERCEPTION_CHANGE,
       handleStreamShortcutInterceptionChange,

--- a/opennow-stable/src/main/window/windowTheme.test.ts
+++ b/opennow-stable/src/main/window/windowTheme.test.ts
@@ -1,0 +1,34 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyNativeAppTheme } from "./windowTheme";
+
+test("native app theme resolves explicit and system window backgrounds", () => {
+  let source: "system" | "light" | "dark" = "system";
+  let systemDark = true;
+  const nativeTheme = {
+    get themeSource(): "system" | "light" | "dark" {
+      return source;
+    },
+    set themeSource(value: "system" | "light" | "dark") {
+      source = value;
+    },
+    get shouldUseDarkColors(): boolean {
+      return source === "system" ? systemDark : source === "dark";
+    },
+  };
+
+  assert.equal(applyNativeAppTheme("light", nativeTheme), "#f8fafc");
+  assert.equal(nativeTheme.themeSource, "light");
+
+  assert.equal(applyNativeAppTheme("dark", nativeTheme), "#101014");
+  assert.equal(nativeTheme.themeSource, "dark");
+
+  assert.equal(applyNativeAppTheme("auto", nativeTheme), "#101014");
+  assert.equal(nativeTheme.themeSource, "system");
+
+  systemDark = false;
+  assert.equal(applyNativeAppTheme("auto", nativeTheme), "#f8fafc");
+});

--- a/opennow-stable/src/main/window/windowTheme.ts
+++ b/opennow-stable/src/main/window/windowTheme.ts
@@ -1,0 +1,11 @@
+import type { AppTheme } from "@shared/gfn";
+
+interface NativeThemeLike {
+  themeSource: "system" | "light" | "dark";
+  readonly shouldUseDarkColors: boolean;
+}
+
+export function applyNativeAppTheme(theme: AppTheme, nativeTheme: NativeThemeLike): string {
+  nativeTheme.themeSource = theme === "auto" ? "system" : theme;
+  return nativeTheme.shouldUseDarkColors ? "#101014" : "#f8fafc";
+}

--- a/opennow-stable/src/renderer/index.html
+++ b/opennow-stable/src/renderer/index.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenNOW</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -923,15 +923,9 @@ export function App(): JSX.Element {
     if (!authSession || streamStatus !== "idle") {
       return;
     }
-    let inFlight = false;
     const refresh = async (): Promise<void> => {
-      if (inFlight || document.visibilityState === "hidden") return;
-      inFlight = true;
-      try {
-        await refreshNavbarActiveSession();
-      } finally {
-        inFlight = false;
-      }
+      if (document.visibilityState === "hidden") return;
+      await refreshNavbarActiveSession();
     };
     const handleVisibilityChange = (): void => {
       if (document.visibilityState !== "hidden") {
@@ -959,16 +953,16 @@ export function App(): JSX.Element {
     if (codecResults || codecTesting || codecStartupTestAttemptedRef.current) {
       return;
     }
-    codecStartupTestAttemptedRef.current = true;
+    const runStartupCodecTest = (): void => {
+      if (codecStartupTestAttemptedRef.current) return;
+      codecStartupTestAttemptedRef.current = true;
+      void runCodecTest();
+    };
     if (typeof window.requestIdleCallback === "function") {
-      const idleCallbackId = window.requestIdleCallback(() => {
-        void runCodecTest();
-      }, { timeout: 4000 });
+      const idleCallbackId = window.requestIdleCallback(runStartupCodecTest, { timeout: 4000 });
       return () => window.cancelIdleCallback(idleCallbackId);
     }
-    const timer = window.setTimeout(() => {
-      void runCodecTest();
-    }, 1500);
+    const timer = window.setTimeout(runStartupCodecTest, 1500);
     return () => window.clearTimeout(timer);
   }, [codecResults, codecTesting, runCodecTest]);
 

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -420,6 +420,7 @@ export function App(): JSX.Element {
   });
   const resetLaunchRuntimeRef = useRef<(options?: { keepLaunchError?: boolean; keepStreamingContext?: boolean }) => void>(() => {});
   const refreshNavbarActiveSessionRef = useRef<(sessionOverride?: AuthSession) => Promise<void>>(async () => {});
+  const navbarActiveSessionRefreshIdRef = useRef(0);
 
   const onBootstrapSettings = useCallback((loadedSettings: Settings, _sessionProxyUrl: string | undefined) => {
     setSettings(loadedSettings);
@@ -829,6 +830,7 @@ export function App(): JSX.Element {
     sessionOverride?: AuthSession,
     streamingBaseUrlOverride?: string,
   ): Promise<void> => {
+    const refreshId = ++navbarActiveSessionRefreshIdRef.current;
     const session = sessionOverride ?? authSession;
     if (!session) {
       setNavbarActiveSession(null);
@@ -843,6 +845,7 @@ export function App(): JSX.Element {
     }
     try {
       const activeSessions = await window.openNow.getActiveSessions(token, streamingBaseUrl);
+      if (navbarActiveSessionRefreshIdRef.current !== refreshId) return;
       const snapshot = runtimeSnapshotRef.current;
       const resumableSessions = activeSessions.filter((entry) => entry.status === 3 || entry.status === 2);
       const candidate =
@@ -856,7 +859,9 @@ export function App(): JSX.Element {
         null;
       setNavbarActiveSession(candidate);
     } catch (error) {
-      console.warn("Failed to refresh active sessions:", error);
+      if (navbarActiveSessionRefreshIdRef.current === refreshId) {
+        console.warn("Failed to refresh active sessions:", error);
+      }
     }
   }, [authSession, effectiveStreamingBaseUrl, settings.region]);
 
@@ -918,11 +923,31 @@ export function App(): JSX.Element {
     if (!authSession || streamStatus !== "idle") {
       return;
     }
-    void refreshNavbarActiveSession();
+    let inFlight = false;
+    const refresh = async (): Promise<void> => {
+      if (inFlight || document.visibilityState === "hidden") return;
+      inFlight = true;
+      try {
+        await refreshNavbarActiveSession();
+      } finally {
+        inFlight = false;
+      }
+    };
+    const handleVisibilityChange = (): void => {
+      if (document.visibilityState !== "hidden") {
+        void refresh();
+      }
+    };
+    void refresh();
     const timer = window.setInterval(() => {
-      void refreshNavbarActiveSession();
+      void refresh();
     }, 10000);
-    return () => window.clearInterval(timer);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      navbarActiveSessionRefreshIdRef.current += 1;
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, [authSession, refreshNavbarActiveSession, streamStatus]);
 
   useEffect(() => {
@@ -935,7 +960,16 @@ export function App(): JSX.Element {
       return;
     }
     codecStartupTestAttemptedRef.current = true;
-    void runCodecTest();
+    if (typeof window.requestIdleCallback === "function") {
+      const idleCallbackId = window.requestIdleCallback(() => {
+        void runCodecTest();
+      }, { timeout: 4000 });
+      return () => window.cancelIdleCallback(idleCallbackId);
+    }
+    const timer = window.setTimeout(() => {
+      void runCodecTest();
+    }, 1500);
+    return () => window.clearTimeout(timer);
   }, [codecResults, codecTesting, runCodecTest]);
 
   const shortcuts = useMemo(() => {
@@ -2445,6 +2479,10 @@ export function App(): JSX.Element {
       playtime,
     );
   }, [libraryGames, searchQuery, catalogSelectedSortId, playtime]);
+  const librarySortOptions = useMemo(
+    () => catalogSortOptions.filter((option) => option.id !== "relevance"),
+    [catalogSortOptions],
+  );
 
   const activeSessionAppIds = useMemo(
     () => (navbarActiveSession ? [navbarActiveSession.appId] : []),
@@ -2473,6 +2511,12 @@ export function App(): JSX.Element {
     }
     setCurrentPage(nextPage);
   }, [currentPage]);
+  const navigateToPreviousControllerPage = useCallback((): void => {
+    navigateControllerPage(-1);
+  }, [navigateControllerPage]);
+  const navigateToNextControllerPage = useCallback((): void => {
+    navigateControllerPage(1);
+  }, [navigateControllerPage]);
 
   const handleNavigate = useCallback((page: AppPage): void => {
     if (page === "settings" && currentPage !== "settings") {
@@ -2507,6 +2551,24 @@ export function App(): JSX.Element {
     setReleaseHighlightsPayload(null);
     setReleaseHighlightsIsAuto(false);
   }, [releaseHighlightsIsAuto]);
+
+  const handleNavbarResumeSession = useCallback((): void => {
+    void handleResumeFromNavbar();
+  }, [handleResumeFromNavbar]);
+  const handleNavbarTerminateSession = useCallback((): void => {
+    void handleTerminateNavbarSession();
+  }, [handleTerminateNavbarSession]);
+  const handleNavbarRemoveAccount = useCallback((userId: string, restoreFocusTarget?: HTMLElement): void => {
+    accountConfirmRestoreFocusRef.current = restoreFocusTarget ?? null;
+    void handleRemoveAccount(userId);
+  }, [handleRemoveAccount]);
+  const handleNavbarLogoutAll = useCallback((restoreFocusTarget?: HTMLElement): void => {
+    accountConfirmRestoreFocusRef.current = restoreFocusTarget ?? null;
+    handleLogout();
+  }, [handleLogout]);
+  const handleOpenFeedback = useCallback((): void => {
+    setFeedbackOpen(true);
+  }, []);
 
   const handleErrorReportingConsent = useCallback(async (granted: boolean): Promise<void> => {
     await updateSetting("errorReportingConsent", granted ? "granted" : "denied");
@@ -2646,25 +2708,15 @@ export function App(): JSX.Element {
         activeSessionGameTitle={activeSessionGameTitle}
         isResumingSession={isResumingNavbarSession}
         isTerminatingSession={isTerminatingNavbarSession}
-        onResumeSession={() => {
-          void handleResumeFromNavbar();
-        }}
-        onTerminateSession={() => {
-          void handleTerminateNavbarSession();
-        }}
+        onResumeSession={handleNavbarResumeSession}
+        onTerminateSession={handleNavbarTerminateSession}
         savedAccounts={savedAccounts}
         onSwitchAccount={handleSwitchAccount}
-        onRemoveAccount={(userId, restoreFocusTarget) => {
-          accountConfirmRestoreFocusRef.current = restoreFocusTarget ?? null;
-          void handleRemoveAccount(userId);
-        }}
+        onRemoveAccount={handleNavbarRemoveAccount}
         onAddAccount={handleAddAccount}
-        onLogoutAll={(restoreFocusTarget) => {
-          accountConfirmRestoreFocusRef.current = restoreFocusTarget ?? null;
-          handleLogout();
-        }}
+        onLogoutAll={handleNavbarLogoutAll}
         onExitApp={handleExitApp}
-        onOpenFeedback={() => setFeedbackOpen(true)}
+        onOpenFeedback={handleOpenFeedback}
         onBlockingOverlayChange={setNavbarOverlayBlocking}
         controllerMode={effectiveControllerMode}
       />
@@ -2708,8 +2760,8 @@ export function App(): JSX.Element {
                 onBuyGame={handleBuyGame}
                 onMarkGameOwned={handleMarkGameOwned}
                 markOwnedInFlightByVariantId={markOwnedInFlightByVariantId}
-                onPreviousControllerPage={() => navigateControllerPage(-1)}
-                onNextControllerPage={() => navigateControllerPage(1)}
+                onPreviousControllerPage={navigateToPreviousControllerPage}
+                onNextControllerPage={navigateToNextControllerPage}
               />
             )}
 
@@ -2729,7 +2781,7 @@ export function App(): JSX.Element {
                   selectedVariantByGameId={variantByGameId}
                   onSelectGameVariant={handleSelectGameVariant}
                   libraryCount={libraryGames.length}
-                  sortOptions={catalogSortOptions.filter((option) => option.id !== "relevance")}
+                  sortOptions={librarySortOptions}
                   selectedSortId={catalogSelectedSortId === "relevance" ? "last_played" : catalogSelectedSortId}
                   onSortChange={setCatalogSelectedSortId}
                   controllerMode={effectiveControllerMode}
@@ -2737,8 +2789,8 @@ export function App(): JSX.Element {
                   featuredGames={featuredGames.length > 0 ? featuredGames : games}
                   activeSessionAppIds={activeSessionAppIds}
                   onBuyGame={handleBuyGame}
-                  onPreviousControllerPage={() => navigateControllerPage(-1)}
-                  onNextControllerPage={() => navigateControllerPage(1)}
+                  onPreviousControllerPage={navigateToPreviousControllerPage}
+                  onNextControllerPage={navigateToNextControllerPage}
                 />
               </PageErrorBoundary>
             )}

--- a/opennow-stable/src/renderer/src/components/LoginScreen.tsx
+++ b/opennow-stable/src/renderer/src/components/LoginScreen.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef, useEffect } from "react";
 import type { JSX } from "react";
-import QRCode from "qrcode";
 import { LogIn, ChevronDown, QrCode } from "lucide-react";
 import { AnimatePresence, m } from "motion/react";
 import type { AuthDeviceLoginChallenge, LoginProvider } from "@shared/gfn";
@@ -68,15 +67,18 @@ export function LoginScreen({
       };
     }
 
-    QRCode.toDataURL(qrLoginChallenge.verificationUriComplete, {
-      errorCorrectionLevel: "M",
-      margin: 1,
-      scale: 8,
-      color: {
-        dark: "#07111f",
-        light: "#ffffff",
+    void import("qrcode").then(({ default: QRCode }) => QRCode.toDataURL(
+      qrLoginChallenge.verificationUriComplete,
+      {
+        errorCorrectionLevel: "M",
+        margin: 1,
+        scale: 8,
+        color: {
+          dark: "#07111f",
+          light: "#ffffff",
+        },
       },
-    }).then((dataUrl) => {
+    )).then((dataUrl) => {
       if (!cancelled) {
         setQrCodeDataUrl(dataUrl);
       }

--- a/opennow-stable/src/renderer/src/components/Navbar.tsx
+++ b/opennow-stable/src/renderer/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import type { ActiveSessionInfo, AuthUser, SavedAccount, SubscriptionInfo } from "@shared/gfn";
 import { House, Library, Settings, User, Timer, HardDrive, X, PlayCircle, Square, ChevronDown, Check, Plus, Store as StoreIcon, MessageSquareText, Power } from "lucide-react";
-import { useEffect, useRef, useState, type JSX } from "react";
+import { memo, useEffect, useRef, useState, type JSX } from "react";
 import { useTranslation } from "../i18n";
 import { OpenNowLogoMark } from "./OpenNowLogoMark";
 import { MotionSpinner } from "./MotionSpinner";
@@ -37,7 +37,7 @@ function getTierDisplay(tier: string): { labelKey: string; className: string } {
   return { labelKey: "app.labels.free", className: "tier-free" };
 }
 
-export function Navbar({
+export const Navbar = memo(function Navbar({
   currentPage,
   onNavigate,
   user,
@@ -564,4 +564,4 @@ export function Navbar({
       {modal}
     </nav>
   );
-}
+});

--- a/opennow-stable/src/renderer/src/components/ShaderAtmosphere.tsx
+++ b/opennow-stable/src/renderer/src/components/ShaderAtmosphere.tsx
@@ -117,6 +117,7 @@ function SignalField({
   pointerRef: RefObject<PointerPosition>;
 }): JSX.Element {
   const materialRef = useRef<ShaderMaterial>(null);
+  const lastRenderAtRef = useRef(Number.NEGATIVE_INFINITY);
   const energy = variant === "controller" ? 0.36 : variant === "queue" ? 0.72 : 1;
   const uniforms = useMemo(
     () => ({
@@ -137,7 +138,11 @@ function SignalField({
       pointerUniform.x += (pointerRef.current.x - pointerUniform.x) * smoothing;
       pointerUniform.y += (pointerRef.current.y - pointerUniform.y) * smoothing;
     }
-  });
+    if (state.clock.elapsedTime - lastRenderAtRef.current >= (1 / 30) - 0.001) {
+      lastRenderAtRef.current = state.clock.elapsedTime;
+      state.gl.render(state.scene, state.camera);
+    }
+  }, 1);
 
   return (
     <mesh>

--- a/opennow-stable/src/renderer/src/components/ShaderAtmosphere.tsx
+++ b/opennow-stable/src/renderer/src/components/ShaderAtmosphere.tsx
@@ -117,7 +117,7 @@ function SignalField({
   pointerRef: RefObject<PointerPosition>;
 }): JSX.Element {
   const materialRef = useRef<ShaderMaterial>(null);
-  const lastRenderAtRef = useRef(Number.NEGATIVE_INFINITY);
+  const renderBudgetRef = useRef(1 / 30);
   const energy = variant === "controller" ? 0.36 : variant === "queue" ? 0.72 : 1;
   const uniforms = useMemo(
     () => ({
@@ -138,8 +138,9 @@ function SignalField({
       pointerUniform.x += (pointerRef.current.x - pointerUniform.x) * smoothing;
       pointerUniform.y += (pointerRef.current.y - pointerUniform.y) * smoothing;
     }
-    if (state.clock.elapsedTime - lastRenderAtRef.current >= (1 / 30) - 0.001) {
-      lastRenderAtRef.current = state.clock.elapsedTime;
+    renderBudgetRef.current += delta;
+    if (renderBudgetRef.current >= (1 / 30) - 0.001) {
+      renderBudgetRef.current %= 1 / 30;
       state.gl.render(state.scene, state.camera);
     }
   }, 1);

--- a/opennow-stable/src/renderer/src/hooks/useCatalogData.ts
+++ b/opennow-stable/src/renderer/src/hooks/useCatalogData.ts
@@ -141,6 +141,18 @@ export function useCatalogData({
   const storePanelsLoadIdRef = useRef(0);
   const runtimeDataLoadIdRef = useRef(0);
   const gamesLoadIdRef = useRef({ main: 0, library: 0 });
+  const gamesLoadingIdRef = useRef({ main: 0, library: 0 });
+  const token = authSession?.tokens.idToken ?? authSession?.tokens.accessToken ?? "";
+  const userId = authSession?.user.userId ?? "";
+  const mainGamesContextKey = `${token}\0${userId}\0${effectiveStreamingBaseUrl}\0${buildProxyAwareCatalogQueryKey(
+    searchQuery,
+    catalogSelectedFilterIds,
+    catalogSelectedSortId,
+    activeSessionProxyUrl,
+  )}`;
+  const libraryGamesContextKey = `${token}\0${userId}\0${effectiveStreamingBaseUrl}\0${getSessionProxyUiScope(activeSessionProxyUrl)}`;
+  const gamesContextKeyRef = useRef({ main: mainGamesContextKey, library: libraryGamesContextKey });
+  gamesContextKeyRef.current = { main: mainGamesContextKey, library: libraryGamesContextKey };
   const lastCatalogQueryRef = useRef<string | null>(null);
   const lastCatalogProxyUrlRef = useRef<string | undefined>(undefined);
 
@@ -340,6 +352,8 @@ export function useCatalogData({
     runtimeDataLoadIdRef.current += 1;
     gamesLoadIdRef.current.main += 1;
     gamesLoadIdRef.current.library += 1;
+    gamesLoadingIdRef.current.main = 0;
+    gamesLoadingIdRef.current.library = 0;
     resetStorePanels();
     setGames([]);
     setLibraryGames([]);
@@ -383,10 +397,13 @@ export function useCatalogData({
     targetSource: "main" | "library",
     options?: { background?: boolean },
   ) => {
+    const contextKey = targetSource === "main" ? mainGamesContextKey : libraryGamesContextKey;
+    if (gamesContextKeyRef.current[targetSource] !== contextKey) return;
     const loadId = ++gamesLoadIdRef.current[targetSource];
     const isCurrentLoad = (): boolean => gamesLoadIdRef.current[targetSource] === loadId;
     const setLoading = targetSource === "main" ? setIsLoadingCatalog : setIsLoadingLibrary;
     if (!options?.background) {
+      gamesLoadingIdRef.current[targetSource] = loadId;
       setLoading(true);
     }
     try {
@@ -430,11 +447,12 @@ export function useCatalogData({
         console.error("Failed to load games:", error);
       }
     } finally {
-      if (isCurrentLoad() && !options?.background) {
+      if (gamesLoadingIdRef.current[targetSource] === loadId) {
+        gamesLoadingIdRef.current[targetSource] = 0;
         setLoading(false);
       }
     }
-  }, [activeSessionProxyUrl, applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, featuredGames.length, searchQuery, catalogFilterKey, catalogSelectedSortId]);
+  }, [activeSessionProxyUrl, applyCatalogBrowseResult, applyVariantSelections, authSession, effectiveStreamingBaseUrl, featuredGames.length, searchQuery, catalogFilterKey, catalogSelectedSortId, libraryGamesContextKey, mainGamesContextKey]);
 
   const loadStorePanels = useCallback(async (options?: { force?: boolean; background?: boolean }) => {
     const session = authSession;

--- a/opennow-stable/src/renderer/src/hooks/useCatalogData.ts
+++ b/opennow-stable/src/renderer/src/hooks/useCatalogData.ts
@@ -140,6 +140,7 @@ export function useCatalogData({
   const storePanelsLoadedContextRef = useRef("");
   const storePanelsLoadIdRef = useRef(0);
   const runtimeDataLoadIdRef = useRef(0);
+  const gamesLoadIdRef = useRef({ main: 0, library: 0 });
   const lastCatalogQueryRef = useRef<string | null>(null);
   const lastCatalogProxyUrlRef = useRef<string | undefined>(undefined);
 
@@ -337,6 +338,8 @@ export function useCatalogData({
 
   const clearSessionCatalog = useCallback((mode: CatalogClearMode, options?: ClearSessionCatalogOptions): void => {
     runtimeDataLoadIdRef.current += 1;
+    gamesLoadIdRef.current.main += 1;
+    gamesLoadIdRef.current.library += 1;
     resetStorePanels();
     setGames([]);
     setLibraryGames([]);
@@ -380,6 +383,8 @@ export function useCatalogData({
     targetSource: "main" | "library",
     options?: { background?: boolean },
   ) => {
+    const loadId = ++gamesLoadIdRef.current[targetSource];
+    const isCurrentLoad = (): boolean => gamesLoadIdRef.current[targetSource] === loadId;
     const setLoading = targetSource === "main" ? setIsLoadingCatalog : setIsLoadingLibrary;
     if (!options?.background) {
       setLoading(true);
@@ -403,10 +408,11 @@ export function useCatalogData({
           sortId: catalogSelectedSortId,
           filterIds: catalogSelectedFilterIds,
         });
+        if (!isCurrentLoad()) return;
         applyCatalogBrowseResult(catalogResult);
         if (featuredGames.length === 0) {
           void window.openNow.fetchFeaturedGames({ token, userId, providerStreamingBaseUrl: baseUrl, proxyUrl }).then((featured) => {
-            if (featured.length > 0) setFeaturedGames(featured);
+            if (isCurrentLoad() && featured.length > 0) setFeaturedGames(featured);
           }).catch((error) => {
             console.warn("Featured games refresh failed:", error);
           });
@@ -415,13 +421,16 @@ export function useCatalogData({
       }
 
       const result = await window.openNow.fetchLibraryGames({ token, userId, providerStreamingBaseUrl: baseUrl, proxyUrl });
+      if (!isCurrentLoad()) return;
       setLibraryGames(result);
       setSelectedGameId((previous) => result.some((game) => game.id === previous) ? previous : (result[0]?.id ?? ""));
       applyVariantSelections(result);
     } catch (error) {
-      console.error("Failed to load games:", error);
+      if (isCurrentLoad()) {
+        console.error("Failed to load games:", error);
+      }
     } finally {
-      if (!options?.background) {
+      if (isCurrentLoad() && !options?.background) {
         setLoading(false);
       }
     }

--- a/opennow-stable/src/renderer/src/i18n.ts
+++ b/opennow-stable/src/renderer/src/i18n.ts
@@ -10,10 +10,12 @@ type TranslationTree = { [key: string]: TranslationLeaf | TranslationTree };
 const FALLBACK_LOCALE = "en";
 const LOCALE_STORAGE_KEY = "opennow.locale";
 
-const localeSources = import.meta.glob<string>("../../../../locales/*.json", {
+const localeSources = import.meta.glob<string>([
+  "../../../../locales/*.json",
+  "!../../../../locales/en.json",
+], {
   query: "?raw",
   import: "default",
-  eager: true,
 });
 
 const fallbackTree = fallbackTranslations as TranslationTree;
@@ -48,11 +50,11 @@ function localeFromPath(path: string): string | null {
   return normalizeLocale(fileName.slice(0, -".json".length));
 }
 
-function getLocaleSource(locale: string): string | null {
+async function getLocaleSource(locale: string): Promise<string | null> {
   const normalized = normalizeLocale(locale);
-  for (const [path, source] of Object.entries(localeSources)) {
+  for (const [path, loadSource] of Object.entries(localeSources)) {
     if (localeFromPath(path) === normalized) {
-      return source;
+      return loadSource();
     }
   }
   return null;
@@ -107,14 +109,14 @@ function parseLocaleJson(locale: string, raw: string): TranslationTree | null {
   }
 }
 
-function loadTranslations(locale: string): TranslationTree | null {
+async function loadTranslations(locale: string): Promise<TranslationTree | null> {
   const normalized = normalizeLocale(locale);
   if (normalized === FALLBACK_LOCALE) return fallbackTree;
 
   const cached = loadedLocales.get(normalized);
   if (cached) return cached;
 
-  const source = getLocaleSource(normalized);
+  const source = await getLocaleSource(normalized);
   if (source === null) return null;
 
   const parsed = parseLocaleJson(normalized, source);
@@ -185,14 +187,14 @@ export function getAvailableLocales(): string[] {
 
 export async function setLocale(locale: string): Promise<void> {
   const normalized = normalizeLocale(locale);
-  const translations = loadTranslations(normalized);
+  const translations = await loadTranslations(normalized);
   writeStoredLocale(normalized);
   setActiveTranslations(normalized, translations);
 }
 
 export async function initializeLocale(): Promise<void> {
   const initialLocale = getInitialLocale();
-  const translations = loadTranslations(initialLocale);
+  const translations = await loadTranslations(initialLocale);
   setActiveTranslations(initialLocale, translations);
 }
 

--- a/opennow-stable/src/renderer/src/i18n.ts
+++ b/opennow-stable/src/renderer/src/i18n.ts
@@ -25,6 +25,7 @@ const listeners = new Set<() => void>();
 let activeLocale = FALLBACK_LOCALE;
 let activeTranslations = fallbackTree;
 let snapshotVersion = 0;
+let localeLoadGeneration = 0;
 
 function subscribe(listener: () => void): () => void {
   listeners.add(listener);
@@ -187,14 +188,18 @@ export function getAvailableLocales(): string[] {
 
 export async function setLocale(locale: string): Promise<void> {
   const normalized = normalizeLocale(locale);
-  const translations = await loadTranslations(normalized);
+  const generation = ++localeLoadGeneration;
   writeStoredLocale(normalized);
+  const translations = await loadTranslations(normalized);
+  if (generation !== localeLoadGeneration) return;
   setActiveTranslations(normalized, translations);
 }
 
 export async function initializeLocale(): Promise<void> {
   const initialLocale = getInitialLocale();
+  const generation = ++localeLoadGeneration;
   const translations = await loadTranslations(initialLocale);
+  if (generation !== localeLoadGeneration) return;
   setActiveTranslations(initialLocale, translations);
 }
 

--- a/opennow-stable/src/renderer/src/lib/gameCatalog.ts
+++ b/opennow-stable/src/renderer/src/lib/gameCatalog.ts
@@ -92,12 +92,17 @@ export function sortLibraryGames(
     return copy.sort(compareTitle);
   }
   if (sortId === "last_played") {
-    return copy.sort((left, right) => {
-      const leftTime = playtimeLastPlayedMs(left.id) || legacyLastPlayedMs(left);
-      const rightTime = playtimeLastPlayedMs(right.id) || legacyLastPlayedMs(right);
-      if (leftTime === rightTime) return compareTitle(left, right);
-      return rightTime - leftTime;
-    });
+    return copy
+      .map((game) => ({
+        game,
+        lastPlayedMs: playtimeLastPlayedMs(game.id) || legacyLastPlayedMs(game),
+      }))
+      .sort((left, right) => (
+        left.lastPlayedMs === right.lastPlayedMs
+          ? compareTitle(left.game, right.game)
+          : right.lastPlayedMs - left.lastPlayedMs
+      ))
+      .map(({ game }) => game);
   }
   if (sortId === "last_added") {
     // Preserve server-provided order. We do not currently have a trustworthy local "addedAt" field.

--- a/opennow-stable/src/renderer/src/main.tsx
+++ b/opennow-stable/src/renderer/src/main.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { scan } from "react-scan";
 
 import { initLogCapture } from "@shared/logger";
 import { App } from "./App";
@@ -13,7 +12,7 @@ initLogCapture("renderer");
 void initializeLocale();
 
 if (import.meta.env.DEV) {
-  scan();
+  void import("react-scan").then(({ scan }) => scan());
 }
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/opennow-stable/src/renderer/src/main.tsx
+++ b/opennow-stable/src/renderer/src/main.tsx
@@ -9,16 +9,23 @@ import "./styles.css";
 
 // Initialize log capture for renderer process
 initLogCapture("renderer");
-void initializeLocale();
 
-if (import.meta.env.DEV) {
-  void import("react-scan").then(({ scan }) => scan());
-}
+const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
+const localeReady = initializeLocale().catch((error) => {
+  console.warn("[i18n] Failed to initialize locale; using English.", error);
+});
+const devToolsReady = import.meta.env.DEV
+  ? import("react-scan").then(({ scan }) => scan()).catch((error) => {
+      console.warn("[React Scan] Failed to initialize.", error);
+    })
+  : Promise.resolve();
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <MotionProvider>
-      <App />
-    </MotionProvider>
-  </React.StrictMode>,
-);
+void Promise.all([localeReady, devToolsReady]).then(() => {
+  root.render(
+    <React.StrictMode>
+      <MotionProvider>
+        <App />
+      </MotionProvider>
+    </React.StrictMode>,
+  );
+});

--- a/opennow-stable/src/renderer/src/platforms/gfn/videoShaderPipeline.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/videoShaderPipeline.ts
@@ -403,8 +403,6 @@ export class VideoShaderPipeline {
       return;
     }
 
-    this.syncCanvasSize();
-
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
     try {

--- a/opennow-stable/src/renderer/src/platforms/gfn/videoShaderPipeline.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/videoShaderPipeline.ts
@@ -161,6 +161,7 @@ export class VideoShaderPipeline {
       this.resizeObserver = new ResizeObserver(() => this.syncCanvasSize());
       this.resizeObserver.observe(videoElement);
     }
+    window.addEventListener?.("resize", this.syncCanvasSize);
 
     this.applyActivation();
   }
@@ -184,6 +185,7 @@ export class VideoShaderPipeline {
     this.stopRenderLoop();
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    window.removeEventListener?.("resize", this.syncCanvasSize);
     this.canvas.removeEventListener("webglcontextlost", this.onContextLost);
     this.canvas.removeEventListener("webglcontextrestored", this.onContextRestored);
     if (this.gl) {
@@ -335,7 +337,7 @@ export class VideoShaderPipeline {
     this.applyActivation();
   };
 
-  private syncCanvasSize(): void {
+  private readonly syncCanvasSize = (): void => {
     if (!this.active) return;
     const rect = this.videoElement.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
@@ -345,7 +347,7 @@ export class VideoShaderPipeline {
       this.canvas.width = width;
       this.canvas.height = height;
     }
-  }
+  };
 
   private startRenderLoop(): void {
     this.stopRenderLoop();

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -7,11 +7,13 @@
   --bg-a: #101014;
   --bg-b: #141418;
   --bg-c: #19191e;
+  --bg-e: var(--bg-c);
 
   /* Panels & cards */
   --panel: #131316;
   --panel-border: color-mix(in srgb, var(--ink) 6%, transparent);
   --panel-border-solid: #2a2a30;
+  --border: var(--panel-border-solid);
   --card: #151518;
   --card-hover: #1c1c20;
   --card-selected: #1a2a22;
@@ -21,6 +23,10 @@
   --ink: #ececef;
   --ink-soft: #9a9aa3;
   --ink-muted: #5c5c66;
+  --ink-dim: var(--ink-muted);
+  --text-secondary: var(--ink-soft);
+  --text-base: 1rem;
+  --text-sm: 0.875rem;
 
   /* Accent — green */
   --accent-rgb: 88, 217, 138;
@@ -85,6 +91,15 @@
   --ink: #0f172a;
   --ink-soft: #334155;
   --ink-muted: #64748b;
+  --error: #dc2626;
+  --error-bg: rgba(220, 38, 38, 0.08);
+  --error-border: rgba(220, 38, 38, 0.22);
+  --warning: #a16207;
+  --info: #2563eb;
+  --success: #15803d;
+  --shadow-sm: 0 2px 8px rgba(15, 23, 42, 0.1);
+  --shadow-md: 0 8px 24px rgba(15, 23, 42, 0.14);
+  --shadow-lg: 0 20px 60px rgba(15, 23, 42, 0.2);
 }
 
 /* ---------- Reset & Base ---------- */
@@ -101,7 +116,7 @@ body,
 #root {
   width: 100%;
   height: 100%;
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: 14px;
   line-height: 1.5;
   color: var(--ink);
@@ -163,6 +178,33 @@ body,
   position: fixed;
   inset: 0;
   z-index: 1080;
+}
+
+.app-container--controller .app-shell,
+.stream-view-layer,
+.game-card-image-wrapper {
+  --bg-a: #101014;
+  --bg-b: #141418;
+  --bg-c: #19191e;
+  --bg-e: #19191e;
+  --panel: #131316;
+  --panel-border: rgba(255, 255, 255, 0.09);
+  --panel-border-solid: #2a2a30;
+  --border: #2a2a30;
+  --card: #151518;
+  --card-hover: #1c1c20;
+  --card-selected: #1a2a22;
+  --chip: #1e1e23;
+  --ink: #f4f4f5;
+  --ink-soft: #c3c7cc;
+  --ink-muted: #858c94;
+  --ink-dim: #858c94;
+  --text-secondary: #c3c7cc;
+  --error: #f87171;
+  --warning: #fbbf24;
+  --info: #60a5fa;
+  --success: #4ade80;
+  color-scheme: dark;
 }
 
 .app-container--controller {
@@ -1576,7 +1618,7 @@ body,
   width: 100%;
   max-width: 380px;
   padding: 32px;
-  background: rgba(21, 21, 24, 0.92);
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
   border: 1px solid var(--panel-border);
   border-radius: var(--r-xl);
   box-shadow: var(--shadow-lg);
@@ -1632,7 +1674,7 @@ body,
   background: rgba(96, 165, 250, 0.08);
   border: 1px solid rgba(96, 165, 250, 0.2);
   border-radius: var(--r-sm);
-  color: #93c5fd;
+  color: var(--info);
   font-size: 0.8rem;
   font-weight: 500;
 }
@@ -1681,7 +1723,7 @@ body,
 }
 
 .login-select:hover:not(:disabled) {
-  border-color: #444;
+  border-color: color-mix(in srgb, var(--ink) 28%, transparent);
 }
 
 .login-select:focus {
@@ -1765,7 +1807,7 @@ body,
   align-items: center;
   margin: 0 0 18px;
   padding: 14px;
-  background: rgba(21, 21, 24, 0.92);
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
   border: 1px solid var(--panel-border-solid);
   border-radius: var(--r-md);
 }
@@ -3750,6 +3792,12 @@ button.controller-hint {
   cursor: pointer;
   transition: border-color var(--t-normal), box-shadow var(--t-normal);
   contain: layout style;
+  content-visibility: auto;
+  contain-intrinsic-block-size: auto 200px;
+}
+
+.library-page .game-card {
+  contain-intrinsic-block-size: auto 320px;
 }
 
 .game-card:focus-within {
@@ -4166,7 +4214,7 @@ button.game-card-store-chip.owned.active:hover {
   inset: 0;
   background:
     linear-gradient(90deg, rgba(4, 6, 8, 0.34), transparent 58%),
-    linear-gradient(to bottom, rgba(4, 6, 8, 0.04) 18%, rgba(4, 6, 8, 0.58) 68%, var(--panel) 100%);
+    linear-gradient(to bottom, rgba(4, 6, 8, 0.04) 18%, rgba(4, 6, 8, 0.58) 68%, rgba(4, 6, 8, 0.92) 100%);
 }
 
 .game-detail-close {

--- a/opennow-stable/src/renderer/src/telemetry/posthog.ts
+++ b/opennow-stable/src/renderer/src/telemetry/posthog.ts
@@ -1,4 +1,3 @@
-import posthog from "posthog-js";
 import type { ErrorReportingConsent, Settings } from "@shared/gfn";
 import { getLogCapture } from "@shared/logger";
 import {
@@ -14,6 +13,13 @@ let initialized = false;
 let exceptionsEnabled = false;
 let activeDistinctId: string | null = null;
 let registeredVersionProperties: Record<string, string | undefined> | null = null;
+type PostHogClient = typeof import("posthog-js").default;
+let posthog: PostHogClient | null = null;
+
+async function loadPostHog(): Promise<PostHogClient> {
+  posthog ??= (await import("posthog-js")).default;
+  return posthog;
+}
 
 function buildRendererBaseProperties(): Record<string, string | undefined> {
   return {
@@ -42,12 +48,13 @@ async function getAppVersionProperties(): Promise<Record<string, string | undefi
 }
 
 async function registerClientProperties(): Promise<void> {
-  if (!initialized) {
+  const client = posthog;
+  if (!initialized || !client) {
     return;
   }
   const versionProperties = await getAppVersionProperties();
   registeredVersionProperties = versionProperties;
-  posthog.register({
+  client.register({
     ...buildRendererBaseProperties(),
     ...versionProperties,
   });
@@ -58,8 +65,9 @@ async function ensureClient(distinctId: string, enableExceptions: boolean): Prom
     return false;
   }
 
+  const client = await loadPostHog();
   if (!initialized) {
-    posthog.init(POSTHOG_PROJECT_TOKEN, {
+    client.init(POSTHOG_PROJECT_TOKEN, {
       api_host: POSTHOG_HOST,
       autocapture: false,
       capture_pageview: false,
@@ -91,19 +99,19 @@ async function ensureClient(distinctId: string, enableExceptions: boolean): Prom
   }
 
   if (activeDistinctId !== distinctId) {
-    posthog.identify(distinctId);
+    client.identify(distinctId);
     activeDistinctId = distinctId;
   }
 
   if (enableExceptions && !exceptionsEnabled) {
-    posthog.startExceptionAutocapture({
+    client.startExceptionAutocapture({
       capture_unhandled_errors: true,
       capture_unhandled_rejections: true,
       capture_console_errors: false,
     });
     exceptionsEnabled = true;
   } else if (!enableExceptions && exceptionsEnabled) {
-    posthog.stopExceptionAutocapture();
+    client.stopExceptionAutocapture();
     exceptionsEnabled = false;
   }
 
@@ -143,7 +151,7 @@ async function ensureInstallId(settings: Settings): Promise<string> {
 export async function syncRendererTelemetry(settings: Settings): Promise<void> {
   const consent: ErrorReportingConsent = settings.errorReportingConsent;
   if (consent !== "granted") {
-    if (initialized && exceptionsEnabled) {
+    if (posthog && initialized && exceptionsEnabled) {
       posthog.stopExceptionAutocapture();
       exceptionsEnabled = false;
     }
@@ -158,7 +166,7 @@ export function captureRendererException(
   error: unknown,
   additionalProperties?: Record<string, unknown>,
 ): void {
-  if (!initialized || !exceptionsEnabled) {
+  if (!posthog || !initialized || !exceptionsEnabled) {
     return;
   }
 
@@ -238,7 +246,7 @@ export async function captureFeedback(
     properties.logs_bytes = logsBytes;
   }
 
-  posthog.capture(FEEDBACK_EVENT_NAME, properties);
+  posthog?.capture(FEEDBACK_EVENT_NAME, properties);
   return true;
 }
 

--- a/opennow-stable/src/renderer/src/telemetry/posthog.ts
+++ b/opennow-stable/src/renderer/src/telemetry/posthog.ts
@@ -13,6 +13,7 @@ let initialized = false;
 let exceptionsEnabled = false;
 let activeDistinctId: string | null = null;
 let registeredVersionProperties: Record<string, string | undefined> | null = null;
+let activeConsent: ErrorReportingConsent = "unset";
 type PostHogClient = typeof import("posthog-js").default;
 let posthog: PostHogClient | null = null;
 
@@ -150,6 +151,7 @@ async function ensureInstallId(settings: Settings): Promise<string> {
  */
 export async function syncRendererTelemetry(settings: Settings): Promise<void> {
   const consent: ErrorReportingConsent = settings.errorReportingConsent;
+  activeConsent = consent;
   if (consent !== "granted") {
     if (posthog && initialized && exceptionsEnabled) {
       posthog.stopExceptionAutocapture();
@@ -160,6 +162,10 @@ export async function syncRendererTelemetry(settings: Settings): Promise<void> {
 
   const distinctId = await ensureInstallId(settings);
   await ensureClient(distinctId, true);
+  if (activeConsent !== "granted" && posthog && exceptionsEnabled) {
+    posthog.stopExceptionAutocapture();
+    exceptionsEnabled = false;
+  }
 }
 
 export function captureRendererException(


### PR DESCRIPTION
## Summary
- repair light theme ownership across the login screen, controller shell, stream overlays, semantic colors, shadows, and native Electron window chrome
- reduce startup work by lazy-loading React Scan, PostHog, QR generation, locales, and Undici; remove the render-blocking Google Fonts request and defer codec probing
- reduce steady-state renderer cost with capped decorative shader rendering, resize-driven stream shader sizing, stable memoized page/navbar props, offscreen card containment, and visibility-aware session polling
- prevent stale catalog responses, precompute last-played timestamps during sorting, limit media gallery payload reads, and enforce recording retention safely
- shrink packaged output by excluding renderer-bundled packages and unused Chromium locale packs while preserving native streamer resources on every supported release platform

## Measured impact
- initial renderer JavaScript: 3,278,539 B → 2,114,430 B (-35.5%)
- default main-process JavaScript: 1,534,281 B → 537,130 B (-65.0%); the 999,943 B proxy chunk now loads only for HTTP(S) proxies
- Linux app.asar: 117,321,604 B → 12,414,074 B (-89.4%)
- Linux unpacked package: 433 MiB → 297 MiB (-31.4%), including the 7.4 MiB native streamer resource
- Chromium locale payload: 55 packs / 45.9 MiB → 15 packs / 9.9 MiB

## Regression review
- verified lazy-load races are latest-selection/consent wins and preserve development Strict Mode behavior
- kept active-session recovery responsive while rejecting stale responses
- prevented stale post-mutation catalog refreshes from crossing query/account boundaries
- protected newly finalized recordings and thumbnail pairs during retention cleanup
- verified shader pause/resume, DPR changes, automatic native-theme updates, and cross-platform native streamer packaging

## Verification
- `npm --prefix opennow-stable test` (464 passed)
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable run lint`
- `npm --prefix opennow-stable run build`
- `npx electron-builder --linux dir --publish never`
- packaged Electron runtime smoke test
- visually verified the logged-out light theme in Electron