### PR TITLE
feat(console): suggest controller mode on gamepad connection

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -192,6 +192,13 @@
     }
   },
   "console": {
+    "controllerPrompt": {
+      "kicker": "Controller detected",
+      "title": "Switch to Controller Mode?",
+      "description": "Use the console-style layout built for a gamepad. You can switch back anytime in Settings.",
+      "accept": "Switch mode",
+      "decline": "No, don't ask again"
+    },
     "splash": {
       "title": "OpenNOW",
       "subtitle": "Console mode"

--- a/opennow-stable/src/main/settings.ts
+++ b/opennow-stable/src/main/settings.ts
@@ -260,6 +260,10 @@ export class SettingsManager {
       settings.translucentUI = false;
       migrated = true;
     }
+    if (typeof settings.controllerModePromptDismissed !== "boolean") {
+      settings.controllerModePromptDismissed = false;
+      migrated = true;
+    }
     if (typeof settings.nativeExternalRenderer !== "boolean") {
       settings.nativeExternalRenderer = false;
       migrated = true;

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -106,11 +106,16 @@ import { GameDetailModal } from "./components/GameDetailModal";
 import { ReleaseHighlightsModal } from "./components/ReleaseHighlightsModal";
 import { ErrorReportingConsentModal } from "./components/ErrorReportingConsentModal";
 import { FeedbackModal } from "./components/FeedbackModal";
+import { ControllerModePromptModal } from "./components/ControllerModePromptModal";
 import { ModalSurface } from "./components/ui/ModalSurface";
 import { overlayMotion, pageTransition, streamRevealTransition } from "./components/MotionProvider";
 import { LazyShaderAtmosphere } from "./components/LazyShaderAtmosphere";
 import { ConsoleProfileGate } from "./components/console/ConsoleProfileGate";
 import { useConsoleShell } from "./hooks/useConsoleShell";
+import {
+  shouldOfferControllerModePrompt,
+  useControllerModePrompt,
+} from "./hooks/useControllerModePrompt";
 import { syncRendererTelemetry } from "./telemetry/posthog";
 
 type AppStyle = CSSProperties & {
@@ -233,6 +238,15 @@ export function App(): JSX.Element {
 
   const [exitPrompt, setExitPrompt] = useState<ExitPromptState>({ open: false, gameTitle: t("app.labels.game") });
   const [settingsFocusSection, setSettingsFocusSection] = useState<"account" | undefined>();
+  const {
+    open: controllerModePromptOpen,
+    dismiss: dismissControllerModePrompt,
+  } = useControllerModePrompt(shouldOfferControllerModePrompt({
+    settingsLoaded,
+    controllerMode: settings.controllerMode,
+    directLaunchConsoleMode,
+    promptDismissed: settings.controllerModePromptDismissed,
+  }));
 
   const { playtime, startSession: startPlaytimeSession, endSession: endPlaytimeSession } = usePlaytime();
   const sessionElapsedSeconds = useElapsedSeconds(sessionStartedAtMs, streamStatus === "streaming");
@@ -316,6 +330,7 @@ export function App(): JSX.Element {
   const [logoutConfirmSurfacePresent, setLogoutConfirmSurfacePresent] = useState(false);
   const [removeAccountConfirmSurfacePresent, setRemoveAccountConfirmSurfacePresent] = useState(false);
   const [releaseHighlightsSurfacePresent, setReleaseHighlightsSurfacePresent] = useState(false);
+  const [controllerModePromptSurfacePresent, setControllerModePromptSurfacePresent] = useState(false);
   const streamRevealComplete = streamRevealPhase === "revealed";
   useEffect(() => {
     isStreamingRef.current = streamStatus === "streaming";
@@ -373,6 +388,10 @@ export function App(): JSX.Element {
   useEffect(() => {
     if (feedbackOpen) setFeedbackSurfacePresent(true);
   }, [feedbackOpen]);
+
+  useEffect(() => {
+    if (controllerModePromptOpen) setControllerModePromptSurfacePresent(true);
+  }, [controllerModePromptOpen]);
 
   useEffect(() => {
     if (settingsLoaded && settings.errorReportingConsent === "unset") {
@@ -2597,6 +2616,29 @@ export function App(): JSX.Element {
 
   const showErrorReportingConsent = settingsLoaded && settings.errorReportingConsent === "unset";
 
+  const handleAcceptControllerMode = useCallback((): void => {
+    dismissControllerModePrompt();
+    void updateSetting("controllerMode", true).catch((error) => {
+      console.warn("[Controller Mode] Failed to save controller mode:", error);
+    });
+  }, [dismissControllerModePrompt, updateSetting]);
+
+  const handleDeclineControllerMode = useCallback((): void => {
+    dismissControllerModePrompt();
+    void updateSetting("controllerModePromptDismissed", true).catch((error) => {
+      console.warn("[Controller Mode] Failed to save prompt preference:", error);
+    });
+  }, [dismissControllerModePrompt, updateSetting]);
+
+  const controllerModePromptModal = (
+    <ControllerModePromptModal
+      open={controllerModePromptOpen}
+      onAccept={handleAcceptControllerMode}
+      onDecline={handleDeclineControllerMode}
+      onExitComplete={() => setControllerModePromptSurfacePresent(false)}
+    />
+  );
+
   const mainPage: AppPage = currentPage === "settings" ? pageBeforeSettings : currentPage;
 
   // Show login screen if not authenticated
@@ -2622,6 +2664,7 @@ export function App(): JSX.Element {
           onDismiss={handleDismissReleaseHighlights}
           onExitComplete={() => setReleaseHighlightsSurfacePresent(false)}
         />
+        {controllerModePromptModal}
         <ErrorReportingConsentModal
           open={showErrorReportingConsent}
           onAccept={() => {
@@ -2670,6 +2713,8 @@ export function App(): JSX.Element {
     || consentSurfacePresent
     || feedbackOpen
     || feedbackSurfacePresent
+    || controllerModePromptOpen
+    || controllerModePromptSurfacePresent
     || logoutConfirmOpen
     || logoutConfirmSurfacePresent
     || removeAccountConfirmOpen
@@ -3031,6 +3076,7 @@ export function App(): JSX.Element {
         onDismiss={handleDismissReleaseHighlights}
         onExitComplete={() => setReleaseHighlightsSurfacePresent(false)}
       />
+      {controllerModePromptModal}
       <ErrorReportingConsentModal
         open={showErrorReportingConsent}
         onAccept={() => {

--- a/opennow-stable/src/renderer/src/components/ControllerModePromptModal.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerModePromptModal.tsx
@@ -1,0 +1,71 @@
+import { ArrowRight, Gamepad2 } from "lucide-react";
+import { useRef, type JSX } from "react";
+import { useTranslation } from "../i18n";
+import { ModalSurface } from "./ui/ModalSurface";
+
+export interface ControllerModePromptModalProps {
+  open: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+  onExitComplete?: () => void;
+}
+
+export function ControllerModePromptModal({
+  open,
+  onAccept,
+  onDecline,
+  onExitComplete,
+}: ControllerModePromptModalProps): JSX.Element {
+  const { t } = useTranslation();
+  const primaryActionRef = useRef<HTMLButtonElement | null>(null);
+
+  return (
+    <ModalSurface
+      open={open}
+      onClose={onDecline}
+      onConfirm={onAccept}
+      onExitComplete={onExitComplete}
+      motion="compact"
+      overlayClassName="rh-overlay controller-mode-prompt-overlay"
+      backdropClassName="rh-backdrop"
+      panelClassName="rh-card controller-mode-prompt-card"
+      ariaLabelledBy="controller-mode-prompt-title"
+      ariaDescribedBy="controller-mode-prompt-description"
+      backdropLabel={t("app.actions.close")}
+      initialFocusRef={primaryActionRef}
+      closeOnBackdrop={false}
+      closeOnEscape={false}
+    >
+      <div className="controller-mode-prompt-content">
+        <div className="controller-mode-prompt-icon" aria-hidden="true">
+          <Gamepad2 size={32} strokeWidth={1.8} />
+          <span className="controller-mode-prompt-status" />
+        </div>
+        <div>
+          <div className="controller-mode-prompt-kicker">{t("console.controllerPrompt.kicker")}</div>
+          <h2 id="controller-mode-prompt-title" className="controller-mode-prompt-title">
+            {t("console.controllerPrompt.title")}
+          </h2>
+          <p id="controller-mode-prompt-description" className="controller-mode-prompt-description">
+            {t("console.controllerPrompt.description")}
+          </p>
+        </div>
+      </div>
+
+      <div className="controller-mode-prompt-actions">
+        <button type="button" className="controller-mode-prompt-decline" onClick={onDecline}>
+          {t("console.controllerPrompt.decline")}
+        </button>
+        <button
+          type="button"
+          className="controller-mode-prompt-accept"
+          onClick={onAccept}
+          ref={primaryActionRef}
+        >
+          {t("console.controllerPrompt.accept")}
+          <ArrowRight size={16} strokeWidth={2.2} aria-hidden="true" />
+        </button>
+      </div>
+    </ModalSurface>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/ControllerModePromptModal.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerModePromptModal.tsx
@@ -3,6 +3,7 @@ import { useRef, type JSX } from "react";
 import { useTranslation } from "../i18n";
 import { useControllerNavigation } from "../hooks/useControllerNavigation";
 import { resolveControllerModePromptAction } from "../hooks/useControllerModePrompt";
+import { ConsoleHintGlyphIcon } from "./console/ConsoleHintBar";
 import { ModalSurface } from "./ui/ModalSurface";
 
 export interface ControllerModePromptModalProps {
@@ -64,12 +65,7 @@ export function ControllerModePromptModal({
 
       <div className="controller-mode-prompt-actions">
         <button type="button" className="controller-mode-prompt-decline" onClick={onDecline}>
-          <span
-            className="controller-mode-prompt-button-glyph controller-mode-prompt-button-glyph--b"
-            aria-hidden="true"
-          >
-            B
-          </span>
+          <ConsoleHintGlyphIcon glyph="b" />
           {t("console.controllerPrompt.decline")}
         </button>
         <button
@@ -78,12 +74,7 @@ export function ControllerModePromptModal({
           onClick={onAccept}
           ref={primaryActionRef}
         >
-          <span
-            className="controller-mode-prompt-button-glyph controller-mode-prompt-button-glyph--a"
-            aria-hidden="true"
-          >
-            A
-          </span>
+          <ConsoleHintGlyphIcon glyph="a" />
           {t("console.controllerPrompt.accept")}
           <ArrowRight size={16} strokeWidth={2.2} aria-hidden="true" />
         </button>

--- a/opennow-stable/src/renderer/src/components/ControllerModePromptModal.tsx
+++ b/opennow-stable/src/renderer/src/components/ControllerModePromptModal.tsx
@@ -1,6 +1,8 @@
 import { ArrowRight, Gamepad2 } from "lucide-react";
 import { useRef, type JSX } from "react";
 import { useTranslation } from "../i18n";
+import { useControllerNavigation } from "../hooks/useControllerNavigation";
+import { resolveControllerModePromptAction } from "../hooks/useControllerModePrompt";
 import { ModalSurface } from "./ui/ModalSurface";
 
 export interface ControllerModePromptModalProps {
@@ -18,6 +20,14 @@ export function ControllerModePromptModal({
 }: ControllerModePromptModalProps): JSX.Element {
   const { t } = useTranslation();
   const primaryActionRef = useRef<HTMLButtonElement | null>(null);
+  useControllerNavigation({
+    enabled: open,
+    onFrame: ({ pressed }) => {
+      const action = resolveControllerModePromptAction(pressed);
+      if (action === "accept") onAccept();
+      if (action === "decline") onDecline();
+    },
+  });
 
   return (
     <ModalSurface
@@ -54,6 +64,12 @@ export function ControllerModePromptModal({
 
       <div className="controller-mode-prompt-actions">
         <button type="button" className="controller-mode-prompt-decline" onClick={onDecline}>
+          <span
+            className="controller-mode-prompt-button-glyph controller-mode-prompt-button-glyph--b"
+            aria-hidden="true"
+          >
+            B
+          </span>
           {t("console.controllerPrompt.decline")}
         </button>
         <button
@@ -62,6 +78,12 @@ export function ControllerModePromptModal({
           onClick={onAccept}
           ref={primaryActionRef}
         >
+          <span
+            className="controller-mode-prompt-button-glyph controller-mode-prompt-button-glyph--a"
+            aria-hidden="true"
+          >
+            A
+          </span>
           {t("console.controllerPrompt.accept")}
           <ArrowRight size={16} strokeWidth={2.2} aria-hidden="true" />
         </button>

--- a/opennow-stable/src/renderer/src/components/console/ConsoleHintBar.tsx
+++ b/opennow-stable/src/renderer/src/components/console/ConsoleHintBar.tsx
@@ -13,15 +13,21 @@ export interface ConsoleHintBarProps {
   hints: ConsoleHint[];
 }
 
+export function ConsoleHintGlyphIcon({ glyph }: { glyph: ConsoleHintGlyph }): JSX.Element {
+  return (
+    <span className={`console-hint-glyph console-hint-glyph--${glyph}`} aria-hidden="true">
+      {glyph === "menu" ? <Menu /> : glyph.toUpperCase()}
+    </span>
+  );
+}
+
 /** Shared button-prompt strip along the bottom of every console surface. */
 export function ConsoleHintBar({ hints }: ConsoleHintBarProps): JSX.Element {
   return (
     <div className="console-hint-bar" role="toolbar">
       {hints.map((hint) => (
         <button key={`${hint.glyph}-${hint.label}`} type="button" className="console-hint" onClick={() => hint.onSelect?.()}>
-          <span className={`console-hint-glyph console-hint-glyph--${hint.glyph}`} aria-hidden="true">
-            {hint.glyph === "menu" ? <Menu /> : hint.glyph.toUpperCase()}
-          </span>
+          <ConsoleHintGlyphIcon glyph={hint.glyph} />
           <span>{hint.label}</span>
         </button>
       ))}

--- a/opennow-stable/src/renderer/src/hooks/useControllerModePrompt.test.ts
+++ b/opennow-stable/src/renderer/src/hooks/useControllerModePrompt.test.ts
@@ -5,8 +5,10 @@ import assert from "node:assert/strict";
 
 import {
   hasConnectedGamepad,
+  resolveControllerModePromptAction,
   shouldOfferControllerModePrompt,
 } from "./useControllerModePrompt";
+import { controllerButton } from "../utils/controllerGamepad";
 
 const ELIGIBLE = {
   settingsLoaded: true,
@@ -30,4 +32,10 @@ test("recognizes only connected gamepads", () => {
   assert.equal(hasConnectedGamepad(undefined), false);
   assert.equal(hasConnectedGamepad([null, disconnected]), false);
   assert.equal(hasConnectedGamepad([null, connected]), true);
+});
+
+test("maps A to switch mode and B to decline", () => {
+  assert.equal(resolveControllerModePromptAction(controllerButton.south), "accept");
+  assert.equal(resolveControllerModePromptAction(controllerButton.east), "decline");
+  assert.equal(resolveControllerModePromptAction(controllerButton.menu), null);
 });

--- a/opennow-stable/src/renderer/src/hooks/useControllerModePrompt.test.ts
+++ b/opennow-stable/src/renderer/src/hooks/useControllerModePrompt.test.ts
@@ -1,0 +1,33 @@
+/// <reference types="node" />
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  hasConnectedGamepad,
+  shouldOfferControllerModePrompt,
+} from "./useControllerModePrompt";
+
+const ELIGIBLE = {
+  settingsLoaded: true,
+  controllerMode: false,
+  directLaunchConsoleMode: false,
+  promptDismissed: false,
+};
+
+test("offers controller mode only from a loaded desktop session that has not opted out", () => {
+  assert.equal(shouldOfferControllerModePrompt(ELIGIBLE), true);
+  assert.equal(shouldOfferControllerModePrompt({ ...ELIGIBLE, settingsLoaded: false }), false);
+  assert.equal(shouldOfferControllerModePrompt({ ...ELIGIBLE, controllerMode: true }), false);
+  assert.equal(shouldOfferControllerModePrompt({ ...ELIGIBLE, directLaunchConsoleMode: true }), false);
+  assert.equal(shouldOfferControllerModePrompt({ ...ELIGIBLE, promptDismissed: true }), false);
+});
+
+test("recognizes only connected gamepads", () => {
+  const connected = { connected: true } as Gamepad;
+  const disconnected = { connected: false } as Gamepad;
+
+  assert.equal(hasConnectedGamepad(undefined), false);
+  assert.equal(hasConnectedGamepad([null, disconnected]), false);
+  assert.equal(hasConnectedGamepad([null, connected]), true);
+});

--- a/opennow-stable/src/renderer/src/hooks/useControllerModePrompt.ts
+++ b/opennow-stable/src/renderer/src/hooks/useControllerModePrompt.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+
+export interface ControllerModePromptEligibility {
+  settingsLoaded: boolean;
+  controllerMode: boolean;
+  directLaunchConsoleMode: boolean;
+  promptDismissed: boolean;
+}
+
+export function shouldOfferControllerModePrompt({
+  settingsLoaded,
+  controllerMode,
+  directLaunchConsoleMode,
+  promptDismissed,
+}: ControllerModePromptEligibility): boolean {
+  return settingsLoaded
+    && !controllerMode
+    && !directLaunchConsoleMode
+    && !promptDismissed;
+}
+
+export function hasConnectedGamepad(
+  gamepads: ArrayLike<Gamepad | null> | undefined,
+): boolean {
+  return gamepads !== undefined
+    && Array.from(gamepads).some((gamepad) => gamepad !== null && gamepad.connected !== false);
+}
+
+export function useControllerModePrompt(enabled: boolean): {
+  open: boolean;
+  dismiss: () => void;
+} {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setOpen(false);
+      return undefined;
+    }
+
+    const showPrompt = (): void => setOpen(true);
+    window.addEventListener("gamepadconnected", showPrompt);
+
+    if (hasConnectedGamepad(navigator.getGamepads?.())) {
+      showPrompt();
+    }
+
+    return () => window.removeEventListener("gamepadconnected", showPrompt);
+  }, [enabled]);
+
+  const dismiss = useCallback((): void => setOpen(false), []);
+  return { open, dismiss };
+}

--- a/opennow-stable/src/renderer/src/hooks/useControllerModePrompt.ts
+++ b/opennow-stable/src/renderer/src/hooks/useControllerModePrompt.ts
@@ -1,4 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
+import { controllerButton } from "../utils/controllerGamepad";
+
+export type ControllerModePromptAction = "accept" | "decline" | null;
+
+export function resolveControllerModePromptAction(pressedButtons: number): ControllerModePromptAction {
+  if (pressedButtons & controllerButton.south) return "accept";
+  if (pressedButtons & controllerButton.east) return "decline";
+  return null;
+}
 
 export interface ControllerModePromptEligibility {
   settingsLoaded: boolean;

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -10058,12 +10058,17 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .controller-mode-prompt-button-glyph--a {
-  color: #fff;
-  background: color-mix(in srgb, #000 16%, transparent);
+  border-color: #22c55e;
+  color: #15803d;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 1px 4px rgba(21, 128, 61, 0.28);
 }
 
 .controller-mode-prompt-button-glyph--b {
-  color: var(--ink-muted);
+  border-color: #ef4444;
+  color: #dc2626;
+  background: color-mix(in srgb, #ef4444 8%, var(--panel));
+  box-shadow: 0 1px 4px rgba(220, 38, 38, 0.16);
 }
 
 .controller-mode-prompt-accept:hover {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -9934,6 +9934,149 @@ button.game-card-store-chip.owned.active:hover {
   border-color: var(--ink-muted);
 }
 
+.controller-mode-prompt-card {
+  width: min(500px, calc(100vw - 32px));
+  overflow: hidden;
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
+  background:
+    radial-gradient(circle at 8% 0%, color-mix(in srgb, var(--accent) 12%, transparent), transparent 42%),
+    var(--panel);
+}
+
+.controller-mode-prompt-content {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 18px;
+  padding: 26px 26px 22px;
+}
+
+.controller-mode-prompt-icon {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 62px;
+  height: 62px;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, var(--border));
+  border-radius: 18px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 11%, var(--panel));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+}
+
+.controller-mode-prompt-status {
+  position: absolute;
+  right: 7px;
+  bottom: 7px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--panel);
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 75%, transparent);
+}
+
+.controller-mode-prompt-kicker {
+  margin: 2px 0 6px;
+  color: var(--accent);
+  font-size: 0.69rem;
+  font-weight: 750;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.controller-mode-prompt-title {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.35rem;
+  font-weight: 780;
+  line-height: 1.18;
+}
+
+.controller-mode-prompt-description {
+  margin: 10px 0 0;
+  color: var(--ink-soft);
+  font-size: 0.91rem;
+  line-height: 1.55;
+}
+
+.controller-mode-prompt-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--ink) 2%, transparent);
+}
+
+.controller-mode-prompt-decline,
+.controller-mode-prompt-accept {
+  min-height: 40px;
+  border-radius: 10px;
+  padding: 0 16px;
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 680;
+  cursor: pointer;
+  transition: transform var(--t-fast), border-color var(--t-fast), background var(--t-fast), opacity var(--t-fast);
+}
+
+.controller-mode-prompt-decline {
+  border: 1px solid var(--border);
+  color: var(--ink-soft);
+  background: transparent;
+}
+
+.controller-mode-prompt-decline:hover {
+  border-color: var(--ink-muted);
+  color: var(--ink);
+  background: color-mix(in srgb, var(--ink) 5%, transparent);
+}
+
+.controller-mode-prompt-accept {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 72%, white 10%);
+  color: #fff;
+  background: var(--accent);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.controller-mode-prompt-accept:hover {
+  opacity: 0.88;
+  transform: translateY(-1px);
+}
+
+.controller-mode-prompt-decline:active,
+.controller-mode-prompt-accept:active {
+  transform: translateY(0);
+}
+
+@media (max-width: 520px) {
+  .controller-mode-prompt-content {
+    grid-template-columns: 1fr;
+    gap: 14px;
+    padding: 22px 20px 18px;
+  }
+
+  .controller-mode-prompt-icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 16px;
+  }
+
+  .controller-mode-prompt-actions {
+    flex-direction: column-reverse;
+  }
+
+  .controller-mode-prompt-decline,
+  .controller-mode-prompt-accept {
+    justify-content: center;
+    width: 100%;
+  }
+}
+
 /* Fallback copy */
 .rh-fallback-text {
   color: var(--ink-muted);

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -10044,33 +10044,6 @@ button.game-card-store-chip.owned.active:hover {
   box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
-.controller-mode-prompt-button-glyph {
-  display: inline-grid;
-  place-items: center;
-  width: 20px;
-  height: 20px;
-  flex: 0 0 20px;
-  border: 1px solid currentColor;
-  border-radius: 50%;
-  font-size: 0.64rem;
-  font-weight: 800;
-  line-height: 1;
-}
-
-.controller-mode-prompt-button-glyph--a {
-  border-color: #22c55e;
-  color: #15803d;
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: 0 1px 4px rgba(21, 128, 61, 0.28);
-}
-
-.controller-mode-prompt-button-glyph--b {
-  border-color: #ef4444;
-  color: #dc2626;
-  background: color-mix(in srgb, #ef4444 8%, var(--panel));
-  box-shadow: 0 1px 4px rgba(220, 38, 38, 0.16);
-}
-
 .controller-mode-prompt-accept:hover {
   opacity: 0.88;
   transform: translateY(-1px);

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -10011,6 +10011,10 @@ button.game-card-store-chip.owned.active:hover {
 
 .controller-mode-prompt-decline,
 .controller-mode-prompt-accept {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   min-height: 40px;
   border-radius: 10px;
   padding: 0 16px;
@@ -10034,13 +10038,32 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .controller-mode-prompt-accept {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
   border: 1px solid color-mix(in srgb, var(--accent) 72%, white 10%);
   color: #fff;
   background: var(--accent);
   box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.controller-mode-prompt-button-glyph {
+  display: inline-grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-size: 0.64rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.controller-mode-prompt-button-glyph--a {
+  color: #fff;
+  background: color-mix(in srgb, #000 16%, transparent);
+}
+
+.controller-mode-prompt-button-glyph--b {
+  color: var(--ink-muted);
 }
 
 .controller-mode-prompt-accept:hover {

--- a/opennow-stable/src/shared/gfn/settings.test.ts
+++ b/opennow-stable/src/shared/gfn/settings.test.ts
@@ -60,6 +60,10 @@ test("uses brief recurring Anti-AFK reminder defaults", () => {
   assert.equal(settings.antiAfkReminderDurationSeconds, 5);
 });
 
+test("offers the controller mode prompt until the user dismisses it", () => {
+  assert.equal(createDefaultSettings("win32").controllerModePromptDismissed, false);
+});
+
 test("creates fresh platform shortcut collections", () => {
   const first = createPlatformShortcutDefaults("linux");
   const second = createPlatformShortcutDefaults("linux");

--- a/opennow-stable/src/shared/gfn/settings.ts
+++ b/opennow-stable/src/shared/gfn/settings.ts
@@ -118,6 +118,8 @@ export interface Settings {
   translucentUI: boolean;
   /** Use the large-screen controller-oriented shell and library layout */
   controllerMode: boolean;
+  /** Permanently suppress the controller-detected suggestion after the user declines it */
+  controllerModePromptDismissed: boolean;
   /** Launch fullscreen with Controller Mode enabled, like GeForce NOW's TV mode */
   launchInConsoleMode: boolean;
   /** Show the "Who's playing?" profile picker when console mode starts */
@@ -307,6 +309,7 @@ export function createDefaultSettings(platform: string): Settings {
     appTheme: "auto",
     translucentUI: false,
     controllerMode: false,
+    controllerModePromptDismissed: false,
     launchInConsoleMode: false,
     consoleProfilePickerOnLaunch: true,
     autoFullScreen: false,


### PR DESCRIPTION
## Summary
- detect newly connected and already-present gamepads while OpenNOW is in desktop mode
- show an accessible, responsive prompt that enables Controller Mode immediately
- support controller-native actions: A switches mode and B declines, with visible button hints
- persist a declined prompt preference so future controller connections stay silent
- add English source copy and focused eligibility, defaults, and button-mapping tests

## Verification
- `npm --prefix opennow-stable test` (579 passed)
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable run lint`
- `npm --prefix opennow-stable run locales:check`
- `npm --prefix opennow-stable run build`
- visually verified the dialog in Electron
- exercised the live gamepad polling path: A persisted Controller Mode and closed the prompt; B persisted the opt-out and suppressed a subsequent connection prompt