### PR TITLE
feat(settings): add top-tab studio variant

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -626,6 +626,8 @@
     "saved": "Saved",
     "searchPlaceholder": "Search settings...",
     "clearSearch": "Clear settings search",
+    "categoryNavigation": "Settings categories",
+    "searchResults": "Search results",
     "noMatches": "No settings matched \"{{query}}\".",
     "sections": {
       "account": "Account",
@@ -635,6 +637,7 @@
       "game": "Game",
       "audio": "Audio",
       "input": "Input",
+      "console": "Console",
       "interface": "Interface",
       "about": "About",
       "thanks": "Thanks"
@@ -774,9 +777,7 @@
       "experimentalL4SRequest": "Experimental L4S Request",
       "experimentalL4SRequestHint": "Request the GeForce NOW L4S streaming feature on newly created sessions. This does not change browser WebRTC behavior by itself and may be ignored by the service or network path.",
       "identifyAsSteamDeck": "Identify as Steam Deck",
-      "identifyAsSteamDeckHint": "Identify as the Steam Deck GFN client to unlock Deck-specific resolutions and 90 FPS. Video options refresh automatically.",
-      "launchInConsoleMode": "Console Mode (TV / Big Picture)",
-      "launchInConsoleModeHint": "Start OpenNOW fullscreen with Controller Mode enabled, like GeForce NOW's TV mode. Sessions ask NVIDIA to launch games gamepad-friendly (big picture) while Console Mode or Controller Mode is active."
+      "identifyAsSteamDeckHint": "Identify as the Steam Deck GFN client to unlock Deck-specific resolutions and 90 FPS. Video options refresh automatically."
     },
     "recording": {
       "title": "Browser Recording",
@@ -886,6 +887,20 @@
       "toggleStreamSidebar": "Toggle stream sidebar",
       "shortcutHint": "Click a field and press the keys to bind, or paste a shortcut ({{examples}}). Escape cancels focus. Full screen: {{fullscreen}}. Stop: {{stop}}. Mic: {{mic}}. Screenshot: {{screenshot}}. Recording: {{recording}}."
     },
+    "console": {
+      "title": "Console Experience",
+      "description": "Configure OpenNOW for controller-first play on a TV or large screen.",
+      "appNavigation": "App Navigation",
+      "appNavigationHint": "Choose how OpenNOW's own library and profile screens work with a controller.",
+      "controllerMode": "Controller Mode",
+      "controllerModeHint": "Use a large-screen console-style shell with controller button hints and a horizontal library layout.",
+      "profilePicker": "Ask who's playing",
+      "profilePickerHint": "Show the profile picker when controller mode starts. Direct game launches are never interrupted.",
+      "sessionLaunch": "Session Launch",
+      "sessionLaunchHint": "Control fullscreen startup and the interface requested from NVIDIA when a stream begins.",
+      "launchMode": "Console Mode (TV / Big Picture)",
+      "launchModeHint": "On the next app launch, start OpenNOW fullscreen with Controller Mode enabled. Streaming sessions request a gamepad-friendly interface such as Big Picture whenever this or Controller Mode is active."
+    },
     "interface": {
       "appearance": "Appearance",
       "appLanguage": "App Language",
@@ -918,10 +933,6 @@
       "antiAfkReminderDurationHint": "How long each periodic Anti-AFK activation reminder stays visible.",
       "autoFullScreen": "Auto Full Screen",
       "autoFullScreenHint": "Automatically enter fullscreen when connecting to or starting a session.",
-      "controllerMode": "Controller Mode",
-      "controllerModeHint": "Use a large-screen console-style shell with controller button hints and a horizontal library layout.",
-      "consoleProfilePicker": "Ask who's playing",
-      "consoleProfilePickerHint": "Show the profile picker when console mode starts. Direct game launches are never interrupted.",
       "escapeExitsFullscreen": "Escape Exits Fullscreen",
       "escapeExitsFullscreenHint": "When enabled, pressing Escape exits fullscreen immediately. When disabled (default), Escape is forwarded to the game while pointer-locked; hold Escape ~1.5s to exit fullscreen.",
       "discordRichPresence": "Discord Rich Presence",

--- a/opennow-stable/src/renderer/src/components/SettingsPage.tsx
+++ b/opennow-stable/src/renderer/src/components/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Check, X } from "lucide-react";
+import { Check, Search, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 
 import type {
@@ -19,6 +19,7 @@ import { SettingsNav } from "./settings/SettingsNav";
 import { SettingsAccountSection } from "./settings/sections/SettingsAccountSection";
 import { SettingsAboutSection } from "./settings/sections/SettingsAboutSection";
 import { SettingsAudioSection } from "./settings/sections/SettingsAudioSection";
+import { SettingsConsoleSection } from "./settings/sections/SettingsConsoleSection";
 import { SettingsDiagnosticsSection } from "./settings/sections/SettingsDiagnosticsSection";
 import { SettingsGameSection } from "./settings/sections/SettingsGameSection";
 import { SettingsInputSection } from "./settings/sections/SettingsInputSection";
@@ -231,16 +232,51 @@ export function SettingsPage({
   const showGame = showAll ? scopeMatchesSearch("game") : activeSection === "game";
   const showAudio = showAll ? scopeMatchesSearch("audio") : activeSection === "audio";
   const showInput = showAll ? scopeMatchesSearch("input") : activeSection === "input";
+  const showConsole = showAll ? scopeMatchesSearch("console") : activeSection === "console";
   const showInterface = showAll ? scopeMatchesSearch("interface") : activeSection === "interface";
   const showAbout = showAll ? scopeMatchesSearch("about") : activeSection === "about";
   const showThanks = showAll ? scopeMatchesSearch("thanks") : activeSection === "thanks";
-  const hasAnySearchMatches = showAccount || showStream || showDiagnostics || showNativeStreamer || showGame || showAudio || showInput || showInterface || showAbout || showThanks;
+  const hasAnySearchMatches = showAccount || showStream || showDiagnostics || showNativeStreamer || showGame || showAudio || showInput || showConsole || showInterface || showAbout || showThanks;
   const shouldRenderSettingsSections = showAll || activeSection !== "thanks";
+  const activeSectionLabel = {
+    account: t("settings.sections.account"),
+    stream: t("settings.sections.stream"),
+    diagnostics: t("settings.sections.diagnostics"),
+    "native-streamer": t("settings.sections.nativeStreamer"),
+    game: t("settings.sections.game"),
+    audio: t("settings.sections.audio"),
+    input: t("settings.sections.input"),
+    console: t("settings.sections.console"),
+    interface: t("settings.sections.interface"),
+    about: t("settings.sections.about"),
+    thanks: t("settings.sections.thanks"),
+  } satisfies Record<SettingsSectionId, string>;
 
   return (
     <>
       <header className="settings-modal-header">
         <h1>{t("settings.title")}</h1>
+        <div className="settings-search-wrap">
+          <Search className="settings-search-icon" aria-hidden="true" />
+          <input
+            type="search"
+            className="settings-search-input"
+            placeholder={t("settings.searchPlaceholder")}
+            aria-label={t("settings.searchPlaceholder")}
+            value={settingsSearch}
+            onChange={(event) => setSettingsSearch(event.target.value)}
+          />
+          {settingsSearch && (
+            <button
+              type="button"
+              className="settings-search-clear"
+              onClick={() => setSettingsSearch("")}
+              aria-label={t("settings.clearSearch")}
+            >
+              <X aria-hidden="true" />
+            </button>
+          )}
+        </div>
         <div className="settings-modal-header-actions">
           <div className={`settings-saved ${savedIndicator ? "visible" : ""}`}>
             <Check size={14} />
@@ -261,21 +297,30 @@ export function SettingsPage({
       <div className="settings-layout">
         <SettingsNav
           activeSection={activeSection}
-          settingsSearch={settingsSearch}
           showAll={showAll}
           onSearchChange={setSettingsSearch}
           onSectionChange={setActiveSection}
         />
 
-        <div ref={settingsContentRef} className="settings-content">
-          {showAll && !hasAnySearchMatches ? (
-            <section className="settings-section">
-              <div className="settings-thanks-state settings-thanks-state--muted">
-                <span>{t("settings.noMatches", { query: settingsSearch.trim() })}</span>
-              </div>
-            </section>
-          ) : (
-            <>
+        <div
+          id="settings-category-panel"
+          ref={settingsContentRef}
+          className="settings-content"
+          role={showAll ? "region" : "tabpanel"}
+          aria-labelledby={showAll ? undefined : `settings-tab-${activeSection}`}
+        >
+          <div className="settings-sheet">
+            <div className="settings-category-header">
+              <h2>{showAll ? t("settings.searchResults") : activeSectionLabel[activeSection]}</h2>
+            </div>
+            {showAll && !hasAnySearchMatches ? (
+              <section className="settings-section">
+                <div className="settings-thanks-state settings-thanks-state--muted">
+                  <span>{t("settings.noMatches", { query: settingsSearch.trim() })}</span>
+                </div>
+              </section>
+            ) : (
+              <>
               {showThanks && <SettingsThanksSection />}
               {shouldRenderSettingsSections && (
                 <>
@@ -347,6 +392,13 @@ export function SettingsPage({
                       handlePreview={handlePreview}
                     />
                   )}
+                  {showConsole && (
+                    <SettingsConsoleSection
+                      settings={settings}
+                      showAll={showAll}
+                      handleChange={handleChange}
+                    />
+                  )}
                   {showInterface && (
                     <SettingsInterfaceSection
                       settings={settings}
@@ -367,8 +419,9 @@ export function SettingsPage({
                   )}
                 </>
               )}
-            </>
-          )}
+              </>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/opennow-stable/src/renderer/src/components/settings/SettingsNav.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/SettingsNav.tsx
@@ -1,11 +1,10 @@
-import { Activity, Search, X, Users, Wifi, Cpu, Globe, Mic, Keyboard, Monitor, Info, Heart } from "lucide-react";
-import { useMemo, type JSX } from "react";
+import { Activity, Users, Wifi, Cpu, Globe, Mic, Keyboard, Gamepad2, Monitor, Info, Heart } from "lucide-react";
+import { useMemo, type JSX, type KeyboardEvent } from "react";
 import { useTranslation } from "../../i18n";
-import type { SettingsNavGroup, SettingsSectionId } from "./settingsTypes";
+import type { SettingsNavItem, SettingsSectionId } from "./settingsTypes";
 
 export interface SettingsNavProps {
   activeSection: SettingsSectionId;
-  settingsSearch: string;
   showAll: boolean;
   onSearchChange: (value: string) => void;
   onSectionChange: (section: SettingsSectionId) => void;
@@ -13,89 +12,68 @@ export interface SettingsNavProps {
 
 export function SettingsNav({
   activeSection,
-  settingsSearch,
   showAll,
   onSearchChange,
   onSectionChange,
 }: SettingsNavProps): JSX.Element {
   const { locale, t } = useTranslation();
 
-  const settingsNavGroups = useMemo<SettingsNavGroup[]>(() => [
-    {
-      label: "Account",
-      items: [
-        { id: "account", label: t("settings.sections.account"), icon: <Users size={15} /> },
-      ],
-    },
-    {
-      label: "Streaming",
-      items: [
-        { id: "stream", label: t("settings.sections.stream"), icon: <Wifi size={15} /> },
-        { id: "diagnostics", label: t("settings.sections.diagnostics"), icon: <Activity size={15} /> },
-        { id: "native-streamer", label: t("settings.sections.nativeStreamer"), icon: <Cpu size={15} /> },
-      ],
-    },
-    {
-      label: "Controls",
-      items: [
-        { id: "game", label: t("settings.sections.game"), icon: <Globe size={15} /> },
-        { id: "audio", label: t("settings.sections.audio"), icon: <Mic size={15} /> },
-        { id: "input", label: t("settings.sections.input"), icon: <Keyboard size={15} /> },
-      ],
-    },
-    {
-      label: "App",
-      items: [
-        { id: "interface", label: t("settings.sections.interface"), icon: <Monitor size={15} /> },
-        { id: "about", label: t("settings.sections.about"), icon: <Info size={15} /> },
-        { id: "thanks", label: t("settings.sections.thanks"), icon: <Heart size={15} /> },
-      ],
-    },
+  const settingsNavItems = useMemo<SettingsNavItem[]>(() => [
+    { id: "account", label: t("settings.sections.account"), icon: <Users /> },
+    { id: "stream", label: t("settings.sections.stream"), icon: <Wifi /> },
+    { id: "diagnostics", label: t("settings.sections.diagnostics"), icon: <Activity /> },
+    { id: "native-streamer", label: t("settings.sections.nativeStreamer"), icon: <Cpu /> },
+    { id: "game", label: t("settings.sections.game"), icon: <Globe /> },
+    { id: "audio", label: t("settings.sections.audio"), icon: <Mic /> },
+    { id: "input", label: t("settings.sections.input"), icon: <Keyboard /> },
+    { id: "console", label: t("settings.sections.console"), icon: <Gamepad2 /> },
+    { id: "interface", label: t("settings.sections.interface"), icon: <Monitor /> },
+    { id: "about", label: t("settings.sections.about"), icon: <Info /> },
+    { id: "thanks", label: t("settings.sections.thanks"), icon: <Heart /> },
   ], [t, locale]);
 
+  const selectTab = (item: SettingsNavItem, button?: HTMLButtonElement): void => {
+    onSectionChange(item.id);
+    onSearchChange("");
+    button?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  };
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number): void => {
+    let nextIndex: number | null = null;
+    if (event.key === "ArrowRight") nextIndex = (index + 1) % settingsNavItems.length;
+    if (event.key === "ArrowLeft") nextIndex = (index - 1 + settingsNavItems.length) % settingsNavItems.length;
+    if (event.key === "Home") nextIndex = 0;
+    if (event.key === "End") nextIndex = settingsNavItems.length - 1;
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    const nextButton = event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>("[role='tab']")[nextIndex];
+    selectTab(settingsNavItems[nextIndex], nextButton);
+    nextButton?.focus();
+  };
+
   return (
-    <nav className="settings-sidebar">
-      <div className="settings-search-wrap">
-        <Search size={13} className="settings-search-icon" />
-        <input
-          type="text"
-          className="settings-search-input"
-          placeholder={t("settings.searchPlaceholder")}
-          aria-label={t("settings.searchPlaceholder")}
-          value={settingsSearch}
-          onChange={(e) => onSearchChange(e.target.value)}
-        />
-        {settingsSearch && (
+    <nav className="settings-category-nav" aria-label={t("settings.categoryNavigation")}>
+      <div className="settings-nav" role="tablist" aria-orientation="horizontal">
+        {settingsNavItems.map((item, index) => (
           <button
+            key={item.id}
+            id={`settings-tab-${item.id}`}
             type="button"
-            className="settings-search-clear"
-            onClick={() => onSearchChange("")}
-            aria-label={t("settings.clearSearch")}
+            role="tab"
+            className={`settings-nav-item ${!showAll && activeSection === item.id ? "active" : ""}`}
+            aria-selected={!showAll && activeSection === item.id}
+            aria-controls="settings-category-panel"
+            tabIndex={activeSection === item.id ? 0 : -1}
+            onClick={(event) => selectTab(item, event.currentTarget)}
+            onKeyDown={(event) => handleTabKeyDown(event, index)}
           >
-            <X size={11} />
+            {item.icon}
+            <span className="settings-nav-item-label">{item.label}</span>
+            {item.id === "native-streamer" && (
+              <span className="settings-nav-badge">{t("app.labels.experimental")}</span>
+            )}
           </button>
-        )}
-      </div>
-      <div className="settings-nav">
-        {settingsNavGroups.map((group) => (
-          <div key={group.label} className="settings-nav-group">
-            <div className="settings-nav-group-label">{group.label}</div>
-            {group.items.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={`settings-nav-item ${!showAll && activeSection === item.id ? "active" : ""}`}
-                onClick={() => { onSectionChange(item.id); onSearchChange(""); }}
-                aria-current={!showAll && activeSection === item.id ? "page" : undefined}
-              >
-                {item.icon}
-                <span className="settings-nav-item-label">{item.label}</span>
-                {item.id === "native-streamer" && (
-                  <span className="settings-nav-badge">{t("app.labels.experimental")}</span>
-                )}
-              </button>
-            ))}
-          </div>
         ))}
       </div>
     </nav>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsConsoleSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsConsoleSection.tsx
@@ -1,0 +1,96 @@
+import type { JSX } from "react";
+import type { Settings } from "@shared/gfn";
+import { useTranslation } from "../../../i18n";
+
+export interface SettingsConsoleSectionProps {
+  settings: Settings;
+  showAll: boolean;
+  handleChange: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+}
+
+export function SettingsConsoleSection({ settings, showAll, handleChange }: SettingsConsoleSectionProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <section className="settings-section">
+      {showAll && <div className="settings-section-context">{t("settings.sections.console")}</div>}
+      <div className="settings-section-header settings-section-header--with-copy">
+        <div>
+          <h2>{t("settings.console.title")}</h2>
+          <p className="settings-section-description">{t("settings.console.description")}</p>
+        </div>
+      </div>
+      <div className="settings-rows settings-rows--grouped">
+        <div className="settings-group">
+          <div className="settings-group-header">
+            <h3>{t("settings.console.appNavigation")}</h3>
+            <p>{t("settings.console.appNavigationHint")}</p>
+          </div>
+          <div className="settings-group-rows">
+            <div className="settings-row settings-row--column">
+              <div className="settings-row-top settings-row-top--compact">
+                <label className="settings-label settings-label--wrap" htmlFor="settings-console-controller-mode">
+                  <span className="settings-label-title">{t("settings.console.controllerMode")}</span>
+                </label>
+                <label className="settings-toggle">
+                  <input
+                    id="settings-console-controller-mode"
+                    type="checkbox"
+                    checked={settings.controllerMode}
+                    onChange={(event) => handleChange("controllerMode", event.target.checked)}
+                  />
+                  <span className="settings-toggle-track" />
+                </label>
+              </div>
+              <span className="settings-subtle-hint">{t("settings.console.controllerModeHint")}</span>
+            </div>
+
+            <div className="settings-row settings-row--column">
+              <div className="settings-row-top settings-row-top--compact">
+                <label className="settings-label settings-label--wrap" htmlFor="settings-console-profile-picker">
+                  <span className="settings-label-title">{t("settings.console.profilePicker")}</span>
+                </label>
+                <label className="settings-toggle">
+                  <input
+                    id="settings-console-profile-picker"
+                    type="checkbox"
+                    checked={settings.consoleProfilePickerOnLaunch}
+                    onChange={(event) => handleChange("consoleProfilePickerOnLaunch", event.target.checked)}
+                  />
+                  <span className="settings-toggle-track" />
+                </label>
+              </div>
+              <span className="settings-subtle-hint">{t("settings.console.profilePickerHint")}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="settings-group">
+          <div className="settings-group-header">
+            <h3>{t("settings.console.sessionLaunch")}</h3>
+            <p>{t("settings.console.sessionLaunchHint")}</p>
+          </div>
+          <div className="settings-group-rows">
+            <div className="settings-row settings-row--column">
+              <div className="settings-row-top settings-row-top--compact">
+                <label className="settings-label settings-label--wrap" htmlFor="settings-console-launch-mode">
+                  <span className="settings-label-title">{t("settings.console.launchMode")}</span>
+                </label>
+                <label className="settings-toggle">
+                  <input
+                    id="settings-console-launch-mode"
+                    type="checkbox"
+                    checked={settings.launchInConsoleMode}
+                    onChange={(event) => handleChange("launchInConsoleMode", event.target.checked)}
+                  />
+                  <span className="settings-toggle-track" />
+                </label>
+              </div>
+              <span className="settings-subtle-hint">{t("settings.console.launchModeHint")}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsInterfaceSection.tsx
@@ -256,42 +256,6 @@ export function SettingsInterfaceSection({ settings, showAll, handleChange, hand
 
           <div className="settings-row settings-row--column">
             <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-controller-mode">
-                <span className="settings-label-title">{t("settings.interface.controllerMode")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-controller-mode"
-                  type="checkbox"
-                  checked={settings.controllerMode}
-                  onChange={(e) => handleChange("controllerMode", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.controllerModeHint")}</span>
-          </div>
-
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
-              <label className="settings-label settings-label--wrap" htmlFor="settings-interface-console-profile-picker">
-                <span className="settings-label-title">{t("settings.interface.consoleProfilePicker")}</span>
-              </label>
-              <label className="settings-toggle">
-                <input
-                  id="settings-interface-console-profile-picker"
-                  type="checkbox"
-                  checked={settings.consoleProfilePickerOnLaunch}
-                  onChange={(e) => handleChange("consoleProfilePickerOnLaunch", e.target.checked)}
-                />
-                <span className="settings-toggle-track" />
-              </label>
-            </div>
-            <span className="settings-subtle-hint">{t("settings.interface.consoleProfilePickerHint")}</span>
-          </div>
-
-          <div className="settings-row settings-row--column">
-            <div className="settings-row-top settings-row-top--compact">
               <label className="settings-label settings-label--wrap" htmlFor="settings-interface-escape-exits-fullscreen">
                 <span className="settings-label-title">{t("settings.interface.escapeExitsFullscreen")}</span>
               </label>

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsNativeStreamerSection.tsx
@@ -303,7 +303,7 @@ export function SettingsNativeStreamerSection({
                 ) : null}
               </div>
 
-              <div className="settings-row settings-row--column settings-native-capability-row">
+              <div className="settings-row settings-row--column settings-row--full settings-native-capability-row">
                 <div className="settings-native-capability-header">
                   <div>
                     <span className="settings-native-capability-kicker">{t("settings.nativeStreamer.thisPc")}</span>

--- a/opennow-stable/src/renderer/src/components/settings/settingsSearch.test.ts
+++ b/opennow-stable/src/renderer/src/components/settings/settingsSearch.test.ts
@@ -45,6 +45,13 @@ test("routes legacy session timing aliases from interface to diagnostics", () =>
   }
 });
 
+test("routes console navigation and session launch searches to the console scope", () => {
+  for (const query of ["profile picker", "controller mode", "ask who's playing", "fullscreen launch", "gamepad friendly session"]) {
+    assert.equal(settingsScopeMatchesSearch("console", query), true);
+    assert.equal(settingsScopeMatchesSearch("interface", query), false);
+  }
+});
+
 test("matches search tokens by word prefix", () => {
   assert.equal(
     settingsScopeMatchesSearch("stream-diagnostics", "diag over"),

--- a/opennow-stable/src/renderer/src/components/settings/settingsTypes.ts
+++ b/opennow-stable/src/renderer/src/components/settings/settingsTypes.ts
@@ -6,16 +6,11 @@ export type SettingsNavItem = {
   icon: JSX.Element;
 };
 
-export type SettingsNavGroup = {
-  label: string;
-  items: SettingsNavItem[];
-};
-
 export type ThanksLoadState = "idle" | "loading" | "loaded" | "error";
 export type StorageResetState = "idle" | "resetting" | "success" | "error";
 export type GameAccountBusyAction = "link" | "unlink" | "resync";
 
-export type SettingsSectionId = "account" | "stream" | "diagnostics" | "native-streamer" | "game" | "audio" | "input" | "interface" | "about" | "thanks";
+export type SettingsSectionId = "account" | "stream" | "diagnostics" | "native-streamer" | "game" | "audio" | "input" | "console" | "interface" | "about" | "thanks";
 export type SettingsSearchScopeId =
   | "account-storage"
   | "stream-region"
@@ -26,6 +21,7 @@ export type SettingsSearchScopeId =
   | "game"
   | "audio"
   | "input"
+  | "console"
   | "interface"
   | "about"
   | "thanks";
@@ -87,10 +83,6 @@ export const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly
     "aspect ratio",
     "l4s",
     "cloud gsync",
-    "console mode",
-    "tv mode",
-    "big picture",
-    "gamepad friendly",
     "video acceleration",
     "filters",
     "shader",
@@ -198,6 +190,20 @@ export const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly
     "recording",
     "screenshot",
   ],
+  console: [
+    "console",
+    "controller mode",
+    "gamepad",
+    "large screen",
+    "tv",
+    "big picture",
+    "profile picker",
+    "ask who's playing",
+    "console profile",
+    "fullscreen launch",
+    "gamepad friendly session",
+    "launch mode",
+  ],
   interface: [
     "interface",
     "ui",
@@ -217,9 +223,6 @@ export const SETTINGS_SCOPE_SEARCH_TERMS: Record<SettingsSearchScopeId, readonly
     "anti afk reminder",
     "afk notification",
     "afk reminder interval",
-    "controller",
-    "gamepad",
-    "big picture",
   ],
   about: [
     "about",

--- a/opennow-stable/src/renderer/src/components/settings/stream/StreamSessionOptions.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/stream/StreamSessionOptions.tsx
@@ -74,33 +74,6 @@ export function StreamSessionOptions({
         </span>
       </div>
 
-      <div className="settings-row settings-row--column">
-        <div className="settings-row-top settings-row-top--compact">
-          <label
-            className="settings-label settings-label--wrap"
-            htmlFor="settings-stream-launch-console-mode"
-          >
-            <span className="settings-label-title">
-              {t("settings.video.launchInConsoleMode")}
-            </span>
-          </label>
-          <label className="settings-toggle">
-            <input
-              id="settings-stream-launch-console-mode"
-              type="checkbox"
-              checked={settings.launchInConsoleMode}
-              onChange={(event) => {
-                handleChange("launchInConsoleMode", event.target.checked);
-              }}
-            />
-            <span className="settings-toggle-track" />
-          </label>
-        </div>
-        <span className="settings-subtle-hint">
-          {t("settings.video.launchInConsoleModeHint")}
-        </span>
-      </div>
     </>
   );
 }
-

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3693,7 +3693,7 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   align-items: flex-start;
   gap: 14px;
-  background: linear-gradient(180deg, rgba(var(--accent-rgb), 0.08), rgba(var(--accent-rgb), 0.03));
+  padding: 18px 20px;
 }
 
 .settings-thanks-hero-icon {
@@ -3768,10 +3768,12 @@ button.game-card-store-chip.owned.active:hover {
   align-items: center;
   gap: 12px;
   min-height: 72px;
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid var(--panel-border);
-  background: color-mix(in srgb, var(--ink) 2%, transparent);
+  padding: 12px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
+}
+
+.settings-person-card:last-child {
+  border-bottom: none;
 }
 
 .settings-person-card--link {
@@ -3781,9 +3783,7 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-person-card--link:hover {
-  border-color: rgba(var(--accent-rgb), 0.24);
-  background: rgba(var(--accent-rgb), 0.06);
-  transform: translateY(-1px);
+  color: var(--accent);
 }
 
 .settings-person-avatar {
@@ -4224,11 +4224,11 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-section {
-  background: color-mix(in srgb, var(--ink) 2%, transparent);
+  --settings-label-col: minmax(14rem, 15.5rem);
+  background: color-mix(in srgb, var(--ink) 1.5%, transparent);
   border: 1px solid var(--panel-border);
-  border-radius: 6px;
+  border-radius: 8px;
   padding: 0;
-  transition: border-color var(--t-normal);
   overflow: visible;
 }
 
@@ -4237,17 +4237,14 @@ button.game-card-store-chip.owned.active:hover {
   z-index: 2;
 }
 
-.settings-section:hover {
-  border-color: color-mix(in srgb, var(--ink) 9%, transparent);
-}
-
 .settings-section-header {
   display: flex;
   align-items: center;
   gap: 10px;
   margin-bottom: 0;
-  padding: 18px 18px 12px;
-  border-bottom: none;
+  min-height: 66px;
+  padding: 17px 20px 15px;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
   color: var(--accent);
 }
 
@@ -4257,8 +4254,8 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-section-header h2 {
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: 0.98rem;
+  font-weight: 700;
   color: var(--ink);
   margin: 0;
   letter-spacing: -0.01em;
@@ -4272,7 +4269,8 @@ button.game-card-store-chip.owned.active:hover {
   min-width: 0;
 }
 
-.settings-section-description {
+.settings-section-description,
+.settings-section-header .settings-section-subtitle {
   max-width: 42rem;
   margin: 4px 0 0;
   color: var(--ink-muted);
@@ -4285,11 +4283,11 @@ button.game-card-store-chip.owned.active:hover {
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 0 18px 16px;
+  padding: 0 20px 8px;
 }
 
 .settings-rows--grouped {
-  gap: 18px;
+  gap: 0;
 }
 
 .settings-group {
@@ -4297,18 +4295,19 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-group + .settings-group {
-  padding-top: 18px;
-  border-top: 1px solid color-mix(in srgb, var(--ink) 7%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--ink) 8%, transparent);
 }
 
 .settings-group-header {
   display: grid;
-  grid-template-columns: minmax(8rem, 13.5rem) minmax(0, 1fr);
-  gap: 16px;
-  padding: 0 0 8px;
+  grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
+  column-gap: 20px;
+  row-gap: 3px;
+  padding: 16px 0 8px;
 }
 
 .settings-group-header h3 {
+  grid-column: 1;
   margin: 0;
   color: var(--ink);
   font-size: 0.78rem;
@@ -4317,6 +4316,7 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-group-header p {
+  grid-column: 1;
   margin: 0;
   color: var(--ink-muted);
   font-size: 0.72rem;
@@ -4332,14 +4332,14 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-row {
-  --settings-label-col: minmax(12.5rem, 13.5rem);
   display: grid;
   grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
   align-items: center;
-  column-gap: 16px;
+  column-gap: 20px;
   row-gap: 6px;
-  padding: 13px 0;
-  border-bottom: 1px solid color-mix(in srgb, var(--ink) 4%, transparent);
+  min-height: 58px;
+  padding: 14px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
 }
 
 .settings-row:last-child {
@@ -4444,10 +4444,11 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-row--column {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
+  align-items: start;
+  column-gap: 20px;
+  row-gap: 7px;
 }
 
 @media (max-width: 760px) {
@@ -4508,20 +4509,45 @@ button.game-card-store-chip.owned.active:hover {
   .settings-group-header {
     gap: 3px;
   }
+
+  .settings-row--column {
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: 12px;
+  }
 }
 
 .settings-row--column > .settings-label,
-.settings-row--column > .settings-chip-row,
-.settings-row--column > .select-dropdown,
-.settings-row--column > .settings-toggle,
-.settings-row--column > .settings-text-input,
-.settings-row--column > .settings-slider,
+.settings-row--column > .settings-row-top > .settings-label,
 .settings-row--column > .settings-subtle-hint,
-.settings-row--column > .settings-input-hint,
-.settings-row--column > .settings-row-control {
-  grid-column: auto;
-  justify-self: stretch;
-  width: 100%;
+.settings-row--column > .settings-input-hint {
+  grid-column: 1;
+}
+
+.settings-row--column > .settings-row-top {
+  display: contents;
+}
+
+.settings-row--column > .settings-row-top > :not(.settings-label),
+.settings-row--column > :not(.settings-row-top):not(.settings-label):not(.settings-subtle-hint):not(.settings-input-hint) {
+  grid-column: 2;
+  min-width: 0;
+}
+
+.settings-row--column > .settings-row-top > .settings-toggle {
+  align-self: center;
+  justify-self: end;
+}
+
+.settings-row--column > .settings-row-top > .settings-value-badge,
+.settings-row--column > .settings-row-top > .settings-shortcut-actions,
+.settings-row--column > .settings-row-top > .settings-icon-button {
+  justify-self: end;
+}
+
+.settings-row--full {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .settings-row-top {
@@ -4535,6 +4561,14 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-row-top--compact {
   margin-bottom: 0;
+}
+
+@media (max-width: 760px) {
+  .settings-row--column > .settings-subtle-hint,
+  .settings-row--column > .settings-input-hint,
+  .settings-row--column > :not(.settings-row-top):not(.settings-label) {
+    grid-column: 1 / -1;
+  }
 }
 
 .settings-shortcut-actions {
@@ -4592,6 +4626,7 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-row--region {
+  display: block;
   border-bottom: none;
   padding-bottom: 4px;
 }
@@ -4712,11 +4747,8 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-storage-card {
-  margin: 0 18px 18px;
-  padding: 18px;
-  border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
-  background: color-mix(in srgb, var(--ink) 2.5%, transparent);
+  margin: 0 20px 8px;
+  padding: 16px 0 12px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -4811,10 +4843,12 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-storage-location-control {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
+  grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
   align-items: end;
-  gap: 14px;
-  padding-top: 2px;
+  gap: 20px;
+  padding: 14px 0;
+  border-top: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
 }
 
 .settings-storage-location-copy {
@@ -4867,10 +4901,10 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-storage-footer {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--settings-label-col) minmax(0, 1fr);
   align-items: flex-end;
-  justify-content: space-between;
-  gap: 16px;
+  gap: 20px;
 }
 
 .settings-storage-meta {
@@ -4952,11 +4986,8 @@ button.game-card-store-chip.owned.active:hover {
 }
 
 .settings-game-accounts-card {
-  margin: 0 18px 18px;
-  padding: 14px;
-  border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
-  background: color-mix(in srgb, var(--ink) 2.5%, transparent);
+  margin: 0 20px 8px;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -4965,7 +4996,7 @@ button.game-card-store-chip.owned.active:hover {
 .settings-game-account-grid {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 0;
 }
 
 .settings-game-account-card {
@@ -4974,11 +5005,13 @@ button.game-card-store-chip.owned.active:hover {
   justify-content: space-between;
   gap: 14px;
   width: 100%;
-  min-height: 96px;
-  padding: 16px;
-  border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--ink) 5.5%, transparent);
-  background: rgba(0, 0, 0, 0.12);
+  min-height: 88px;
+  padding: 15px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
+}
+
+.settings-game-account-card:last-child {
+  border-bottom: none;
 }
 
 .settings-game-account-main {
@@ -5540,43 +5573,28 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-native-capability-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
   width: 100%;
   min-width: 0;
 }
 
 .settings-native-capability-card {
-  position: relative;
   display: flex;
   min-width: 0;
   flex-direction: column;
   gap: 9px;
-  padding: 12px 12px 14px;
-  overflow: hidden;
-  border: 1px solid var(--panel-border);
-  border-radius: 9px;
-  background:
-    linear-gradient(145deg, color-mix(in srgb, var(--ink) 3%, transparent), transparent 55%),
-    var(--bg-e);
+  padding: 13px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 6%, transparent);
   box-sizing: border-box;
 }
 
-.settings-native-capability-card::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 2px;
-  background: var(--panel-border-solid);
-}
-
-.settings-native-capability-card.is-supported::before {
-  background: var(--accent);
+.settings-native-capability-card:last-child {
+  border-bottom: none;
 }
 
 .settings-native-capability-card.is-active {
-  border-color: rgba(var(--accent-rgb), 0.3);
-  box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb), 0.05);
+  color: var(--ink);
 }
 
 .settings-native-capability-card.is-unsupported {

--- a/opennow-stable/src/renderer/src/styles.css
+++ b/opennow-stable/src/renderer/src/styles.css
@@ -3596,9 +3596,8 @@ button.game-card-store-chip.owned.active:hover {
 .settings-modal-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 16px;
-  padding: 18px 22px;
+  padding: 14px 18px;
   border-bottom: 1px solid var(--panel-border);
   flex-shrink: 0;
 }
@@ -3609,12 +3608,14 @@ button.game-card-store-chip.owned.active:hover {
   margin: 0;
   color: var(--ink);
   letter-spacing: -0.01em;
+  flex: 0 0 auto;
 }
 
 .settings-modal-header-actions {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex: 0 0 auto;
 }
 
 .settings-modal-close {
@@ -3675,7 +3676,7 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-thanks-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: 14px;
   align-items: start;
   min-width: 0;
@@ -3911,29 +3912,26 @@ button.game-card-store-chip.owned.active:hover {
   gap: 14px;
 }
 
-/* ── Settings two-panel layout ───────────────────────── */
+/* ── Settings studio layout ──────────────────────────── */
 .settings-layout {
   display: flex;
+  flex-direction: column;
   gap: 0;
   min-height: 0;
   flex: 1;
   overflow: hidden;
 }
 
-.settings-sidebar {
-  width: 220px;
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  background: var(--panel);
-  border-right: 1px solid var(--panel-border);
-  padding: 14px 12px;
-  overflow-y: auto;
+.settings-category-nav {
+  position: relative;
+  flex: 0 0 auto;
+  min-width: 0;
+  border-bottom: 1px solid var(--panel-border);
+  background: color-mix(in srgb, var(--ink) 1.5%, transparent);
 }
 
-[data-translucent="true"] .settings-sidebar {
-  background: color-mix(in srgb, var(--ink) 1.5%, transparent);
+[data-translucent="true"] .settings-category-nav {
+  background: color-mix(in srgb, var(--bg-b) 24%, transparent);
 }
 
 .settings-search-wrap {
@@ -3941,18 +3939,26 @@ button.game-card-store-chip.owned.active:hover {
   align-items: center;
   gap: 8px;
   padding: 0 11px;
-  min-height: 36px;
+  min-height: 34px;
+  width: min(360px, 100%);
+  margin-left: auto;
   background: color-mix(in srgb, var(--ink) 4%, transparent);
   border: 1px solid var(--panel-border);
   border-radius: 6px;
-  margin-bottom: 12px;
-  flex-shrink: 0;
+  flex: 1 1 260px;
+  transition: border-color var(--t-fast), background var(--t-fast), box-shadow var(--t-fast);
+}
+
+.settings-search-wrap:focus-within {
+  border-color: rgba(var(--accent-rgb), 0.48);
+  background: color-mix(in srgb, var(--ink) 5%, transparent);
+  box-shadow: 0 0 0 2px rgba(var(--accent-rgb), 0.1);
 }
 
 .settings-search-icon {
   display: block;
-  width: 13px;
-  height: 13px;
+  width: 14px;
+  height: 14px;
   color: var(--ink-muted);
   flex-shrink: 0;
   align-self: center;
@@ -3971,6 +3977,11 @@ button.game-card-store-chip.owned.active:hover {
   padding: 0;
   margin: 0;
   align-self: center;
+  appearance: none;
+}
+
+.settings-search-input::-webkit-search-cancel-button {
+  display: none;
 }
 
 .settings-search-input::placeholder {
@@ -3986,9 +3997,16 @@ button.game-card-store-chip.owned.active:hover {
   border: none;
   color: var(--ink-muted);
   cursor: pointer;
-  padding: 2px;
+  width: 22px;
+  height: 22px;
+  padding: 5px;
   border-radius: 4px;
   transition: color var(--t-fast), background var(--t-fast);
+}
+
+.settings-search-clear svg {
+  width: 12px;
+  height: 12px;
 }
 
 .settings-search-clear:hover {
@@ -3998,76 +4016,80 @@ button.game-card-store-chip.owned.active:hover {
 
 .settings-nav {
   display: flex;
-  flex-direction: column;
-  gap: 14px;
+  align-items: stretch;
+  gap: 5px;
+  padding: 8px 18px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--ink) 20%, transparent) transparent;
 }
 
-.settings-nav-group {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.settings-nav::-webkit-scrollbar {
+  height: 4px;
 }
 
-.settings-nav-group-label {
-  padding: 0 10px 6px;
-  font-size: 0.64rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--ink-muted);
+.settings-nav::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ink) 18%, transparent);
 }
 
 .settings-nav-item {
   position: relative;
   display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  padding: 0 12px 0 14px;
-  min-height: 38px;
+  justify-content: center;
+  gap: 4px;
+  min-width: 70px;
+  min-height: 55px;
+  padding: 7px 10px 6px;
   border-radius: 6px;
-  border: none;
+  border: 1px solid transparent;
   background: transparent;
   color: var(--ink-soft);
-  font-size: 0.86rem;
+  font-size: 0.72rem;
   line-height: 1.2;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
-  text-align: left;
-  transition: background var(--t-fast), color var(--t-fast);
+  text-align: center;
+  transition: background var(--t-fast), border-color var(--t-fast), color var(--t-fast);
   white-space: nowrap;
 }
 
 .settings-nav-item svg {
   display: block;
-  width: 15px;
-  height: 15px;
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
   color: var(--ink-muted);
   transition: color var(--t-fast);
 }
 
 .settings-nav-item-label {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.1;
 }
 
 .settings-nav-badge {
-  flex: none;
-  padding: 2px 4px;
-  border: 1px solid color-mix(in srgb, var(--warning, #fbbf24) 32%, transparent);
-  border-radius: 4px;
-  color: color-mix(in srgb, var(--warning, #fbbf24) 78%, var(--ink));
-  font-size: 0.52rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  color: color-mix(in srgb, var(--warning, #fbbf24) 82%, var(--ink));
+  font-size: 0.42rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
   line-height: 1;
   text-transform: uppercase;
 }
 
+.settings-nav-item:has(.settings-nav-badge) {
+  min-width: 102px;
+}
+
 .settings-nav-item:hover {
+  border-color: color-mix(in srgb, var(--ink) 7%, transparent);
   background: color-mix(in srgb, var(--ink) 4%, transparent);
   color: var(--ink);
 }
@@ -4076,22 +4098,26 @@ button.game-card-store-chip.owned.active:hover {
   color: var(--ink-soft);
 }
 
-.settings-nav-item.active {
-  background: rgba(var(--accent-rgb), 0.1);
-  color: var(--ink);
-  font-weight: 600;
+.settings-nav-item:focus-visible {
+  outline: 2px solid rgba(var(--accent-rgb), 0.72);
+  outline-offset: -2px;
 }
 
-.settings-nav-item.active::before {
+.settings-nav-item.active {
+  border-color: rgba(var(--accent-rgb), 0.22);
+  background: rgba(var(--accent-rgb), 0.09);
+  color: var(--ink);
+}
+
+.settings-nav-item.active::after {
   content: "";
   position: absolute;
-  left: 0;
-  top: 50%;
-  width: 2px;
-  height: 16px;
-  border-radius: 999px;
+  right: 12px;
+  bottom: -9px;
+  left: 12px;
+  height: 2px;
+  border-radius: 999px 999px 0 0;
   background: var(--accent);
-  transform: translateY(-50%);
 }
 
 .settings-nav-item.active svg {
@@ -4107,10 +4133,31 @@ button.game-card-store-chip.owned.active:hover {
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: color-mix(in srgb, var(--ink) 28%, transparent) transparent;
-  padding: 20px 22px 28px;
+  padding: 22px 28px 30px;
+}
+
+.settings-sheet {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
+  width: min(100%, 740px);
+  margin: 0 auto;
+}
+
+.settings-category-header {
+  display: flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 2px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 7%, transparent);
+}
+
+.settings-category-header h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.24rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
 }
 
 .settings-content::-webkit-scrollbar {
@@ -4410,13 +4457,35 @@ button.game-card-store-chip.owned.active:hover {
     max-height: calc(100vh - 32px);
   }
 
-  .settings-sidebar {
-    width: 184px;
-    padding-inline: 8px;
+  .settings-modal-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px 12px;
+    padding: 12px 14px;
+  }
+
+  .settings-modal-header-actions {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .settings-modal-header .settings-search-wrap {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    width: 100%;
+    margin: 0;
+  }
+
+  .settings-nav {
+    padding-inline: 12px;
   }
 
   .settings-content {
     padding: 16px 14px 22px;
+  }
+
+  .settings-category-header h2 {
+    font-size: 1.12rem;
   }
 
   .settings-row:not(.settings-row--column),


### PR DESCRIPTION
## Summary
- replace the left settings sidebar with a horizontally scrollable, keyboard-accessible icon tab bar
- move search into the modal header and present each category in a centered settings sheet
- apply one aligned label, description, control, toggle, divider, and section-header system across every settings category
- flatten competing nested cards in account, diagnostics, native streamer, and contributor content
- consolidate Controller Mode, profile selection, and TV / Big Picture startup into one Console category

## Validation
- 580 tests passed
- typecheck passed
- lint passed with 0 warnings/errors
- locale key check passed
- Stream, Input, Interface, About, Console, Account, and Thanks inspected across light, dark, and translucent themes
- `git diff --check` passed