### PR TITLE
fix(console): harden profile PINs and controller flows

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -213,6 +213,8 @@
       "lockedOut": "Too many attempts. Try again in {{seconds}}s.",
       "recoveryHint": "Hold B to remove this profile",
       "recoveryReady": "Release to choose",
+      "forgotPin": "Forgot PIN?",
+      "recoveryPrompt": "Remove this profile and sign out?",
       "removeProfile": "Remove this profile"
     },
     "manage": {

--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -476,6 +476,7 @@ function registerIpcHandlers(): void {
 
   registerConsolePinIpcHandlers({
     getConsoleProfiles: () => authService.getConsoleProfiles(),
+    isSavedAccount: (userId) => authService.getSavedAccounts().some((account) => account.userId === userId),
   });
 
   registerSessionIpcHandlers({

--- a/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
+++ b/opennow-stable/src/main/ipc/accountCatalogHandlers.ts
@@ -179,8 +179,9 @@ export function registerAccountCatalogIpcHandlers(
 
   ipcMain.handle(
     IPC_CHANNELS.AUTH_SWITCH_ACCOUNT,
-    async (_event, userId: string) => {
-      return authService.switchAccount(userId);
+    async (_event, input: string | { userId: string; pin?: string }) => {
+      const { userId, pin } = typeof input === "string" ? { userId: input, pin: undefined } : input;
+      return authService.switchAccount(userId, pin);
     },
   );
 

--- a/opennow-stable/src/main/ipc/consolePinHandlers.ts
+++ b/opennow-stable/src/main/ipc/consolePinHandlers.ts
@@ -11,9 +11,11 @@ import type {
 import { IPC_CHANNELS } from "@shared/ipc";
 
 import type { ConsoleProfileStore } from "../platforms/gfn/auth/consoleProfileStore";
+import { PIN_MAX_ATTEMPTS } from "../platforms/gfn/auth/pinPolicy";
 
 export interface ConsolePinIpcDependencies {
   getConsoleProfiles: () => ConsoleProfileStore;
+  isSavedAccount: (userId: string) => boolean;
 }
 
 /**
@@ -26,25 +28,34 @@ export interface ConsolePinIpcDependencies {
 export function registerConsolePinIpcHandlers(deps: ConsolePinIpcDependencies): void {
   ipcMain.handle(
     IPC_CHANNELS.CONSOLE_PIN_GET_STATUS,
-    (_event, userId: string): ConsolePinStatus =>
-      deps.getConsoleProfiles().getStatus(userId, Date.now()),
+    (_event, userId: string): ConsolePinStatus => deps.isSavedAccount(userId)
+      ? deps.getConsoleProfiles().getStatus(userId, Date.now())
+      : { userId, hasPin: false, lockedUntilMs: null, remainingAttempts: PIN_MAX_ATTEMPTS },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.CONSOLE_PIN_SET,
-    (_event, input: ConsolePinSetRequest): Promise<ConsolePinMutationResult> =>
-      deps.getConsoleProfiles().setPin(input.userId, input.pin, input.currentPin),
+    (_event, input: ConsolePinSetRequest): Promise<ConsolePinMutationResult> => deps.isSavedAccount(input.userId)
+      ? deps.getConsoleProfiles().setPin(input.userId, input.pin, input.currentPin)
+      : Promise.resolve({ ok: false, reason: "unknown_account", hasPin: false }),
   );
 
   ipcMain.handle(
     IPC_CHANNELS.CONSOLE_PIN_CLEAR,
-    (_event, input: ConsolePinClearRequest): Promise<ConsolePinMutationResult> =>
-      deps.getConsoleProfiles().clearPin(input.userId, input.currentPin),
+    (_event, input: ConsolePinClearRequest): Promise<ConsolePinMutationResult> => deps.isSavedAccount(input.userId)
+      ? deps.getConsoleProfiles().clearPin(input.userId, input.currentPin)
+      : Promise.resolve({ ok: false, reason: "unknown_account", hasPin: false }),
   );
 
   ipcMain.handle(
     IPC_CHANNELS.CONSOLE_PIN_VERIFY,
-    (_event, input: ConsolePinVerifyRequest): Promise<ConsolePinVerifyResult> =>
-      deps.getConsoleProfiles().verifyPin(input.userId, input.pin),
+    (_event, input: ConsolePinVerifyRequest): Promise<ConsolePinVerifyResult> => deps.isSavedAccount(input.userId)
+      ? deps.getConsoleProfiles().verifyPin(input.userId, input.pin)
+      : Promise.resolve({
+        ok: false,
+        reason: "unknown_account",
+        remainingAttempts: 0,
+        lockedUntilMs: null,
+      }),
   );
 }

--- a/opennow-stable/src/main/platforms/gfn/auth.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth.ts
@@ -90,8 +90,11 @@ export class AuthService {
   }
 
   async initialize(): Promise<void> {
-    await this.consoleProfiles.initialize();
     const restoredSession = await this.state.initialize();
+    await this.consoleProfiles.initialize();
+    await this.consoleProfiles.retainUsers(
+      this.state.accounts.getSavedAccounts().map((account) => account.userId),
+    );
     if (restoredSession) {
       this.state.accounts.setSelectedProvider(restoredSession.provider);
       await this.enrichmentCaches.enrichUserTier();
@@ -115,11 +118,12 @@ export class AuthService {
     return this.accountManager.getSavedAccounts();
   }
 
-  async switchAccount(userId: string): Promise<AuthSession> {
+  async switchAccount(userId: string, pin?: string): Promise<AuthSession> {
     return this.accountManager.switchAccount(
       userId,
       (forceRefresh, expectedUserId) =>
         this.ensureValidSessionWithStatus(forceRefresh, expectedUserId),
+      pin,
     );
   }
 

--- a/opennow-stable/src/main/platforms/gfn/auth/accountManager.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/accountManager.test.ts
@@ -108,6 +108,40 @@ test("AccountManager reports hasPin per account and never leaks the hash", async
   }
 });
 
+test("AccountManager requires the PIN before switching to a locked account", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "opennow-auth-account-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const state = new PersistedAccountState(join(directory, "auth.json"));
+  const first = session("first");
+  const locked = session("locked");
+  state.accounts.setSession(first);
+  state.accounts.setSession(locked);
+  state.accounts.setActiveAccount("first");
+
+  const profiles = new ConsoleProfileStore(join(directory, "console-profiles.json"), passthroughCrypto);
+  await profiles.initialize();
+  await profiles.setPin("locked", "1234");
+
+  const manager = new AccountManager(state, () => {}, profiles);
+  let refreshCalls = 0;
+  const ensureSession = async () => {
+    refreshCalls += 1;
+    return {
+      session: locked,
+      refresh: { attempted: false, forced: true, outcome: "not_attempted" as const, message: "Current" },
+    };
+  };
+
+  await assert.rejects(() => manager.switchAccount("locked", ensureSession), /PIN is required or incorrect/);
+  await assert.rejects(() => manager.switchAccount("locked", ensureSession, "0000"), /PIN is required or incorrect/);
+  assert.equal(refreshCalls, 0);
+  assert.equal(state.accounts.getActiveUserId(), "first");
+
+  assert.equal((await manager.switchAccount("locked", ensureSession, "1234")).user.userId, "locked");
+  assert.equal(refreshCalls, 1);
+});
+
 test("AccountManager defaults hasPin to false without a lock store", async (t) => {
   const directory = await mkdtemp(join(tmpdir(), "opennow-auth-account-"));
   t.after(() => rm(directory, { recursive: true, force: true }));

--- a/opennow-stable/src/main/platforms/gfn/auth/accountManager.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/accountManager.ts
@@ -46,10 +46,17 @@ export class AccountManager {
     return this.state.accounts.getSession() as AuthSession;
   }
 
-  async switchAccount(userId: string, ensureSession: EnsureSession): Promise<AuthSession> {
+  async switchAccount(userId: string, ensureSession: EnsureSession, pin?: string): Promise<AuthSession> {
     const target = this.state.accounts.getSessionForUser(userId);
     if (!target) {
       throw new Error("Saved account not found");
+    }
+
+    if (this.consoleProfiles?.hasPin(userId)) {
+      const verification = await this.consoleProfiles.verifyPin(userId, pin ?? "");
+      if (!verification.ok) {
+        throw new Error(verification.reason === "locked_out" ? "Profile PIN is temporarily locked" : "Profile PIN is required or incorrect");
+      }
     }
 
     const previousActiveUserId = this.state.accounts.getActiveUserId();
@@ -98,7 +105,9 @@ export class AccountManager {
     }
     this.clearCaches();
     await this.state.persist();
-    await this.consoleProfiles?.forgetUser(userId);
+    await this.consoleProfiles?.forgetUser(userId).catch((error) => {
+      console.warn("Failed to persist removed account PIN cleanup:", error);
+    });
   }
 
   async logout(): Promise<void> {
@@ -110,13 +119,17 @@ export class AccountManager {
     this.state.accounts.setActiveAccount(this.state.accounts.firstUserId());
     this.clearCaches();
     await this.state.persist();
-    await this.consoleProfiles?.forgetUser(activeUserId);
+    await this.consoleProfiles?.forgetUser(activeUserId).catch((error) => {
+      console.warn("Failed to persist signed-out account PIN cleanup:", error);
+    });
   }
 
   async logoutAll(): Promise<void> {
     this.state.accounts.reset();
     this.clearCaches();
     await this.state.persist();
-    await this.consoleProfiles?.forgetAll();
+    await this.consoleProfiles?.forgetAll().catch((error) => {
+      console.warn("Failed to persist all-account PIN cleanup:", error);
+    });
   }
 }

--- a/opennow-stable/src/main/platforms/gfn/auth/consoleProfileStore.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/consoleProfileStore.test.ts
@@ -142,6 +142,20 @@ test("lockout survives a store restart", async () => {
   assert.equal((await second.verifyPin(USER, "1111", 1_000)).reason, "locked_out");
 });
 
+test("parallel failures cannot overwrite the lockout", async () => {
+  const path = await tempPath();
+  const first = await openStore(path);
+  await first.setPin(USER, "1111");
+
+  await Promise.all(
+    Array.from({ length: PIN_MAX_ATTEMPTS + 2 }, () => first.verifyPin(USER, "0000", 1_000)),
+  );
+
+  assert.equal(first.getStatus(USER, 1_000).lockedUntilMs, 1_000 + PIN_LOCKOUT_STEPS_MS[0]);
+  const second = await openStore(path);
+  assert.equal(second.getStatus(USER, 1_000).lockedUntilMs, 1_000 + PIN_LOCKOUT_STEPS_MS[0]);
+});
+
 test("a successful verify clears the failure counter", async () => {
   const store = await openStore(await tempPath());
   await store.setPin(USER, "1111");
@@ -161,6 +175,20 @@ test("forgetUser drops the lock and persists the removal", async () => {
 
   const second = await openStore(path);
   assert.equal(second.hasPin(USER), false);
+});
+
+test("retainUsers prunes orphaned profile locks", async () => {
+  const path = await tempPath();
+  const first = await openStore(path);
+  await first.setPin("kept", "1111");
+  await first.setPin("orphan", "2222");
+  await first.retainUsers(["kept"]);
+
+  assert.equal(first.hasPin("kept"), true);
+  assert.equal(first.hasPin("orphan"), false);
+  const second = await openStore(path);
+  assert.equal(second.hasPin("kept"), true);
+  assert.equal(second.hasPin("orphan"), false);
 });
 
 test("round-trips when OS encryption is unavailable", async () => {

--- a/opennow-stable/src/main/platforms/gfn/auth/consoleProfileStore.ts
+++ b/opennow-stable/src/main/platforms/gfn/auth/consoleProfileStore.ts
@@ -44,6 +44,7 @@ const EMPTY_DOCUMENT: ConsoleProfileDocument = { version: 1, profiles: [] };
 export class ConsoleProfileStore {
   private profiles = new Map<string, ConsoleProfileRecord>();
   private initialized = false;
+  private mutationQueue: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly filePath: string,
@@ -70,6 +71,12 @@ export class ConsoleProfileStore {
       version: 1,
       profiles: [...this.profiles.values()],
     });
+  }
+
+  private runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.mutationQueue.then(operation, operation);
+    this.mutationQueue = result.then(() => undefined, () => undefined);
+    return result;
   }
 
   private ensureRecord(userId: string): ConsoleProfileRecord {
@@ -104,100 +111,123 @@ export class ConsoleProfileStore {
   }
 
   async setPin(userId: string, pin: string, currentPin?: string, nowMs = Date.now()): Promise<ConsolePinMutationResult> {
-    if (!this.initialized) return { ok: false, reason: "storage_unavailable", hasPin: false };
-    if (!isPinFormatValid(pin)) return { ok: false, reason: "invalid_format", hasPin: this.hasPin(userId) };
+    return this.runExclusive(async () => {
+      if (!this.initialized) return { ok: false, reason: "storage_unavailable", hasPin: false };
+      if (!isPinFormatValid(pin)) return { ok: false, reason: "invalid_format", hasPin: this.hasPin(userId) };
 
-    const record = this.ensureRecord(userId);
-    if (record.pin) {
-      // Replacing a PIN requires proving you know the current one, otherwise the
-      // lock could be reset from the manage screen without ever unlocking it.
-      if (currentPin === undefined || !isPinFormatValid(currentPin)) {
-        return { ok: false, reason: "invalid_format", hasPin: true };
+      const record = this.ensureRecord(userId);
+      if (record.pin) {
+        // Replacing a PIN requires proving you know the current one, otherwise the
+        // lock could be reset from the manage screen without ever unlocking it.
+        if (currentPin === undefined || !isPinFormatValid(currentPin)) {
+          return { ok: false, reason: "invalid_format", hasPin: true };
+        }
+        const gate = evaluatePinGate(record.attempts, nowMs);
+        if (!gate.allowed) return { ok: false, reason: "locked_out", hasPin: true };
+        if (!(await verifyPinHash(currentPin, record.pin))) {
+          record.attempts = registerPinFailure(record.attempts, nowMs);
+          await this.persist();
+          return { ok: false, reason: "invalid_pin", hasPin: true };
+        }
       }
+
+      record.pin = await hashPin(pin);
+      record.attempts = createPinAttemptState();
+      record.updatedAtMs = nowMs;
+      await this.persist();
+      return { ok: true, hasPin: true };
+    });
+  }
+
+  async clearPin(userId: string, currentPin: string, nowMs = Date.now()): Promise<ConsolePinMutationResult> {
+    return this.runExclusive(async () => {
+      if (!this.initialized) return { ok: false, reason: "storage_unavailable", hasPin: false };
+
+      const record = this.profiles.get(userId);
+      if (!record?.pin) return { ok: false, reason: "no_pin_set", hasPin: false };
+
       const gate = evaluatePinGate(record.attempts, nowMs);
       if (!gate.allowed) return { ok: false, reason: "locked_out", hasPin: true };
+      if (!isPinFormatValid(currentPin)) return { ok: false, reason: "invalid_format", hasPin: true };
+
       if (!(await verifyPinHash(currentPin, record.pin))) {
         record.attempts = registerPinFailure(record.attempts, nowMs);
         await this.persist();
         return { ok: false, reason: "invalid_pin", hasPin: true };
       }
-    }
 
-    record.pin = await hashPin(pin);
-    record.attempts = createPinAttemptState();
-    record.updatedAtMs = nowMs;
-    await this.persist();
-    return { ok: true, hasPin: true };
-  }
-
-  async clearPin(userId: string, currentPin: string, nowMs = Date.now()): Promise<ConsolePinMutationResult> {
-    if (!this.initialized) return { ok: false, reason: "storage_unavailable", hasPin: false };
-
-    const record = this.profiles.get(userId);
-    if (!record?.pin) return { ok: false, reason: "no_pin_set", hasPin: false };
-
-    const gate = evaluatePinGate(record.attempts, nowMs);
-    if (!gate.allowed) return { ok: false, reason: "locked_out", hasPin: true };
-    if (!isPinFormatValid(currentPin)) return { ok: false, reason: "invalid_format", hasPin: true };
-
-    if (!(await verifyPinHash(currentPin, record.pin))) {
-      record.attempts = registerPinFailure(record.attempts, nowMs);
+      record.pin = null;
+      record.attempts = createPinAttemptState();
+      record.updatedAtMs = nowMs;
       await this.persist();
-      return { ok: false, reason: "invalid_pin", hasPin: true };
-    }
-
-    record.pin = null;
-    record.attempts = createPinAttemptState();
-    record.updatedAtMs = nowMs;
-    await this.persist();
-    return { ok: true, hasPin: false };
+      return { ok: true, hasPin: false };
+    });
   }
 
   async verifyPin(userId: string, pin: string, nowMs = Date.now()): Promise<ConsolePinVerifyResult> {
-    if (!this.initialized) {
-      return { ok: false, reason: "storage_unavailable", remainingAttempts: 0, lockedUntilMs: null };
-    }
+    return this.runExclusive(async () => {
+      if (!this.initialized) {
+        return { ok: false, reason: "storage_unavailable", remainingAttempts: 0, lockedUntilMs: null };
+      }
 
-    const record = this.profiles.get(userId);
-    if (!record?.pin) {
-      return { ok: true, reason: "no_pin_set", remainingAttempts: PIN_MAX_ATTEMPTS, lockedUntilMs: null };
-    }
+      const record = this.profiles.get(userId);
+      if (!record?.pin) {
+        return { ok: true, reason: "no_pin_set", remainingAttempts: PIN_MAX_ATTEMPTS, lockedUntilMs: null };
+      }
 
-    const gate = evaluatePinGate(record.attempts, nowMs);
-    if (!gate.allowed) {
-      return { ok: false, reason: "locked_out", remainingAttempts: 0, lockedUntilMs: gate.lockedUntilMs };
-    }
+      const gate = evaluatePinGate(record.attempts, nowMs);
+      if (!gate.allowed) {
+        return { ok: false, reason: "locked_out", remainingAttempts: 0, lockedUntilMs: gate.lockedUntilMs };
+      }
 
-    if (!isPinFormatValid(pin)) {
-      return { ok: false, reason: "invalid_format", remainingAttempts: gate.remainingAttempts, lockedUntilMs: null };
-    }
+      if (!isPinFormatValid(pin)) {
+        return { ok: false, reason: "invalid_format", remainingAttempts: gate.remainingAttempts, lockedUntilMs: null };
+      }
 
-    if (await verifyPinHash(pin, record.pin)) {
-      record.attempts = registerPinSuccess(record.attempts);
+      if (await verifyPinHash(pin, record.pin)) {
+        record.attempts = registerPinSuccess(record.attempts);
+        await this.persist();
+        return { ok: true, remainingAttempts: PIN_MAX_ATTEMPTS, lockedUntilMs: null };
+      }
+
+      record.attempts = registerPinFailure(record.attempts, nowMs);
       await this.persist();
-      return { ok: true, remainingAttempts: PIN_MAX_ATTEMPTS, lockedUntilMs: null };
-    }
-
-    record.attempts = registerPinFailure(record.attempts, nowMs);
-    await this.persist();
-    const nextGate = evaluatePinGate(record.attempts, nowMs);
-    return {
-      ok: false,
-      reason: nextGate.allowed ? "invalid_pin" : "locked_out",
-      remainingAttempts: nextGate.remainingAttempts,
-      lockedUntilMs: nextGate.lockedUntilMs,
-    };
+      const nextGate = evaluatePinGate(record.attempts, nowMs);
+      return {
+        ok: false,
+        reason: nextGate.allowed ? "invalid_pin" : "locked_out",
+        remainingAttempts: nextGate.remainingAttempts,
+        lockedUntilMs: nextGate.lockedUntilMs,
+      };
+    });
   }
 
   /** Drops a profile's lock when the underlying account is removed. */
   async forgetUser(userId: string): Promise<void> {
-    if (!this.profiles.delete(userId)) return;
-    await this.persist();
+    await this.runExclusive(async () => {
+      if (!this.profiles.delete(userId)) return;
+      await this.persist();
+    });
   }
 
   async forgetAll(): Promise<void> {
-    if (this.profiles.size === 0) return;
-    this.profiles.clear();
-    await this.persist();
+    await this.runExclusive(async () => {
+      if (this.profiles.size === 0) return;
+      this.profiles.clear();
+      await this.persist();
+    });
+  }
+
+  async retainUsers(userIds: Iterable<string>): Promise<void> {
+    const retained = new Set(userIds);
+    await this.runExclusive(async () => {
+      let changed = false;
+      for (const userId of this.profiles.keys()) {
+        if (retained.has(userId)) continue;
+        this.profiles.delete(userId);
+        changed = true;
+      }
+      if (changed) await this.persist();
+    });
   }
 }

--- a/opennow-stable/src/main/security/encryptedJsonFile.ts
+++ b/opennow-stable/src/main/security/encryptedJsonFile.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import { dirname } from "node:path";
 
 /**
@@ -76,5 +77,17 @@ export async function writeEncryptedJson<T>(
   }
 
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(envelope, null, 2), "utf8");
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  let handle: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    handle = await open(temporaryPath, "w", 0o600);
+    await handle.writeFile(JSON.stringify(envelope, null, 2), "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await rename(temporaryPath, path);
+  } finally {
+    await handle?.close().catch(() => undefined);
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+  }
 }

--- a/opennow-stable/src/preload/index.ts
+++ b/opennow-stable/src/preload/index.ts
@@ -96,8 +96,8 @@ const api: OpenNowApi = {
   logout: () => ipcRenderer.invoke(IPC_CHANNELS.AUTH_LOGOUT),
   logoutAll: () => ipcRenderer.invoke(IPC_CHANNELS.AUTH_LOGOUT_ALL),
   getSavedAccounts: (): Promise<SavedAccount[]> => ipcRenderer.invoke(IPC_CHANNELS.AUTH_GET_SAVED_ACCOUNTS),
-  switchAccount: (userId: string): Promise<AuthSession> =>
-    ipcRenderer.invoke(IPC_CHANNELS.AUTH_SWITCH_ACCOUNT, userId),
+  switchAccount: (userId: string, pin?: string): Promise<AuthSession> =>
+    ipcRenderer.invoke(IPC_CHANNELS.AUTH_SWITCH_ACCOUNT, { userId, pin }),
   removeAccount: (userId: string): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.AUTH_REMOVE_ACCOUNT, userId),
   getConsolePinStatus: (userId: string): Promise<ConsolePinStatus> =>
     ipcRenderer.invoke(IPC_CHANNELS.CONSOLE_PIN_GET_STATUS, userId),

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -464,6 +464,7 @@ export function App(): JSX.Element {
     handleCancelQrLogin,
     handleSwitchAccount,
     handleRemoveAccount,
+    removeAccountNow,
     confirmRemoveAccount,
     handleAddAccount,
     refreshSavedAccounts,
@@ -680,12 +681,10 @@ export function App(): JSX.Element {
     hasAuthSession: authSession !== null,
     savedAccounts,
     activeUserId: authSession?.user.userId ?? null,
+    switchFailedMessage: t("console.profiles.switchFailed"),
     onSwitchAccount: handleSwitchAccount,
     onAddAccount: handleAddAccount,
-    onRemoveAccount: async (userId) => {
-      await window.openNow.removeAccount(userId);
-      await refreshSavedAccounts();
-    },
+    onRemoveAccount: removeAccountNow,
   });
 
   const buildCurrentStreamSettings = useCallback((subscriptionOverride?: SubscriptionInfo | null): StreamSettings => {
@@ -2687,10 +2686,8 @@ export function App(): JSX.Element {
         savedAccounts={savedAccounts}
         activeUserId={authSession?.user.userId ?? null}
         onAddAccount={handleAddAccount}
-        onRemoveAccount={async (userId) => {
-          await window.openNow.removeAccount(userId);
-          await refreshSavedAccounts();
-        }}
+        onProfilesChanged={async () => { await refreshSavedAccounts(); }}
+        onRemoveAccount={removeAccountNow}
         onLogoutAll={() => setLogoutConfirmOpen(true)}
       />
       <div

--- a/opennow-stable/src/renderer/src/components/HomePage.tsx
+++ b/opennow-stable/src/renderer/src/components/HomePage.tsx
@@ -4,6 +4,8 @@ import type { JSX } from "react";
 import type { CatalogFilterGroup, CatalogSortOption, GameInfo, GamePanelResult } from "@shared/gfn";
 import { GameCardListItem, useCatalogCardActionsRef } from "./GameCardListItem";
 import { gameNeedsPurchase, getNextVariantId } from "../lib/controllerCatalogUi";
+import { matchesGameSearch } from "../lib/gameCatalog";
+import { isControllerKeyboardActivationTarget } from "../lib/controllerKeyboard";
 import { clampRowFocus, moveRowFocus, type RowFocusDirection } from "../lib/consoleRowFocus";
 import { getConsoleStoreChoices } from "../lib/consoleStoreChoices";
 import { useTranslation } from "../i18n";
@@ -97,13 +99,29 @@ export const HomePage = memo(function HomePage({
   const scrollFocusIntoView = useControllerFocusScroll(controllerSurfaceActive);
 
   const controllerSections = useMemo(
-    () => storePanels.flatMap((panel) => panel.sections).filter((section) => section.games.length > 0),
-    [storePanels],
+    () => storePanels
+      .flatMap((panel) => panel.sections)
+      .map((section) => ({
+        ...section,
+        games: searchQuery.trim()
+          ? section.games.filter((game) => matchesGameSearch(game, searchQuery))
+          : section.games,
+      }))
+      .filter((section) => section.games.length > 0),
+    [searchQuery, storePanels],
   );
   const controllerRowLengths = useMemo(
     () => controllerSections.map((section) => Math.min(section.games.length, CONTROLLER_STORE_ROW_LIMIT)),
     [controllerSections],
   );
+
+  useEffect(() => {
+    if (!detailsGame) return;
+    const currentGame = controllerSections
+      .flatMap((section) => section.games)
+      .find((game) => game.id === detailsGame.id);
+    if (currentGame && currentGame !== detailsGame) setDetailsGame(currentGame);
+  }, [controllerSections, detailsGame]);
 
   const focusTile = (rowIndex: number, columnIndex: number): void => {
     if (!surfaceActive || controllerRowLengths.length === 0) return;
@@ -212,6 +230,7 @@ export const HomePage = memo(function HomePage({
   }, [controllerMode, controllerRowLengths, controllerSections, focusedColumnIndex, focusedRowIndex, onSelectGame, selectedGameId, surfaceActive]);
 
   useControllerKeyDown(controllerSurfaceActive, (event) => {
+    if ((event.key === "Enter" || event.key === " ") && isControllerKeyboardActivationTarget(event.target)) return;
     if (detailsGame && storePickerOpen) {
       const choices = storeChoicesFor(detailsGame);
       if (event.key === "Escape" || event.key.toLowerCase() === "b") {

--- a/opennow-stable/src/renderer/src/components/LibraryPage.tsx
+++ b/opennow-stable/src/renderer/src/components/LibraryPage.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "../i18n";
 import { formatCatalogLastPlayed } from "../utils/lastPlayedFormat";
 import { controllerButton } from "../utils/controllerGamepad";
 import { wasReleasedAsTap } from "../lib/controllerInputState";
+import { isControllerKeyboardActivationTarget } from "../lib/controllerKeyboard";
 import { useControllerFocusScroll } from "../hooks/useControllerFocusScroll";
 import { useControllerKeyDown, useControllerNavigation } from "../hooks/useControllerNavigation";
 import { pageTransition } from "./MotionProvider";
@@ -292,6 +293,7 @@ export const LibraryPage = memo(function LibraryPage({
   };
 
   useControllerKeyDown(controllerSurfaceActive, (event) => {
+    if ((event.key === "Enter" || event.key === " ") && isControllerKeyboardActivationTarget(event.target)) return;
     if (detailsGame && storePickerOpen) {
       const choices = storeChoicesFor(detailsGame);
       if (event.key === "Escape" || event.key.toLowerCase() === "b") {

--- a/opennow-stable/src/renderer/src/components/Navbar.tsx
+++ b/opennow-stable/src/renderer/src/components/Navbar.tsx
@@ -489,7 +489,8 @@ export const Navbar = memo(function Navbar({
                             role="menuitem"
                             onClick={() => {
                               if (!isActive) {
-                                void onSwitchAccount(account.userId);
+                                if (account.hasPin) onOpenProfilePicker?.();
+                                else void onSwitchAccount(account.userId);
                               }
                               setAccountDropdownOpen(false);
                             }}

--- a/opennow-stable/src/renderer/src/components/console/ConsoleGameDetails.tsx
+++ b/opennow-stable/src/renderer/src/components/console/ConsoleGameDetails.tsx
@@ -93,6 +93,7 @@ export function ConsoleGameDetails({
                 type="button"
                 className={`console-action console-action--${action.tone ?? "secondary"}${index === focusedActionIndex ? " is-focused" : ""}`}
                 disabled={action.disabled}
+                onFocus={() => onFocusAction(index)}
                 onClick={() => {
                   onFocusAction(index);
                   action.onSelect();

--- a/opennow-stable/src/renderer/src/components/console/ConsoleManageProfiles.tsx
+++ b/opennow-stable/src/renderer/src/components/console/ConsoleManageProfiles.tsx
@@ -1,8 +1,10 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { CSSProperties, JSX } from "react";
 import type { ConsolePinMutationResult, SavedAccount } from "@shared/gfn";
 
 import { isPinComplete } from "../../lib/consolePinInput";
+import { useControllerKeyDown, useControllerNavigation } from "../../hooks/useControllerNavigation";
+import { controllerButton } from "../../utils/controllerGamepad";
 import { useTranslation } from "../../i18n";
 import { ConsoleHintBar } from "./ConsoleHintBar";
 import { ConsoleOverlay } from "./ConsoleOverlay";
@@ -17,6 +19,7 @@ export interface ConsoleManageProfilesProps {
   savedAccounts: SavedAccount[];
   activeUserId: string | null;
   onAddAccount: () => void;
+  onProfilesChanged: () => Promise<void> | void;
   onRemoveAccount: (userId: string) => Promise<void> | void;
   onLogoutAll: () => void;
   onBack: () => void;
@@ -41,6 +44,7 @@ export function ConsoleManageProfiles({
   savedAccounts,
   activeUserId,
   onAddAccount,
+  onProfilesChanged,
   onRemoveAccount,
   onLogoutAll,
   onBack,
@@ -51,6 +55,8 @@ export function ConsoleManageProfiles({
   const [nextPin, setNextPin] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [focusedControlIndex, setFocusedControlIndex] = useState(0);
+  const rootRef = useRef<HTMLDivElement | null>(null);
 
   const closeDialog = useCallback(() => {
     setDialog(null);
@@ -78,18 +84,104 @@ export function ConsoleManageProfiles({
         setNextPin("");
         return;
       }
+      await onProfilesChanged();
       closeDialog();
+    } catch {
+      setError(t("console.manage.pinFailed"));
     } finally {
       setBusy(false);
     }
-  }, [busy, closeDialog, currentPin, dialog, nextPin, t]);
+  }, [busy, closeDialog, currentPin, dialog, nextPin, onProfilesChanged, t]);
 
   const canSubmit = dialog !== null && !busy && (dialog.mode === "clear"
     ? isPinComplete(currentPin)
     : isPinComplete(nextPin) && (dialog.mode === "set" || isPinComplete(currentPin)));
 
+  const getControls = useCallback(() => Array.from(
+    rootRef.current?.querySelectorAll<HTMLElement>("[data-console-manage-control]:not(:disabled)") ?? [],
+  ), []);
+
+  const focusControl = useCallback((index: number) => {
+    const controls = getControls();
+    if (controls.length === 0) return;
+    const nextIndex = Math.max(0, Math.min(index, controls.length - 1));
+    setFocusedControlIndex(nextIndex);
+    controls[nextIndex]?.focus({ preventScroll: true });
+    controls[nextIndex]?.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "auto" });
+  }, [getControls]);
+
+  const moveControl = useCallback((delta: -1 | 1) => {
+    const controls = getControls();
+    const activeIndex = controls.findIndex((control) => control === document.activeElement || control.contains(document.activeElement));
+    focusControl((activeIndex >= 0 ? activeIndex : focusedControlIndex) + delta);
+  }, [focusControl, focusedControlIndex, getControls]);
+
+  const activateFocusedControl = useCallback(() => {
+    const controls = getControls();
+    const active = controls.find((control) => control === document.activeElement || control.contains(document.activeElement));
+    (active ?? controls[focusedControlIndex])?.click();
+  }, [focusedControlIndex, getControls]);
+
+  useEffect(() => {
+    setFocusedControlIndex(0);
+    const frame = window.requestAnimationFrame(() => focusControl(0));
+    return () => window.cancelAnimationFrame(frame);
+  }, [dialog, focusControl]);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return undefined;
+    const handleFocusIn = (event: FocusEvent): void => {
+      const control = event.target instanceof Element
+        ? event.target.closest<HTMLElement>("[data-console-manage-control]")
+        : null;
+      if (!control) return;
+      const index = getControls().indexOf(control);
+      if (index >= 0) setFocusedControlIndex(index);
+    };
+    root.addEventListener("focusin", handleFocusIn);
+    return () => root.removeEventListener("focusin", handleFocusIn);
+  }, [getControls]);
+
+  useControllerKeyDown(true, (event) => {
+    if (event.key === "Escape" || event.key.toLowerCase() === "b") {
+      event.preventDefault();
+      if (dialog) closeDialog();
+      else onBack();
+      return;
+    }
+    if (["ArrowLeft", "ArrowUp"].includes(event.key)) {
+      event.preventDefault();
+      moveControl(-1);
+      return;
+    }
+    if (["ArrowRight", "ArrowDown"].includes(event.key)) {
+      event.preventDefault();
+      moveControl(1);
+      return;
+    }
+    if (event.key === "Enter" && event.target instanceof HTMLInputElement) {
+      event.preventDefault();
+      if (canSubmit) void submit();
+    }
+  });
+
+  useControllerNavigation({
+    enabled: true,
+    onFrame: ({ pressed }) => {
+      if (pressed & controllerButton.east) {
+        if (dialog) closeDialog();
+        else onBack();
+        return;
+      }
+      if (pressed & (controllerButton.left | controllerButton.up)) moveControl(-1);
+      if (pressed & (controllerButton.right | controllerButton.down)) moveControl(1);
+      if (pressed & controllerButton.south) activateFocusedControl();
+    },
+  });
+
   return (
-    <>
+    <div className="console-manage" ref={rootRef}>
       <h1 className="console-gate-title">{t("console.manage.title")}</h1>
       <p className="console-gate-subtitle">{t("console.manage.subtitle")}</p>
 
@@ -115,6 +207,7 @@ export function ConsoleManageProfiles({
                   <button
                     type="button"
                     className="console-action console-action--secondary"
+                    data-console-manage-control
                     onClick={() => { closeDialog(); setDialog({ mode: "change", account }); }}
                   >
                     {t("console.manage.changePin")}
@@ -122,6 +215,7 @@ export function ConsoleManageProfiles({
                   <button
                     type="button"
                     className="console-action console-action--secondary"
+                    data-console-manage-control
                     onClick={() => { closeDialog(); setDialog({ mode: "clear", account }); }}
                   >
                     {t("console.manage.removePin")}
@@ -131,6 +225,7 @@ export function ConsoleManageProfiles({
                 <button
                   type="button"
                   className="console-action console-action--secondary"
+                  data-console-manage-control
                   onClick={() => { closeDialog(); setDialog({ mode: "set", account }); }}
                 >
                   {t("console.manage.setPin")}
@@ -140,7 +235,10 @@ export function ConsoleManageProfiles({
                 <button
                   type="button"
                   className="console-action console-action--danger"
-                  onClick={() => void onRemoveAccount(account.userId)}
+                  data-console-manage-control
+                  onClick={() => {
+                    void Promise.resolve(onRemoveAccount(account.userId)).catch(() => setError(t("console.manage.pinFailed")));
+                  }}
                 >
                   {t("auth.accounts.removeAccount")}
                 </button>
@@ -151,10 +249,10 @@ export function ConsoleManageProfiles({
       </div>
 
       <div className="console-overlay-actions">
-        <button type="button" className="console-action console-action--secondary" onClick={onAddAccount}>
+        <button type="button" className="console-action console-action--secondary" data-console-manage-control onClick={onAddAccount}>
           {t("auth.accounts.addAccount")}
         </button>
-        <button type="button" className="console-action console-action--danger" onClick={onLogoutAll}>
+        <button type="button" className="console-action console-action--danger" data-console-manage-control onClick={onLogoutAll}>
           {t("auth.accounts.signOutAllAccounts")}
         </button>
       </div>
@@ -176,6 +274,7 @@ export function ConsoleManageProfiles({
           {dialog.mode !== "set" && (
             <input
               className="console-search-input"
+              data-console-manage-control
               type="password"
               inputMode="numeric"
               autoComplete="off"
@@ -189,6 +288,7 @@ export function ConsoleManageProfiles({
           {dialog.mode !== "clear" && (
             <input
               className="console-search-input"
+              data-console-manage-control
               type="password"
               inputMode="numeric"
               autoComplete="off"
@@ -205,16 +305,17 @@ export function ConsoleManageProfiles({
               type="button"
               className="console-action console-action--primary"
               disabled={!canSubmit}
+              data-console-manage-control
               onClick={() => void submit()}
             >
               {t("app.actions.save")}
             </button>
-            <button type="button" className="console-action console-action--secondary" onClick={closeDialog}>
+            <button type="button" className="console-action console-action--secondary" data-console-manage-control onClick={closeDialog}>
               {t("app.actions.back")}
             </button>
           </div>
         </ConsoleOverlay>
       )}
-    </>
+    </div>
   );
 }

--- a/opennow-stable/src/renderer/src/components/console/ConsolePosterCard.tsx
+++ b/opennow-stable/src/renderer/src/components/console/ConsolePosterCard.tsx
@@ -62,6 +62,7 @@ export function ConsolePosterCard({
       data-console-column={index}
       data-poster-fallback={isLandscapeFallback ? "landscape" : undefined}
       aria-label={game.title}
+      onFocus={onSelect}
       onClick={onSelect}
       onDoubleClick={onActivate}
     >

--- a/opennow-stable/src/renderer/src/components/console/ConsoleProfileGate.tsx
+++ b/opennow-stable/src/renderer/src/components/console/ConsoleProfileGate.tsx
@@ -10,11 +10,13 @@ import {
   PIN_RECOVERY_HOLD_MS,
 } from "../../lib/consolePinInput";
 import { clampRowFocus, moveRowFocus, type RowFocusDirection } from "../../lib/consoleRowFocus";
+import { isControllerKeyboardActivationTarget } from "../../lib/controllerKeyboard";
 import { useControllerKeyDown, useControllerNavigation } from "../../hooks/useControllerNavigation";
 import type { ConsoleShell } from "../../hooks/useConsoleShell";
 import { controllerButton } from "../../utils/controllerGamepad";
 import { useTranslation } from "../../i18n";
 import { ConsoleManageProfiles } from "./ConsoleManageProfiles";
+import { ConsoleOverlay } from "./ConsoleOverlay";
 import { ConsolePinPad, PIN_KEYPAD_ROWS } from "./ConsolePinPad";
 import { ConsoleProfilePicker } from "./ConsoleProfilePicker";
 import { ConsoleSplash } from "./ConsoleSplash";
@@ -27,6 +29,7 @@ export interface ConsoleProfileGateProps {
   savedAccounts: SavedAccount[];
   activeUserId: string | null;
   onAddAccount: () => void;
+  onProfilesChanged: () => Promise<void> | void;
   onRemoveAccount: (userId: string) => Promise<void> | void;
   onLogoutAll: () => void;
 }
@@ -52,6 +55,7 @@ export function ConsoleProfileGate({
   savedAccounts,
   activeUserId,
   onAddAccount,
+  onProfilesChanged,
   onRemoveAccount,
   onLogoutAll,
 }: ConsoleProfileGateProps): JSX.Element | null {
@@ -64,6 +68,9 @@ export function ConsoleProfileGate({
   const [pinError, setPinError] = useState(false);
   const [recoveryProgress, setRecoveryProgress] = useState(0);
   const [recoveryArmed, setRecoveryArmed] = useState(false);
+  const [recoveryActionIndex, setRecoveryActionIndex] = useState(0);
+  const [recoveryBusy, setRecoveryBusy] = useState(false);
+  const [recoveryError, setRecoveryError] = useState<string | null>(null);
   const [nowMs, setNowMs] = useState(() => Date.now());
   const recoveryStartedAtRef = useRef<number | null>(null);
   const submittingRef = useRef(false);
@@ -85,6 +92,9 @@ export function ConsoleProfileGate({
     setPinFocus({ rowIndex: 0, columnIndex: 0 });
     setRecoveryProgress(0);
     setRecoveryArmed(false);
+    setRecoveryActionIndex(0);
+    setRecoveryBusy(false);
+    setRecoveryError(null);
     recoveryStartedAtRef.current = null;
   }, [pendingAccount?.userId, stage]);
 
@@ -155,7 +165,21 @@ export function ConsoleProfileGate({
     setRecoveryProgress(0);
   }, []);
 
-  useControllerKeyDown(stage !== "shell", (event) => {
+  const confirmRecovery = useCallback(async () => {
+    if (recoveryBusy) return;
+    setRecoveryBusy(true);
+    setRecoveryError(null);
+    try {
+      await shell.removePendingProfile();
+    } catch {
+      setRecoveryError(t("console.manage.pinFailed"));
+    } finally {
+      setRecoveryBusy(false);
+    }
+  }, [recoveryBusy, shell, t]);
+
+  useControllerKeyDown(stage !== "shell" && stage !== "manage", (event) => {
+    if ((event.key === "Enter" || event.key === " ") && isControllerKeyboardActivationTarget(event.target)) return;
     if (stage === "splash") {
       event.preventDefault();
       shell.skipSplash();
@@ -167,6 +191,10 @@ export function ConsoleProfileGate({
       else if (event.key === "ArrowRight") { event.preventDefault(); movePickerFocus("right"); }
       else if (event.key === "ArrowUp") { event.preventDefault(); movePickerFocus("up"); }
       else if (event.key === "ArrowDown") { event.preventDefault(); movePickerFocus("down"); }
+      else if (shell.canClosePicker && (event.key === "Escape" || event.key.toLowerCase() === "b")) {
+        event.preventDefault();
+        shell.closeToShell();
+      }
       else if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
         void shell.selectPickerEntry(pickerIndex);
@@ -175,6 +203,23 @@ export function ConsoleProfileGate({
     }
 
     if (stage === "pin") {
+      if (recoveryArmed) {
+        if (event.key === "Escape" || event.key.toLowerCase() === "b") {
+          event.preventDefault();
+          setRecoveryArmed(false);
+        } else if (["ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"].includes(event.key)) {
+          event.preventDefault();
+          setRecoveryActionIndex((index) => index === 0 ? 1 : 0);
+        } else if (event.key === "Enter") {
+          event.preventDefault();
+          if (recoveryActionIndex === 0 && !recoveryBusy) {
+            void confirmRecovery();
+          } else {
+            setRecoveryArmed(false);
+          }
+        }
+        return;
+      }
       if (/^[0-9]$/.test(event.key)) { event.preventDefault(); pressPinKey(event.key); }
       else if (event.key === "Backspace") { event.preventDefault(); pressPinKey("delete"); }
       else if (event.key === "Escape") { event.preventDefault(); shell.cancelPin(); }
@@ -186,14 +231,10 @@ export function ConsoleProfileGate({
       return;
     }
 
-    if (stage === "manage" && (event.key === "Escape" || event.key.toLowerCase() === "b")) {
-      event.preventDefault();
-      shell.openPicker();
-    }
   });
 
   useControllerNavigation({
-    enabled: stage !== "shell",
+    enabled: stage !== "shell" && stage !== "manage",
     onFrame: ({ buttons, pressed }) => {
       if (stage === "splash") {
         if (pressed) shell.skipSplash();
@@ -205,11 +246,26 @@ export function ConsoleProfileGate({
         if (pressed & controllerButton.right) movePickerFocus("right");
         if (pressed & controllerButton.up) movePickerFocus("up");
         if (pressed & controllerButton.down) movePickerFocus("down");
+        if (shell.canClosePicker && (pressed & controllerButton.east)) shell.closeToShell();
         if (pressed & controllerButton.south) void shell.selectPickerEntry(pickerIndex);
         return;
       }
 
       if (stage === "pin") {
+        if (recoveryArmed) {
+          if (pressed & (controllerButton.left | controllerButton.up | controllerButton.right | controllerButton.down)) {
+            setRecoveryActionIndex((index) => index === 0 ? 1 : 0);
+          }
+          if (pressed & controllerButton.east) setRecoveryArmed(false);
+          if (pressed & controllerButton.south) {
+            if (recoveryActionIndex === 0 && !recoveryBusy) {
+              void confirmRecovery();
+            } else {
+              setRecoveryArmed(false);
+            }
+          }
+          return;
+        }
         // Hold B for the recovery option; a tap cancels. Progress is derived
         // from the live hold rather than a timer so releasing resets it.
         if (buttons & controllerButton.east) {
@@ -218,7 +274,12 @@ export function ConsoleProfileGate({
           if (startedAt !== null) {
             const progress = Math.min(1, (performance.now() - startedAt) / PIN_RECOVERY_HOLD_MS);
             setRecoveryProgress(progress);
-            if (progress >= 1 && !recoveryArmed) setRecoveryArmed(true);
+            if (progress >= 1) {
+              recoveryStartedAtRef.current = null;
+              setRecoveryProgress(0);
+              setRecoveryActionIndex(0);
+              setRecoveryArmed(true);
+            }
           }
         } else if (recoveryStartedAtRef.current !== null) {
           const wasArmed = recoveryArmed;
@@ -233,8 +294,6 @@ export function ConsoleProfileGate({
         if (pressed & controllerButton.south) pressFocusedPinKey();
         return;
       }
-
-      if (stage === "manage" && (pressed & controllerButton.east)) shell.openPicker();
     },
   });
 
@@ -252,7 +311,7 @@ export function ConsoleProfileGate({
           errorMessage={shell.errorMessage ?? undefined}
           onFocus={setPickerIndex}
           onSelect={(index) => void shell.selectPickerEntry(index)}
-          onBack={activeUserId ? shell.closeToShell : undefined}
+          onBack={shell.canClosePicker ? shell.closeToShell : undefined}
         />
       )}
 
@@ -272,23 +331,36 @@ export function ConsoleProfileGate({
             recoveryProgress={recoveryProgress}
             recoveryHint={recoveryArmed ? t("console.pin.recoveryReady") : t("console.pin.recoveryHint")}
           />
+          <button
+            type="button"
+            className="console-action console-action--secondary console-pin-recovery-action"
+            onClick={() => { setRecoveryActionIndex(0); setRecoveryArmed(true); }}
+          >
+            {t("console.pin.forgotPin")}
+          </button>
           {recoveryArmed && (
-            <div className="console-overlay-actions">
-              <button
-                type="button"
-                className="console-action console-action--danger"
-                onClick={() => void shell.removePendingProfile()}
-              >
-                {t("console.pin.removeProfile")}
-              </button>
-              <button
-                type="button"
-                className="console-action console-action--secondary"
-                onClick={() => { setRecoveryArmed(false); endRecoveryHold(); }}
-              >
-                {t("app.actions.back")}
-              </button>
-            </div>
+            <ConsoleOverlay label={t("console.pin.removeProfile")} title={t("console.pin.recoveryPrompt")}>
+              {recoveryError && <p className="console-gate-error">{recoveryError}</p>}
+              <div className="console-overlay-actions">
+                <button
+                  type="button"
+                  className={`console-action console-action--danger${recoveryActionIndex === 0 ? " is-focused" : ""}`}
+                  disabled={recoveryBusy}
+                  onFocus={() => setRecoveryActionIndex(0)}
+                  onClick={() => void confirmRecovery()}
+                >
+                  {t("console.pin.removeProfile")}
+                </button>
+                <button
+                  type="button"
+                  className={`console-action console-action--secondary${recoveryActionIndex === 1 ? " is-focused" : ""}`}
+                  onFocus={() => setRecoveryActionIndex(1)}
+                  onClick={() => { setRecoveryArmed(false); endRecoveryHold(); }}
+                >
+                  {t("app.actions.back")}
+                </button>
+              </div>
+            </ConsoleOverlay>
           )}
         </>
       )}
@@ -298,6 +370,7 @@ export function ConsoleProfileGate({
           savedAccounts={savedAccounts}
           activeUserId={activeUserId}
           onAddAccount={onAddAccount}
+          onProfilesChanged={onProfilesChanged}
           onRemoveAccount={onRemoveAccount}
           onLogoutAll={onLogoutAll}
           onBack={shell.openPicker}

--- a/opennow-stable/src/renderer/src/components/console/ConsoleStorePicker.tsx
+++ b/opennow-stable/src/renderer/src/components/console/ConsoleStorePicker.tsx
@@ -48,6 +48,7 @@ export function ConsoleStorePicker({
                 className={`console-store-choice${index === focusedIndex ? " is-focused" : ""}${choice.isActive ? " is-active" : ""}`}
                 style={{ "--i": index } as CSSProperties}
                 data-console-store-choice={choice.variantId}
+                onFocus={() => onFocus(index)}
                 onClick={() => {
                   onFocus(index);
                   onSelect(choice.variantId);

--- a/opennow-stable/src/renderer/src/components/console/ConsoleStoreView.tsx
+++ b/opennow-stable/src/renderer/src/components/console/ConsoleStoreView.tsx
@@ -1,4 +1,4 @@
-import { Gamepad2 } from "lucide-react";
+import { Gamepad2, Search } from "lucide-react";
 import type { JSX, RefObject } from "react";
 import type { GameInfo } from "@shared/gfn";
 import { gameNeedsPurchase, getSelectedVariant } from "../../lib/controllerCatalogUi";
@@ -101,12 +101,35 @@ export function ConsoleStoreView({
 
   if (sections.length === 0) {
     return (
-      <div className="console-page">
+      <div className="console-page console-store">
         <div className="console-empty">
-          <Gamepad2 className="console-empty-icon" size={64} />
-          <h3>{t("home.controller.emptyTitle")}</h3>
-          <p>{t("home.controller.emptyBody")}</p>
+          {searchQuery.trim() ? <Search className="console-empty-icon" size={64} /> : <Gamepad2 className="console-empty-icon" size={64} />}
+          <h3>{searchQuery.trim() ? t("home.empty.noGamesFound") : t("home.controller.emptyTitle")}</h3>
+          <p>{searchQuery.trim() ? t("home.empty.tryAdjustingSearch") : t("home.controller.emptyBody")}</p>
         </div>
+        <ConsoleHintBar
+          hints={[
+            { glyph: "b", label: t("app.actions.back"), onSelect: onBack },
+            { glyph: "x", label: t("app.actions.search"), onSelect: onOpenSearch },
+          ]}
+        />
+        {searchOpen && (
+          <ConsoleOverlay label={t("app.actions.search")} eyebrow={t("app.actions.search")}>
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={(event) => onSearchChange(event.target.value)}
+              placeholder={t("home.searchPlaceholder")}
+              className="console-search-input"
+            />
+            <div className="console-overlay-actions">
+              <button type="button" className="console-action console-action--secondary" onClick={onCloseSearch}>
+                {t("app.actions.back")}
+              </button>
+            </div>
+          </ConsoleOverlay>
+        )}
       </div>
     );
   }

--- a/opennow-stable/src/renderer/src/hooks/useAuthSession.ts
+++ b/opennow-stable/src/renderer/src/hooks/useAuthSession.ts
@@ -70,8 +70,9 @@ export interface AuthSessionApi {
   handleLogin: () => Promise<void>;
   handleQrLogin: () => Promise<void>;
   handleCancelQrLogin: () => void;
-  handleSwitchAccount: (userId: string) => Promise<void>;
+  handleSwitchAccount: (userId: string, pin?: string) => Promise<boolean>;
   handleRemoveAccount: (userId: string) => void;
+  removeAccountNow: (userId: string) => Promise<void>;
   confirmRemoveAccount: () => Promise<void>;
   handleAddAccount: () => void;
   confirmLogout: () => Promise<void>;
@@ -327,14 +328,15 @@ export function useAuthSession({
     }
   }, [loadSessionRuntimeData, providerIdpId, qrLoginChallenge, refreshSavedAccounts, t]);
 
-  const handleSwitchAccount = useCallback(async (userId: string) => {
+  const handleSwitchAccount = useCallback(async (userId: string, pin?: string) => {
     try {
-      const session = await window.openNow.switchAccount(userId);
+      const session = await window.openNow.switchAccount(userId, pin);
       setAuthSession(session);
       setProviderIdpId(session.provider.idpId);
       await refreshSavedAccounts();
       await loadSessionRuntimeData(session);
       await refreshNavbarActiveSession(session);
+      return true;
     } catch (error) {
       console.warn("Failed to switch account:", error);
       setLoginError(error instanceof Error ? error.message : t("errors.switchAccountFailed"));
@@ -353,6 +355,7 @@ export function useAuthSession({
       } catch (recoveryError) {
         console.warn("Failed to recover account state after switch failure:", recoveryError);
       }
+      return false;
     }
   }, [
     clearSessionCatalog,
@@ -368,6 +371,24 @@ export function useAuthSession({
     setRemoveAccountConfirmOpen(true);
   }, []);
 
+  const removeAccountNow = useCallback(async (userId: string) => {
+    await window.openNow.removeAccount(userId);
+    const [accounts, sessionResult] = await Promise.all([
+      window.openNow.getSavedAccounts(),
+      window.openNow.getAuthSession(),
+    ]);
+    setSavedAccounts(accounts);
+    setAuthSession(sessionResult.session);
+    if (sessionResult.session) {
+      setProviderIdpId(sessionResult.session.provider.idpId);
+      await loadSessionRuntimeData(sessionResult.session);
+      await refreshNavbarActiveSession(sessionResult.session);
+      return;
+    }
+    clearSessionCatalog("no-session", { clearFeatured: true });
+    setNavbarActiveSession(null);
+  }, [clearSessionCatalog, loadSessionRuntimeData, refreshNavbarActiveSession, setNavbarActiveSession]);
+
   const confirmRemoveAccount = useCallback(async () => {
     if (!accountToRemove || removeAccountInFlightRef.current) return;
     removeAccountInFlightRef.current = true;
@@ -376,30 +397,13 @@ export function useAuthSession({
     setAccountToRemove(null);
 
     try {
-      await window.openNow.removeAccount(targetUserId);
-      const [accounts, sessionResult] = await Promise.all([
-        window.openNow.getSavedAccounts(),
-        window.openNow.getAuthSession(),
-      ]);
-      setSavedAccounts(accounts);
-      setAuthSession(sessionResult.session);
-      if (sessionResult.session) {
-        setProviderIdpId(sessionResult.session.provider.idpId);
-        await loadSessionRuntimeData(sessionResult.session);
-        await refreshNavbarActiveSession(sessionResult.session);
-        return;
-      }
-      clearSessionCatalog("no-session", { clearFeatured: true });
-      setNavbarActiveSession(null);
+      await removeAccountNow(targetUserId);
     } finally {
       removeAccountInFlightRef.current = false;
     }
   }, [
     accountToRemove,
-    clearSessionCatalog,
-    loadSessionRuntimeData,
-    refreshNavbarActiveSession,
-    setNavbarActiveSession,
+    removeAccountNow,
   ]);
 
   const handleAddAccount = useCallback(() => {
@@ -476,6 +480,7 @@ export function useAuthSession({
     handleCancelQrLogin,
     handleSwitchAccount,
     handleRemoveAccount,
+    removeAccountNow,
     confirmRemoveAccount,
     handleAddAccount,
     confirmLogout,

--- a/opennow-stable/src/renderer/src/hooks/useCatalogData.ts
+++ b/opennow-stable/src/renderer/src/hooks/useCatalogData.ts
@@ -478,13 +478,7 @@ export function useCatalogData({
       storePanelsLoadedContextRef.current = contextKey;
       setStorePanels(panels);
       setSelectedGameId((previous) => panelGames.some((game) => game.id === previous) ? previous : (panelGames[0]?.id ?? ""));
-      setVariantByGameId((previous) => {
-        const next = { ...previous };
-        for (const game of panelGames) {
-          next[game.id] = defaultVariantId(game);
-        }
-        return next;
-      });
+      setVariantByGameId((previous) => mergeVariantSelections(previous, panelGames));
     } catch (error) {
       if (!isCurrentLoad()) return;
       console.error("Failed to load Store panels:", error);

--- a/opennow-stable/src/renderer/src/hooks/useConsoleShell.ts
+++ b/opennow-stable/src/renderer/src/hooks/useConsoleShell.ts
@@ -18,7 +18,8 @@ export interface UseConsoleShellInput {
   hasAuthSession: boolean;
   savedAccounts: SavedAccount[];
   activeUserId: string | null;
-  onSwitchAccount: (userId: string) => Promise<void> | void;
+  switchFailedMessage: string;
+  onSwitchAccount: (userId: string, pin?: string) => Promise<boolean> | boolean;
   onAddAccount: () => void;
   onRemoveAccount: (userId: string) => Promise<void> | void;
 }
@@ -29,6 +30,7 @@ export interface ConsoleShell {
   pendingAccount: SavedAccount | undefined;
   verifyResult: ConsolePinVerifyResult | null;
   errorMessage: string | null;
+  canClosePicker: boolean;
   openPicker: () => void;
   skipSplash: () => void;
   closeToShell: () => void;
@@ -51,6 +53,7 @@ export function useConsoleShell({
   hasAuthSession,
   savedAccounts,
   activeUserId,
+  switchFailedMessage,
   onSwitchAccount,
   onAddAccount,
   onRemoveAccount,
@@ -59,6 +62,7 @@ export function useConsoleShell({
   const [pendingUserId, setPendingUserId] = useState<string | null>(null);
   const [verifyResult, setVerifyResult] = useState<ConsolePinVerifyResult | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [canClosePicker, setCanClosePicker] = useState(false);
   const bootResolvedRef = useRef(false);
 
   // Resolve the launch stage exactly once, and only from a definitively loaded
@@ -72,13 +76,15 @@ export function useConsoleShell({
     if (isInitializing) return;
     if (!hasAuthSession || savedAccounts.length === 0) return;
     bootResolvedRef.current = true;
-    setStage(resolveInitialConsoleStage({
+    const initialStage = resolveInitialConsoleStage({
       controllerMode,
       directLaunchConsoleMode,
       pickerEnabled,
       hasAuthSession,
       savedAccountCount: savedAccounts.length,
-    }));
+    });
+    setCanClosePicker(initialStage === "shell");
+    setStage(initialStage);
   }, [
     controllerMode,
     directLaunchConsoleMode,
@@ -92,6 +98,7 @@ export function useConsoleShell({
   useEffect(() => {
     if (controllerMode) return;
     bootResolvedRef.current = false;
+    setCanClosePicker(true);
     setStage("shell");
     setPendingUserId(null);
   }, [controllerMode]);
@@ -129,6 +136,7 @@ export function useConsoleShell({
     setErrorMessage(null);
     setPendingUserId(null);
     setVerifyResult(null);
+    setCanClosePicker(true);
     setStage("shell");
   }, []);
 
@@ -140,7 +148,12 @@ export function useConsoleShell({
   const enterAccount = useCallback(async (account: SavedAccount, alreadyActive: boolean) => {
     if (!alreadyActive) {
       try {
-        await onSwitchAccount(account.userId);
+        const switched = await onSwitchAccount(account.userId);
+        if (!switched) {
+          setErrorMessage(switchFailedMessage);
+          setStage("picker");
+          return;
+        }
       } catch (error) {
         setErrorMessage(error instanceof Error ? error.message : String(error));
         setStage("picker");
@@ -148,7 +161,7 @@ export function useConsoleShell({
       }
     }
     closeToShell();
-  }, [closeToShell, onSwitchAccount]);
+  }, [closeToShell, onSwitchAccount, switchFailedMessage]);
 
   const selectPickerEntry = useCallback(async (index: number) => {
     const entry = pickerEntries[index];
@@ -183,13 +196,27 @@ export function useConsoleShell({
 
   const verifyPin = useCallback(async (pin: string): Promise<boolean> => {
     if (!pendingAccount) return false;
+    if (pendingAccount.userId !== activeUserId) {
+      const switched = await onSwitchAccount(pendingAccount.userId, pin);
+      if (!switched) {
+        const status = await window.openNow.getConsolePinStatus(pendingAccount.userId);
+        setVerifyResult({
+          ok: false,
+          remainingAttempts: status.remainingAttempts,
+          lockedUntilMs: status.lockedUntilMs,
+        });
+        return false;
+      }
+      closeToShell();
+      return true;
+    }
     const result = await window.openNow.verifyConsolePin({ userId: pendingAccount.userId, pin });
     setVerifyResult(result);
     if (!result.ok) return false;
 
     await enterAccount(pendingAccount, pendingAccount.userId === activeUserId);
     return true;
-  }, [activeUserId, enterAccount, pendingAccount]);
+  }, [activeUserId, closeToShell, enterAccount, onSwitchAccount, pendingAccount]);
 
   const cancelPin = useCallback(() => {
     setPendingUserId(null);
@@ -223,6 +250,7 @@ export function useConsoleShell({
     pendingAccount,
     verifyResult,
     errorMessage,
+    canClosePicker,
     openPicker,
     skipSplash,
     closeToShell,

--- a/opennow-stable/src/renderer/src/lib/controllerKeyboard.ts
+++ b/opennow-stable/src/renderer/src/lib/controllerKeyboard.ts
@@ -1,0 +1,4 @@
+export function isControllerKeyboardActivationTarget(target: EventTarget | null): boolean {
+  return target instanceof Element
+    && target.closest("button, a, input, select, textarea, [role='button'], [role='option']") !== null;
+}

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -188,6 +188,7 @@ body,
 }
 
 .app-container--controller .app-shell,
+.console-gate,
 .stream-view-layer,
 .game-card-image-wrapper {
   --bg-a: #101014;

--- a/opennow-stable/src/renderer/src/styles/console.css
+++ b/opennow-stable/src/renderer/src/styles/console.css
@@ -393,7 +393,8 @@
   padding: calc(var(--console-u) * 0.619) calc(var(--console-u) * 2);
   border-radius: var(--r-md);
   border: 1px solid transparent;
-  font-size: calc(var(--console-u) * 1.05);
+  min-height: 2.75rem;
+  font-size: max(0.8rem, calc(var(--console-u) * 1.05));
   font-weight: 700;
   cursor: pointer;
   white-space: nowrap;
@@ -433,6 +434,11 @@
 
 .console-action.is-focused {
   transform: scale(1.05);
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.console-action:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
@@ -484,14 +490,14 @@
 
 .console-row-title {
   margin: 0;
-  font-size: calc(var(--console-u) * 1.35);
+  font-size: max(0.95rem, calc(var(--console-u) * 1.35));
   font-weight: 700;
   letter-spacing: -0.01em;
   color: var(--ink);
 }
 
 .console-row-count {
-  font-size: calc(var(--console-u) * 0.85);
+  font-size: max(0.72rem, calc(var(--console-u) * 0.85));
   color: var(--ink-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -625,7 +631,7 @@
 }
 
 .console-card-title {
-  font-size: calc(var(--console-u) * 0.82);
+  font-size: max(0.72rem, calc(var(--console-u) * 0.82));
   font-weight: 700;
   line-height: 1.25;
   color: var(--ink);
@@ -661,7 +667,7 @@
   left: calc(var(--console-u) * 0.417);
   padding: 2px calc(var(--console-u) * 0.417);
   border-radius: 999px;
-  font-size: calc(var(--console-u) * 0.6);
+  font-size: max(0.625rem, calc(var(--console-u) * 0.6));
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -717,7 +723,7 @@
   border: none;
   background: none;
   color: var(--ink-soft);
-  font-size: calc(var(--console-u) * 0.82);
+  font-size: max(0.72rem, calc(var(--console-u) * 0.82));
   font-weight: 600;
   cursor: pointer;
   transition: color var(--console-t-focus) var(--console-ease-out);
@@ -731,7 +737,9 @@
   width: calc(var(--console-u) * 1.6);
   height: calc(var(--console-u) * 1.6);
   border-radius: 999px;
-  font-size: calc(var(--console-u) * 0.72);
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  font-size: max(0.625rem, calc(var(--console-u) * 0.72));
   font-weight: 800;
   color: #0b0b0d;
 }
@@ -1402,7 +1410,19 @@
   transition: stroke-dashoffset 120ms linear;
 }
 
+.console-pin-recovery-action {
+  flex: 0 0 auto;
+}
+
 /* ---------- Manage profiles ---------- */
+
+.console-manage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: calc(var(--console-u) * 1.688);
+  width: 100%;
+}
 
 .console-manage-list {
   display: flex;
@@ -1424,7 +1444,8 @@
     transform var(--console-t-focus) var(--console-ease-out);
 }
 
-.console-manage-row.is-focused {
+.console-manage-row.is-focused,
+.console-manage-row:focus-within {
   background: rgba(255, 255, 255, 0.11);
   border-color: var(--accent);
   transform: translate3d(6px, 0, 0);

--- a/opennow-stable/src/shared/gfn/api.ts
+++ b/opennow-stable/src/shared/gfn/api.ts
@@ -107,7 +107,7 @@ export interface OpenNowApi {
   logout(): Promise<void>;
   logoutAll(): Promise<void>;
   getSavedAccounts(): Promise<SavedAccount[]>;
-  switchAccount(userId: string): Promise<AuthSession>;
+  switchAccount(userId: string, pin?: string): Promise<AuthSession>;
   removeAccount(userId: string): Promise<void>;
   getConsolePinStatus(userId: string): Promise<ConsolePinStatus>;
   setConsolePin(input: ConsolePinSetRequest): Promise<ConsolePinMutationResult>;


### PR DESCRIPTION
## Summary

- enforce profile PIN verification in the main-process account switch path, refresh PIN state after mutations, reconcile account removal, reject unknown-account PIN operations, and prevent the launch picker from closing before the active profile is unlocked
- serialize PIN mutations and verification, persist encrypted profile data with an fsynced atomic replacement, and prune orphaned profile locks during startup
- make profile management and forgotten-PIN recovery controller/keyboard operable with visible focus and error handling
- restore console Store search, preserve storefront selections across panel refreshes, and keep open game details synchronized after ownership changes
- keep console gates consistently dark, improve minimum-window readability, and prevent virtual shortcuts from overriding focused native controls

## Verification

- `npm --prefix opennow-stable test` — 575 passed
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable run lint`
- `npm --prefix opennow-stable run build`
- `npm --prefix opennow-stable run locales:check`
- visually exercised the login screen plus console Store and Manage Profiles probes at desktop and windowed sizes