### PR TITLE
fix(gfn): pin sessions to the selected region

### DIFF
--- a/opennow-stable/src/main/ipc/sessionHandlers.test.ts
+++ b/opennow-stable/src/main/ipc/sessionHandlers.test.ts
@@ -352,3 +352,56 @@ test("CREATE_SESSION preserves a launching session when persistence is not echoe
   assert.deepEqual(createBodies, []);
   assert.equal((result as { sessionId?: string }).sessionId, "sess-unknown");
 });
+
+test("GET_ACTIVE_SESSIONS honors the renderer's selected region", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+  const calls: string[] = [];
+  const selectedRegion = "https://np-mia-04.cloudmatchbeta.nvidiagrid.net/";
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  });
+
+  console.warn = () => {};
+
+  globalThis.fetch = (async (input) => {
+    calls.push(String(input));
+    return new Response(JSON.stringify({
+      requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS" },
+      sessions: [],
+    }), { status: 200 });
+  }) as typeof fetch;
+
+  const ipcMain = {
+    handle(channel: string, handler: (...args: unknown[]) => Promise<unknown>): void {
+      handlers.set(channel, handler);
+    },
+  } as unknown as IpcMain;
+
+  registerSessionIpcHandlers({
+    ipcMain,
+    authService: {
+      getSelectedProvider: () => ({ streamingServiceUrl: "https://prod.cloudmatchbeta.nvidiagrid.net/" }),
+    } as never,
+    settingsManager: {
+      get: () => false,
+    } as never,
+    resolveJwt: async () => "token",
+    setActivity: async () => {},
+    clearActivity: async () => {},
+    dialog: {
+      showMessageBox: async () => ({ response: 2, checkboxChecked: false }),
+    } as never,
+    getMainWindow: () => null,
+  });
+
+  const getActiveSessionsHandler = handlers.get(IPC_CHANNELS.GET_ACTIVE_SESSIONS);
+  assert.ok(getActiveSessionsHandler);
+
+  await getActiveSessionsHandler(null, "renderer-token", selectedRegion);
+
+  assert.deepEqual(calls, ["https://np-mia-04.cloudmatchbeta.nvidiagrid.net/v2/session"]);
+});

--- a/opennow-stable/src/main/ipc/sessionHandlers.ts
+++ b/opennow-stable/src/main/ipc/sessionHandlers.ts
@@ -286,9 +286,11 @@ export function registerSessionIpcHandlers(deps: SessionIpcHandlerDeps): void {
 
   ipcMain.handle(
     IPC_CHANNELS.GET_ACTIVE_SESSIONS,
-    async (_event, token?: string, _streamingBaseUrl?: string) => {
+    async (_event, token?: string, streamingBaseUrl?: string) => {
       const jwt = await resolveJwt(token);
-      const baseUrl = authService.getSelectedProvider().streamingServiceUrl;
+      const baseUrl =
+        streamingBaseUrl ??
+        authService.getSelectedProvider().streamingServiceUrl;
       return getActiveSessions(jwt, baseUrl);
     },
   );

--- a/opennow-stable/src/main/platforms/gfn/cloudmatch.test.ts
+++ b/opennow-stable/src/main/platforms/gfn/cloudmatch.test.ts
@@ -209,7 +209,7 @@ test("CloudMatch extracts local serverInfo region before fallback regions", () =
   ]);
 });
 
-test("CloudMatch resolves default prod endpoint to serverInfo local region before creating a session", async () => {
+test("CloudMatch pins the resolved region with a network-test session before creating a session", async () => {
   const originalFetch = globalThis.fetch;
   const originalWarn = console.warn;
   const calls: string[] = [];
@@ -232,7 +232,15 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
       };
     };
   };
+  type CapturedNetworkTestRequestBody = {
+    netTestRequestData: {
+      netTestProfile: {
+        framesPerSecond: number;
+      };
+    };
+  };
   let requestBody: CapturedSessionRequestBody | null = null;
+  let networkTestRequestBody: CapturedNetworkTestRequestBody | null = null;
   const expectedSessionUrl = `https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/session?${new URLSearchParams({
     keyboardLayout: resolveGfnKeyboardLayout(DEFAULT_KEYBOARD_LAYOUT, process.platform),
     languageCode: "en_US",
@@ -252,6 +260,16 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
           { key: "US West", value: "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/" },
           { key: "US East", value: "https://np-ash-01.cloudmatchbeta.nvidiagrid.net/" },
         ],
+      }), { status: 200 });
+    }
+
+    if (url === "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession") {
+      networkTestRequestBody = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
+        netTestSession: {
+          sessionId: "nettest-lax-1",
+        },
       }), { status: 200 });
     }
 
@@ -299,8 +317,12 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
     assert.equal(session.enablePersistingInGameSettings, false);
     assert.deepEqual(calls, [
       "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
+      "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession",
       expectedSessionUrl,
     ]);
+    const capturedNetworkTestRequestBody = networkTestRequestBody as CapturedNetworkTestRequestBody | null;
+    assert.ok(capturedNetworkTestRequestBody);
+    assert.equal(capturedNetworkTestRequestBody.netTestRequestData.netTestProfile.framesPerSecond, 90);
     const capturedRequestBody = requestBody as CapturedSessionRequestBody | null;
     assert.ok(capturedRequestBody);
     assert.equal(capturedRequestBody.sessionRequestData.clientRequestMonitorSettings[0]?.framesPerSecond, 90);
@@ -313,11 +335,87 @@ test("CloudMatch resolves default prod endpoint to serverInfo local region befor
     assert.equal(capturedRequestBody.sessionRequestData.requestedStreamingFeatures.audioChannelCount, 2);
     assert.equal(capturedRequestBody.sessionRequestData.appLaunchMode, 2);
     assert.equal(capturedRequestBody.sessionRequestData.enablePersistingInGameSettings, false);
-    assert.equal(capturedRequestBody.sessionRequestData.networkTestSessionId, null);
+    assert.equal(capturedRequestBody.sessionRequestData.networkTestSessionId, "nettest-lax-1");
   } finally {
     globalThis.fetch = originalFetch;
     console.warn = originalWarn;
   }
+});
+
+test("CloudMatch pins a manually selected zone before creating a session", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  const calls: string[] = [];
+  let networkTestSessionId: string | null | undefined;
+  const base = "https://np-mia-04.cloudmatchbeta.nvidiagrid.net";
+  const expectedSessionUrl = `${base}/v2/session?${new URLSearchParams({
+    keyboardLayout: resolveGfnKeyboardLayout(DEFAULT_KEYBOARD_LAYOUT, process.platform),
+    languageCode: "en_US",
+  }).toString()}`;
+
+  console.log = () => {};
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    console.log = originalLog;
+  });
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    calls.push(url);
+
+    if (url === `${base}/v2/nettestsession`) {
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-MIA-04" },
+        netTestSession: {
+          sessionId: "nettest-mia-1",
+        },
+      }), { status: 200 });
+    }
+
+    if (url === expectedSessionUrl) {
+      const body = JSON.parse(String(init?.body)) as {
+        sessionRequestData: {
+          networkTestSessionId?: string | null;
+          requestedStreamingFeatures?: unknown;
+        };
+      };
+      networkTestSessionId = body.sessionRequestData.networkTestSessionId;
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-MIA-04" },
+        session: {
+          sessionId: "session-mia-1",
+          status: 1,
+          seatSetupInfo: { seatSetupStep: 0 },
+          sessionControlInfo: { ip: "np-mia-04.cloudmatchbeta.nvidiagrid.net" },
+          connectionInfo: [],
+          iceServerConfiguration: {
+            iceServers: [{ urls: "stun:127.0.0.1:19302" }],
+          },
+          sessionRequestData: {
+            requestedStreamingFeatures: body.sessionRequestData.requestedStreamingFeatures,
+          },
+        },
+      }), { status: 200 });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  await createSession({
+    token: "manual-region-token",
+    streamingBaseUrl: `${base}/`,
+    appId: "1001",
+    internalTitle: "Test Game",
+    accountLinked: true,
+    zone: "prod",
+    settings: makeSettings({ fps: 60 }),
+  });
+
+  assert.deepEqual(calls, [
+    `${base}/v2/nettestsession`,
+    expectedSessionUrl,
+  ]);
+  assert.equal(networkTestSessionId, "nettest-mia-1");
 });
 
 test("CloudMatch retries transient serverInfo failures before creating a session", async () => {
@@ -348,6 +446,15 @@ test("CloudMatch retries transient serverInfo failures before creating a session
           { key: "gfn-regions", value: "US West" },
           { key: "US West", value: "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/" },
         ],
+      }), { status: 200 });
+    }
+
+    if (url === "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession") {
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-LAX-01" },
+        netTestSession: {
+          sessionId: "nettest-lax-retry",
+        },
       }), { status: 200 });
     }
 
@@ -393,6 +500,7 @@ test("CloudMatch retries transient serverInfo failures before creating a session
     assert.deepEqual(calls, [
       "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
       "https://prod.cloudmatchbeta.nvidiagrid.net/v2/serverInfo",
+      "https://np-lax-01.cloudmatchbeta.nvidiagrid.net/v2/nettestsession",
       expectedSessionUrl,
     ]);
   } finally {
@@ -420,6 +528,15 @@ test("CloudMatch only sends in-game settings persistence when user opt-in and ga
 
   globalThis.fetch = (async (input, init) => {
     const url = String(input);
+    if (url === "https://np-test.example.test/v2/nettestsession") {
+      return new Response(JSON.stringify({
+        requestStatus: { statusCode: 1, statusDescription: "SUCCESS_STATUS", serverId: "NP-TEST" },
+        netTestSession: {
+          sessionId: "nettest-persistence",
+        },
+      }), { status: 200 });
+    }
+
     if (url !== expectedSessionUrl) {
       throw new Error(`Unexpected fetch: ${url}`);
     }

--- a/opennow-stable/src/main/platforms/gfn/cloudmatch.ts
+++ b/opennow-stable/src/main/platforms/gfn/cloudmatch.ts
@@ -49,6 +49,7 @@ import {
   buildClaimRequestBody,
   buildSessionRequestBody,
 } from "./cloudmatchSessionRequest";
+import { createNetworkTestSession } from "./networkTestSession";
 import {
   echoedSessionAppLaunchMode,
   extractAdState,
@@ -100,12 +101,20 @@ export async function createSession(input: SessionCreateRequest): Promise<Sessio
     deviceId,
     input.proxyUrl,
   );
-  const body = buildSessionRequestBody(input, deviceId, null);
+  const networkTestSessionId = await createNetworkTestSession({
+    base,
+    token: input.token,
+    clientId,
+    deviceId,
+    settings: input.settings,
+    proxyUrl: input.proxyUrl,
+  });
+  const body = buildSessionRequestBody(input, deviceId, networkTestSessionId);
   console.log(
     `[CloudMatch] createSession in-game settings persistence: user=${input.enablePersistingInGameSettings === true}, ` +
     `gameSupport=${input.supportsInGameSettingsPersistence === true}, ` +
     `sent=${body.sessionRequestData.enablePersistingInGameSettings}, ` +
-    "networkTestSessionId=none",
+    `networkTestSessionId=${networkTestSessionId ?? "none"}`,
   );
 
   const keyboardLayout = resolveGfnKeyboardLayout(input.settings.keyboardLayout ?? DEFAULT_KEYBOARD_LAYOUT, process.platform);

--- a/opennow-stable/src/main/platforms/gfn/networkTestSession.ts
+++ b/opennow-stable/src/main/platforms/gfn/networkTestSession.ts
@@ -1,0 +1,124 @@
+import { createHash } from "node:crypto";
+
+import type { StreamSettings } from "@shared/gfn";
+
+import { buildGfnCloudMatchHeaders } from "./clientHeaders";
+import { resolveGfnDeviceIdentity } from "./deviceIdentity";
+import {
+  fetchCloudMatch,
+  formatErrorForLog,
+} from "./cloudmatchTransport";
+
+const NETWORK_TEST_SESSION_TIMEOUT_MS = 8_000;
+const NETWORK_TEST_SESSION_CACHE_TTL_MS = 30 * 60 * 1000;
+
+const networkTestSessionCache = new Map<string, { sessionId: string; expiresAt: number }>();
+
+interface NetworkTestSessionResponse {
+  requestStatus?: {
+    statusCode?: number;
+    statusDescription?: string;
+  };
+  netTestSession?: {
+    sessionId?: string;
+  };
+}
+
+function parseResolution(input: string): { width: number; height: number } {
+  const [rawWidth, rawHeight] = input.split("x");
+  const width = Number.parseInt(rawWidth ?? "", 10);
+  const height = Number.parseInt(rawHeight ?? "", 10);
+
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return { width: 1920, height: 1080 };
+  }
+
+  return { width, height };
+}
+
+function cacheKey(base: string, settings: StreamSettings, token: string, proxyUrl?: string): string {
+  const { width, height } = parseResolution(settings.resolution);
+  const identityHash = createHash("sha256")
+    .update(token)
+    .update("\0")
+    .update(proxyUrl ?? "")
+    .digest("hex")
+    .slice(0, 16);
+  return `${base}\0${width}x${height}@${settings.fps}\0${identityHash}`;
+}
+
+export async function createNetworkTestSession(input: {
+  base: string;
+  token: string;
+  clientId: string;
+  deviceId: string;
+  settings: StreamSettings;
+  proxyUrl?: string;
+}): Promise<string | null> {
+  const key = cacheKey(input.base, input.settings, input.token, input.proxyUrl);
+  const cached = networkTestSessionCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.sessionId;
+  }
+  networkTestSessionCache.delete(key);
+
+  const { width, height } = parseResolution(input.settings.resolution);
+  const body = {
+    netTestRequestData: {
+      clientPlatformName: resolveGfnDeviceIdentity().clientPlatformName,
+      netTestProfile: {
+        widthInPixels: width,
+        heightInPixels: height,
+        framesPerSecond: input.settings.fps,
+      },
+    },
+  };
+
+  try {
+    const response = await fetchCloudMatch(`${input.base}/v2/nettestsession`, {
+      method: "POST",
+      headers: buildGfnCloudMatchHeaders({
+        token: input.token,
+        clientId: input.clientId,
+        deviceId: input.deviceId,
+        includeOrigin: true,
+      }),
+      body: JSON.stringify(body),
+    }, {
+      proxyUrl: input.proxyUrl,
+      timeoutMs: NETWORK_TEST_SESSION_TIMEOUT_MS,
+      retries: 0,
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `[CloudMatch] nettestsession failed HTTP ${response.status}: ${(await response.text()).slice(0, 200)}`,
+      );
+      return null;
+    }
+
+    const payload = (await response.json()) as NetworkTestSessionResponse;
+    if (payload.requestStatus?.statusCode !== 1) {
+      console.warn(
+        `[CloudMatch] nettestsession API error: ${payload.requestStatus?.statusCode ?? "unknown"} ` +
+        `${payload.requestStatus?.statusDescription ?? ""}`.trim(),
+      );
+      return null;
+    }
+
+    const sessionId = payload.netTestSession?.sessionId?.trim();
+    if (!sessionId) {
+      console.warn("[CloudMatch] nettestsession response did not include a sessionId");
+      return null;
+    }
+
+    networkTestSessionCache.set(key, {
+      sessionId,
+      expiresAt: Date.now() + NETWORK_TEST_SESSION_CACHE_TTL_MS,
+    });
+    return sessionId;
+  } catch (error) {
+    console.warn(`[CloudMatch] nettestsession creation failed: ${formatErrorForLog(error)}`);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

The v0.5.5 report is reproducible from the attached evidence and was **not fixed** on current `dev` (`0647741`). The reporter's final launch queued through `NP-MIA-04`, but every create request logged `networkTestSessionId=none`; the completed session report then identified the allocated rig as `US East (NP-ATL-03)`.

This restores the region-scoped CloudMatch network-test session removed by `0e60f32` and forwards its ID into session creation. The network-test and game-session requests now use the same already-resolved selected base, client/device identity, proxy, and stream profile. Successful IDs are cached for 30 minutes; failures remain fail-open so a network-test outage does not block launch.

It also restores the selected region passed to `GET_ACTIVE_SESSIONS`. The handler had ignored that argument since `5b3a5c9` and queried the provider default, allowing pre-launch resume checks to escape the user's manual selection. The downstream CloudMatch client still validates the URL as a trusted NVIDIA HTTPS origin.

Reporter: <@1536958044527661086> (OpenNOW-Desktop Bug Reports)

## Evidence

- Reported build: v0.5.5 code 51, commit `84a4659e2ab2688079a67323383198318905a68c`.
- Latest tagged repository version: v0.5.5 at `44b80f207e84a2e4a6cda58205aa54e67aacb56f`; it contains the same region flow as the report.
- Log timeline: the 14:07 launch created a new session, queued on `np-mia-04`, and sent no network-test ID. There is no claim/resume event for that launch.
- Session report: `serverLocation` is `US East (NP-ATL-03)`.
- Regression history: `7c79108` added region-scoped `/v2/nettestsession` creation and forwarding; `0e60f32` removed it and hard-coded `null` five days before the report.

## Verification

- `npm --prefix opennow-stable test` — 620 passed
- `npm --prefix opennow-stable test -- --test-name-pattern 'CloudMatch|GET_ACTIVE_SESSIONS'` — 138 passed
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable run lint`
- `npm --prefix opennow-stable run build`

Regression coverage asserts that a manually selected Miami launch calls `NP-MIA-04` for both `/v2/nettestsession` and `/v2/session`, forwards the returned network-test ID, and never contacts the default or Atlanta endpoints. IPC coverage asserts that active-session discovery also uses the renderer's selected Miami base.

## Visual proof

No meaningful screenshot applies to this fix. It changes authenticated main-process CloudMatch transport only and has no renderer, DOM, CSS, or visible-state change. I rendered the branch through the OpenNOW sign-in screen successfully, but reaching server selection and observing the allocated rig requires a real NVIDIA/GFN account and live seat; a screenshot of the unchanged sign-in or settings UI would not prove this behavior, so none is included rather than presenting unrelated visual evidence.