### PR TITLE
fix(streamer): crop Windows decoder padding without rebuilding video resources

### DIFF
--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/aperture.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/aperture.rs
@@ -1,0 +1,110 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VideoAperture {
+    pub(crate) x: u32,
+    pub(crate) y: u32,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+}
+
+impl VideoAperture {
+    pub(crate) fn new(
+        media_width: u32,
+        media_height: u32,
+        area: Option<(i32, i32, i32, i32)>,
+    ) -> Result<Self, String> {
+        let aperture = match area {
+            None | Some((0, 0, 0, 0)) => Self {
+                x: 0,
+                y: 0,
+                width: media_width,
+                height: media_height,
+            },
+            Some((x, y, width, height)) if x >= 0 && y >= 0 && width > 0 && height > 0 => Self {
+                x: x as u32,
+                y: y as u32,
+                width: width as u32,
+                height: height as u32,
+            },
+            Some(_) => return Err("invalid decoder display aperture".to_owned()),
+        };
+        aperture.validate_extent(media_width, media_height)?;
+        Ok(aperture)
+    }
+
+    pub(crate) fn validate_extent(self, width: u32, height: u32) -> Result<(), String> {
+        if width == 0
+            || height == 0
+            || width > i32::MAX as u32
+            || height > i32::MAX as u32
+            || self.width == 0
+            || self.height == 0
+            || self
+                .x
+                .checked_add(self.width)
+                .is_none_or(|right| right > width)
+            || self
+                .y
+                .checked_add(self.height)
+                .is_none_or(|bottom| bottom > height)
+        {
+            return Err(format!(
+                "decoder display aperture {self:?} exceeds frame extent {width}x{height}"
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn padded_allocation_does_not_change_visible_extent() {
+        let aperture = VideoAperture::new(1920, 1080, None).unwrap();
+        for _ in 0..120 {
+            aperture.validate_extent(1920, 1088).unwrap();
+            assert_eq!((aperture.width, aperture.height), (1920, 1080));
+        }
+    }
+
+    #[test]
+    fn explicit_aperture_preserves_offsets_and_excludes_padding() {
+        let aperture = VideoAperture::new(1920, 1088, Some((8, 4, 1904, 1080))).unwrap();
+        assert_eq!((aperture.x, aperture.y), (8, 4));
+        assert_eq!(
+            (aperture.x + aperture.width, aperture.y + aperture.height),
+            (1912, 1084)
+        );
+        aperture.validate_extent(1920, 1088).unwrap();
+        assert!(aperture.validate_extent(1920, 1080).is_err());
+    }
+
+    #[test]
+    fn absent_and_default_apertures_use_media_not_allocation_extent() {
+        assert_eq!(
+            VideoAperture::new(1920, 1080, None),
+            VideoAperture::new(1920, 1080, Some((0, 0, 0, 0)))
+        );
+    }
+
+    #[test]
+    fn malformed_apertures_are_rejected_without_clamping() {
+        for area in [
+            (-1, 0, 1920, 1080),
+            (0, -1, 1920, 1080),
+            (0, 0, -1, 1080),
+            (0, 0, 1920, 0),
+            (1, 0, 1920, 1080),
+            (0, 9, 1920, 1080),
+            (1, 0, 0, 0),
+        ] {
+            assert!(
+                VideoAperture::new(1920, 1088, Some(area)).is_err(),
+                "{area:?}"
+            );
+        }
+        assert!(VideoAperture::new(0, 1080, None).is_err());
+        assert!(VideoAperture::new(u32::MAX, 1080, None).is_err());
+    }
+}

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
+#[cfg(any(windows, test))]
+mod aperture;
 mod format;
 mod queue;
 

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/decoder.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/decoder.rs
@@ -18,27 +18,30 @@ use ::windows::Win32::Media::MediaFoundation::{
     D3D12_VIDEO_DECODE_PROFILE_HEVC_MAIN_444, D3D12_VIDEO_DECODE_PROFILE_HEVC_MAIN10_444,
 };
 use ::windows::Win32::Media::MediaFoundation::{
-    IMFActivate, IMFAttributes, IMFDXGIBuffer, IMFMediaEventGenerator, IMFSample, IMFTransform,
-    METransformHaveOutput, METransformNeedInput, MF_E_NO_EVENTS_AVAILABLE,
-    MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE, MF_EVENT_FLAG_NO_WAIT,
-    MF_LOW_LATENCY, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_INTERLACE_MODE,
-    MF_MT_MAJOR_TYPE, MF_MT_PIXEL_ASPECT_RATIO, MF_MT_SUBTYPE, MF_MT_VIDEO_NOMINAL_RANGE,
-    MF_SA_D3D11_AWARE, MF_TRANSFORM_ASYNC, MF_TRANSFORM_ASYNC_UNLOCK, MFCreateAttributes,
-    MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video,
-    MFNominalRange_0_255, MFSampleExtension_CleanPoint, MFT_CATEGORY_VIDEO_DECODER,
-    MFT_ENUM_ADAPTER_LUID, MFT_ENUM_FLAG, MFT_ENUM_FLAG_ASYNCMFT, MFT_ENUM_FLAG_HARDWARE,
-    MFT_ENUM_FLAG_SORTANDFILTER, MFT_ENUM_FLAG_SYNCMFT, MFT_ENUM_HARDWARE_URL_Attribute,
-    MFT_FRIENDLY_NAME_Attribute, MFT_MESSAGE_COMMAND_FLUSH, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
+    IMFActivate, IMFAttributes, IMFDXGIBuffer, IMFMediaEventGenerator, IMFMediaType, IMFSample,
+    IMFTransform, METransformHaveOutput, METransformNeedInput, MF_E_ATTRIBUTENOTFOUND,
+    MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE,
+    MF_EVENT_FLAG_NO_WAIT, MF_LOW_LATENCY, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE,
+    MF_MT_GEOMETRIC_APERTURE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE,
+    MF_MT_MINIMUM_DISPLAY_APERTURE, MF_MT_PAN_SCAN_APERTURE, MF_MT_PAN_SCAN_ENABLED,
+    MF_MT_PIXEL_ASPECT_RATIO, MF_MT_SUBTYPE, MF_MT_VIDEO_NOMINAL_RANGE, MF_SA_D3D11_AWARE,
+    MF_TRANSFORM_ASYNC, MF_TRANSFORM_ASYNC_UNLOCK, MFCreateAttributes, MFCreateMediaType,
+    MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video, MFNominalRange_0_255,
+    MFSampleExtension_CleanPoint, MFT_CATEGORY_VIDEO_DECODER, MFT_ENUM_ADAPTER_LUID, MFT_ENUM_FLAG,
+    MFT_ENUM_FLAG_ASYNCMFT, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER,
+    MFT_ENUM_FLAG_SYNCMFT, MFT_ENUM_HARDWARE_URL_Attribute, MFT_FRIENDLY_NAME_Attribute,
+    MFT_MESSAGE_COMMAND_FLUSH, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
     MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_END_STREAMING,
     MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER,
     MFT_OUTPUT_STREAM_CAN_PROVIDE_SAMPLES, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES,
-    MFT_REGISTER_TYPE_INFO, MFTEnum2, MFVideoFormat_AV1, MFVideoFormat_AYUV, MFVideoFormat_H264,
-    MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoFormat_P010, MFVideoFormat_Y410,
-    MFVideoInterlace_MixedInterlaceOrProgressive,
+    MFT_REGISTER_TYPE_INFO, MFTEnum2, MFVideoArea, MFVideoFormat_AV1, MFVideoFormat_AYUV,
+    MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoFormat_P010,
+    MFVideoFormat_Y410, MFVideoInterlace_MixedInterlaceOrProgressive,
 };
 use ::windows::Win32::System::Com::CoTaskMemFree;
 use ::windows::core::Interface;
 
+use crate::aperture::VideoAperture;
 use crate::queue::BoundedQueue;
 use crate::{
     ADAPTIVE_VIDEO_QUEUE_CAPACITY, BackendEvent, EncodedVideoFrame, Subsystem, VideoChromaFormat,
@@ -52,6 +55,8 @@ pub(super) trait DecoderDevice {
 }
 
 pub(super) struct DecodedVideoFrame {
+    pub(super) format: VideoFormat,
+    pub(super) aperture: VideoAperture,
     pub(super) texture: ID3D11Texture2D,
     pub(super) subresource: u32,
     pub(super) timestamp_100ns: i64,
@@ -65,7 +70,11 @@ pub(super) struct DecodedVideoFrame {
 }
 
 impl DecodedVideoFrame {
-    pub(super) fn from_sample(sample: IMFSample, fallback_duration: i64) -> Result<Self, String> {
+    pub(super) fn from_sample(
+        sample: IMFSample,
+        format: VideoFormat,
+        aperture: VideoAperture,
+    ) -> Result<Self, String> {
         let (texture, subresource) = dxgi_surface(&sample)?;
         let timestamp_100ns = unsafe { sample.GetSampleTime().unwrap_or(0) };
         let duration_100ns = unsafe {
@@ -73,9 +82,11 @@ impl DecodedVideoFrame {
                 .GetSampleDuration()
                 .ok()
                 .filter(|duration| *duration > 0)
-                .unwrap_or(fallback_duration)
+                .unwrap_or(format.frame_duration_100ns())
         };
         Ok(Self {
+            format,
+            aperture,
             texture,
             subresource,
             timestamp_100ns,
@@ -93,6 +104,7 @@ pub(super) struct Decoder {
     output_stream: u32,
     input_credits: u32,
     format: VideoFormat,
+    aperture: VideoAperture,
     preferred_pixel_format: VideoPixelFormat,
     output_provides_samples: bool,
     stopped: bool,
@@ -136,6 +148,7 @@ impl Decoder {
                     output_provides_samples,
                     pixel_format,
                     full_range,
+                    aperture,
                 )) => {
                     let input_credits = u32::from(events.is_none());
                     let friendly_name =
@@ -159,11 +172,14 @@ impl Decoder {
                         output_stream,
                         input_credits,
                         format: VideoFormat {
+                            width: aperture.width,
+                            height: aperture.height,
                             pixel_format,
                             chroma_format: chroma_format(pixel_format),
                             full_range,
                             ..format
                         },
+                        aperture,
                         preferred_pixel_format: format.pixel_format,
                         output_provides_samples,
                         stopped: false,
@@ -309,16 +325,18 @@ impl Decoder {
             }
             if error.code() == MF_E_TRANSFORM_STREAM_CHANGE {
                 let pixel_format = self.select_video_output_type()?;
-                let (dimensions, full_range) = self.output_format()?;
+                let (aperture, full_range) =
+                    output_format(&self.transform, self.output_stream, self.format)?;
                 let updated = VideoFormat {
-                    width: dimensions.0,
-                    height: dimensions.1,
+                    width: aperture.width,
+                    height: aperture.height,
                     pixel_format,
                     chroma_format: chroma_format(pixel_format),
                     full_range,
                     ..self.format
                 };
                 self.format = updated;
+                self.aperture = aperture;
                 let _ = event_queue.push(BackendEvent::VideoFormatChanged(updated));
                 return Ok(OutputPoll::Produced);
             }
@@ -332,7 +350,7 @@ impl Decoder {
                 "hardware decoder requires caller-allocated output samples".to_owned()
             }
         })?;
-        let frame = DecodedVideoFrame::from_sample(sample, self.format.frame_duration_100ns())?;
+        let frame = DecodedVideoFrame::from_sample(sample, self.format, self.aperture)?;
         if decoded_frames.len() == ADAPTIVE_VIDEO_QUEUE_CAPACITY {
             decoded_frames.pop_front();
             let _ = event_queue.push(BackendEvent::QueueOverflow(Subsystem::VideoPresentation));
@@ -366,25 +384,6 @@ impl Decoder {
             self.preferred_pixel_format,
         )
     }
-
-    fn output_format(&self) -> Result<((u32, u32), bool), String> {
-        unsafe {
-            let media_type = self
-                .transform
-                .GetOutputCurrentType(self.output_stream)
-                .map_err(|error| error.to_string())?;
-            let packed = media_type
-                .GetUINT64(&MF_MT_FRAME_SIZE)
-                .map_err(|error| error.to_string())?;
-            let nominal_range = media_type
-                .GetUINT32(&MF_MT_VIDEO_NOMINAL_RANGE)
-                .unwrap_or_default();
-            Ok((
-                ((packed >> 32) as u32, packed as u32),
-                nominal_range == MFNominalRange_0_255.0 as u32,
-            ))
-        }
-    }
 }
 
 fn activation_string(activation: &IMFActivate, key: &::windows::core::GUID) -> Option<String> {
@@ -416,6 +415,7 @@ type ConfiguredTransform = (
     bool,
     VideoPixelFormat,
     bool,
+    VideoAperture,
 );
 
 fn configure_transform<G: DecoderDevice>(
@@ -487,7 +487,7 @@ fn configure_transform<G: DecoderDevice>(
             .map_err(|error| error.to_string())?;
         let pixel_format =
             select_video_output_type(&transform, output_stream, format.pixel_format)?;
-        let full_range = output_full_range(&transform, output_stream);
+        let (aperture, full_range) = output_format(&transform, output_stream, format)?;
 
         let stream_info = transform
             .GetOutputStreamInfo(output_stream)
@@ -515,6 +515,7 @@ fn configure_transform<G: DecoderDevice>(
             true,
             pixel_format,
             full_range,
+            aperture,
         ))
     }
 }
@@ -798,14 +799,73 @@ fn chroma_format(pixel_format: VideoPixelFormat) -> VideoChromaFormat {
     }
 }
 
-fn output_full_range(transform: &IMFTransform, output_stream: u32) -> bool {
+fn output_format(
+    transform: &IMFTransform,
+    output_stream: u32,
+    fallback: VideoFormat,
+) -> Result<(VideoAperture, bool), String> {
     unsafe {
-        transform
+        let media_type = transform
             .GetOutputCurrentType(output_stream)
+            .map_err(|error| error.to_string())?;
+        let aperture = output_aperture(&media_type, fallback)?;
+        let full_range = media_type
+            .GetUINT32(&MF_MT_VIDEO_NOMINAL_RANGE)
             .ok()
-            .and_then(|media_type| media_type.GetUINT32(&MF_MT_VIDEO_NOMINAL_RANGE).ok())
-            .is_some_and(|range| range == MFNominalRange_0_255.0 as u32)
+            .filter(|range| *range != 0)
+            .map_or(fallback.full_range, |range| {
+                range == MFNominalRange_0_255.0 as u32
+            });
+        Ok((aperture, full_range))
     }
+}
+
+fn output_aperture(
+    media_type: &IMFMediaType,
+    fallback: VideoFormat,
+) -> Result<VideoAperture, String> {
+    let packed = match unsafe { media_type.GetUINT64(&MF_MT_FRAME_SIZE) } {
+        Ok(packed) => packed,
+        Err(error) if error.code() == MF_E_ATTRIBUTENOTFOUND => {
+            pack_pair(fallback.width, fallback.height)
+        }
+        Err(error) => return Err(error.to_string()),
+    };
+    let pan_scan = unsafe { media_type.GetUINT32(&MF_MT_PAN_SCAN_ENABLED).unwrap_or(0) != 0 };
+    for key in [
+        pan_scan.then_some(&MF_MT_PAN_SCAN_APERTURE),
+        Some(&MF_MT_MINIMUM_DISPLAY_APERTURE),
+        Some(&MF_MT_GEOMETRIC_APERTURE),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let size = match unsafe { media_type.GetBlobSize(key) } {
+            Ok(size) => size as usize,
+            Err(error) if error.code() == MF_E_ATTRIBUTENOTFOUND => continue,
+            Err(error) => return Err(error.to_string()),
+        };
+        if size != size_of::<MFVideoArea>() {
+            return Err(format!("invalid decoder aperture blob size {size}"));
+        }
+        let mut bytes = [0_u8; size_of::<MFVideoArea>()];
+        unsafe { media_type.GetBlob(key, &mut bytes, None) }.map_err(|error| error.to_string())?;
+        let area = unsafe { ptr::read_unaligned(bytes.as_ptr().cast::<MFVideoArea>()) };
+        if area.OffsetX.fract != 0 || area.OffsetY.fract != 0 {
+            return Err("fractional decoder aperture offsets cannot be represented by a D3D11 source rectangle".to_owned());
+        }
+        let area = (
+            i32::from(area.OffsetX.value),
+            i32::from(area.OffsetY.value),
+            area.Area.cx,
+            area.Area.cy,
+        );
+        if area == (0, 0, 0, 0) {
+            continue;
+        }
+        return VideoAperture::new((packed >> 32) as u32, packed as u32, Some(area));
+    }
+    VideoAperture::new((packed >> 32) as u32, packed as u32, None)
 }
 
 fn video_subtype(codec: VideoCodec) -> &'static ::windows::core::GUID {
@@ -846,6 +906,88 @@ fn pack_pair(high: u32, low: u32) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn media_type_apertures_handle_padding_defaults_precedence_and_invalid_offsets() {
+        let _runtime = super::super::MediaRuntime::initialize().unwrap();
+        let format = VideoFormat {
+            codec: VideoCodec::H264,
+            width: 1920,
+            height: 1080,
+            frame_rate_numerator: std::num::NonZeroU32::new(60).unwrap(),
+            frame_rate_denominator: std::num::NonZeroU32::new(1).unwrap(),
+            average_bitrate: 10_000_000,
+            pixel_format: VideoPixelFormat::Nv12,
+            chroma_format: VideoChromaFormat::Cs420,
+            full_range: true,
+        };
+        let media_type = unsafe { MFCreateMediaType().unwrap() };
+        assert_eq!(
+            output_aperture(&media_type, format).unwrap(),
+            VideoAperture::new(1920, 1080, None).unwrap()
+        );
+        unsafe {
+            media_type
+                .SetUINT64(&MF_MT_FRAME_SIZE, pack_pair(1920, 1088))
+                .unwrap();
+        }
+        assert_eq!(output_aperture(&media_type, format).unwrap().height, 1088);
+        let set_area = |key, area: MFVideoArea| {
+            let bytes = unsafe {
+                std::slice::from_raw_parts(
+                    (&area as *const MFVideoArea).cast::<u8>(),
+                    size_of::<MFVideoArea>(),
+                )
+            };
+            unsafe {
+                media_type.SetBlob(key, bytes).unwrap();
+            }
+        };
+        let mut area = MFVideoArea::default();
+        set_area(&MF_MT_MINIMUM_DISPLAY_APERTURE, area);
+        assert_eq!(output_aperture(&media_type, format).unwrap().height, 1088);
+        area.Area.cx = 1904;
+        area.Area.cy = 1080;
+        area.OffsetX.value = 8;
+        area.OffsetY.value = 4;
+        set_area(&MF_MT_GEOMETRIC_APERTURE, area);
+        let visible = output_aperture(&media_type, format).unwrap();
+        assert_eq!(
+            visible,
+            VideoAperture::new(1920, 1088, Some((8, 4, 1904, 1080))).unwrap()
+        );
+        area.Area.cy = 1072;
+        set_area(&MF_MT_MINIMUM_DISPLAY_APERTURE, area);
+        assert_eq!(output_aperture(&media_type, format).unwrap().height, 1072);
+        area.Area.cy = 1064;
+        set_area(&MF_MT_PAN_SCAN_APERTURE, area);
+        assert_eq!(output_aperture(&media_type, format).unwrap().height, 1072);
+        unsafe {
+            media_type.SetUINT32(&MF_MT_PAN_SCAN_ENABLED, 1).unwrap();
+        }
+        assert_eq!(output_aperture(&media_type, format).unwrap().height, 1064);
+        area.OffsetX.fract = 1;
+        set_area(&MF_MT_PAN_SCAN_APERTURE, area);
+        assert!(
+            output_aperture(&media_type, format)
+                .unwrap_err()
+                .contains("fractional")
+        );
+        area.OffsetX.fract = 0;
+        area.OffsetX.value = -1;
+        set_area(&MF_MT_PAN_SCAN_APERTURE, area);
+        assert!(output_aperture(&media_type, format).is_err());
+        unsafe {
+            media_type
+                .SetBlob(&MF_MT_PAN_SCAN_APERTURE, &[0_u8; 1])
+                .unwrap();
+        }
+        assert!(
+            output_aperture(&media_type, format)
+                .unwrap_err()
+                .contains("blob size")
+        );
+    }
 
     #[test]
     fn hardware_profiles_do_not_confuse_codec_depth_or_chroma() {

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/embedded.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/embedded.rs
@@ -44,7 +44,7 @@ use ::windows::core::{IUnknown, Interface};
 use crate::queue::BoundedQueue;
 use crate::{
     ADAPTIVE_VIDEO_QUEUE_CAPACITY, BackendError, BackendEvent, EncodedVideoFrame, PushOutcome,
-    Subsystem, VideoChromaFormat, VideoFormat, VideoPixelFormat, WindowsDecoderMode,
+    Subsystem, VideoFormat, VideoPixelFormat, WindowsDecoderMode,
 };
 
 use super::decoder::{DecodedVideoFrame, Decoder, DecoderDevice};
@@ -354,19 +354,16 @@ impl AdoptedResources {
                 input_description.Format.0
             )
         })?;
-        if pixel_format != self.format.pixel_format
-            || input_description.Width != self.format.width
-            || input_description.Height != self.format.height
-        {
-            self.format = VideoFormat {
-                width: input_description.Width,
-                height: input_description.Height,
-                pixel_format,
-                chroma_format: chroma_format(pixel_format),
-                ..self.format
-            };
-            self.processor = None;
+        if pixel_format != frame.format.pixel_format {
+            return Err(format!(
+                "decoder texture format {pixel_format:?} does not match media format {:?}",
+                frame.format.pixel_format
+            ));
         }
+        frame
+            .aperture
+            .validate_extent(input_description.Width, input_description.Height)?;
+        self.reconfigure(frame.format);
         let array_slice = decoder_array_slice(
             frame.subresource,
             input_description.MipLevels,
@@ -376,8 +373,8 @@ impl AdoptedResources {
             input_description.Width,
             input_description.Height,
             input_description.Format,
-            input_description.Width,
-            input_description.Height,
+            frame.aperture.width,
+            frame.aperture.height,
         )?;
         let processor = self
             .processor
@@ -413,10 +410,10 @@ impl AdoptedResources {
             view
         };
         let source = RECT {
-            left: 0,
-            top: 0,
-            right: processor.input_width as i32,
-            bottom: processor.input_height as i32,
+            left: frame.aperture.x as i32,
+            top: frame.aperture.y as i32,
+            right: (frame.aperture.x + frame.aperture.width) as i32,
+            bottom: (frame.aperture.y + frame.aperture.height) as i32,
         };
         let destination = RECT {
             left: 0,
@@ -666,7 +663,6 @@ impl DecoderDevice for DecoderDeviceSnapshot {
 
 struct ReadyDecodedFrame {
     frame: DecodedVideoFrame,
-    format: VideoFormat,
     decoder_generation: u64,
 }
 
@@ -701,19 +697,11 @@ unsafe impl Sync for D3d11Frame {}
 
 impl D3d11Frame {
     pub fn width(&self) -> u32 {
-        let mut description = D3D11_TEXTURE2D_DESC::default();
-        unsafe {
-            self.frame.texture.GetDesc(&mut description);
-        }
-        description.Width
+        self.frame.aperture.width
     }
 
     pub fn height(&self) -> u32 {
-        let mut description = D3D11_TEXTURE2D_DESC::default();
-        unsafe {
-            self.frame.texture.GetDesc(&mut description);
-        }
-        description.Height
+        self.frame.aperture.height
     }
 
     pub const fn sequence(&self) -> u64 {
@@ -900,7 +888,6 @@ impl D3d11Pipeline {
             self.resources.reset_decoder_views();
             self.presented_decoder_generation = ready.decoder_generation;
         }
-        self.resources.reconfigure(ready.format);
         Ok(Some(ready.frame))
     }
 
@@ -1010,7 +997,6 @@ fn run_decoder_worker(
                 made_progress |= produced > 0;
                 produced_frames = produced_frames.saturating_add(produced as u64);
                 if produced > 0 {
-                    let output_format = decoder.format();
                     let generation = decoder_generation.load(Ordering::Acquire);
                     let mut ready = decoded
                         .lock()
@@ -1023,7 +1009,6 @@ fn run_decoder_worker(
                         }
                         ready.push_back(ReadyDecodedFrame {
                             frame,
-                            format: output_format,
                             decoder_generation: generation,
                         });
                     }
@@ -1365,7 +1350,9 @@ fn pixel_format_from_dxgi(format: DXGI_FORMAT) -> Option<VideoPixelFormat> {
     }
 }
 
-fn chroma_format(format: VideoPixelFormat) -> VideoChromaFormat {
+#[cfg(test)]
+fn chroma_format(format: VideoPixelFormat) -> crate::VideoChromaFormat {
+    use crate::VideoChromaFormat;
     match format {
         VideoPixelFormat::Nv12 | VideoPixelFormat::P010 => VideoChromaFormat::Cs420,
         VideoPixelFormat::Ayuv | VideoPixelFormat::Y410 => VideoChromaFormat::Cs444,
@@ -1375,6 +1362,132 @@ fn chroma_format(format: VideoPixelFormat) -> VideoChromaFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::VideoChromaFormat;
+
+    #[test]
+    fn padded_decoder_frames_crop_and_reuse_processor_views_and_slots() {
+        let _runtime = EmbeddedMediaRuntime::initialize().expect("Media Foundation");
+        let mut device = None;
+        let mut context = None;
+        unsafe {
+            D3D11CreateDevice(
+                None::<&IDXGIAdapter>,
+                D3D_DRIVER_TYPE_HARDWARE,
+                HMODULE::default(),
+                D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+                Some(&[D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0]),
+                D3D11_SDK_VERSION,
+                Some(&mut device),
+                None,
+                Some(&mut context),
+            )
+            .expect("D3D11 test device");
+        }
+        let device = device.unwrap();
+        let context = context.unwrap();
+        if let Err(error) = device.cast::<ID3D11VideoDevice>() {
+            assert_eq!(
+                error.code().0 as u32,
+                0x80004002,
+                "unexpected video probe error: {error}"
+            );
+            eprintln!("SKIP GPU conversion: D3D11 video interface unavailable ({error})");
+            return;
+        }
+        let format = VideoFormat {
+            codec: crate::VideoCodec::H264,
+            width: 1920,
+            height: 1080,
+            frame_rate_numerator: std::num::NonZeroU32::new(60).unwrap(),
+            frame_rate_denominator: std::num::NonZeroU32::new(1).unwrap(),
+            average_bitrate: 10_000_000,
+            pixel_format: VideoPixelFormat::Nv12,
+            chroma_format: VideoChromaFormat::Cs420,
+            full_range: true,
+        };
+        for (allocation_width, aperture) in [
+            (
+                1920,
+                crate::aperture::VideoAperture::new(1920, 1080, None).unwrap(),
+            ),
+            (
+                1936,
+                crate::aperture::VideoAperture::new(1936, 1088, Some((8, 4, 1920, 1080))).unwrap(),
+            ),
+        ] {
+            let mut resources = unsafe {
+                AdoptedResources::new(
+                    AdoptedD3d11Context {
+                        device: device.as_raw(),
+                        immediate_context: context.as_raw(),
+                    },
+                    format,
+                )
+            }
+            .unwrap();
+            let mut description = frame_slot_description(allocation_width, 1088, DXGI_FORMAT_NV12);
+            description.BindFlags =
+                ::windows::Win32::Graphics::Direct3D11::D3D11_BIND_DECODER.0 as u32;
+            description.ArraySize = 2;
+            let mut texture = None;
+            let sample = unsafe {
+                device
+                    .CreateTexture2D(&description, None, Some(&mut texture))
+                    .unwrap();
+                let buffer =
+                    MFCreateDXGISurfaceBuffer(&ID3D11Texture2D::IID, &texture.unwrap(), 1, false)
+                        .unwrap();
+                let sample = MFCreateSample().unwrap();
+                sample.AddBuffer(&buffer).unwrap();
+                sample.SetSampleTime(1_234_567).unwrap();
+                sample.SetSampleDuration(166_667).unwrap();
+                sample
+            };
+            let frame = DecodedVideoFrame::from_sample(sample, format, aperture).unwrap();
+            let first = resources.record(0, &frame).unwrap();
+            let processor = resources.processor.as_ref().unwrap().processor.clone();
+            for _ in 0..3 {
+                resources.reconfigure(format);
+                let recorded = resources.record(0, &frame).unwrap();
+                assert_eq!(resources.format, format);
+                assert_eq!((recorded.width, recorded.height), (1920, 1080));
+                assert_eq!(recorded.texture, first.texture);
+                assert_eq!(recorded.presentation_time_ns, 123_456_700);
+                assert_eq!(frame.subresource, 1);
+                assert_eq!(frame.duration_100ns, 166_667);
+                let active = resources.processor.as_ref().unwrap();
+                assert_eq!(active.processor.as_raw(), processor.as_raw());
+                assert_eq!(
+                    (active.input_width, active.input_height),
+                    (allocation_width, 1088)
+                );
+                assert_eq!(active.input_views.len(), 1);
+                let mut enabled = Default::default();
+                let mut source = RECT::default();
+                unsafe {
+                    resources.video_context.VideoProcessorGetStreamSourceRect(
+                        &processor,
+                        0,
+                        &mut enabled,
+                        &mut source,
+                    );
+                }
+                assert!(enabled.as_bool());
+                assert_eq!(
+                    (source.left, source.top, source.right, source.bottom),
+                    (
+                        aperture.x as i32,
+                        aperture.y as i32,
+                        (aperture.x + 1920) as i32,
+                        (aperture.y + 1080) as i32
+                    )
+                );
+            }
+            resources.reset_decoder_views();
+            assert!(resources.processor.as_ref().unwrap().input_views.is_empty());
+            assert_eq!(resources.record(0, &frame).unwrap().texture, first.texture);
+        }
+    }
     #[test]
     fn decoder_worker_retries_are_bounded_until_old_workers_exit() {
         let mut leases: Vec<_> = (0..4)
@@ -1600,7 +1713,12 @@ mod tests {
             sample
         };
         let baseline_refs = sample_ref_count(&sample);
-        let frame = DecodedVideoFrame::from_sample(sample.clone(), 166_667).unwrap();
+        let frame = DecodedVideoFrame::from_sample(
+            sample.clone(),
+            format,
+            crate::aperture::VideoAperture::new(format.width, format.height, None).unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             sample_ref_count(&sample),
             baseline_refs + 1,


### PR DESCRIPTION
Preserve Media Foundation’s visible aperture separately from decoder texture allocation dimensions. Each leased sample carries its format and aperture through embedded D3D11 conversion, so padded surfaces are cropped correctly and stable frames reuse the video processor, input views, and output slots.

Validate aperture bounds and metadata, preserve the configured color range when output metadata is absent, and retain source sample/timestamp/subresource ownership.

Validation:
- Windows platform crate: 23 host tests passed; native workspace: 302 passed.
- All-target compile checks passed for Windows x64 GNU, Windows x64 MSVC, and Windows ARM64 MSVC.
- Host and Windows x64 MSVC clippy passed; touched-file rustfmt and diff checks passed.
- Added aperture, Media Foundation metadata, and padded-surface crop/resource-reuse coverage. The two Windows-only tests compile but still require execution on a Windows GPU; this Linux environment cannot provide that runtime evidence.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1VZEFE3C8EJY5CGQDFA5M9D"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->