### PR TITLE
Improve desktop diagnostic logging

### DIFF
--- a/opennow-stable/src/main/index.ts
+++ b/opennow-stable/src/main/index.ts
@@ -12,6 +12,7 @@ import {
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
+import { cpus, totalmem } from "node:os";
 
 // Keyboard shortcuts reference (matching Rust implementation):
 // Screenshot keybind - configurable, handled in renderer
@@ -21,7 +22,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { IPC_CHANNELS } from "@shared/ipc";
 import { registerOpenNowMediaProtocol } from "./mediaPaths";
-import { initLogCapture } from "@shared/logger";
+import { initLogCapture, setLogContext } from "@shared/logger";
 import { cacheManager } from "./services/cacheManager";
 import { refreshScheduler } from "./services/refreshScheduler";
 import { cacheEventBus } from "./services/cacheEventBus";
@@ -81,6 +82,10 @@ import { shutdownMainTelemetry, syncMainTelemetry } from "./telemetry/posthog";
 import { createMainWindow } from "./window/mainWindow";
 import { resolveAppInstanceProfile } from "./appInstance";
 import { shouldDefaultLinuxShellToX11 } from "./nativeStreamer/runtime";
+import {
+  DiagnosticHistoryController,
+  DiagnosticHistoryStore,
+} from "./services/diagnosticHistory";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -93,6 +98,24 @@ if (appInstanceProfile.isSecondary) {
   app.setPath("userData", appInstanceProfile.userDataPath);
   app.setPath("sessionData", appInstanceProfile.userDataPath);
 }
+
+// Capture bootstrap decisions as well as app-ready/runtime output. Android's
+// diagnostic export follows the same full-lifecycle model.
+const mainLogCapture = initLogCapture("main");
+const cpuInfo = cpus();
+setLogContext("application.main", {
+  version: app.getVersion(),
+  packaged: app.isPackaged,
+  platform: process.platform,
+  architecture: process.arch,
+  electron: process.versions.electron,
+  chromium: process.versions.chrome,
+  node: process.versions.node,
+  cpuModel: cpuInfo[0]?.model ?? "unknown",
+  processorCount: cpuInfo.length,
+  memoryMiB: Math.round(totalmem() / (1024 * 1024)),
+  secondaryInstance: appInstanceProfile.isSecondary,
+});
 
 // Configure Chromium video, WebRTC, and input behavior before app.whenReady().
 
@@ -192,6 +215,7 @@ let signalingCoordinator: SignalingCoordinator | null = null;
 let authService: AuthService;
 let settingsManager: SettingsManager;
 let appUpdater: AppUpdaterController | null = null;
+let diagnosticHistoryController: DiagnosticHistoryController | null = null;
 const EXPLICIT_SHUTDOWN_FORCE_EXIT_DELAY_MS = 2000;
 let isShutdownRequested = false;
 let isShutdownCleanupComplete = false;
@@ -277,6 +301,10 @@ function runShutdownCleanup(reason = "app-quit"): void {
   void shutdownMainTelemetry();
   appUpdater?.dispose();
   appUpdater = null;
+  diagnosticHistoryController?.stop();
+  void diagnosticHistoryController?.flush().catch((error) => {
+    console.warn("[Diagnostics] Failed to flush shutdown diagnostic snapshot:", error);
+  });
 
   const windowToClose = mainWindow;
   if (windowToClose && !windowToClose.isDestroyed()) {
@@ -549,8 +577,16 @@ if (!gotSingleInstanceLock) {
 
 if (gotSingleInstanceLock) {
 app.whenReady().then(async () => {
-  // Initialize log capture first to capture all console output
-  initLogCapture("main");
+  diagnosticHistoryController = new DiagnosticHistoryController(
+    new DiagnosticHistoryStore(app.getPath("userData")),
+    mainLogCapture,
+  );
+  try {
+    await diagnosticHistoryController.start();
+  } catch (error) {
+    console.warn("[Diagnostics] Failed to initialize previous-run history:", error);
+    diagnosticHistoryController = null;
+  }
   if (appInstanceProfile.isSecondary) {
     console.log(`[Main] Secondary instance profile: ${appInstanceProfile.userDataPath}`);
   }

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -2,6 +2,7 @@ import electron from "electron";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { basename } from "node:path";
 
 import {
   createUnsupportedNativeStreamerStatus,
@@ -19,6 +20,7 @@ import {
   type NativeRenderSurface,
   type NativeStreamerSessionContext,
   type SendAnswerRequest,
+  streamDiagnosticId,
 } from "@shared/gfn";
 import {
   NATIVE_STREAMER_PROTOCOL_VERSION,
@@ -29,7 +31,7 @@ import {
   type NativeStreamerMessage,
   type NativeStreamerResponse,
 } from "@shared/nativeStreamer";
-import { isTerminalBrokenWriteError } from "@shared/logger";
+import { isTerminalBrokenWriteError, setLogContext } from "@shared/logger";
 import type { NativeStreamerShortcutBindings } from "@shared/gfn";
 import {
   createNativeStreamerDetectionFailureStatus,
@@ -114,6 +116,10 @@ export class NativeStreamerManager {
   private readonly surfaceUpdates: NativeSurfaceUpdateQueue;
   private videoBackendOverride: NativeVideoBackendPreference | null = null;
   private suppressNextStoppedEvent = false;
+  private diagnosticState: Record<string, unknown> = {
+    processState: "not-started",
+    sessionState: "idle",
+  };
 
   constructor(private readonly options: NativeStreamerManagerOptions) {
     this.surfaceUpdates = new NativeSurfaceUpdateQueue(
@@ -130,6 +136,14 @@ export class NativeStreamerManager {
     return this.activeSessionId !== null;
   }
 
+  private retainDiagnosticState(values: Record<string, unknown>): void {
+    this.diagnosticState = {
+      ...this.diagnosticState,
+      ...values,
+    };
+    setLogContext("nativeStreamer.latest", this.diagnosticState);
+  }
+
   setVideoBackendOverride(value: NativeVideoBackendPreference | null): void {
     this.videoBackendOverride = value;
   }
@@ -139,6 +153,14 @@ export class NativeStreamerManager {
       await this.stop("new native streamer session");
     }
     this.prepareRemoteIceQueue(context.session.sessionId);
+    this.retainDiagnosticState({
+      streamKey: streamDiagnosticId(context.session.sessionId),
+      sessionState: "preparing",
+      requestedResolution: context.settings.resolution,
+      requestedFps: context.settings.fps,
+      requestedCodec: context.settings.codec,
+      transportMode: context.settings.transportMode ?? "webrtc",
+    });
 
     await this.ensureProcess();
 
@@ -157,6 +179,7 @@ export class NativeStreamerManager {
       context,
     }, SESSION_START_TIMEOUT_MS);
     this.activeSessionId = context.session.sessionId;
+    this.retainDiagnosticState({ sessionState: "ready" });
     await this.flushQueuedRemoteIce(context.session.sessionId);
   }
 
@@ -165,7 +188,7 @@ export class NativeStreamerManager {
     console.log(
       "[NativeStreamer] Session context:",
       JSON.stringify({
-        sessionId: context.session.sessionId,
+        streamKey: streamDiagnosticId(context.session.sessionId),
         requestedResolution: context.settings.resolution,
         requestedFps: context.settings.fps,
         requestedCodec: context.settings.codec,
@@ -178,6 +201,12 @@ export class NativeStreamerManager {
     );
 
     await this.prepareForSession(context);
+    this.retainDiagnosticState({
+      sessionState: "negotiating-offer",
+      negotiatedResolution: negotiatedProfile?.resolution ?? "unknown",
+      negotiatedFps: negotiatedProfile?.fps ?? "unknown",
+      negotiatedCodec: negotiatedProfile?.codec ?? context.settings.codec,
+    });
 
     if (!this.capabilities?.supportsOfferAnswer) {
       console.warn(
@@ -204,6 +233,10 @@ export class NativeStreamerManager {
         throw new Error("Native streamer answer rejected the video m-line.");
       }
       console.log(`[NativeStreamer] Answer negotiated video codec: ${negotiatedCodec}`);
+      this.retainDiagnosticState({
+        sessionState: "answer-sent",
+        negotiatedCodec,
+      });
       await this.options.sendAnswer(response.answer);
       this.answerInFlight = false;
       await this.flushQueuedLocalIce();
@@ -372,12 +405,23 @@ export class NativeStreamerManager {
       this.suppressNextStoppedEvent = true;
     }
     const child = this.child;
+    const streamKey = streamDiagnosticId(this.activeSessionId);
+    this.retainDiagnosticState({
+      streamKey,
+      sessionState: "stopping",
+      stopReason: reason,
+    });
     this.activeSessionId = null;
     this.capabilities = null;
     this.surfaceUpdates.markNotReady();
     this.clearQueuedRemoteIce();
 
     if (!child) {
+      this.retainDiagnosticState({
+        processState: "stopped",
+        sessionState: "stopped",
+        stopReason: reason,
+      });
       return;
     }
 
@@ -388,10 +432,21 @@ export class NativeStreamerManager {
     } finally {
       this.terminateProcess();
       this.suppressNextStoppedEvent = false;
+      this.retainDiagnosticState({
+        processState: "stopped",
+        sessionState: "stopped",
+        stopReason: reason,
+      });
     }
   }
 
   dispose(reason = "disposed"): void {
+    this.retainDiagnosticState({
+      streamKey: streamDiagnosticId(this.activeSessionId),
+      processState: "disposed",
+      sessionState: "disposed",
+      stopReason: reason,
+    });
     this.activeSessionId = null;
     this.capabilities = null;
     this.surfaceUpdates.markNotReady();
@@ -449,6 +504,11 @@ export class NativeStreamerManager {
           return;
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
+          this.retainDiagnosticState({
+            processState: "initialization-failed",
+            sessionState: "failed",
+            lastError: formatError(lastError),
+          });
           console.warn(
             `[NativeStreamer] Failed to initialize ${executablePath}: ${formatError(lastError)}`,
           );
@@ -477,10 +537,16 @@ export class NativeStreamerManager {
     executablePath: string,
     backendPreference: NativeStreamerBackendPreference,
   ): Promise<void> {
+    this.retainDiagnosticState({
+      processState: "starting",
+      executable: basename(executablePath),
+      backendPreference,
+    });
     console.log("[NativeStreamer] Starting:", executablePath);
     console.log("[NativeStreamer] Backend preference:", backendPreference);
     const videoBackendPreference = this.videoBackendOverride
       ?? this.options.getVideoBackendPreference();
+    this.retainDiagnosticState({ videoBackendPreference });
     console.log("[NativeStreamer] Video backend preference:", videoBackendPreference);
 
     const { env: childEnv, runtimeStatus } = createNativeStreamerRuntimeEnvironment({
@@ -501,6 +567,10 @@ export class NativeStreamerManager {
       d3dFullscreenMode: this.options.getD3dFullscreenMode(),
     });
     this.gstreamerRuntime = runtimeStatus;
+    this.retainDiagnosticState({
+      runtimeBundled: runtimeStatus.bundled,
+      runtimeState: runtimeStatus.message,
+    });
     if (runtimeStatus.bundled) {
       console.log("[NativeStreamer] Using bundled GStreamer runtime:", runtimeStatus.path);
     } else {
@@ -555,6 +625,13 @@ export class NativeStreamerManager {
     }
 
     this.capabilities = response.capabilities;
+    this.retainDiagnosticState({
+      processState: "ready",
+      backend: response.capabilities.backend,
+      protocolVersion: response.capabilities.protocolVersion,
+      supportsOfferAnswer: response.capabilities.supportsOfferAnswer,
+      supportsInput: response.capabilities.supportsInput,
+    });
     console.log("[NativeStreamer] Capabilities:", response.capabilities);
     if (response.capabilities.protocolVersion !== NATIVE_STREAMER_PROTOCOL_VERSION) {
       throw new Error(
@@ -777,6 +854,28 @@ export class NativeStreamerManager {
     }
 
     if (message.type === "stats") {
+      this.retainDiagnosticState({
+        sessionState: "streaming",
+        statsCapturedAt: new Date().toISOString(),
+        codec: message.stats.codec,
+        resolution: message.stats.resolution,
+        hardwareAcceleration: message.stats.hardwareAcceleration,
+        memoryMode: message.stats.memoryMode ?? "unknown",
+        zeroCopy: message.stats.zeroCopy ?? false,
+        bitrateKbps: message.stats.bitrateKbps,
+        targetBitrateKbps: message.stats.targetBitrateKbps,
+        decodedFps: message.stats.decodedFps,
+        renderFps: message.stats.renderFps,
+        framesDecoded: message.stats.framesDecoded,
+        framesRendered: message.stats.framesRendered,
+        sinkDropped: message.stats.sinkDropped ?? 0,
+        queueMode: message.stats.queueMode ?? "unknown",
+        partialFlushCount: message.stats.partialFlushCount ?? 0,
+        completeFlushCount: message.stats.completeFlushCount ?? 0,
+        lastTransition: message.stats.lastTransitionSummary ?? "none",
+        serverGpuType: message.stats.serverGpuType ?? "unknown",
+        serverLocation: message.stats.serverLocation ?? "unknown",
+      });
       this.options.emit({
         type: "native-stream-stats",
         stats: message.stats,
@@ -786,6 +885,10 @@ export class NativeStreamerManager {
 
     if (message.type === "status") {
       console.log(`[NativeStreamer] Status: ${message.status}${message.message ? ` (${message.message})` : ""}`);
+      this.retainDiagnosticState({
+        sessionState: message.status,
+        statusMessage: message.message ?? "",
+      });
       if (message.status === "streaming") {
         this.options.emit({ type: "native-stream-started", message: message.message });
       } else if (message.status === "stopped") {
@@ -858,6 +961,13 @@ export class NativeStreamerManager {
     const hadActiveSession = this.activeSessionId !== null;
     const stoppedReason = `process ended (${reason})`;
     console.warn(`[NativeStreamer] Process ended (${reason})${tail}`);
+    this.retainDiagnosticState({
+      streamKey: streamDiagnosticId(this.activeSessionId),
+      processState: "ended",
+      sessionState: hadActiveSession ? "interrupted" : "idle",
+      processEndReason: reason,
+      recentStderr: tail || "none",
+    });
     this.child = null;
     this.stdoutBuffer = "";
     this.stderrTail = [];

--- a/opennow-stable/src/main/platforms/gfn/signaling.ts
+++ b/opennow-stable/src/main/platforms/gfn/signaling.ts
@@ -8,6 +8,13 @@ import type {
   MainToRendererSignalingEvent,
   SendAnswerRequest,
 } from "@shared/gfn";
+import {
+  iceCandidateDiagnosticSummary,
+  sdpDiagnosticSummary,
+  signalingUrlForDiagnostics,
+  streamDiagnosticId,
+} from "@shared/gfn";
+import { setLogContext } from "@shared/logger";
 import { GFN_PLAY_ORIGIN, GFN_USER_AGENT } from "./clientHeaders";
 
 interface SignalingMessage {
@@ -57,9 +64,7 @@ export class GfnSignalingClient {
     signInUrl.searchParams.set("peer_role", "1");
     signInUrl.searchParams.set("pairing_id", this.sessionId);
 
-    const url = signInUrl.toString();
-    console.log("[Signaling] URL:", url, "(server:", this.signalingServer, ", signalingUrl:", this.signalingUrl, ")");
-    return url;
+    return signInUrl.toString();
   }
 
   onEvent(listener: (event: MainToRendererSignalingEvent) => void): () => void {
@@ -78,11 +83,23 @@ export class GfnSignalingClient {
     return this.ackCounter;
   }
 
-  private sendJson(payload: unknown): void {
+  private sendJson(payload: unknown): boolean {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      return;
+      return false;
     }
     this.ws.send(JSON.stringify(payload));
+    return true;
+  }
+
+  private retainState(state: string, details: Record<string, unknown> = {}): void {
+    setLogContext("signaling.latest", {
+      streamKey: streamDiagnosticId(this.sessionId),
+      state,
+      server: this.signalingServer,
+      url: signalingUrlForDiagnostics(this.signalingUrl, this.sessionId),
+      heartbeatIntervalMs: 5000,
+      ...details,
+    });
   }
 
   private setupHeartbeat(): void {
@@ -125,9 +142,10 @@ export class GfnSignalingClient {
     const protocol = `x-nv-sessionid.${this.sessionId}`;
     const generation = ++this.connectionGeneration;
 
-    console.log("[Signaling] Connecting to:", url);
-    console.log("[Signaling] Session ID:", this.sessionId);
-    console.log("[Signaling] Protocol:", protocol);
+    this.retainState("connecting");
+    console.log(
+      `[Signaling] Connecting session=${streamDiagnosticId(this.sessionId)} url=${signalingUrlForDiagnostics(url, this.sessionId)}`,
+    );
 
     await new Promise<void>((resolve, reject) => {
       // Extract host:port for the Host header (matching Rust behavior)
@@ -150,6 +168,13 @@ export class GfnSignalingClient {
         if (!isCurrentSocket()) {
           return;
         }
+        this.retainState("connect-failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        console.warn(
+          `[Signaling] Connect failed session=${streamDiagnosticId(this.sessionId)}:`,
+          error,
+        );
         this.emit({ type: "error", message: `Signaling connect failed: ${String(error)}` });
         reject(error);
       });
@@ -160,6 +185,10 @@ export class GfnSignalingClient {
         }
         this.sendPeerInfo();
         this.setupHeartbeat();
+        this.retainState("connected", { protocol: `x-nv-sessionid.${streamDiagnosticId(this.sessionId)}` });
+        console.log(
+          `[Signaling] Connected session=${streamDiagnosticId(this.sessionId)} heartbeatMs=5000`,
+        );
         this.emit({ type: "connected" });
         resolve();
       });
@@ -172,7 +201,7 @@ export class GfnSignalingClient {
         this.handleMessage(text);
       });
 
-      ws.on("close", (_code, reason) => {
+      ws.on("close", (code, reason) => {
         this.clearHeartbeat();
 
         if (!isCurrentSocket()) {
@@ -182,6 +211,10 @@ export class GfnSignalingClient {
         this.ws = null;
 
         const reasonText = typeof reason === "string" ? reason : reason.toString("utf8");
+        this.retainState("closed", { closeCode: code, closeReason: reasonText || "socket closed" });
+        console.warn(
+          `[Signaling] Closed session=${streamDiagnosticId(this.sessionId)} code=${code} reason=${reasonText || "none"}`,
+        );
         this.emit({ type: "disconnected", reason: reasonText || "socket closed" });
       });
     });
@@ -246,8 +279,7 @@ export class GfnSignalingClient {
     }
 
     if (peerPayload.type === "offer" && typeof peerPayload.sdp === "string") {
-      console.log(`[Signaling] Received OFFER SDP (${peerPayload.sdp.length} chars), first 500 chars:`);
-      console.log(peerPayload.sdp.slice(0, 500));
+      console.log(`[Signaling] ${sdpDiagnosticSummary("Received offer", peerPayload.sdp)}`);
       this.emit({ type: "offer", sdp: peerPayload.sdp });
       return;
     }
@@ -257,23 +289,22 @@ export class GfnSignalingClient {
         typeof peerPayload.sdpMLineIndex === "number" || peerPayload.sdpMLineIndex === null
           ? peerPayload.sdpMLineIndex
           : 0;
-      console.log(
-        `[Signaling] Received remote ICE candidate: ${peerPayload.candidate} (sdpMLineIndex=${sdpMLineIndex})`,
-      );
+      const candidate = {
+        candidate: peerPayload.candidate,
+        sdpMid:
+          typeof peerPayload.sdpMid === "string" || peerPayload.sdpMid === null
+            ? peerPayload.sdpMid
+            : undefined,
+        sdpMLineIndex,
+        usernameFragment:
+          typeof peerPayload.usernameFragment === "string" || peerPayload.usernameFragment === null
+            ? peerPayload.usernameFragment
+            : undefined,
+      } satisfies IceCandidatePayload;
+      console.log(`[Signaling] Received remote ICE candidate ${iceCandidateDiagnosticSummary(candidate)}`);
       this.emit({
         type: "remote-ice",
-        candidate: {
-          candidate: peerPayload.candidate,
-          sdpMid:
-            typeof peerPayload.sdpMid === "string" || peerPayload.sdpMid === null
-              ? peerPayload.sdpMid
-              : undefined,
-          sdpMLineIndex,
-          usernameFragment:
-            typeof peerPayload.usernameFragment === "string" || peerPayload.usernameFragment === null
-              ? peerPayload.usernameFragment
-              : undefined,
-        },
+        candidate,
       });
       return;
     }
@@ -283,11 +314,11 @@ export class GfnSignalingClient {
   }
 
   async sendAnswer(payload: SendAnswerRequest): Promise<void> {
-    console.log(`[Signaling] Sending ANSWER SDP (${payload.sdp.length} chars), first 500 chars:`);
-    console.log(payload.sdp.slice(0, 500));
+    console.log(`[Signaling] ${sdpDiagnosticSummary("Sending answer", payload.sdp)}`);
     if (payload.nvstSdp) {
-      console.log(`[Signaling] Sending nvstSdp (${payload.nvstSdp.length} chars):`);
-      console.log(payload.nvstSdp);
+      console.log(
+        `[Signaling] Sending NVST SDP lines=${payload.nvstSdp.split(/\r?\n/).filter(Boolean).length} bytes=${payload.nvstSdp.length}`,
+      );
     }
     const answer = {
       type: "answer",
@@ -308,11 +339,11 @@ export class GfnSignalingClient {
 
   async sendIceCandidate(candidate: IceCandidatePayload): Promise<void> {
     if (isTcpIceCandidate(candidate.candidate)) {
-      console.log(`[Signaling] Dropping TCP local ICE candidate: ${candidate.candidate}`);
+      console.log(`[Signaling] Dropping TCP local ICE candidate ${iceCandidateDiagnosticSummary(candidate)}`);
       return;
     }
 
-    console.log(`[Signaling] Sending local ICE candidate: ${candidate.candidate} (sdpMid=${candidate.sdpMid})`);
+    console.log(`[Signaling] Sending local ICE candidate ${iceCandidateDiagnosticSummary(candidate)}`);
     console.log(`[Signaling] Sending ICE peer_msg from=${this.peerId} to=${this.remotePeerId}`);
     this.sendJson({
       peer_msg: {
@@ -356,6 +387,8 @@ export class GfnSignalingClient {
       this.ws = null;
       socket.close();
     }
+    this.retainState("client-disconnect");
+    console.log(`[Signaling] Client disconnect session=${streamDiagnosticId(this.sessionId)}`);
   }
 }
 

--- a/opennow-stable/src/main/services/diagnosticHistory.test.ts
+++ b/opennow-stable/src/main/services/diagnosticHistory.test.ts
@@ -1,0 +1,56 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+
+import {
+  boundDiagnosticSnapshot,
+  DiagnosticHistoryStore,
+} from "./diagnosticHistory";
+
+async function temporaryDirectory(t: TestContext): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "opennow-diagnostics-"));
+  t.after(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+test("promotes the latest current-process snapshot on the next app run", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = new DiagnosticHistoryStore(directory, () => 1234);
+
+  assert.equal(await store.beginAppRun(), null);
+  await store.saveCurrent("OpenNOW Desktop diagnostics\nevent.1 stream failed");
+
+  assert.deepEqual(await store.beginAppRun(), {
+    capturedAt: 1234,
+    text: "OpenNOW Desktop diagnostics\nevent.1 stream failed",
+  });
+});
+
+test("a corrupt current snapshot preserves the last readable run", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = new DiagnosticHistoryStore(directory, () => 10);
+  await store.saveCurrent("readable previous run");
+  await store.beginAppRun();
+  await writeFile(join(directory, "diagnostic-history", "current.txt.gz"), "not gzip");
+
+  assert.deepEqual(await store.beginAppRun(), {
+    capturedAt: 10,
+    text: "readable previous run",
+  });
+});
+
+test("bounded snapshots keep both startup context and the latest failure", () => {
+  const original = `header-${"x".repeat(500)}-latest`;
+  const bounded = boundDiagnosticSnapshot(original, 256);
+
+  assert.equal(bounded.startsWith("header-"), true);
+  assert.equal(bounded.endsWith("-latest"), true);
+  assert.match(bounded, /persisted diagnostic snapshot truncated/);
+  assert.ok(bounded.length <= 256);
+});

--- a/opennow-stable/src/main/services/diagnosticHistory.ts
+++ b/opennow-stable/src/main/services/diagnosticHistory.ts
@@ -1,0 +1,200 @@
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { gunzip, gzip } from "node:zlib";
+
+import type { LogCapture, PreviousLogSnapshot } from "@shared/logger";
+
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
+
+const DIRECTORY_NAME = "diagnostic-history";
+const CURRENT_FILE_NAME = "current.txt.gz";
+const PREVIOUS_FILE_NAME = "previous.txt.gz";
+const DEFAULT_MAX_CHARACTERS = 1_500_000;
+const DEFAULT_PERSIST_INTERVAL_MS = 15_000;
+const PERSISTED_EVENT_LIMIT = 1200;
+
+async function isFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function boundDiagnosticSnapshot(
+  text: string,
+  maxCharacters = DEFAULT_MAX_CHARACTERS,
+): string {
+  if (maxCharacters < 256) {
+    throw new Error("Diagnostic snapshot bound must be at least 256 characters");
+  }
+  if (text.length <= maxCharacters) return text;
+  const marker = `\n... persisted diagnostic snapshot truncated ${text.length - maxCharacters} characters ...\n`;
+  const available = Math.max(2, maxCharacters - marker.length);
+  const headLength = Math.floor(available / 2);
+  const tailLength = available - headLength;
+  return text.slice(0, headLength) + marker + text.slice(-tailLength);
+}
+
+/**
+ * Rotates one bounded, already-redacted snapshot between app runs. A corrupt
+ * current snapshot never replaces the last readable previous-run evidence.
+ */
+export class DiagnosticHistoryStore {
+  private readonly historyDirectory: string;
+  private readonly currentFile: string;
+  private readonly previousFile: string;
+
+  constructor(
+    userDataDirectory: string,
+    private readonly now: () => number = Date.now,
+  ) {
+    this.historyDirectory = join(userDataDirectory, DIRECTORY_NAME);
+    this.currentFile = join(this.historyDirectory, CURRENT_FILE_NAME);
+    this.previousFile = join(this.historyDirectory, PREVIOUS_FILE_NAME);
+  }
+
+  async beginAppRun(): Promise<PreviousLogSnapshot | null> {
+    await mkdir(this.historyDirectory, { recursive: true });
+    await this.recoverInterruptedReplacement(this.currentFile);
+    await this.recoverInterruptedReplacement(this.previousFile);
+    const current = await this.readSnapshot(this.currentFile);
+    if (!current) {
+      await rm(this.currentFile, { force: true });
+      return this.readSnapshot(this.previousFile);
+    }
+
+    const stagedPrevious = `${this.previousFile}.stage`;
+    await rm(stagedPrevious, { force: true });
+    await copyFile(this.currentFile, stagedPrevious);
+    await this.replaceFile(stagedPrevious, this.previousFile);
+    await rm(this.currentFile, { force: true });
+    return this.readSnapshot(this.previousFile);
+  }
+
+  async saveCurrent(text: string): Promise<void> {
+    await mkdir(this.historyDirectory, { recursive: true });
+    await this.recoverInterruptedReplacement(this.currentFile);
+    const stagedCurrent = `${this.currentFile}.stage`;
+    await rm(stagedCurrent, { force: true });
+    const bounded = boundDiagnosticSnapshot(text);
+    const payload = Buffer.from(`${this.now()}\n${bounded}`, "utf8");
+    const compressed = await gzipAsync(payload, { level: 1 });
+    await writeFile(stagedCurrent, compressed);
+    await this.replaceFile(stagedCurrent, this.currentFile);
+  }
+
+  private async readSnapshot(path: string): Promise<PreviousLogSnapshot | null> {
+    if (!await isFile(path)) return null;
+    try {
+      const compressed = await readFile(path);
+      const raw = (await gunzipAsync(compressed)).toString("utf8");
+      const newline = raw.indexOf("\n");
+      if (newline <= 0) return null;
+      const capturedAt = Number.parseInt(raw.slice(0, newline), 10);
+      const text = raw.slice(newline + 1).trimEnd();
+      if (!Number.isFinite(capturedAt) || !text) return null;
+      return { capturedAt, text };
+    } catch {
+      return null;
+    }
+  }
+
+  private async recoverInterruptedReplacement(target: string): Promise<void> {
+    const backup = `${target}.backup`;
+    if (!await isFile(target) && await isFile(backup)) {
+      await rename(backup, target);
+    } else if (await isFile(target)) {
+      await rm(backup, { force: true });
+    }
+  }
+
+  private async replaceFile(staged: string, target: string): Promise<void> {
+    const backup = `${target}.backup`;
+    await rm(backup, { force: true });
+    const hadTarget = await isFile(target);
+    if (hadTarget) {
+      await rename(target, backup);
+    }
+    try {
+      await rename(staged, target);
+    } catch (error) {
+      if (hadTarget && await isFile(backup)) {
+        await rename(backup, target);
+      }
+      await rm(staged, { force: true });
+      throw error;
+    }
+    await rm(backup, { force: true });
+  }
+}
+
+export class DiagnosticHistoryController {
+  private timer: NodeJS.Timeout | null = null;
+  private lastPersistedRevision = -1;
+  private writeInFlight: Promise<void> | null = null;
+  private persistAgain = false;
+
+  constructor(
+    private readonly store: DiagnosticHistoryStore,
+    private readonly capture: LogCapture,
+    private readonly intervalMs = DEFAULT_PERSIST_INTERVAL_MS,
+  ) {}
+
+  async start(): Promise<void> {
+    this.capture.setPreviousRunSnapshot(await this.store.beginAppRun());
+    await this.persistIfChanged(true);
+    this.timer = setInterval(() => {
+      void this.persistIfChanged().catch((error) => {
+        console.warn("[Diagnostics] Failed to persist current diagnostic snapshot:", error);
+      });
+    }, this.intervalMs);
+    this.timer.unref?.();
+  }
+
+  async flush(): Promise<void> {
+    await this.persistIfChanged(true);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async persistIfChanged(force = false): Promise<void> {
+    const revision = this.capture.getRevision();
+    if (!force && revision === this.lastPersistedRevision) return;
+    if (this.writeInFlight) {
+      this.persistAgain = true;
+      await this.writeInFlight;
+      return;
+    }
+
+    // Manual exports keep the full in-memory ring. Periodic crash history uses
+    // a smaller tail plus retained state so it cannot contend with streaming.
+    const snapshot = this.capture.exportCurrentRedacted(PERSISTED_EVENT_LIMIT);
+    this.writeInFlight = this.store.saveCurrent(snapshot);
+    try {
+      await this.writeInFlight;
+      this.lastPersistedRevision = revision;
+    } finally {
+      this.writeInFlight = null;
+    }
+    if (this.persistAgain) {
+      this.persistAgain = false;
+      await this.persistIfChanged();
+    }
+  }
+}

--- a/opennow-stable/src/main/signaling/signalingCoordinator.ts
+++ b/opennow-stable/src/main/signaling/signalingCoordinator.ts
@@ -13,6 +13,8 @@ import type {
   Settings,
   SignalingConnectRequest,
 } from "@shared/gfn";
+import { streamDiagnosticId } from "@shared/gfn";
+import { setLogContext } from "@shared/logger";
 import { GfnSignalingClient } from "../platforms/gfn/signaling";
 import { NativeStreamerManager } from "../nativeStreamer/manager";
 import { normalizeNativeInputPacket } from "../nativeStreamer/input";
@@ -35,8 +37,19 @@ export class SignalingCoordinator {
   private nativeStreamerFallbackSessionId: string | null = null;
   private nativeSoftwareRetrySessionId: string | null = null;
   private lastSignalingPayload: SignalingConnectRequest | null = null;
+  private sessionDiagnosticState: Record<string, unknown> = {
+    phase: "idle",
+  };
 
   constructor(private readonly deps: SignalingCoordinatorDeps) {}
+
+  private retainSessionState(values: Record<string, unknown>): void {
+    this.sessionDiagnosticState = {
+      ...this.sessionDiagnosticState,
+      ...values,
+    };
+    setLogContext("session.latest", this.sessionDiagnosticState);
+  }
 
   registerIpcHandlers(): void {
     const { ipcMain } = this.deps;
@@ -176,6 +189,10 @@ export class SignalingCoordinator {
     emitDisconnectEvent: boolean;
     reason: string;
   }): void {
+    this.retainSessionState({
+      phase: "shutdown",
+      stopReason: options.reason,
+    });
     if (options.emitDisconnectEvent) {
       this.signalingClient?.disconnect();
     }
@@ -283,11 +300,32 @@ export class SignalingCoordinator {
     const nextKey = `${payload.sessionId}|${payload.signalingServer}|${payload.signalingUrl ?? ""}`;
     this.nativeStreamerContext = payload.nativeStreamer ?? null;
     this.nativeStreamerFallbackSessionId = null;
+    const nativeContext = this.nativeStreamerContext;
+    this.retainSessionState({
+      streamKey: streamDiagnosticId(payload.sessionId),
+      phase: "signaling-connect",
+      appId: nativeContext?.session.appId ?? "unknown",
+      sessionStatus: nativeContext?.session.status ?? "unknown",
+      queuePosition: nativeContext?.session.queuePosition ?? 0,
+      seatSetupStep: nativeContext?.session.seatSetupStep ?? 0,
+      zone: nativeContext?.session.zone ?? "unknown",
+      serverLocation: nativeContext?.session.serverLocation ?? "unknown",
+      serverGpuType: nativeContext?.session.gpuType ?? "unknown",
+      streamer: nativeContext ? "native" : "web",
+      requestedResolution: nativeContext?.settings.resolution ?? "renderer-owned",
+      requestedFps: nativeContext?.settings.fps ?? "renderer-owned",
+      requestedCodec: nativeContext?.settings.codec ?? "renderer-owned",
+      negotiatedResolution: nativeContext?.session.negotiatedStreamProfile?.resolution ?? "unknown",
+      negotiatedFps: nativeContext?.session.negotiatedStreamProfile?.fps ?? "unknown",
+      negotiatedCodec: nativeContext?.session.negotiatedStreamProfile?.codec ?? "unknown",
+      transportMode: nativeContext?.settings.transportMode ?? "webrtc",
+      connectedAt: new Date().toISOString(),
+    });
     if (this.nativeStreamerContext) {
       console.log(
         "[NativeStreamer] Signaling connect context:",
         JSON.stringify({
-          sessionId: this.nativeStreamerContext.session.sessionId,
+          streamKey: streamDiagnosticId(this.nativeStreamerContext.session.sessionId),
           resolution: this.nativeStreamerContext.settings.resolution,
           fps: this.nativeStreamerContext.settings.fps,
           codec: this.nativeStreamerContext.settings.codec,
@@ -325,7 +363,12 @@ export class SignalingCoordinator {
     this.signalingClient.onEvent((event) => this.routeSignalingEvent(event));
     try {
       await this.signalingClient.connect();
+      this.retainSessionState({ phase: "signaling-connected" });
     } catch (error) {
+      this.retainSessionState({
+        phase: "signaling-connect-failed",
+        lastError: error instanceof Error ? error.message : String(error),
+      });
       await this.nativeStreamerManager
         ?.stop("signaling connect failed")
         .catch(() => undefined);
@@ -336,6 +379,10 @@ export class SignalingCoordinator {
   }
 
   private async disconnectSignaling(): Promise<void> {
+    this.retainSessionState({
+      phase: "disconnecting",
+      stopReason: "renderer signaling disconnect",
+    });
     await this.nativeStreamerManager?.stop("signaling disconnect");
     this.nativeStreamerManager?.setVideoBackendOverride(null);
     this.nativeStreamerContext = null;
@@ -345,6 +392,7 @@ export class SignalingCoordinator {
     this.signalingClient?.disconnect();
     this.signalingClient = null;
     this.signalingClientKey = null;
+    this.retainSessionState({ phase: "disconnected" });
   }
 
   private emitToRenderer(event: MainToRendererSignalingEvent): void {
@@ -463,6 +511,10 @@ export class SignalingCoordinator {
 
   private routeSignalingEvent(event: MainToRendererSignalingEvent): void {
     if (event.type === "disconnected") {
+      this.retainSessionState({
+        phase: "remote-disconnected",
+        stopReason: event.reason,
+      });
       void this.nativeStreamerManager?.stop(
         `signaling disconnected: ${event.reason}`,
       );
@@ -511,6 +563,11 @@ export class SignalingCoordinator {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.warn("[NativeStreamer] Falling back to web streamer:", message);
+      this.retainSessionState({
+        streamer: "web-fallback",
+        phase: "native-fallback",
+        lastError: message,
+      });
       this.nativeStreamerFallbackSessionId = context.session.sessionId;
       const queuedRemoteIce =
         this.nativeStreamerManager?.drainQueuedRemoteIce(
@@ -562,6 +619,11 @@ export class SignalingCoordinator {
         "[NativeStreamer] Pre-attach startup failed; falling back to web streamer:",
         message,
       );
+      this.retainSessionState({
+        streamer: "web-fallback",
+        phase: "native-pre-attach-fallback",
+        lastError: message,
+      });
       this.nativeStreamerFallbackSessionId = context.session.sessionId;
       await this.nativeStreamerManager
         ?.stop("native streamer pre-attach fallback")

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -30,7 +30,9 @@ import {
   resolveEntitledStreamProfile,
   resolveRuntimePlatform,
   SAFE_FALLBACK_STREAM_PROFILE,
+  streamDiagnosticId,
 } from "@shared/gfn";
+import { setLogContext } from "@shared/logger";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
 import { dispatchStreamShortcutAction } from "./streamShortcutActions";
 import { useElapsedSeconds } from "./utils/useElapsedSeconds";
@@ -251,6 +253,104 @@ export function App(): JSX.Element {
     scheduleStableRecoveryReset,
   } = recovery;
   const { persistRuntimeSnapshotNow } = snapshot;
+
+  useEffect(() => {
+    setLogContext("application.renderer", {
+      locale,
+      platform: navigator.platform,
+      userAgent: navigator.userAgent,
+    });
+  }, [locale]);
+
+  useEffect(() => {
+    setLogContext("application.state", {
+      page: currentPage,
+      streamPhase: streamStatus,
+      settingsLoaded,
+      queuePosition: queuePosition ?? 0,
+      hasActiveSession: session !== null,
+      launchError: launchError?.codeLabel ?? launchError?.title ?? "none",
+    });
+  }, [currentPage, launchError, queuePosition, session, settingsLoaded, streamStatus]);
+
+  useEffect(() => {
+    if (!settingsLoaded) return;
+    setLogContext("stream.settings", {
+      resolution: settings.resolution,
+      fps: settings.fps,
+      codec: settings.codec,
+      colorQuality: settings.colorQuality,
+      maxBitrateMbps: settings.maxBitrateMbps,
+      clientMode: settings.streamClientMode,
+      nativeVideoBackend: settings.nativeVideoBackend,
+      transportMode: settings.transportMode,
+      keyboardLayout: settings.keyboardLayout,
+      microphoneMode: settings.microphoneMode,
+      cloudGsync: settings.enableCloudGsync,
+    });
+  }, [settings, settingsLoaded]);
+
+  useEffect(() => {
+    const retainLatestStream = (): void => {
+      const stats = diagnosticsStore.getSnapshot();
+      const hasStreamEvidence = streamStatus !== "idle"
+        || session !== null
+        || stats.connectionState !== "closed"
+        || stats.nativeRendererActive;
+      if (!hasStreamEvidence) return;
+
+      setLogContext("stream.latest", {
+        streamKey: streamDiagnosticId(session?.sessionId),
+        phase: streamStatus,
+        appId: session?.appId ?? "unknown",
+        sessionStatus: session?.status ?? "unknown",
+        queuePosition: session?.queuePosition ?? queuePosition ?? 0,
+        seatSetupStep: session?.seatSetupStep ?? 0,
+        zone: session?.zone ?? "unknown",
+        serverLocation: stats.serverLocation || session?.serverLocation || "unknown",
+        serverRegion: stats.serverRegion || "unknown",
+        serverGpuType: stats.serverGpuType || session?.gpuType || "unknown",
+        streamer: stats.nativeRendererActive || settings.streamClientMode === "native" ? "native" : "web",
+        requestedResolution: settings.resolution,
+        requestedFps: settings.fps,
+        requestedCodec: settings.codec,
+        negotiatedResolution: session?.negotiatedStreamProfile?.resolution ?? "unknown",
+        negotiatedFps: session?.negotiatedStreamProfile?.fps ?? "unknown",
+        negotiatedCodec: (session?.negotiatedStreamProfile?.codec ?? stats.codec) || "unknown",
+        activeResolution: stats.resolution || "unknown",
+        activeCodec: stats.codec || "unknown",
+        connectionState: stats.connectionState,
+        transportType: stats.transportType,
+        hardwareAcceleration: stats.hardwareAcceleration || "unknown",
+        bitrateKbps: stats.bitrateKbps,
+        targetBitrateKbps: stats.targetBitrateKbps,
+        availableBitrateKbps: stats.availableBitrateKbps,
+        receiveFps: stats.receiveFps,
+        decodeFps: stats.decodeFps,
+        renderFps: stats.renderFps,
+        framesReceived: stats.framesReceived,
+        framesDecoded: stats.framesDecoded,
+        framesDropped: stats.framesDropped,
+        packetLossPercent: stats.packetLossPercent,
+        jitterMs: stats.jitterMs,
+        jitterBufferDelayMs: stats.jitterBufferDelayMs,
+        rttMs: stats.rttMs,
+        inputReady: stats.inputReady,
+        inputQueueDropCount: stats.inputQueueDropCount,
+        decoderPressureActive: stats.decoderPressureActive,
+        decoderRecoveryAttempts: stats.decoderRecoveryAttempts,
+        lagReason: stats.lagReason,
+        lagReasonDetail: stats.lagReasonDetail,
+        nativeQueueMode: stats.nativeQueueMode ?? "unknown",
+        nativePartialFlushCount: stats.nativePartialFlushCount ?? 0,
+        nativeCompleteFlushCount: stats.nativeCompleteFlushCount ?? 0,
+        nativeTransition: stats.nativeTransitionSummary ?? "none",
+        capturedAt: new Date().toISOString(),
+      });
+    };
+    retainLatestStream();
+    return diagnosticsStore.subscribe(retainLatestStream);
+  }, [diagnosticsStore, queuePosition, session, settings, streamStatus]);
 
   const [exitPrompt, setExitPrompt] = useState<ExitPromptState>({ open: false, gameTitle: t("app.labels.game") });
   const [settingsFocusSection, setSettingsFocusSection] = useState<"account" | undefined>();

--- a/opennow-stable/src/renderer/src/components/settings/sections/SettingsAboutSection.tsx
+++ b/opennow-stable/src/renderer/src/components/settings/sections/SettingsAboutSection.tsx
@@ -1,6 +1,7 @@
 import { Info, MessageSquareText, RefreshCcw, Download, FileDown, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState, type JSX } from "react";
 import type { AppUpdaterState, Settings } from "@shared/gfn";
+import { getLogCapture } from "@shared/logger";
 import { useTranslation } from "../../../i18n";
 import { formatBytes, formatUpdaterTimestamp, getUpdaterBadgeLabel } from "../settingsFormatters";
 import { MotionSpinner } from "../../MotionSpinner";
@@ -296,7 +297,16 @@ export function SettingsAboutSection({
             className="settings-export-logs-btn"
             onClick={async () => {
               try {
-                const logs = await window.openNow.exportLogs("text");
+                const mainLogs = await window.openNow.exportLogs("text");
+                const rendererLogs = getLogCapture()?.exportRedacted() ?? "[renderer logs unavailable]";
+                const logs = [
+                  "===== MAIN =====",
+                  mainLogs.trimEnd(),
+                  "",
+                  "===== RENDERER =====",
+                  rendererLogs.trimEnd(),
+                  "",
+                ].join("\n");
                 const blob = new Blob([logs], { type: "text/plain" });
                 const url = URL.createObjectURL(blob);
                 const a = document.createElement("a");

--- a/opennow-stable/src/renderer/src/platforms/gfn/sdp/nvstOffer.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/sdp/nvstOffer.ts
@@ -41,7 +41,9 @@ interface NvstParams {
 // into sdp.rs; native mode works with its current profile.
 export function buildNvstSdp(params: NvstParams): string {
   console.log(`[SDP] buildNvstSdp: ${params.width}x${params.height}@${params.fps}fps, codec=${params.codec}, colorQuality=${params.colorQuality}, maxBitrate=${params.maxBitrateKbps}kbps`);
-  console.log(`[SDP] buildNvstSdp: ICE ufrag=${params.credentials.ufrag}, pwd=${params.credentials.pwd.slice(0, 8)}..., fingerprint=${params.credentials.fingerprint.slice(0, 20)}...`);
+  console.log(
+    `[SDP] buildNvstSdp: ICE credentials present ufragBytes=${params.credentials.ufrag.length}, pwdBytes=${params.credentials.pwd.length}, fingerprintBytes=${params.credentials.fingerprint.length}`,
+  );
   const maxBitrate = Math.max(OFFICIAL_MIN_BITRATE_KBPS, Math.floor(params.maxBitrateKbps));
   const startupBitrate = Math.max(OFFICIAL_MIN_BITRATE_KBPS, Math.round(maxBitrate / 4));
   const isHighFps = params.fps >= 90;

--- a/opennow-stable/src/renderer/src/platforms/gfn/webrtcClient.ts
+++ b/opennow-stable/src/renderer/src/platforms/gfn/webrtcClient.ts
@@ -9,6 +9,12 @@ import type {
   NativeTransitionDiagnostics,
   KeyboardLayout,
 } from "@shared/gfn";
+import {
+  iceCandidateDiagnosticSummary,
+  sdpDiagnosticSummary,
+  signalingUrlForDiagnostics,
+  streamDiagnosticId,
+} from "@shared/gfn";
 
 import {
   InputEncoder,
@@ -1977,8 +1983,8 @@ export class GfnWebRtcClient {
     this.cleanupPeerConnection();
     this.remoteIceEndpoint = session.mediaConnectionInfo ?? null;
     this.log("=== handleOffer START ===");
-    this.log(`Session: id=${session.sessionId}, status=${session.status}, serverIp=${session.serverIp}`);
-    this.log(`Signaling: server=${session.signalingServer}, url=${session.signalingUrl}`);
+    this.log(`Session: key=${streamDiagnosticId(session.sessionId)}, status=${session.status}, serverIp=${session.serverIp}`);
+    this.log(`Signaling: server=${session.signalingServer}, url=${signalingUrlForDiagnostics(session.signalingUrl, session.sessionId)}`);
     this.log(`MediaConnectionInfo: ${session.mediaConnectionInfo ? `ip=${session.mediaConnectionInfo.ip}, port=${session.mediaConnectionInfo.port}` : "NONE"}`);
     this.log(
       `Settings: codec=${settings.codec}, colorQuality=${settings.colorQuality}, resolution=${settings.resolution}, fps=${settings.fps}, maxBitrate=${settings.maxBitrateKbps}kbps`,
@@ -1987,13 +1993,7 @@ export class GfnWebRtcClient {
       this.log(`Negotiated stream profile override: ${JSON.stringify(session.negotiatedStreamProfile)}`);
     }
     this.log(`ICE servers: ${session.iceServers.length} (${session.iceServers.map(s => s.urls.join(",")).join(" | ")})`);
-    this.log(`Offer SDP length: ${offerSdp.length} chars`);
-    // Log full offer SDP for ICE debugging
-    this.log(`=== FULL OFFER SDP START ===`);
-    for (const line of offerSdp.split(/\r?\n/)) {
-      this.log(`  SDP> ${line}`);
-    }
-    this.log(`=== FULL OFFER SDP END ===`);
+    this.log(sdpDiagnosticSummary("Received offer", offerSdp));
 
     this.riInputCapabilities = parseRiInputCapabilities(offerSdp);
     this.inputChannelPolicyController.updateCapabilities(this.riInputCapabilities);
@@ -2044,13 +2044,13 @@ export class GfnWebRtcClient {
       if (!payload.candidate) {
         return;
       }
-      this.log(`Local ICE candidate: ${payload.candidate}`);
       const candidate: IceCandidatePayload = {
         candidate: payload.candidate,
         sdpMid: payload.sdpMid,
         sdpMLineIndex: payload.sdpMLineIndex,
         usernameFragment: payload.usernameFragment,
       };
+      this.log(`Local ICE candidate ${iceCandidateDiagnosticSummary(candidate)}`);
       if (!answerSent) {
         queuedLocalIce.push(candidate);
         this.log("Queued local ICE candidate until answer is sent");
@@ -2114,7 +2114,9 @@ export class GfnWebRtcClient {
       const hostCandidate = "hostCandidate" in e
         ? (e as RTCPeerConnectionIceErrorEvent & { hostCandidate?: string }).hostCandidate
         : undefined;
-      this.log(`ICE candidate error: ${e.errorCode} ${e.errorText} (${e.url ?? "no url"}) hostCandidate=${hostCandidate ?? "?"}`);
+      this.log(
+        `ICE candidate error: ${e.errorCode} ${e.errorText} url=${signalingUrlForDiagnostics(e.url, session.sessionId)} hostCandidate=${hostCandidate ?? "?"}`,
+      );
     };
 
     pc.oniceconnectionstatechange = () => {
@@ -2283,11 +2285,13 @@ export class GfnWebRtcClient {
       this.diagnostics.codec = effectiveCodec;
       this.emitStats();
     }
-    this.log(`Immediate local SDP length: ${finalSdp.length} chars`);
+    this.log(sdpDiagnosticSummary("Created answer", finalSdp));
     await this.flushQueuedCandidates();
 
     const credentials = extractIceCredentials(finalSdp);
-    this.log(`Extracted ICE credentials: ufrag=${credentials.ufrag}, pwd=${credentials.pwd.slice(0, 8)}...`);
+    this.log(
+      `Extracted ICE credentials: ufragBytes=${credentials.ufrag.length}, pwdBytes=${credentials.pwd.length}`,
+    );
     const { width, height } = parseResolution(settings.resolution);
 
     const nvstSdp = buildNvstSdp({
@@ -2329,7 +2333,7 @@ export class GfnWebRtcClient {
   async addRemoteCandidate(candidate: IceCandidatePayload): Promise<void> {
     const sdpMLineIndex = candidate.sdpMLineIndex ?? (candidate.sdpMid == null ? 0 : undefined);
     this.log(
-      `Remote ICE candidate received: ${candidate.candidate} (sdpMid=${candidate.sdpMid}, sdpMLineIndex=${sdpMLineIndex})`,
+      `Remote ICE candidate received ${iceCandidateDiagnosticSummary({ ...candidate, sdpMLineIndex })}`,
     );
     const init: RTCIceCandidateInit = {
       candidate: candidate.candidate,

--- a/opennow-stable/src/shared/gfn/diagnostics.test.ts
+++ b/opennow-stable/src/shared/gfn/diagnostics.test.ts
@@ -1,0 +1,60 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  iceCandidateDiagnosticSummary,
+  sdpDiagnosticSummary,
+  signalingUrlForDiagnostics,
+  streamDiagnosticId,
+} from "./diagnostics";
+
+test("shortens session IDs while preserving a stable correlation key", () => {
+  assert.equal(streamDiagnosticId("01234567-89ab-4cde-8fab-0123456789ab"), "0123...6789ab");
+  assert.equal(streamDiagnosticId("short-id"), "short-id");
+  assert.equal(streamDiagnosticId(null), "-");
+});
+
+test("redacts signaling URL secrets and replaces the full session ID", () => {
+  const sessionId = "01234567-89ab-4cde-8fab-0123456789ab";
+  const result = signalingUrlForDiagnostics(
+    `wss://example.test/nvst/sign_in?pairing_id=${sessionId}&access_token=secret&version=2`,
+    sessionId,
+  );
+
+  assert.doesNotMatch(result, /01234567-89ab-4cde-8fab-0123456789ab|secret/);
+  assert.match(result, /0123(?:\.{3}|%2E%2E%2E)6789ab/);
+  assert.match(result, /access_token=%5Bredacted%5D/);
+});
+
+test("summarizes SDP without copying credentials or the complete payload", () => {
+  const sdp = [
+    "v=0",
+    "m=video 9 UDP/TLS/RTP/SAVPF 96",
+    "a=rtpmap:96 H264/90000",
+    "a=ice-ufrag:user-secret",
+    "a=ice-pwd:password-secret",
+    "a=fingerprint:sha-256 fingerprint-secret",
+    "a=candidate:1 1 udp 1 192.0.2.10 5000 typ host",
+  ].join("\r\n");
+
+  const result = sdpDiagnosticSummary("Received offer", sdp);
+
+  assert.match(result, /lines=7/);
+  assert.match(result, /codecs=H264/);
+  assert.match(result, /candidates=1/);
+  assert.match(result, /ice=true fingerprint=true/);
+  assert.doesNotMatch(result, /user-secret|password-secret|fingerprint-secret/);
+});
+
+test("summarizes ICE transport without retaining the full candidate line", () => {
+  const result = iceCandidateDiagnosticSummary({
+    candidate: "candidate:1 1 udp 2122260223 192.0.2.10 5000 typ host generation 0 ufrag private",
+    sdpMid: "0",
+    sdpMLineIndex: 0,
+  });
+
+  assert.equal(result, "mid=0 line=0 type=host protocol=udp address=192.0.2.10:5000");
+  assert.doesNotMatch(result, /ufrag|private/);
+});

--- a/opennow-stable/src/shared/gfn/diagnostics.ts
+++ b/opennow-stable/src/shared/gfn/diagnostics.ts
@@ -1,0 +1,84 @@
+import type { IceCandidatePayload } from "./signaling";
+
+const SENSITIVE_QUERY_KEY = /(authorization|token|credential|password|secret|cookie|code|deviceid|userid)/i;
+
+/** Keep a stable correlation key without copying the complete provider session ID into logs. */
+export function streamDiagnosticId(value: string | null | undefined): string {
+  const cleaned = value?.trim() ?? "";
+  if (!cleaned) return "-";
+  return cleaned.length <= 12
+    ? cleaned
+    : `${cleaned.slice(0, 4)}...${cleaned.slice(-6)}`;
+}
+
+/** Redact sensitive query values and shorten the session correlation value. */
+export function signalingUrlForDiagnostics(
+  raw: string | null | undefined,
+  sessionId: string,
+): string {
+  if (!raw?.trim()) return "(default signaling URL)";
+  try {
+    const url = new URL(raw);
+    for (const key of url.searchParams.keys()) {
+      const value = url.searchParams.get(key) ?? "";
+      if (SENSITIVE_QUERY_KEY.test(key)) {
+        url.searchParams.set(key, "[redacted]");
+      } else if (sessionId && value.includes(sessionId)) {
+        url.searchParams.set(key, value.replaceAll(sessionId, streamDiagnosticId(sessionId)));
+      }
+    }
+    return url.toString().replaceAll(sessionId, streamDiagnosticId(sessionId));
+  } catch {
+    return raw.replaceAll(sessionId, streamDiagnosticId(sessionId));
+  }
+}
+
+/** Summarize negotiation shape without retaining full SDP credentials or payloads. */
+export function sdpDiagnosticSummary(label: string, sdp: string): string {
+  const lines = sdp.split(/\r?\n/).filter(Boolean);
+  const media = lines.filter((line) => line.startsWith("m=")).join("|").slice(0, 180);
+  const endpoints = lines
+    .filter((line) => line.startsWith("a=candidate:"))
+    .map((line) => line.match(/^a=candidate:\S+\s+\d+\s+\S+\s+\d+\s+([^\s]+)\s+(\d+)/i))
+    .filter((match): match is RegExpMatchArray => Boolean(match))
+    .map((match) => `${match[1]}:${match[2]}`)
+    .filter((value, index, all) => all.indexOf(value) === index)
+    .slice(0, 6)
+    .join(",");
+  const codecs = lines
+    .filter((line) => line.startsWith("a=rtpmap:"))
+    .map((line) => line.slice(line.indexOf(" ") + 1).split("/")[0]?.trim())
+    .filter((codec): codec is string => Boolean(codec))
+    .filter((codec, index, all) => all.indexOf(codec) === index)
+    .slice(0, 12)
+    .join(",");
+  const candidateCount = lines.filter((line) => line.startsWith("a=candidate:")).length;
+  const hasIce = lines.some((line) => line.startsWith("a=ice-ufrag:"))
+    && lines.some((line) => line.startsWith("a=ice-pwd:"));
+  const hasFingerprint = lines.some((line) => line.startsWith("a=fingerprint:"));
+  return [
+    label,
+    `lines=${lines.length}`,
+    `media=${media || "none"}`,
+    `codecs=${codecs || "unknown"}`,
+    `candidates=${candidateCount}`,
+    `endpoints=${endpoints || "none"}`,
+    `ice=${hasIce}`,
+    `fingerprint=${hasFingerprint}`,
+  ].join(" ");
+}
+
+/** Preserve transport/type evidence while keeping noisy ICE lines out of the event log. */
+export function iceCandidateDiagnosticSummary(candidate: IceCandidatePayload): string {
+  const raw = candidate.candidate;
+  const protocol = raw.match(/\s(udp|tcp)\s/i)?.[1]?.toLowerCase() ?? "unknown";
+  const type = raw.match(/\styp\s+([a-z0-9]+)/i)?.[1]?.toLowerCase() ?? "unknown";
+  const endpoint = raw.match(/^candidate:\S+\s+\d+\s+\S+\s+\d+\s+([^\s]+)\s+(\d+)/i);
+  return [
+    `mid=${candidate.sdpMid ?? ""}`,
+    `line=${candidate.sdpMLineIndex ?? 0}`,
+    `type=${type}`,
+    `protocol=${protocol}`,
+    `address=${endpoint ? `${endpoint[1]}:${endpoint[2]}` : "unknown"}`,
+  ].join(" ");
+}

--- a/opennow-stable/src/shared/gfn/index.ts
+++ b/opennow-stable/src/shared/gfn/index.ts
@@ -24,3 +24,4 @@ export * from "./media";
 export * from "./printedWaste";
 export * from "./endpoints";
 export * from "./sdpValidation";
+export * from "./diagnostics";

--- a/opennow-stable/src/shared/logger.test.ts
+++ b/opennow-stable/src/shared/logger.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import test from "node:test";
 
-import { LogCapture } from "./logger";
+import { LogCapture, redactSensitiveData } from "./logger";
 
 type ConsoleOutputStreams = NonNullable<ConstructorParameters<typeof LogCapture>[1]>;
 
@@ -114,5 +114,52 @@ test("leaves unrelated asynchronous stream errors to existing reporters", async 
   } finally {
     capture.restoreConsole();
     console.warn = originalWarn;
+  }
+});
+
+test("exports retained diagnostic context before categorized events", () => {
+  const capture = new LogCapture("renderer", {});
+  capture.setContext("stream.latest", {
+    streamKey: "0123...6789ab",
+    phase: "streaming",
+    codec: "H265",
+  });
+  capture.addEntry("warn", "NativeStreamer", "Decoder recovery started", []);
+
+  const exported = capture.exportRedacted();
+
+  assert.match(exported, /^OpenNOW Desktop diagnostics/m);
+  assert.match(exported, /context\.stream\.latest\.streamKey=0123\.\.\.6789ab/);
+  assert.match(exported, /events\.count=1 max=5000/);
+  assert.match(exported, /WARN \[NativeStreamer\] Decoder recovery started/);
+});
+
+test("appends a bounded previous-run snapshot only to the full export", () => {
+  const capture = new LogCapture("main", {});
+  capture.setPreviousRunSnapshot({ capturedAt: 1234, text: "prior diagnostic evidence" });
+
+  assert.doesNotMatch(capture.exportCurrentRedacted(), /previousAppRun/);
+  assert.match(capture.exportRedacted(), /previousAppRun\.capturedAt=1970-01-01T00:00:01\.234Z/);
+  assert.match(capture.exportRedacted(), /prior diagnostic evidence/);
+});
+
+test("redacts unlabelled UUIDs, IPv6 addresses, credentials, and user-home paths", () => {
+  const raw = [
+    "session 01234567-89ab-4cde-8fab-0123456789ab",
+    "ipv6=2001:db8::1234",
+    "a=ice-pwd:private-credential",
+    "Bearer header.payload.signature",
+    "/Users/example/OpenNOW/native-streamer",
+  ].join("\n");
+  const redacted = redactSensitiveData(raw);
+
+  for (const sensitive of [
+    "01234567-89ab-4cde-8fab-0123456789ab",
+    "2001:db8::1234",
+    "private-credential",
+    "header.payload.signature",
+    "/Users/example",
+  ]) {
+    assert.doesNotMatch(redacted, new RegExp(sensitive.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
 });

--- a/opennow-stable/src/shared/logger.ts
+++ b/opennow-stable/src/shared/logger.ts
@@ -11,6 +11,16 @@ export interface LogEntry {
   args: unknown[];
 }
 
+export interface PreviousLogSnapshot {
+  capturedAt: number;
+  text: string;
+}
+
+interface RetainedLogContext {
+  updatedAt: number;
+  values: Record<string, unknown>;
+}
+
 interface ConsoleOutputStream {
   destroyed?: boolean;
   writable?: boolean;
@@ -36,18 +46,25 @@ const BROKEN_WRITE_ERROR_CODES = new Set([
 /** Maximum number of log entries to keep in memory */
 const MAX_LOG_ENTRIES = 5000;
 
+/** Retained state is intentionally small so frequent runtime updates stay cheap. */
+const MAX_CONTEXT_SECTIONS = 32;
+const MAX_CONTEXT_FIELDS = 64;
+const MAX_CONTEXT_VALUE_CHARACTERS = 4000;
+
 /** Patterns for sensitive data redaction */
 const SENSITIVE_PATTERNS = [
   // Email addresses
   { pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, replacement: "[Redacted for privacy]" },
   // Authorization tokens (GFNJWT, Bearer, etc.)
   { pattern: /Authorization["']?\s*[:=]\s*["']?[a-zA-Z0-9_-]+\s+[a-zA-Z0-9_-]+/gi, replacement: 'Authorization: [Redacted for privacy]' },
+  { pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, replacement: "Bearer [Redacted for privacy]" },
   // JWT tokens (three base64url parts separated by dots)
   { pattern: /[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}/g, replacement: "[Redacted for privacy]" },
   // Client tokens, access tokens
   { pattern: /client[_-]?token["']?\s*[:=]\s*["']?[a-zA-Z0-9_-]{20,}/gi, replacement: 'client_token: [Redacted for privacy]' },
   { pattern: /access[_-]?token["']?\s*[:=]\s*["']?[a-zA-Z0-9_-]{20,}/gi, replacement: 'access_token: [Redacted for privacy]' },
   { pattern: /refresh[_-]?token["']?\s*[:=]\s*["']?[a-zA-Z0-9_-]{20,}/gi, replacement: 'refresh_token: [Redacted for privacy]' },
+  { pattern: /\b(?:ice[_-]?pwd|ice[_-]?ufrag|pwd|ufrag)["']?\s*[:=]\s*["']?[^\s"',;&]+/gi, replacement: 'ice_credential: [Redacted for privacy]' },
   // Session IDs (UUID-like)
   { pattern: /session[_-]?id["']?\s*[:=]\s*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, replacement: 'session_id: [Redacted for privacy]' },
   // Passwords
@@ -59,6 +76,8 @@ const SENSITIVE_PATTERNS = [
   { pattern: /secret["']?\s*[:=]\s*["']?[^\s"']{8,}/gi, replacement: 'secret: [Redacted for privacy]' },
   // IP addresses (might be sensitive in some contexts)
   { pattern: /\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b/g, replacement: "[Redacted IP]" },
+  { pattern: /(?<![A-F0-9:])(?:[A-F0-9]{1,4}:){2,7}[A-F0-9]{1,4}(?![A-F0-9:])/gi, replacement: "[Redacted IP]" },
+  { pattern: /(?<![A-F0-9:])(?:(?:[A-F0-9]{1,4}:){1,7}:|::(?:[A-F0-9]{1,4}:){0,6})(?:[A-F0-9]{1,4})?(?![A-F0-9:])/gi, replacement: "[Redacted IP]" },
   // Device IDs, client IDs (UUID-like patterns)
   { pattern: /device[_-]?id["']?\s*[:=]\s*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, replacement: 'device_id: [Redacted for privacy]' },
   { pattern: /client[_-]?id["']?\s*[:=]\s*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, replacement: 'client_id: [Redacted for privacy]' },
@@ -68,7 +87,27 @@ const SENSITIVE_PATTERNS = [
   { pattern: /code["']?\s*[:=]\s*["']?[a-zA-Z0-9_-]{20,}/gi, replacement: 'code: [Redacted for privacy]' },
   // Peer names/IDs in signaling
   { pattern: /peer[_-]?name["']?\s*[:=]\s*["']?peer-\d+/gi, replacement: 'peer_name: [Redacted for privacy]' },
+  // UUIDs and user-home paths can appear without a descriptive key.
+  { pattern: /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi, replacement: "[Redacted ID]" },
+  { pattern: /([/\\](?:Users|home)[/\\])[^/\\\s"']+/g, replacement: "$1[Redacted]" },
 ];
+
+function serializeLogValue(value: unknown): string {
+  try {
+    const serialized = typeof value === "string"
+      ? value
+      : typeof value === "object" && value !== null
+        ? JSON.stringify(value)
+        : String(value);
+    const singleLine = serialized.replace(/\s+/g, " ").trim();
+    if (singleLine.length <= MAX_CONTEXT_VALUE_CHARACTERS) {
+      return singleLine;
+    }
+    return `${singleLine.slice(0, MAX_CONTEXT_VALUE_CHARACTERS)}... [truncated ${singleLine.length - MAX_CONTEXT_VALUE_CHARACTERS} chars]`;
+  } catch {
+    return "[Unserializable value]";
+  }
+}
 
 /**
  * Redact sensitive information from a string
@@ -153,6 +192,9 @@ function getProcessOutputStreams(): ConsoleOutputStreams {
  */
 export class LogCapture {
   private entries: LogEntry[] = [];
+  private retainedContext = new Map<string, RetainedLogContext>();
+  private previousRunSnapshot: PreviousLogSnapshot | null = null;
+  private revision = 0;
   private originalConsole: Partial<typeof console> | null = null;
   private streamErrorListeners: Array<{
     stream: ConsoleOutputStream;
@@ -179,6 +221,7 @@ export class LogCapture {
    */
   clear(): void {
     this.entries = [];
+    this.revision += 1;
   }
 
   /**
@@ -186,6 +229,41 @@ export class LogCapture {
    */
   getCount(): number {
     return this.entries.length;
+  }
+
+  getRevision(): number {
+    return this.revision;
+  }
+
+  /**
+   * Keep the latest bounded state for a diagnostic concern. Replacing rather
+   * than merging makes ownership explicit and prevents stale fields from
+   * surviving when a module changes what it reports.
+   */
+  setContext(section: string, values: Record<string, unknown>): void {
+    const normalizedSection = section.trim().replace(/[^a-zA-Z0-9_.-]+/g, "-");
+    if (!normalizedSection) {
+      return;
+    }
+
+    const boundedValues = Object.fromEntries(
+      Object.entries(values).slice(0, MAX_CONTEXT_FIELDS),
+    );
+    if (!this.retainedContext.has(normalizedSection) && this.retainedContext.size >= MAX_CONTEXT_SECTIONS) {
+      const oldestSection = this.retainedContext.keys().next().value;
+      if (typeof oldestSection === "string") {
+        this.retainedContext.delete(oldestSection);
+      }
+    }
+    this.retainedContext.set(normalizedSection, {
+      updatedAt: Date.now(),
+      values: boundedValues,
+    });
+    this.revision += 1;
+  }
+
+  setPreviousRunSnapshot(snapshot: PreviousLogSnapshot | null): void {
+    this.previousRunSnapshot = snapshot;
   }
 
   /**
@@ -201,6 +279,7 @@ export class LogCapture {
     };
 
     this.entries.push(entry);
+    this.revision += 1;
 
     // Keep log size bounded
     if (this.entries.length > MAX_LOG_ENTRIES) {
@@ -343,10 +422,46 @@ export class LogCapture {
   /**
    * Export logs as redacted text
    */
-  exportRedacted(): string {
-    const header = `OpenNOW Logs Export\nGenerated: ${new Date().toISOString()}\nSource: ${this.processName}\nTotal Entries: ${this.entries.length}\n${"=".repeat(60)}\n\n`;
-    const redactedLogs = createRedactedLogExport(this.entries);
-    return header + redactedLogs;
+  exportCurrentRedacted(entryLimit = MAX_LOG_ENTRIES): string {
+    const boundedEntryLimit = Math.max(0, Math.min(MAX_LOG_ENTRIES, Math.floor(entryLimit)));
+    const exportedEntries = boundedEntryLimit === 0 ? [] : this.entries.slice(-boundedEntryLimit);
+    const contextLines: string[] = [];
+    for (const [section, context] of [...this.retainedContext.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+      contextLines.push(`context.${section}.updatedAt=${new Date(context.updatedAt).toISOString()}`);
+      for (const [key, value] of Object.entries(context.values).sort(([left], [right]) => left.localeCompare(right))) {
+        contextLines.push(`context.${section}.${key}=${serializeLogValue(value)}`);
+      }
+    }
+
+    const header = [
+      "OpenNOW Desktop diagnostics",
+      `generatedAt=${new Date().toISOString()}`,
+      `source=${this.processName}`,
+      `context.count=${this.retainedContext.size} max=${MAX_CONTEXT_SECTIONS}`,
+      ...contextLines,
+      `events.count=${exportedEntries.length} max=${MAX_LOG_ENTRIES}`,
+      ...(exportedEntries.length < this.entries.length
+        ? [`events.omittedEarlier=${this.entries.length - exportedEntries.length}`]
+        : []),
+    ].join("\n");
+    const redactedLogs = createRedactedLogExport(exportedEntries);
+    return redactSensitiveData(`${header}\n${redactedLogs}`.trimEnd());
+  }
+
+  exportRedacted(includePreviousRun = true): string {
+    const current = this.exportCurrentRedacted();
+    if (!includePreviousRun || !this.previousRunSnapshot) {
+      return current;
+    }
+    return [
+      current,
+      "",
+      "previousAppRun.diagnostics:",
+      `previousAppRun.capturedAt=${new Date(this.previousRunSnapshot.capturedAt).toISOString()}`,
+      "----- BEGIN PREVIOUS APP RUN -----",
+      redactSensitiveData(this.previousRunSnapshot.text.trimEnd()),
+      "----- END PREVIOUS APP RUN -----",
+    ].join("\n");
   }
 
   /**
@@ -357,6 +472,20 @@ export class LogCapture {
       source: this.processName,
       generatedAt: Date.now(),
       entryCount: this.entries.length,
+      context: Object.fromEntries(
+        [...this.retainedContext.entries()].map(([section, context]) => [
+          section,
+          {
+            updatedAt: context.updatedAt,
+            values: Object.fromEntries(
+              Object.entries(context.values).map(([key, value]) => [
+                key,
+                redactSensitiveData(serializeLogValue(value)),
+              ]),
+            ),
+          },
+        ]),
+      ),
       entries: this.entries.map(entry => ({
         ...entry,
         // Redact sensitive data in messages and args
@@ -375,8 +504,14 @@ export class LogCapture {
           return arg;
         }),
       })),
+      ...(this.previousRunSnapshot ? {
+        previousAppRun: {
+          capturedAt: this.previousRunSnapshot.capturedAt,
+          text: this.previousRunSnapshot.text,
+        },
+      } : {}),
     };
-    return JSON.stringify(exportData, null, 2);
+    return redactSensitiveData(JSON.stringify(exportData, null, 2));
   }
 }
 
@@ -399,6 +534,11 @@ export function initLogCapture(processName: string): LogCapture {
  */
 export function getLogCapture(): LogCapture | null {
   return globalLogCapture;
+}
+
+/** Retain the latest diagnostic state in the current process log export. */
+export function setLogContext(section: string, values: Record<string, unknown>): void {
+  globalLogCapture?.setContext(section, values);
 }
 
 /**


### PR DESCRIPTION
## Summary
- retain Android-style app, session, renderer, and native-streamer diagnostic context
- replace raw signaling payload logs with compact SDP/ICE summaries and stronger export redaction
- persist a bounded atomic previous-run snapshot and combine main/renderer manual exports

## Validation
- npm test (643 passed)
- npm run lint
- npm run typecheck
- npm run build

Live desktop streaming and crash-recovery behavior were not device-tested in this change.