### PR TITLE
fix(playnite): preserve catalog integrity and reliable game launches

### DIFF
--- a/playnite/OpenNow.Playnite.Tests/OpenNow.Playnite.Tests.csproj
+++ b/playnite/OpenNow.Playnite.Tests/OpenNow.Playnite.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="PlayniteSDK" Version="6.13.0" />
+    <Compile Include="Program.cs" />
+    <Compile Include="../OpenNow.Playnite/OpenNowPlayController.cs" Link="OpenNowPlayController.cs" />
+    <Compile Include="../OpenNow.Playnite/Common/GameNameMatcher.cs" Link="GameNameMatcher.cs" />
+    <Compile Include="../OpenNow.Playnite/Models/GfnGraphQlResponse.cs" Link="GfnGraphQlResponse.cs" />
+    <Compile Include="../OpenNow.Playnite/Services/GameDetectionService.cs" Link="GameDetectionService.cs" />
+    <Compile Include="../OpenNow.Playnite/Services/GeforceNowService.cs" Link="GeforceNowService.cs" />
+    <Compile Include="../OpenNow.Playnite/Services/OpenNowLauncher.cs" Link="OpenNowLauncher.cs" />
+  </ItemGroup>
+</Project>

--- a/playnite/OpenNow.Playnite.Tests/Program.cs
+++ b/playnite/OpenNow.Playnite.Tests/Program.cs
@@ -1,0 +1,269 @@
+using System.Net;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using OpenNow.Playnite.Models;
+using OpenNow.Playnite;
+using OpenNow.Playnite.Services;
+using Playnite.SDK;
+using Playnite.SDK.Data;
+using Playnite.SDK.Models;
+using Playnite.SDK.Plugins;
+
+typeof(Serialization).GetMethod("Init", BindingFlags.Static | BindingFlags.NonPublic)
+    .Invoke(null, new object[] { DispatchProxy.Create<IDataSerializer, SerializerProxy>() });
+LogManager.Init(new TestLogProvider());
+
+var tests = new (string Name, Action Run)[]
+{
+    ("Windows argument quoting", () =>
+    {
+        Equal("--launch-app-id=2147483648 --launch-title=\"Game\"", OpenNowLauncher.BuildLaunchArguments("Game", 2147483648L));
+        Equal("--launch-title=\"Game\tName\"", OpenNowLauncher.BuildLaunchArguments("Game\tName", null));
+        Equal("""
+            --launch-title="Game \\\"Name\"\\"
+            """, OpenNowLauncher.BuildLaunchArguments("Game \\\"Name\"\\", 0));
+        Equal("--launch-title=\"\"", OpenNowLauncher.BuildLaunchArguments(null, -1));
+    }),
+    ("Exact edition wins over normalized collision in either order", () =>
+    {
+        var standard = Variant(1, "Example", AppStore.Epic);
+        var premium = Variant(2, "Example Premium Edition", AppStore.Epic);
+        foreach (var variants in new[] { new[] { standard, premium }, new[] { premium, standard } })
+        {
+            var service = Database(variants);
+            Equal(1L, Match(service, "Example")?.Id);
+            Equal(2L, Match(service, "Example Premium Edition")?.Id);
+            Equal(null, Match(service, "Example Game of the Year Edition"));
+            Equal(2, service.AllVariants.Count);
+        }
+    }),
+    ("Unambiguous edition fallback and trademarks still match", () =>
+    {
+        var service = Database(Variant(5, "Example™ Premium Edition", AppStore.Epic));
+        Equal(5L, Match(service, "Example")?.Id);
+        Equal(5L, Match(service, "Example Premium Edition")?.Id);
+    }),
+    ("Identical titles with distinct IDs are not arbitrarily selected", () =>
+    {
+        var service = Database(Variant(1, "Example", AppStore.Epic), Variant(2, "Example", AppStore.Epic));
+        Equal(null, Match(service, "Example"));
+        Equal(2, service.AllVariants.Count);
+    }),
+    ("Origin and EA app share title detection", () =>
+    {
+        foreach (var store in new[] { AppStore.Origin, AppStore.EA_APP })
+        {
+            var service = Database(Variant(6, "Example", store));
+            Equal(6L, service.GetMatchingVariant(new Game { Name = "Example", PluginId = BuiltinExtensions.GetIdFromExtension(BuiltinExtension.OriginLibrary) })?.Id);
+            Equal(6L, service.GetMatchingVariant(new Game { Name = "Example", PluginId = Guid.Parse("85dd7072-2f20-4e76-a007-41035e390724") })?.Id);
+        }
+    }),
+    ("Store IDs remain store scoped and database replacement clears indexes", () =>
+    {
+        var steam = Variant(7, "Example", AppStore.Steam);
+        steam.StoreId = "42";
+        var service = Database(steam, null);
+        var game = new Game { GameId = "42", PluginId = BuiltinExtensions.GetIdFromExtension(BuiltinExtension.SteamLibrary) };
+        Equal(7L, service.GetMatchingVariant(game)?.Id);
+        Equal(null, Match(service, "Example"));
+        service.SetDatabase(new GeforceNowItem[] { null, new() { Type = AppType.Dlc, Variants = new() { steam } } });
+        Equal(false, service.HasEntries);
+        Equal(null, service.GetMatchingVariant(game));
+    }),
+    ("Non-Windows variants are excluded", () =>
+    {
+        var linux = Variant(8, "Example", AppStore.Epic);
+        linux.OsType = OsType.Linux;
+        Equal(false, Database(linux).HasEntries);
+    }),
+    ("Complete pages accumulate and cursor is GraphQL escaped", () =>
+    {
+        var cursor = "cursor\"\\\n";
+        using var handler = new CatalogHandler((page, request) =>
+        {
+            using var body = JsonDocument.Parse(request.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+            if (page == 2)
+                True(body.RootElement.GetProperty("query").GetString().Contains("after: " + Serialization.ToJson(cursor)));
+            return Page(page == 1, cursor);
+        });
+        using var client = new HttpClient(handler);
+        Equal(2, GeforceNowService.GetGeforceNowDatabase(client, CancellationToken.None).Count);
+        Equal(2, handler.Count);
+        True(handler.Contents.All(content => content.Disposed));
+        foreach (var request in handler.Requests)
+            Throws<ObjectDisposedException>(() => request.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+    }),
+    ("HTTP failure never returns a partial catalog", () =>
+    {
+        using var handler = new CatalogHandler((page, _) => page == 1 ? Page(true, "next") : new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        using var client = new HttpClient(handler);
+        Throws<HttpRequestException>(() => GeforceNowService.GetGeforceNowDatabase(client, CancellationToken.None));
+        True(handler.Contents.All(content => content.Disposed));
+    }),
+    ("Malformed and GraphQL-error pages reject partial catalogs", () =>
+    {
+        foreach (var invalid in new[] { "{}", "{\"errors\":[{\"message\":\"failed\"}],\"data\":{\"apps\":{\"items\":[],\"pageInfo\":{\"hasNextPage\":false}}}}", "{\"data\":{\"apps\":{\"items\":[]}}}" })
+        {
+            using var handler = new CatalogHandler((page, _) => page == 1 ? Page(true, "next") : JsonResponse(invalid));
+            using var client = new HttpClient(handler);
+            Throws<InvalidOperationException>(() => GeforceNowService.GetGeforceNowDatabase(client, CancellationToken.None));
+        }
+    }),
+    ("Repeated, cyclic, missing and empty-page cursors stop pagination", () =>
+    {
+        foreach (var cursor in new[] { "same", "", null })
+        {
+            using var handler = new CatalogHandler((_, _) => Page(true, cursor));
+            using var client = new HttpClient(handler);
+            Throws<InvalidOperationException>(() => GeforceNowService.GetGeforceNowDatabase(client, CancellationToken.None));
+            True(handler.Count <= 2);
+        }
+        using var cyclic = new CatalogHandler((page, _) => Page(true, (page % 2).ToString()));
+        using var cyclicClient = new HttpClient(cyclic);
+        Throws<InvalidOperationException>(() => GeforceNowService.GetGeforceNowDatabase(cyclicClient, CancellationToken.None));
+        Equal(3, cyclic.Count);
+        using var empty = new CatalogHandler((_, _) => Page(true, "next", 0));
+        using var emptyClient = new HttpClient(empty);
+        Throws<InvalidOperationException>(() => GeforceNowService.GetGeforceNowDatabase(emptyClient, CancellationToken.None));
+        Equal(1, empty.Count);
+    }),
+    ("Page and item limits reject oversized catalogs", () =>
+    {
+        using var handler = new CatalogHandler((page, _) => Page(true, page.ToString()));
+        using var client = new HttpClient(handler);
+        Throws<InvalidOperationException>(() => GeforceNowService.GetGeforceNowDatabase(client, CancellationToken.None));
+        Equal(100, handler.Count);
+        using var oversized = new CatalogHandler((_, _) => Page(false, null, 50001));
+        using var oversizedClient = new HttpClient(oversized);
+        Throws<InvalidOperationException>(() => GeforceNowService.GetGeforceNowDatabase(oversizedClient, CancellationToken.None));
+    }),
+    ("Cancellation prevents requests and interrupts in-flight requests", () =>
+    {
+        using var handler = new CatalogHandler((_, _) => Page(false, null));
+        using var client = new HttpClient(handler);
+        Throws<OperationCanceledException>(() => GeforceNowService.GetGeforceNowDatabase(client, new CancellationToken(true)));
+        Equal(0, handler.Count);
+        using var blockedClient = new HttpClient(new BlockingHandler());
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        Throws<OperationCanceledException>(() => GeforceNowService.GetGeforceNowDatabase(blockedClient, timeout.Token));
+    }),
+    ("Startup watcher stops after its deadline without reporting a started game", () =>
+    {
+        var processes = Process.GetProcessesByName("OpenNOW");
+        foreach (var process in processes) process.Dispose();
+        Equal(0, processes.Length);
+        using var controller = (OpenNowPlayController)RuntimeHelpers.GetUninitializedObject(typeof(OpenNowPlayController));
+        typeof(PlayController).GetField("execContext", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(controller, new SynchronizationContext());
+        var stopped = new TaskCompletionSource<ulong>();
+        var started = false;
+        typeof(PlayController).GetEvent("Started", BindingFlags.Instance | BindingFlags.NonPublic)
+            .GetAddMethod(true).Invoke(controller, new object[] { new EventHandler<GameStartedEventArgs>((_, _) => started = true) });
+        typeof(PlayController).GetEvent("Stopped", BindingFlags.Instance | BindingFlags.NonPublic)
+            .GetAddMethod(true).Invoke(controller, new object[] { new EventHandler<GameStoppedEventArgs>((_, args) => stopped.TrySetResult(args.SessionLength)) });
+        typeof(OpenNowPlayController).GetField("stopWatch", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(controller, Stopwatch.StartNew());
+        typeof(OpenNowPlayController).GetMethod("StartWatching", BindingFlags.Instance | BindingFlags.NonPublic)
+            .Invoke(controller, null);
+        Equal(0UL, stopped.Task.WaitAsync(TimeSpan.FromSeconds(35)).GetAwaiter().GetResult());
+        Equal(false, started);
+    }),
+};
+
+var failures = 0;
+foreach (var (name, run) in tests)
+{
+    try { run(); Console.WriteLine($"PASS {name}"); }
+    catch (Exception error) { failures++; Console.Error.WriteLine($"FAIL {name}: {error}"); }
+}
+Console.WriteLine($"{tests.Length - failures}/{tests.Length} tests passed");
+return failures == 0 ? 0 : 1;
+
+static void Equal(object expected, object actual)
+{
+    if (!Equals(expected, actual)) throw new Exception($"Expected [{expected}], got [{actual}]");
+}
+static void True(bool value) { if (!value) throw new Exception("Expected true"); }
+static void Throws<T>(Action action) where T : Exception
+{
+    try { action(); } catch (T) { return; }
+    throw new Exception($"Expected {typeof(T).Name}");
+}
+static GeforceNowItemVariant Variant(long id, string title, AppStore store) => new() { Id = id, Title = title, AppStore = store };
+static GameDetectionService Database(params GeforceNowItemVariant[] variants)
+{
+    var service = new GameDetectionService();
+    service.SetDatabase(new[] { new GeforceNowItem { Type = AppType.Game, Variants = variants.ToList() } });
+    return service;
+}
+static GeforceNowItemVariant Match(GameDetectionService service, string title) => service.GetMatchingVariant(new Game
+{
+    Name = title, PluginId = BuiltinExtensions.GetIdFromExtension(BuiltinExtension.EpicLibrary)
+});
+static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK) { Content = new TrackedContent(json) };
+static HttpResponseMessage Page(bool hasNextPage, string cursor, int count = 1) => JsonResponse(JsonSerializer.Serialize(new
+{
+    data = new { apps = new { items = Enumerable.Range(0, count).Select(_ => new { type = "Game", variants = Array.Empty<object>() }), pageInfo = new { hasNextPage, endCursor = cursor } } }
+}));
+
+class TrackedContent(string json) : StringContent(json)
+{
+    public bool Disposed { get; private set; }
+    protected override void Dispose(bool disposing) { Disposed = true; base.Dispose(disposing); }
+}
+class CatalogHandler(Func<int, HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+{
+    public int Count { get; private set; }
+    public List<TrackedContent> Contents { get; } = new();
+    public List<HttpRequestMessage> Requests { get; } = new();
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Requests.Add(request);
+        var response = respond(++Count, request);
+        if (response.Content is TrackedContent content) Contents.Add(content);
+        return Task.FromResult(response);
+    }
+}
+class BlockingHandler : HttpMessageHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.Infinite, cancellationToken);
+        throw new InvalidOperationException();
+    }
+}
+public class SerializerProxy : DispatchProxy
+{
+    private static readonly JsonSerializerOptions Options = CreateOptions();
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var resolver = new DefaultJsonTypeInfoResolver();
+        resolver.Modifiers.Add(info =>
+        {
+            foreach (var property in info.Properties)
+                if (property.AttributeProvider?.GetCustomAttributes(typeof(SerializationPropertyNameAttribute), true).FirstOrDefault() is SerializationPropertyNameAttribute name)
+                    property.Name = name.PropertyName;
+        });
+        var options = new JsonSerializerOptions { TypeInfoResolver = resolver };
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
+    }
+    protected override object Invoke(MethodInfo method, object[] args) => method.Name switch
+    {
+        "ToJson" => JsonSerializer.Serialize(args[0], Options),
+        "FromJson" => JsonSerializer.Deserialize((string)args[0], method.ReturnType, Options),
+        _ => throw new NotSupportedException(method.Name)
+    };
+}
+public class LoggerProxy : DispatchProxy
+{
+    protected override object Invoke(MethodInfo method, object[] args) => null;
+}
+class TestLogProvider : ILogProvider
+{
+    public ILogger GetLogger(string name) => DispatchProxy.Create<ILogger, LoggerProxy>();
+}

--- a/playnite/OpenNow.Playnite/Models/GfnGraphQlResponse.cs
+++ b/playnite/OpenNow.Playnite/Models/GfnGraphQlResponse.cs
@@ -6,6 +6,9 @@ namespace OpenNow.Playnite.Models
 {
     public class GfnGraphQlResponse
     {
+        [SerializationPropertyName("errors")]
+        public List<object> Errors { get; set; }
+
         [SerializationPropertyName("data")]
         public GfnGraphQlData Data { get; set; }
     }

--- a/playnite/OpenNow.Playnite/OpenNow.Playnite.csproj
+++ b/playnite/OpenNow.Playnite/OpenNow.Playnite.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>OpenNow.Playnite</AssemblyName>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
+    <EnableDefaultPageItems>false</EnableDefaultPageItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
@@ -18,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="System.Net.Http" />
     <PackageReference Include="PlayniteSDK" Version="6.13.0" />
   </ItemGroup>
 

--- a/playnite/OpenNow.Playnite/OpenNowLibraryClient.cs
+++ b/playnite/OpenNow.Playnite/OpenNowLibraryClient.cs
@@ -37,12 +37,14 @@ namespace OpenNow.Playnite
                 return;
             }
 
-            Process.Start(new ProcessStartInfo
+            using (Process.Start(new ProcessStartInfo
             {
                 FileName = path,
                 UseShellExecute = true,
                 WorkingDirectory = Path.GetDirectoryName(path),
-            });
+            }))
+            {
+            }
         }
     }
 }

--- a/playnite/OpenNow.Playnite/OpenNowLibraryPlugin.cs
+++ b/playnite/OpenNow.Playnite/OpenNowLibraryPlugin.cs
@@ -194,7 +194,7 @@ namespace OpenNow.Playnite
 
         private OpenNowPlayController CreateController(Game game, string cmsId, string title, string executablePath)
         {
-            int? appId = int.TryParse(cmsId, out var parsed) ? parsed : (int?)null;
+            long? appId = long.TryParse(cmsId, out var parsed) ? parsed : (long?)null;
             return new OpenNowPlayController(game, title, appId, executablePath);
         }
 
@@ -204,7 +204,12 @@ namespace OpenNow.Playnite
                 "opennow-exe-not-found",
                 string.Format(ResourceProvider.GetString("LOCOpenNow_NotificationMessage"), executablePath ?? "(auto-detect failed)"),
                 NotificationType.Error,
-                () => Process.Start(new ProcessStartInfo("https://github.com/OpenCloudGaming/OpenNOW/releases") { UseShellExecute = true }));
+                () =>
+                {
+                    using (Process.Start(new ProcessStartInfo("https://github.com/OpenCloudGaming/OpenNOW/releases") { UseShellExecute = true }))
+                    {
+                    }
+                }));
         }
 
         public bool DownloadAndRefreshGameList(bool showDialogs)

--- a/playnite/OpenNow.Playnite/OpenNowPlayController.cs
+++ b/playnite/OpenNow.Playnite/OpenNowPlayController.cs
@@ -12,11 +12,11 @@ namespace OpenNow.Playnite
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
         private readonly string launchTitle;
-        private readonly int? launchAppId;
+        private readonly long? launchAppId;
         private readonly string openNowExecutablePath;
         private Stopwatch stopWatch;
 
-        public OpenNowPlayController(Game game, string launchTitle, int? launchAppId, string openNowExecutablePath)
+        public OpenNowPlayController(Game game, string launchTitle, long? launchAppId, string openNowExecutablePath)
             : base(game)
         {
             Name = ResourceProvider.GetString("LOCOpenNow_ControllerLaunchInOpenNow");
@@ -39,22 +39,40 @@ namespace OpenNow.Playnite
 
         private static bool IsOpenNowRunning()
         {
-            return Process.GetProcessesByName("OpenNOW").Length > 0;
+            var processes = Process.GetProcessesByName("OpenNOW");
+            try
+            {
+                return processes.Length > 0;
+            }
+            finally
+            {
+                foreach (var process in processes)
+                {
+                    process.Dispose();
+                }
+            }
         }
 
         private async void StartWatching()
         {
-            while (true)
+            while (stopWatch.Elapsed < TimeSpan.FromSeconds(30))
             {
                 if (IsOpenNowRunning())
                 {
                     InvokeOnStarted(new GameStartedEventArgs());
-                    break;
+                    await WatchUntilStopped();
+                    return;
                 }
 
                 await Task.Delay(2000);
             }
 
+            Logger.Warn("OpenNOW did not appear within 30 seconds of launch.");
+            InvokeOnStopped(new GameStoppedEventArgs(0));
+        }
+
+        private async Task WatchUntilStopped()
+        {
             while (true)
             {
                 if (!IsOpenNowRunning())

--- a/playnite/OpenNow.Playnite/Services/GameDetectionService.cs
+++ b/playnite/OpenNow.Playnite/Services/GameDetectionService.cs
@@ -12,6 +12,9 @@ namespace OpenNow.Playnite.Services
     {
         private readonly Dictionary<Tuple<AppStore, string>, GeforceNowItemVariant> detectionDictionary
             = new Dictionary<Tuple<AppStore, string>, GeforceNowItemVariant>();
+        private readonly Dictionary<Tuple<AppStore, string>, GeforceNowItemVariant> exactNameDictionary
+            = new Dictionary<Tuple<AppStore, string>, GeforceNowItemVariant>();
+        private readonly List<GeforceNowItemVariant> allVariants = new List<GeforceNowItemVariant>();
 
         private readonly Dictionary<Guid, AppStore> pluginIdToAppStoreMapper;
         private readonly HashSet<AppStore> appStoresToMatchByName;
@@ -49,37 +52,66 @@ namespace OpenNow.Playnite.Services
 
         public bool HasEntries => detectionDictionary.Count > 0;
 
-        public IReadOnlyCollection<GeforceNowItemVariant> AllVariants => detectionDictionary.Values;
+        public IReadOnlyCollection<GeforceNowItemVariant> AllVariants => allVariants;
 
         public void SetDatabase(IEnumerable<GeforceNowItem> items)
         {
             detectionDictionary.Clear();
+            exactNameDictionary.Clear();
+            allVariants.Clear();
             foreach (var item in items ?? Enumerable.Empty<GeforceNowItem>())
             {
-                if (item.Type != AppType.Game || item.Variants == null)
+                if (item == null || item.Type != AppType.Game || item.Variants == null)
                 {
                     continue;
                 }
 
                 foreach (var variant in item.Variants)
                 {
-                    if (variant.OsType != OsType.Windows)
+                    if (variant == null || variant.OsType != OsType.Windows)
                     {
                         continue;
                     }
 
-                    var key = appStoresToMatchByName.Contains(variant.AppStore)
-                        ? Tuple.Create(variant.AppStore, GameNameMatcher.SanitizeForMatching(variant.Title))
-                        : Tuple.Create(variant.AppStore, variant.StoreId ?? string.Empty);
+                    allVariants.Add(variant);
+                    var store = NormalizeStore(variant.AppStore);
+                    var matchByName = appStoresToMatchByName.Contains(store);
+                    var key = matchByName
+                        ? Tuple.Create(store, GameNameMatcher.SanitizeForMatching(variant.Title))
+                        : Tuple.Create(store, variant.StoreId ?? string.Empty);
 
                     if (string.IsNullOrWhiteSpace(key.Item2))
                     {
                         continue;
                     }
 
-                    detectionDictionary[key] = variant;
+                    AddUnambiguousMatch(detectionDictionary, key, variant);
+                    if (matchByName)
+                    {
+                        AddUnambiguousMatch(exactNameDictionary,
+                            Tuple.Create(store, GameNameMatcher.Satinize(variant.Title)), variant);
+                    }
                 }
             }
+        }
+
+        private static AppStore NormalizeStore(AppStore store)
+        {
+            return store == AppStore.Origin ? AppStore.EA_APP : store;
+        }
+
+        private static void AddUnambiguousMatch(
+            Dictionary<Tuple<AppStore, string>, GeforceNowItemVariant> dictionary,
+            Tuple<AppStore, string> key, GeforceNowItemVariant variant)
+        {
+            if (dictionary.TryGetValue(key, out var existing)
+                && (existing == null || existing.Id != variant.Id))
+            {
+                dictionary[key] = null;
+                return;
+            }
+
+            dictionary[key] = variant;
         }
 
         public GeforceNowItemVariant GetMatchingVariant(Game game)
@@ -89,8 +121,15 @@ namespace OpenNow.Playnite.Services
                 return null;
             }
 
+            appStore = NormalizeStore(appStore);
             if (appStoresToMatchByName.Contains(appStore))
             {
+                var exactKey = Tuple.Create(appStore, GameNameMatcher.Satinize(game.Name));
+                if (exactNameDictionary.TryGetValue(exactKey, out var exactMatch))
+                {
+                    return exactMatch;
+                }
+
                 var key = Tuple.Create(appStore, GameNameMatcher.SanitizeForMatching(game.Name));
                 return detectionDictionary.TryGetValue(key, out var byName) ? byName : null;
             }

--- a/playnite/OpenNow.Playnite/Services/GeforceNowService.cs
+++ b/playnite/OpenNow.Playnite/Services/GeforceNowService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 
 namespace OpenNow.Playnite.Services
 {
@@ -16,7 +17,7 @@ namespace OpenNow.Playnite.Services
         private static string BuildQuery(string after, string country = "US", string language = "en_US")
         {
             return $@"{{
-  apps(country:""{country}"", language:""{language}"", after: ""{after}"") {{
+  apps(country:{Serialization.ToJson(country)}, language:{Serialization.ToJson(language)}, after: {Serialization.ToJson(after)}) {{
     numberReturned,
     pageInfo {{
       hasNextPage,
@@ -44,57 +45,66 @@ namespace OpenNow.Playnite.Services
 
         public static List<GeforceNowItem> GetGeforceNowDatabase()
         {
+            using (var client = new HttpClient { MaxResponseContentBufferSize = 8 * 1024 * 1024 })
+            using (var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
+            {
+                return GetGeforceNowDatabase(client, timeout.Token);
+            }
+        }
+
+        internal static List<GeforceNowItem> GetGeforceNowDatabase(HttpClient client, CancellationToken cancellationToken)
+        {
             var afterValue = string.Empty;
             var items = new List<GeforceNowItem>();
             var pageCount = 0;
+            var cursors = new HashSet<string>(StringComparer.Ordinal);
 
             Logger.Info("Fetching GeForce NOW database for OpenNOW Library...");
-            using (var client = new HttpClient())
+            while (pageCount < 100)
             {
-                while (true)
+                cancellationToken.ThrowIfCancellationRequested();
+                pageCount++;
+                var requestBody = Serialization.ToJson(new GraphQlRequest
                 {
-                    pageCount++;
-                    var requestBody = Serialization.ToJson(new GraphQlRequest
-                    {
-                        Query = BuildQuery(afterValue),
-                    });
+                    Query = BuildQuery(afterValue),
+                });
 
-                    var response = client.PostAsync(
-                        GraphQlEndpoint,
-                        new StringContent(requestBody, Encoding.UTF8, "application/json")).GetAwaiter().GetResult();
-
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        Logger.Warn($"GeForce NOW request failed on page {pageCount}: {(int)response.StatusCode}");
-                        break;
-                    }
+                using (var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/json"))
+                using (var response = client.PostAsync(GraphQlEndpoint, requestContent, cancellationToken).GetAwaiter().GetResult())
+                {
+                    response.EnsureSuccessStatusCode();
 
                     var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                     var parsed = Serialization.FromJson<GfnGraphQlResponse>(content);
-                    var pageItems = parsed?.Data?.Apps?.Items;
-                    if (pageItems == null || pageItems.Count == 0)
+                    var apps = parsed?.Data?.Apps;
+                    var pageItems = apps?.Items;
+                    if (parsed?.Errors?.Count > 0 || pageItems == null || apps.PageInfo == null)
                     {
-                        break;
+                        throw new InvalidOperationException("GeForce NOW returned an incomplete catalog page.");
                     }
 
+                    if (items.Count + pageItems.Count > 50000)
+                    {
+                        throw new InvalidOperationException("GeForce NOW catalog exceeded the item limit.");
+                    }
                     items.AddRange(pageItems);
                     Logger.Debug($"Fetched GeForce NOW page {pageCount}: {pageItems.Count} items");
 
-                    if (parsed.Data.Apps.PageInfo?.HasNextPage != true)
+                    if (!apps.PageInfo.HasNextPage)
                     {
-                        break;
+                        Logger.Info($"Finished fetching GeForce NOW database. Pages: {pageCount}, items: {items.Count}");
+                        return items;
                     }
 
-                    afterValue = parsed.Data.Apps.PageInfo.EndCursor ?? string.Empty;
-                    if (string.IsNullOrWhiteSpace(afterValue))
+                    afterValue = apps.PageInfo.EndCursor;
+                    if (pageItems.Count == 0 || string.IsNullOrWhiteSpace(afterValue) || !cursors.Add(afterValue))
                     {
-                        break;
+                        throw new InvalidOperationException("GeForce NOW catalog pagination did not advance.");
                     }
                 }
             }
 
-            Logger.Info($"Finished fetching GeForce NOW database. Pages: {pageCount}, items: {items.Count}");
-            return items;
+            throw new InvalidOperationException("GeForce NOW catalog exceeded the page limit.");
         }
 
         private sealed class GraphQlRequest

--- a/playnite/OpenNow.Playnite/Services/OpenNowLauncher.cs
+++ b/playnite/OpenNow.Playnite/Services/OpenNowLauncher.cs
@@ -13,7 +13,7 @@ namespace OpenNow.Playnite.Services
         public const string PlayActionName = "Play via OpenNOW";
         public const string FeatureName = "OpenNOW";
 
-        public static string BuildLaunchArguments(string title, int? appId)
+        public static string BuildLaunchArguments(string title, long? appId)
         {
             var builder = new StringBuilder();
             if (appId.HasValue && appId.Value > 0)
@@ -34,7 +34,7 @@ namespace OpenNow.Playnite.Services
                 && arguments.IndexOf("--launch-title", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
-        public static bool TryLaunch(string executablePath, string title, int? appId, out string errorMessage)
+        public static bool TryLaunch(string executablePath, string title, long? appId, out string errorMessage)
         {
             errorMessage = null;
             if (string.IsNullOrWhiteSpace(executablePath) || !System.IO.File.Exists(executablePath))
@@ -51,13 +51,15 @@ namespace OpenNow.Playnite.Services
 
             try
             {
-                Process.Start(new ProcessStartInfo
+                using (Process.Start(new ProcessStartInfo
                 {
                     FileName = executablePath,
                     Arguments = BuildLaunchArguments(title.Trim(), appId),
                     UseShellExecute = true,
                     WorkingDirectory = System.IO.Path.GetDirectoryName(executablePath),
-                });
+                }))
+                {
+                }
                 return true;
             }
             catch (Exception ex)
@@ -80,17 +82,24 @@ namespace OpenNow.Playnite.Services
 
         private static string EscapeArgument(string value)
         {
-            if (value.IndexOf('"') >= 0)
+            var escaped = new StringBuilder("\"");
+            var backslashes = 0;
+            foreach (var character in value ?? string.Empty)
             {
-                value = value.Replace("\"", "\\\"");
+                if (character == '\\')
+                {
+                    backslashes++;
+                    continue;
+                }
+
+                escaped.Append('\\', character == '"' ? backslashes * 2 + 1 : backslashes);
+                escaped.Append(character);
+                backslashes = 0;
             }
 
-            if (value.IndexOf(' ') >= 0 || value.IndexOf('"') >= 0)
-            {
-                return $"\"{value}\"";
-            }
-
-            return value;
+            escaped.Append('\\', backslashes * 2);
+            escaped.Append('"');
+            return escaped.ToString();
         }
     }
 }

--- a/playnite/README.md
+++ b/playnite/README.md
@@ -40,6 +40,35 @@ dotnet build -c Release
 
 Output: `playnite/OpenNow.Playnite/bin/Release/`
 
+## Focused regression tests
+
+With the .NET 8 SDK, run from the repository root on Linux or Windows:
+
+```sh
+dotnet run --project playnite/OpenNow.Playnite.Tests -c Release
+dotnet build playnite/OpenNow.Playnite/OpenNow.Playnite.csproj -c Release
+```
+
+The regression harness links the production C# matching, catalog, launcher, and controller sources
+and references the real Playnite SDK 6.13.0. It exits nonzero on any failed assertion. It covers
+edition collisions, EA/Origin detection, store IDs, Windows argument quoting, 64-bit launch IDs,
+catalog pagination/failure bounds, cancellation, HTTP content disposal, and the 30-second startup
+watcher deadline. Close OpenNOW before running the harness; the timeout test requires no OpenNOW
+process to be running and takes about 30 seconds.
+
+Serialization and logging are **test adapters**, not the Playnite host.
+The serializer adapter uses System.Text.Json with the SDK's property-name attributes and string
+enums; HTTP responses are local fixtures, with no NVIDIA requests. NuGet emits NU1701 because the
+SDK targets .NET Framework rather than .NET 8. This harness exercises only its compatible APIs.
+
+The net462 production plugin also compiles with the .NET 8 SDK on Linux, including XAML resources.
+Neither a successful build nor the harness validates **Windows Playnite-host behavior**: extension
+loading, WPF rendering, Windows shell argument parsing, process launch/single-instance handoff,
+library synchronization, and real account/gameplay flows still need Windows acceptance testing.
+The startup test bypasses the WPF-dependent controller constructor and invokes the watcher directly,
+using reflection to attach the SDK's internal event hooks and a test synchronization context. It does
+not launch OpenNOW or validate Playnite's UI.
+
 ## Install for development
 
 1. Playnite → **Settings → For developers → External extensions**
@@ -81,7 +110,14 @@ Install the generated `.pext` by opening it or dragging it onto Playnite.
 
 - **Steam / GOG / Ubisoft / Battle.net / Bethesda / Rockstar**: matched by store/game ID.
 - **Epic / EA app / Xbox**: matched by normalized game title (store IDs often differ from Playnite).
+- Legacy **Origin** and **EA app** catalog entries share title matching.
 - Name normalization removes punctuation/edition noise similar to the reference plugin.
+- Exact normalized titles take priority over edition-stripped matches. Ambiguous keys with distinct
+  launch IDs are not matched automatically; all Windows game variants remain visible in the browser.
+
+Catalog refreshes only replace the cache after complete pagination. HTTP/GraphQL errors, missing or
+repeated cursors, and non-progressing pages fail the refresh rather than saving a partial catalog.
+Requests are bounded to two minutes total, 100 pages, 50,000 items, and an 8 MiB response per page.
 
 If a game is on GeForce NOW but not detected, use **Open GeForce NOW database browser** to verify the catalog title/store ID, then adjust the Playnite game name if needed.
 


### PR DESCRIPTION
## Catalog and matching
- Reject incomplete or failed GraphQL pagination rather than replacing the cache with partial results. Bound the total request duration, response size, page count and item count; reject repeated/missing cursors and dispose HTTP resources.
- Prefer exact normalized editions, reject ambiguous launch IDs instead of selecting the last collision, and retain all Windows variants for browsing. Normalize Origin/EA app detection.

## Launching and build
- Correct Windows quoting for quotes, tabs and trailing backslashes; preserve 64-bit CMS launch IDs.
- Dispose process handles and end the startup watcher after 30 seconds when OpenNOW never appears, without reporting a started game or phantom playtime.
- Repair the missing notification-call parenthesis, duplicate XAML Page items and missing System.Net.Http assembly reference so the net462 plugin builds.

## Verification
- Added a documented .NET 8 harness linking production sources and real Playnite SDK types: **14/14 tests passed**, including the real startup deadline.
- `dotnet build playnite/OpenNow.Playnite/OpenNow.Playnite.csproj -c Release -t:Rebuild`: **passed with 0 warnings/errors**, including XAML/BAML generation on Linux.
- `git diff --check`: passed.

The harness uses serializer/logger test adapters and emits the documented NU1701 SDK compatibility warning. It does not validate Windows Playnite extension loading, WPF rendering, native command-line parsing, actual process launch/single-instance handoff, or real account/gameplay behavior. No Qt/native desktop files changed.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1VTV9AFQAV3RQ0YTBPGB8VD"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->