### PR TITLE
fix(android): keep controller Select input in game on TV

### DIFF
--- a/android/app/src/main/java/com/opencloudgaming/opennow/StreamInputRouting.kt
+++ b/android/app/src/main/java/com/opencloudgaming/opennow/StreamInputRouting.kt
@@ -768,13 +768,7 @@ object NativeStreamInputRouter {
         androidTvProfile: Boolean = false,
         dpadSource: Boolean = false,
     ): Boolean =
-        // On Android TV the back/exit key must always open the stream overlay: some TV remotes
-        // are reported as controller devices (joystick source), which would otherwise route BACK
-        // into the game and leave the user with no way to open the controls menu. Gamepads keep
-        // their own B button (KEYCODE_BUTTON_B) for in-game back, so stealing KEYCODE_BACK is
-        // safe on TV.
-        (androidTvProfile && keyCode == KeyEvent.KEYCODE_BACK) ||
-            (keyCode == KeyEvent.KEYCODE_BACK && !controllerInputDevice) ||
+        (keyCode == KeyEvent.KEYCODE_BACK && !controllerInputDevice) ||
             (androidTvProfile &&
                 dpadSource &&
                 keyCode == KeyEvent.KEYCODE_BUTTON_B &&

--- a/android/app/src/test/java/com/opencloudgaming/opennow/InputEncoderGamepadTest.kt
+++ b/android/app/src/test/java/com/opencloudgaming/opennow/InputEncoderGamepadTest.kt
@@ -495,11 +495,19 @@ class InputEncoderGamepadTest {
     }
 
     @Test
-    fun backAlwaysOpensOverlayOnAndroidTvEvenForControllerSource() {
-        assertTrue(
+    fun controllerBackStaysInGameOnAndroidTvWhileRemoteBackOpensOverlay() {
+        assertFalse(
             NativeStreamInputRouter.shouldHandleStreamExitKey(
                 KeyEvent.KEYCODE_BACK,
                 controllerInputDevice = true,
+                hardwareKeyboardSource = false,
+                androidTvProfile = true,
+            ),
+        )
+        assertTrue(
+            NativeStreamInputRouter.shouldHandleStreamExitKey(
+                KeyEvent.KEYCODE_BACK,
+                controllerInputDevice = false,
                 hardwareKeyboardSource = false,
                 androidTvProfile = true,
             ),


### PR DESCRIPTION
## Summary
- keep controller-sourced Android `BACK` events on the cloud gamepad path for Android TV
- preserve stream-overlay access through remote/system Back and the controller Guide button
- add focused coverage for controller Back versus remote Back routing on TV

## Root cause
The reporter's AFTKA diagnostics contain eight `key=4 source=1281 controller=true dpad=false route=stream_overlay` events. This controller exposes its physical Select/View control as Android `KEYCODE_BACK`, but the Android TV shortcut policy intercepted every Back event before gamepad encoding. Once left on the controller path, existing encoding correctly maps controller `KEYCODE_BACK` to XInput Back/View.

The `input-measured` override is report-preflight metadata, not a runtime input mode. It was triggered by an early no-channel drop; the same snapshot shows both input channels open and 1,570 successful input heartbeats, so it is not involved in this mapping bug.

Reporter: <@1528120058986106890>

## Validation
- `./gradlew testDebugUnitTest --tests com.opencloudgaming.opennow.InputEncoderGamepadTest` — passed
- `./gradlew assembleDebug` — passed, including `armeabi-v7a`
- `./gradlew testDebugUnitTest` — 594/595 passed; the pre-existing unrelated `StreamPointForTouchTest.stretchAndZoomMapTheVisibleFilledSurface` fails consistently (`expected 405.0`, `was 360.0`)

## Reproduction
On an Android TV stream with the affected controller, press Select/View. Before this change the stream settings overlay opens; after this change the event reaches the game as XInput Back/View. Remote Back and controller Guide still open the overlay.

## Visual proof
There is no visual surface change to screenshot: the corrected result is that pressing a hardware controller button no longer mounts the overlay and instead sends an input packet to the remote game. A still image cannot demonstrate either the absence of an overlay transition or downstream game input, and reproducing the event requires the reporter's AFTKA/controller combination plus a GFN account. No unrelated or fabricated screenshot is included.