### PR TITLE
fix(qt): finish desktop Paper UI polish

### DIFF
--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -28,6 +28,16 @@ the complete OpenH264-LICENSE.txt is packaged beside this notice.
 
 https://github.com/cisco/openh264
 
+Lucide
+======
+
+The Qt desktop shell uses Lucide 1.31.0 icons, recolored to match the OpenNOW
+interface. Lucide is available under the ISC license, with icons derived from
+Feather also covered by the MIT license. The complete Lucide-LICENSE.txt is
+packaged beside this notice.
+
+https://lucide.dev/
+
 Opus
 ====
 

--- a/opennow-qt/packaging/licenses/Lucide-LICENSE.txt
+++ b/opennow-qt/packaging/licenses/Lucide-LICENSE.txt
@@ -1,0 +1,43 @@
+ISC License
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following Lucide icons are derived from the Feather project:
+
+airplay, alert-circle, alert-octagon, alert-triangle, aperture, arrow-down-circle, arrow-down-left, arrow-down-right, arrow-down, arrow-left-circle, arrow-left, arrow-right-circle, arrow-right, arrow-up-circle, arrow-up-left, arrow-up-right, arrow-up, at-sign, calendar, cast, check, chevron-down, chevron-left, chevron-right, chevron-up, chevrons-down, chevrons-left, chevrons-right, chevrons-up, circle, clipboard, clock, code, columns, command, compass, corner-down-left, corner-down-right, corner-left-down, corner-left-up, corner-right-down, corner-right-up, crosshair, database, divide-circle, divide-square, dollar-sign, download, external-link, feather, frown, hash, headphones, help-circle, info, italic, key, layout, life-buoy, link-2, link, loader, lock, log-in, log-out, maximize, meh, minimize, minimize-2, minus-circle, minus-square, minus, monitor, moon, more-horizontal, more-vertical, move, music, navigation-2, navigation, octagon, pause-circle, percent, plus-circle, plus-square, plus, power, radio, rss, search, server, share, shopping-bag, sidebar, smartphone, smile, square, table-2, tablet, target, terminal, trash-2, trash, triangle, tv, type, upload, x-circle, x-octagon, x-square, x, zoom-in, zoom-out
+
+The MIT License (MIT) (for the icons listed above)
+
+Copyright (c) 2013-present Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/opennow-qt/qml/desktop/DesktopApp.qml
+++ b/opennow-qt/qml/desktop/DesktopApp.qml
@@ -89,7 +89,7 @@ FocusScope {
             sourceComponent: root.contentForRoute(root.route)
             opacity: 1
             onLoaded: {
-                if (shell.visible && item && item.forceActiveFocus)
+                if (shell.visible && root.route !== "game-detail" && !root.commandOpen && item && item.forceActiveFocus)
                     Qt.callLater(() => item.forceActiveFocus())
             }
             Behavior on opacity { NumberAnimation { duration: DesktopTokens.quickDuration } }
@@ -101,6 +101,7 @@ FocusScope {
         visible: root.sessionStartingVisible
         focus: visible
         z: 80
+        onVisibleChanged: if (visible) forceActiveFocus()
         onCancelRequested: ShellStore.stopStreamingSession()
     }
 
@@ -161,14 +162,18 @@ FocusScope {
         function onRouteChanged() {
             root.commandOpen = false
             root.searchText = ""
+            if (root.route !== "game-detail" && shell.visible && pageLoader.item)
+                Qt.callLater(() => pageLoader.item.forceActiveFocus())
         }
     }
     onSignInVisibleChanged: Qt.callLater(() => {
         if (root.signInVisible)
             desktopSignIn.forceActiveFocus()
-        else if (pageLoader.item)
+        else if (shell.visible && pageLoader.item)
             pageLoader.item.forceActiveFocus()
     })
+    onCommandOpenChanged: if (!commandOpen && shell.visible && pageLoader.item)
+        Qt.callLater(() => pageLoader.item.forceActiveFocus())
     Component.onCompleted: Qt.callLater(() => {
         if (root.signInVisible)
             desktopSignIn.forceActiveFocus()

--- a/opennow-qt/qml/desktop/DesktopButton.qml
+++ b/opennow-qt/qml/desktop/DesktopButton.qml
@@ -11,6 +11,7 @@ Button {
     property int glyphSize: 16
     property int cornerRadius: 10
     height: 36
+    implicitWidth: Math.max(68, contentRow.implicitWidth + leftPadding + rightPadding)
     leftPadding: 14
     rightPadding: 14
     focusPolicy: Qt.StrongFocus
@@ -38,7 +39,10 @@ Button {
         }
     }
     contentItem: Item {
+        implicitWidth: contentRow.implicitWidth
+        implicitHeight: contentRow.implicitHeight
         Row {
+            id: contentRow
             anchors.centerIn: parent
             spacing: root.glyph !== "" ? 11 : 8
             DesktopGlyph {

--- a/opennow-qt/qml/desktop/DesktopCommandPalette.qml
+++ b/opennow-qt/qml/desktop/DesktopCommandPalette.qml
@@ -8,6 +8,7 @@ FocusScope {
     signal closeRequested()
     signal routeRequested(string route)
     anchors.fill: parent
+    onVisibleChanged: if (visible) field.forceActiveFocus()
 
     readonly property var actions: [
         { icon: "desktop-nav-home.svg", name: qsTr("Go to Home"), detail: qsTr("Open your desktop"), route: "home", key: "1" },
@@ -47,7 +48,6 @@ FocusScope {
                 font.weight: Font.DemiBold
                 background: Item {}
                 onTextChanged: root.query = text
-                Component.onCompleted: forceActiveFocus()
             }
             Rectangle {
                 anchors.right: parent.right; anchors.rightMargin: 18; anchors.verticalCenter: parent.verticalCenter

--- a/opennow-qt/qml/desktop/DesktopGameModal.qml
+++ b/opennow-qt/qml/desktop/DesktopGameModal.qml
@@ -8,6 +8,7 @@ FocusScope {
     signal closeRequested()
     signal playRequested()
     focus: visible
+    onVisibleChanged: if (visible) Qt.callLater(() => primaryAction.forceActiveFocus())
 
     readonly property int gutter: DesktopTokens.px(32)
     readonly property int dialogWidth: Math.min(DesktopTokens.px(896), Math.max(DesktopTokens.px(640), parent.width - gutter * 2))
@@ -338,6 +339,7 @@ FocusScope {
             anchors.topMargin: DesktopTokens.px(18)
             spacing: DesktopTokens.px(10)
             DesktopButton {
+                id: primaryAction
                 width: DesktopTokens.px(156)
                 height: DesktopTokens.px(40)
                 primary: true
@@ -345,7 +347,6 @@ FocusScope {
                 glyphSize: DesktopTokens.px(12)
                 text: root.hasPlayed ? qsTr("Resume") : qsTr("Play")
                 shortcutText: qsTr("ENTER")
-                Component.onCompleted: forceActiveFocus()
                 onClicked: root.playRequested()
             }
             DesktopButton {

--- a/opennow-qt/qml/desktop/DesktopHomeScreen.qml
+++ b/opennow-qt/qml/desktop/DesktopHomeScreen.qml
@@ -524,7 +524,8 @@ FocusScope {
     Component.onCompleted: {
         root.focusZone = 0
         root.focusIndex = Math.max(0, Math.min(5, ShellStore.focusIndex("desktop-home")))
-        Qt.callLater(root.forceActiveFocus)
+        if (root.active)
+            Qt.callLater(root.forceActiveFocus)
     }
     onFocusIndexChanged: ShellStore.rememberFocus("desktop-home", focusIndex)
 }

--- a/opennow-qt/qml/desktop/DesktopLibraryScreen.qml
+++ b/opennow-qt/qml/desktop/DesktopLibraryScreen.qml
@@ -144,9 +144,11 @@ FocusScope {
         }
     }
     Text {
+        id: libraryHint
         anchors.right: parent.right
         anchors.rightMargin: 24
         anchors.verticalCenter: filterRow.verticalCenter
+        visible: root.width - 24 - libraryHint.implicitWidth > 40 + filterRow.width
         text: qsTr("RIGHT-CLICK A GAME FOR ACTIONS")
         color: DesktopTokens.textFaint
         font.family: DesktopTokens.monoFont

--- a/opennow-qt/qml/desktop/DesktopSettingsDropdown.qml
+++ b/opennow-qt/qml/desktop/DesktopSettingsDropdown.qml
@@ -49,8 +49,13 @@ Item {
     }
 
     function dismiss() {
+        const wasOpen = root.opened
         opened = false
         closeTimer.restart()
+        if (wasOpen && anchorItem) {
+            const anchor = anchorItem
+            Qt.callLater(() => { if (anchor) anchor.forceActiveFocus() })
+        }
     }
 
     Timer {
@@ -88,7 +93,6 @@ Item {
             contentHeight: Math.max(choiceColumn.implicitHeight, root.menuContentHeight)
             clip: true
             boundsBehavior: Flickable.StopAtBounds
-            focus: true
             Keys.onEscapePressed: event => { root.dismiss(); event.accepted = true }
 
             Column {

--- a/opennow-qt/qml/desktop/DesktopSettingsRow.qml
+++ b/opennow-qt/qml/desktop/DesktopSettingsRow.qml
@@ -9,12 +9,48 @@ Item {
     property string value: ""
     property int rowHeight: DesktopTokens.rowHeight
     property bool showDivider: true
+    property string leadingLetter: ""
+    property url leadingIcon: ""
+    property color leadingColor: Qt.rgba(1, 1, 1, 0.06)
+    readonly property bool hasLeading: leadingLetter !== "" || leadingIcon.toString() !== ""
     default property alias trailing: trailingSlot.data
 
     implicitHeight: rowHeight
 
+    Rectangle {
+        id: leadingTile
+        visible: root.hasLeading
+        x: 0
+        anchors.verticalCenter: parent.verticalCenter
+        width: 36
+        height: 36
+        radius: 10
+        color: root.leadingColor
+        border.width: 1
+        border.color: Qt.rgba(1, 1, 1, 0.14)
+        Image {
+            anchors.centerIn: parent
+            width: 19
+            height: 19
+            source: root.leadingIcon
+            sourceSize: Qt.size(width, height)
+            fillMode: Image.PreserveAspectFit
+            visible: root.leadingIcon.toString() !== ""
+        }
+        Text {
+            anchors.centerIn: parent
+            text: root.leadingLetter
+            visible: root.leadingIcon.toString() === ""
+            color: Theme.label
+            font.family: DesktopTokens.bodyFont
+            font.pixelSize: 16
+            font.weight: Font.Black
+        }
+    }
+
     Column {
         anchors.left: parent.left
+        anchors.leftMargin: root.hasLeading ? 50 : 0
         anchors.right: trailingSlot.left
         anchors.rightMargin: 20
         anchors.verticalCenter: parent.verticalCenter

--- a/opennow-qt/qml/desktop/DesktopSettingsScreen.qml
+++ b/opennow-qt/qml/desktop/DesktopSettingsScreen.qml
@@ -181,14 +181,14 @@ FocusScope {
 
     function themeMeta(id) {
         const packs = {
-            aurora: { name: qsTr("Aurora"), blurb: qsTr("Cool teal shell with a mint focus ring.") },
-            nocturne: { name: qsTr("Carbon"), blurb: qsTr("Near-black nocturne shell with a sky focus ring.") },
-            kraft: { name: qsTr("Kraft"), blurb: qsTr("Warm brown shell with a brass focus ring.") },
-            phosphor: { name: qsTr("Mint"), blurb: qsTr("Deep green shell with a phosphor focus ring.") },
-            hibiscus: { name: qsTr("Sunset"), blurb: qsTr("Wine shell with a rose focus ring.") },
-            chapel: { name: qsTr("Chapel"), blurb: qsTr("Violet night shell with a gold focus ring.") },
-            bone: { name: qsTr("Bone"), blurb: qsTr("Light paper shell for daytime use.") },
-            cobalt: { name: qsTr("Cobalt"), blurb: qsTr("Light blue-white shell with a cobalt focus ring.") }
+            aurora: { name: qsTr("Aurora"), blurb: qsTr("Cool teal shell with a mint focus ring."), accent: "#56E6A5" },
+            nocturne: { name: qsTr("Nocturne"), blurb: qsTr("Near-black nocturne shell with a sky focus ring."), accent: "#7FD4FF" },
+            kraft: { name: qsTr("Kraft"), blurb: qsTr("Warm brown shell with a brass focus ring."), accent: "#C6A46A" },
+            phosphor: { name: qsTr("Mint"), blurb: qsTr("Deep green shell with a phosphor focus ring."), accent: "#56E6A5" },
+            hibiscus: { name: qsTr("Sunset"), blurb: qsTr("Wine shell with a rose focus ring."), accent: "#FF8A80" },
+            chapel: { name: qsTr("Chapel"), blurb: qsTr("Violet night shell with a gold focus ring."), accent: "#FFD166" },
+            bone: { name: qsTr("Bone"), blurb: qsTr("Light paper shell for daytime use."), accent: "#C6A46A" },
+            cobalt: { name: qsTr("Cobalt"), blurb: qsTr("Light blue-white shell with a cobalt focus ring."), accent: "#7FD4FF" }
         }
         return packs[id] || { name: String(id || qsTr("Theme")), blurb: qsTr("Installed theme pack.") }
     }
@@ -219,6 +219,32 @@ FocusScope {
         if (chips.length === 0)
             chips.push(String(sub.membershipTier || qsTr("Free")).toUpperCase())
         return chips
+    }
+
+    function storeLetter(account) {
+        const provider = String(account.provider || account.label || "").trim()
+        return provider ? provider.charAt(0).toUpperCase() : ""
+    }
+
+    function storeIcon(account) {
+        const provider = String(account.provider || account.label || "").toLowerCase()
+        const base = "qrc:/qt/qml/OpenNOW/res/icons/"
+        if (provider.indexOf("steam") >= 0) return base + "store-steam.svg"
+        if (provider.indexOf("epic") >= 0) return base + "store-epic.svg"
+        if (provider.indexOf("ubisoft") >= 0 || provider.indexOf("uplay") >= 0) return base + "store-ubisoft.svg"
+        if (provider.indexOf("battle") >= 0) return base + "store-battlenet.svg"
+        return base + "desktop-nav-store.svg"
+    }
+
+    function storeAccent(account) {
+        const provider = String(account.provider || account.label || "").toLowerCase()
+        if (provider.indexOf("steam") >= 0) return Theme.cartSteam
+        if (provider.indexOf("epic") >= 0) return Theme.cartEpic
+        if (provider.indexOf("ubisoft") >= 0 || provider.indexOf("uplay") >= 0) return Theme.cartUbisoft
+        if (provider.indexOf("xbox") >= 0) return Theme.cartXbox
+        if (provider.indexOf("gog") >= 0) return Theme.cartGog
+        if (provider.indexOf("battle") >= 0) return Theme.cartBattlenet
+        return Qt.rgba(1, 1, 1, 0.08)
     }
 
     function storeStatus(account) {
@@ -574,6 +600,9 @@ FocusScope {
                         readonly property var status: root.storeStatus(modelData)
                         width: parent.width
                         rowHeight: 62
+                        leadingLetter: root.storeLetter(modelData)
+                        leadingIcon: root.storeIcon(modelData)
+                        leadingColor: root.storeAccent(modelData)
                         title: modelData.label || modelData.provider
                         description: root.storeDescription(modelData)
                         showDivider: index < (ShellStore.gameAccounts || []).length - 1
@@ -698,7 +727,7 @@ FocusScope {
                 }
                 Repeater { model: [{name:"Xbox Wireless Controller",desc:"Player 1 · Bluetooth · battery 74% · firmware 5.17",glyph:"XBOX GLYPHS",state:"● ACTIVE",active:true},{name:"DualSense Edge",desc:"Player 2 · USB-C · idle for 12 minutes",glyph:"PS GLYPHS"}]
                     delegate: Rectangle { required property var modelData; width: parent.width; height: 62; radius: 11; color: modelData.active ? Qt.rgba(0.25,0.38,0.68,0.15) : Qt.rgba(1,1,1,0.025); border.width: 1; border.color: modelData.active ? Qt.rgba(0.35,0.56,0.95,0.28) : Qt.rgba(1,1,1,0.08)
-                        Rectangle { x: 14; anchors.verticalCenter: parent.verticalCenter; width: 34; height: 34; radius: 9; color: Qt.rgba(1,1,1,0.07); Text { anchors.centerIn: parent; text: "◉"; color: Theme.textMuted; font.pixelSize: 15 } }
+                        Rectangle { x: 14; anchors.verticalCenter: parent.verticalCenter; width: 34; height: 34; radius: 9; color: Qt.rgba(1,1,1,0.07); DesktopGlyph { anchors.centerIn: parent; width: 20; height: 14; icon: "desktop-gamepad.svg" } }
                         Column { x: 62; anchors.verticalCenter: parent.verticalCenter; spacing: 2; Text { text: modelData.name; color: modelData.active ? Theme.label : Theme.textMuted; font.family: Theme.bodyFont; font.pixelSize: 14; font.weight: Font.Bold } Text { text: modelData.desc; color: Theme.textMuted; font.family: Theme.bodyFont; font.pixelSize: 11 } }
                         Row { anchors.right: parent.right; anchors.rightMargin: 14; anchors.verticalCenter: parent.verticalCenter; spacing: 8
                             Text { text: modelData.glyph; color: Theme.textMuted; font.family: Theme.monoFont; font.pixelSize: 9; font.weight: Font.Bold; anchors.verticalCenter: parent.verticalCenter }
@@ -778,7 +807,7 @@ FocusScope {
         id: interfacePage
         Column {
             id: interfacePageRoot
-            width: contentFlick.width; spacing: 14
+            width: contentFlick.width; spacing: 10
             property bool startAtLogin: false
             property string openOn: "HOME"
             property bool keepInTray: true
@@ -789,44 +818,44 @@ FocusScope {
             property bool notifyFriends: false
             property bool notifyBuilds: true
             DesktopSettingsPanel {
-                width: parent.width; padding: 18
-                DesktopSettingsRow { width: parent.width; rowHeight: 62; title: "Start OpenNOW when I log in"; description: "Starts minimized in the tray, ready in about a second"
+                width: parent.width; padding: 16
+                DesktopSettingsRow { width: parent.width; rowHeight: 52; title: "Start OpenNOW when I log in"; description: "Starts minimized in the tray, ready in about a second"
                     DesktopSettingsToggle { checked: interfacePageRoot.startAtLogin; onValueChangedByUser: value => interfacePageRoot.startAtLogin = value }
                 }
-                DesktopSettingsRow { width: parent.width; rowHeight: 62; title: "Open on"; description: "Where the window lands after launch"
+                DesktopSettingsRow { width: parent.width; rowHeight: 52; title: "Open on"; description: "Where the window lands after launch"
                     DesktopSettingsSegmented { options: ["HOME","LIBRARY","LAST PAGE"]; optionWidth: 72; selectedIndex: ["HOME","LIBRARY","LAST PAGE"].indexOf(interfacePageRoot.openOn); onSelected: (index,value) => interfacePageRoot.openOn = value }
                 }
-                DesktopSettingsRow { width: parent.width; rowHeight: 62; title: "Closing the window keeps OpenNOW in the tray"; description: "A running session is never killed by closing the window"
+                DesktopSettingsRow { width: parent.width; rowHeight: 52; title: "Closing the window keeps OpenNOW in the tray"; description: "A running session is never killed by closing the window"
                     DesktopSettingsToggle { checked: interfacePageRoot.keepInTray; onValueChangedByUser: value => interfacePageRoot.keepInTray = value }
                 }
-                DesktopSettingsRow { width: parent.width; rowHeight: 62; title: "Language"; description: "Community translated through Crowdin · 14 languages"; showDivider: false
+                DesktopSettingsRow { width: parent.width; rowHeight: 52; title: "Language"; description: "Community translated through Crowdin · 14 languages"; showDivider: false
                     DesktopSettingsButton { id: languageButton; text: String(root.valueSetting("appLanguage", "en")).toLowerCase() === "en" ? "ENGLISH (UK)" : String(root.valueSetting("appLanguage", "system")).toUpperCase(); compact: true; onClicked: root.openChoices(languageButton, "appLanguage", root.choices([{kind:"choice",label:"System",value:"system"},{kind:"choice",label:"English (UK)",value:"en"},{kind:"choice",label:"Nederlands",value:"nl"},{kind:"choice",label:"Deutsch",value:"de"},{kind:"choice",label:"Français",value:"fr"},{kind:"choice",label:"Türkçe",value:"tr"}])) }
                 }
             }
             DesktopSettingsPanel {
-                width: parent.width; padding: 18
-                DesktopSettingsRow { width: parent.width; rowHeight: 62; title: "Sidebar"; description: "Collapsed shows icons only and expands on hover · Ctrl B toggles"
+                width: parent.width; padding: 16
+                DesktopSettingsRow { width: parent.width; rowHeight: 52; title: "Sidebar"; description: "Collapsed shows icons only and expands on hover · Ctrl B toggles"
                     DesktopSettingsSegmented { options: ["EXPANDED","COLLAPSED","REMEMBER"]; optionWidth: 83; selectedIndex: ["EXPANDED","COLLAPSED","REMEMBER"].indexOf(interfacePageRoot.sidebarMode); onSelected: (index,value) => interfacePageRoot.sidebarMode = value }
                 }
-                DesktopSettingsRow { width: parent.width; rowHeight: 62; title: "Grid density"; description: "Cover size in Library and Store"
+                DesktopSettingsRow { width: parent.width; rowHeight: 52; title: "Grid density"; description: "Cover size in Library and Store"
                     DesktopSettingsSegmented { options: ["DENSE","COMFORTABLE","LARGE"]; optionWidth: 74; selectedIndex: ["DENSE","COMFORTABLE","LARGE"].indexOf(interfacePageRoot.density); onSelected: (index,value) => { interfacePageRoot.density = value; root.setSetting("posterSizeScale", value === "DENSE" ? 0.9 : value === "LARGE" ? 1.25 : 1.05) } }
                 }
-                DesktopSettingsRow { width: parent.width; rowHeight: 62; title: "Reduce motion"; description: "Cuts parallax and cover animations · follows your OS by default"
+                DesktopSettingsRow { width: parent.width; rowHeight: 52; title: "Reduce motion"; description: "Cuts parallax and cover animations · follows your OS by default"
                     DesktopSettingsToggle { checked: root.boolSetting("reducedMotion", false); onValueChangedByUser: value => root.setSetting("reducedMotion", value) }
                 }
-                DesktopSettingsRow { width: parent.width; rowHeight: 62; title: "Hardware acceleration"; description: "Needs a restart · turn off only if the shell flickers"; showDivider: false
+                DesktopSettingsRow { width: parent.width; rowHeight: 52; title: "Hardware acceleration"; description: "Needs a restart · turn off only if the shell flickers"; showDivider: false
                     DesktopSettingsToggle { checked: interfacePageRoot.hardwareAcceleration; onValueChangedByUser: value => interfacePageRoot.hardwareAcceleration = value }
                 }
             }
             DesktopSettingsPanel {
-                width: parent.width; padding: 18
-                DesktopSettingsRow { width: parent.width; rowHeight: 56; title: "Tell me when a queued session is ready"
+                width: parent.width; padding: 16
+                DesktopSettingsRow { width: parent.width; rowHeight: 48; title: "Tell me when a queued session is ready"
                     DesktopSettingsToggle { checked: interfacePageRoot.notifyQueue; onValueChangedByUser: value => interfacePageRoot.notifyQueue = value }
                 }
-                DesktopSettingsRow { width: parent.width; rowHeight: 56; title: "Tell me when a friend starts playing"
+                DesktopSettingsRow { width: parent.width; rowHeight: 48; title: "Tell me when a friend starts playing"
                     DesktopSettingsToggle { checked: interfacePageRoot.notifyFriends; onValueChangedByUser: value => interfacePageRoot.notifyFriends = value }
                 }
-                DesktopSettingsRow { width: parent.width; rowHeight: 56; title: "Tell me when a new OpenNOW build lands"; showDivider: false
+                DesktopSettingsRow { width: parent.width; rowHeight: 48; title: "Tell me when a new OpenNOW build lands"; showDivider: false
                     DesktopSettingsToggle { checked: interfacePageRoot.notifyBuilds; onValueChangedByUser: value => interfacePageRoot.notifyBuilds = value }
                 }
             }
@@ -836,16 +865,18 @@ FocusScope {
     Component {
         id: themesPage
         Column {
+            id: themesPageRoot
             width: contentFlick.width; spacing: 14
+            readonly property var activeTheme: root.themeMeta(String(ShellStore.settings.themePack || "nocturne"))
             DesktopSettingsPanel {
                 width: parent.width; padding: 18
                 Row {
                     width: parent.width
                     height: 114
                     spacing: 18
-                    Rectangle { width: 212; height: 100; radius: 12; color: Theme.shell; border.width: 1; border.color: DesktopTokens.focus
+                    Rectangle { width: 212; height: 100; radius: 12; color: Theme.shell; border.width: 1; border.color: themesPageRoot.activeTheme.accent
                         Row { x: 50; y: 34; spacing: 7
-                            Repeater { model: [Theme.focus, Theme.violet, Theme.mint]; delegate: Rectangle { required property var modelData; width: 44; height: 56; radius: 6; color: modelData } }
+                            Repeater { model: [themesPageRoot.activeTheme.accent, Qt.darker(themesPageRoot.activeTheme.accent, 1.35), Qt.lighter(themesPageRoot.activeTheme.accent, 1.4)]; delegate: Rectangle { required property var modelData; width: 44; height: 56; radius: 6; color: modelData } }
                         }
                     }
                     Column {
@@ -869,12 +900,28 @@ FocusScope {
                     DesktopSettingsButton { width: 126; text: "Open theme store"; compact: true; onClicked: AppController.navigate("theme-store") }
                 }
                 Row { width: parent.width; height: 124; spacing: 10
-                    Repeater { model: [{n:"Aurora",c:"#3D315C",s:"IN USE",id:"aurora"},{n:"Carbon",c:"#222329",s:"USE",id:"nocturne"},{n:"Sunset",c:"#6A3939",s:"UPDATE",id:"hibiscus"},{n:"Mint",c:"#164B3C",s:"USE",id:"phosphor"},{n:"+\nNew theme",c:"transparent",s:"FROM CURRENT",id:""}]
-                        delegate: Button { required property var modelData; width: (parent.width - 40) / 5; height: 116; hoverEnabled: true; onClicked: { if (modelData.id !== "") root.setSetting("themePack", modelData.id) }
-                            background: Rectangle { radius: 11; color: Qt.rgba(1,1,1,0.025); border.width: 1; border.color: modelData.id === String(root.valueSetting("themePack","aurora")) ? DesktopTokens.focus : Qt.rgba(1,1,1,0.13) }
-                            contentItem: Item { Rectangle { visible: modelData.id !== ""; x: 8; y: 8; width: parent.width - 16; height: 76; radius: 7; color: modelData.c; gradient: Gradient { GradientStop { position: 0; color: Qt.lighter(modelData.c,1.25) } GradientStop { position: 1; color: Qt.darker(modelData.c,1.2) } } }
+                    Repeater { model: [{n:"Aurora",c:"#3D315C",a:"#56E6A5",s:"USE",id:"aurora"},{n:"Nocturne",c:"#222329",a:"#7FD4FF",s:"USE",id:"nocturne"},{n:"Sunset",c:"#6A3939",a:"#FF8A80",s:"UPDATE",id:"hibiscus"},{n:"Mint",c:"#164B3C",a:"#56E6A5",s:"USE",id:"phosphor"},{n:"+\nNew theme",c:"transparent",a:"#FFFFFF",s:"FROM CURRENT",id:""}]
+                        delegate: Button { id: themeCard; required property var modelData; readonly property bool inUse: modelData.id !== "" && modelData.id === String(root.valueSetting("themePack","nocturne")); width: (parent.width - 40) / 5; height: 116; hoverEnabled: true; onClicked: { if (modelData.id !== "") root.setSetting("themePack", modelData.id) }
+                            background: Rectangle { radius: 11; color: Qt.rgba(1,1,1,0.025); border.width: 1; border.color: themeCard.inUse ? DesktopTokens.focus : Qt.rgba(1,1,1,0.13) }
+                            contentItem: Item {
+                                Rectangle { id: swatch; visible: modelData.id !== ""; x: 8; y: 8; width: parent.width - 16; height: 76; radius: 7; color: modelData.c; gradient: Gradient { GradientStop { position: 0; color: Qt.lighter(modelData.c,1.25) } GradientStop { position: 1; color: Qt.darker(modelData.c,1.2) } }
+                                    Rectangle { x: 3; y: 3; width: 17; height: 70; radius: 5; color: Qt.darker(modelData.c, 1.6)
+                                        Column { x: 5; y: 8; spacing: 6
+                                            Repeater { model: 3; delegate: Rectangle { required property int index; width: 7; height: 2; radius: 1; color: index === 0 ? themeCard.modelData.a : Qt.rgba(1,1,1,0.4) } }
+                                        }
+                                    }
+                                    Rectangle { x: 24; y: 3; width: swatch.width - 27; height: 32; radius: 4; color: Qt.rgba(1,1,1,0.12)
+                                        Rectangle { x: 5; y: 13; width: 22; height: 3; radius: 1.5; color: modelData.a }
+                                        Rectangle { x: 5; y: 19; width: 14; height: 2; radius: 1; color: Qt.rgba(1,1,1,0.35) }
+                                    }
+                                    Rectangle { x: 24; y: 39; width: swatch.width - 27; height: 34; radius: 4; color: Qt.rgba(0,0,0,0.2)
+                                        Column { x: 5; y: 6; spacing: 6
+                                            Repeater { model: 3; delegate: Rectangle { width: swatch.width - 40; height: 4; radius: 2; color: Qt.rgba(1,1,1,0.14) } }
+                                        }
+                                    }
+                                }
                                 Text { anchors.left: parent.left; anchors.leftMargin: 10; anchors.bottom: parent.bottom; anchors.bottomMargin: 8; width: parent.width - 20; text: modelData.n; color: Theme.label; font.family: Theme.bodyFont; font.pixelSize: 12; font.weight: Font.Bold; horizontalAlignment: modelData.id === "" ? Text.AlignHCenter : Text.AlignLeft }
-                                Text { visible: modelData.id !== ""; anchors.right: parent.right; anchors.rightMargin: 10; anchors.bottom: parent.bottom; anchors.bottomMargin: 9; text: modelData.s; color: modelData.s === "UPDATE" ? Theme.yellow : modelData.s === "IN USE" ? DesktopTokens.focus : Theme.textMuted; font.family: Theme.monoFont; font.pixelSize: 7; font.weight: Font.Bold }
+                                Text { visible: modelData.id !== ""; anchors.right: parent.right; anchors.rightMargin: 10; anchors.bottom: parent.bottom; anchors.bottomMargin: 9; text: themeCard.inUse ? qsTr("IN USE") : modelData.s; color: themeCard.inUse ? DesktopTokens.focus : modelData.s === "UPDATE" ? Theme.yellow : Theme.textMuted; font.family: Theme.monoFont; font.pixelSize: 7; font.weight: Font.Bold }
                             }
                         }
                     }
@@ -898,16 +945,30 @@ FocusScope {
             property string uiScale: "COUCH"
             DesktopSettingsPanel {
                 width: parent.width; padding: 18
-                Row { width: parent.width; height: 120; spacing: 18
-                    Rectangle { width: 212; height: 120; radius: 12; color: Theme.shell; border.width: 1; border.color: Qt.rgba(0.6,0.5,1,0.25)
-                        Row { x: 12; y: 34; spacing: 7; Repeater { model: [Theme.focus, Theme.violet, Theme.mint]; delegate: Rectangle { required property var modelData; width: 50; height: 56; radius: 7; color: modelData } }
+                Item { width: parent.width; height: Math.max(120, consoleCopy.implicitHeight + 48)
+                    Rectangle { id: consolePreview
+                        x: 0; y: (parent.height - height) / 2
+                        width: Math.min(212, Math.max(160, parent.width * 0.26)); height: 120
+                        radius: 12; color: Theme.shell; border.width: 1; border.color: Qt.rgba(0.6,0.5,1,0.25)
+                        Row { x: (parent.width - 164) / 2; y: 34; spacing: 7; Repeater { model: [Theme.focus, Theme.violet, Theme.mint]; delegate: Rectangle { required property var modelData; width: 50; height: 56; radius: 7; color: modelData } } }
                         Text { x: 12; y: 96; text: "A  PLAY   B  BACK"; color: Theme.textMuted; font.family: Theme.monoFont; font.pixelSize: 7; font.weight: Font.Bold }
                     }
-                    Column { width: parent.width - 212 - 158 - 36; anchors.verticalCenter: parent.verticalCenter; spacing: 9
+                    Column {
+                        id: consoleCopy
+                        anchors.left: consolePreview.right
+                        anchors.leftMargin: 18
+                        anchors.right: consoleActions.left
+                        anchors.rightMargin: 18
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: 9
                         Row { spacing: 10; Text { text: qsTr("One app, two shells"); color: Theme.label; font.family: Theme.displayFont; font.pixelSize: 20; font.weight: Font.Black } Text { text: qsTr("GAMEPAD READY"); color: DesktopTokens.green; font.family: Theme.monoFont; font.pixelSize: 9; font.weight: Font.Bold; anchors.verticalCenter: parent.verticalCenter } }
                         Text { width: parent.width; wrapMode: Text.WordWrap; text: qsTr("Console mode swaps the desktop chrome for big art, focus rings and glyph hints. Same session, same settings, same themes — nothing restarts and a running stream keeps going."); color: Theme.textMuted; font.family: Theme.bodyFont; font.pixelSize: 11; lineHeight: 1.45 }
                     }
-                    Column { width: 158; anchors.verticalCenter: parent.verticalCenter; spacing: 8
+                    Column {
+                        id: consoleActions
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 158; spacing: 8
                         DesktopSettingsButton { width: 158; text: qsTr("Switch now"); suffix: "F10"; primary: true; onClicked: root.requestConsoleMode(true) }
                         DesktopSettingsButton { width: 158; text: qsTr("Preview on this screen"); onClicked: root.requestConsoleMode(true) }
                     }
@@ -947,7 +1008,6 @@ FocusScope {
                 }
             }
         }
-    }
     }
 
     Component {

--- a/opennow-qt/qml/desktop/DesktopShell.qml
+++ b/opennow-qt/qml/desktop/DesktopShell.qml
@@ -115,10 +115,8 @@ FocusScope {
         width: root.width - root.contentInset
         height: root.height
         z: 20
-        color: "#99060912"
-        opacity: sidebar.overlayOpen ? 1 : 0
-        visible: opacity > 0
-        Behavior on opacity { NumberAnimation { duration: DesktopTokens.motionDuration; easing.type: Easing.OutCubic } }
+        color: "transparent"
+        visible: sidebar.overlayOpen
         TapHandler { onTapped: sidebar.closeOverlay() }
     }
 

--- a/opennow-qt/qml/desktop/DesktopSidebar.qml
+++ b/opennow-qt/qml/desktop/DesktopSidebar.qml
@@ -325,9 +325,9 @@ FocusScope {
                         }
                         Rectangle {
                             anchors.right: parent.right
-                            anchors.rightMargin: root.compact ? (parent.width - 4) / 2 : 10
+                            anchors.rightMargin: 10
                             anchors.verticalCenter: parent.verticalCenter
-                            visible: navButton.selected
+                            visible: navButton.selected && !root.compact
                             width: 4
                             height: 16
                             radius: 999

--- a/opennow-qt/qml/desktop/DesktopSignInScreen.qml
+++ b/opennow-qt/qml/desktop/DesktopSignInScreen.qml
@@ -238,7 +238,7 @@ FocusScope {
                                 }
                             }
                         }
-                        Component.onCompleted: forceActiveFocus()
+                        Component.onCompleted: if (root.visible) forceActiveFocus()
                         onClicked: root.providerOpen = !root.providerOpen
                     }
                     Text {

--- a/opennow-qt/qml/desktop/DesktopStoreChip.qml
+++ b/opennow-qt/qml/desktop/DesktopStoreChip.qml
@@ -48,15 +48,12 @@ Button {
             font.weight: root.selected ? Font.ExtraBold : Font.DemiBold
         }
 
-        Text {
+        DesktopGlyph {
             anchors.verticalCenter: parent.verticalCenter
             visible: root.hasMenu
-            text: "⌄"
-            color: Qt.rgba(1, 1, 1, 0.54)
-            font.family: Theme.bodyFont
-            font.pixelSize: 13
-            font.weight: Font.Bold
-            y: -1
+            width: 10
+            height: 6
+            icon: "desktop-chevron-down.svg"
         }
     }
 }

--- a/opennow-qt/qml/desktop/DesktopStoreHero.qml
+++ b/opennow-qt/qml/desktop/DesktopStoreHero.qml
@@ -16,6 +16,9 @@ Item {
     width: 1160
     height: 224
 
+    readonly property int artCardCount: Math.max(0, Math.min(root.games.length, 4, Math.floor((root.width - 420) / 130)))
+    readonly property int artRowWidth: root.artCardCount * 130 - 12
+
     Rectangle {
         id: heroMask
         anchors.fill: parent
@@ -66,7 +69,7 @@ Item {
     Column {
         x: 22
         y: 22
-        width: 530
+        width: Math.min(530, Math.max(300, root.width - root.artRowWidth - 60))
         spacing: 12
 
         Row {
@@ -114,7 +117,7 @@ Item {
         }
 
         Text {
-            width: 440
+            width: parent.width
             text: qsTr("Claimed games stay in your library and stream instantly — no download, no install. Linked Steam, Epic and GOG purchases show up here too.")
             color: Qt.rgba(1, 1, 1, 0.72)
             font.family: Theme.bodyFont
@@ -190,12 +193,13 @@ Item {
     }
 
     Row {
-        x: 629
+        anchors.right: parent.right
+        anchors.rightMargin: 22
         y: 23
         spacing: 12
 
         Repeater {
-            model: Math.min(4, root.games.length)
+            model: root.artCardCount
 
             Item {
                 required property int index

--- a/opennow-qt/res/icons/desktop-check-focus.svg
+++ b/opennow-qt/res/icons/desktop-check-focus.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none">
-  <path d="M2 6.2L4.6 8.6L10 3.2" stroke="#7FD4FF" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-check"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#7FD4FF"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 6 9 17l-5-5" />
 </svg>

--- a/opennow-qt/res/icons/desktop-check-light.svg
+++ b/opennow-qt/res/icons/desktop-check-light.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 8" fill="none">
-  <path d="M1 4.1l2.6 2.6L9 1.3" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-check"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 6 9 17l-5-5" />
 </svg>

--- a/opennow-qt/res/icons/desktop-check-mint.svg
+++ b/opennow-qt/res/icons/desktop-check-mint.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <path d="M3 7.4L5.8 10L11 3.8" stroke="#6EE7B7" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-check"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#6EE7B7"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 6 9 17l-5-5" />
 </svg>

--- a/opennow-qt/res/icons/desktop-check.svg
+++ b/opennow-qt/res/icons/desktop-check.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 8" fill="none">
-  <path d="M1 4.1l2.6 2.6L9 1.3" stroke="#0A0D14" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-check"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#0A0D14"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 6 9 17l-5-5" />
 </svg>

--- a/opennow-qt/res/icons/desktop-chevron-down.svg
+++ b/opennow-qt/res/icons/desktop-chevron-down.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6" fill="none">
-  <path d="M1.2 1.2L5 4.8L8.8 1.2" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.5" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-chevron-down"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.541"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m6 9 6 6 6-6" />
 </svg>

--- a/opennow-qt/res/icons/desktop-chevron-up.svg
+++ b/opennow-qt/res/icons/desktop-chevron-up.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" fill="none">
-  <path d="M2.4 6.2L5 3.6L7.6 6.2" stroke="#FFFFFF" stroke-opacity="0.4" stroke-width="1.4" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-chevron-up"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.4"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m18 15-6-6-6 6" />
 </svg>

--- a/opennow-qt/res/icons/desktop-clock.svg
+++ b/opennow-qt/res/icons/desktop-clock.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <circle cx="7" cy="7" r="5.2" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.3"/>
-  <path d="M7 4.2V7L9.2 8.4" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.3" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-clock-3"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M12 6v6h4" />
 </svg>

--- a/opennow-qt/res/icons/desktop-close.svg
+++ b/opennow-qt/res/icons/desktop-close.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <path d="M3.6 3.6L10.4 10.4" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.6" stroke-linecap="round"/>
-  <path d="M10.4 3.6L3.6 10.4" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.6" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-x"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 6 6 18" />
+  <path d="m6 6 12 12" />
 </svg>

--- a/opennow-qt/res/icons/desktop-collapse.svg
+++ b/opennow-qt/res/icons/desktop-collapse.svg
@@ -1,4 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <path d="M8.6 3L4.6 7L8.6 11" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M11.4 3V11" stroke="#FFFFFF" stroke-opacity="0.502" stroke-width="1.5" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-panel-left-close"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M9 3v18" />
+  <path d="m16 15-3-3 3-3" />
 </svg>

--- a/opennow-qt/res/icons/desktop-coop.svg
+++ b/opennow-qt/res/icons/desktop-coop.svg
@@ -1,4 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <circle cx="5.3" cy="7" r="3.7" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.3"/>
-  <circle cx="8.7" cy="7" r="3.7" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.3"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-users-round"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 21a8 8 0 0 0-16 0" />
+  <circle cx="10" cy="8" r="5" />
+  <path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3" />
 </svg>

--- a/opennow-qt/res/icons/desktop-expand.svg
+++ b/opennow-qt/res/icons/desktop-expand.svg
@@ -1,4 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <path d="M5.4 3L9.4 7L5.4 11" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M2.6 3V11" stroke="#FFFFFF" stroke-opacity="0.502" stroke-width="1.5" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-panel-left-open"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M9 3v18" />
+  <path d="m14 9 3 3-3 3" />
 </svg>

--- a/opennow-qt/res/icons/desktop-folder.svg
+++ b/opennow-qt/res/icons/desktop-folder.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
-  <path d="M2.4 4.8C2.4 4.1 3 3.6 3.6 3.6H6.4L7.8 5.2H12.4C13 5.2 13.6 5.7 13.6 6.4V11.6C13.6 12.3 13 12.8 12.4 12.8H3.6C3 12.8 2.4 12.3 2.4 11.6V4.8Z" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-folder"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-gamepad.svg
+++ b/opennow-qt/res/icons/desktop-gamepad.svg
@@ -1,5 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 17" fill="none">
-  <path d="M5.6 5.4H11.4C13.2 5.4 14.6 7.6 15.1 10.2C15.5 12.2 14.6 13.4 13.4 13.4C12.2 13.4 11.6 11.6 10 11.6H7C5.4 11.6 4.8 13.4 3.6 13.4C2.4 13.4 1.5 12.2 1.9 10.2C2.4 7.6 3.8 5.4 5.6 5.4Z" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.4" stroke-linejoin="round"/>
-  <path d="M5.9 8.9H7.5M6.7 8.1V9.7" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.3" stroke-linecap="round"/>
-  <circle cx="10.9" cy="8.9" r="0.85" fill="#FFFFFF" fill-opacity="0.541"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-gamepad-2"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.541"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <line x1="6" x2="10" y1="11" y2="11" />
+  <line x1="8" x2="8" y1="9" y2="13" />
+  <line x1="15" x2="15.01" y1="12" y2="12" />
+  <line x1="18" x2="18.01" y1="10" y2="10" />
+  <path d="M17.32 5H6.68a4 4 0 0 0-3.978 3.59c-.006.052-.01.101-.017.152C2.604 9.416 2 14.456 2 16a3 3 0 0 0 3 3c1 0 1.5-.5 2-1l1.414-1.414A2 2 0 0 1 9.828 16h4.344a2 2 0 0 1 1.414.586L17 18c.5.5 1 1 2 1a3 3 0 0 0 3-3c0-1.545-.604-6.584-.685-7.258-.007-.05-.011-.1-.017-.151A4 4 0 0 0 17.32 5z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-info.svg
+++ b/opennow-qt/res/icons/desktop-info.svg
@@ -1,5 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <circle cx="7" cy="7" r="5.9" stroke="#FFFFFF" stroke-opacity="0.322" stroke-width="1.3"/>
-  <path d="M7 6.2v4" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.4" stroke-linecap="round"/>
-  <circle cx="7" cy="4.1" r="0.8" fill="#FFFFFF" fill-opacity="0.541"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-info"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.541"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M12 16v-4" />
+  <path d="M12 8h.01" />
 </svg>

--- a/opennow-qt/res/icons/desktop-lock.svg
+++ b/opennow-qt/res/icons/desktop-lock.svg
@@ -1,4 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 12" fill="none">
-  <rect x="0.9" y="5" width="8.2" height="6.2" rx="1.6" stroke="#FFD166" stroke-width="1.3"/>
-  <path d="M2.9 5V3.4a2.1 2.1 0 0 1 4.2 0V5" stroke="#FFD166" stroke-width="1.3" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-lock-keyhole"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFD166"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="16" r="1" />
+  <rect x="3" y="10" width="18" height="12" rx="2" />
+  <path d="M7 10V7a5 5 0 0 1 10 0v3" />
 </svg>

--- a/opennow-qt/res/icons/desktop-logout.svg
+++ b/opennow-qt/res/icons/desktop-logout.svg
@@ -1,5 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
-  <path d="M6.4 2.6H4C3.1 2.6 2.4 3.3 2.4 4.2V11.8C2.4 12.7 3.1 13.4 4 13.4H6.4" stroke="#FFA8A8" stroke-width="1.4" stroke-linecap="round"/>
-  <path d="M10 5.4L12.8 8L10 10.6" stroke="#FFA8A8" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M6 8H12.6" stroke="#FFA8A8" stroke-width="1.4" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-log-out"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFA8A8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m16 17 5-5-5-5" />
+  <path d="M21 12H9" />
+  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
 </svg>

--- a/opennow-qt/res/icons/desktop-message.svg
+++ b/opennow-qt/res/icons/desktop-message.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
-  <path d="M2.6 4.2C2.6 3.5 3.1 3 3.8 3H12.2C12.9 3 13.4 3.5 13.4 4.2V9.4C13.4 10.1 12.9 10.6 12.2 10.6H6.4L3.6 13V10.6H3.8C3.1 10.6 2.6 10.1 2.6 9.4V4.2Z" stroke="#FFFFFF" stroke-opacity="0.722" stroke-width="1.4" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-message-circle"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.722"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719" />
 </svg>

--- a/opennow-qt/res/icons/desktop-mic-off.svg
+++ b/opennow-qt/res/icons/desktop-mic-off.svg
@@ -1,5 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <rect x="5.2" y="1.8" width="3.6" height="6.4" rx="1.8" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.4"/>
-  <path d="M3.4 7.4C3.4 9.4 5 10.8 7 10.8C9 10.8 10.6 9.4 10.6 7.4" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.4" stroke-linecap="round"/>
-  <path d="M2.6 2L11.4 12" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.4" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-mic-off"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.541"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 19v3" />
+  <path d="M15 9.34V5a3 3 0 0 0-5.68-1.33" />
+  <path d="M16.95 16.95A7 7 0 0 1 5 12v-2" />
+  <path d="M18.89 13.23A7 7 0 0 0 19 12v-2" />
+  <path d="m2 2 20 20" />
+  <path d="M9 9v3a3 3 0 0 0 5.12 2.12" />
 </svg>

--- a/opennow-qt/res/icons/desktop-mic.svg
+++ b/opennow-qt/res/icons/desktop-mic.svg
@@ -1,5 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <rect x="5.2" y="1.8" width="3.6" height="6.4" rx="1.8" stroke="#6EE7B7" stroke-width="1.4"/>
-  <path d="M3.4 7.4C3.4 9.4 5 10.8 7 10.8C9 10.8 10.6 9.4 10.6 7.4" stroke="#6EE7B7" stroke-width="1.4" stroke-linecap="round"/>
-  <path d="M7 10.8V12.6" stroke="#6EE7B7" stroke-width="1.4" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-mic"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#6EE7B7"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 19v3" />
+  <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+  <rect x="9" y="2" width="6" height="13" rx="3" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-friends-active.svg
+++ b/opennow-qt/res/icons/desktop-nav-friends-active.svg
@@ -1,6 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <circle cx="6.6" cy="6.1" r="2.5" stroke="#7FD4FF" stroke-width="1.5"/>
-  <path d="M2.3 15.2C2.3 12.7 4.2 11.2 6.6 11.2C9 11.2 10.9 12.7 10.9 15.2" stroke="#7FD4FF" stroke-width="1.5" stroke-linecap="round"/>
-  <circle cx="12.4" cy="6.6" r="2.1" stroke="#7FD4FF" stroke-width="1.5"/>
-  <path d="M12 11.4C13.9 11.7 15.6 13 15.7 15.2" stroke="#7FD4FF" stroke-width="1.5" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-users"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#7FD4FF"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+  <path d="M16 3.128a4 4 0 0 1 0 7.744" />
+  <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+  <circle cx="9" cy="7" r="4" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-friends.svg
+++ b/opennow-qt/res/icons/desktop-nav-friends.svg
@@ -1,6 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <circle cx="6.6" cy="6.1" r="2.5" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5"/>
-  <path d="M2.3 15.2C2.3 12.7 4.2 11.2 6.6 11.2C9 11.2 10.9 12.7 10.9 15.2" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5" stroke-linecap="round"/>
-  <circle cx="12.4" cy="6.6" r="2.1" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5"/>
-  <path d="M12 11.4C13.9 11.7 15.6 13 15.7 15.2" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-users"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.88"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+  <path d="M16 3.128a4 4 0 0 1 0 7.744" />
+  <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+  <circle cx="9" cy="7" r="4" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-home-active.svg
+++ b/opennow-qt/res/icons/desktop-nav-home-active.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <path d="M2.4 8.1L9 2.6L15.6 8.1" stroke="#7FD4FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M4.1 7.4V14.6C4.1 15.2 4.6 15.7 5.2 15.7H7.7V11.1H10.3V15.7H12.8C13.4 15.7 13.9 15.2 13.9 14.6V7.4" stroke="#7FD4FF" stroke-width="1.5" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-house"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#7FD4FF"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" />
+  <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-home.svg
+++ b/opennow-qt/res/icons/desktop-nav-home.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <path d="M2.4 8.1L9 2.6L15.6 8.1" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M4.1 7.4V14.6C4.1 15.2 4.6 15.7 5.2 15.7H7.7V11.1H10.3V15.7H12.8C13.4 15.7 13.9 15.2 13.9 14.6V7.4" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-house"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.88"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" />
+  <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-library-active.svg
+++ b/opennow-qt/res/icons/desktop-nav-library-active.svg
@@ -1,5 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <rect x="2.2" y="3.2" width="5.4" height="11.6" rx="1.4" stroke="#7FD4FF" stroke-width="1.5"/>
-  <rect x="9.2" y="3.2" width="6.6" height="7.4" rx="1.4" stroke="#7FD4FF" stroke-width="1.5"/>
-  <rect x="9.2" y="11.8" width="6.6" height="3" rx="1" stroke="#7FD4FF" stroke-width="1.5"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-library"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#7FD4FF"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m16 6 4 14" />
+  <path d="M12 6v14" />
+  <path d="M8 8v12" />
+  <path d="M4 4v16" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-library.svg
+++ b/opennow-qt/res/icons/desktop-nav-library.svg
@@ -1,5 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <rect x="2.2" y="3.2" width="5.4" height="11.6" rx="1.4" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5"/>
-  <rect x="9.2" y="3.2" width="6.6" height="7.4" rx="1.4" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5"/>
-  <rect x="9.2" y="11.8" width="6.6" height="3" rx="1" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-library"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.88"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m16 6 4 14" />
+  <path d="M12 6v14" />
+  <path d="M8 8v12" />
+  <path d="M4 4v16" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-settings-active.svg
+++ b/opennow-qt/res/icons/desktop-nav-settings-active.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <path d="M7.15 2.35h3.7l.55 1.85 1.75.7 1.8-.55 1.85 3.2-1.25 1.45.15 1.85 1.1 1.6-1.85 3.2-1.8-.5-1.5 1.25-.55 1.9H7.15l-.55-1.9-1.5-1.25-1.8.5-1.85-3.2 1.1-1.6.15-1.85-1.25-1.45 1.85-3.2 1.8.55 1.75-.7.55-1.85Z" stroke="#7FD4FF" stroke-width="1.5" stroke-linejoin="round"/>
-  <circle cx="9" cy="9" r="2.15" stroke="#7FD4FF" stroke-width="1.5"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-settings"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#7FD4FF"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+  <circle cx="12" cy="12" r="3" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-settings.svg
+++ b/opennow-qt/res/icons/desktop-nav-settings.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <path d="M7.15 2.35h3.7l.55 1.85 1.75.7 1.8-.55 1.85 3.2-1.25 1.45.15 1.85 1.1 1.6-1.85 3.2-1.8-.5-1.5 1.25-.55 1.9H7.15l-.55-1.9-1.5-1.25-1.8.5-1.85-3.2 1.1-1.6.15-1.85-1.25-1.45 1.85-3.2 1.8.55 1.75-.7.55-1.85Z" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5" stroke-linejoin="round"/>
-  <circle cx="9" cy="9" r="2.15" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-settings"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.88"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+  <circle cx="12" cy="12" r="3" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-store-active.svg
+++ b/opennow-qt/res/icons/desktop-nav-store-active.svg
@@ -1,4 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <path d="M3.2 6.4H14.8L13.9 14.8C13.84 15.36 13.38 15.8 12.82 15.8H5.18C4.62 15.8 4.16 15.36 4.1 14.8L3.2 6.4Z" stroke="#7FD4FF" stroke-width="1.5" stroke-linejoin="round"/>
-  <path d="M6.3 6.4V4.9C6.3 3.4 7.5 2.3 9 2.3C10.5 2.3 11.7 3.4 11.7 4.9V6.4" stroke="#7FD4FF" stroke-width="1.5" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-shopping-bag"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#7FD4FF"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 10a4 4 0 0 1-8 0" />
+  <path d="M3.103 6.034h17.794" />
+  <path d="M3.4 5.467a2 2 0 0 0-.4 1.2V20a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6.667a2 2 0 0 0-.4-1.2l-2-2.667A2 2 0 0 0 17 2H7a2 2 0 0 0-1.6.8z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-nav-store.svg
+++ b/opennow-qt/res/icons/desktop-nav-store.svg
@@ -1,4 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <path d="M3.2 6.4H14.8L13.9 14.8C13.84 15.36 13.38 15.8 12.82 15.8H5.18C4.62 15.8 4.16 15.36 4.1 14.8L3.2 6.4Z" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5" stroke-linejoin="round"/>
-  <path d="M6.3 6.4V4.9C6.3 3.4 7.5 2.3 9 2.3C10.5 2.3 11.7 3.4 11.7 4.9V6.4" stroke="#FFFFFF" stroke-opacity="0.88" stroke-width="1.5" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-shopping-bag"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.88"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 10a4 4 0 0 1-8 0" />
+  <path d="M3.103 6.034h17.794" />
+  <path d="M3.4 5.467a2 2 0 0 0-.4 1.2V20a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6.667a2 2 0 0 0-.4-1.2l-2-2.667A2 2 0 0 0 17 2H7a2 2 0 0 0-1.6.8z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-play-stroke.svg
+++ b/opennow-qt/res/icons/desktop-play-stroke.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <path d="M3 2.2L11 7L3 11.8V2.2Z" stroke="#FFFFFF" stroke-opacity="0.722" stroke-width="1.4" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-play"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.722"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-play.svg
+++ b/opennow-qt/res/icons/desktop-play.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 12">
-  <path d="M1.6 1L8.6 6L1.6 11V1Z" fill="#0B0F1A"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-play"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#0B0F1A"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-plus-ink.svg
+++ b/opennow-qt/res/icons/desktop-plus-ink.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none">
-  <path d="M6 2V10" stroke="#0B0F1A" stroke-width="1.7" stroke-linecap="round"/>
-  <path d="M2 6H10" stroke="#0B0F1A" stroke-width="1.7" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-plus"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#0B0F1A"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 12h14" />
+  <path d="M12 5v14" />
 </svg>

--- a/opennow-qt/res/icons/desktop-plus.svg
+++ b/opennow-qt/res/icons/desktop-plus.svg
@@ -1,3 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" fill="none">
-  <path d="M5.5 1.6V9.4M1.6 5.5H9.4" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-plus"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 12h14" />
+  <path d="M12 5v14" />
 </svg>

--- a/opennow-qt/res/icons/desktop-qr.svg
+++ b/opennow-qt/res/icons/desktop-qr.svg
@@ -1,6 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 15" fill="none">
-  <rect x="1.2" y="1.2" width="4.8" height="4.8" rx="1.2" stroke="#FFFFFF" stroke-opacity="0.878" stroke-width="1.4"/>
-  <rect x="9" y="1.2" width="4.8" height="4.8" rx="1.2" stroke="#FFFFFF" stroke-opacity="0.878" stroke-width="1.4"/>
-  <rect x="1.2" y="9" width="4.8" height="4.8" rx="1.2" stroke="#FFFFFF" stroke-opacity="0.878" stroke-width="1.4"/>
-  <path d="M9 9h2.2v2.2H9zM12.6 12.6h1.2" stroke="#FFFFFF" stroke-opacity="0.878" stroke-width="1.4" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-qr-code"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.878"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="5" height="5" x="3" y="3" rx="1" />
+  <rect width="5" height="5" x="16" y="3" rx="1" />
+  <rect width="5" height="5" x="3" y="16" rx="1" />
+  <path d="M21 16h-3a2 2 0 0 0-2 2v3" />
+  <path d="M21 21v.01" />
+  <path d="M12 7v3a2 2 0 0 1-2 2H7" />
+  <path d="M3 12h.01" />
+  <path d="M12 3h.01" />
+  <path d="M12 16v.01" />
+  <path d="M16 12h1" />
+  <path d="M21 12v.01" />
+  <path d="M12 21v-1" />
 </svg>

--- a/opennow-qt/res/icons/desktop-rtx.svg
+++ b/opennow-qt/res/icons/desktop-rtx.svg
@@ -1,3 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none">
-  <path d="M7.8 1.6L3.4 7.8H6.6L6.2 12.4L10.6 6.2H7.4L7.8 1.6Z" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.3" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-sparkles"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" />
+  <path d="M20 2v4" />
+  <path d="M22 4h-4" />
+  <circle cx="4" cy="20" r="2" />
 </svg>

--- a/opennow-qt/res/icons/desktop-search.svg
+++ b/opennow-qt/res/icons/desktop-search.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" fill="none">
-  <circle cx="8" cy="8" r="5.4" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.6"/>
-  <path d="M12.2 12.2L15.4 15.4" stroke="#FFFFFF" stroke-opacity="0.541" stroke-width="1.6" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-search"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.541"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m21 21-4.34-4.34" />
+  <circle cx="11" cy="11" r="8" />
 </svg>

--- a/opennow-qt/res/icons/desktop-shield.svg
+++ b/opennow-qt/res/icons/desktop-shield.svg
@@ -1,4 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
-  <path d="M8 1.4l5.4 2.2v3.9c0 3.2-2.2 5.9-5.4 7.1-3.2-1.2-5.4-3.9-5.4-7.1V3.6L8 1.4Z" stroke="#0A0D14" stroke-width="1.5" stroke-linejoin="round"/>
-  <path d="M5.7 8.1l1.7 1.7 3.1-3.4" stroke="#0A0D14" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-shield-check"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#0A0D14"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+  <path d="m9 12 2 2 4-4" />
 </svg>

--- a/opennow-qt/res/icons/desktop-sliders.svg
+++ b/opennow-qt/res/icons/desktop-sliders.svg
@@ -1,6 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
-  <path d="M2 5.2H14" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4" stroke-linecap="round"/>
-  <path d="M2 10.8H14" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4" stroke-linecap="round"/>
-  <circle cx="6" cy="5.2" r="1.8" fill="#0A0E15" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4"/>
-  <circle cx="10.4" cy="10.8" r="1.8" fill="#0A0E15" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-sliders-horizontal"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 5H3" />
+  <path d="M12 19H3" />
+  <path d="M14 3v4" />
+  <path d="M16 17v4" />
+  <path d="M21 12h-9" />
+  <path d="M21 19h-5" />
+  <path d="M21 5h-7" />
+  <path d="M8 10v4" />
+  <path d="M8 12H3" />
 </svg>

--- a/opennow-qt/res/icons/desktop-star.svg
+++ b/opennow-qt/res/icons/desktop-star.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
-  <path d="M8 2L9.8 5.9L14 6.4L10.9 9.3L11.7 13.5L8 11.4L4.3 13.5L5.1 9.3L2 6.4L6.2 5.9L8 2Z" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4" stroke-linejoin="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-star"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z" />
 </svg>

--- a/opennow-qt/res/icons/desktop-user-plus.svg
+++ b/opennow-qt/res/icons/desktop-user-plus.svg
@@ -1,6 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
-  <circle cx="6.4" cy="5.6" r="2.6" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4"/>
-  <path d="M2.4 12.8C2.4 10.9 4.2 9.6 6.4 9.6C8.6 9.6 10.4 10.9 10.4 12.8" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4" stroke-linecap="round"/>
-  <path d="M12.4 5V9" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4" stroke-linecap="round"/>
-  <path d="M10.4 7H14.4" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1.4" stroke-linecap="round"/>
+<!-- @license lucide-static v1.31.0 - ISC -->
+<svg
+  class="lucide lucide-user-plus"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF" opacity="0.8"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+  <circle cx="9" cy="7" r="4" />
+  <line x1="19" x2="19" y1="8" y2="14" />
+  <line x1="22" x2="16" y1="11" y2="11" />
 </svg>


### PR DESCRIPTION
## Summary

- align the desktop shell, Store hero, Library filters, settings pages, and compact rail behavior with the Paper references
- restore predictable keyboard focus across command palette, game modal, session, sign-in, and settings dropdown overlays
- make Store and settings layouts responsive at 1024×720, use supplied provider/chevron SVGs, and keep theme names and active states consistent

## Verification

- `cmake --build build/opennow-qt --parallel 4`
- 17/17 focused desktop route, settings, game-detail, and session-inserting tests passed
- full CTest: 53/54 passed; `opennow-localization-tests` has the same extracted-string catalog failure on exact base commit `cbba3f8`
- manually verified authenticated Home, Library, Store, Friends, Controllers, Linked stores, Interface, Themes, Console mode, command palette, game modal, dropdown dismissal/focus restoration, and rail outside-click behavior at 1405×900 and 1024×720
- `git diff --check`

## Screenshots

**Store — 1405×900**

![Store](https://api-nightly.capy.ai/pr-assets/gOuElkFM3rqHDenjv9iBAq1vAYNzpjmne_CgJwsqRwo)

**Themes — 1405×900**

![Themes](https://api-nightly.capy.ai/pr-assets/fmy0tkGzKqShCm6zY4Jj_Ci4850EoJhONRsfaCFCp9o)

**Game details — 1024×720**

![Game details](https://api-nightly.capy.ai/pr-assets/ZgxF89K1HEZpsu5qOv5jUksg9VvFyqBXcNiLdh272KU)