### PR TITLE
feat(gfn): use Railway community session proxy

### DIFF
--- a/opennow-stable/src/main/community/provisionSessionProxy.ts
+++ b/opennow-stable/src/main/community/provisionSessionProxy.ts
@@ -9,7 +9,9 @@ import { getStableDeviceId } from "../platforms/gfn/deviceId";
 import { normalizeSessionProxyUrl } from "../platforms/gfn/proxyUrl";
 import { fetchWithTimeout } from "../services/requestTimeout";
 
-const PROVISION_TIMEOUT_MS = 15_000;
+const PROVISION_TIMEOUT_MS = 45_000;
+const PROVISION_RETRY_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const PROVISION_RETRY_DELAY_MS = 1_500;
 
 interface ProvisionResponseBody {
   proxyUrl?: unknown;
@@ -18,9 +20,8 @@ interface ProvisionResponseBody {
   message?: unknown;
 }
 
-export async function provisionZortosCommunityProxy(): Promise<CommunityProxyProvisionResult> {
-  const clientId = getStableDeviceId();
-  const response = await fetchWithTimeout(
+async function requestCommunityProxyProvision(clientId: string): Promise<Response> {
+  return fetchWithTimeout(
     ZORTOS_COMMUNITY_PROXY_PROVISION_URL,
     {
       method: "POST",
@@ -34,6 +35,15 @@ export async function provisionZortosCommunityProxy(): Promise<CommunityProxyPro
     PROVISION_TIMEOUT_MS,
     "Zortos community proxy provision",
   );
+}
+
+export async function provisionZortosCommunityProxy(): Promise<CommunityProxyProvisionResult> {
+  const clientId = getStableDeviceId();
+  let response = await requestCommunityProxyProvision(clientId);
+  if (!response.ok && PROVISION_RETRY_STATUSES.has(response.status)) {
+    await new Promise((resolve) => setTimeout(resolve, PROVISION_RETRY_DELAY_MS));
+    response = await requestCommunityProxyProvision(clientId);
+  }
 
   if (!response.ok) {
     let detail = "";

--- a/opennow-stable/src/shared/communityProxy.test.ts
+++ b/opennow-stable/src/shared/communityProxy.test.ts
@@ -1,0 +1,33 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildZortosCommunityProxyUrl,
+  isZortosCommunityProxyUrl,
+  ZORTOS_COMMUNITY_PROXY_HOST,
+  ZORTOS_COMMUNITY_PROXY_PORT,
+  ZORTOS_COMMUNITY_PROXY_PROVISION_URL,
+} from "./communityProxy";
+
+test("provisions against the Railway community proxy", () => {
+  assert.equal(ZORTOS_COMMUNITY_PROXY_HOST, "altaria.proxy.rlwy.net");
+  assert.equal(ZORTOS_COMMUNITY_PROXY_PORT, 51545);
+  assert.equal(
+    ZORTOS_COMMUNITY_PROXY_PROVISION_URL,
+    "https://opennow-proxy-production.up.railway.app/api/public/proxy",
+  );
+  assert.equal(
+    buildZortosCommunityProxyUrl("user", "p@ss"),
+    "http://user:p%40ss@altaria.proxy.rlwy.net:51545",
+  );
+});
+
+test("recognizes current and legacy community proxy URLs", () => {
+  assert.equal(isZortosCommunityProxyUrl("http://user:pass@altaria.proxy.rlwy.net:51545"), true);
+  assert.equal(isZortosCommunityProxyUrl("http://user:pass@opennow-proxy-tcp.zortos.me:3128"), true);
+  assert.equal(isZortosCommunityProxyUrl("http://user:pass@217.76.50.166:3128"), true);
+  assert.equal(isZortosCommunityProxyUrl("http://user:pass@proxy.example.com:8080"), false);
+  assert.equal(isZortosCommunityProxyUrl(""), false);
+});

--- a/opennow-stable/src/shared/communityProxy.ts
+++ b/opennow-stable/src/shared/communityProxy.ts
@@ -1,8 +1,13 @@
-export const ZORTOS_COMMUNITY_PROXY_HOST = "opennow-proxy-tcp.zortos.me";
-export const ZORTOS_COMMUNITY_PROXY_FALLBACK_HOST = "217.76.50.166";
-export const ZORTOS_COMMUNITY_PROXY_PORT = 3128;
-export const ZORTOS_COMMUNITY_PROXY_PROVISION_URL = "https://opennow-proxy.zortos.me/api/public/proxy";
+export const ZORTOS_COMMUNITY_PROXY_HOST = "altaria.proxy.rlwy.net";
+export const ZORTOS_COMMUNITY_PROXY_PORT = 51545;
+export const ZORTOS_COMMUNITY_PROXY_PROVISION_URL =
+  "https://opennow-proxy-production.up.railway.app/api/public/proxy";
 export const ZORTOS_GITHUB_SPONSORS_URL = "https://github.com/sponsors/zortos293";
+
+const LEGACY_COMMUNITY_PROXY_ENDPOINTS = [
+  { host: "opennow-proxy-tcp.zortos.me", port: "3128" },
+  { host: "217.76.50.166", port: "3128" },
+] as const;
 
 export interface CommunityProxyProvisionResult {
   proxyUrl: string;
@@ -10,6 +15,13 @@ export interface CommunityProxyProvisionResult {
 
 export function buildZortosCommunityProxyUrl(username: string, password: string): string {
   return `http://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${ZORTOS_COMMUNITY_PROXY_HOST}:${ZORTOS_COMMUNITY_PROXY_PORT}`;
+}
+
+function isCommunityProxyEndpoint(host: string, port: string): boolean {
+  if (host === ZORTOS_COMMUNITY_PROXY_HOST && port === String(ZORTOS_COMMUNITY_PROXY_PORT)) {
+    return true;
+  }
+  return LEGACY_COMMUNITY_PROXY_ENDPOINTS.some((endpoint) => endpoint.host === host && endpoint.port === port);
 }
 
 export function isZortosCommunityProxyUrl(raw?: string): boolean {
@@ -21,11 +33,7 @@ export function isZortosCommunityProxyUrl(raw?: string): boolean {
   try {
     const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
     const parsed = new URL(candidate);
-    const host = parsed.hostname.toLowerCase();
-    return (
-      (host === ZORTOS_COMMUNITY_PROXY_HOST || host === ZORTOS_COMMUNITY_PROXY_FALLBACK_HOST)
-      && parsed.port === String(ZORTOS_COMMUNITY_PROXY_PORT)
-    );
+    return isCommunityProxyEndpoint(parsed.hostname.toLowerCase(), parsed.port);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- Point community-proxy provision at the Railway HTTPS API (`opennow-proxy-production.up.railway.app`) and CONNECT endpoint (`altaria.proxy.rlwy.net:51545`).
- Keep recognizing the old zortos.me / VPS URLs so existing settings still show the community-proxy badge.
- Retry 502/503-style provision failures and allow 45s so Railway serverless cold starts do not fail the settings toggle.

## Test plan
- [x] `npm --prefix opennow-stable test -- --test-name-pattern "community proxy|Railway community|legacy community"`
- [x] `npm --prefix opennow-stable run typecheck`
- [ ] In Settings → Stream, enable Zortos community proxy and confirm provision returns a Railway `proxyUrl`
- [ ] Confirm catalog / session create works through the new proxy
- [ ] Confirm a previously saved `opennow-proxy-tcp.zortos.me:3128` URL still shows the community-proxy badge


Made with [Cursor](https://cursor.com)