### PR TITLE
perf(ci): cache Qt and Rust builds on Blacksmith

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -93,22 +93,6 @@ jobs:
             package-generator: ZIP
             rust-target: aarch64-pc-windows-msvc
             cmake-arch: ARM64
-          - label: macos-arm64
-            os: blacksmith-6vcpu-macos-15
-            build-parallel: 6
-            qt-host: mac
-            qt-arch: clang_64
-            package-generator: "DragNDrop;ZIP"
-            rust-target: aarch64-apple-darwin
-            cmake-arch: arm64
-          - label: macos-x64
-            os: blacksmith-6vcpu-macos-15
-            build-parallel: 6
-            qt-host: mac
-            qt-arch: clang_64
-            package-generator: "DragNDrop;ZIP"
-            rust-target: x86_64-apple-darwin
-            cmake-arch: x86_64
 
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -239,7 +239,33 @@ jobs:
             nasm \
             pkg-config
 
+      - name: Cache Rust dependencies and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          key: qt-ci-${{ matrix.os }}-${{ matrix.label }}
+          cache-bin: false
+          workspaces: |
+            native/opennow-core -> target
+            native/opennow-streamer -> target
+            native/opennow-core -> ../../build/opennow-qt-release/rust-target
+            native/opennow-streamer -> ../../build/opennow-qt-release/streamer-rust-target
+
+      - name: Cache Qt C++ compilation
+        if: runner.os != 'Windows'
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
+        with:
+          key: qt-ci-${{ matrix.os }}-${{ matrix.label }}
+          max-size: 500M
+
+      - name: Cache SDL3 installation
+        id: sdl-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/SDL-install
+          key: qt-ci-sdl-v1-${{ matrix.os }}-${{ matrix.label }}-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-ci.yml') }}
+
       - name: Build SDL3
+        if: steps.sdl-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
@@ -316,6 +342,9 @@ jobs:
           fi
           if [[ -n "${OPENNOW_QT_HOST_PATH:-}" ]]; then
             OPENNOW_CMAKE_ARGS+=("-DQT_HOST_PATH=${OPENNOW_QT_HOST_PATH}")
+          fi
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
+            OPENNOW_CMAKE_ARGS+=("-DCMAKE_C_COMPILER_LAUNCHER=ccache" "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
           fi
           cmake -S opennow-qt -B build/opennow-qt-release \
             -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -114,7 +114,30 @@ jobs:
             libxcursor-dev libxext-dev libxfixes-dev libxi-dev \
             libxrandr-dev libxrender-dev libxss-dev make nasm pkg-config
 
+      - name: Cache Rust dependencies and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          key: qt-release-${{ matrix.runner }}-${{ matrix.arch }}
+          cache-bin: false
+          workspaces: |
+            native/opennow-core -> ../../build/qt-release/rust-target
+            native/opennow-streamer -> ../../build/qt-release/streamer-rust-target
+
+      - name: Cache Qt C++ compilation
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
+        with:
+          key: qt-release-${{ matrix.runner }}-${{ matrix.arch }}
+          max-size: 500M
+
+      - name: Cache SDL3 installation
+        id: sdl-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/SDL-install
+          key: qt-release-sdl-v1-${{ matrix.runner }}-${{ matrix.arch }}-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-release-candidate.yml') }}
+
       - name: Build SDL3
+        if: steps.sdl-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
@@ -130,6 +153,7 @@ jobs:
           UPDATE_PUBLIC_KEY: ${{ inputs.update_public_key }}
         run: |
           cmake -S opennow-qt -B build/qt-release -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install" \
             -DOPENNOW_BUILD_VERSION="$RELEASE_VERSION" \
             -DOPENNOW_UPDATE_ED25519_PUBLIC_KEY="$UPDATE_PUBLIC_KEY"
@@ -293,7 +317,24 @@ jobs:
           cache: true
           cache-key-prefix: qt-release-windows-${{ matrix.arch }}
 
+      - name: Cache Rust dependencies and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          key: qt-release-windows-2025-${{ matrix.arch }}
+          cache-bin: false
+          workspaces: |
+            native/opennow-core -> ../../build/qt-release/rust-target
+            native/opennow-streamer -> ../../build/qt-release/streamer-rust-target
+
+      - name: Cache SDL3 installation
+        id: sdl-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/SDL-install
+          key: qt-release-sdl-v1-windows-2025-${{ matrix.arch }}-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-release-candidate.yml') }}
+
       - name: Build SDL3
+        if: steps.sdl-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
@@ -427,7 +468,30 @@ jobs:
           cache: true
           cache-key-prefix: qt-release-macos-${{ matrix.arch }}
 
+      - name: Cache Rust dependencies and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          key: qt-release-macos-15-${{ matrix.arch }}
+          cache-bin: false
+          workspaces: |
+            native/opennow-core -> ../../build/qt-release/rust-target
+            native/opennow-streamer -> ../../build/qt-release/streamer-rust-target
+
+      - name: Cache Qt C++ compilation
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
+        with:
+          key: qt-release-macos-15-${{ matrix.arch }}
+          max-size: 500M
+
+      - name: Cache SDL3 installation
+        id: sdl-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/SDL-install
+          key: qt-release-sdl-v1-macos-15-${{ matrix.arch }}-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-release-candidate.yml') }}
+
       - name: Build SDL3
+        if: steps.sdl-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
@@ -445,6 +509,7 @@ jobs:
         run: |
           cmake -S opennow-qt -B build/qt-release -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_OSX_ARCHITECTURES=${{ matrix.cmake_arch }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DOPENNOW_RUST_TARGET=${{ matrix.rust_target }} \
             -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install" \
             -DOPENNOW_BUILD_VERSION="$RELEASE_VERSION" \

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -434,187 +434,11 @@ jobs:
             build/release-artifacts/SHA256SUMS
           if-no-files-found: error
 
-  macos:
-    name: macos-${{ matrix.arch }}
-    needs: preflight
-    runs-on: blacksmith-6vcpu-macos-15
-    environment: qt-production-release
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: arm64
-            rust_target: aarch64-apple-darwin
-            cmake_arch: arm64
-          - arch: x64
-            rust_target: x86_64-apple-darwin
-            cmake_arch: x86_64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.preflight.outputs.source_sha }}
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - run: rustup target add ${{ matrix.rust_target }}
-
-      - uses: jurplel/install-qt-action@v4
-        with:
-          version: ${{ env.QT_VERSION }}
-          host: mac
-          target: desktop
-          arch: clang_64
-          modules: qtmultimedia qtshadertools
-          cache: true
-          cache-key-prefix: qt-release-macos-${{ matrix.arch }}
-
-      - name: Cache Rust dependencies and build artifacts
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
-        with:
-          key: qt-release-macos-15-${{ matrix.arch }}
-          cache-bin: false
-          workspaces: |
-            native/opennow-core -> ../../build/qt-release/rust-target
-            native/opennow-streamer -> ../../build/qt-release/streamer-rust-target
-
-      - name: Cache Qt C++ compilation
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
-        with:
-          key: qt-release-macos-15-${{ matrix.arch }}
-          max-size: 500M
-
-      - name: Cache SDL3 installation
-        id: sdl-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/SDL-install
-          key: qt-release-sdl-v1-macos-15-${{ matrix.arch }}-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-release-candidate.yml') }}
-
-      - name: Build SDL3
-        if: steps.sdl-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
-          cmake -S "$RUNNER_TEMP/SDL" -B "$RUNNER_TEMP/SDL-build" -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.cmake_arch }} -DSDL_SHARED=ON -DSDL_STATIC=OFF \
-            -DSDL_TEST_LIBRARY=OFF -DSDL_TESTS=OFF
-          cmake --build "$RUNNER_TEMP/SDL-build" --config Release --parallel
-          cmake --install "$RUNNER_TEMP/SDL-build" --config Release --prefix "$RUNNER_TEMP/SDL-install"
-
-      - name: Configure, build, test, and install release app
-        shell: bash
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-          UPDATE_PUBLIC_KEY: ${{ inputs.update_public_key }}
-        run: |
-          cmake -S opennow-qt -B build/qt-release -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.cmake_arch }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DOPENNOW_RUST_TARGET=${{ matrix.rust_target }} \
-            -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install" \
-            -DOPENNOW_BUILD_VERSION="$RELEASE_VERSION" \
-            -DOPENNOW_UPDATE_ED25519_PUBLIC_KEY="$UPDATE_PUBLIC_KEY"
-          cmake --build build/qt-release --config Release --parallel
-          ctest --test-dir build/qt-release -C Release --output-on-failure --parallel 4
-          cmake --install build/qt-release --config Release --prefix "$RUNNER_TEMP/stage"
-
-      - name: Import Developer ID certificate
-        shell: bash
-        env:
-          MACOS_P12_BASE64: ${{ secrets.OPENNOW_MACOS_DEVELOPER_ID_P12_BASE64 }}
-          MACOS_P12_PASSWORD: ${{ secrets.OPENNOW_MACOS_DEVELOPER_ID_P12_PASSWORD }}
-        run: |
-          set -euo pipefail
-          keychain="$RUNNER_TEMP/opennow-signing.keychain-db"
-          password=$(openssl rand -hex 24)
-          printf '%s' "$MACOS_P12_BASE64" | openssl base64 -d -A > "$RUNNER_TEMP/opennow-signing.p12"
-          security create-keychain -p "$password" "$keychain"
-          security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$password" "$keychain"
-          security import "$RUNNER_TEMP/opennow-signing.p12" -k "$keychain" \
-            -P "$MACOS_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$password" "$keychain"
-          security list-keychains -d user -s "$keychain" login.keychain-db
-          echo "OPENNOW_SIGNING_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
-
-      - name: Sign, notarize, and package app
-        shell: bash
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-          SIGN_IDENTITY: ${{ secrets.OPENNOW_MACOS_SIGN_IDENTITY }}
-          APPLE_API_KEY_BASE64: ${{ secrets.OPENNOW_APPLE_API_KEY_BASE64 }}
-          APPLE_API_KEY_ID: ${{ secrets.OPENNOW_APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER_ID: ${{ secrets.OPENNOW_APPLE_API_ISSUER_ID }}
-        run: |
-          set -euo pipefail
-          mkdir -p build/release-artifacts
-          app="$RUNNER_TEMP/stage/OpenNOW.app"
-          test -d "$app"
-          test -f "$app/Contents/MacOS/libopennow_streamer_ffi.dylib"
-          test -x "$app/Contents/MacOS/opennow-streamer"
-          while IFS= read -r -d '' item; do
-            codesign --force --options runtime --timestamp --keychain "$OPENNOW_SIGNING_KEYCHAIN" \
-              --sign "$SIGN_IDENTITY" "$item"
-          done < <(find "$app/Contents/Frameworks" "$app/Contents/PlugIns" "$app/Contents/MacOS" \
-            -type f \( -perm -111 -o -name '*.dylib' \) -print0 2>/dev/null)
-          while IFS= read -r framework; do
-            codesign --force --options runtime --timestamp --keychain "$OPENNOW_SIGNING_KEYCHAIN" \
-              --sign "$SIGN_IDENTITY" "$framework"
-          done < <(find "$app/Contents/Frameworks" -type d -name '*.framework' -print 2>/dev/null | sort -r)
-          codesign --force --options runtime --timestamp --keychain "$OPENNOW_SIGNING_KEYCHAIN" \
-            --sign "$SIGN_IDENTITY" "$app"
-          codesign --verify --deep --strict --verbose=2 "$app"
-          printf '%s' "$APPLE_API_KEY_BASE64" | openssl base64 -d -A > "$RUNNER_TEMP/AuthKey.p8"
-          preflight_zip="$RUNNER_TEMP/OpenNOW-notarization.zip"
-          ditto -c -k --sequesterRsrc --keepParent "$app" "$preflight_zip"
-          xcrun notarytool submit "$preflight_zip" --wait \
-            --key "$RUNNER_TEMP/AuthKey.p8" --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID" --output-format json > "$RUNNER_TEMP/notary-app.json"
-          jq -e '.status == "Accepted"' "$RUNNER_TEMP/notary-app.json"
-          xcrun stapler staple "$app"
-          xcrun stapler validate "$app"
-          spctl --assess --type execute --verbose=2 "$app"
-          zip="build/release-artifacts/OpenNOW-Qt-${RELEASE_VERSION}-macOS-${{ matrix.arch }}.zip"
-          ditto -c -k --sequesterRsrc --keepParent "$app" "$zip"
-          dmg="build/release-artifacts/OpenNOW-Qt-${RELEASE_VERSION}-macOS-${{ matrix.arch }}.dmg"
-          hdiutil create -volname OpenNOW -srcfolder "$app" -ov -format UDZO "$dmg"
-          codesign --force --timestamp --keychain "$OPENNOW_SIGNING_KEYCHAIN" \
-            --sign "$SIGN_IDENTITY" "$dmg"
-          xcrun notarytool submit "$dmg" --wait \
-            --key "$RUNNER_TEMP/AuthKey.p8" --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID" --output-format json > "$RUNNER_TEMP/notary-dmg.json"
-          jq -e '.status == "Accepted"' "$RUNNER_TEMP/notary-dmg.json"
-          xcrun stapler staple "$dmg"
-          xcrun stapler validate "$dmg"
-          spctl --assess --type open --context context:primary-signature --verbose=2 "$dmg"
-
-      - name: Record artifact checksums
-        shell: bash
-        run: |
-          set -euo pipefail
-          (cd build/release-artifacts && shasum -a 256 -- *.dmg *.zip > SHA256SUMS)
-
-      - name: Remove temporary signing material
-        if: always()
-        shell: bash
-        run: |
-          security delete-keychain "$OPENNOW_SIGNING_KEYCHAIN" 2>/dev/null || true
-          rm -f "$RUNNER_TEMP/opennow-signing.p12" "$RUNNER_TEMP/AuthKey.p8"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: opennow-qt-${{ inputs.version }}-macos-${{ matrix.arch }}-signed-notarized
-          path: |
-            build/release-artifacts/*.dmg
-            build/release-artifacts/*.zip
-            build/release-artifacts/SHA256SUMS
-          if-no-files-found: error
-
   inventory:
     name: isolated-update-signing-and-inventory
     runs-on: [self-hosted, opennow-release-signer]
     environment: qt-update-signing
-    needs: [preflight, linux, windows, macos]
+    needs: [preflight, linux, windows]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -634,13 +458,13 @@ jobs:
             exit 1
           fi
           [[ $(find candidate -type f -name '*.msi' | wc -l) -eq 2 ]]
-          [[ $(find candidate -type f -name '*.dmg' | wc -l) -eq 2 ]]
+          [[ $(find candidate -type f -name '*.dmg' | wc -l) -eq 0 ]]
           [[ $(find candidate -type f -name '*.AppImage' | wc -l) -eq 2 ]]
           [[ $(find candidate -type f -name '*.deb' | wc -l) -eq 2 ]]
-          [[ $(find candidate -type f -name '*.zip' | wc -l) -eq 4 ]]
+          [[ $(find candidate -type f -name '*.zip' | wc -l) -eq 2 ]]
           assets=$(find candidate -type f \( -name '*.msi' -o -name '*.dmg' -o -name '*.AppImage' \
             -o -name '*.deb' -o -name '*.zip' \) | wc -l)
-          [[ "$assets" -eq 12 ]]
+          [[ "$assets" -eq 8 ]]
 
           signing_dir=$(mktemp -d "$RUNNER_TEMP/opennow-update-signing.XXXXXX")
           trap 'rm -rf "$signing_dir"' EXIT

--- a/docs/ci-caching.md
+++ b/docs/ci-caching.md
@@ -4,6 +4,9 @@ The `qt-ci` and `qt-release-candidate` workflows use upstream cache actions.
 [Blacksmith automatically routes these actions to its colocated cache](https://docs.blacksmith.sh/blacksmith-caching/dependencies-actions);
 its old `useblacksmith/cache` and language-specific cache forks are archived.
 
+Actions currently builds Windows and Linux only, each on x64 and ARM64. The macOS
+CI matrix entries and release-candidate job are removed for now.
+
 ## Cached build inputs
 
 - **Qt SDK:** `install-qt-action` already caches the downloaded SDK and Windows
@@ -18,7 +21,7 @@ its old `useblacksmith/cache` and language-specific cache forks are archived.
   and update-public-key changes; final executables and signing material are not
   cache inputs.
 - **Qt C++:** `ccache-action` persists a compressed compiler cache capped at 500 MB
-  per Linux/macOS matrix entry. CMake explicitly uses `ccache` as its C/C++ compiler
+  per Linux matrix entry. CMake explicitly uses `ccache` as its C/C++ compiler
   launcher. Windows keeps its existing Visual Studio generator: CMake compiler
   launchers do not support that generator, so enabling one would not cache MSVC
   compilation. Windows still benefits from Rust and SDL caching.

--- a/docs/ci-caching.md
+++ b/docs/ci-caching.md
@@ -1,0 +1,58 @@
+# Qt/native CI caching
+
+The `qt-ci` and `qt-release-candidate` workflows use upstream cache actions.
+[Blacksmith automatically routes these actions to its colocated cache](https://docs.blacksmith.sh/blacksmith-caching/dependencies-actions);
+its old `useblacksmith/cache` and language-specific cache forks are archived.
+
+## Cached build inputs
+
+- **Qt SDK:** `install-qt-action` already caches the downloaded SDK and Windows
+  ARM64 host tools. That configuration is unchanged.
+- **Rust:** `Swatinem/rust-cache` caches Cargo downloads and compiled dependencies
+  for both native workspaces. CI includes their normal `target` directories for
+  Clippy/tests and the separate `rust-target` and `streamer-rust-target` directories
+  that CMake actually builds. Release candidates cache only the CMake Cargo
+  directories. The action keys dependencies by Rust toolchain, Cargo manifests,
+  lockfiles, and compiler environment, and removes workspace and incremental
+  artifacts before saving. Application code is rebuilt, including release-version
+  and update-public-key changes; final executables and signing material are not
+  cache inputs.
+- **Qt C++:** `ccache-action` persists a compressed compiler cache capped at 500 MB
+  per Linux/macOS matrix entry. CMake explicitly uses `ccache` as its C/C++ compiler
+  launcher. Windows keeps its existing Visual Studio generator: CMake compiler
+  launchers do not support that generator, so enabling one would not cache MSVC
+  compilation. Windows still benefits from Rust and SDL caching.
+- **SDL3:** `actions/cache` persists only the Release installation. An exact hit
+  skips cloning, configuring, compiling, and installing SDL. The key includes the
+  target architecture, runner image family, SDL version, and workflow hash; changes
+  to the build recipe invalidate it. There is deliberately no partial-key restore
+  for this prebuilt dependency.
+
+CI and release-candidate caches have separate key namespaces. All compiler and
+dependency caches distinguish the target architecture, including cross-builds on
+the same host. Keep Blacksmith's **Branch Protected Caches** setting enabled to
+preserve GitHub-style branch isolation; workflow keys are not a security boundary.
+No cache is required for correctness: misses rebuild from source, and the test,
+packaging, smoke, and signing steps remain unchanged.
+
+## Verify the improvement
+
+The successful [baseline run 34043105324](https://github.com/opencloudgaming/opennow/actions/runs/34043105324)
+spent 452–453 seconds in `Build Qt release` on Windows and 422 seconds on Linux
+ARM64. Linux ARM64 also spent 88 seconds in Rust formatting/Clippy and 140 seconds
+in Rust tests. SDL compilation took 19–43 seconds across the six targets. These
+are baseline measurements, not promised savings.
+
+Compare a successful cold run with a rerun of the same commit and cache scope.
+Check Rust cache restore/save logs, the skipped SDL build on an exact hit, and
+the ccache post-step hit statistics. Compare total job time as well as build time:
+cache transfer and cleanup are part of the cost. A new stable Rust toolchain or
+an evicted cache will require another cold build. Signed release-candidate
+validation still requires the protected release environment and its credentials.
+
+[Sticky Disks](https://docs.blacksmith.sh/blacksmith-caching/dependencies-sticky-disks)
+are intentionally not enabled. They add storage charges and need separately
+configured branch protection before trusted builds can safely reuse them. Consider
+them only if measured cache transfer time becomes a bottleneck. Rust sccache's
+GitHub Actions backend is also not used: Blacksmith currently documents it as an
+exception that still goes to GitHub rather than the colocated cache.

--- a/docs/qt-release-candidate.md
+++ b/docs/qt-release-candidate.md
@@ -1,7 +1,7 @@
 # Qt production release candidates
 
-The `qt-release-candidate` workflow builds one immutable Qt/Rust source commit for all seven
-release architectures/window families. It does not publish a GitHub release;
+The `qt-release-candidate` workflow builds one immutable Qt/Rust source commit for Windows and
+Linux, each on x64 and ARM64. macOS builds are temporarily disabled in Actions. The workflow does not publish a GitHub release;
 it produces protected candidate artifacts that must still pass the live matrix and staged rollout.
 
 ## Protected environment
@@ -23,6 +23,10 @@ only `OPENNOW_UPDATE_ED25519_PRIVATE_KEY`; restrict it to a dedicated self-hoste
 | `OPENNOW_APPLE_API_KEY_ID` | Notarization API key ID |
 | `OPENNOW_APPLE_API_ISSUER_ID` | Notarization issuer ID |
 
+The macOS/Apple secrets are only needed when macOS builds are re-enabled. To restore macOS,
+restore its release job from Git history, its inventory dependency and the 12-artifact checks,
+and both macOS entries in the `qt-ci` matrix together.
+
 The matching Ed25519 public key is a workflow input, not a secret. The workflow embeds that exact
 value into every core. Ordinary Linux, Windows and macOS build workers never receive the update
 private seed. After their platform-signed artifacts are uploaded, the isolated signer downloads
@@ -40,12 +44,12 @@ ephemeral or reset after each approved release operation.
   diagnostics, telemetry and updater selection.
 - Windows x64/ARM64 application executables and MSI installers are timestamped with Authenticode;
   the portable ZIPs are unpacked and every executable is verified again.
-- macOS Intel/Apple-Silicon apps use hardened-runtime Developer ID signing. The app is notarized and
-  stapled before final ZIP/DMG creation; the DMG is then signed, notarized, stapled and assessed.
+- Current candidates do not include macOS packages. Re-enabling macOS must restore its Developer
+  ID signing, notarization, and stapling steps along with the build job.
 - Linux x64/ARM64 DEB and checksum-pinned AppImage builds use native runners.
 - Every installable artifact receives a sibling Ed25519 update manifest after platform signing.
-- The inventory job fails unless it finds both Windows MSI/ZIP pairs, both macOS DMG/ZIP pairs, both
-  Linux AppImage/DEB pairs and exactly one manifest per artifact. It records the immutable commit and
+- The inventory job fails unless it finds both Windows MSI/ZIP pairs, both Linux AppImage/DEB pairs,
+  no macOS DMGs, and exactly one manifest per artifact (eight artifacts total). It records the immutable commit and
   SHA-256 of every candidate file.
 
 Run the workflow manually with an exact reviewed 40-character source commit, version, and public


### PR DESCRIPTION
## Changes

- Cache Rust downloads and compiled dependencies for both native workspaces, including the separate Cargo output directories used by CMake. Cover Windows/Linux x64 and ARM64 in CI and release candidates with architecture-specific keys.
- Cache SDL3 Release installations and skip the source build on exact hits. Invalidate on runner image family, target, SDL version, or workflow recipe changes; do not restore partial matches.
- Add a 500 MB C++ compiler cache per Linux target and wire it into CMake. Keep the Windows Visual Studio generator unchanged; Windows benefits from the Rust and SDL caches.
- Temporarily disable macOS builds by removing both CI matrix entries and the release job. Update release inventory dependencies and assertions to require eight Windows/Linux artifacts without macOS DMGs. Preserve Windows/Linux tests, packaging, smoke checks, and signing.
- Document cache behavior, branch-protection requirements, baseline timings, cold/warm verification, and how to restore macOS builds.

Blacksmith's current documentation recommends upstream cache actions: it routes them to its colocated backend automatically, while its own cache forks are archived. This does not enable paid Sticky Disks or Rust sccache's GitHub-backed remote cache. Newly introduced third-party actions are pinned to commits.

## Verification

- `actionlint -color=false .github/workflows/qt-ci.yml .github/workflows/qt-release-candidate.yml` passed.
- Matrix checks passed for eight active platform builds and 16 distinct Rust/SDL cache keys; verified CMake Cargo output coverage, restore/build ordering, and unchanged Windows/Linux tests and signing/package steps.
- All 25 remaining embedded Bash scripts passed `bash -n`; `git diff --check` passed.
- Executed the inventory count gates against scratch fixtures: accepted eight Windows/Linux artifacts and rejected a missing Windows ZIP or unexpected DMG.
- Baseline run [34043105324](https://github.com/opencloudgaming/opennow/actions/runs/34043105324) spent 452–453 seconds in the Windows build step and 422 seconds on Linux ARM64. These are baseline timings, not claimed savings.

Hosted CI for the Windows/Linux-only revision and warm-cache comparison are pending. An earlier push run timed out in the macOS `qml-idle-mode` test; the parallel PR run passed that target. No tests were changed to bypass it. The protected signed release-candidate workflow has not been dispatched.