### PR TITLE
fix: harden Qt and native session recovery after regression audit

### DIFF
--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -149,13 +149,10 @@ jobs:
           cpack --config build/qt-release/CPackConfig.cmake -C Release -G DEB -B build/release-artifacts
           cmake --install build/qt-release --config Release --prefix "$PWD/build/AppDir/usr"
           test -f build/AppDir/usr/bin/libopennow_streamer_ffi.so
-          test ! -e build/AppDir/usr/bin/opennow-streamer
+          test -x build/AppDir/usr/bin/opennow-streamer
           deb=$(find build/release-artifacts -maxdepth 1 -type f -name '*.deb' -print -quit)
-          dpkg-deb --fsys-tarfile "$deb" | tar -tf - | grep -qx './usr/bin/libopennow_streamer_ffi.so'
-          if dpkg-deb --fsys-tarfile "$deb" | tar -tf - | grep -qx './usr/bin/opennow-streamer'; then
-            echo 'Standalone streamer must not be packaged' >&2
-            exit 1
-          fi
+          dpkg-deb --fsys-tarfile "$deb" | tar -tf - | grep -Fx './usr/bin/libopennow_streamer_ffi.so'
+          dpkg-deb --fsys-tarfile "$deb" | tar -tf - | grep -Fx './usr/bin/opennow-streamer'
           curl --fail --location --retry 3 \
             "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage" \
             --output "build/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage"
@@ -364,14 +361,14 @@ jobs:
           $process = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/a `"$($msi.FullName)`" /qn TARGETDIR=`"$msiExpanded`""
           if ($process.ExitCode -ne 0) { throw "MSI administrative extraction failed" }
           if (-not (Get-ChildItem $msiExpanded -Recurse -Filter opennow_streamer_ffi.dll)) { throw "MSI is missing the embedded streamer runtime" }
-          if (Get-ChildItem $msiExpanded -Recurse -Filter opennow-streamer.exe) { throw "MSI contains the obsolete standalone streamer" }
+          if (-not (Get-ChildItem $msiExpanded -Recurse -File -Filter opennow-streamer.exe)) { throw "MSI is missing the streamer capability probe" }
           Get-ChildItem $msiExpanded -Recurse -Filter *.exe | ForEach-Object { signtool verify /pa /all $_.FullName }
           $zip = Get-ChildItem build/release-artifacts -Filter *.zip
           if ($zip.Count -ne 1) { throw "Expected one portable ZIP" }
           $expanded = Join-Path $env:RUNNER_TEMP "portable"
           Expand-Archive $zip.FullName $expanded
           if (-not (Get-ChildItem $expanded -Recurse -Filter opennow_streamer_ffi.dll)) { throw "Portable ZIP is missing the embedded streamer runtime" }
-          if (Get-ChildItem $expanded -Recurse -Filter opennow-streamer.exe) { throw "Portable ZIP contains the obsolete standalone streamer" }
+          if (-not (Get-ChildItem $expanded -Recurse -File -Filter opennow-streamer.exe)) { throw "Portable ZIP is missing the streamer capability probe" }
           Get-ChildItem $expanded -Recurse -Filter *.exe | ForEach-Object { signtool verify /pa /all $_.FullName }
 
       - name: Record artifact checksums
@@ -489,7 +486,7 @@ jobs:
           app="$RUNNER_TEMP/stage/OpenNOW.app"
           test -d "$app"
           test -f "$app/Contents/MacOS/libopennow_streamer_ffi.dylib"
-          test ! -e "$app/Contents/MacOS/opennow-streamer"
+          test -x "$app/Contents/MacOS/opennow-streamer"
           while IFS= read -r -d '' item; do
             codesign --force --options runtime --timestamp --keychain "$OPENNOW_SIGNING_KEYCHAIN" \
               --sign "$SIGN_IDENTITY" "$item"

--- a/native/opennow-core/src/gfn.rs
+++ b/native/opennow-core/src/gfn.rs
@@ -15,6 +15,7 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::env;
+use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -324,23 +325,32 @@ pub struct ServiceError {
 }
 
 impl ServiceError {
-    fn network(context: &str, error: impl std::fmt::Display) -> Self {
+    fn network(context: &str, error: reqwest::Error) -> Self {
         Self {
             code: "network_error",
-            message: format!("{context}: {error}"),
+            message: format!("{context}: {}", error.without_url()),
         }
     }
 
     fn response(context: &str, response: Response) -> Self {
         let status = response.status();
-        let detail = response.text().unwrap_or_default();
-        let detail = detail.chars().take(400).collect::<String>();
+        let mut body = Vec::new();
+        let payload = response
+            .take(16 * 1024 + 1)
+            .read_to_end(&mut body)
+            .ok()
+            .filter(|_| body.len() <= 16 * 1024)
+            .and_then(|_| serde_json::from_slice::<Value>(&body).ok());
+        let detail = payload
+            .as_ref()
+            .and_then(|payload| payload["error"].as_str())
+            .filter(|_| matches!(status.as_u16(), 400 | 401))
+            .filter(|error| matches!(*error, "invalid_grant" | "invalid_token" | "token_revoked"));
         Self {
             code: "upstream_error",
-            message: if detail.is_empty() {
-                format!("{context} ({status})")
-            } else {
-                format!("{context} ({status}): {detail}")
+            message: match detail {
+                Some(detail) => format!("{context} ({status}): {detail}"),
+                None => format!("{context} ({status})"),
             },
         }
     }
@@ -363,6 +373,7 @@ pub struct GfnService {
     account_connections: AccountConnectionsService,
     persistent_storage: PersistentStorageService,
     store_cache: crate::store_cache::StoreCache,
+    auth_operation: Mutex<()>,
     state: Mutex<ServiceState>,
 }
 
@@ -398,6 +409,7 @@ impl GfnService {
             vault,
             profiles: ConsoleProfiles::load(&data_dir),
             store_cache: crate::store_cache::StoreCache::new(data_dir),
+            auth_operation: Mutex::new(()),
             state: Mutex::new(ServiceState::default()),
         }
     }
@@ -634,6 +646,11 @@ impl GfnService {
     }
 
     pub fn complete_device_login(&self, params: &Value) -> Result<Value, ServiceError> {
+        let _operation = self
+            .auth_operation
+            .lock()
+            .expect("GFN auth operation poisoned");
+        crate::requests::check()?;
         let attempt_id = required_param(params, "attemptId")?;
         let mut state = self.state.lock().expect("GFN state poisoned");
         let attempt = state
@@ -678,6 +695,15 @@ impl GfnService {
     }
 
     pub fn session(&self) -> Result<Value, ServiceError> {
+        let _operation = self
+            .auth_operation
+            .lock()
+            .expect("GFN auth operation poisoned");
+        crate::requests::check()?;
+        self.session_locked()
+    }
+
+    fn session_locked(&self) -> Result<Value, ServiceError> {
         {
             let mut state = self.state.lock().expect("GFN state poisoned");
             if state.session.is_none() && !state.restore_attempted {
@@ -798,6 +824,11 @@ impl GfnService {
     }
 
     pub fn logout(&self) -> Result<Value, ServiceError> {
+        let _operation = self
+            .auth_operation
+            .lock()
+            .expect("GFN auth operation poisoned");
+        crate::requests::check()?;
         let user_id = self
             .state
             .lock()
@@ -835,6 +866,11 @@ impl GfnService {
     }
 
     pub fn logout_all(&self) -> Result<Value, ServiceError> {
+        let _operation = self
+            .auth_operation
+            .lock()
+            .expect("GFN auth operation poisoned");
+        crate::requests::check()?;
         self.vault.remove_all().map_err(|message| ServiceError {
             code: "credential_store_error",
             message,
@@ -882,6 +918,11 @@ impl GfnService {
     }
 
     pub fn switch_account(&self, params: &Value) -> Result<Value, ServiceError> {
+        let _operation = self
+            .auth_operation
+            .lock()
+            .expect("GFN auth operation poisoned");
+        crate::requests::check()?;
         let user_id = required_param(params, "userId")?;
         if self.profiles.has_pin(user_id) {
             let verification = self
@@ -934,13 +975,18 @@ impl GfnService {
             state.session = Some(session);
             state.persistence_state = "local-store".to_owned();
         }
-        let result = self.session()?;
+        let result = self.session_locked()?;
         Ok(
             json!({"session":result["session"],"persistence":result["persistence"],"refresh":result["refresh"]}),
         )
     }
 
     pub fn remove_account(&self, params: &Value) -> Result<Value, ServiceError> {
+        let _operation = self
+            .auth_operation
+            .lock()
+            .expect("GFN auth operation poisoned");
+        crate::requests::check()?;
         let user_id = required_param(params, "userId")?;
         let was_active = self
             .state
@@ -1749,7 +1795,7 @@ impl GfnService {
             ];
             match self.token_refresh_request(&form, "Client-token refresh failed") {
                 Ok(payload) => return self.finish_token_refresh(session, &payload),
-                Err(error) => errors.push(error.message),
+                Err(error) => errors.push(error),
             }
         }
         if let Some(refresh_token) = session.tokens.refresh_token.as_deref() {
@@ -1760,15 +1806,23 @@ impl GfnService {
             ];
             match self.token_refresh_request(&form, "Refresh-token exchange failed") {
                 Ok(payload) => return self.finish_token_refresh(session, &payload),
-                Err(error) => errors.push(error.message),
+                Err(error) => errors.push(error),
             }
         }
         Err(ServiceError {
-            code: "session_refresh_failed",
+            code: if !errors.is_empty() && errors.iter().all(is_definitive_auth_revocation) {
+                "session_revoked"
+            } else {
+                "session_refresh_failed"
+            },
             message: if errors.is_empty() {
                 "Session has no refresh mechanism".to_owned()
             } else {
-                errors.join(" | ")
+                errors
+                    .into_iter()
+                    .map(|error| error.message)
+                    .collect::<Vec<_>>()
+                    .join(" | ")
             },
         })
     }
@@ -1892,6 +1946,12 @@ impl GfnService {
 }
 
 fn is_definitive_auth_revocation(error: &ServiceError) -> bool {
+    if error.code == "session_revoked" {
+        return true;
+    }
+    if error.code != "upstream_error" {
+        return false;
+    }
     let message = error.message.to_ascii_lowercase();
     message.contains("invalid_grant")
         || message.contains("invalid_token")
@@ -2601,6 +2661,279 @@ fn required_string(payload: &Value, key: &str) -> Result<String, ServiceError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn mock_responses(
+        responses: Vec<(u16, Value)>,
+        before_response: impl Fn(usize) + Send + 'static,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{BufRead, BufReader, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let worker = std::thread::spawn(move || {
+            for (index, (status, body)) in responses.into_iter().enumerate() {
+                let deadline = std::time::Instant::now() + Duration::from_secs(10);
+                let mut stream = loop {
+                    match listener.accept() {
+                        Ok((stream, _)) => break stream,
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            assert!(std::time::Instant::now() < deadline, "missing HTTP request");
+                            std::thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(error) => panic!("{error}"),
+                    }
+                };
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let mut reader = BufReader::new(&mut stream);
+                let mut length = 0;
+                loop {
+                    let mut line = String::new();
+                    assert!(reader.read_line(&mut line).unwrap() > 0);
+                    if line == "\r\n" {
+                        break;
+                    }
+                    if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                        length = value.trim().parse::<usize>().unwrap();
+                    }
+                }
+                reader.read_exact(&mut vec![0; length]).unwrap();
+                before_response(index);
+                let body = body.to_string();
+                write!(stream, "HTTP/1.1 {status} Test\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{body}", body.len()).unwrap();
+            }
+        });
+        (url, worker)
+    }
+
+    fn auth_fixture(user: &str) -> AuthSession {
+        serde_json::from_value(json!({
+            "provider": LoginProvider::default_nvidia(),
+            "tokens": {"accessToken":"test-access", "refreshToken":"test-refresh",
+                "clientToken":"test-client", "expiresAt":now_ms() + 3_600_000,
+                "clientTokenExpiresAt":now_ms() + 3_600_000, "authClientId":"test-client-id"},
+            "user":{"userId":user,"displayName":"Test","membershipTier":"FREE"}
+        }))
+        .unwrap()
+    }
+
+    fn test_service(url: &str) -> (GfnService, PathBuf) {
+        let path =
+            std::env::temp_dir().join(format!("opennow-auth-test-{}", rand::random::<u64>()));
+        let client = Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
+        let service = GfnService::with_client(
+            client,
+            Endpoints {
+                token: url.to_owned(),
+                client_token: url.to_owned(),
+                ..Endpoints::default()
+            },
+            path.clone(),
+        );
+        (service, path)
+    }
+
+    #[test]
+    fn refresh_cannot_overwrite_a_new_login() {
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let (url, server) = mock_responses(
+            vec![(200, json!({"client_token":"updated", "expires_in":3600}))],
+            move |_| {
+                entered_tx.send(()).unwrap();
+                release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            },
+        );
+        let (service, path) = test_service(&url);
+        let service = std::sync::Arc::new(service);
+        {
+            let mut state = service.state.lock().unwrap();
+            let mut old = auth_fixture("old-account");
+            old.tokens.client_token_expires_at = None;
+            state.session = Some(old);
+            state.persistence_state = "none".into();
+            state.attempts.insert(
+                "new-login".into(),
+                DeviceAttempt {
+                    provider: LoginProvider::default_nvidia(),
+                    device_code: "test-device".into(),
+                    expires_at: now_ms() + 60_000,
+                    pending_session: Some(auth_fixture("new-account")),
+                },
+            );
+        }
+        let refreshing = service.clone();
+        let refresh = std::thread::spawn(move || refreshing.session().unwrap());
+        entered_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        let signing_in = service.clone();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let login = std::thread::spawn(move || {
+            let result = signing_in
+                .complete_device_login(&json!({"attemptId":"new-login", "staySignedIn":false}));
+            done_tx.send(()).unwrap();
+            result.unwrap()
+        });
+        let completed_during_refresh = done_rx.recv_timeout(Duration::from_millis(100)).is_ok();
+        release_tx.send(()).unwrap();
+        refresh.join().unwrap();
+        login.join().unwrap();
+        server.join().unwrap();
+        assert_eq!(
+            service
+                .state
+                .lock()
+                .unwrap()
+                .session
+                .as_ref()
+                .unwrap()
+                .user
+                .user_id,
+            "new-account"
+        );
+        assert!(!completed_during_refresh);
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn cancelled_auth_mutations_do_not_run_after_waiting_for_refresh() {
+        type Mutation = fn(&GfnService) -> Result<Value, ServiceError>;
+        let mutations: [Mutation; 5] = [
+            |service| {
+                service.complete_device_login(&json!({"attemptId":"pending", "staySignedIn":false}))
+            },
+            GfnService::logout,
+            GfnService::logout_all,
+            |service| service.switch_account(&json!({"userId":"new-account"})),
+            |service| service.remove_account(&json!({"userId":"old-account"})),
+        ];
+        let (service, path) = test_service("http://127.0.0.1:1");
+        {
+            let mut state = service.state.lock().unwrap();
+            state.session = Some(auth_fixture("old-account"));
+            state.persistence_state = "none".into();
+            state.attempts.insert(
+                "pending".into(),
+                DeviceAttempt {
+                    provider: LoginProvider::default_nvidia(),
+                    device_code: "test-device".into(),
+                    expires_at: now_ms() + 60_000,
+                    pending_session: Some(auth_fixture("new-account")),
+                },
+            );
+        }
+        let requests = std::sync::Arc::new(crate::requests::Requests::default());
+        for mutation in mutations {
+            let operation = service.auth_operation.lock().unwrap();
+            let permit = requests.admit("mutation", "auth.mutation").unwrap();
+            let token = permit.token.clone();
+            let (started_tx, started_rx) = std::sync::mpsc::channel();
+            std::thread::scope(|scope| {
+                let worker = scope.spawn(|| {
+                    crate::requests::scope(token, || {
+                        crate::requests::check().unwrap();
+                        started_tx.send(()).unwrap();
+                        mutation(&service)
+                    })
+                });
+                started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+                requests.cancel("mutation");
+                drop(operation);
+                assert_eq!(worker.join().unwrap().unwrap_err().code, "cancelled");
+            });
+            let state = service.state.lock().unwrap();
+            assert_eq!(state.session.as_ref().unwrap().user.user_id, "old-account");
+            assert!(state.attempts.contains_key("pending"));
+            assert!(!path.join("accounts.json").exists());
+            drop(permit);
+        }
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn transient_fallback_failure_does_not_revoke_saved_session() {
+        let (url, server) = mock_responses(
+            vec![
+                (400, json!({"error":"invalid_grant"})),
+                (503, json!({"error":"temporarily_unavailable"})),
+            ],
+            |_| {},
+        );
+        let (service, path) = test_service(&url);
+        let error = service
+            .refresh_session(&auth_fixture("test-account"))
+            .unwrap_err();
+        server.join().unwrap();
+        assert_eq!(error.code, "session_refresh_failed");
+        assert!(!is_definitive_auth_revocation(&error));
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn all_revoked_refresh_mechanisms_are_definitive() {
+        let (url, server) = mock_responses(
+            vec![
+                (400, json!({"error":"invalid_grant"})),
+                (401, json!({"error":"invalid_token"})),
+            ],
+            |_| {},
+        );
+        let (service, path) = test_service(&url);
+        let error = service
+            .refresh_session(&auth_fixture("test-account"))
+            .unwrap_err();
+        server.join().unwrap();
+        assert!(is_definitive_auth_revocation(&error));
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn upstream_errors_do_not_echo_credentials_or_trust_server_error_revocation() {
+        let (url, server) = mock_responses(
+            vec![
+                (
+                    400,
+                    json!({"error":"invalid_grant", "error_description":"test-secret-token"}),
+                ),
+                (
+                    503,
+                    json!({"error":"invalid_grant", "access_token":"test-secret-token"}),
+                ),
+            ],
+            |_| {},
+        );
+        let client = Client::builder().no_proxy().build().unwrap();
+        let error = ServiceError::response("Test", client.get(&url).send().unwrap());
+        assert!(!error.message.contains("test-secret-token"));
+        assert!(is_definitive_auth_revocation(&error));
+        let error = ServiceError::response("Test", client.get(&url).send().unwrap());
+        assert!(!error.message.contains("test-secret-token"));
+        assert!(!is_definitive_auth_revocation(&error));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn network_errors_do_not_include_request_urls() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let error = Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(1))
+            .build()
+            .unwrap()
+            .get(format!("http://{address}/?access_token=test-secret-token"))
+            .send()
+            .unwrap_err();
+        let error = ServiceError::network("Test request", error);
+        assert_eq!(error.code, "network_error");
+        assert!(!error.message.contains("test-secret-token"));
+        assert!(!error.message.contains(&address.to_string()));
+    }
 
     #[test]
     fn browser_service_identity_keeps_nvidia_required_webrtc_label() {

--- a/native/opennow-core/src/updater.rs
+++ b/native/opennow-core/src/updater.rs
@@ -80,6 +80,7 @@ struct UpdateManifest {
 pub struct UpdaterService {
     client: Client,
     staging_dir: PathBuf,
+    operation: Mutex<()>,
     state: Mutex<State>,
 }
 
@@ -96,6 +97,7 @@ impl UpdaterService {
         Ok(Self {
             client,
             staging_dir,
+            operation: Mutex::new(()),
             state: Mutex::new(State {
                 status: "idle",
                 available_version: None,
@@ -115,6 +117,7 @@ impl UpdaterService {
     }
 
     pub fn check(&self, params: &Value) -> Result<Value, String> {
+        let _operation = self.begin_operation()?;
         let channel = params["channel"].as_str().unwrap_or("stable");
         if !matches!(channel, "stable" | "nightly") {
             return Err("Unsupported update channel".to_owned());
@@ -205,6 +208,7 @@ impl UpdaterService {
     }
 
     pub fn download(&self) -> Result<Value, String> {
+        let _operation = self.begin_operation()?;
         let available = {
             let mut state = self.state.lock().expect("updater state poisoned");
             let available = state
@@ -238,6 +242,7 @@ impl UpdaterService {
     }
 
     pub fn install(&self, params: &Value) -> Result<Value, String> {
+        let _operation = self.begin_operation()?;
         if params["confirmed"].as_bool() != Some(true) {
             return Err("Update installation requires explicit confirmation".to_owned());
         }
@@ -264,6 +269,17 @@ impl UpdaterService {
             "bodyMarkdown": state.notes,
             "releaseUrl": state.release_url
         })
+    }
+
+    fn begin_operation(&self) -> Result<std::sync::MutexGuard<'_, ()>, String> {
+        let operation = self
+            .operation
+            .try_lock()
+            .map_err(|_| "An update operation is already in progress".to_owned())?;
+        if self.state.lock().expect("updater state poisoned").status == "installing" {
+            return Err("Update installation is already in progress".to_owned());
+        }
+        Ok(operation)
     }
 
     fn download_verified(&self, available: &AvailableUpdate) -> Result<DownloadedUpdate, String> {
@@ -702,6 +718,40 @@ fn now_ms() -> u128 {
 mod tests {
     use super::*;
     use ed25519_dalek::{Signer as _, SigningKey};
+
+    #[test]
+    fn overlapping_update_operations_are_rejected_without_mutating_state() {
+        let path =
+            std::env::temp_dir().join(format!("opennow-update-busy-{}", rand::random::<u64>()));
+        let updater = UpdaterService::new(&path).unwrap();
+        let operation = updater.begin_operation().unwrap();
+        let before = updater.state();
+        for result in [
+            updater.check(&json!({"channel":"invalid"})),
+            updater.download(),
+            updater.install(&json!({"confirmed":true})),
+        ] {
+            assert_eq!(
+                result.unwrap_err(),
+                "An update operation is already in progress"
+            );
+            assert_eq!(updater.state(), before);
+        }
+        drop(operation);
+        assert!(updater.begin_operation().is_ok());
+        updater.state.lock().unwrap().status = "installing";
+        for result in [
+            updater.check(&json!({"channel":"invalid"})),
+            updater.download(),
+            updater.install(&json!({"confirmed":true})),
+        ] {
+            assert_eq!(
+                result.unwrap_err(),
+                "Update installation is already in progress"
+            );
+        }
+        std::fs::remove_dir_all(path).unwrap();
+    }
 
     fn release(version: &str, prerelease: bool) -> Release {
         Release {

--- a/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/frame_producer.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/frame_producer.rs
@@ -185,6 +185,7 @@ impl LinuxGpuFrame {
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
         if state.render != Some(render) {
+            state.render = None;
             state.producer = None;
             state.producer = Some(unsafe {
                 LinuxFrameProducer::new_with_slots(render, self.producer.slot_count)?
@@ -1805,6 +1806,46 @@ fn decode_readiness(result: std::result::Result<(), vk::Result>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn failed_device_recreation_clears_the_cached_device_identity() {
+        let producer = LinuxGpuFrameProducer::new(3).unwrap();
+        let previous = VulkanRenderDevice {
+            instance: 0,
+            physical_device: 0,
+            device: 0,
+            queue_family: 0,
+        };
+        producer.state.lock().unwrap().render = Some(previous);
+        let frame = LinuxGpuFrame {
+            frame: DecodedVideoFrame {
+                format: crate::StreamFormat::video_default(2, 2).unwrap(),
+                planes: Vec::new(),
+                dmabuf: None,
+                vulkan: None,
+                timestamp_us: 0,
+            },
+            producer: producer.clone(),
+            sequence: 0,
+        };
+        let replacement = VulkanRenderDevice {
+            queue_family: 1,
+            ..previous
+        };
+        assert!(matches!(
+            unsafe { frame.record(replacement, 0, 0) },
+            Err(Error::InvalidFormat(_))
+        ));
+        let state = producer.state.lock().unwrap();
+        assert_eq!(state.render, None);
+        assert!(state.producer.is_none());
+        drop(state);
+        assert!(matches!(
+            unsafe { frame.record(previous, 0, 0) },
+            Err(Error::InvalidFormat(_))
+        ));
+    }
+
     #[test]
     fn readiness_is_not_a_render_failure_and_device_loss_is_not_hidden() {
         assert!(decode_readiness(Ok(())).is_ok());

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/ring.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/ring.rs
@@ -5,6 +5,7 @@ pub(crate) struct PcmRing {
     samples: Box<[UnsafeCell<f32>]>,
     read: AtomicUsize,
     write: AtomicUsize,
+    discard_before: AtomicUsize,
 }
 
 // Exactly one Opus worker calls push and exactly one CoreAudio callback calls pop_into. Acquire and
@@ -19,6 +20,7 @@ impl PcmRing {
             samples: (0..capacity).map(|_| UnsafeCell::new(0.0)).collect(),
             read: AtomicUsize::new(0),
             write: AtomicUsize::new(0),
+            discard_before: AtomicUsize::new(0),
         }
     }
 
@@ -37,8 +39,12 @@ impl PcmRing {
     }
 
     pub(crate) fn pop_into(&self, output: &mut [f32]) -> usize {
-        let read = self.read.load(Ordering::Relaxed);
+        let mut read = self.read.load(Ordering::Relaxed);
+        let discard_before = self.discard_before.load(Ordering::Acquire);
         let write = self.write.load(Ordering::Acquire);
+        if discard_before.wrapping_sub(read) <= write.wrapping_sub(read) {
+            read = discard_before;
+        }
         let count = output.len().min(write.wrapping_sub(read));
         for (offset, sample) in output[..count].iter_mut().enumerate() {
             let index = read.wrapping_add(offset) % self.samples.len();
@@ -50,7 +56,7 @@ impl PcmRing {
 
     pub(crate) fn clear(&self) {
         let write = self.write.load(Ordering::Acquire);
-        self.read.store(write, Ordering::Release);
+        self.discard_before.store(write, Ordering::Release);
     }
 }
 
@@ -99,5 +105,33 @@ mod tests {
             expected += 1;
         }
         producer.join().unwrap();
+    }
+
+    #[test]
+    fn clear_defers_slot_reuse_until_the_consumer_releases_samples() {
+        let ring = PcmRing::new(4);
+        assert_eq!(ring.push(&[1.0, 2.0, 3.0, 4.0]), 4);
+        ring.clear();
+        assert_eq!(ring.read.load(Ordering::Relaxed), 0);
+        assert_eq!(ring.push(&[5.0, 6.0]), 0);
+        assert_eq!(ring.pop_into(&mut [0.0; 4]), 0);
+        assert_eq!(ring.push(&[5.0, 6.0]), 2);
+        let mut output = [0.0; 2];
+        assert_eq!(ring.pop_into(&mut output), 2);
+        assert_eq!(output, [5.0, 6.0]);
+    }
+
+    #[test]
+    fn clear_keeps_samples_published_after_the_request() {
+        let ring = PcmRing::new(4);
+        assert_eq!(ring.push(&[1.0, 2.0]), 2);
+        ring.clear();
+        assert_eq!(ring.push(&[3.0, 4.0]), 2);
+        let mut output = [0.0; 4];
+        assert_eq!(ring.pop_into(&mut output), 2);
+        assert_eq!(&output[..2], &[3.0, 4.0]);
+        assert_eq!(ring.push(&[5.0, 6.0]), 2);
+        assert_eq!(ring.pop_into(&mut output), 2);
+        assert_eq!(&output[..2], &[5.0, 6.0]);
     }
 }

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -2354,7 +2354,7 @@ fn strip_trailing_access_unit_delimiter(codec: NvstVideoCodec, bytes: &mut Vec<u
         let start = offset + start;
         let nal_start = start + prefix_len;
         last_nal = Some((start, nal_start));
-        offset = nal_start + 1;
+        offset = nal_start;
     }
     if let Some((start, nal_start)) = last_nal
         && bytes.get(nal_start).is_some_and(|header| match codec {
@@ -2412,14 +2412,15 @@ fn video_access_unit_is_keyframe(
 }
 
 fn find_annex_b_start_code(bytes: &[u8]) -> Option<(usize, usize)> {
-    let four_byte = bytes.windows(4).position(|window| window == [0, 0, 0, 1]);
-    let three_byte = bytes.windows(3).position(|window| window == [0, 0, 1]);
-    match (four_byte, three_byte) {
-        (Some(four_byte), Some(three_byte)) if four_byte <= three_byte => Some((four_byte, 4)),
-        (_, Some(three_byte)) => Some((three_byte, 3)),
-        (Some(four_byte), None) => Some((four_byte, 4)),
-        (None, None) => None,
+    for (offset, prefix) in bytes.windows(3).enumerate() {
+        if prefix == [0, 0, 1] {
+            return Some((offset, 3));
+        }
+        if prefix == [0, 0, 0] && bytes.get(offset + 3) == Some(&1) {
+            return Some((offset, 4));
+        }
     }
+    None
 }
 
 struct RtpReorderBuffer {
@@ -3359,6 +3360,7 @@ impl NvstVideoReceiver {
             return None;
         }
         self.reset_media_state();
+        self.last_authenticated_packet = None;
         self.timeout_origin = Instant::now();
         self.state = NvstReceiverState::Running;
         Some(NvstReceiveEvent::Lifecycle(self.state))
@@ -3369,6 +3371,7 @@ impl NvstVideoReceiver {
             return None;
         }
         self.reset_media_state();
+        self.last_authenticated_packet = None;
         self.timeout_origin = Instant::now();
         self.state = NvstReceiverState::Running;
         Some(NvstReceiveEvent::Lifecycle(self.state))
@@ -7215,6 +7218,20 @@ mod tests {
     }
 
     #[test]
+    fn annex_b_terminal_start_code_does_not_panic() {
+        for codec in [NvstVideoCodec::H264, NvstVideoCodec::H265] {
+            for suffix in [&[0, 0, 1][..], &[0, 0, 0, 1][..]] {
+                let mut bytes = vec![0, 0, 1, 0x61, 0xaa];
+                bytes.extend_from_slice(suffix);
+                let expected = bytes.clone();
+                strip_trailing_access_unit_delimiter(codec, &mut bytes);
+                assert_eq!(bytes, expected);
+                assert!(!video_access_unit_is_keyframe(codec, &bytes, false));
+            }
+        }
+    }
+
+    #[test]
     fn assembles_a_single_packet_frame_without_the_picture_data_flag() {
         let header = NvVideoPacket {
             stream_packet_index: 25,
@@ -8295,6 +8312,30 @@ mod tests {
             ))
         ));
         assert_eq!(receiver.state(), NvstReceiverState::RecoveryRequired);
+    }
+
+    #[test]
+    fn recovery_and_resume_start_a_fresh_media_timeout() {
+        for paused in [false, true] {
+            let mut receiver = NvstVideoReceiver::new(config());
+            receiver.last_authenticated_packet = Some(Instant::now() - Duration::from_secs(1));
+            if paused {
+                receiver.pause().expect("pause running receiver");
+                receiver.resume().expect("resume paused receiver");
+            } else {
+                receiver
+                    .poll_timeout(Instant::now())
+                    .expect("initial timeout");
+                receiver.recover().expect("recover timed out receiver");
+            }
+            assert_eq!(receiver.poll_timeout(Instant::now()), None);
+            assert!(matches!(
+                receiver.poll_timeout(receiver.timeout_origin + receiver.config.timeout),
+                Some(NvstReceiveEvent::RecoveryNeeded(
+                    NvstRecovery::Timeout { .. }
+                ))
+            ));
+        }
     }
 
     #[test]

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -78,9 +78,10 @@ chrome. The shell sends one complete CloudMatch session context and never
 proxies RTSPS, ICE, SRTP or encoded media. Decoders publish native GPU frames
 through the C FFI; `StreamVideoItem` imports and samples them on Qt's QRhi
 render command stream without a child streamer process or native presenter
-window. CPack installs the Qt executable, `opennow-core` and the runtime library;
-there is no separate streamer application. CI produces the platform packages
-from that layout.
+window. CPack installs the Qt executable, `opennow-core`, the runtime library
+and `opennow-streamer` for the core's capability probe. Qt streaming still runs
+in process through the runtime library, not in the probe executable. CI produces
+the platform packages from that layout.
 The screenshot shortcut captures the exact stream region, and F12 records the
 negotiated H.264/H.265/AV1 source stream plus Opus audio atomically into Matroska
 before generating a media thumbnail. Microphone capture is not part of the

--- a/opennow-qt/src/CoreClient.cpp
+++ b/opennow-qt/src/CoreClient.cpp
@@ -203,6 +203,11 @@ bool CoreClient::cancel(const QString &requestId)
 
 void CoreClient::processStdout()
 {
+    if (m_state != u"ready"_s && m_state != u"handshaking"_s) {
+        m_process.readAllStandardOutput();
+        m_stdoutBuffer.clear();
+        return;
+    }
     m_stdoutBuffer += m_process.readAllStandardOutput();
     if (m_stdoutBuffer.size() > MaximumLineBytes && !m_stdoutBuffer.contains('\n')) {
         protocolFailure(u"Core sent an oversized protocol line"_s);
@@ -219,6 +224,10 @@ void CoreClient::processStdout()
         }
         if (!line.isEmpty()) {
             processLine(line);
+            if (m_state != u"ready"_s && m_state != u"handshaking"_s) {
+                m_stdoutBuffer.clear();
+                return;
+            }
         }
     }
 }
@@ -289,6 +298,10 @@ void CoreClient::setState(const QString &state)
 {
     if (m_state == state) return;
     m_state = state;
+    if (state == u"failed"_s || state == u"stopping"_s || state == u"stopped"_s) {
+        m_events.clear();
+        m_droppedEvents = 0;
+    }
     emit stateChanged();
 }
 

--- a/opennow-qt/src/Localization.cpp
+++ b/opennow-qt/src/Localization.cpp
@@ -123,10 +123,13 @@ QString Localization::interpolate(QString value, const QVariantMap &values)
     while (match.hasMatch()) {
         const auto token = match.captured(1);
         const auto replacement = values.value(token);
+        auto nextOffset = match.capturedEnd();
         if (replacement.isValid()) {
-            value.replace(match.capturedStart(), match.capturedLength(), replacement.toString());
+            const auto text = replacement.toString();
+            value.replace(match.capturedStart(), match.capturedLength(), text);
+            nextOffset = match.capturedStart() + text.size();
         }
-        match = placeholder.match(value, match.capturedStart() + 1);
+        match = placeholder.match(value, nextOffset);
     }
     return value;
 }

--- a/opennow-qt/src/NativeStreamRuntime.cpp
+++ b/opennow-qt/src/NativeStreamRuntime.cpp
@@ -218,7 +218,9 @@ void NativeStreamRuntime::invalidatePresentation()
 
 void NativeStreamRuntime::reportPresentationError(const QString &message)
 {
-    QMetaObject::invokeMethod(this, [this, message] {
+    const auto generation = presentationGeneration();
+    QMetaObject::invokeMethod(this, [this, message, generation] {
+        if (generation != presentationGeneration()) return;
         invalidatePresentation();
         setLastError(message);
         qWarning("Stream presentation: %s", qUtf8Printable(message));
@@ -298,19 +300,12 @@ bool NativeStreamRuntime::send(const QJsonObject &command)
 
 bool NativeStreamRuntime::sendBytes(const QByteArray &command)
 {
-    const auto object = QJsonDocument::fromJson(command).object();
-    const auto type = object.value(u"type"_s).toString();
-    if (type == u"start"_s || type == u"stop"_s) {
-        invalidatePresentation();
-        if (type == u"start"_s) {
-            d->firstNotification = false;
-            d->presentationStartId = object.value(u"id"_s).toString();
-        }
-    }
     if (command.size() > MaximumCallbackBytes) {
         setLastError(statusText(OPENNOW_STREAMER_MESSAGE_TOO_LARGE));
         return false;
     }
+    const auto object = QJsonDocument::fromJson(command).object();
+    const auto type = object.value(u"type"_s).toString();
 
     OpenNowStreamerStatus status = OPENNOW_STREAMER_CLOSED;
     {
@@ -326,6 +321,13 @@ bool NativeStreamRuntime::sendBytes(const QByteArray &command)
     if (status != OPENNOW_STREAMER_OK) {
         setLastError(statusText(status));
         return false;
+    }
+    if (type == u"start"_s || type == u"stop"_s) {
+        invalidatePresentation();
+        if (type == u"start"_s) {
+            d->firstNotification = false;
+            d->presentationStartId = object.value(u"id"_s).toString();
+        }
     }
     setLastError({});
     return true;
@@ -642,6 +644,11 @@ void NativeStreamRuntime::scheduleDrain(const std::shared_ptr<CallbackState> &st
 
 void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &state)
 {
+    const QPointer<NativeStreamRuntime> guard(this);
+    const auto current = [&] {
+        return guard && state->target == this && d->callbackState == state;
+    };
+    if (!current()) return;
     QQueue<CallbackState::Message> messages;
     int dropped = 0;
     bool framePending = false;
@@ -660,6 +667,7 @@ void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &s
     if (dropped > 0) {
         handshakeLog(u"callback_queue dropped=%1"_s.arg(dropped));
         emit callbacksDropped(dropped);
+        if (!current()) return;
     }
     if (framePending) {
         if (!d->firstNotification) {
@@ -667,8 +675,10 @@ void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &s
             d->firstNotification = true;
         }
         emit frameAvailable();
+        if (!current()) return;
     }
     while (!messages.isEmpty()) {
+        if (!current()) return;
         const auto message = messages.dequeue();
         if (message.cursor) {
             emit cursorUpdated(message.bytes);
@@ -686,11 +696,13 @@ void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &s
         if (message.event && (kind == u"error"_s
                 || (kind == u"status"_s && (status == u"stopped"_s || status == u"error"_s)))) {
             invalidatePresentation();
+            if (!current()) return;
         } else if (!message.event && !d->presentationStartId.isEmpty()
                 && document.object().value(u"id"_s).toString() == d->presentationStartId) {
             d->presentationStartId.clear();
             d->presentationAllowed.store(kind == u"ok"_s, std::memory_order_release);
             emit frameAvailable();
+            if (!current()) return;
         }
         if (kind != u"telemetry"_s && kind != u"stats"_s && kind != u"log"_s)
             handshakeLog(u"delivered %1 bytes=%2"_s.arg(handshakeSummary(document.object()))
@@ -700,7 +712,7 @@ void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &s
         else
             emit responseReceived(document.object());
     }
-    if (reschedule) scheduleDrain(state);
+    if (current() && reschedule) scheduleDrain(state);
 }
 
 void NativeStreamRuntime::setLastError(const QString &error)

--- a/opennow-qt/tests/fake_core.cpp
+++ b/opennow-qt/tests/fake_core.cpp
@@ -86,6 +86,10 @@ int main(int argc, char **argv)
             std::cout << "{\"type\":\"event\",\"name\":\"catalog.changed\",\"payload\":{\"revision\":2}}\n";
             std::cout << "{\"type\":\"response\",\"id\":\"" << id
                       << "\",\"ok\":true,\"result\":{}}\n" << std::flush;
+        } else if (method == "test.malformed-event-batch") {
+            std::cout << "{invalid json}\n"
+                      << "{\"type\":\"event\",\"name\":\"session.changed\",\"payload\":{\"status\":\"streaming\"}}\n"
+                      << std::flush;
         } else if (method == "test.error") {
             std::cout << "{\"type\":\"response\",\"id\":\"" << id
                       << "\",\"ok\":false,\"error\":{\"code\":\"expected\",\"message\":\"Expected failure\"}}\n" << std::flush;

--- a/opennow-qt/tests/tst_coreclient.cpp
+++ b/opennow-qt/tests/tst_coreclient.cpp
@@ -98,6 +98,38 @@ private slots:
                  QStringLiteral("native-streamer: decoder diagnostic"));
     }
 
+    void rejectsMessagesFollowingFatalProtocolError()
+    {
+        CoreClient client;
+        QSignalSpy failures(&client, &CoreClient::requestFailed);
+        QSignalSpy events(&client, &CoreClient::eventReceived);
+        QVERIFY(client.start(fakeCorePath()));
+        QTRY_COMPARE_WITH_TIMEOUT(client.state(), QStringLiteral("ready"), 2'000);
+        const auto requestId = client.request(QStringLiteral("test.malformed-event-batch"));
+        QTRY_VERIFY_WITH_TIMEOUT(!failures.isEmpty(), 2'000);
+        QCOMPARE(failures.first().at(0).toString(), requestId);
+        QCOMPARE(failures.first().at(1).toString(), QStringLiteral("protocol_error"));
+        client.stop();
+        QCoreApplication::processEvents();
+        QCOMPARE(events.size(), 0);
+    }
+
+    void stopDiscardsAlreadyQueuedEvents()
+    {
+        CoreClient client;
+        QSignalSpy events(&client, &CoreClient::eventReceived);
+        QVERIFY(client.start(fakeCorePath()));
+        QTRY_COMPARE_WITH_TIMEOUT(client.state(), QStringLiteral("ready"), 2'000);
+        const auto requestId = client.request(QStringLiteral("test.event"));
+        connect(&client, &CoreClient::responseReceived, &client,
+                [&client, requestId](const QString &id, const QJsonObject &) {
+                    if (id == requestId) client.stop();
+                });
+        QTRY_COMPARE_WITH_TIMEOUT(client.state(), QStringLiteral("stopped"), 2'000);
+        QCoreApplication::processEvents();
+        QCOMPARE(events.size(), 0);
+    }
+
     void restartsAfterUnexpectedExit()
     {
         CoreClient client;

--- a/opennow-qt/tests/tst_localization.cpp
+++ b/opennow-qt/tests/tst_localization.cpp
@@ -38,6 +38,32 @@ private slots:
                  QStringLiteral("2 games"));
     }
 
+    void interpolationTreatsReplacementTextLiterally()
+    {
+        Localization localization;
+        localization.setLocale(QStringLiteral("en"));
+        QCOMPARE(localization.text(QStringLiteral("library.filteredGameCount"),
+                     {{QStringLiteral("shown"), QStringLiteral("game {{total}}")},
+                      {QStringLiteral("total"), 8}}),
+                 QStringLiteral("game {{total}} of 8 games"));
+        QCOMPARE(localization.text(QStringLiteral("library.filteredGameCount"),
+                     {{QStringLiteral("shown"), QStringLiteral("game {{shown}}")}}),
+                 QStringLiteral("game {{shown}} of {{total}} games"));
+    }
+
+    void interpolationHandlesEmptyAdjacentValues()
+    {
+        Localization localization;
+        localization.setLocale(QStringLiteral("en"));
+        QCOMPARE(localization.text(QStringLiteral("stream.stats.advancedNativeTransition"),
+                     {{QStringLiteral("transition"), QStringLiteral("ready")},
+                      {QStringLiteral("queue"), 0}, {QStringLiteral("caps"), QString()},
+                      {QStringLiteral("requested"), QStringLiteral("requested")},
+                      {QStringLiteral("pending"), QString()},
+                      {QStringLiteral("flush"), QStringLiteral("flush")}}),
+                 QStringLiteral("Native transition ready · queue 0 · caps requestedflush"));
+    }
+
     void everySupportedLocaleLoadsWithFallback()
     {
         Localization localization;

--- a/opennow-qt/tests/tst_nativestreamruntime.cpp
+++ b/opennow-qt/tests/tst_nativestreamruntime.cpp
@@ -12,6 +12,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <utility>
 
 namespace {
 struct FakeRuntime {
@@ -20,6 +21,7 @@ struct FakeRuntime {
 };
 
 int nextDestroyDelayMs = 0;
+OpenNowStreamerStatus sendStatus = OPENNOW_STREAMER_OK;
 std::mutex graphicsCallMutex;
 std::condition_variable graphicsCallChanged;
 bool recordCallEntered = false;
@@ -39,6 +41,7 @@ OpenNowStreamerStatus fakeSend(const OpenNowStreamer *handle, const std::uint8_t
                                std::size_t length)
 {
     if (!handle || (!bytes && length)) return OPENNOW_STREAMER_NULL_POINTER;
+    if (sendStatus != OPENNOW_STREAMER_OK) return sendStatus;
     const auto *runtime = reinterpret_cast<const FakeRuntime *>(handle);
     const QByteArray command(reinterpret_cast<const char *>(bytes),
                              static_cast<qsizetype>(length));
@@ -140,6 +143,7 @@ private slots:
     void init()
     {
         nextDestroyDelayMs = 0;
+        sendStatus = OPENNOW_STREAMER_OK;
         const std::lock_guard lock(graphicsCallMutex);
         recordCallEntered = false;
         allowRecordCallToFinish = false;
@@ -203,6 +207,88 @@ private slots:
         QTRY_COMPARE_WITH_TIMEOUT(cursors.size(), 1, 1'000);
         QCOMPARE(cursors.first().first().toByteArray(), QByteArray::fromHex("000c0000000000"));
         QVERIFY(runtime.shutdown());
+    }
+
+    void discardsPresentationErrorsFromAnEarlierSession()
+    {
+        NativeStreamRuntime runtime(fakeApi());
+        QSignalSpy errors(&runtime, &NativeStreamRuntime::presentationError);
+        QVERIFY(runtime.start());
+        runtime.reportPresentationError(QStringLiteral("old device lost"));
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("new-session")}}));
+        QTRY_VERIFY(runtime.presentationAllowed());
+        QCOMPARE(errors.size(), 0);
+        QVERIFY(runtime.lastError().isEmpty());
+        QVERIFY(runtime.shutdown());
+    }
+
+    void rejectedSessionCommandsPreservePresentation()
+    {
+        NativeStreamRuntime runtime(fakeApi());
+        QVERIFY(runtime.start());
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("active-session")}}));
+        QTRY_VERIFY(runtime.presentationAllowed());
+        const auto generation = runtime.presentationGeneration();
+        sendStatus = OPENNOW_STREAMER_QUEUE_FULL;
+        for (const auto &type : {QStringLiteral("stop"), QStringLiteral("start")}) {
+            QVERIFY(!runtime.send({{QStringLiteral("type"), type},
+                                   {QStringLiteral("id"), QStringLiteral("rejected")}}));
+            QVERIFY(runtime.presentationAllowed());
+            QCOMPARE(runtime.presentationGeneration(), generation);
+        }
+        const auto oversized = QJsonDocument(QJsonObject{
+            {QStringLiteral("type"), QStringLiteral("stop")},
+            {QStringLiteral("padding"), QString(NativeStreamRuntime::MaximumCallbackBytes, 'x')}
+        }).toJson(QJsonDocument::Compact);
+        QVERIFY(!runtime.sendBytes(oversized));
+        QVERIFY(runtime.presentationAllowed());
+        QCOMPARE(runtime.presentationGeneration(), generation);
+        QVERIFY(runtime.shutdown());
+    }
+
+    void discardsDrainedCallbacksWhenASignalRestartsTheRuntime()
+    {
+        NativeStreamRuntime runtime(fakeApi());
+        QSignalSpy responses(&runtime, &NativeStreamRuntime::responseReceived);
+        QSignalSpy cursors(&runtime, &NativeStreamRuntime::cursorUpdated);
+        QVERIFY(runtime.start());
+        bool restarted = false;
+        connect(&runtime, &NativeStreamRuntime::frameAvailable, &runtime, [&] {
+            if (restarted) return;
+            restarted = true;
+            QVERIFY(runtime.shutdown());
+            QVERIFY(runtime.start());
+        });
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("hello")},
+                              {QStringLiteral("id"), QStringLiteral("old-runtime")}}));
+        QTRY_VERIFY(restarted);
+        QCOMPARE(responses.size(), 0);
+        QCOMPARE(cursors.size(), 0);
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("hello")},
+                              {QStringLiteral("id"), QStringLiteral("new-runtime")}}));
+        QTRY_COMPARE(responses.size(), 1);
+        QCOMPARE(responses.first().first().toJsonObject().value(QStringLiteral("id")).toString(),
+                 QStringLiteral("new-runtime"));
+        QTRY_COMPARE(cursors.size(), 1);
+        QVERIFY(runtime.shutdown());
+    }
+
+    void callbackHandlerCanDeleteTheRuntime()
+    {
+        auto *runtime = new NativeStreamRuntime(fakeApi());
+        QSignalSpy responses(runtime, &NativeStreamRuntime::responseReceived);
+        QSignalSpy cursors(runtime, &NativeStreamRuntime::cursorUpdated);
+        QVERIFY(runtime->start());
+        connect(runtime, &NativeStreamRuntime::responseReceived, this, [&] {
+            delete std::exchange(runtime, nullptr);
+        });
+        QVERIFY(runtime->send({{QStringLiteral("type"), QStringLiteral("hello")},
+                               {QStringLiteral("id"), QStringLiteral("delete-runtime")}}));
+        QTRY_VERIFY(!runtime);
+        QCOMPARE(responses.size(), 1);
+        QCOMPARE(cursors.size(), 0);
     }
 
     void boundsShutdownWhenTheFfiDestroyCallStalls()


### PR DESCRIPTION
## Runtime and transport
- Discard Qt callback batches after runtime restart/deletion and reject presentation failures from older generations. Rejected or oversized start/stop commands no longer disable an active presentation.
- Stop core event delivery after protocol failure/shutdown. Interpolate localized replacement values literally, including empty adjacent placeholders.
- Fix an Annex B terminal-prefix panic and replace repeated suffix scanning with a linear forward search. Reset packet timeout history on receiver resume/recovery.
- Keep the CoreAudio ring read cursor consumer-owned during clears, and leave Linux Vulkan device recreation failures in a retryable state.

## Accounts, updates, and packaging
- Serialize authentication refresh/account mutations and recheck cancellation after waiting. Require all refresh mechanisms to be definitively revoked before treating the account as revoked.
- Bound GFN error-body reads and exclude arbitrary upstream bodies and request URLs from reported errors.
- Reject overlapping updater operations and repeated installation to protect state and staging files.
- Align release artifact checks and documentation with the existing packaged capability-probe executable; embedded Qt streaming remains in process. Drain DEB listings rather than terminating their pipelines early.

## Verification
- Full Qt 6.8.3 Debug build and CTest: **137/137 passed**. The stream-video test retains **3 platform/GPU skips** under offscreen Linux.
- Integrated native streamer workspace: **298 tests passed**; workspace Clippy (`--all-targets -- -D warnings`) and formatting passed.
- Rust application core: **129 tests passed** across all targets; strict Clippy and formatting passed.
- Localization validation and its 6 tooling tests passed; release workflow actionlint passed.
- Actual Linux install layout verified. Layout-only DEB/AppImage fixtures accept the required runtime/probe and reject missing or nonexecutable components.
- Added regression cases were reproduced against the original implementations. A synthetic optimized Annex B benchmark confirms the pathological scaling fix; it is not an end-to-end gameplay benchmark.

Live GFN sessions, physical GPU/device-loss behavior, native macOS/Windows APIs, and production signed release creation were not validated in this Linux environment. Existing tests were not weakened.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1VTV9AFQAV3RQ0YTBPGB8VD"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->