### PR TITLE
fix(android): preserve mixed Finger Mouse gestures

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowStreamSurface.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/OpenNowStreamSurface.kt
@@ -1613,7 +1613,7 @@ private fun FingerMouseInputLayer(
                     pinchActive = false
                     lastPinchDistance = 0f
                     lastPinchCentroid = Offset.Zero
-                    return@pointerInteropFilter true
+                    return@pointerInteropFilter NativeStreamInputRouter.dispatchTouch(event, width, height)
                 }
                 if (event.pointerCount >= 2) {
                     // 3-finger touch is reserved for the Direct Click toggle gesture

--- a/android/app/src/main/java/com/opencloudgaming/opennow/StreamInputRouting.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/StreamInputRouting.kt
@@ -82,6 +82,8 @@ internal class NativeUiTouchRoutingState {
         touchControllerVisible = false
     }
 
+    fun routesTouchMouseThroughCompose(): Boolean = touchControllerVisible
+
     fun touchesRegisteredUi(x: Float, y: Float, width: Int, height: Int): Boolean {
         if (streamChromeBounds?.contains(x, y) == true) return true
         if (streamPanelBounds?.contains(x, y) == true) return true
@@ -487,6 +489,14 @@ object NativeStreamInputRouter {
             return false
         }
         updateNativeUiTouchPointers(event, width, height)
+        if (
+            touchMouseEnabled &&
+            event.isFingerTouchEvent() &&
+            !isNativeTouch &&
+            nativeUiTouchRouting.routesTouchMouseThroughCompose()
+        ) {
+            return false
+        }
         if (!eventHasStreamTouchPointer(event, width, height)) return false
         // The single-pointer restriction below belongs to the cursor paths, where only one finger
         // can drive the pointer. Native touch forwards every finger by definition, so a two-finger

--- a/android/app/src/test/java/com/opencloudgaming/opennow/NativeTouchTest.kt
+++ b/android/app/src/test/java/com/opencloudgaming/opennow/NativeTouchTest.kt
@@ -72,6 +72,31 @@ class NativeTouchTest {
     }
 
     @Test
+    fun visibleControllerKeepsFingerMouseGestureInComposeForEitherPointerOrder() {
+        val routing = NativeUiTouchRoutingState()
+        assertFalse(routing.routesTouchMouseThroughCompose())
+
+        routing.setTouchControllerVisible(true)
+        routing.setTouchControllerBound("left-stick", left = 20, top = 450, right = 260, bottom = 700)
+
+        assertTrue(routing.routesTouchMouseThroughCompose())
+
+        routing.beginPointerGesture(pointerId = 1, touchesUi = false)
+        routing.addPointer(pointerId = 2, touchesUi = true)
+        assertFalse(routing.ownsPointer(1))
+        assertTrue(routing.ownsPointer(2))
+
+        routing.endPointerGesture()
+        routing.beginPointerGesture(pointerId = 2, touchesUi = true)
+        routing.addPointer(pointerId = 1, touchesUi = false)
+        assertFalse(routing.ownsPointer(1))
+        assertTrue(routing.ownsPointer(2))
+
+        routing.setTouchControllerVisible(false)
+        assertFalse(routing.routesTouchMouseThroughCompose())
+    }
+
+    @Test
     fun pointerOwnershipDoesNotChangeWhenFingerCrossesControllerBounds() {
         val routing = NativeUiTouchRoutingState()
 


### PR DESCRIPTION
Fixes the order-dependent stutter/failure when Finger Mouse is used concurrently with the on-screen virtual gamepad.

Original report: **Finger Mouse Stuttering** (report `7df53ec4-5411-444c-8974-389691708d67`), credited to <@1528120058986106890> (OpenNOW Bug Reports).

## Root cause

`MainActivity.dispatchTouchEvent()` forwarded and captured an empty-space Finger Mouse `ACTION_DOWN` before Compose. If the player then put another finger on the virtual controller, routing switched mid-gesture so Compose received `ACTION_POINTER_DOWN`/move events without the initial down required by `awaitFirstDown()`. Reversing the finger order worked because Compose saw the controller down first, which made the symptom intermittent and independent of the game or network.

The diagnostic snapshot supports both sides of this split route: 33 downs were forwarded before views, 466 were consumed by views, and 11 reached the Compose Finger Mouse layer. The gamepad encoder and both input channels were active, so this was not a missing-channel or controller-packet defect.

## Changes

- Keep the complete finger gesture in Compose whenever the virtual controller is visible, while retaining Activity-level pointer classification.
- Continue dispatching the non-UI pointer through Finger Mouse when a UI-owned controller pointer is active; controller pointer IDs remain excluded by the existing ownership map.
- Add a regression test covering both pointer orders and controller visibility transitions.

## Network and scheduling findings

The steady stream samples averaged 79.7 ms RTT, 3.4 ms jitter, 0.06% loss, 59.6 decoded fps, 20.8 ms decode time, and 20.4% device CPU capacity. There was no sender backpressure, worker rejection, ANR, Choreographer stall, or thermal throttling in the attachment. The `network-measured` override is generic preflight acknowledgement metadata: it is selected when report wording matches a network symptom and the connection card has a warning. It can describe baseline latency but does not cause, or explain, the local pointer-order interaction.

The input sender can still queue reliable mouse and active-gamepad packets on one worker, but this log has no evidence of queue pressure; no workaround-only queue changes are included.

## Verification

- `./gradlew testDebugUnitTest --tests com.opencloudgaming.opennow.NativeTouchTest --tests com.opencloudgaming.opennow.InputEncoderGamepadTest` — passed
- `./gradlew assembleDebug` — passed
- Full `testDebugUnitTest` — 585/586 passed; `StreamPointForTouchTest.stretchAndZoomMapTheVisibleFilledSurface` fails identically on the clean `android-native` baseline
- `./gradlew lintDebug` — blocked by 40 existing baseline errors; the first is `AndroidAppDataReset.kt:45` (`Context.dataDir` requires API 24 while minSdk is 23). Existing findings in touched source files are outside the changed lines.
- `git diff --check` — passed

## Visual proof

There is no visual change to screenshot: this patch only changes hidden touch-event ownership and the stream UI renders identically. Reproducing the affected surface also requires an authenticated live GFN session plus simultaneous physical multi-touch; this environment has neither a physical touch device nor requester credentials. The debug APK was built successfully, but a sign-in screen screenshot would not demonstrate this fix.

## Limitation

The attachment reports app 1.3.0/build 86, while the required `android-native` target currently declares 1.2.8/build 84. The diagnostic strings and implicated routing code match this branch, but device-level validation should still repeat both pointer orders on the reporter’s build/device after installation.