### PR TITLE
feat(settings): unify sidebar and console controls

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -627,6 +627,8 @@
     "searchPlaceholder": "Search settings...",
     "clearSearch": "Clear settings search",
     "noMatches": "No settings matched \"{{query}}\".",
+    "searchResults": "Search results",
+    "searchResultsDescription": "Settings matching “{{query}}” across every category.",
     "sections": {
       "account": "Account",
       "stream": "Stream",
@@ -635,9 +637,23 @@
       "game": "Game",
       "audio": "Audio",
       "input": "Input",
+      "console": "Console",
       "interface": "Interface",
       "about": "About",
       "thanks": "Thanks"
+    },
+    "sectionDescriptions": {
+      "account": "Manage cloud storage and the game accounts connected to your membership.",
+      "stream": "Choose your region, stream quality, recording, and connection behavior.",
+      "diagnostics": "Inspect codec support and configure in-stream performance information.",
+      "nativeStreamer": "Configure the experimental native streaming backend and its shortcuts.",
+      "game": "Set the language and persistence behavior used when games launch.",
+      "audio": "Choose how OpenNOW captures your microphone during a stream.",
+      "input": "Tune mouse, keyboard, controller, cursor, and shortcut behavior.",
+      "console": "Configure the controller-first experience for TVs and living-room play.",
+      "interface": "Personalize OpenNOW’s appearance, language, and desktop behavior.",
+      "about": "Review updates, privacy controls, logs, and application details.",
+      "thanks": "Meet the contributors and supporters who make OpenNOW possible."
     },
     "region": {
       "title": "Region",
@@ -774,9 +790,7 @@
       "experimentalL4SRequest": "Experimental L4S Request",
       "experimentalL4SRequestHint": "Request the GeForce NOW L4S streaming feature on newly created sessions. This does not change browser WebRTC behavior by itself and may be ignored by the service or network path.",
       "identifyAsSteamDeck": "Identify as Steam Deck",
-      "identifyAsSteamDeckHint": "Identify as the Steam Deck GFN client to unlock Deck-specific resolutions and 90 FPS. Video options refresh automatically.",
-      "launchInConsoleMode": "Console Mode (TV / Big Picture)",
-      "launchInConsoleModeHint": "Start OpenNOW fullscreen with Controller Mode enabled, like GeForce NOW's TV mode. Sessions ask NVIDIA to launch games gamepad-friendly (big picture) while Console Mode or Controller Mode is active."
+      "identifyAsSteamDeckHint": "Identify as the Steam Deck GFN client to unlock Deck-specific resolutions and 90 FPS. Video options refresh automatically."
     },
     "recording": {
       "title": "Browser Recording",
@@ -886,6 +900,16 @@
       "toggleStreamSidebar": "Toggle stream sidebar",
       "shortcutHint": "Click a field and press the keys to bind, or paste a shortcut ({{examples}}). Escape cancels focus. Full screen: {{fullscreen}}. Stop: {{stop}}. Mic: {{mic}}. Screenshot: {{screenshot}}. Recording: {{recording}}."
     },
+    "console": {
+      "title": "Console Experience",
+      "description": "Controller-first shell and startup options for a TV or handheld setup.",
+      "controllerMode": "Controller Mode",
+      "controllerModeHint": "Use a large-screen console-style shell with controller button hints and a horizontal library layout.",
+      "profilePicker": "Ask who’s playing",
+      "profilePickerHint": "Show the profile picker when console mode starts. Direct game launches are never interrupted.",
+      "launchMode": "Launch in Console Mode",
+      "launchModeHint": "Start OpenNOW fullscreen with Controller Mode enabled. Sessions also ask NVIDIA to launch games in a gamepad-friendly big-picture layout."
+    },
     "interface": {
       "appearance": "Appearance",
       "appLanguage": "App Language",
@@ -918,10 +942,6 @@
       "antiAfkReminderDurationHint": "How long each periodic Anti-AFK activation reminder stays visible.",
       "autoFullScreen": "Auto Full Screen",
       "autoFullScreenHint": "Automatically enter fullscreen when connecting to or starting a session.",
-      "controllerMode": "Controller Mode",
-      "controllerModeHint": "Use a large-screen console-style shell with controller button hints and a horizontal library layout.",
-      "consoleProfilePicker": "Ask who's playing",
-      "consoleProfilePickerHint": "Show the profile picker when console mode starts. Direct game launches are never interrupted.",
       "escapeExitsFullscreen": "Escape Exits Fullscreen",
       "escapeExitsFullscreenHint": "When enabled, pressing Escape exits fullscreen immediately. When disabled (default), Escape is forwarded to the game while pointer-locked; hold Escape ~1.5s to exit fullscreen.",
       "discordRichPresence": "Discord Rich Presence",

--- a/locales/en.json
+++ b/locales/en.json
@@ -657,6 +657,7 @@
     },
     "region": {
       "title": "Region",
+      "description": "Choose the GeForce NOW data center OpenNOW uses for new sessions.",
       "autoBest": "Auto (Best)",
       "searchPlaceholder": "Search regions...",
       "refreshPing": "Refresh ping",
@@ -739,6 +740,7 @@
     },
     "video": {
       "title": "Stream Quality",
+      "description": "Tune video quality, session compatibility, and local processing in one place.",
       "profile": "Quality Profile",
       "profileHint": "Set the stream resolution, frame rate, and bandwidth ceiling.",
       "codecAndColor": "Codec & Color",
@@ -840,6 +842,7 @@
     },
     "game": {
       "title": "Game",
+      "description": "Choose the language and persistence behavior applied when a game starts.",
       "language": "Language",
       "inGameLanguageHint": "Language for in-game menus, subtitles, and audio (where supported)",
       "persistInGameSettings": "Save in-game graphics settings",
@@ -850,6 +853,7 @@
     },
     "audio": {
       "title": "Audio",
+      "description": "Configure microphone capture and the input device used during streams.",
       "microphone": "Microphone",
       "microphoneHint": "Enable voice chat during streaming",
       "microphoneMode": "Microphone Mode",
@@ -869,6 +873,7 @@
     },
     "input": {
       "title": "Input",
+      "description": "Configure keyboard, mouse, controller, cursor, and shortcut behavior.",
       "mouseAndKeyboard": "Mouse and Keyboard",
       "clipboardPaste": "Clipboard Paste",
       "gyroscopeControls": "Gyroscope Controls",
@@ -912,6 +917,7 @@
     },
     "interface": {
       "appearance": "Appearance",
+      "description": "Personalize OpenNOW’s theme, language, overlays, and desktop behavior.",
       "appLanguage": "App Language",
       "appLanguageHint": "Changes OpenNOW's interface language. English is used for untranslated strings.",
       "theme": "Theme",
@@ -967,6 +973,7 @@
       "posTopRight": "Top right"
     },
     "about": {
+      "description": "Manage updates, diagnostics sharing, logs, cache, and application details.",
       "applicationUpdates": "Application Updates",
       "version": "Version {{version}}",
       "backgroundChecksOn": "Packaged builds check GitHub Releases in the background.",
@@ -1010,6 +1017,7 @@
     },
     "nativeStreamer": {
       "title": "Native Streamer",
+      "description": "Configure the experimental native backend, its renderer, and host capabilities.",
       "nativeStreaming": "Native Streaming",
       "nativeStreamingHint": "Native streaming is experimental and may have platform-specific bugs, glitches, or fallbacks to Chromium/WebRTC. Enable it only if you are comfortable testing the GStreamer-based desktop streamer for new sessions.",
       "enablePromptKicker": "Experimental",

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1,5 +1,5 @@
-import { Check, X } from "lucide-react";
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { Activity, Check, Cpu, Gamepad2, Globe, Heart, Info, Keyboard, Mic, Monitor, Search, Users, Wifi, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
 
 import type {
   EntitledResolution,
@@ -13,12 +13,13 @@ import {
   loadCachedEntitledResolutions,
   saveCachedEntitledResolutions,
 } from "./settings/settingsFormatters";
-import type { SettingsSectionId, SettingsSearchScopeId } from "./settings/settingsTypes";
+import type { SettingsNavItem, SettingsSectionId, SettingsSearchScopeId } from "./settings/settingsTypes";
 import { settingsScopeMatchesSearch } from "./settings/settingsSearch";
 import { SettingsNav } from "./settings/SettingsNav";
 import { SettingsAccountSection } from "./settings/sections/SettingsAccountSection";
 import { SettingsAboutSection } from "./settings/sections/SettingsAboutSection";
 import { SettingsAudioSection } from "./settings/sections/SettingsAudioSection";
+import { SettingsConsoleSection } from "./settings/sections/SettingsConsoleSection";
 import { SettingsDiagnosticsSection } from "./settings/sections/SettingsDiagnosticsSection";
 import { SettingsGameSection } from "./settings/sections/SettingsGameSection";
 import { SettingsInputSection } from "./settings/sections/SettingsInputSection";
@@ -58,7 +59,7 @@ export function SettingsPage({
   onOpenWhatsNew,
   onOpenFeedback,
 }: SettingsPageProps): JSX.Element {
-  const { t } = useTranslation();
+  const { locale, t } = useTranslation();
   const [savedIndicator, setSavedIndicator] = useState(false);
   const [activeSection, setActiveSection] = useState<SettingsSectionId>("stream");
   const [settingsSearch, setSettingsSearch] = useState("");
@@ -75,6 +76,21 @@ export function SettingsPage({
   const identifyAsSteamDeckRef = useRef(settings.identifyAsSteamDeck);
   const subscriptionLoadIdRef = useRef(0);
   identifyAsSteamDeckRef.current = settings.identifyAsSteamDeck;
+
+  const settingsNavItems = useMemo<SettingsNavItem[]>(() => [
+    { id: "account", label: t("settings.sections.account"), description: t("settings.sectionDescriptions.account"), icon: <Users /> },
+    { id: "stream", label: t("settings.sections.stream"), description: t("settings.sectionDescriptions.stream"), icon: <Wifi /> },
+    { id: "diagnostics", label: t("settings.sections.diagnostics"), description: t("settings.sectionDescriptions.diagnostics"), icon: <Activity /> },
+    { id: "native-streamer", label: t("settings.sections.nativeStreamer"), description: t("settings.sectionDescriptions.nativeStreamer"), icon: <Cpu /> },
+    { id: "game", label: t("settings.sections.game"), description: t("settings.sectionDescriptions.game"), icon: <Globe /> },
+    { id: "audio", label: t("settings.sections.audio"), description: t("settings.sectionDescriptions.audio"), icon: <Mic /> },
+    { id: "input", label: t("settings.sections.input"), description: t("settings.sectionDescriptions.input"), icon: <Keyboard /> },
+    { id: "console", label: t("settings.sections.console"), description: t("settings.sectionDescriptions.console"), icon: <Gamepad2 /> },
+    { id: "interface", label: t("settings.sections.interface"), description: t("settings.sectionDescriptions.interface"), icon: <Monitor /> },
+    { id: "about", label: t("settings.sections.about"), description: t("settings.sectionDescriptions.about"), icon: <Info /> },
+    { id: "thanks", label: t("settings.sections.thanks"), description: t("settings.sectionDescriptions.thanks"), icon: <Heart /> },
+  ], [locale, t]);
+  const activeNavItem = settingsNavItems.find((item) => item.id === activeSection) ?? settingsNavItems[0];
 
   useEffect(() => {
     settingsContentRef.current?.scrollTo({ top: 0 });
@@ -231,10 +247,11 @@ export function SettingsPage({
   const showGame = showAll ? scopeMatchesSearch("game") : activeSection === "game";
   const showAudio = showAll ? scopeMatchesSearch("audio") : activeSection === "audio";
   const showInput = showAll ? scopeMatchesSearch("input") : activeSection === "input";
+  const showConsole = showAll ? scopeMatchesSearch("console") : activeSection === "console";
   const showInterface = showAll ? scopeMatchesSearch("interface") : activeSection === "interface";
   const showAbout = showAll ? scopeMatchesSearch("about") : activeSection === "about";
   const showThanks = showAll ? scopeMatchesSearch("thanks") : activeSection === "thanks";
-  const hasAnySearchMatches = showAccount || showStream || showDiagnostics || showNativeStreamer || showGame || showAudio || showInput || showInterface || showAbout || showThanks;
+  const hasAnySearchMatches = showAccount || showStream || showDiagnostics || showNativeStreamer || showGame || showAudio || showInput || showConsole || showInterface || showAbout || showThanks;
   const shouldRenderSettingsSections = showAll || activeSection !== "thanks";
 
   return (
@@ -263,11 +280,25 @@ export function SettingsPage({
           activeSection={activeSection}
           settingsSearch={settingsSearch}
           showAll={showAll}
+          items={settingsNavItems}
           onSearchChange={setSettingsSearch}
           onSectionChange={setActiveSection}
         />
 
         <div ref={settingsContentRef} className="settings-content">
+          <div className="settings-page-heading">
+            <div className="settings-page-heading-icon" aria-hidden="true">
+              {showAll ? <Search /> : activeNavItem.icon}
+            </div>
+            <div className="settings-page-heading-copy">
+              <h2>{showAll ? t("settings.searchResults") : activeNavItem.label}</h2>
+              <p>
+                {showAll
+                  ? t("settings.searchResultsDescription", { query: settingsSearch.trim() })
+                  : activeNavItem.description}
+              </p>
+            </div>
+          </div>
           {showAll && !hasAnySearchMatches ? (
             <section className="settings-section">
               <div className="settings-thanks-state settings-thanks-state--muted">
@@ -345,6 +376,13 @@ export function SettingsPage({
                       showAll={showAll}
                       handleChange={handleChange}
                       handlePreview={handlePreview}
+                    />
+                  )}
+                  {showConsole && (
+                    <SettingsConsoleSection
+                      settings={settings}
+                      showAll={showAll}
+                      handleChange={handleChange}
                     />
                   )}
                   {showInterface && (

--- a/opennow-stable/src/renderer/src/components/settings/SettingRow.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/SettingRow.tsx
@@ -1,0 +1,55 @@
+import type { JSX, ReactNode } from "react";
+
+interface SettingRowProps {
+  label: ReactNode;
+  description?: ReactNode;
+  htmlFor?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function SettingRow({
+  label,
+  description,
+  htmlFor,
+  children,
+  className = "",
+}: SettingRowProps): JSX.Element {
+  return (
+    <div className={`settings-row ${className}`.trim()}>
+      <label className="settings-label settings-label--wrap" htmlFor={htmlFor}>
+        <span className="settings-label-title">{label}</span>
+        {description ? <span className="settings-hint">{description}</span> : null}
+      </label>
+      <div className="settings-row-control">{children}</div>
+    </div>
+  );
+}
+
+interface SettingToggleRowProps extends Omit<SettingRowProps, "children"> {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+export function SettingToggleRow({
+  checked,
+  onChange,
+  disabled = false,
+  ...rowProps
+}: SettingToggleRowProps): JSX.Element {
+  return (
+    <SettingRow {...rowProps}>
+      <label className="settings-toggle">
+        <input
+          id={rowProps.htmlFor}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.checked)}
+        />
+        <span className="settings-toggle-track" />
+      </label>
+    </SettingRow>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/settings/SettingsNav.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/SettingsNav.tsx
@@ -1,12 +1,13 @@
-import { Activity, Search, X, Users, Wifi, Cpu, Globe, Mic, Keyboard, Monitor, Info, Heart } from "lucide-react";
-import { useMemo, type JSX } from "react";
+import { Search, X } from "lucide-react";
+import { type JSX } from "react";
 import { useTranslation } from "../../i18n";
-import type { SettingsNavGroup, SettingsSectionId } from "./settingsTypes";
+import type { SettingsNavItem, SettingsSectionId } from "./settingsTypes";
 
 export interface SettingsNavProps {
   activeSection: SettingsSectionId;
   settingsSearch: string;
   showAll: boolean;
+  items: readonly SettingsNavItem[];
   onSearchChange: (value: string) => void;
   onSectionChange: (section: SettingsSectionId) => void;
 }
@@ -15,43 +16,11 @@ export function SettingsNav({
   activeSection,
   settingsSearch,
   showAll,
+  items,
   onSearchChange,
   onSectionChange,
 }: SettingsNavProps): JSX.Element {
-  const { locale, t } = useTranslation();
-
-  const settingsNavGroups = useMemo<SettingsNavGroup[]>(() => [
-    {
-      label: "Account",
-      items: [
-        { id: "account", label: t("settings.sections.account"), icon: <Users size={15} /> },
-      ],
-    },
-    {
-      label: "Streaming",
-      items: [
-        { id: "stream", label: t("settings.sections.stream"), icon: <Wifi size={15} /> },
-        { id: "diagnostics", label: t("settings.sections.diagnostics"), icon: <Activity size={15} /> },
-        { id: "native-streamer", label: t("settings.sections.nativeStreamer"), icon: <Cpu size={15} /> },
-      ],
-    },
-    {
-      label: "Controls",
-      items: [
-        { id: "game", label: t("settings.sections.game"), icon: <Globe size={15} /> },
-        { id: "audio", label: t("settings.sections.audio"), icon: <Mic size={15} /> },
-        { id: "input", label: t("settings.sections.input"), icon: <Keyboard size={15} /> },
-      ],
-    },
-    {
-      label: "App",
-      items: [
-        { id: "interface", label: t("settings.sections.interface"), icon: <Monitor size={15} /> },
-        { id: "about", label: t("settings.sections.about"), icon: <Info size={15} /> },
-        { id: "thanks", label: t("settings.sections.thanks"), icon: <Heart size={15} /> },
-      ],
-    },
-  ], [t, locale]);
+  const { t } = useTranslation();
 
   return (
     <nav className="settings-sidebar">
@@ -77,25 +46,17 @@ export function SettingsNav({
         )}
       </div>
       <div className="settings-nav">
-        {settingsNavGroups.map((group) => (
-          <div key={group.label} className="settings-nav-group">
-            <div className="settings-nav-group-label">{group.label}</div>
-            {group.items.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={`settings-nav-item ${!showAll && activeSection === item.id ? "active" : ""}`}
-                onClick={() => { onSectionChange(item.id); onSearchChange(""); }}
-                aria-current={!showAll && activeSection === item.id ? "page" : undefined}
-              >
-                {item.icon}
-                <span className="settings-nav-item-label">{item.label}</span>
-                {item.id === "native-streamer" && (
-                  <span className="settings-nav-badge">{t("app.labels.experimental")}</span>
-                )}
-              </button>
-            ))}
-          </div>
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className={`settings-nav-item ${!showAll && activeSection === item.id ? "active" : ""}`}
+            onClick={() => { onSectionChange(item.id); onSearchChange(""); }}
+            aria-current={!showAll && activeSection === item.id ? "page" : undefined}
+          >
+            {item.icon}
+            <span className="settings-nav-item-label">{item.label}</span>
+          </button>
         ))}
       </div>
     </nav>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsAboutSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsAboutSection.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "../../../i18n";
 import { formatBytes, formatUpdaterTimestamp, getUpdaterBadgeLabel } from "../settingsFormatters";
 import { MotionSpinner } from "../../MotionSpinner";
 import { SelectDropdown } from "../../ui/SelectDropdown";
+import { SettingToggleRow } from "../SettingRow";
 
 export interface SettingsAboutSectionProps {
   settings: Settings;
@@ -74,8 +75,11 @@ export function SettingsAboutSection({
   return (
     <section className="settings-section settings-about-section">
       {showAll && <div className="settings-section-context">{t("settings.sections.about")}</div>}
-      <div className="settings-section-header">
-        <h2>{t("settings.sections.about")}</h2>
+      <div className="settings-section-header settings-section-header--with-copy">
+        <div>
+          <h2>{t("settings.sections.about")}</h2>
+          <p className="settings-section-description">{t("settings.about.description")}</p>
+        </div>
       </div>
       <div className="settings-rows">
         <div className="settings-row">
@@ -196,31 +200,18 @@ export function SettingsAboutSection({
           </div>
         </div>
 
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap" htmlFor="settings-about-auto-check-updates">
-              <span className="settings-label-title">{t("settings.about.automaticallyCheckForUpdates")}</span>
-            </label>
-            <label className="settings-toggle">
-              <input
-                id="settings-about-auto-check-updates"
-                type="checkbox"
-                checked={settings.autoCheckForUpdates}
-                onChange={(e) => handleChange("autoCheckForUpdates", e.target.checked)}
-              />
-              <span className="settings-toggle-track" />
-            </label>
-          </div>
-          <span className="settings-subtle-hint">
-            {t("settings.about.automaticallyCheckForUpdatesOnHint")}
-          </span>
-          <span className="settings-subtle-hint">
-            {t("settings.about.automaticallyCheckForUpdatesOffHint")}
-          </span>
-        </div>
+        <SettingToggleRow
+          htmlFor="settings-about-auto-check-updates"
+          label={t("settings.about.automaticallyCheckForUpdates")}
+          description={settings.autoCheckForUpdates
+            ? t("settings.about.automaticallyCheckForUpdatesOnHint")
+            : t("settings.about.automaticallyCheckForUpdatesOffHint")}
+          checked={settings.autoCheckForUpdates}
+          onChange={(checked) => handleChange("autoCheckForUpdates", checked)}
+        />
 
         {updaterState.status === "downloading" && updaterState.progress ? (
-          <div className="settings-row settings-row--column">
+          <div className="settings-row settings-row--full">
             <div
               className="settings-updater-progress"
               role="progressbar"
@@ -235,25 +226,13 @@ export function SettingsAboutSection({
           </div>
         ) : null}
 
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap" htmlFor="settings-about-error-reporting">
-              <span className="settings-label-title">{t("settings.about.errorReporting")}</span>
-            </label>
-            <label className="settings-toggle">
-              <input
-                id="settings-about-error-reporting"
-                type="checkbox"
-                checked={settings.errorReportingConsent === "granted"}
-                onChange={(e) => handleChange("errorReportingConsent", e.target.checked ? "granted" : "denied")}
-              />
-              <span className="settings-toggle-track" />
-            </label>
-          </div>
-          <span className="settings-subtle-hint">
-            {t("settings.about.errorReportingHint")}
-          </span>
-        </div>
+        <SettingToggleRow
+          htmlFor="settings-about-error-reporting"
+          label={t("settings.about.errorReporting")}
+          description={t("settings.about.errorReportingHint")}
+          checked={settings.errorReportingConsent === "granted"}
+          onChange={(checked) => handleChange("errorReportingConsent", checked ? "granted" : "denied")}
+        />
 
         <div className="settings-row">
           <label className="settings-label">

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsAccountSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsAccountSection.tsx
@@ -311,10 +311,9 @@ export function SettingsAccountSection({
     <section className="settings-section settings-storage-section">
       {showAll && <div className="settings-section-context">{t("settings.sections.account")}</div>}
       <div className="settings-section-header settings-section-header--with-copy">
-        <HardDrive size={18} />
         <div>
           <h2>{t("settings.persistentStorage.title")}</h2>
-          <p className="settings-section-subtitle">{t("settings.persistentStorage.description")}</p>
+          <p className="settings-section-description">{t("settings.persistentStorage.description")}</p>
         </div>
       </div>
       <div className="settings-storage-card">
@@ -421,10 +420,9 @@ export function SettingsAccountSection({
     <section className="settings-section settings-game-accounts-section">
       {showAll && <div className="settings-section-context">{t("settings.sections.account")}</div>}
       <div className="settings-section-header settings-section-header--with-copy settings-game-accounts-header">
-        <Users size={18} />
         <div>
           <h2>{t("settings.accountConnections.title")}</h2>
-          <p className="settings-section-subtitle">{t("settings.accountConnections.description")}</p>
+          <p className="settings-section-description">{t("settings.accountConnections.description")}</p>
         </div>
         <button
           type="button"

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsAudioSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsAudioSection.tsx
@@ -141,8 +141,11 @@ export function SettingsAudioSection({ settings, showAll, handleChange }: Settin
   return (
     <section className="settings-section">
       {showAll && <div className="settings-section-context">{t("settings.sections.audio")}</div>}
-      <div className="settings-section-header">
-        <h2>{t("settings.audio.title")}</h2>
+      <div className="settings-section-header settings-section-header--with-copy">
+        <div>
+          <h2>{t("settings.audio.title")}</h2>
+          <p className="settings-section-description">{t("settings.audio.description")}</p>
+        </div>
       </div>
       <div className="settings-rows">
         <div className="settings-row">

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsConsoleSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsConsoleSection.tsx
@@ -1,0 +1,78 @@
+import type { JSX } from "react";
+import type { Settings } from "@shared/gfn";
+import { useTranslation } from "../../../i18n";
+
+export interface SettingsConsoleSectionProps {
+  settings: Settings;
+  showAll: boolean;
+  handleChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+}
+
+export function SettingsConsoleSection({
+  settings,
+  showAll,
+  handleChange,
+}: SettingsConsoleSectionProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <section className="settings-section">
+      {showAll && <div className="settings-section-context">{t("settings.sections.console")}</div>}
+      <div className="settings-section-header settings-section-header--with-copy">
+        <div>
+          <h2>{t("settings.console.title")}</h2>
+          <p className="settings-section-description">{t("settings.console.description")}</p>
+        </div>
+      </div>
+      <div className="settings-rows">
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="settings-console-controller-mode">
+            {t("settings.console.controllerMode")}
+            <span className="settings-hint">{t("settings.console.controllerModeHint")}</span>
+          </label>
+          <label className="settings-toggle">
+            <input
+              id="settings-console-controller-mode"
+              type="checkbox"
+              checked={settings.controllerMode}
+              onChange={(event) => handleChange("controllerMode", event.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="settings-console-profile-picker">
+            {t("settings.console.profilePicker")}
+            <span className="settings-hint">{t("settings.console.profilePickerHint")}</span>
+          </label>
+          <label className="settings-toggle">
+            <input
+              id="settings-console-profile-picker"
+              type="checkbox"
+              checked={settings.consoleProfilePickerOnLaunch}
+              onChange={(event) => handleChange("consoleProfilePickerOnLaunch", event.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="settings-console-launch-mode">
+            {t("settings.console.launchMode")}
+            <span className="settings-hint">{t("settings.console.launchModeHint")}</span>
+          </label>
+          <label className="settings-toggle">
+            <input
+              id="settings-console-launch-mode"
+              type="checkbox"
+              checked={settings.launchInConsoleMode}
+              onChange={(event) => handleChange("launchInConsoleMode", event.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsConsoleSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsConsoleSection.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "react";
 import type { Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
+import { SettingToggleRow } from "../SettingRow";
 
 export interface SettingsConsoleSectionProps {
   settings: Settings;
@@ -25,53 +26,27 @@ export function SettingsConsoleSection({
         </div>
       </div>
       <div className="settings-rows">
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="settings-console-controller-mode">
-            {t("settings.console.controllerMode")}
-            <span className="settings-hint">{t("settings.console.controllerModeHint")}</span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-console-controller-mode"
-              type="checkbox"
-              checked={settings.controllerMode}
-              onChange={(event) => handleChange("controllerMode", event.target.checked)}
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="settings-console-profile-picker">
-            {t("settings.console.profilePicker")}
-            <span className="settings-hint">{t("settings.console.profilePickerHint")}</span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-console-profile-picker"
-              type="checkbox"
-              checked={settings.consoleProfilePickerOnLaunch}
-              onChange={(event) => handleChange("consoleProfilePickerOnLaunch", event.target.checked)}
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="settings-console-launch-mode">
-            {t("settings.console.launchMode")}
-            <span className="settings-hint">{t("settings.console.launchModeHint")}</span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-console-launch-mode"
-              type="checkbox"
-              checked={settings.launchInConsoleMode}
-              onChange={(event) => handleChange("launchInConsoleMode", event.target.checked)}
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
+        <SettingToggleRow
+          htmlFor="settings-console-controller-mode"
+          label={t("settings.console.controllerMode")}
+          description={t("settings.console.controllerModeHint")}
+          checked={settings.controllerMode}
+          onChange={(checked) => handleChange("controllerMode", checked)}
+        />
+        <SettingToggleRow
+          htmlFor="settings-console-profile-picker"
+          label={t("settings.console.profilePicker")}
+          description={t("settings.console.profilePickerHint")}
+          checked={settings.consoleProfilePickerOnLaunch}
+          onChange={(checked) => handleChange("consoleProfilePickerOnLaunch", checked)}
+        />
+        <SettingToggleRow
+          htmlFor="settings-console-launch-mode"
+          label={t("settings.console.launchMode")}
+          description={t("settings.console.launchModeHint")}
+          checked={settings.launchInConsoleMode}
+          onChange={(checked) => handleChange("launchInConsoleMode", checked)}
+        />
       </div>
     </section>
   );

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsDiagnosticsSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsDiagnosticsSection.tsx
@@ -1,4 +1,3 @@
-import { Activity } from "lucide-react";
 import { type JSX } from "react";
 import type { Settings } from "@shared/gfn";
 import type { CodecTestResult } from "../../../lib/codecDiagnostics";
@@ -35,7 +34,6 @@ export function SettingsDiagnosticsSection({
         </div>
       )}
       <div className="settings-section-header settings-section-header--with-copy">
-        <Activity size={18} />
         <div>
           <h2>{t("settings.diagnostics.title")}</h2>
           <p className="settings-section-description">

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsGameSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsGameSection.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 import type { GameLanguage, Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
+import { SettingToggleRow } from "../SettingRow";
 import { gameLanguageOptions } from "../settingsFormatters";
 
 export interface SettingsGameSectionProps {
@@ -18,8 +19,11 @@ export function SettingsGameSection({ settings, showAll, handleChange }: Setting
   return (
     <section className="settings-section">
       {showAll && <div className="settings-section-context">{t("settings.sections.game")}</div>}
-      <div className="settings-section-header">
-        <h2>{t("settings.game.title")}</h2>
+      <div className="settings-section-header settings-section-header--with-copy">
+        <div>
+          <h2>{t("settings.game.title")}</h2>
+          <p className="settings-section-description">{t("settings.game.description")}</p>
+        </div>
       </div>
       <div className="settings-rows">
         <div className="settings-row">
@@ -37,27 +41,13 @@ export function SettingsGameSection({ settings, showAll, handleChange }: Setting
             />
           </div>
         </div>
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap" htmlFor={persistSettingsId}>
-              <span className="settings-label-title">
-                {t("settings.game.persistInGameSettings")}
-              </span>
-            </label>
-            <label className="settings-toggle">
-              <input
-                id={persistSettingsId}
-                type="checkbox"
-                checked={settings.enablePersistingInGameSettings}
-                onChange={(e) => handleChange("enablePersistingInGameSettings", e.target.checked)}
-              />
-              <span className="settings-toggle-track" />
-            </label>
-          </div>
-          <span className="settings-subtle-hint">
-            {t("settings.game.persistInGameSettingsHint")}
-          </span>
-        </div>
+        <SettingToggleRow
+          htmlFor={persistSettingsId}
+          label={t("settings.game.persistInGameSettings")}
+          description={t("settings.game.persistInGameSettingsHint")}
+          checked={settings.enablePersistingInGameSettings}
+          onChange={(checked) => handleChange("enablePersistingInGameSettings", checked)}
+        />
       </div>
     </section>
   );

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsInputSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsInputSection.tsx
@@ -5,6 +5,7 @@ import { formatShortcutForDisplay, normalizeShortcut, shortcutFromKeyboardEvent 
 import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
 import { SettingRange } from "../SettingRange";
+import { SettingRow, SettingToggleRow } from "../SettingRow";
 import {
   getShortcutConflictMessage,
   isMac,
@@ -305,89 +306,39 @@ export function SettingsInputSection({ settings, showAll, handleChange, handlePr
   return (
     <section className="settings-section">
       {showAll && <div className="settings-section-context">{t("settings.sections.input")}</div>}
-      <div className="settings-section-header">
-        <h2>{t("settings.input.title")}</h2>
+      <div className="settings-section-header settings-section-header--with-copy">
+        <div>
+          <h2>{t("settings.input.title")}</h2>
+          <p className="settings-section-description">{t("settings.input.description")}</p>
+        </div>
       </div>
       <div className="settings-rows">
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label" htmlFor="settings-input-clipboard-paste">{t("settings.input.clipboardPaste")}</label>
-            <label className="settings-toggle">
-              <input
-                id="settings-input-clipboard-paste"
-                type="checkbox"
-                checked={settings.clipboardPaste}
-                onChange={(e) => handleChange("clipboardPaste", e.target.checked)}
-              />
-              <span className="settings-toggle-track" />
-            </label>
-          </div>
-        </div>
-
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap" htmlFor="settings-input-gyroscope-controls">
-              <span className="settings-label-title">
-                {t("settings.input.gyroscopeControls")}
-                <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span>
-              </span>
-            </label>
-            <label className="settings-toggle">
-              <input
-                id="settings-input-gyroscope-controls"
-                type="checkbox"
-                checked={settings.enableGyroscopeControls}
-                onChange={(e) => handleChange("enableGyroscopeControls", e.target.checked)}
-              />
-              <span className="settings-toggle-track" />
-            </label>
-          </div>
-          <span className="settings-subtle-hint">{t("settings.input.gyroscopeControlsHint")}</span>
-        </div>
+        <SettingToggleRow htmlFor="settings-input-clipboard-paste" label={t("settings.input.clipboardPaste")} checked={settings.clipboardPaste} onChange={(checked) => handleChange("clipboardPaste", checked)} />
+        <SettingToggleRow
+          htmlFor="settings-input-gyroscope-controls"
+          label={<>{t("settings.input.gyroscopeControls")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span></>}
+          description={t("settings.input.gyroscopeControlsHint")}
+          checked={settings.enableGyroscopeControls}
+          onChange={(checked) => handleChange("enableGyroscopeControls", checked)}
+        />
 
         {isMac && (
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-input-steam-controller-compatibility">
-                <span className="settings-label-title">
-                  {t("settings.input.steamControllerCompatibilityMode")}
-                  <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span>
-                </span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-input-steam-controller-compatibility"
-                  type="checkbox"
-                  checked={settings.steamControllerCompatibilityMode}
-                  onChange={(e) => handleChange("steamControllerCompatibilityMode", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.input.steamControllerCompatibilityModeHint")}</span>
-          </div>
+          <SettingToggleRow
+            htmlFor="settings-input-steam-controller-compatibility"
+            label={<>{t("settings.input.steamControllerCompatibilityMode")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span></>}
+            description={t("settings.input.steamControllerCompatibilityModeHint")}
+            checked={settings.steamControllerCompatibilityMode}
+            onChange={(checked) => handleChange("steamControllerCompatibilityMode", checked)}
+          />
         )}
 
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top settings-row-top--compact">
-            <label className="settings-label settings-label--wrap" htmlFor="settings-input-native-cursor-overlay">
-              <span className="settings-label-title">
-                {t("settings.input.nativeCursorOverlay")}
-                <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span>
-              </span>
-            </label>
-            <label className="settings-toggle">
-              <input
-                id="settings-input-native-cursor-overlay"
-                type="checkbox"
-                checked={settings.nativeCursorOverlay}
-                onChange={(e) => handleChange("nativeCursorOverlay", e.target.checked)}
-              />
-              <span className="settings-toggle-track" />
-            </label>
-          </div>
-          <span className="settings-subtle-hint">{t("settings.input.nativeCursorOverlayHint")}</span>
-        </div>
+        <SettingToggleRow
+          htmlFor="settings-input-native-cursor-overlay"
+          label={<>{t("settings.input.nativeCursorOverlay")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span></>}
+          description={t("settings.input.nativeCursorOverlayHint")}
+          checked={settings.nativeCursorOverlay}
+          onChange={(checked) => handleChange("nativeCursorOverlay", checked)}
+        />
 
         <div className="settings-row">
           <label className="settings-label settings-label--wrap" htmlFor="settings-input-keyboard-layout">
@@ -406,11 +357,8 @@ export function SettingsInputSection({ settings, showAll, handleChange, handlePr
         </div>
 
         {/* Mouse Sensitivity */}
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top">
-            <label id="settings-input-mouse-sensitivity-label" className="settings-label" htmlFor="settings-input-mouse-sensitivity-slider">{t("settings.input.mouseSensitivity")}</label>
-            <span className="settings-value-badge">{settings.mouseSensitivity.toFixed(2)}x</span>
-          </div>
+        <SettingRow htmlFor="settings-input-mouse-sensitivity-slider" label={t("settings.input.mouseSensitivity")} description={t("settings.input.mouseSensitivityHint")}>
+          <span className="settings-value-badge settings-value-badge--control">{settings.mouseSensitivity.toFixed(2)}x</span>
           <div className="settings-slider-control">
             <SettingRange
               id="settings-input-mouse-sensitivity-slider"
@@ -429,7 +377,7 @@ export function SettingsInputSection({ settings, showAll, handleChange, handlePr
               id="settings-input-mouse-sensitivity-number"
               type="number"
               className="settings-text-input settings-number-input"
-              aria-labelledby="settings-input-mouse-sensitivity-label"
+              aria-label={t("settings.input.mouseSensitivity")}
               min={0.1}
               max={4}
               step={0.01}
@@ -445,14 +393,10 @@ export function SettingsInputSection({ settings, showAll, handleChange, handlePr
               }}
             />
           </div>
-          <span className="settings-subtle-hint">{t("settings.input.mouseSensitivityHint")}</span>
-        </div>
+        </SettingRow>
 
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top">
-            <label id="settings-input-mouse-acceleration-label" className="settings-label" htmlFor="settings-input-mouse-acceleration-slider">{t("settings.input.mouseAccelerator")}</label>
-            <span className="settings-value-badge">{Math.round(settings.mouseAcceleration)}%</span>
-          </div>
+        <SettingRow htmlFor="settings-input-mouse-acceleration-slider" label={t("settings.input.mouseAccelerator")} description={t("settings.input.mouseAcceleratorHint")}>
+          <span className="settings-value-badge settings-value-badge--control">{Math.round(settings.mouseAcceleration)}%</span>
           <div className="settings-slider-control">
             <SettingRange
               id="settings-input-mouse-acceleration-slider"
@@ -472,7 +416,7 @@ export function SettingsInputSection({ settings, showAll, handleChange, handlePr
               id="settings-input-mouse-acceleration-number"
               type="number"
               className="settings-text-input settings-number-input"
-              aria-labelledby="settings-input-mouse-acceleration-label"
+              aria-label={t("settings.input.mouseAccelerator")}
               min={1}
               max={150}
               step={1}
@@ -488,8 +432,7 @@ export function SettingsInputSection({ settings, showAll, handleChange, handlePr
               }}
             />
           </div>
-          <span className="settings-subtle-hint">{t("settings.input.mouseAcceleratorHint")}</span>
-        </div>
+        </SettingRow>
 
         {/* Shortcuts */}
         <div className="settings-row settings-row--column">

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
@@ -3,6 +3,7 @@ import type { AppAccentColor, Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
 import { SettingRange } from "../SettingRange";
+import { SettingRow, SettingToggleRow } from "../SettingRow";
 import {
   accentColorOptions,
   getAppLanguageLabel,
@@ -61,8 +62,11 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, hand
       {/* ── Appearance ── */}
       <section className="settings-section">
         {showAll && <div className="settings-section-context">{t("settings.sections.interface")}</div>}
-        <div className="settings-section-header">
-          <h2>{t("settings.interface.appearance")}</h2>
+        <div className="settings-section-header settings-section-header--with-copy">
+          <div>
+            <h2>{t("settings.interface.appearance")}</h2>
+            <p className="settings-section-description">{t("settings.interface.description")}</p>
+          </div>
         </div>
         <div className="settings-rows">
           <div className="settings-row">
@@ -100,23 +104,13 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, hand
             </div>
           </div>
 
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-translucent-ui">
-                <span className="settings-label-title">{t("settings.interface.translucentUI") || "Translucent UI"}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-translucent-ui"
-                  type="checkbox"
-                  checked={settings.translucentUI}
-                  onChange={(e) => handleChange("translucentUI", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.translucentUIHint") || "Enable glassmorphism and translucent overlays."}</span>
-          </div>
+          <SettingToggleRow
+            htmlFor="settings-interface-translucent-ui"
+            label={t("settings.interface.translucentUI") || "Translucent UI"}
+            description={t("settings.interface.translucentUIHint") || "Enable glassmorphism and translucent overlays."}
+            checked={settings.translucentUI}
+            onChange={(checked) => handleChange("translucentUI", checked)}
+          />
 
           <div className="settings-row">
             <label className="settings-label" htmlFor="settings-interface-accent-color">
@@ -133,73 +127,17 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, hand
             </div>
           </div>
 
-          {/* Appearance toggles */}
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-hide-stream-buttons">
-                <span className="settings-label-title">{t("settings.interface.hideStreamOverlayButtons")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-hide-stream-buttons"
-                  type="checkbox"
-                  checked={settings.hideStreamButtons}
-                  onChange={(e) => handleChange("hideStreamButtons", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.hideStreamOverlayButtonsHint")}</span>
-          </div>
+          <SettingToggleRow htmlFor="settings-interface-hide-stream-buttons" label={t("settings.interface.hideStreamOverlayButtons")} description={t("settings.interface.hideStreamOverlayButtonsHint")} checked={settings.hideStreamButtons} onChange={(checked) => handleChange("hideStreamButtons", checked)} />
+          <SettingToggleRow htmlFor="settings-interface-hide-server-selector" label={t("settings.interface.hideServerSelector")} description={t("settings.interface.hideServerSelectorHint")} checked={settings.hideServerSelector} onChange={(checked) => handleChange("hideServerSelector", checked)} />
+          <SettingToggleRow htmlFor="settings-interface-show-anti-afk-indicator" label={t("settings.interface.showAntiAfkIndicator")} description={t("settings.interface.showAntiAfkIndicatorHint")} checked={settings.showAntiAfkIndicator} onChange={(checked) => handleChange("showAntiAfkIndicator", checked)} />
 
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-hide-server-selector">
-                <span className="settings-label-title">{t("settings.interface.hideServerSelector")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-hide-server-selector"
-                  type="checkbox"
-                  checked={settings.hideServerSelector}
-                  onChange={(e) => handleChange("hideServerSelector", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.hideServerSelectorHint")}</span>
-          </div>
-
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-show-anti-afk-indicator">
-                <span className="settings-label-title">{t("settings.interface.showAntiAfkIndicator")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-show-anti-afk-indicator"
-                  type="checkbox"
-                  checked={settings.showAntiAfkIndicator}
-                  onChange={(e) => handleChange("showAntiAfkIndicator", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.showAntiAfkIndicatorHint")}</span>
-          </div>
-
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top">
-              <label className="settings-label" htmlFor="settings-interface-anti-afk-reminder-interval">
-                {t("settings.interface.antiAfkReminderInterval")}
-              </label>
-              <span className="settings-value-badge">
+          <SettingRow htmlFor="settings-interface-anti-afk-reminder-interval" label={t("settings.interface.antiAfkReminderInterval")} description={t("settings.interface.antiAfkReminderIntervalHint")}>
+              <span className="settings-value-badge settings-value-badge--control">
                 {settings.antiAfkReminderEveryMinutes === 0
                   ? t("settings.interface.off")
                   : t("settings.interface.everyMinutes", { count: settings.antiAfkReminderEveryMinutes })}
               </span>
-            </div>
-            <SettingRange
+              <SettingRange
               id="settings-interface-anti-afk-reminder-interval"
               className="settings-slider"
               min={0}
@@ -209,20 +147,14 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, hand
               onPreview={(value) => handlePreview("antiAfkReminderEveryMinutes", value)}
               onCommit={(value) => handleChange("antiAfkReminderEveryMinutes", value)}
             />
-            <span className="settings-subtle-hint">{t("settings.interface.antiAfkReminderIntervalHint")}</span>
-          </div>
+          </SettingRow>
 
           {settings.antiAfkReminderEveryMinutes > 0 && (
-            <div className="settings-row settings-row--column">
-              <div className="settings-row-top">
-                <label className="settings-label" htmlFor="settings-interface-anti-afk-reminder-duration">
-                  {t("settings.interface.antiAfkReminderDuration")}
-                </label>
-                <span className="settings-value-badge">
+            <SettingRow htmlFor="settings-interface-anti-afk-reminder-duration" label={t("settings.interface.antiAfkReminderDuration")} description={t("settings.interface.antiAfkReminderDurationHint")}>
+                <span className="settings-value-badge settings-value-badge--control">
                   {t("app.units.seconds", { value: settings.antiAfkReminderDurationSeconds })}
                 </span>
-              </div>
-              <SettingRange
+                <SettingRange
                 id="settings-interface-anti-afk-reminder-duration"
                 className="settings-slider"
                 min={5}
@@ -232,69 +164,15 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, hand
                 onPreview={(value) => handlePreview("antiAfkReminderDurationSeconds", value)}
                 onCommit={(value) => handleChange("antiAfkReminderDurationSeconds", value)}
               />
-              <span className="settings-subtle-hint">{t("settings.interface.antiAfkReminderDurationHint")}</span>
-            </div>
+            </SettingRow>
           )}
 
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-auto-fullscreen">
-                <span className="settings-label-title">{t("settings.interface.autoFullScreen")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-auto-fullscreen"
-                  type="checkbox"
-                  checked={settings.autoFullScreen}
-                  onChange={(e) => handleChange("autoFullScreen", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.autoFullScreenHint")}</span>
-          </div>
+          <SettingToggleRow htmlFor="settings-interface-auto-fullscreen" label={t("settings.interface.autoFullScreen")} description={t("settings.interface.autoFullScreenHint")} checked={settings.autoFullScreen} onChange={(checked) => handleChange("autoFullScreen", checked)} />
+          <SettingToggleRow htmlFor="settings-interface-escape-exits-fullscreen" label={t("settings.interface.escapeExitsFullscreen")} description={t("settings.interface.escapeExitsFullscreenHint")} checked={Boolean(settings.allowEscapeToExitFullscreen)} onChange={(checked) => handleChange("allowEscapeToExitFullscreen", checked)} />
+          <SettingToggleRow htmlFor="settings-interface-discord-rich-presence" label={t("settings.interface.discordRichPresence")} description={t("settings.interface.discordRichPresenceHint")} checked={settings.discordRichPresence} onChange={(checked) => handleChange("discordRichPresence", checked)} />
 
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-escape-exits-fullscreen">
-                <span className="settings-label-title">{t("settings.interface.escapeExitsFullscreen")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-escape-exits-fullscreen"
-                  type="checkbox"
-                  checked={Boolean(settings.allowEscapeToExitFullscreen)}
-                  onChange={(e) => handleChange("allowEscapeToExitFullscreen", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.escapeExitsFullscreenHint")}</span>
-          </div>
-
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-discord-rich-presence">
-                <span className="settings-label-title">{t("settings.interface.discordRichPresence")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-discord-rich-presence"
-                  type="checkbox"
-                  checked={settings.discordRichPresence}
-                  onChange={(e) => handleChange("discordRichPresence", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.discordRichPresenceHint")}</span>
-          </div>
-
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top">
-              <label className="settings-label" htmlFor="settings-interface-poster-size">{t("settings.interface.posterSize")}</label>
-              <span className="settings-value-badge">{posterSizePercent}%</span>
-            </div>
+          <SettingRow htmlFor="settings-interface-poster-size" label={t("settings.interface.posterSize")} description={t("settings.interface.posterSizeHint")}>
+            <span className="settings-value-badge settings-value-badge--control">{posterSizePercent}%</span>
             <SettingRange
               id="settings-interface-poster-size"
               className="settings-slider"
@@ -306,8 +184,7 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, hand
               onPreview={(value) => handlePreview("posterSizeScale", value)}
               onCommit={(value) => handleChange("posterSizeScale", value)}
             />
-            <span className="settings-subtle-hint">{t("settings.interface.posterSizeHint")}</span>
-          </div>
+          </SettingRow>
 
         </div>
       </section>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
@@ -256,42 +256,6 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, hand
 
           <div className="settings-row settings-row--column">
             <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-controller-mode">
-                <span className="settings-label-title">{t("settings.interface.controllerMode")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-controller-mode"
-                  type="checkbox"
-                  checked={settings.controllerMode}
-                  onChange={(e) => handleChange("controllerMode", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.controllerModeHint")}</span>
-          </div>
-
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-console-profile-picker">
-                <span className="settings-label-title">{t("settings.interface.consoleProfilePicker")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-console-profile-picker"
-                  type="checkbox"
-                  checked={settings.consoleProfilePickerOnLaunch}
-                  onChange={(e) => handleChange("consoleProfilePickerOnLaunch", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.consoleProfilePickerHint")}</span>
-          </div>
-
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
               <label className="settings-label settings-label--wrap" htmlFor="settings-interface-escape-exits-fullscreen">
                 <span className="settings-label-title">{t("settings.interface.escapeExitsFullscreen")}</span>
               </label>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
@@ -8,6 +8,7 @@ import {
   NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE,
 } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
+import { SettingRow, SettingToggleRow } from "../SettingRow";
 import {
   formatGstreamerRuntimeLabel,
   formatNativeVideoCodec,
@@ -162,35 +163,23 @@ export function SettingsNativeStreamerSection({
       {showSection && (
       <section className="settings-section">
         {showAll && <div className="settings-section-context">{t("settings.sections.nativeStreamer")}</div>}
-        <div className="settings-section-header">
-          <h2>{t("settings.nativeStreamer.title")}</h2>
+        <div className="settings-section-header settings-section-header--with-copy">
+          <div>
+            <h2>{t("settings.nativeStreamer.title")}</h2>
+            <p className="settings-section-description">{t("settings.nativeStreamer.description")}</p>
+          </div>
         </div>
         <div className="settings-rows">
           {!isNativeStreamerPlatform ? (
-            <div className="settings-row settings-row--column">
-              <div className="settings-row-top settings-row-top--compact">
-                <label className="settings-label settings-label--wrap">
-                  <span className="settings-label-title">
-                    {t("settings.nativeStreamer.nativeStreaming")}
-                    <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span>
-                  </span>
-                </label>
-              </div>
+            <SettingRow label={<>{t("settings.nativeStreamer.nativeStreaming")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span></>} description={NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE}>
               <span className="settings-input-hint">
                 {NATIVE_STREAMER_UNSUPPORTED_PLATFORM_MESSAGE}
               </span>
-            </div>
+            </SettingRow>
           ) : (
             <>
-              <div className="settings-row settings-row--column">
-                <div className="settings-row-top settings-row-top--compact">
-                  <label className="settings-label settings-label--wrap" htmlFor="settings-native-streaming-enabled">
-                    <span className="settings-label-title">
-                      {t("settings.nativeStreamer.nativeStreaming")}
-                      <span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span>
-                    </span>
-                  </label>
-                  <label className="settings-toggle">
+              <SettingRow htmlFor="settings-native-streaming-enabled" label={<>{t("settings.nativeStreamer.nativeStreaming")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span></>} description={t("settings.nativeStreamer.nativeStreamingHint")}>
+                  <label className="settings-toggle settings-toggle--control">
                     <input
                       id="settings-native-streaming-enabled"
                       type="checkbox"
@@ -199,10 +188,6 @@ export function SettingsNativeStreamerSection({
                     />
                     <span className="settings-toggle-track" />
                   </label>
-                </div>
-                <span className="settings-subtle-hint">
-                  {t("settings.nativeStreamer.nativeStreamingHint")}
-                </span>
                 <div className="settings-native-report-links">
                   <a href="https://github.com/OpenCloudGaming/OpenNOW/issues" target="_blank" rel="noreferrer">
                     <span>{t("settings.nativeStreamer.reportOnGithubIssues")}</span>
@@ -213,27 +198,9 @@ export function SettingsNativeStreamerSection({
                     <ExternalLink size={12} />
                   </a>
                 </div>
-              </div>
+              </SettingRow>
 
-              <div className="settings-row settings-row--column">
-                <div className="settings-row-top settings-row-top--compact">
-                  <label className="settings-label settings-label--wrap" htmlFor="settings-native-show-stats">
-                    <span className="settings-label-title">{t("settings.nativeStreamer.showNativeStreamerStats")}</span>
-                  </label>
-                  <label className="settings-toggle">
-                    <input
-                      id="settings-native-show-stats"
-                      type="checkbox"
-                      checked={settings.showNativeStreamerStats}
-                      onChange={(e) => handleChange("showNativeStreamerStats", e.target.checked)}
-                    />
-                    <span className="settings-toggle-track" />
-                  </label>
-                </div>
-                <span className="settings-subtle-hint">
-                  {t("settings.nativeStreamer.showNativeStreamerStatsHint")}
-                </span>
-              </div>
+              <SettingToggleRow htmlFor="settings-native-show-stats" label={t("settings.nativeStreamer.showNativeStreamerStats")} description={t("settings.nativeStreamer.showNativeStreamerStatsHint")} checked={settings.showNativeStreamerStats} onChange={(checked) => handleChange("showNativeStreamerStats", checked)} />
 
               <div className="settings-row settings-row--column">
                 <div className="settings-row-top settings-row-top--compact">

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsThanksSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsThanksSection.tsx
@@ -1,4 +1,4 @@
-import { Heart, Users, ExternalLink } from "lucide-react";
+import { Heart, ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import type { ThankYouContributor, ThankYouDataResult, ThankYouSupporter } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
@@ -169,11 +169,10 @@ export function SettingsThanksSection(): JSX.Element {
 
       <div className="settings-thanks-grid">
         <section className="settings-section">
-          <div className="settings-section-header settings-section-header--thanks">
-            <Users size={18} />
+          <div className="settings-section-header settings-section-header--with-copy settings-section-header--thanks">
             <div>
               <h2>{t("settings.thanks.contributorsTitle")}</h2>
-              <p className="settings-section-subtitle">{t("settings.thanks.contributorsSubtitle")}</p>
+              <p className="settings-section-description">{t("settings.thanks.contributorsSubtitle")}</p>
             </div>
           </div>
           {thanksLoadState === "loading" && !thanksData ? (
@@ -195,11 +194,10 @@ export function SettingsThanksSection(): JSX.Element {
         </section>
 
         <section className="settings-section">
-          <div className="settings-section-header settings-section-header--thanks">
-            <Heart size={18} />
+          <div className="settings-section-header settings-section-header--with-copy settings-section-header--thanks">
             <div>
               <h2>{t("settings.thanks.supportersTitle")}</h2>
-              <p className="settings-section-subtitle">{t("settings.thanks.supportersSubtitle")}</p>
+              <p className="settings-section-description">{t("settings.thanks.supportersSubtitle")}</p>
             </div>
           </div>
           {thanksLoadState === "loading" && !thanksData ? (

--- a/opennow-stable/src/renderer/src/components/settings/settingsSearch.test.ts
+++ b/opennow-stable/src/renderer/src/components/settings/settingsSearch.test.ts
@@ -45,6 +45,21 @@ test("routes legacy session timing aliases from interface to diagnostics", () =>
   }
 });
 
+test("routes controller-first shell settings to console", () => {
+  const movedQueries = [
+    "controller mode",
+    "profile picker",
+    "tv mode",
+    "big picture",
+  ];
+
+  for (const query of movedQueries) {
+    assert.equal(settingsScopeMatchesSearch("console", query), true);
+    assert.equal(settingsScopeMatchesSearch("interface", query), false);
+    assert.equal(settingsScopeMatchesSearch("stream-video", query), false);
+  }
+});
+
 test("matches search tokens by word prefix", () => {
   assert.equal(
     settingsScopeMatchesSearch("stream-diagnostics", "diag over"),

--- a/opennow-stable/src/renderer/src/components/settings/settingsTypes.ts
+++ b/opennow-stable/src/renderer/src/components/settings/settingsTypes.ts
@@ -3,19 +3,15 @@ import type { JSX } from "react";
 export type SettingsNavItem = {
   id: SettingsSectionId;
   label: string;
+  description: string;
   icon: JSX.Element;
-};
-
-export type SettingsNavGroup = {
-  label: string;
-  items: SettingsNavItem[];
 };
 
 export type ThanksLoadState = "idle" | "loading" | "loaded" | "error";
 export type StorageResetState = "idle" | "resetting" | "success" | "error";
 export type GameAccountBusyAction = "link" | "unlink" | "resync";
 
-export type SettingsSectionId = "account" | "stream" | "diagnostics" | "native-streamer" | "game" | "audio" | "input" | "interface" | "about" | "thanks";
+export type SettingsSectionId = "account" | "stream" | "diagnostics" | "native-streamer" | "game" | "audio" | "input" | "console" | "interface" | "about" | "thanks";
 export type SettingsSearchScopeId =
   | "account-storage"
   | "stream-region"
@@ -26,6 +22,7 @@ export type SettingsSearchScopeId =
   | "game"
   | "audio"
   | "input"
+  | "console"
   | "interface"
   | "about"
   | "thanks";
@@ -87,10 +84,6 @@ export const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly
     "aspect ratio",
     "l4s",
     "cloud gsync",
-    "console mode",
-    "tv mode",
-    "big picture",
-    "gamepad friendly",
     "video acceleration",
     "filters",
     "shader",
@@ -198,6 +191,21 @@ export const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly
     "recording",
     "screenshot",
   ],
+  console: [
+    "console",
+    "console mode",
+    "controller mode",
+    "controller shell",
+    "gamepad",
+    "gamepad friendly",
+    "tv",
+    "tv mode",
+    "big picture",
+    "profile",
+    "profile picker",
+    "who is playing",
+    "fullscreen launch",
+  ],
   interface: [
     "interface",
     "ui",
@@ -217,9 +225,6 @@ export const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly
     "anti afk reminder",
     "afk notification",
     "afk reminder interval",
-    "controller",
-    "gamepad",
-    "big picture",
   ],
   about: [
     "about",

--- a/opennow-stable/src/renderer/src/components/settings/stream/BrowserRecordingSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/BrowserRecordingSection.tsx
@@ -1,4 +1,3 @@
-import { Video } from "lucide-react";
 import { type JSX } from "react";
 import type { Settings } from "@shared/gfn";
 import {
@@ -10,6 +9,7 @@ import {
 import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
 import { SettingRange } from "../SettingRange";
+import { SettingRow } from "../SettingRow";
 import type { SettingsChangeHandler } from "./streamSettingsTypes";
 
 interface BrowserRecordingSectionProps {
@@ -35,7 +35,6 @@ export function BrowserRecordingSection({
         </div>
       )}
       <div className="settings-section-header settings-section-header--with-copy">
-        <Video size={18} />
         <div>
           <h2>{t("settings.recording.title")}</h2>
           <p className="settings-section-description">
@@ -91,20 +90,12 @@ export function BrowserRecordingSection({
           </div>
         </div>
 
-        <div className="settings-row settings-row--column">
-          <div className="settings-row-top">
-            <label
-              className="settings-label"
-              htmlFor="settings-stream-recording-bitrate"
-            >
-              {t("settings.video.recordingBitrate")}
-            </label>
-            <span className="settings-value-badge">
+        <SettingRow htmlFor="settings-stream-recording-bitrate" label={t("settings.video.recordingBitrate")} description={t("settings.video.recordingBitrateHint")}>
+            <span className="settings-value-badge settings-value-badge--control">
               {settings.recordingBitrateMbps === null
                 ? t("app.labels.auto")
                 : `${settings.recordingBitrateMbps} Mbps`}
             </span>
-          </div>
           <div className="settings-chip-row">
             <button
               type="button"
@@ -143,10 +134,7 @@ export function BrowserRecordingSection({
             onPreview={(value) => handlePreview("recordingBitrateMbps", value)}
             onCommit={(value) => handleChange("recordingBitrateMbps", value)}
           />
-          <span className="settings-subtle-hint">
-            {t("settings.video.recordingBitrateHint")}
-          </span>
-        </div>
+        </SettingRow>
       </div>
     </section>
   );

--- a/opennow-stable/src/renderer/src/components/settings/stream/RegionSelectionSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/RegionSelectionSection.tsx
@@ -1,4 +1,4 @@
-import { Check, Globe, MapPin, Search, Wifi, X } from "lucide-react";
+import { Check, Globe, Search, Wifi, X } from "lucide-react";
 import { type JSX } from "react";
 import type { Settings, StreamRegion } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
@@ -46,9 +46,11 @@ export function RegionSelectionSection({
   return (
     <section className="settings-section settings-section--dropdown">
       {showAll && <div className="settings-section-context">{t("settings.sections.stream")}</div>}
-      <div className="settings-section-header">
-        <MapPin size={18} />
-        <h2>{t("settings.region.title")}</h2>
+      <div className="settings-section-header settings-section-header--with-copy">
+        <div>
+          <h2>{t("settings.region.title")}</h2>
+          <p className="settings-section-description">{t("settings.region.description")}</p>
+        </div>
       </div>
       <div className="settings-rows">
         <div className="settings-row settings-row--column settings-row--region">

--- a/opennow-stable/src/renderer/src/components/settings/stream/SessionProxySettings.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/SessionProxySettings.tsx
@@ -4,6 +4,7 @@ import type { Settings } from "@shared/gfn";
 import { isZortosCommunityProxyUrl } from "@shared/communityProxy";
 import { useTranslation } from "../../../i18n";
 import { ModalSurface } from "../../ui/ModalSurface";
+import { SettingRow } from "../SettingRow";
 import type { SettingsChangeHandler } from "./streamSettingsTypes";
 import { useCommunityProxyProvisioning } from "./useCommunityProxyProvisioning";
 
@@ -28,20 +29,12 @@ export function SessionProxySettings({
 
   return (
     <>
-      <div className="settings-row settings-row--column">
-        <div className="settings-row-top settings-row-top--compact">
-          <label
-            className="settings-label settings-label--wrap"
-            htmlFor="settings-stream-session-proxy"
-          >
-            <span className="settings-label-title">
-              {t("settings.video.sessionProxy")}
-              <span className="settings-inline-badge settings-inline-badge--beta">
-                {t("app.labels.beta")}
-              </span>
-            </span>
-          </label>
-          <label className="settings-toggle">
+      <SettingRow
+        htmlFor="settings-stream-session-proxy"
+        label={<>{t("settings.video.sessionProxy")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span></>}
+        description={t("settings.video.sessionProxyHint")}
+      >
+          <label className="settings-toggle settings-toggle--control">
             <input
               id="settings-stream-session-proxy"
               type="checkbox"
@@ -52,8 +45,6 @@ export function SessionProxySettings({
             />
             <span className="settings-toggle-track" />
           </label>
-        </div>
-        <span className="settings-subtle-hint">{t("settings.video.sessionProxyHint")}</span>
         <div className="settings-community-proxy-row">
           {isUsingZortosCommunityProxy ? (
             <span className="settings-inline-badge settings-inline-badge--beta">
@@ -79,7 +70,7 @@ export function SessionProxySettings({
             onChange={(event) => handleChange("sessionProxyUrl", event.target.value)}
           />
         )}
-      </div>
+      </SettingRow>
 
       <ModalSurface
         open={communityProxy.promptOpen}

--- a/opennow-stable/src/renderer/src/components/settings/stream/StatsOverlayControls.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/StatsOverlayControls.tsx
@@ -3,6 +3,7 @@ import type { Settings, StatsOverlayPosition } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
 import { SelectDropdown } from "../../ui/SelectDropdown";
 import { SettingRange } from "../SettingRange";
+import { SettingRow, SettingToggleRow } from "../SettingRow";
 import type { SettingsChangeHandler } from "./streamSettingsTypes";
 
 interface StatsOverlayControlsProps {
@@ -20,32 +21,7 @@ export function StatsOverlayControls({
 
   return (
     <>
-      <div className="settings-row settings-row--column">
-        <div className="settings-row-top settings-row-top--compact">
-          <label
-            className="settings-label settings-label--wrap"
-            htmlFor="settings-interface-show-stats-on-launch"
-          >
-            <span className="settings-label-title">
-              {t("settings.interface.showStatsOnStreamLaunch")}
-            </span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-interface-show-stats-on-launch"
-              type="checkbox"
-              checked={settings.showStatsOnLaunch}
-              onChange={(event) =>
-                handleChange("showStatsOnLaunch", event.target.checked)
-              }
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-        <span className="settings-subtle-hint">
-          {t("settings.interface.showStatsOnStreamLaunchHint")}
-        </span>
-      </div>
+      <SettingToggleRow htmlFor="settings-interface-show-stats-on-launch" label={t("settings.interface.showStatsOnStreamLaunch")} description={t("settings.interface.showStatsOnStreamLaunchHint")} checked={settings.showStatsOnLaunch} onChange={(checked) => handleChange("showStatsOnLaunch", checked)} />
 
       <div className="settings-row">
         <label
@@ -86,81 +62,19 @@ export function StatsOverlayControls({
         </div>
       </div>
 
-      <div className="settings-row settings-row--column">
-        <div className="settings-row-top settings-row-top--compact">
-          <label
-            className="settings-label settings-label--wrap"
-            htmlFor="settings-interface-show-session-time-remaining"
-          >
-            <span className="settings-label-title">
-              {t("settings.interface.showSessionTimeRemainingInStatsOverlay")}
-            </span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-interface-show-session-time-remaining"
-              type="checkbox"
-              checked={settings.showSessionTimeRemainingInStatsOverlay}
-              onChange={(event) =>
-                handleChange(
-                  "showSessionTimeRemainingInStatsOverlay",
-                  event.target.checked,
-                )
-              }
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-        <span className="settings-subtle-hint">
-          {t("settings.interface.showSessionTimeRemainingInStatsOverlayHint")}
-        </span>
-      </div>
-
-      <div className="settings-row settings-row--column">
-        <div className="settings-row-top settings-row-top--compact">
-          <label
-            className="settings-label settings-label--wrap"
-            htmlFor="settings-interface-session-counter"
-          >
-            <span className="settings-label-title">
-              {t("settings.interface.sessionElapsedCounter")}
-            </span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-interface-session-counter"
-              type="checkbox"
-              checked={settings.sessionCounterEnabled}
-              onChange={(event) =>
-                handleChange("sessionCounterEnabled", event.target.checked)
-              }
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-        <span className="settings-subtle-hint">
-          {t("settings.interface.sessionElapsedCounterHint")}
-        </span>
-      </div>
+      <SettingToggleRow htmlFor="settings-interface-show-session-time-remaining" label={t("settings.interface.showSessionTimeRemainingInStatsOverlay")} description={t("settings.interface.showSessionTimeRemainingInStatsOverlayHint")} checked={settings.showSessionTimeRemainingInStatsOverlay} onChange={(checked) => handleChange("showSessionTimeRemainingInStatsOverlay", checked)} />
+      <SettingToggleRow htmlFor="settings-interface-session-counter" label={t("settings.interface.sessionElapsedCounter")} description={t("settings.interface.sessionElapsedCounterHint")} checked={settings.sessionCounterEnabled} onChange={(checked) => handleChange("sessionCounterEnabled", checked)} />
 
       {settings.sessionCounterEnabled && (
         <>
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top">
-              <label
-                className="settings-label"
-                htmlFor="settings-interface-session-timer-reappear"
-              >
-                {t("settings.interface.sessionTimerReappear")}
-              </label>
-              <span className="settings-value-badge">
+          <SettingRow htmlFor="settings-interface-session-timer-reappear" label={t("settings.interface.sessionTimerReappear")} description={t("settings.interface.sessionTimerReappearHint")}>
+              <span className="settings-value-badge settings-value-badge--control">
                 {settings.sessionClockShowEveryMinutes === 0
                   ? t("settings.interface.off")
                   : t("settings.interface.everyMinutes", {
                       count: settings.sessionClockShowEveryMinutes,
                     })}
               </span>
-            </div>
             <SettingRange
               id="settings-interface-session-timer-reappear"
               className="settings-slider"
@@ -175,25 +89,14 @@ export function StatsOverlayControls({
                 handleChange("sessionClockShowEveryMinutes", value)
               }
             />
-            <span className="settings-subtle-hint">
-              {t("settings.interface.sessionTimerReappearHint")}
-            </span>
-          </div>
+          </SettingRow>
 
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top">
-              <label
-                className="settings-label"
-                htmlFor="settings-interface-session-timer-visible-time"
-              >
-                {t("settings.interface.sessionTimerVisibleTime")}
-              </label>
-              <span className="settings-value-badge">
+          <SettingRow htmlFor="settings-interface-session-timer-visible-time" label={t("settings.interface.sessionTimerVisibleTime")} description={t("settings.interface.sessionTimerVisibleTimeHint")}>
+              <span className="settings-value-badge settings-value-badge--control">
                 {t("app.units.seconds", {
                   value: settings.sessionClockShowDurationSeconds,
                 })}
               </span>
-            </div>
             <SettingRange
               id="settings-interface-session-timer-visible-time"
               className="settings-slider"
@@ -208,10 +111,7 @@ export function StatsOverlayControls({
                 handleChange("sessionClockShowDurationSeconds", value)
               }
             />
-            <span className="settings-subtle-hint">
-              {t("settings.interface.sessionTimerVisibleTimeHint")}
-            </span>
-          </div>
+          </SettingRow>
         </>
       )}
     </>

--- a/opennow-stable/src/renderer/src/components/settings/stream/StreamSessionOptions.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/StreamSessionOptions.tsx
@@ -74,33 +74,6 @@ export function StreamSessionOptions({
         </span>
       </div>
 
-      <div className="settings-row settings-row--column">
-        <div className="settings-row-top settings-row-top--compact">
-          <label
-            className="settings-label settings-label--wrap"
-            htmlFor="settings-stream-launch-console-mode"
-          >
-            <span className="settings-label-title">
-              {t("settings.video.launchInConsoleMode")}
-            </span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-stream-launch-console-mode"
-              type="checkbox"
-              checked={settings.launchInConsoleMode}
-              onChange={(event) => {
-                handleChange("launchInConsoleMode", event.target.checked);
-              }}
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-        <span className="settings-subtle-hint">
-          {t("settings.video.launchInConsoleModeHint")}
-        </span>
-      </div>
     </>
   );
 }
-

--- a/opennow-stable/src/renderer/src/components/settings/stream/StreamSessionOptions.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/StreamSessionOptions.tsx
@@ -1,6 +1,7 @@
 import { type JSX } from "react";
 import type { Settings } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
+import { SettingToggleRow } from "../SettingRow";
 import type { SettingsChangeHandler } from "./streamSettingsTypes";
 
 interface StreamSessionOptionsProps {
@@ -16,63 +17,20 @@ export function StreamSessionOptions({
 
   return (
     <>
-      <div className="settings-row settings-row--column">
-        <div className="settings-row-top settings-row-top--compact">
-          <label
-            className="settings-label settings-label--wrap"
-            htmlFor="settings-stream-enable-l4s"
-          >
-            <span className="settings-label-title">
-              {t("settings.video.experimentalL4SRequest")}
-              <span className="settings-inline-badge settings-inline-badge--beta">
-                {t("app.labels.beta")}
-              </span>
-            </span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-stream-enable-l4s"
-              type="checkbox"
-              checked={settings.enableL4S}
-              onChange={(event) => handleChange("enableL4S", event.target.checked)}
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-        <span className="settings-subtle-hint">
-          {t("settings.video.experimentalL4SRequestHint")}
-        </span>
-      </div>
-
-      <div className="settings-row settings-row--column">
-        <div className="settings-row-top settings-row-top--compact">
-          <label
-            className="settings-label settings-label--wrap"
-            htmlFor="settings-stream-identify-steam-deck"
-          >
-            <span className="settings-label-title">
-              {t("settings.video.identifyAsSteamDeck")}
-              <span className="settings-inline-badge settings-inline-badge--beta">
-                {t("app.labels.experimental")}
-              </span>
-            </span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-stream-identify-steam-deck"
-              type="checkbox"
-              checked={settings.identifyAsSteamDeck}
-              onChange={(event) => {
-                handleChange("identifyAsSteamDeck", event.target.checked);
-              }}
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-        <span className="settings-subtle-hint">
-          {t("settings.video.identifyAsSteamDeckHint")}
-        </span>
-      </div>
+      <SettingToggleRow
+        htmlFor="settings-stream-enable-l4s"
+        label={<>{t("settings.video.experimentalL4SRequest")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.beta")}</span></>}
+        description={t("settings.video.experimentalL4SRequestHint")}
+        checked={settings.enableL4S}
+        onChange={(checked) => handleChange("enableL4S", checked)}
+      />
+      <SettingToggleRow
+        htmlFor="settings-stream-identify-steam-deck"
+        label={<>{t("settings.video.identifyAsSteamDeck")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span></>}
+        description={t("settings.video.identifyAsSteamDeckHint")}
+        checked={settings.identifyAsSteamDeck}
+        onChange={(checked) => handleChange("identifyAsSteamDeck", checked)}
+      />
 
     </>
   );

--- a/opennow-stable/src/renderer/src/components/settings/stream/StreamVideoSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/StreamVideoSection.tsx
@@ -1,4 +1,3 @@
-import { Monitor } from "lucide-react";
 import { type JSX } from "react";
 import type { EntitledResolution, Settings } from "@shared/gfn";
 import type { CodecTestResult } from "../../../lib/codecDiagnostics";
@@ -39,9 +38,11 @@ export function StreamVideoSection({
   return (
     <section className="settings-section">
       {showAll && <div className="settings-section-context">{t("settings.sections.stream")}</div>}
-      <div className="settings-section-header">
-        <Monitor size={18} />
-        <h2>{t("settings.video.title")}</h2>
+      <div className="settings-section-header settings-section-header--with-copy">
+        <div>
+          <h2>{t("settings.video.title")}</h2>
+          <p className="settings-section-description">{t("settings.video.description")}</p>
+        </div>
       </div>
       <div className="settings-rows settings-rows--grouped">
         <StreamQualityControls

--- a/opennow-stable/src/renderer/src/components/settings/stream/VideoShaderControls.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/VideoShaderControls.tsx
@@ -3,6 +3,7 @@ import type { Settings } from "@shared/gfn";
 import { DEFAULT_VIDEO_SHADER_SETTINGS } from "@shared/gfn";
 import { useTranslation } from "../../../i18n";
 import { SettingRange } from "../SettingRange";
+import { SettingRow, SettingToggleRow } from "../SettingRow";
 import type { SettingsChangeHandler } from "./streamSettingsTypes";
 
 const VIDEO_SHADER_CONTROLS = [
@@ -28,54 +29,21 @@ export function VideoShaderControls({
   const { t } = useTranslation();
 
   return (
-    <div className="settings-row settings-row--column">
-      <div className="settings-row-top settings-row-top--compact">
-        <label
-          className="settings-label settings-label--wrap"
-          htmlFor="settings-stream-video-filters-enabled"
-        >
-          <span className="settings-label-title">
-            {t("settings.videoFilters.title")}
-            <span className="settings-inline-badge settings-inline-badge--beta">
-              {t("app.labels.experimental")}
-            </span>
-          </span>
-        </label>
-        <label className="settings-toggle">
-          <input
-            id="settings-stream-video-filters-enabled"
-            type="checkbox"
-            checked={settings.videoShader.enabled}
-            onChange={(event) => {
-              handleChange("videoShader", {
-                ...settings.videoShader,
-                enabled: event.target.checked,
-              });
-            }}
-          />
-          <span className="settings-toggle-track" />
-        </label>
-      </div>
-      <span className="settings-subtle-hint">
-        {settings.streamClientMode === "native"
-          ? t("settings.videoFilters.nativeUnavailable")
-          : t("settings.videoFilters.hint")}
-      </span>
+    <>
+      <SettingToggleRow
+        htmlFor="settings-stream-video-filters-enabled"
+        label={<>{t("settings.videoFilters.title")}<span className="settings-inline-badge settings-inline-badge--beta">{t("app.labels.experimental")}</span></>}
+        description={settings.streamClientMode === "native" ? t("settings.videoFilters.nativeUnavailable") : t("settings.videoFilters.hint")}
+        checked={settings.videoShader.enabled}
+        onChange={(checked) => handleChange("videoShader", { ...settings.videoShader, enabled: checked })}
+      />
       {settings.videoShader.enabled && (
         <>
           {VIDEO_SHADER_CONTROLS.map((control) => (
-            <div key={control.key} className="settings-row settings-row--column">
-              <div className="settings-row-top">
-                <label
-                  className="settings-label"
-                  htmlFor={`settings-stream-video-filter-${control.key}`}
-                >
-                  {t(control.labelKey)}
-                </label>
-                <span className="settings-value-badge">
+            <SettingRow key={control.key} htmlFor={`settings-stream-video-filter-${control.key}`} label={t(control.labelKey)}>
+                <span className="settings-value-badge settings-value-badge--control">
                   {settings.videoShader[control.key]}%
                 </span>
-              </div>
               <SettingRange
                 id={`settings-stream-video-filter-${control.key}`}
                 className="settings-slider"
@@ -96,9 +64,9 @@ export function VideoShaderControls({
                   });
                 }}
               />
-            </div>
+            </SettingRow>
           ))}
-          <div className="settings-chip-row">
+          <div className="settings-row settings-row--actions">
             <button
               type="button"
               className="settings-chip"
@@ -114,6 +82,6 @@ export function VideoShaderControls({
           </div>
         </>
       )}
-    </div>
+    </>
   );
 }

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3769,8 +3769,8 @@ button.game-card-store-chip.owned.active:hover {
   min-height: 72px;
   padding: 12px;
   border-radius: 10px;
-  border: 1px solid var(--panel-border);
-  background: color-mix(in srgb, var(--ink) 2%, transparent);
+  border: 0;
+  background: color-mix(in srgb, var(--ink) 3.5%, transparent);
 }
 
 .settings-person-card--link {
@@ -4284,10 +4284,8 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-group-header {
-  display: grid;
-  grid-template-columns: minmax(8rem, 13.5rem) minmax(0, 1fr);
-  gap: 16px;
-  padding: 0 0 8px;
+  display: block;
+  padding: 0 0 10px;
 }
 
 .settings-group-header h3 {
@@ -4299,7 +4297,8 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-group-header p {
-  margin: 0;
+  max-width: 38rem;
+  margin: 3px 0 0;
   color: var(--ink-muted);
   font-size: 0.72rem;
   line-height: 1.45;
@@ -4315,12 +4314,14 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-row {
   --settings-label-col: minmax(12rem, 1fr);
+  --settings-control-col: minmax(16rem, 0.92fr);
   display: grid;
-  grid-template-columns: var(--settings-label-col) minmax(13.5rem, 0.9fr);
+  grid-template-columns: var(--settings-label-col) var(--settings-control-col);
   align-items: center;
   column-gap: 22px;
-  row-gap: 6px;
-  padding: 14px 0;
+  row-gap: 5px;
+  min-height: 62px;
+  padding: 12px 0;
   border-bottom: 1px solid color-mix(in srgb, var(--ink) 5%, transparent);
 }
 
@@ -4351,6 +4352,15 @@ button.game-card-store-chip.owned.active:hover {
   min-width: 0;
   width: 100%;
   justify-self: stretch;
+}
+
+.settings-row-control > .settings-toggle,
+.settings-row-control > .settings-toggle--control {
+  align-self: flex-end;
+}
+
+.settings-row-control > .settings-value-badge--control {
+  align-self: flex-end;
 }
 
 .settings-row-control > .select-dropdown {
@@ -4426,38 +4436,57 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-row--column {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 8px;
-}
-
-.settings-row--column:has(> .settings-row-top--compact) {
   display: grid;
-  grid-template-columns: var(--settings-label-col) minmax(13.5rem, 0.9fr);
+  grid-template-columns: var(--settings-label-col) var(--settings-control-col);
   align-items: start;
   column-gap: 22px;
-  row-gap: 3px;
+  row-gap: 5px;
 }
 
-.settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact {
+.settings-row--column > .settings-row-top {
   display: contents;
 }
 
-.settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact > .settings-label {
+.settings-row--column > .settings-row-top > .settings-label,
+.settings-row--column > .settings-label,
+.settings-row--column > .settings-subtle-hint,
+.settings-row--column > .settings-input-hint {
   grid-column: 1;
-  grid-row: 1;
+  width: auto;
 }
 
-.settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact > .settings-toggle {
+.settings-row--column > .settings-row-top > :not(.settings-label),
+.settings-row--column > .settings-chip-row,
+.settings-row--column > .settings-slider,
+.settings-row--column > .settings-slider-control,
+.settings-row--column > .settings-text-input,
+.settings-row--column > .settings-row-control,
+.settings-row--column > .settings-community-proxy-row,
+.settings-row--column > .settings-shortcut-grid,
+.settings-row--column > .settings-native-report-links,
+.settings-row--column > .settings-native-runtime-path,
+.settings-row--column > .settings-install-steps {
   grid-column: 2;
-  grid-row: 1 / span 2;
+  width: 100%;
+}
+
+.settings-row--column > .settings-row-top > .settings-toggle,
+.settings-row--column > .settings-row-top > .settings-icon-button,
+.settings-row--column > .settings-row-top > .settings-value-badge {
   justify-self: end;
 }
 
-.settings-row--column:has(> .settings-row-top--compact) > .settings-subtle-hint {
-  grid-column: 1;
-  grid-row: 2;
+.settings-row--full,
+.settings-row--actions,
+.settings-row--region,
+.settings-native-capability-row {
+  display: block;
+  min-height: 0;
+}
+
+.settings-row--actions {
+  padding-block: 12px;
+  text-align: right;
 }
 
 @media (max-width: 760px) {
@@ -4476,47 +4505,41 @@ button.game-card-store-chip.owned.active:hover {
     padding: 16px 14px 22px;
   }
 
-  .settings-row:not(.settings-row--column),
-  .settings-row--column:has(> .settings-row-top--compact),
-  .settings-group-header {
+  .settings-row,
+  .settings-row--column {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact > .settings-label,
-  .settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact > .settings-toggle,
-  .settings-row--column:has(> .settings-row-top--compact) > .settings-subtle-hint {
+  .settings-row > .settings-label,
+  .settings-row > .settings-row-control,
+  .settings-row > .settings-chip-row,
+  .settings-row > .select-dropdown,
+  .settings-row > .codec-test-btn,
+  .settings-row--column > .settings-row-top > *,
+  .settings-row--column > .settings-label,
+  .settings-row--column > .settings-subtle-hint,
+  .settings-row--column > .settings-input-hint,
+  .settings-row--column > .settings-chip-row,
+  .settings-row--column > .settings-slider,
+  .settings-row--column > .settings-slider-control,
+  .settings-row--column > .settings-text-input,
+  .settings-row--column > .settings-row-control,
+  .settings-row--column > .settings-community-proxy-row,
+  .settings-row--column > .settings-shortcut-grid,
+  .settings-row--column > .settings-native-report-links,
+  .settings-row--column > .settings-native-runtime-path,
+  .settings-row--column > .settings-install-steps {
     grid-column: 1;
   }
 
-  .settings-row:not(.settings-row--column) > .settings-label,
-  .settings-row:not(.settings-row--column) > .settings-row-control,
-  .settings-row:not(.settings-row--column) > .settings-chip-row,
-  .settings-row:not(.settings-row--column) > .select-dropdown,
-  .settings-row:not(.settings-row--column) > .codec-test-btn {
-    grid-column: 1;
+  .settings-row-control {
+    grid-row: 2;
   }
 
-  .settings-row:not(.settings-row--column) > .codec-test-btn {
+  .settings-row > .codec-test-btn {
     justify-self: start;
   }
 
-  .settings-group-header {
-    gap: 3px;
-  }
-}
-
-.settings-row--column > .settings-label,
-.settings-row--column > .settings-chip-row,
-.settings-row--column > .select-dropdown,
-.settings-row--column > .settings-toggle,
-.settings-row--column > .settings-text-input,
-.settings-row--column > .settings-slider,
-.settings-row--column > .settings-subtle-hint,
-.settings-row--column > .settings-input-hint,
-.settings-row--column > .settings-row-control {
-  grid-column: auto;
-  justify-self: stretch;
-  width: 100%;
 }
 
 .settings-row-top {
@@ -4970,8 +4993,8 @@ button.game-card-store-chip.owned.active:hover {
   min-height: 96px;
   padding: 16px;
   border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--ink) 5.5%, transparent);
-  background: rgba(0, 0, 0, 0.12);
+  border: 0;
+  background: color-mix(in srgb, var(--ink) 3.5%, transparent);
 }
 
 .settings-game-account-main {
@@ -5423,7 +5446,7 @@ button.game-card-store-chip.owned.active:hover {
   flex-direction: column;
   gap: 5px;
   padding: 9px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: 8px;
   background: var(--bg-e);
 }

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3571,7 +3571,7 @@ button.game-card-store-chip.owned.active:hover {
 .settings-modal {
   position: relative;
   z-index: 1;
-  width: min(940px, calc(100vw - 48px));
+  width: min(1020px, calc(100vw - 48px));
   height: min(720px, calc(100vh - 72px));
   max-height: calc(100vh - 72px);
   display: flex;
@@ -3921,14 +3921,14 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-sidebar {
-  width: 220px;
+  width: 190px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
   gap: 0;
-  background: var(--panel);
+  background: color-mix(in srgb, var(--bg-b) 78%, var(--panel));
   border-right: 1px solid var(--panel-border);
-  padding: 14px 12px;
+  padding: 16px 10px;
   overflow-y: auto;
 }
 
@@ -3940,12 +3940,12 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 11px;
-  min-height: 36px;
-  background: color-mix(in srgb, var(--ink) 4%, transparent);
+  padding: 0 10px;
+  min-height: 34px;
+  background: color-mix(in srgb, var(--ink) 3%, transparent);
   border: 1px solid var(--panel-border);
-  border-radius: 6px;
-  margin-bottom: 12px;
+  border-radius: 7px;
+  margin-bottom: 14px;
   flex-shrink: 0;
 }
 
@@ -3999,36 +3999,21 @@ button.game-card-store-chip.owned.active:hover {
 .settings-nav {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-}
-
-.settings-nav-group {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.settings-nav-group-label {
-  padding: 0 10px 6px;
-  font-size: 0.64rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--ink-muted);
+  gap: 3px;
 }
 
 .settings-nav-item {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 12px 0 14px;
-  min-height: 38px;
-  border-radius: 6px;
+  gap: 9px;
+  padding: 0 10px;
+  min-height: 36px;
+  border-radius: 7px;
   border: none;
   background: transparent;
   color: var(--ink-soft);
-  font-size: 0.86rem;
+  font-size: 0.82rem;
   line-height: 1.2;
   font-weight: 500;
   font-family: inherit;
@@ -4077,7 +4062,7 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-nav-item.active {
-  background: rgba(var(--accent-rgb), 0.1);
+  background: rgba(var(--accent-rgb), 0.12);
   color: var(--ink);
   font-weight: 600;
 }
@@ -4085,10 +4070,10 @@ button.game-card-store-chip.owned.active:hover {
 .settings-nav-item.active::before {
   content: "";
   position: absolute;
-  left: 0;
+  left: -1px;
   top: 50%;
   width: 2px;
-  height: 16px;
+  height: 18px;
   border-radius: 999px;
   background: var(--accent);
   transform: translateY(-50%);
@@ -4107,10 +4092,58 @@ button.game-card-store-chip.owned.active:hover {
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: color-mix(in srgb, var(--ink) 28%, transparent) transparent;
-  padding: 20px 22px 28px;
+  padding: 26px 30px 32px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
+}
+
+.settings-page-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 0 2px 6px;
+  flex: none;
+}
+
+.settings-page-heading-icon {
+  width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  border-radius: 9px;
+  background: rgba(var(--accent-rgb), 0.11);
+  color: var(--accent);
+}
+
+.settings-page-heading-icon svg {
+  width: 19px;
+  height: 19px;
+  stroke-width: 1.8;
+}
+
+.settings-page-heading-copy {
+  min-width: 0;
+  padding-top: 1px;
+}
+
+.settings-page-heading h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.3rem;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.025em;
+}
+
+.settings-page-heading p {
+  max-width: 42rem;
+  margin: 5px 0 0;
+  color: var(--ink-muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
 }
 
 .settings-content::-webkit-scrollbar {
@@ -4177,11 +4210,10 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-section {
-  background: color-mix(in srgb, var(--ink) 2%, transparent);
+  background: color-mix(in srgb, var(--panel) 84%, transparent);
   border: 1px solid var(--panel-border);
-  border-radius: 6px;
+  border-radius: 10px;
   padding: 0;
-  transition: border-color var(--t-normal);
   overflow: visible;
 }
 
@@ -4190,28 +4222,25 @@ button.game-card-store-chip.owned.active:hover {
   z-index: 2;
 }
 
-.settings-section:hover {
-  border-color: color-mix(in srgb, var(--ink) 9%, transparent);
-}
-
 .settings-section-header {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 9px;
   margin-bottom: 0;
-  padding: 18px 18px 12px;
+  padding: 18px 20px 12px;
   border-bottom: none;
   color: var(--accent);
 }
 
 .settings-section-header svg {
-  width: 20px;
-  height: 20px;
+  width: 17px;
+  height: 17px;
+  stroke-width: 1.8;
 }
 
 .settings-section-header h2 {
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: 0.98rem;
+  font-weight: 700;
   color: var(--ink);
   margin: 0;
   letter-spacing: -0.01em;
@@ -4229,7 +4258,7 @@ button.game-card-store-chip.owned.active:hover {
   max-width: 42rem;
   margin: 4px 0 0;
   color: var(--ink-muted);
-  font-size: 0.76rem;
+  font-size: 0.75rem;
   line-height: 1.45;
 }
 
@@ -4238,7 +4267,7 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 0 18px 16px;
+  padding: 0 20px 10px;
 }
 
 .settings-rows--grouped {
@@ -4285,14 +4314,14 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-row {
-  --settings-label-col: minmax(12.5rem, 13.5rem);
+  --settings-label-col: minmax(12rem, 1fr);
   display: grid;
-  grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
+  grid-template-columns: var(--settings-label-col) minmax(13.5rem, 0.9fr);
   align-items: center;
-  column-gap: 16px;
+  column-gap: 22px;
   row-gap: 6px;
-  padding: 13px 0;
-  border-bottom: 1px solid color-mix(in srgb, var(--ink) 4%, transparent);
+  padding: 14px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 5%, transparent);
 }
 
 .settings-row:last-child {
@@ -4403,6 +4432,34 @@ button.game-card-store-chip.owned.active:hover {
   gap: 8px;
 }
 
+.settings-row--column:has(> .settings-row-top--compact) {
+  display: grid;
+  grid-template-columns: var(--settings-label-col) minmax(13.5rem, 0.9fr);
+  align-items: start;
+  column-gap: 22px;
+  row-gap: 3px;
+}
+
+.settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact {
+  display: contents;
+}
+
+.settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact > .settings-label {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact > .settings-toggle {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  justify-self: end;
+}
+
+.settings-row--column:has(> .settings-row-top--compact) > .settings-subtle-hint {
+  grid-column: 1;
+  grid-row: 2;
+}
+
 @media (max-width: 760px) {
   .settings-modal {
     width: calc(100vw - 24px);
@@ -4411,7 +4468,7 @@ button.game-card-store-chip.owned.active:hover {
   }
 
   .settings-sidebar {
-    width: 184px;
+    width: 168px;
     padding-inline: 8px;
   }
 
@@ -4420,8 +4477,15 @@ button.game-card-store-chip.owned.active:hover {
   }
 
   .settings-row:not(.settings-row--column),
+  .settings-row--column:has(> .settings-row-top--compact),
   .settings-group-header {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact > .settings-label,
+  .settings-row--column:has(> .settings-row-top--compact) > .settings-row-top--compact > .settings-toggle,
+  .settings-row--column:has(> .settings-row-top--compact) > .settings-subtle-hint {
+    grid-column: 1;
   }
 
   .settings-row:not(.settings-row--column) > .settings-label,
@@ -4499,10 +4563,10 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-label {
-  font-size: 0.92rem;
+  font-size: 0.86rem;
   line-height: 1.3;
   color: var(--ink-soft);
-  font-weight: 500;
+  font-weight: 600;
   flex: 1 1 auto;
   min-width: 0;
   max-width: 100%;
@@ -4631,7 +4695,7 @@ button.game-card-store-chip.owned.active:hover {
   margin-top: 2px;
   font-size: 0.78rem;
   color: var(--ink-muted);
-  font-weight: 500;
+  font-weight: 400;
   line-height: 1.35;
   max-width: 100%;
   overflow-wrap: anywhere;
@@ -4643,11 +4707,10 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-storage-card {
-  margin: 0 18px 18px;
-  padding: 18px;
-  border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
-  background: color-mix(in srgb, var(--ink) 2.5%, transparent);
+  margin: 0;
+  padding: 4px 20px 20px;
+  border: 0;
+  background: transparent;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -4883,11 +4946,10 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-game-accounts-card {
-  margin: 0 18px 18px;
-  padding: 14px;
-  border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
-  background: color-mix(in srgb, var(--ink) 2.5%, transparent);
+  margin: 0;
+  padding: 4px 20px 20px;
+  border: 0;
+  background: transparent;
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -4357,6 +4357,10 @@ button.game-card-store-chip.owned.active:hover {
 .settings-row-control > .settings-toggle,
 .settings-row-control > .settings-toggle--control {
   align-self: flex-end;
+  flex: none;
+  width: 46px;
+  min-width: 46px;
+  height: 24px;
 }
 
 .settings-row-control > .settings-value-badge--control {


### PR DESCRIPTION
## Summary
- simplify the settings navigation into a slim, consistently labeled sidebar
- introduce shared setting-row primitives and migrate every category to one aligned label, description, and control system
- align all toggles at the same right edge and normalize sliders, chips, selects, actions, and responsive rows
- reduce competing nested borders across account, stream, diagnostics, native streamer, interface, and contributor content
- consolidate Controller Mode, profile selection, and TV / Big Picture startup into one Console category

## Validation
- 580 tests passed
- typecheck passed
- lint passed with 0 warnings/errors
- locale key check passed
- Stream, Input, Interface, and Console visually inspected after the final switch-size fix
- `git diff --check` passed