### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ Contributions are welcome. Read the [contributing guide](.github/CONTRIBUTING.md
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=OpenCloudGaming%2FOpenNOW&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#OpenCloudGaming/OpenNOW&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=OpenCloudGaming/OpenNOW&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=OpenCloudGaming/OpenNOW&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=OpenCloudGaming/OpenNOW&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=OpenCloudGaming%2FOpenNOW&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=OpenCloudGaming%2FOpenNOW&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=OpenCloudGaming%2FOpenNOW&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the upstream service it relied on stopped working after GitHub's Stargazer API restrictions. This PR points the chart to a working alternative that needs no API token, so OpenNOW's star history is rendered correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Star History chart links and image sources to use the new hosting service.
  - Preserved dark/light theme variants and existing chart metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->