### PR TITLE
fix(streamer): harden Windows video transport and bounded recovery

### DIFF
--- a/docs/native-streamer-no-video.md
+++ b/docs/native-streamer-no-video.md
@@ -1,0 +1,55 @@
+# Native Qt: audio works, video is blank
+
+The Windows capture from 2026-09-04 completed RTSPS OPTIONS, DESCRIBE, SETUP,
+ANNOUNCE and PLAY, as well as ICE/DTLS/SCTP. The separate Mjolnir video socket
+reported `inbound=0`, `auth=0`, `frames=0` through both eight-second receive
+timeouts. This is a video **delivery** failure before authentication or decoding,
+not evidence of an unsupported GPU or codec. Subsequent OPTIONS 400 responses
+and an HTTP 503 are control-channel failures during recovery.
+
+## Client corrections
+
+- Unicast UDP reservations do not enable address/port sharing. Windows explicitly
+  uses `SO_EXCLUSIVEADDRUSE`; an occupied video or bundle port triggers the bounded
+  adjacent-port fallback, rather than an ambiguous shared bind.
+- ANNOUNCE's local address follows the negotiated bundle peer's route, not the
+  route to a public DNS server. This matters on split-tunnel/multi-NIC systems.
+- Seat readiness, PLAY success and audio/control traffic do not reset the recovery
+  budget. A failure's error/stopped notifications count once; two media retries
+  and two session claims exhaust automatic recovery. Only the first converted
+  video frame, a new session, or explicit user retry resets the episode.
+- Both Qt stream screens keep the active video item visible while the recovery
+  budget waits for video progress. The embedded D3D11 path emits its first-frame
+  notification once after a successful GPU-frame conversion, not for bootstrap
+  tokens that have no decoded frame.
+- Receive counters, zero-datagram timeouts, decoder progress/failures and RTSPS
+  failures reach `diagnostics/native-streamer.log` in packaged builds. No SRTP
+  keys, ICE credentials or packet payloads are added to these diagnostics.
+
+These corrections do not establish which network condition affected the remote
+PC. A firewall, VPN, router or server can still prevent video UDP delivery. Do
+not disable the firewall or change the user's VPN automatically.
+
+## Verification
+
+Run the native streamer workspace tests and `opennow-embedded-orchestration-tests`.
+The latter executes ShellStore recovery functions and each screen's status
+calculation, including duplicate terminal events, repeated ready-seat replies,
+retry exhaustion, manual retry and video-progress reset. Transport tests exercise
+exclusive ownership, occupied-port fallback, negotiated-peer routing and NATT
+wire bytes. The Windows media test checks one-shot first-frame reporting.
+
+On the affected Windows 11 / GTX 1650 PC, retest H.264 1920x1080 at 120 FPS using
+the complete rebuilt package in a fresh folder. Keep the same settings initially.
+Check windowed/fullscreen playback and F3/Ctrl+G overlays without replacing the
+video surface. Success requires rising authenticated/assembled video counters,
+decoder `produced` progress, visible video and working audio/input.
+
+If `inbound=0` persists, inspect application-specific firewall permissions, VPN
+routes and competing UDP listeners; preserve the new log before another attempt.
+The private local IP alone is not proof that a VPN caused the failure. An HTTP 503
+does not justify changing decoder settings or unbounded session retries.
+
+For deep Windows worktree paths, CMake accepts `OPENNOW_STREAMER_TARGET_DIR` as a
+cache path override. A shorter artifact directory avoids MSBuild MAX_PATH errors
+in bundled media dependency builds without changing the application's runtime.

--- a/native/opennow-streamer/Cargo.lock
+++ b/native/opennow-streamer/Cargo.lock
@@ -1744,6 +1744,7 @@ dependencies = [
  "str0m",
  "subtle",
  "thiserror 2.0.18",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
@@ -1514,6 +1514,7 @@ fn emit_nvst_terminal<R: NvstSessionResources>(
         lifecycle.state = State::Idle;
     }
     resources.stop();
+    opennow_streamer_protocol::log::log_line("WARN", "transport", &format!("{code}: {message}"));
     let _ = output.send(event("error", json!({ "code": code, "message": &message })));
     let _ = output.send(event(
         "status",

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
@@ -87,10 +87,9 @@ impl RtspClient {
             .headers_mut()
             .insert("content-length", HeaderValue::from_static("0"));
         let (mut socket, _) = connect(request).map_err(|error| {
-            NvstRtspError::new(
-                "nvst-connect-failed",
-                format!("Could not open RTSPS control channel: {error}"),
-            )
+            let failure = rtsp_connect_error(&error);
+            opennow_streamer_protocol::log::log_line("WARN", "rtsp", &failure.message);
+            failure
         })?;
         set_read_timeout(&mut socket, REQUEST_TIMEOUT);
         Ok((
@@ -191,6 +190,28 @@ impl RtspClient {
             }
         }
     }
+}
+
+fn rtsp_connect_error(error: &tungstenite::Error) -> NvstRtspError {
+    if let tungstenite::Error::Http(response) = error {
+        let status = response.status().as_u16();
+        return NvstRtspError::new(
+            if status == 503 {
+                "nvst-service-unavailable"
+            } else {
+                "nvst-connect-failed"
+            },
+            if status == 503 {
+                "The GeForce NOW RTSPS service is temporarily unavailable (HTTP 503). The media connection was not established; this is not a video decoder error.".to_owned()
+            } else {
+                format!("Could not open RTSPS control channel: HTTP {status}")
+            },
+        );
+    }
+    NvstRtspError::new(
+        "nvst-connect-failed",
+        format!("Could not open RTSPS control channel: {error}"),
+    )
 }
 
 pub struct PreparedNvstRtspSession {
@@ -403,12 +424,6 @@ pub fn prepare_owned_nvst(
         .mjolnir_local_addr()
         .map_err(|error| NvstRtspError::new("nvst-bind-failed", error.to_string()))?
         .port();
-    let local_address = bundle.advertised_local_address().ok_or_else(|| {
-        NvstRtspError::new(
-            "nvst-bind-failed",
-            "Could not determine a routable local IPv4 address for NVST",
-        )
-    })?;
     let identity = bundle.identity();
 
     let (mut client, target) = RtspClient::connect(endpoint, session_id)?;
@@ -478,6 +493,39 @@ pub fn prepare_owned_nvst(
             "SETUP did not return the NVST video peer",
         )
     })?;
+    let (bundle_peer_ip, bundle_peer_port) = context
+        .session
+        .media_connection_info
+        .as_ref()
+        .map(|media| (media.ip.as_str(), media.port))
+        .unwrap_or((&video_peer_ip, u32::from(video_peer_port)));
+    let bundle_peer_port = u16::try_from(bundle_peer_port)
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| {
+            NvstRtspError::new("invalid-media-peer", "NVST media peer port is invalid")
+        })?;
+    let bundle_peer = bundle_peer_ip
+        .parse::<IpAddr>()
+        .map(|ip| std::net::SocketAddr::new(ip, bundle_peer_port))
+        .map_err(|_| {
+            NvstRtspError::new("invalid-media-peer", "NVST media peer is not an IP address")
+        })?;
+    let local_address = bundle
+        .advertised_local_address_for(bundle_peer)
+        .map_err(|error| {
+            NvstRtspError::new(
+                "nvst-bind-failed",
+                format!("Could not select the local route to the NVST media peer: {error}"),
+            )
+        })?;
+    opennow_streamer_protocol::log::log_line(
+        "INFO",
+        "transport",
+        &format!(
+            "NVST media route local={local_address} bundlePort={client_port} videoPort={mjolnir_port} bundlePeer={bundle_peer} videoPeer={video_peer_ip}:{video_peer_port}"
+        ),
+    );
     let setup_ping_payload = header_value(&setup, "x-nv-ping-payload").map(ToOwned::to_owned);
     let ping_version = header_value(&setup, "x-nv-ping")
         .and_then(|value| value.parse::<u8>().ok())
@@ -851,13 +899,15 @@ fn ensure_rtsp_ok(step: &str, response: &RtspResponse) -> Result<(), NvstRtspErr
     if response.status == 200 {
         Ok(())
     } else {
-        Err(NvstRtspError::new(
+        let failure = NvstRtspError::new(
             "nvst-rtsp-failed",
             format!(
                 "{step} failed: {} {}",
                 response.status, response.status_text
             ),
-        ))
+        );
+        opennow_streamer_protocol::log::log_line("WARN", "rtsp", &failure.message);
+        Err(failure)
     }
 }
 
@@ -1129,6 +1179,18 @@ fn set_read_timeout(socket: &mut WebSocket<MaybeTlsStream<TcpStream>>, timeout: 
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn http_503_is_a_control_service_failure_not_a_decoder_failure() {
+        let response = tungstenite::http::Response::builder()
+            .status(503)
+            .body(Some(b"private response body".to_vec()))
+            .unwrap();
+        let error = rtsp_connect_error(&tungstenite::Error::Http(Box::new(response)));
+        assert_eq!(error.code, "nvst-service-unavailable");
+        assert!(error.message.contains("HTTP 503"));
+        assert!(!error.message.contains("private response body"));
+    }
 
     fn context() -> SessionContext {
         serde_json::from_value(json!({

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/embedded.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/embedded.rs
@@ -902,11 +902,11 @@ fn run_decoder_worker(
         return;
     }
 
-    eprintln!(
+    opennow_streamer_protocol::log::diagnostic("INFO", "decode", &format!(
         "Embedded D3D11 decoder worker started codec={} pollMs={}",
         format.codec.label(),
         DECODER_POLL_INTERVAL.as_millis()
-    );
+    ));
     let mut submitted_any = false;
     let mut submitted_frames = 0_u64;
     let mut produced_frames = 0_u64;
@@ -948,7 +948,7 @@ fn run_decoder_worker(
                     .clear();
                 encoded.clear();
                 decoder_generation.fetch_add(1, Ordering::AcqRel);
-                eprintln!("Embedded D3D11 decoder failed: {message}");
+                opennow_streamer_protocol::log::diagnostic("WARN", "decode", &format!("Embedded D3D11 decoder failed: {message}"));
                 let _ = events.push(BackendEvent::DeviceLost {
                     subsystem: Subsystem::VideoDecode,
                     message,
@@ -996,7 +996,7 @@ fn run_decoder_worker(
                         break;
                     }
                     Err(message) => {
-                        eprintln!("Embedded D3D11 decoder reset failed: {message}");
+                        opennow_streamer_protocol::log::diagnostic("WARN", "decode", &format!("Embedded D3D11 decoder reset failed: {message}"));
                         let _ = events.push(BackendEvent::DeviceLost {
                             subsystem: Subsystem::VideoDecode,
                             message,
@@ -1029,7 +1029,7 @@ fn run_decoder_worker(
                     .clear();
                 encoded.clear();
                 decoder_generation.fetch_add(1, Ordering::AcqRel);
-                eprintln!("Embedded D3D11 decoder input failed: {message}");
+                opennow_streamer_protocol::log::diagnostic("WARN", "decode", &format!("Embedded D3D11 decoder input failed: {message}"));
                 let _ = events.push(BackendEvent::DeviceLost {
                     subsystem: Subsystem::VideoDecode,
                     message,
@@ -1062,12 +1062,12 @@ fn run_decoder_worker(
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .len();
-            eprintln!(
+            opennow_streamer_protocol::log::diagnostic("INFO", "decode", &format!(
                 "Embedded D3D11 decoder progress codec={} submitted={submitted_frames} produced={produced_frames} encodedQueued={} decodedReady={decoded_ready} generation={}",
                 format.codec.label(),
                 encoded.len(),
                 decoder_generation.load(Ordering::Acquire),
-            );
+            ));
             last_progress_log = Instant::now();
         }
 
@@ -1118,7 +1118,7 @@ fn wait_for_recovery_keyframe(
                 return;
             }
             Err(message) => {
-                eprintln!("Embedded D3D11 decoder recovery failed: {message}");
+                opennow_streamer_protocol::log::diagnostic("WARN", "decode", &format!("Embedded D3D11 decoder recovery failed: {message}"));
                 let _ = events.push(BackendEvent::DeviceLost {
                     subsystem: Subsystem::VideoDecode,
                     message,

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
@@ -1599,6 +1599,7 @@ struct EmbeddedD3d11State {
     producer: Option<(crate::GraphicsContext, crate::D3d11FrameProducer)>,
     frame_ready: Arc<dyn Fn() + Send + Sync>,
     keyframe_required: bool,
+    first_frame_recorded: bool,
 }
 
 #[cfg(target_os = "windows")]
@@ -1655,6 +1656,7 @@ impl EmbeddedD3d11State {
             producer: None,
             frame_ready: Arc::new(|| {}),
             keyframe_required: false,
+            first_frame_recorded: false,
         }
     }
 
@@ -1673,6 +1675,10 @@ impl EmbeddedD3d11State {
 
     fn take_keyframe_required(&mut self) -> bool {
         std::mem::take(&mut self.keyframe_required)
+    }
+
+    fn take_first_recorded_frame(&mut self, succeeded: bool) -> bool {
+        succeeded && !std::mem::replace(&mut self.first_frame_recorded, true)
     }
 
     fn record(
@@ -1932,8 +1938,14 @@ impl crate::GraphicsFrame for PendingD3d11Frame {
     ) -> Result<crate::GraphicsRecordedFrame, String> {
         let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
         let result = state.record(context, command);
+        let first_frame = state.take_first_recorded_frame(result.is_ok());
         let keyframe_required = state.take_keyframe_required();
         drop(state);
+        if first_frame {
+            let _ = self.shared.feedback.send(MediaFeedback::PlaybackStarted {
+                backend: "embedded D3D11",
+            });
+        }
         if keyframe_required {
             self.shared.video_desynced.store(true, Ordering::Release);
             request_keyframe(
@@ -3581,6 +3593,21 @@ fn mark_macos_video_desynced(shared: &SharedPipeline, mid: &str, reason: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn embedded_playback_starts_only_once_after_a_successful_record() {
+        let mut state = EmbeddedD3d11State::new(
+            MediaStreamConfig::default(),
+            Arc::new(Mutex::new(EmbeddedD3d11Submission::new())),
+        );
+        assert!(!state.take_first_recorded_frame(false));
+        assert!(!state.take_first_recorded_frame(false));
+        assert!(state.take_first_recorded_frame(true));
+        assert!(!state.take_first_recorded_frame(true));
+        state.reset();
+        assert!(!state.take_first_recorded_frame(true), "surface recreation is not a new session");
+    }
 
     #[cfg(target_os = "windows")]
     fn embedded_h264_frame(

--- a/native/opennow-streamer/crates/opennow-streamer-protocol/src/log.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-protocol/src/log.rs
@@ -114,6 +114,13 @@ pub fn log_line(level: &str, area: &str, message: &str) {
     write_line(level, area, message);
 }
 
+/// Low-frequency pipeline diagnostics must be visible both in standalone stderr
+/// captures and in the embedded Qt file sink. Never pass credentials or payloads.
+pub fn diagnostic(level: &str, area: &str, message: &str) {
+    log_line(level, area, message);
+    eprintln!("{message}");
+}
+
 /// Appends the first hit for `key` and then every [`THROTTLE_EVERY`]th
 /// repeat, tagging repeats with their running count. For hot paths where
 /// the same failure recurs per frame.
@@ -161,8 +168,10 @@ mod tests {
         set_log_file(&path).unwrap();
         assert_eq!(log_file_path().as_deref(), Some(path.as_str()));
         log_line("INFO", "engine", "hello");
+        diagnostic("INFO", "transport", "NVST rx-stats inbound=0 pings=97");
         let body = std::fs::read_to_string(&path).unwrap();
         assert!(body.contains("INFO engine hello"), "body was: {body}");
+        assert!(body.contains("INFO transport NVST rx-stats inbound=0 pings=97"));
         reset_for_tests();
         let _ = std::fs::remove_file(&path);
     }

--- a/native/opennow-streamer/crates/opennow-streamer-transport/Cargo.toml
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/Cargo.toml
@@ -21,6 +21,7 @@ thiserror.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 str0m = { workspace = true, features = ["wincrypto-dimpl"] }
+windows-sys = { version = "0.52", features = ["Win32_Networking_WinSock"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Keep transport crypto architecture-independent. The Apple/Swift provider's

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -4056,6 +4056,22 @@ impl ReservedNvstBundle {
         }
     }
 
+    /// Use the route to the negotiated media peer, not a public DNS service.
+    /// Split-tunnel VPNs can send those destinations through different NICs.
+    pub fn advertised_local_address_for(&self, peer: SocketAddr) -> std::io::Result<String> {
+        let local = self.socket.local_addr()?;
+        let probe = UdpSocket::bind(SocketAddr::new(local.ip(), 0))?;
+        probe.connect(peer)?;
+        let address = probe.local_addr()?.ip();
+        if address.is_unspecified() || !address.is_ipv4() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                "no local IPv4 route to the NVST media peer",
+            ));
+        }
+        Ok(address.to_string())
+    }
+
     pub fn identity(&mut self) -> NvstBundleIdentity {
         nvst_local_bundle_identity(&mut self.rtc)
     }
@@ -4194,14 +4210,37 @@ fn bind_nvst_udp_socket(bind_ip: IpAddr, port: u16) -> std::io::Result<UdpSocket
         Domain::IPV6
     };
     let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
-    socket.set_reuse_address(true)?;
+    // These unicast sockets have exactly one owner. REUSEADDR/REUSEPORT can
+    // silently share the preferred ports with another client instead of taking
+    // the dynamic-port fallback, leaving audio alive but video at inbound=0.
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawSocket;
+        use windows_sys::Win32::Networking::WinSock::{
+            SO_REUSEADDR, SOCKET_ERROR, SOL_SOCKET, WSAGetLastError, setsockopt,
+        };
+        let enabled = 1_i32;
+        // Winsock defines SO_EXCLUSIVEADDRUSE as (~SO_REUSEADDR).
+        let result = unsafe {
+            setsockopt(
+                socket.as_raw_socket() as usize,
+                SOL_SOCKET,
+                !SO_REUSEADDR,
+                (&enabled as *const i32).cast(),
+                std::mem::size_of_val(&enabled) as i32,
+            )
+        };
+        if result == SOCKET_ERROR {
+            return Err(std::io::Error::from_raw_os_error(unsafe {
+                WSAGetLastError()
+            }));
+        }
+    }
     if let Err(error) = socket.set_recv_buffer_size(NVST_UDP_RECEIVE_BUFFER_BYTES) {
         eprintln!(
             "NVST could not enlarge UDP receive buffer to {NVST_UDP_RECEIVE_BUFFER_BYTES} bytes: {error}"
         );
     }
-    #[cfg(unix)]
-    socket.set_reuse_port(true)?;
     socket.bind(&SocketAddr::new(bind_ip, port).into())?;
     Ok(socket.into())
 }
@@ -4213,6 +4252,12 @@ pub fn reserve_nvst_mjolnir_udp_socket() -> std::io::Result<UdpSocket> {
 }
 
 fn reserve_nvst_socket_pair() -> std::io::Result<(UdpSocket, UdpSocket)> {
+    reserve_nvst_socket_pair_from(49_005)
+}
+
+fn reserve_nvst_socket_pair_from(
+    preferred_video_port: u16,
+) -> std::io::Result<(UdpSocket, UdpSocket)> {
     // Bifrost's Windows client reserves this exact pair first
     // (`general.clientPorts.useReserved=1`) and only falls back to dynamic
     // ports when it is unavailable. Some cloud seats do not route the
@@ -4220,17 +4265,26 @@ fn reserve_nvst_socket_pair() -> std::io::Result<(UdpSocket, UdpSocket)> {
     // though the version-6 NATT request is otherwise valid. Match the
     // official preference while preserving a non-fatal fallback for users
     // that already have either port occupied.
-    const OFFICIAL_MJOLNIR_PORT: u16 = 49_005;
-    const OFFICIAL_BUNDLE_PORT: u16 = 49_006;
     const MAX_PAIR_ATTEMPTS: usize = 32;
     let bind_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-    let mut last_error = match bind_nvst_udp_socket(bind_ip, OFFICIAL_MJOLNIR_PORT) {
-        Ok(mjolnir) => match bind_nvst_udp_socket(bind_ip, OFFICIAL_BUNDLE_PORT) {
+    let preferred_bundle_port = preferred_video_port.checked_add(1).ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "NVST port pair overflows")
+    })?;
+    let mut last_error = match bind_nvst_udp_socket(bind_ip, preferred_video_port) {
+        Ok(mjolnir) => match bind_nvst_udp_socket(bind_ip, preferred_bundle_port) {
             Ok(bundle) => return Ok((bundle, mjolnir)),
             Err(error) => error,
         },
         Err(error) => error,
     };
+
+    opennow_streamer_protocol::log::log_line(
+        "INFO",
+        "transport",
+        &format!(
+            "NVST preferred UDP pair unavailable; reserving an exclusive dynamic pair: {last_error}"
+        ),
+    );
 
     for _ in 0..MAX_PAIR_ATTEMPTS {
         let mjolnir = reserve_nvst_mjolnir_udp_socket()?;
@@ -4314,12 +4368,17 @@ pub fn spawn_nvst_mjolnir_receiver(
     media_consumer: MediaConsumer,
     event_sender: Sender<NvstReceiveEvent>,
 ) -> Result<NvstUdpReceiverSession, NvstUdpReceiverError> {
-    eprintln!(
-        "NVST Mjolnir raw-SRTP video receiver arming on {}",
-        socket
-            .local_addr()
-            .map(|addr| addr.to_string())
-            .unwrap_or_else(|_| "unknown".to_owned())
+    opennow_streamer_protocol::log::diagnostic(
+        "INFO",
+        "transport",
+        &format!(
+            "NVST Mjolnir raw-SRTP video receiver arming on {} peer={}",
+            socket
+                .local_addr()
+                .map(|addr| addr.to_string())
+                .unwrap_or_else(|_| "unknown".to_owned()),
+            config.video_peer,
+        ),
     );
     spawn_receiver_thread(
         "opennow-nvst-mjolnir",
@@ -5548,9 +5607,13 @@ fn run_nvst_udp_receiver(
             Ok((length, source)) => {
                 inbound_datagrams += 1;
                 if inbound_datagrams == 1 {
-                    eprintln!(
-                        "NVST raw-SRTP inbound first datagram: source={source} bytes={length} peer={}",
-                        receiver.config.video_peer
+                    opennow_streamer_protocol::log::diagnostic(
+                        "INFO",
+                        "transport",
+                        &format!(
+                            "NVST raw-SRTP inbound first datagram: source={source} bytes={length} peer={}",
+                            receiver.config.video_peer
+                        ),
                     );
                 }
                 if source != receiver.config.video_peer {
@@ -5610,16 +5673,31 @@ fn run_nvst_udp_receiver(
         }
         if now.duration_since(last_stats_log) >= Duration::from_secs(2) {
             last_stats_log = now;
-            eprintln!(
-                "NVST rx-stats {} inbound={inbound_datagrams} pings={pings_sent} rr={receiver_reports_sent}",
-                receiver.stats_line(stats_origin),
+            opennow_streamer_protocol::log::diagnostic(
+                "INFO",
+                "transport",
+                &format!(
+                    "NVST rx-stats {} inbound={inbound_datagrams} pings={pings_sent} rr={receiver_reports_sent}",
+                    receiver.stats_line(stats_origin),
+                ),
             );
         }
         let timeout = receiver.poll_timeout(now);
         if timeout.is_some() {
-            eprintln!(
-                "NVST transport timeout counters: pings={pings_sent}, inbound={inbound_datagrams}, stunHandled={handled_stun}, stunInvalid={invalid_stun}, nonStun={non_stun}, wrongSource={wrong_source}"
+            opennow_streamer_protocol::log::diagnostic(
+                "WARN",
+                "transport",
+                &format!(
+                    "NVST transport timeout counters: pings={pings_sent}, inbound={inbound_datagrams}, stunHandled={handled_stun}, stunInvalid={invalid_stun}, nonStun={non_stun}, wrongSource={wrong_source}"
+                ),
             );
+            if inbound_datagrams == 0 {
+                opennow_streamer_protocol::log::diagnostic(
+                    "WARN",
+                    "transport",
+                    "NVST video UDP path received no datagrams; audio/control may still work. Check firewall/VPN routing and UDP port ownership. No video has reached SRTP authentication or decoding.",
+                );
+            }
         }
         forward_optional(&event_sender, timeout);
     }
@@ -6022,6 +6100,50 @@ mod tests {
         assert!(bundle_addr.ip().is_unspecified());
         assert!(video_addr.ip().is_unspecified());
         assert_eq!(bundle_addr.port(), video_addr.port() + 1);
+    }
+
+    #[test]
+    fn nvst_unicast_socket_cannot_share_an_existing_port() {
+        let owner = reserve_nvst_mjolnir_udp_socket().unwrap();
+        let address = owner.local_addr().unwrap();
+        assert!(bind_nvst_udp_socket(address.ip(), address.port()).is_err());
+        let competitor = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).unwrap();
+        competitor.set_reuse_address(true).unwrap();
+        assert!(competitor.bind(&address.into()).is_err());
+    }
+
+    #[test]
+    fn nvst_pair_falls_back_when_either_preferred_port_is_occupied() {
+        let (bundle, video) = reserve_nvst_socket_pair().unwrap();
+        let preferred = video.local_addr().unwrap().port();
+        let (other_bundle, other_video) = reserve_nvst_socket_pair_from(preferred).unwrap();
+        assert_ne!(other_video.local_addr().unwrap().port(), preferred);
+        assert_eq!(
+            other_bundle.local_addr().unwrap().port(),
+            other_video.local_addr().unwrap().port() + 1
+        );
+        drop(video);
+        let (third_bundle, third_video) = reserve_nvst_socket_pair_from(preferred).unwrap();
+        assert_ne!(third_video.local_addr().unwrap().port(), preferred);
+        assert_eq!(
+            third_bundle.local_addr().unwrap().port(),
+            third_video.local_addr().unwrap().port() + 1
+        );
+        // The failed pair attempt must release its first socket.
+        assert!(bind_nvst_udp_socket(IpAddr::V4(Ipv4Addr::UNSPECIFIED), preferred).is_ok());
+        drop(bundle);
+    }
+
+    #[test]
+    fn advertised_media_address_uses_the_requested_peer_route() {
+        // No packets or Internet access: UDP connect only asks the OS for a route.
+        let bundle = ReservedNvstBundle::reserve().unwrap();
+        assert_eq!(
+            bundle
+                .advertised_local_address_for("127.0.0.1:5004".parse().unwrap())
+                .unwrap(),
+            "127.0.0.1"
+        );
     }
 
     #[test]

--- a/opennow-qt/CMakeLists.txt
+++ b/opennow-qt/CMakeLists.txt
@@ -382,7 +382,8 @@ add_custom_target(opennow-license-notices ALL
 )
 add_dependencies(opennow-qt opennow-license-notices)
 
-set(OPENNOW_STREAMER_TARGET_DIR "${CMAKE_BINARY_DIR}/streamer-rust-target")
+set(OPENNOW_STREAMER_TARGET_DIR "${CMAKE_BINARY_DIR}/streamer-rust-target" CACHE PATH
+    "Streamer Cargo artifacts; use a shorter path if Windows MSBuild exceeds MAX_PATH")
 set(OPENNOW_STREAMER_ARTIFACT_ROOT "${OPENNOW_STREAMER_TARGET_DIR}")
 if(OPENNOW_RUST_TARGET)
     set(OPENNOW_STREAMER_ARTIFACT_ROOT
@@ -644,7 +645,7 @@ if(BUILD_TESTING)
     qt_add_executable(opennow-embedded-orchestration-tests
         tests/tst_embeddedorchestration.cpp
     )
-    target_link_libraries(opennow-embedded-orchestration-tests PRIVATE Qt6::Test Qt6::Core)
+    target_link_libraries(opennow-embedded-orchestration-tests PRIVATE Qt6::Test Qt6::Core Qt6::Qml)
     target_compile_definitions(opennow-embedded-orchestration-tests PRIVATE
         OPENNOW_QT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
     add_test(NAME opennow-embedded-orchestration-tests

--- a/opennow-qt/qml/desktop/DesktopStreamScreen.qml
+++ b/opennow-qt/qml/desktop/DesktopStreamScreen.qml
@@ -19,7 +19,8 @@ FocusScope {
     readonly property string status: {
         if (ShellStore.streamState === "error")
             return "error"
-        if (ShellStore.streamState === "reconnecting" || ShellStore.streamerRestartAttempts > 0)
+        if (ShellStore.streamState === "reconnecting"
+                || (ShellStore.streamerRestartAttempts > 0 && root.streamer.status !== "streaming"))
             return "reconnecting"
         return String(root.streamer.status || ShellStore.streamState || "starting")
     }

--- a/opennow-qt/qml/screens/StreamScreen.qml
+++ b/opennow-qt/qml/screens/StreamScreen.qml
@@ -14,7 +14,8 @@ FocusScope {
     readonly property string status: {
         if (ShellStore.streamState === "error")
             return "error"
-        if (ShellStore.streamState === "reconnecting" || ShellStore.streamerRestartAttempts > 0)
+        if (ShellStore.streamState === "reconnecting"
+                || (ShellStore.streamerRestartAttempts > 0 && root.streamer.status !== "streaming"))
             return "reconnecting"
         return String(streamer.status || ShellStore.streamState || "starting")
     }

--- a/opennow-qt/qml/state/ShellStore.qml
+++ b/opennow-qt/qml/state/ShellStore.qml
@@ -86,6 +86,7 @@ QtObject {
     property string streamState: "idle"
     property string streamMessage: ""
     property int streamerRestartAttempts: 0
+    property bool streamerRecoveryExhausted: false
     property int sessionReconnectAttempts: 0
     property int streamerRestartRecoveryCount: 0
     property int sessionRecoveryCount: 0
@@ -1088,6 +1089,7 @@ QtObject {
         if (!ready || streamBusy)
             return
         streamerRestartAttempts = 0
+        streamerRecoveryExhausted = false
         sessionReconnectAttempts = 0
         streamerRestartRecoveryCount = 0
         sessionRecoveryCount = 0
@@ -1212,6 +1214,12 @@ QtObject {
     function acceptStreamingSession(session) {
         const previousSession = activeSession
         activeSession = normalizedStreamingSession(session)
+        if (!activeSession || !previousSession || previousSession.sessionId !== activeSession.sessionId) {
+            streamerRestartTimer.stop()
+            streamerRestartAttempts = 0
+            sessionReconnectAttempts = 0
+            streamerRecoveryExhausted = false
+        }
         if (!activeSession) {
             runtimeStreamProfile = ({})
             if (previousSession && streamer && streamer.status !== "stopped")
@@ -1227,6 +1235,10 @@ QtObject {
             syncDiscordPresence()
             return
         }
+        // A seat still being ready does not mean its media path recovered.
+        // Polls and claim replies must not restart an exhausted media episode.
+        if (streamerRecoveryExhausted)
+            return
         streamState = activeSession.phase || (Number(activeSession.status) >= 2 ? "ready" : "preparing")
         const adState = activeSession.adState || ({})
         const ads = adState.sessionAds || adState.ads || []
@@ -1236,9 +1248,6 @@ QtObject {
         if (streamState === "ready" || streamState === "streaming") {
             if (streamStartedAtMs === 0)
                 streamStartedAtMs = Date.now()
-            if (sessionReconnectAttempts > 0)
-                sessionRecoveryCount += 1
-            sessionReconnectAttempts = 0
             streamMessage = qsTr("Your GeForce NOW seat is ready.")
             streamPollTimer.stop()
             if (AppController.route !== "stream")
@@ -1292,7 +1301,8 @@ QtObject {
 
     function startNativeStreamer() {
         if (!ready || !activeSession || streamerStartRequestId !== ""
-                || streamerPrepareRequestId !== "")
+                || streamerPrepareRequestId !== "" || sessionClaimRequestId !== ""
+                || streamerRestartTimer.running || streamerRecoveryExhausted)
             return
         if (streamer && streamer.sessionId === activeSession.sessionId
                 && streamer.status !== "stopped" && streamer.status !== "error"
@@ -1328,12 +1338,21 @@ QtObject {
     }
 
     function retryNativeStreamer() {
+        streamerRestartTimer.stop()
         streamerRestartAttempts = 0
+        sessionReconnectAttempts = 0
+        streamerRecoveryExhausted = false
         streamer = null
         startNativeStreamer()
     }
 
     function acceptStreamerSnapshot(snapshot) {
+        // One failure produces both error and stopped, plus late input replies.
+        // Count it once and preserve the original, actionable error message.
+        const wasTerminal = streamer && (streamer.status === "error" || streamer.status === "stopped")
+        const isTerminal = snapshot && (snapshot.status === "error" || snapshot.status === "stopped")
+        if (wasTerminal && isTerminal)
+            return
         streamer = snapshot ? Object.assign({}, snapshot, {
             codec: snapshot.codec || runtimeStreamProfile.codec || "",
             outputWidth: snapshot.outputWidth || runtimeStreamProfile.width || 0,
@@ -1359,10 +1378,6 @@ QtObject {
             setStreamInputPaused(desiredStreamInputPaused)
         }
         if (status === "streaming") {
-            if (streamerRestartAttempts > 0) {
-                streamerRestartRecoveryCount += streamerRestartAttempts
-                streamerRestartAttempts = 0
-            }
             return
         }
         if (status !== "error" && status !== "stopped")
@@ -1397,6 +1412,8 @@ QtObject {
         if (!ready || !activeSession || sessionClaimRequestId !== "")
             return
         if (sessionReconnectAttempts >= 2) {
+            streamerRecoveryExhausted = true
+            streamerRestartTimer.stop()
             streamState = "error"
             streamMessage = reason || qsTr("The streaming session could not be recovered")
             lastError = streamMessage
@@ -1492,6 +1509,7 @@ QtObject {
     }
 
     function stopNativeStreamer(reason) {
+        streamerRestartTimer.stop()
         if (streamerStopRequestId !== "")
             return
         // A runtime that never started, or that already reported "stopped", has
@@ -2000,6 +2018,17 @@ QtObject {
         if (event.peakBitrateMbps !== undefined)
             fields.peakBitrateMbps = Number(event.peakBitrateMbps)
         if (event.event === "first-frame") {
+            if (!activeSession || !streamer || streamer.status === "error" || streamer.status === "stopped")
+                return
+            // Only real video progress closes the recovery episode. A ready
+            // seat, successful PLAY, or audio/control traffic is insufficient.
+            streamerRestartRecoveryCount += streamerRestartAttempts
+            if (sessionReconnectAttempts > 0)
+                sessionRecoveryCount += 1
+            streamerRestartAttempts = 0
+            sessionReconnectAttempts = 0
+            streamerRecoveryExhausted = false
+            streamerRestartTimer.stop()
             if (streamer && (streamer.firstFrameLatencyMs === undefined
                     || streamer.firstFrameLatencyMs === null)) {
                 fields.firstFrameLatencyMs = Math.max(0,
@@ -2654,6 +2683,10 @@ QtObject {
                     root.streamMessage = qsTr("Session recovery was interrupted. Retrying…")
                     Qt.callLater(() => root.recoverStreamingSession(message))
                 } else {
+                    if (recovering) {
+                        root.streamerRecoveryExhausted = true
+                        root.streamerRestartTimer.stop()
+                    }
                     root.streamState = "error"
                     root.streamMessage = message
                 }

--- a/opennow-qt/tests/tst_embeddedorchestration.cpp
+++ b/opennow-qt/tests/tst_embeddedorchestration.cpp
@@ -1,4 +1,5 @@
 #include <QFile>
+#include <QJSEngine>
 #include <QRegularExpression>
 #include <QTest>
 
@@ -16,6 +17,132 @@ class EmbeddedOrchestrationTest final : public QObject
     Q_OBJECT
 
 private slots:
+    void pendingRecoveryDoesNotHideAStartedVideoSurface()
+    {
+        for (const auto &path : {"qml/screens/StreamScreen.qml", "qml/desktop/DesktopStreamScreen.qml"}) {
+            const QRegularExpression status(QStringLiteral(
+                "readonly property string status: \\{(.*?)\\n    \\}"),
+                QRegularExpression::DotMatchesEverythingOption);
+            const auto match = status.match(source(QString::fromLatin1(path)));
+            QVERIFY(match.hasMatch());
+            QJSEngine engine;
+            engine.evaluate(QStringLiteral(
+                "var streamer = {status:'streaming'}; var root = {streamer:streamer};"
+                "var ShellStore = {streamState:'streaming', streamerRestartAttempts:2};"));
+            const auto result = engine.evaluate(
+                QStringLiteral("(function() {%1})()").arg(match.captured(1)));
+            QVERIFY2(!result.isError(), qPrintable(result.toString()));
+            QCOMPARE(result.toString(), QStringLiteral("streaming"));
+        }
+    }
+
+    void mediaRecoveryIsBoundedUntilVideoActuallyStarts()
+    {
+        // Execute the actual ShellStore functions with side effects stubbed,
+        // rather than just checking source text for a retry-limit constant.
+        QJSEngine engine;
+        auto evaluate = [&](const QString &script) {
+            const auto result = engine.evaluate(script);
+            if (result.isError())
+                qWarning().noquote() << result.toString() << result.property("stack").toString();
+            return result;
+        };
+        QVERIFY(!evaluate(QStringLiteral(R"JS(
+            var ready = true, activeSession = {sessionId: 'seat', phase: 'ready'};
+            var streamer = {status: 'starting', sessionId: 'seat'};
+            var runtimeStreamProfile = {}, streamMessage = '', streamState = '', lastError = '';
+            var streamerRestartAttempts = 0, sessionReconnectAttempts = 0;
+            var streamerRecoveryExhausted = false, streamerRestartRecoveryCount = 0, sessionRecoveryCount = 0;
+            var streamerStopExpected = false, streamInputStateKnown = false, streamRecordingActive = false;
+            var streamStartedAtMs = 1, desiredStreamInputPaused = false, sessionClaimRequestId = '';
+            var sessionClaimIsRecovery = false, streamerStartRequestId = '', streamerPrepareRequestId = '';
+            var nativeRuntimeReady = true, prepares = 0, claims = 0;
+            var streamerRestartTimer = {running: false, restarts: 0,
+                restart: function() { this.running = true; this.restarts++; },
+                stop: function() { this.running = false; }};
+            var streamPollTimer = {stop: function() {}, restart: function() {}};
+            var CoreClient = {request: function(type) {
+                if (type === 'streamer.prepare') { prepares++; return 'prepare'; }
+                if (type === 'session.claim') { claims++; return 'claim'; }
+                throw new Error('Unexpected request: ' + type);
+            }};
+            var AppController = {route: 'stream', overlay: ''};
+            function qsTr(text) { return text; }
+            function inspectStreamerOverlayRequest() {}
+            function inspectStreamerScreenshotRequest() {}
+            function inspectStreamerRecordingRequest() {}
+            function inspectStreamerShortcutAction() {}
+            function setStreamInputPaused() {}
+            function syncDiscordPresence() {}
+            function sendNativeCommand() {}
+            function updateStreamerFields(fields) { acceptStreamerSnapshot(Object.assign({}, streamer, fields)); }
+        )JS")).isError());
+        const auto shell = source(QStringLiteral("qml/state/ShellStore.qml"));
+        for (const auto &name : {"acceptStreamerSnapshot", "recoverStreamingSession",
+                                "normalizedStreamingSession", "acceptStreamingSession",
+                                "startNativeStreamer", "retryNativeStreamer", "acceptNativeEvent"}) {
+            const QRegularExpression function(QStringLiteral(
+                "    function %1\\([^\\n]*\\) \\{.*?\\n    \\}").arg(QString::fromLatin1(name)),
+                QRegularExpression::DotMatchesEverythingOption);
+            const auto match = function.match(shell);
+            QVERIFY2(match.hasMatch(), name);
+            QVERIFY(!evaluate(match.captured()).isError());
+        }
+        auto check = [&](const QString &expression) {
+            const auto result = evaluate(expression);
+            return !result.isError() && result.toBool();
+        };
+        QVERIFY(check(QStringLiteral(R"JS(
+            acceptStreamerSnapshot({status: 'error', message: 'No video UDP packets'});
+            acceptStreamerSnapshot({status: 'stopped', message: 'Stopped'});
+            acceptStreamerSnapshot({status: 'error', message: 'Late response'});
+            streamerRestartAttempts === 1 && streamerRestartTimer.restarts === 1
+                && streamer.message === 'No video UDP packets';
+        )JS")));
+        QVERIFY(check(QStringLiteral(R"JS(
+            acceptStreamingSession(activeSession);
+            prepares === 0 && streamerRestartAttempts === 1;
+        )JS")));
+        QVERIFY(check(QStringLiteral(R"JS(
+            streamerRestartTimer.running = false;
+            streamer = {status: 'starting', sessionId: 'seat'};
+            acceptStreamerSnapshot({status: 'streaming', sessionId: 'seat'});
+            acceptStreamerSnapshot({status: 'error', message: 'Still no video'});
+            streamerRestartAttempts === 2;
+        )JS")));
+        QVERIFY(check(QStringLiteral(R"JS(
+            streamerRestartTimer.running = false;
+            streamer = {status: 'starting', sessionId: 'seat'};
+            acceptStreamerSnapshot({status: 'error', message: 'OPTIONS failed: 400'});
+            sessionClaimRequestId = '';
+            acceptStreamingSession(activeSession);
+            streamerPrepareRequestId = '';
+            acceptStreamerSnapshot({status: 'error', message: 'OPTIONS failed: 400'});
+            sessionClaimRequestId = '';
+            acceptStreamingSession(activeSession);
+            streamerPrepareRequestId = '';
+            acceptStreamerSnapshot({status: 'error', message: 'HTTP 503'});
+            var previousPrepares = prepares;
+            acceptStreamingSession(activeSession);
+            startNativeStreamer();
+            streamerRecoveryExhausted && claims === 2 && prepares === previousPrepares
+                && streamState === 'error' && streamMessage === 'HTTP 503';
+        )JS")));
+        QVERIFY(check(QStringLiteral(R"JS(
+            retryNativeStreamer();
+            !streamerRecoveryExhausted && streamerRestartAttempts === 0
+                && sessionReconnectAttempts === 0 && prepares === previousPrepares + 1;
+        )JS")));
+        QVERIFY(check(QStringLiteral(R"JS(
+            streamerRestartAttempts = 2; sessionReconnectAttempts = 1;
+            acceptStreamerSnapshot({status: 'streaming', sessionId: 'seat'});
+            var unchanged = streamerRestartAttempts === 2 && sessionReconnectAttempts === 1;
+            acceptNativeEvent({type: 'status', event: 'first-frame', status: 'streaming', backend: 'D3D11'});
+            unchanged && streamerRestartAttempts === 0 && sessionReconnectAttempts === 0
+                && streamerRestartRecoveryCount === 2 && sessionRecoveryCount === 1;
+        )JS")));
+    }
+
     void shellUsesCoreOnlyToPrepareEmbeddedContext()
     {
         const auto shell = source(QStringLiteral("qml/state/ShellStore.qml"));


### PR DESCRIPTION
## Summary
- Reserve exclusive Windows UDP sockets with bounded occupied-port fallback, and advertise the local address routed to the negotiated media peer.
- Bound media recovery across duplicate terminal events and session claims; reset only on real video progress and keep the embedded video surface visible during recovery.
- Report first-frame progress from the D3D11 path and persist transport/decode/control diagnostics, including zero-video-datagram and HTTP 503 failures.
- Add regression coverage and affected-PC retest guidance; support a shorter native artifact path for Windows builds.

## Verification
- Native streamer workspace: 268 tests passed.
- Complete Qt suite: 64 tests passed; includes fullscreen/F3 and overlay smoke coverage.
- Full Windows build, packaged ZIP smoke test, and git diff --check passed.

## Scope and remaining validation
The supplied trace received zero video UDP datagrams before decoding. These changes fix client transport/recovery defects, but playback on the affected Windows 11 / GTX 1650 PC still needs confirmation. External firewall/VPN/server failures, including HTTP 503, cannot be guaranteed resolved by a client patch.