### PR TITLE
fix(gfn): fall back when catalog proxy requests fail

### DIFF
--- a/opennow-stable/src/main/platforms/gfn/catalogFetch.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/catalogFetch.test.ts
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createCatalogFetcher } from "./catalogFetch";
+
+const proxyUrl = "http://proxy.example.com:8080";
+
+test("catalog requests use the configured proxy when it is healthy", async () => {
+  let proxyCalls = 0;
+  let directCalls = 0;
+  const fetchCatalog = createCatalogFetcher({
+    proxyFetch: async () => {
+      proxyCalls += 1;
+      return new Response("proxied", { status: 200 });
+    },
+    directFetch: async () => {
+      directCalls += 1;
+      return new Response("direct", { status: 200 });
+    },
+  });
+
+  const response = await fetchCatalog("https://games.geforce.com/graphql", undefined, proxyUrl);
+
+  assert.equal(await response.text(), "proxied");
+  assert.equal(proxyCalls, 1);
+  assert.equal(directCalls, 0);
+});
+
+test("catalog requests fall back to direct access and temporarily bypass a failed proxy", async () => {
+  let now = 1_000;
+  let proxyCalls = 0;
+  let directCalls = 0;
+  const warnings: string[] = [];
+  const fetchCatalog = createCatalogFetcher({
+    proxyFetch: async () => {
+      proxyCalls += 1;
+      throw new Error("proxy unavailable");
+    },
+    directFetch: async () => {
+      directCalls += 1;
+      return new Response("direct", { status: 200 });
+    },
+    now: () => now,
+    retryAfterMs: 60_000,
+    warn: (message) => warnings.push(message),
+  });
+
+  const first = await fetchCatalog("https://games.geforce.com/graphql", undefined, proxyUrl);
+  const second = await fetchCatalog("https://games.geforce.com/graphql", undefined, proxyUrl);
+  now += 60_001;
+  const third = await fetchCatalog("https://games.geforce.com/graphql", undefined, proxyUrl);
+
+  assert.equal(await first.text(), "direct");
+  assert.equal(await second.text(), "direct");
+  assert.equal(await third.text(), "direct");
+  assert.equal(proxyCalls, 2);
+  assert.equal(directCalls, 3);
+  assert.equal(warnings.length, 2);
+  assert.match(warnings[0], /proxy unavailable/);
+});
+
+test("catalog requests fall back on transient proxy responses", async () => {
+  let directCalls = 0;
+  const fetchCatalog = createCatalogFetcher({
+    proxyFetch: async () => new Response("upstream unavailable", { status: 503 }),
+    directFetch: async () => {
+      directCalls += 1;
+      return new Response("direct", { status: 200 });
+    },
+    warn: () => undefined,
+  });
+
+  const response = await fetchCatalog("https://games.geforce.com/graphql", undefined, proxyUrl);
+
+  assert.equal(await response.text(), "direct");
+  assert.equal(directCalls, 1);
+});
+
+test("catalog requests preserve GraphQL protocol responses from the proxy", async () => {
+  let directCalls = 0;
+  const fetchCatalog = createCatalogFetcher({
+    proxyFetch: async () => new Response("persisted query not found", { status: 400 }),
+    directFetch: async () => {
+      directCalls += 1;
+      return new Response("direct", { status: 200 });
+    },
+  });
+
+  const response = await fetchCatalog("https://games.geforce.com/graphql", undefined, proxyUrl);
+
+  assert.equal(response.status, 400);
+  assert.equal(directCalls, 0);
+});
+
+test("catalog requests time out an unresponsive proxy before falling back", async () => {
+  const fetchCatalog = createCatalogFetcher({
+    proxyFetch: (_input, init) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+    }),
+    directFetch: async () => new Response("direct", { status: 200 }),
+    proxyTimeoutMs: 5,
+    warn: () => undefined,
+  });
+
+  const response = await fetchCatalog("https://games.geforce.com/graphql", undefined, proxyUrl);
+
+  assert.equal(await response.text(), "direct");
+});
+
+test("catalog requests do not retry directly after caller cancellation", async () => {
+  let directCalls = 0;
+  const controller = new AbortController();
+  controller.abort(new Error("cancelled"));
+  const fetchCatalog = createCatalogFetcher({
+    proxyFetch: async (_input, init) => {
+      throw init?.signal?.reason;
+    },
+    directFetch: async () => {
+      directCalls += 1;
+      return new Response("direct", { status: 200 });
+    },
+  });
+
+  await assert.rejects(
+    fetchCatalog("https://games.geforce.com/graphql", { signal: controller.signal }, proxyUrl),
+    /cancelled/,
+  );
+  assert.equal(directCalls, 0);
+});

--- a/opennow-stable/src/main/platforms/gfn/catalogFetch.ts
+++ b/opennow-stable/src/main/platforms/gfn/catalogFetch.ts
@@ -1,0 +1,104 @@
+import { fetchWithOptionalProxy } from "./proxyFetch";
+import { normalizeSessionProxyUrl } from "./proxyUrl";
+
+export const CATALOG_PROXY_TIMEOUT_MS = 10_000;
+export const CATALOG_PROXY_RETRY_AFTER_MS = 60_000;
+
+const CATALOG_PROXY_FALLBACK_STATUSES = new Set([407, 408, 425, 429, 500, 502, 503, 504]);
+
+type ProxyFetch = (
+  input: string,
+  init: RequestInit | undefined,
+  proxyUrl?: string,
+) => Promise<Response>;
+
+interface CatalogFetcherDependencies {
+  proxyFetch: ProxyFetch;
+  directFetch: (input: string, init?: RequestInit) => Promise<Response>;
+  now?: () => number;
+  proxyTimeoutMs?: number;
+  retryAfterMs?: number;
+  warn?: (message: string) => void;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function createCatalogFetcher({
+  proxyFetch,
+  directFetch,
+  now = Date.now,
+  proxyTimeoutMs = CATALOG_PROXY_TIMEOUT_MS,
+  retryAfterMs = CATALOG_PROXY_RETRY_AFTER_MS,
+  warn = (message) => console.warn(message),
+}: CatalogFetcherDependencies): ProxyFetch {
+  const retryDirectUntilByProxy = new Map<string, number>();
+
+  return async (input, init, proxyUrl) => {
+    const normalizedProxyUrl = normalizeSessionProxyUrl(proxyUrl);
+    if (!normalizedProxyUrl) {
+      return directFetch(input, init);
+    }
+
+    if ((retryDirectUntilByProxy.get(normalizedProxyUrl) ?? 0) > now()) {
+      return directFetch(input, init);
+    }
+
+    const timeoutController = new AbortController();
+    const callerSignal = init?.signal;
+    const abortFromCaller = (): void => timeoutController.abort(callerSignal?.reason);
+    if (callerSignal?.aborted) {
+      abortFromCaller();
+    } else {
+      callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+    }
+
+    const timeoutError = new Error(`Catalog proxy request timed out after ${proxyTimeoutMs}ms`);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => {
+        timeoutController.abort(timeoutError);
+        reject(timeoutError);
+      }, proxyTimeoutMs);
+    });
+
+    try {
+      const response = await Promise.race([
+        proxyFetch(input, { ...init, signal: timeoutController.signal }, normalizedProxyUrl),
+        timeoutPromise,
+      ]);
+
+      if (!CATALOG_PROXY_FALLBACK_STATUSES.has(response.status)) {
+        retryDirectUntilByProxy.delete(normalizedProxyUrl);
+        return response;
+      }
+
+      await response.body?.cancel().catch(() => undefined);
+      retryDirectUntilByProxy.set(normalizedProxyUrl, now() + retryAfterMs);
+      warn(`[Games] Catalog proxy returned HTTP ${response.status}; retrying directly.`);
+    } catch (error) {
+      if (callerSignal?.aborted) {
+        throw error;
+      }
+
+      retryDirectUntilByProxy.set(normalizedProxyUrl, now() + retryAfterMs);
+      warn(`[Games] Catalog proxy request failed; retrying directly: ${errorMessage(error)}`);
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+      callerSignal?.removeEventListener("abort", abortFromCaller);
+    }
+
+    return directFetch(input, init);
+  };
+}
+
+export const fetchCatalogRequest = createCatalogFetcher({
+  proxyFetch: fetchWithOptionalProxy,
+  directFetch: (input, init) => fetch(input, init),
+});

--- a/opennow-stable/src/main/platforms/gfn/gameAppMapper.ts
+++ b/opennow-stable/src/main/platforms/gfn/gameAppMapper.ts
@@ -8,9 +8,9 @@ import {
   buildGfnGraphQlHeaders,
   buildGfnLcarsHeaders,
 } from "./clientHeaders";
+import { fetchCatalogRequest } from "./catalogFetch";
 import { supportsInGameSettingsPersistence } from "./gameFeatures";
 import { fetchLcarsGraphQl } from "./lcarsGraphql";
-import { fetchWithOptionalProxy } from "./proxyFetch";
 import type { AppsPageResponse } from "./paginatedApps";
 
 export const GRAPHQL_URL = "https://games.geforce.com/graphql";
@@ -161,7 +161,7 @@ export async function postGraphQl<T>(
   token?: string,
   proxyUrl?: string,
 ): Promise<T> {
-  const response = await fetchWithOptionalProxy(GRAPHQL_URL, {
+  const response = await fetchCatalogRequest(GRAPHQL_URL, {
     method: "POST",
     headers: buildGfnGraphQlHeaders(token),
     body: JSON.stringify({ query, variables }),
@@ -198,7 +198,7 @@ export async function getVpcId(token: string, providerStreamingBaseUrl?: string,
 
   const serverInfoUrl = new URL("v2/serverInfo", validatedBaseUrl);
 
-  const response = await fetchWithOptionalProxy(serverInfoUrl.toString(), {
+  const response = await fetchCatalogRequest(serverInfoUrl.toString(), {
     headers: buildGfnLcarsHeaders({
       token,
       clientType: "NATIVE",

--- a/opennow-stable/src/main/platforms/gfn/lcarsGraphql.ts
+++ b/opennow-stable/src/main/platforms/gfn/lcarsGraphql.ts
@@ -1,5 +1,5 @@
 import { buildGfnGraphQlHeaders } from "./clientHeaders";
-import { fetchWithOptionalProxy } from "./proxyFetch";
+import { fetchCatalogRequest } from "./catalogFetch";
 
 export const LCARS_GRAPHQL_URL = "https://apps.gxn.nvidia.com/graphql";
 export const LCARS_CDN_GRAPHQL_URL = "https://games.geforce.com/graphql";
@@ -512,11 +512,11 @@ export async function fetchLcarsGraphQl<T extends GraphQlResponsePayload>(
     "Content-Type": "application/graphql",
   };
 
-  let response = await fetchWithOptionalProxy(`${endpoint}?${params.toString()}`, { headers }, proxyUrl);
+  let response = await fetchCatalogRequest(`${endpoint}?${params.toString()}`, { headers }, proxyUrl);
 
   if (response.status === 400 && query) {
     params.set("query", query);
-    response = await fetchWithOptionalProxy(`${endpoint}?${params.toString()}`, { headers }, proxyUrl);
+    response = await fetchCatalogRequest(`${endpoint}?${params.toString()}`, { headers }, proxyUrl);
   }
 
   if (!response.ok) {
@@ -533,7 +533,7 @@ export async function postLcarsGraphQl<T extends GraphQlResponsePayload>(
   token: string,
   proxyUrl?: string,
 ): Promise<T> {
-  const response = await fetchWithOptionalProxy(LCARS_GRAPHQL_URL, {
+  const response = await fetchCatalogRequest(LCARS_GRAPHQL_URL, {
     method: "POST",
     headers: buildGfnGraphQlHeaders(token),
     body: JSON.stringify({ query, variables }),

--- a/opennow-stable/src/main/platforms/gfn/publicGames.ts
+++ b/opennow-stable/src/main/platforms/gfn/publicGames.ts
@@ -1,7 +1,7 @@
 import type { GameInfo, GameVariant } from "@shared/gfn";
 import { normalizeGameStore } from "@shared/gfn";
 import { GFN_USER_AGENT } from "./clientHeaders";
-import { fetchWithOptionalProxy } from "./proxyFetch";
+import { fetchCatalogRequest } from "./catalogFetch";
 
 export interface RawPublicGame {
   id?: string | number;
@@ -190,7 +190,7 @@ export function appendPublicGameSearchMatches(
 }
 
 export async function fetchPublicGamesUncached(proxyUrl?: string): Promise<GameInfo[]> {
-  const response = await fetchWithOptionalProxy(
+  const response = await fetchCatalogRequest(
     "https://static.nvidiagrid.net/supported-public-game-list/locales/gfnpc-en-US.json",
     {
       headers: {


### PR DESCRIPTION
Fixes #667.

## What changed

- Bound proxied game-catalog requests to 10 seconds and retry them directly when the proxy times out, fails at the transport layer, or returns a transient/proxy error.
- Temporarily bypass a failed proxy for subsequent catalog requests so one overloaded proxy does not delay every GraphQL, VPC, metadata, and public-games request.
- Keep healthy proxy behavior and GraphQL persisted-query responses unchanged; CloudMatch session and queue traffic continues to use the configured session proxy.
- Add regression coverage for healthy proxy routing, direct fallback, cooldown recovery, transient statuses, timeouts, GraphQL HTTP 400 handling, and caller cancellation.

## Verification

- `npm test` — 618 passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`