### PR TITLE
docs(android): assess Discord Rich Presence support

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -35,3 +35,7 @@ APK and debug builds check `https://api.printedwaste.com/releases/opennow/latest
 - GFN auth, catalog, subscription, CloudMatch session creation/polling/claim/stop, signaling, and input packet behavior are implemented in Kotlin from the Electron project contracts.
 - Streaming uses Android WebRTC plus hardware MediaCodec probing. The bundled `opennow_native` JNI library exposes native runtime diagnostics and keeps the NDK/CMake path wired for media-sensitive code.
 - Queue ad metadata is preserved in `SessionInfo`; ad playback can use the included Media3 dependency when the server returns an ad media URL.
+
+## Discord Rich Presence
+
+Android Rich Presence is supported by Discord Social SDK 1.10+, but implementation is currently blocked on OpenNOW's Discord Developer Portal setup and the official Android SDK artifact. See [the Android Rich Presence decision and integration prerequisites](docs/discord-rich-presence.md).

--- a/android/docs/discord-rich-presence.md
+++ b/android/docs/discord-rich-presence.md
@@ -1,0 +1,79 @@
+# Discord Rich Presence on native Android
+
+## Decision
+
+Discord Rich Presence is technically supported on Android, but it cannot be added to OpenNOW as a buildable integration until the project owners enable the Discord Social SDK for the OpenNOW Discord application and provide the official Android SDK artifact.
+
+Do not port the Electron app's `discord-rpc` package or connect directly to Discord's legacy localhost/WebSocket RPC endpoints. Discord's supported Android path is the native Discord Social SDK 1.10 or newer.
+
+## Current Discord support
+
+Discord added unauthenticated Android Rich Presence in Social SDK 1.10 on August 3, 2026. It communicates with the installed Discord Android app, so it requires:
+
+- Android 7.0 or newer;
+- Discord installed and signed in on the same device;
+- activity sharing enabled in the user's Discord privacy settings;
+- a Discord application with the Social SDK enabled and a valid application ID; and
+- `discord_partner_sdk.aar` from that application's Developer Portal downloads.
+
+No Discord login or OAuth token is required for this limited Rich Presence mode. The application ID identifies OpenNOW and is not a secret. Client secrets, bot tokens, or user tokens must never be placed in the app.
+
+Official references:
+
+- [Setting Rich Presence](https://docs.discord.com/developers/discord-social-sdk/development-guides/setting-rich-presence#rich-presence-without-authentication)
+- [Discord Social SDK on Mobile](https://docs.discord.com/developers/discord-social-sdk/core-concepts/mobile)
+- [Android standalone C++ setup](https://docs.discord.com/developers/discord-social-sdk/development-guides/account-linking-on-mobile#cpp-standalone-setup)
+- [Platform compatibility](https://docs.discord.com/developers/discord-social-sdk/core-concepts/platform-compatibility)
+
+## Repository fit
+
+The native Android app already has the state needed for accurate presence:
+
+- `OpenNowUiState.streamGame.title` is the user-visible game title.
+- `streamStatus` distinguishes queueing, connecting, streaming, and idle states.
+- `SessionInfo.timerStartedAtMs` provides the stable session start time.
+- `streamSession` and `SessionInfo.isReadyForStream()` distinguish a real stream from a selected catalog item.
+- `MainActivity` collects `OpenNowViewModel.state` and owns `onResume`/`onStop`, while `stopStream()` and launch failure paths return state to idle.
+- The app already has a CMake/JNI library, so the standalone C++ SDK is the appropriate integration rather than a Kotlin RPC reimplementation.
+
+The Android project currently targets API 36, supports API 23+, builds `arm64-v8a`, `armeabi-v7a`, and `x86_64`, and compiles its JNI target as C++17. Discord supports Android 7.0+ and its current standalone SDK requires C++20, so an implementation must guard API 23 devices and update the native target only after confirming the downloaded AAR contains every ABI OpenNOW ships.
+
+The Electron implementation uses application ID `1479944467112001669`. That public identifier may be reusable, but the repository does not prove that its Discord application has Social SDK access or an Android 1.10+ download. The Android SDK is not published as a normal Maven dependency: Discord provides `discord_partner_sdk.aar` through the authenticated Developer Portal after Social SDK enablement. The artifact is absent from this repository, and adding source code that requires it would break local and CI builds.
+
+## Required owner prerequisites
+
+1. In the Discord Developer Portal, confirm that application `1479944467112001669` is owned by OpenNOW and enable its Social SDK integration. Create a separate OpenNOW application instead if that ownership or configuration cannot be confirmed.
+2. Download the latest supported Android Social SDK, version 1.10 or newer, and review Discord's redistribution/license terms before committing or hosting the AAR.
+3. Confirm the AAR contains `arm64-v8a`, `armeabi-v7a`, and `x86_64`. If it does not, decide whether Discord presence is excluded from unsupported build variants or OpenNOW's ABI support changes independently.
+4. Configure OpenNOW's application name and Rich Presence artwork in the Developer Portal. No OAuth redirect is needed while using only unauthenticated Android Rich Presence.
+5. Decide where CI obtains the version-pinned artifact without a developer's personal login. Builds must not silently download an unpinned binary or require a Discord credential.
+
+## Minimal implementation after prerequisites
+
+Keep the feature optional and off by default because it publishes the game title to the user's Discord profile.
+
+1. Add a `Share current game on Discord` privacy setting explaining that Discord must be installed and signed in.
+2. Add the pinned AAR, enable Gradle Prefab, link `discord_partner_sdk::discord_partner_sdk`, compile the JNI target as C++20, and call `DiscordSocialSdkInit.setEngineActivity(this)` on supported Android versions.
+3. Put the Discord bridge in a focused owner (for example, `DiscordRichPresence.kt` plus `discord_rich_presence.cpp`) rather than in streaming or Compose UI code.
+4. Create one unauthenticated SDK client, set the application ID, and run Discord callbacks on a single lifecycle-owned worker. SDK errors must remain non-fatal.
+5. Publish only when `streamStatus == "streaming"`, `streamSession.isReadyForStream()`, and `streamGame.title` are all valid:
+   - name: the configured OpenNOW Discord application name;
+   - details: the game title;
+   - state: `Streaming via OpenNOW`;
+   - start timestamp: `SessionInfo.timerStartedAtMs` converted to Unix seconds.
+6. Clear presence immediately when the setting is disabled, the stream becomes idle, a launch/recovery fails, the stream disconnects, the game/session changes, or the activity stops. Restore it on resume only if the same stream is still active. Do not publish session IDs, server addresses, account identifiers, access tokens, queue metadata, or join secrets.
+7. Deduplicate identical updates, serialize update/clear calls, and make clear win over stale in-flight updates so reconnects cannot restore an ended game.
+
+## Validation after prerequisites
+
+Automated tests should cover state-to-presence mapping, title/session changes, API-level gating, user opt-out, deduplication, and clear winning over an in-flight update. Then validate on a physical Android 7.0+ device:
+
+1. Install and sign in to Discord, enable activity sharing, and opt in inside OpenNOW.
+2. Start a game and wait for `streaming`; confirm Discord shows the exact game title and an elapsed timer.
+3. Change/recover the session and confirm the title/timer update without duplicate activities.
+4. Background/stop OpenNOW, disconnect, end the stream, and disable the setting; confirm presence clears in every case.
+5. Repeat with Discord absent or signed out and on API 23; OpenNOW must continue normally with no presence and no crash.
+
+## Closest available alternative
+
+Until the owner prerequisites are complete, Android users cannot automatically publish the streamed game from OpenNOW. They can set a manual Discord custom status, or use the desktop OpenNOW client, whose local desktop RPC integration already publishes the active game when Discord is running.


### PR DESCRIPTION
## Outcome

Discord Rich Presence is now supported on Android through Discord Social SDK 1.10+, but OpenNOW cannot ship a buildable integration until its Discord application has Social SDK access and the official `discord_partner_sdk.aar` is supplied through a reviewed, reproducible build path.

This documents why the Electron `discord-rpc` package and legacy localhost/WebSocket RPC are not appropriate Android substitutes, maps the native app's existing game/session/lifecycle state to a future minimal implementation, and records privacy, lifecycle, ABI, API-level, and validation requirements.

Requested by <@950685454083166229> (Dkprokiller).

## Repository evidence reviewed

- `android/app/build.gradle.kts` and `android/app/src/main/cpp/CMakeLists.txt`
- `android/app/src/main/AndroidManifest.xml`
- `MainActivity.kt`, `OpenNowViewModel.kt`, `Models.kt`, `Streaming.kt`, and `GfnApi.kt`
- `opennow-stable/src/main/discordRpc.ts` and the Electron package configuration
- Discord's current Rich Presence, mobile support, standalone Android C++, and platform compatibility documentation

## Checks

- `git diff --cached --check`
- Confirmed all four linked Discord documentation URLs return HTTP 200
- `cd android && ./gradlew testDebugUnitTest` — could not configure because this runner has no Android SDK (`SDK location not found`); no application code changed

## Remaining prerequisites

The OpenNOW owner must confirm/enable Social SDK access for the Discord application, download and license-review SDK 1.10+, verify its ABI coverage, and define how CI obtains the pinned proprietary AAR without personal credentials.

## Visual proof

No screenshot is included because this PR deliberately makes no user-facing Android change: the supported integration cannot be compiled or rendered without the owner-only Discord SDK artifact and Developer Portal setup. Adding a mock UI would imply functionality that the branch cannot deliver or validate.