### PR TITLE
fix(streaming): fall back from native Wayland sessions

### DIFF
--- a/native/opennow-streamer/src/gstreamer_pipeline.rs
+++ b/native/opennow-streamer/src/gstreamer_pipeline.rs
@@ -2876,7 +2876,7 @@ fn link_decoded_media_pad(
             None,
             event_sender,
             streaming_reported,
-            None,
+            Some(video_liveness),
         ),
         DecodedMediaKind::Unknown => Err(format!(
             "Unsupported decoded media caps {:?}; routing to fallback sink.",

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -42,7 +42,10 @@ import {
   isNativeStreamerResponse,
   type NativeStreamerCommandInput,
 } from "./protocol";
-import { createNativeStreamerRuntimeEnvironment } from "./runtime";
+import {
+  createNativeStreamerRuntimeEnvironment,
+  nativeStreamerDisplayFallbackReason,
+} from "./runtime";
 import { NativeSurfaceUpdateQueue } from "./surfaceUpdateQueue";
 
 const { app } = electron;
@@ -128,6 +131,15 @@ export class NativeStreamerManager {
   }
 
   async prepareForSession(context: NativeStreamerSessionContext): Promise<void> {
+    const displayFallbackReason = nativeStreamerDisplayFallbackReason(
+      process.platform,
+      process.env,
+      app.commandLine.getSwitchValue("ozone-platform"),
+    );
+    if (displayFallbackReason) {
+      throw new Error(displayFallbackReason);
+    }
+
     if (this.activeSessionId && this.activeSessionId !== context.session.sessionId) {
       await this.stop("new native streamer session");
     }
@@ -483,8 +495,7 @@ export class NativeStreamerManager {
       externalRendererEnabled: process.platform === "win32"
         ? this.options.getExternalRendererEnabled()
         : false,
-      linuxOzonePlatform: app.commandLine.getSwitchValue("ozone-platform")
-        || app.commandLine.getSwitchValue("ozone-platform-hint"),
+      linuxOzonePlatform: app.commandLine.getSwitchValue("ozone-platform"),
       cloudGsyncMode: this.options.getCloudGsyncMode(),
       d3dFullscreenMode: this.options.getD3dFullscreenMode(),
     });

--- a/opennow-stable/src/main/nativeStreamer/runtime.test.ts
+++ b/opennow-stable/src/main/nativeStreamer/runtime.test.ts
@@ -8,6 +8,7 @@ import {
   createNativeStreamerRuntimeEnvironment,
   isNativeWaylandSession,
   isPathInside,
+  nativeStreamerDisplayFallbackReason,
   nativeStreamerExecutableName,
   nativeStreamerPlatformKey,
   normalizePathForComparison,
@@ -48,9 +49,16 @@ test("explicit X11 keeps Linux child-surface embedding enabled", () => {
 
   assert.equal(isNativeWaylandSession(waylandEnvironment, "x11"), false);
   assert.equal(isNativeWaylandSession({ XDG_SESSION_TYPE: "x11" }), false);
+});
+
+test("current Wayland session indicators override obsolete Ozone hints", () => {
   assert.equal(
-    isNativeWaylandSession({ ELECTRON_OZONE_PLATFORM_HINT: "x11" }),
-    false,
+    isNativeWaylandSession({
+      ELECTRON_OZONE_PLATFORM_HINT: "x11",
+      WAYLAND_DISPLAY: "wayland-0",
+      XDG_SESSION_TYPE: "wayland",
+    }),
+    true,
   );
 });
 
@@ -66,6 +74,32 @@ test("Linux runtime selects the renderer for the Electron windowing backend", ()
       "x11",
     ).OPENNOW_NATIVE_EXTERNAL_RENDERER,
     "0",
+  );
+});
+
+test("native sessions fall back to web only for Linux Wayland", () => {
+  assert.match(
+    nativeStreamerDisplayFallbackReason(
+      "linux",
+      { WAYLAND_DISPLAY: "wayland-0" },
+    ) ?? "",
+    /cannot safely present video and capture input/i,
+  );
+  assert.equal(
+    nativeStreamerDisplayFallbackReason(
+      "linux",
+      { WAYLAND_DISPLAY: "wayland-0" },
+      "x11",
+    ),
+    null,
+  );
+  assert.equal(
+    nativeStreamerDisplayFallbackReason("linux", { XDG_SESSION_TYPE: "x11" }),
+    null,
+  );
+  assert.equal(
+    nativeStreamerDisplayFallbackReason("win32", { WAYLAND_DISPLAY: "wayland-0" }),
+    null,
   );
 });
 

--- a/opennow-stable/src/main/nativeStreamer/runtime.ts
+++ b/opennow-stable/src/main/nativeStreamer/runtime.ts
@@ -35,6 +35,9 @@ export interface NativeStreamerRuntimeEnvironment {
   runtimeStatus: NativeGstreamerRuntimeStatus;
 }
 
+export const NATIVE_WAYLAND_FALLBACK_REASON =
+  "Native streaming cannot safely present video and capture input in an Electron Wayland session yet. Start OpenNOW with --ozone-platform=x11 to use the native streamer.";
+
 const LINUX_GSTREAMER_INSTALL_INSTRUCTIONS: NativeGstreamerInstallInstruction[] = [
   {
     distro: "Debian / Ubuntu / Mint / Pop!_OS / KDE neon",
@@ -124,12 +127,18 @@ export function isNativeWaylandSession(
   if (explicitPlatform === "x11") return false;
   if (explicitPlatform === "wayland") return true;
 
-  const environmentHint = env.ELECTRON_OZONE_PLATFORM_HINT?.trim().toLowerCase();
-  if (!explicitPlatform && environmentHint === "x11") return false;
-  if (!explicitPlatform && environmentHint === "wayland") return true;
-
   return env.XDG_SESSION_TYPE?.trim().toLowerCase() === "wayland"
     || Boolean(env.WAYLAND_DISPLAY?.trim());
+}
+
+export function nativeStreamerDisplayFallbackReason(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  ozonePlatform?: string,
+): string | null {
+  return platform === "linux" && isNativeWaylandSession(env, ozonePlatform)
+    ? NATIVE_WAYLAND_FALLBACK_REASON
+    : null;
 }
 
 function prependEnvPath(env: NodeJS.ProcessEnv, key: string, directory: string): void {

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -24,6 +24,7 @@ import { useScreenshotGallery } from "../hooks/useScreenshotGallery";
 import { useStreamMenuNavigation } from "../hooks/useStreamMenuNavigation";
 import { useStreamRecorder } from "../hooks/useStreamRecorder";
 import { formatSessionTimeRemaining, formatWarningSeconds } from "./stream/streamFormatters";
+import { shouldUseNativeRendererHole } from "./stream/streamRuntimeHelpers";
 import { AntiAfkIndicator, MicrophoneIndicator, RecordingIndicator } from "./stream/StreamIndicators";
 import { StreamTitleBar } from "./stream/StreamTitleBar";
 import {
@@ -674,8 +675,10 @@ export function StreamView({
     };
   }, [exitPrompt.open, isConnecting, showSideBar]);
 
-  const nativeInternalHole =
-    (nativeRendererActive || gstreamerEnabled) && !nativeExternalRenderer;
+  const nativeInternalHole = shouldUseNativeRendererHole(
+    nativeRendererActive,
+    nativeExternalRenderer,
+  );
 
   return (
     <div className={["sv", streamVideoReady ? "sv--video-ready" : "sv--video-pending", nativeInternalHole ? "sv--native-hole" : "", className].filter(Boolean).join(" ")}>

--- a/opennow-stable/src/renderer/src/components/stream/streamRuntimeHelpers.test.ts
+++ b/opennow-stable/src/renderer/src/components/stream/streamRuntimeHelpers.test.ts
@@ -7,6 +7,7 @@ import {
   fitThumbnailSize,
   getShortcutConflictError,
   selectRecordingMimeType,
+  shouldUseNativeRendererHole,
 } from "./streamRuntimeHelpers";
 
 test("shortcut conflict validation preserves empty, invalid, and conflict errors", () => {
@@ -25,6 +26,12 @@ test("recording MIME selection uses the first supported preference", () => {
     "video/webm;codecs=h264",
   );
   assert.equal(selectRecordingMimeType(() => false), "video/webm");
+});
+
+test("native renderer hole follows the effective session renderer", () => {
+  assert.equal(shouldUseNativeRendererHole(true, false), true);
+  assert.equal(shouldUseNativeRendererHole(true, true), false);
+  assert.equal(shouldUseNativeRendererHole(false, false), false);
 });
 
 test("thumbnail sizing preserves aspect ratio within recording bounds", () => {

--- a/opennow-stable/src/renderer/src/components/stream/streamRuntimeHelpers.ts
+++ b/opennow-stable/src/renderer/src/components/stream/streamRuntimeHelpers.ts
@@ -40,6 +40,13 @@ export function selectRecordingMimeType(
   return RECORDING_MIME_TYPES.find(isTypeSupported) ?? "video/webm";
 }
 
+export function shouldUseNativeRendererHole(
+  nativeRendererActive: boolean,
+  nativeExternalRenderer: boolean,
+): boolean {
+  return nativeRendererActive && !nativeExternalRenderer;
+}
+
 export interface ThumbnailSize {
   width: number;
   height: number;


### PR DESCRIPTION
## Summary

- route Linux Wayland sessions through the existing browser/WebRTC renderer instead of starting the native GStreamer renderer, while preserving native streaming on Windows and Linux/X11
- let current Wayland session indicators override stale `ELECTRON_OZONE_PLATFORM_HINT` values, and stop passing the obsolete hint to the native process
- keep the Electron video surface opaque unless the native renderer is actually active, so a failed native preparation can show browser video instead of a transparent hole
- count decoded audio buffers as media liveness so startup recovery can fire when audio arrives but video never does

## Diagnosis

Discord reporter <@531109193386557460> supplied the session log and screenshot used for this investigation.

The captured session completed signaling and selected the native AV1 path (`rtpav1depay → av1parse → nvav1dec → videoconvert → glimagesink`); audio reached its sink, but the log never emitted the first encoded-video, decoded-video, or sink-rate milestone. Existing telemetry cannot distinguish whether video stopped before RTP observation, in depayloading/parsing, or in NVDEC, so this change does not claim to repair an unproved AV1 decoder fault.

The actionable failures are deterministic: Linux Wayland native rendering uses a GStreamer-owned toplevel while Electron owns the stream input path, and audio was not wired into `VideoLivenessMonitor`, preventing the existing startup-recovery path from acting on an audio-only stream. Falling back before native session preparation keeps rendering and input in the same Electron browser surface on Wayland; X11 remains available for users who explicitly need the native streamer.

## Visual evidence

**Reported failure (audio/input active, no visible video):**

![Reported Linux Wayland black-video session](https://cdn.discordapp.com/attachments/1538173697578242148/1538173699168014406/image.png?ex=6a81b763&is=6a8065e3&hm=890fe71c243725c69939f1f1ff065c4cf4d98b3eda9a3426cb0a9574b7dd3e00&)

An honest after screenshot of the affected transition requires both a Hyprland/Wayland compositor and an authenticated GFN cloud session; neither is available in the test environment. The app was launched locally and rendered through the sign-in screen, but that image would not prove the stream fallback. End-to-end Hyprland/GFN confirmation remains required before claiming live cloud playback is restored.

## Verification

- `npm --prefix opennow-stable test -- --test-name-pattern='native sessions fall back|current Wayland session|native renderer hole|native Wayland sessions|Linux runtime selects'` — 124 passed
- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable run lint` — 0 warnings, 0 errors
- `cd native/opennow-streamer && cargo check --features gstreamer`
- `cd native/opennow-streamer && cargo test --features gstreamer` — 89 passed
- `git diff --check`
- launched the Electron app on the available X11 display and verified it rendered through the sign-in screen
