### PR TITLE
Fix Android touch input after session recovery

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/Models.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/Models.kt
@@ -1649,6 +1649,8 @@ internal fun activeSessionRecoveryCandidate(
     }
 }
 
+internal fun shouldCreateFreshRecoverySession(activeSessionCount: Int): Boolean = activeSessionCount == 0
+
 internal fun activeSessionLaunchConflict(
     sessions: List<ActiveSessionInfo>,
     launchAppId: Int?,

--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowViewModel.kt
@@ -2776,6 +2776,19 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
                 }
                 val activeSessions = sessionRepository.getActiveSessions(token, baseUrl, currentSettings)
                 recordDebugEvent("recovery", "Recovery active sessions count=${activeSessions.size} base=${hostForDebug(baseUrl)}")
+                if (shouldCreateFreshRecoverySession(activeSessions.size)) {
+                    return@runCatching createFreshRecoverySession(
+                        token = token,
+                        auth = auth,
+                        previousSession = previousSession,
+                        active = active,
+                        game = game,
+                        settings = currentSettings,
+                        resolvedAppId = resolvedAppId,
+                        reason = "missing active session",
+                        stopPreviousSession = false,
+                    )
+                }
                 val readyCandidate = activeSessionRecoveryCandidate(
                     sessions = activeSessions,
                     previousSessionId = previousSession.sessionId,
@@ -2866,6 +2879,7 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
         settings: StreamSettings,
         resolvedAppId: String?,
         reason: String,
+        stopPreviousSession: Boolean = true,
     ): SessionInfo {
         val launchAppId = resolvedAppId
             ?: error("Could not resolve appId for fresh stream recovery.")
@@ -2890,17 +2904,21 @@ class OpenNowViewModel(application: Application) : AndroidViewModel(application)
             "Escalating $reason to fresh cloud session old=${previousSession.shortDebugId()} " +
                 "zone=${normalizedZone.orEmpty()} base=${hostForDebug(creationBase)}",
         )
-        runCatching {
-            sessionRepository.stopSession(token, previousSession, settings)
-        }.onSuccess {
-            sessionTimerAnchorStore.clear(previousSession.sessionId)
-            recordDebugEvent("recovery", "Stopped stalled session before fresh recovery ${previousSession.shortDebugId()}")
-        }.onFailure { error ->
-            recordDebugEvent(
-                "recovery",
-                "Failed to stop stalled session before fresh recovery ${previousSession.shortDebugId()} error=${error.debugMessage()}",
-            )
-        }.getOrThrow()
+        if (stopPreviousSession) {
+            runCatching {
+                sessionRepository.stopSession(token, previousSession, settings)
+            }.onSuccess {
+                recordDebugEvent("recovery", "Stopped stalled session before fresh recovery ${previousSession.shortDebugId()}")
+            }.onFailure { error ->
+                recordDebugEvent(
+                    "recovery",
+                    "Failed to stop stalled session before fresh recovery ${previousSession.shortDebugId()} error=${error.debugMessage()}",
+                )
+            }.getOrThrow()
+        } else {
+            recordDebugEvent("recovery", "Skipped stop for missing stalled session ${previousSession.shortDebugId()}")
+        }
+        sessionTimerAnchorStore.clear(previousSession.sessionId)
 
         _state.update { it.copy(activeSession = null, launchPhase = "Creating fresh stream session") }
         val created = sessionRepository.createSession(

--- a/android/app/src/main/java/com/opencloudgaming/opennow/StreamInputRouting.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/StreamInputRouting.kt
@@ -23,6 +23,7 @@ internal class NativeUiTouchRoutingState {
     @Volatile
     private var touchControllerVisible = false
 
+    private val trackedPointerIds = mutableSetOf<Int>()
     private val ownedPointerIds = mutableSetOf<Int>()
 
     @Volatile
@@ -98,28 +99,36 @@ internal class NativeUiTouchRoutingState {
     }
 
     fun beginPointerGesture(pointerId: Int, touchesUi: Boolean) {
+        trackedPointerIds.clear()
         ownedPointerIds.clear()
+        trackedPointerIds += pointerId
         if (touchesUi) ownedPointerIds += pointerId
         syncPassthroughActive()
     }
 
     fun addPointer(pointerId: Int, touchesUi: Boolean) {
+        trackedPointerIds += pointerId
         if (touchesUi) ownedPointerIds += pointerId
         syncPassthroughActive()
     }
 
     fun ownsPointer(pointerId: Int): Boolean = pointerId in ownedPointerIds
 
+    fun classifiesPointerAsUi(pointerId: Int, touchesUiNow: Boolean): Boolean =
+        if (pointerId in trackedPointerIds) ownsPointer(pointerId) else touchesUiNow
+
     fun hasOwnedPointer(): Boolean = ownedPointerIds.isNotEmpty()
 
     fun ownedPointers(): Set<Int> = ownedPointerIds
 
     fun releasePointer(pointerId: Int) {
+        trackedPointerIds.remove(pointerId)
         ownedPointerIds.remove(pointerId)
         syncPassthroughActive()
     }
 
     fun endPointerGesture() {
+        trackedPointerIds.clear()
         ownedPointerIds.clear()
         syncPassthroughActive()
     }
@@ -234,10 +243,9 @@ object NativeStreamInputRouter {
 
     fun detach(next: NativeStreamClient) {
         if (client === next) {
+            releaseTouchMouseForLifecycle()
             client = null
             touchMouseState.forgetCursorPosition()
-            touchSlots.clear()
-            nativeUiTouchRouting.endPointerGesture()
             decodedStreamResolution = 0 to 0
             resetPresentationTransform()
         }
@@ -251,6 +259,7 @@ object NativeStreamInputRouter {
     fun releaseTouchMouseForLifecycle() {
         touchMouseState.reset(client)
         releaseAllNativeTouches()
+        nativeTouchDownPoints.clear()
         nativeUiTouchRouting.endPointerGesture()
     }
 
@@ -951,8 +960,10 @@ object NativeStreamInputRouter {
         }
 
     private fun isNativeUiTouchPointer(event: MotionEvent, index: Int, width: Int, height: Int): Boolean =
-        nativeUiTouchRouting.ownsPointer(event.getPointerId(index)) ||
-            pointerTouchesNativeUi(event, index, width, height)
+        nativeUiTouchRouting.classifiesPointerAsUi(
+            pointerId = event.getPointerId(index),
+            touchesUiNow = pointerTouchesNativeUi(event, index, width, height),
+        )
 
     private fun pointerTouchesNativeUi(event: MotionEvent, index: Int, width: Int, height: Int): Boolean {
         if (index !in 0 until event.pointerCount) return false

--- a/android/app/src/test/java/com/opencloudgaming/opennow/NativeTouchTest.kt
+++ b/android/app/src/test/java/com/opencloudgaming/opennow/NativeTouchTest.kt
@@ -72,6 +72,26 @@ class NativeTouchTest {
     }
 
     @Test
+    fun pointerOwnershipDoesNotChangeWhenFingerCrossesControllerBounds() {
+        val routing = NativeUiTouchRoutingState()
+
+        routing.beginPointerGesture(pointerId = 4, touchesUi = false)
+        assertFalse(routing.classifiesPointerAsUi(pointerId = 4, touchesUiNow = true))
+
+        routing.endPointerGesture()
+        routing.beginPointerGesture(pointerId = 7, touchesUi = true)
+        assertTrue(routing.classifiesPointerAsUi(pointerId = 7, touchesUiNow = false))
+    }
+
+    @Test
+    fun untrackedPointerFallsBackToCurrentUiBounds() {
+        val routing = NativeUiTouchRoutingState()
+
+        assertTrue(routing.classifiesPointerAsUi(pointerId = 9, touchesUiNow = true))
+        assertFalse(routing.classifiesPointerAsUi(pointerId = 9, touchesUiNow = false))
+    }
+
+    @Test
     fun onlyAnOwnedLauncherGestureIsConsumedAfterUiOpens() {
         assertTrue(shouldConsumeNativeUiTransitionTouch(streamUiActive = true, hasOwnedPointer = true))
         assertFalse(shouldConsumeNativeUiTransitionTouch(streamUiActive = false, hasOwnedPointer = true))

--- a/android/app/src/test/java/com/opencloudgaming/opennow/StreamResolutionTest.kt
+++ b/android/app/src/test/java/com/opencloudgaming/opennow/StreamResolutionTest.kt
@@ -746,6 +746,12 @@ class StreamResolutionTest {
     }
 
     @Test
+    fun recoveryCreatesFreshSessionWhenProviderNoLongerListsTheOldOne() {
+        assertEquals(true, shouldCreateFreshRecoverySession(activeSessionCount = 0))
+        assertEquals(false, shouldCreateFreshRecoverySession(activeSessionCount = 1))
+    }
+
+    @Test
     fun activeSessionWithUnknownMonitorModeIsNotReusedForLaunch() {
         val settings = StreamSettings(resolution = "1680x720", aspectRatio = "21:9", fps = 60)
         val active = activeSession(


### PR DESCRIPTION
Fixes the Android cursor/controller failure reported by <@700873802065641482> (mezo0077).

## What changed

- Recover with a fresh cloud session immediately when CloudMatch no longer lists the disconnected session, instead of stopping with no input channels. The missing session is not stopped a second time, but its timer anchor is cleared before creating the replacement.
- Keep each finger's UI-versus-stream ownership fixed from pointer-down until pointer-up, so dragging across measured touch-controller bounds cannot make an active Finger Mouse pointer switch routes mid-gesture.
- Release held touch-mouse buttons and native-touch contacts before detaching the old stream client, preventing teardown/recreation from carrying an in-flight input state into the next session.
- Add regression coverage for empty-session recovery and stable pointer ownership.

## Diagnostic evidence

The supplied build 84 log reaches healthy streaming with both input channels open, then records signaling EOF, reliable and partially reliable channels closing, ICE disconnecting, 503/404 reconnect attempts, and input drops while no channel exists. CloudMatch subsequently returns zero active sessions and recovery stops with `The running session could not be found anymore`. The older retained run shows mouse press/release events being consumed locally while neither channel exists. No log event shows a touch gesture causing the transport failure.

## Verification

- `./gradlew testDebugUnitTest --tests com.opencloudgaming.opennow.NativeTouchTest --tests com.opencloudgaming.opennow.InputDiagnosticsTest --tests com.opencloudgaming.opennow.VirtualCursorTest --tests com.opencloudgaming.opennow.StreamResolutionTest`
- `./gradlew assembleDebug`
- `./gradlew lintDebug` was also run; it reaches the repository's existing baseline of 40 unrelated errors, beginning at `AndroidAppDataReset.kt:45` (`Context#getDataDir` requires API 24 while minSdk is 23). Changed files add no lint errors.

## Visual proof

No screenshot is attached because this fix has no new or changed visual surface: it changes input ownership, teardown, and cloud-session recovery behavior behind the existing stream UI. Reproducing the affected experience requires a real NVIDIA/GFN account, an active cloud stream, and the reporter's intermittent signaling/session failure; this environment has no account credentials, so a screenshot could not honestly demonstrate the behavioral result.