### PR TITLE
fix(input): neutralize controllers and capture native Wayland pointer motion

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -211,6 +211,7 @@ jobs:
             libsecret-1-dev \
             libva-dev \
             libvulkan-dev \
+            libwayland-dev \
             libx11-dev \
             libxcursor-dev \
             libxext-dev \
@@ -221,7 +222,8 @@ jobs:
             libxss-dev \
             make \
             nasm \
-            pkg-config
+            pkg-config \
+            wayland-protocols
 
       - name: Cache Rust dependencies and build artifacts
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -111,8 +111,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libasound2-dev libdbus-1-dev libdrm-dev libpulse-dev libsecret-1-dev \
             libgstreamer-plugins-bad1.0-0 libgstreamer-plugins-good1.0-0 libva-dev libvulkan-dev libx11-dev \
-            libxcursor-dev libxext-dev libxfixes-dev libxi-dev \
-            libxrandr-dev libxrender-dev libxss-dev make nasm pkg-config
+            libwayland-dev libxcursor-dev libxext-dev libxfixes-dev libxi-dev \
+            libxrandr-dev libxrender-dev libxss-dev make nasm pkg-config wayland-protocols
 
       - name: Cache Rust dependencies and build artifacts
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6

--- a/locales/en.json
+++ b/locales/en.json
@@ -2914,6 +2914,8 @@
     "s_qt_resume_wait_session": "The previous session is not available yet. Retrying…",
     "s_qt_resume_wait_claim": "Waiting to resume the session…",
     "s_qt_resume_ready_timeout": "The resumed session did not become ready. Retrying…",
-    "s_qt_resume_wait_ready": "Waiting for the resumed session…"
+    "s_qt_resume_wait_ready": "Waiting for the resumed session…",
+    "s_qt_relative_input_unavailable": "Relative mouse input unavailable",
+    "s_qt_input_media_continues": "Video and audio are still running."
   }
 }

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/embedded_input.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/embedded_input.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -15,6 +14,7 @@ pub enum EmbeddedLocalAction {
 pub struct EmbeddedInputCapture {
     queue: Arc<CapturedInputQueue>,
     active: AtomicBool,
+    gamepads: Mutex<[Option<u16>; 4]>,
     #[cfg(target_os = "linux")]
     raw: Mutex<Option<crate::linux_xinput::LinuxXInputController>>,
     #[cfg(target_os = "windows")]
@@ -26,12 +26,53 @@ impl EmbeddedInputCapture {
         Self {
             queue,
             active: AtomicBool::new(false),
+            gamepads: Mutex::new([None; 4]),
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             raw: Mutex::new(None),
         }
     }
 
     pub fn submit(&self, input: CapturedInput) {
+        let mut gamepads = self
+            .gamepads
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let CapturedInput::Gamepad {
+            controller_id,
+            bitmap,
+            buttons,
+            left_trigger,
+            right_trigger,
+            left_stick_x,
+            left_stick_y,
+            right_stick_x,
+            right_stick_y,
+        } = &input
+        {
+            if usize::from(*controller_id) >= gamepads.len() {
+                return;
+            }
+            let neutral = (
+                *buttons,
+                *left_trigger,
+                *right_trigger,
+                *left_stick_x,
+                *left_stick_y,
+                *right_stick_x,
+                *right_stick_y,
+            ) == (0, 0, 0, 0, 0, 0, 0);
+            if !self.active.load(Ordering::Acquire) && !neutral {
+                return;
+            }
+            for value in gamepads.iter_mut().flatten() {
+                *value = *bitmap;
+            }
+            gamepads[usize::from(*controller_id)] = Some(*bitmap);
+            if neutral && !self.active.load(Ordering::Acquire) {
+                self.queue.release_gamepad(*controller_id, *bitmap);
+                return;
+            }
+        }
         if self.active.load(Ordering::Acquire) {
             self.queue.push(input);
         }
@@ -46,7 +87,18 @@ impl EmbeddedInputCapture {
     }
 
     pub fn set_active(&self, active: bool, relative_mouse: bool, window_handle: usize) -> bool {
+        let mut gamepads = self
+            .gamepads
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if !active {
+            if self.active.load(Ordering::Acquire) {
+                for (controller_id, bitmap) in gamepads.iter_mut().enumerate() {
+                    if let Some(bitmap) = bitmap.take() {
+                        self.queue.release_gamepad(controller_id as u8, bitmap);
+                    }
+                }
+            }
             self.active.store(false, Ordering::Release);
         } else {
             self.active.store(true, Ordering::Release);
@@ -54,8 +106,7 @@ impl EmbeddedInputCapture {
 
         #[cfg(target_os = "linux")]
         {
-            let _ = window_handle;
-            let raw_enabled = raw_capture_enabled(active, relative_mouse);
+            let raw_enabled = x11_raw_capture_enabled(active, relative_mouse, window_handle);
             let mut raw = self
                 .raw
                 .lock()
@@ -117,6 +168,11 @@ impl EmbeddedInputCapture {
     }
 }
 
+#[cfg(any(target_os = "linux", test))]
+const fn x11_raw_capture_enabled(active: bool, relative_mouse: bool, x11_window: usize) -> bool {
+    raw_capture_enabled(active, relative_mouse) && x11_window != 0
+}
+
 #[cfg(any(target_os = "linux", target_os = "windows", test))]
 const fn raw_capture_enabled(active: bool, relative_mouse: bool) -> bool {
     active && relative_mouse
@@ -125,6 +181,144 @@ const fn raw_capture_enabled(active: bool, relative_mouse: bool) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn gamepad(controller_id: u8, bitmap: u16, buttons: u16) -> CapturedInput {
+        CapturedInput::Gamepad {
+            controller_id,
+            bitmap,
+            buttons,
+            left_trigger: 0,
+            right_trigger: 0,
+            left_stick_x: 0,
+            left_stick_y: 0,
+            right_stick_x: 0,
+            right_stick_y: 0,
+        }
+    }
+
+    #[test]
+    fn closing_capture_neutralizes_all_controllers_before_rejecting_held_input() {
+        let queue = Arc::new(CapturedInputQueue::default());
+        let capture = EmbeddedInputCapture::new(Arc::clone(&queue));
+        capture.set_active(true, false, 0);
+        for id in 0..4 {
+            capture.submit(gamepad(id, 0x0f0f, 0x1000));
+            assert_eq!(queue.take(), Some(gamepad(id, 0x0f0f, 0x1000)));
+        }
+        capture.set_active(false, false, 0);
+        capture.submit(gamepad(0, 0x0f0f, 0x1000));
+        for id in 0..4 {
+            assert_eq!(queue.take(), Some(gamepad(id, 0x0f0f, 0)));
+        }
+        assert_eq!(queue.take(), None);
+        capture.set_active(false, false, 0);
+        assert_eq!(queue.take(), None);
+    }
+
+    #[test]
+    fn controller_disconnect_is_preserved_after_capture_closes() {
+        let queue = Arc::new(CapturedInputQueue::default());
+        let capture = EmbeddedInputCapture::new(Arc::clone(&queue));
+        capture.set_active(true, false, 0);
+        capture.submit(gamepad(0, 0x0101, 0x1000));
+        capture.set_active(false, false, 0);
+        capture.submit(gamepad(0, 0, 0));
+        assert_eq!(queue.take(), Some(gamepad(0, 0, 0)));
+        assert_eq!(queue.take(), None);
+    }
+
+    #[test]
+    fn concurrent_controller_submission_cannot_follow_a_capture_closure_neutral() {
+        let queue = Arc::new(CapturedInputQueue::default());
+        let capture = Arc::new(EmbeddedInputCapture::new(Arc::clone(&queue)));
+        capture.set_active(true, false, 0);
+        capture.submit(gamepad(0, 0x0101, 0x1000));
+        queue.take();
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let producer = {
+            let capture = Arc::clone(&capture);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..64 {
+                    capture.submit(gamepad(0, 0x0101, 0x1000));
+                }
+            })
+        };
+        barrier.wait();
+        capture.set_active(false, false, 0);
+        producer.join().unwrap();
+        assert_eq!(queue.take(), Some(gamepad(0, 0x0101, 0)));
+        assert_eq!(queue.take(), None);
+        assert!(!queue.take_overflowed());
+    }
+
+    #[test]
+    fn capture_closure_resets_triggers_and_both_sticks_without_a_button_press() {
+        let queue = Arc::new(CapturedInputQueue::default());
+        let capture = EmbeddedInputCapture::new(Arc::clone(&queue));
+        capture.set_active(true, false, 0);
+        capture.submit(CapturedInput::Gamepad {
+            controller_id: 0,
+            bitmap: 0x0101,
+            buttons: 0,
+            left_trigger: 255,
+            right_trigger: 128,
+            left_stick_x: 32767,
+            left_stick_y: -32768,
+            right_stick_x: 24000,
+            right_stick_y: -24000,
+        });
+        queue.take();
+        capture.set_active(false, false, 0);
+        assert_eq!(queue.take(), Some(gamepad(0, 0x0101, 0)));
+        assert_eq!(queue.take(), None);
+    }
+
+    #[test]
+    fn capture_closure_reserves_neutral_slots_even_when_normal_queue_is_full() {
+        let queue = Arc::new(CapturedInputQueue::default());
+        let capture = EmbeddedInputCapture::new(Arc::clone(&queue));
+        capture.set_active(true, false, 0);
+        for id in 0..4 {
+            capture.submit(gamepad(id, 0x0f0f, 0x1000));
+            queue.take();
+        }
+        for _ in 0..256 {
+            capture.submit_local_action(EmbeddedLocalAction::Guide);
+        }
+        capture.set_active(false, false, 0);
+        assert!(!queue.take_overflowed());
+        for _ in 0..256 {
+            assert_eq!(queue.take(), Some(CapturedInput::Guide));
+        }
+        for id in 0..4 {
+            assert_eq!(queue.take(), Some(gamepad(id, 0x0f0f, 0)));
+        }
+        assert_eq!(queue.take(), None);
+    }
+
+    #[test]
+    fn capture_reacquisition_does_not_replay_stale_controller_state() {
+        let queue = Arc::new(CapturedInputQueue::default());
+        let capture = EmbeddedInputCapture::new(Arc::clone(&queue));
+        for _ in 0..3 {
+            capture.set_active(true, false, 0);
+            assert_eq!(queue.take(), None);
+            capture.submit(gamepad(0, 0x0101, 0x1000));
+            capture.set_active(false, false, 0);
+            assert_eq!(queue.take(), Some(gamepad(0, 0x0101, 0)));
+            assert_eq!(queue.take(), None);
+        }
+    }
+
+    #[test]
+    fn xinput_requires_an_explicit_x11_window_even_with_relative_mode_enabled() {
+        assert!(!x11_raw_capture_enabled(true, true, 0));
+        assert!(x11_raw_capture_enabled(true, true, 42));
+        assert!(!x11_raw_capture_enabled(true, false, 42));
+        assert!(!x11_raw_capture_enabled(false, true, 42));
+    }
 
     #[test]
     fn inactive_capture_drops_input_and_active_capture_preserves_typed_events() {

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
@@ -463,7 +463,7 @@ impl CapturedInputQueue {
         {
             pending.pop_back();
         }
-        if pending.len() == CAPTURED_INPUT_CAPACITY {
+        if pending.len() >= CAPTURED_INPUT_CAPACITY {
             if let Some(index) = pending.iter().position(|event| {
                 matches!(
                     &event.input,
@@ -477,6 +477,33 @@ impl CapturedInputQueue {
             }
         }
         pending.push_back(sample);
+    }
+
+    pub(crate) fn release_gamepad(&self, controller_id: u8, bitmap: u16) {
+        assert!(controller_id < 4);
+        let mut pending = self
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        pending.retain(|sample| {
+            !matches!(sample.input,
+            CapturedInput::Gamepad { controller_id: id, .. } if id == controller_id)
+        });
+        pending.push_back(CapturedInputSample {
+            input: CapturedInput::Gamepad {
+                controller_id,
+                bitmap,
+                buttons: 0,
+                left_trigger: 0,
+                right_trigger: 0,
+                left_stick_x: 0,
+                left_stick_y: 0,
+                right_stick_x: 0,
+                right_stick_y: 0,
+            },
+            captured_at: Instant::now(),
+        });
+        debug_assert!(pending.len() <= CAPTURED_INPUT_CAPACITY + 4);
     }
 
     pub fn take(&self) -> Option<CapturedInput> {

--- a/opennow-qt/CMakeLists.txt
+++ b/opennow-qt/CMakeLists.txt
@@ -49,6 +49,7 @@ set(OPENNOW_RUST_TARGET "" CACHE STRING
     "Optional Rust target triple for cross-architecture desktop packages")
 
 qt_standard_project_setup(REQUIRES 6.8)
+include(cmake/PlatformInput.cmake)
 
 set_source_files_properties(qml/theme/Theme.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
 set_source_files_properties(qml/state/ShellStore.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
@@ -166,6 +167,7 @@ qt_add_qml_module(opennow-qt
         qml/desktop/DesktopStoreShelf.qml
         qml/desktop/DesktopApp.qml
         qml/components/AppChrome.qml
+        qml/components/StreamInputNotice.qml
         qml/components/ReleaseNotes.qml
         qml/components/ArtworkSource.qml
         qml/components/ControllerGlyph.qml
@@ -307,6 +309,7 @@ qt_add_qml_module(opennow-qt
 
 target_include_directories(opennow-qt PRIVATE src)
 target_link_libraries(opennow-qt PRIVATE
+    opennow-platform-input
     Qt6::Quick
     Qt6::QuickControls2
     Qt6::GuiPrivate
@@ -764,6 +767,7 @@ if(BUILD_TESTING)
         FILES shaders/streamvideo.vert shaders/streamvideo.frag
     )
     target_link_libraries(opennow-streamvideo-tests PRIVATE
+        opennow-platform-input
         Qt6::Test Qt6::Core Qt6::Gui Qt6::GuiPrivate Qt6::Qml Qt6::Quick
         opennow-streamer-ffi)
     if(WIN32)
@@ -777,6 +781,11 @@ if(BUILD_TESTING)
              COMMAND opennow-streamvideo-tests -o -,txt)
     set_tests_properties(opennow-streamvideo-tests PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+    qt_add_executable(opennow-waylandpointer-tests tests/tst_waylandpointercapture.cpp)
+    target_link_libraries(opennow-waylandpointer-tests PRIVATE opennow-platform-input Qt6::Test)
+    add_test(NAME opennow-waylandpointer-tests COMMAND opennow-waylandpointer-tests -o -,txt)
+    set_tests_properties(opennow-waylandpointer-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
     qt_add_executable(opennow-nativestreamruntime-tests
         tests/tst_nativestreamruntime.cpp
@@ -867,6 +876,7 @@ if(BUILD_TESTING)
             opennow-qt-tests
             opennow-coreclient-tests
             opennow-streamvideo-tests
+            opennow-waylandpointer-tests
             opennow-nativestreamruntime-tests
             opennow-embedded-orchestration-tests
             opennow-singleinstance-tests
@@ -908,6 +918,7 @@ if(BUILD_TESTING)
                 opennow-qt-tests
                 opennow-coreclient-tests
                 opennow-streamvideo-tests
+                opennow-waylandpointer-tests
                 opennow-nativestreamruntime-tests
                 opennow-embedded-orchestration-tests
                 opennow-singleinstance-tests
@@ -1025,6 +1036,17 @@ if(BUILD_TESTING)
             ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
             TIMEOUT ${OPENNOW_QT_SMOKE_TIMEOUT}
         )
+    endforeach()
+    foreach(surface desktop console)
+        set(input_notice_mode --console)
+        if(surface STREQUAL "desktop")
+            set(input_notice_mode --desktop)
+        endif()
+        add_test(NAME "qml-${surface}-input-capture-error"
+            COMMAND opennow-qt --smoke-test --allow-multiple-instances ${input_notice_mode}
+                --route stream --smoke-input-capture-error --reduced-motion)
+        set_tests_properties("qml-${surface}-input-capture-error" PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT ${OPENNOW_QT_SMOKE_TIMEOUT})
     endforeach()
     add_test(NAME qml-fullscreen-stream-stats-shortcut
              COMMAND opennow-qt --smoke-test --allow-multiple-instances

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -27,6 +27,10 @@ No per-packet or per-input file logging is added to the gameplay path.
 
 Install the Qt ShaderTools development module with Qt Quick and Multimedia; CMake
 bakes the portable video-composition shaders into the executable at build time.
+Linux input also requires `pkg-config`, `libwayland-dev` (including `wayland-scanner`),
+and `wayland-protocols`. These are mandatory build dependencies, including for builds
+that will run on X11. The Wayland backend uses the display, surface and pointer owned
+by Qt; it does not create a second connection or presenter window.
 
 ```sh
 cmake -S opennow-qt -B build/opennow-qt -DCMAKE_BUILD_TYPE=Debug
@@ -44,6 +48,40 @@ QT_QPA_PLATFORM=offscreen ./build/opennow-qt/opennow-qt \
 Useful development switches are `--route <name>`, `--overlay <name>`,
 `--reduced-motion`, `--core <path>` and `--screenshot <png-path>`. The test suite
 opens every route and overlay with QML warnings treated as failures.
+
+### Native input acceptance
+
+Run the controller, stream video, native runtime and Wayland pointer unit tests first:
+
+```sh
+ctest --test-dir build/opennow-qt --output-on-failure \
+  -R 'opennow-(controllerinput|streamvideo|nativestreamruntime|waylandpointer)-tests'
+```
+
+With a native Wayland compositor and an interactive pointer seat, run these opt-in
+tests and move/click the pointer inside the test window when requested by capture:
+
+```sh
+QT_QPA_PLATFORM=wayland OPENNOW_TEST_WAYLAND_CAPTURE=1 \
+  ./build/opennow-qt/opennow-waylandpointer-tests compositorCaptureLifecycle
+QT_QPA_PLATFORM=wayland OPENNOW_TEST_WAYLAND_CAPTURE=1 \
+  ./build/opennow-qt/opennow-streamvideo-tests \
+  waylandAbsoluteToPendingRelativeLockSurvivesUntilCompositorAcknowledges
+```
+
+The compositor must provide `zwp_relative_pointer_manager_v1` and
+`zwp_pointer_constraints_v1`. Missing support visibly disables relative gameplay
+capture without stopping audio/video. Native Wayland never falls back to XWayland
+XInput2 or cursor warping. X11 retains XInput2 and Windows retains Raw Input.
+The ordinary input queue remains bounded to 256 events, with four coalesced controller
+neutral slots reserved for capture closure. Focus loss never depends on QML callback
+ordering to release a held controller.
+
+The public-safe `--smoke-test --route stream --smoke-input-capture-error` fixture
+renders the shared error banner over the existing stream item. Add `--desktop` for
+the desktop shell and `--screenshot /absolute/path.png` to save visual evidence.
+Offscreen and nested compositor tests do not replace live Windows/X11/Wayland
+controller and mouse acceptance on real streaming sessions.
 
 The representative-hardware performance workload drives production route and popup motion,
 checks focus after every transition, and records refresh-relative frame budgets atomically:

--- a/opennow-qt/cmake/PlatformInput.cmake
+++ b/opennow-qt/cmake/PlatformInput.cmake
@@ -1,0 +1,30 @@
+add_library(opennow-platform-input STATIC
+    "${CMAKE_CURRENT_LIST_DIR}/../src/WaylandPointerCapture.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/../src/WaylandPointerCapture.h")
+target_link_libraries(opennow-platform-input PUBLIC Qt6::Gui PRIVATE Qt6::GuiPrivate)
+target_include_directories(opennow-platform-input PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../src")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    enable_language(C)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(WAYLAND_CLIENT REQUIRED IMPORTED_TARGET wayland-client)
+    pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols)
+    pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
+    find_program(WAYLAND_SCANNER wayland-scanner REQUIRED)
+    set(OPENNOW_INPUT_PROTOCOL_DIR "${CMAKE_CURRENT_BINARY_DIR}/input-protocols")
+    file(MAKE_DIRECTORY "${OPENNOW_INPUT_PROTOCOL_DIR}")
+    foreach(protocol relative-pointer pointer-constraints)
+        set(protocol_name "${protocol}-unstable-v1")
+        set(protocol_xml "${WAYLAND_PROTOCOLS_DIR}/unstable/${protocol}/${protocol_name}.xml")
+        set(protocol_header "${OPENNOW_INPUT_PROTOCOL_DIR}/${protocol_name}-client-protocol.h")
+        set(protocol_code "${OPENNOW_INPUT_PROTOCOL_DIR}/${protocol_name}-protocol.c")
+        add_custom_command(OUTPUT "${protocol_header}" "${protocol_code}"
+            COMMAND "${WAYLAND_SCANNER}" client-header "${protocol_xml}" "${protocol_header}"
+            COMMAND "${WAYLAND_SCANNER}" private-code "${protocol_xml}" "${protocol_code}"
+            DEPENDS "${protocol_xml}" VERBATIM)
+        target_sources(opennow-platform-input PRIVATE "${protocol_header}" "${protocol_code}")
+    endforeach()
+    target_include_directories(opennow-platform-input PRIVATE "${OPENNOW_INPUT_PROTOCOL_DIR}")
+    target_compile_definitions(opennow-platform-input PRIVATE OPENNOW_WAYLAND_INPUT)
+    target_link_libraries(opennow-platform-input PRIVATE PkgConfig::WAYLAND_CLIENT)
+endif()

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -113,6 +113,7 @@ ApplicationWindow {
             fullscreenInputSync.restart()
     }
     onVisibilityChanged: if (activeRoute === "stream") fullscreenInputSync.restart()
+    onActiveChanged: syncInputOwnership()
     onDesktopSurfaceActiveChanged: ShellStore.desktopUiActive = desktopSurfaceActive
 
     Connections {
@@ -124,7 +125,8 @@ ApplicationWindow {
     }
 
     function syncInputOwnership() {
-        const shellOwnsInput = AppController.route !== "stream"
+        ControllerInput.inputSuspended = !window.active
+        const shellOwnsInput = !window.active || AppController.route !== "stream"
             || ShellStore.streamOverlayBlocksGameplayInput(AppController.overlay)
         ControllerInput.shellCaptureEnabled = shellOwnsInput
             && ShellStore.settings.controllerMode !== false

--- a/opennow-qt/qml/components/StreamInputNotice.qml
+++ b/opennow-qt/qml/components/StreamInputNotice.qml
@@ -1,0 +1,46 @@
+import QtQuick
+
+Rectangle {
+    id: root
+    objectName: "streamInputCaptureNotice"
+    property string message: ""
+    visible: message.length > 0
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.bottom: parent.bottom
+    anchors.bottomMargin: 96
+    width: Math.min(680, parent.width - 48)
+    height: copy.implicitHeight + 32
+    radius: 12
+    color: "#F0222936"
+    border.color: "#BC9554"
+    border.width: 1
+    Accessible.role: Accessible.AlertMessage
+    Accessible.name: heading.text + ". " + detail.text
+
+    Column {
+        id: copy
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.margins: 16
+        spacing: 6
+
+        Text {
+            id: heading
+            width: parent.width
+            text: qsTr("Relative mouse input unavailable")
+            font.pixelSize: 17
+            font.weight: Font.DemiBold
+            color: "#FFE0A6"
+            wrapMode: Text.Wrap
+        }
+        Text {
+            id: detail
+            width: parent.width
+            text: root.message + "\n" + qsTr("Video and audio are still running.")
+            font.pixelSize: 14
+            color: "#E3E7EF"
+            wrapMode: Text.Wrap
+        }
+    }
+}

--- a/opennow-qt/qml/desktop/DesktopStreamScreen.qml
+++ b/opennow-qt/qml/desktop/DesktopStreamScreen.qml
@@ -107,6 +107,11 @@ FocusScope {
         onLocalShortcutRequested: action => ShellStore.applyStreamShortcutAction(action)
     }
 
+    StreamInputNotice {
+        message: root.streaming && streamVideo.relativeMouse ? streamVideo.inputCaptureError : ""
+        z: 3
+    }
+
     Connections {
         target: ShellStore
         function onPointerLockToggleRequested() {

--- a/opennow-qt/qml/screens/StreamScreen.qml
+++ b/opennow-qt/qml/screens/StreamScreen.qml
@@ -94,6 +94,11 @@ FocusScope {
         onLocalShortcutRequested: action => ShellStore.applyStreamShortcutAction(action)
     }
 
+    StreamInputNotice {
+        message: root.streaming && streamVideo.relativeMouse ? streamVideo.inputCaptureError : ""
+        z: 3
+    }
+
     Connections {
         target: ShellStore
         function onPointerLockToggleRequested() {

--- a/opennow-qt/src/ControllerInput.cpp
+++ b/opennow-qt/src/ControllerInput.cpp
@@ -43,6 +43,7 @@ ControllerInput::ControllerInput(QObject *parent)
 ControllerInput::~ControllerInput()
 {
     m_pollTimer.stop();
+    publishConnectedGamepads(true);
     for (auto &slot : m_slots) {
         if (slot.gamepad) SDL_CloseGamepad(slot.gamepad);
         slot = {};
@@ -65,7 +66,7 @@ void ControllerInput::updatePollInterval()
 {
     // Keep hotplug discovery alive without waking the GUI 250 times/second
     // when there is no controller. Gameplay retains its low-latency cadence.
-    const auto interval = m_gamepadSlots.isEmpty() ? 100 : m_shellCaptureEnabled ? 16 : 4;
+    const auto interval = m_gamepadSlots.isEmpty() || m_inputSuspended ? 100 : m_shellCaptureEnabled ? 16 : 4;
     m_pollTimer.setTimerType(interval == 4 ? Qt::PreciseTimer : Qt::CoarseTimer);
     if (m_pollTimer.interval() != interval) m_pollTimer.setInterval(interval);
 }
@@ -98,6 +99,27 @@ void ControllerInput::refreshControllerMetadata()
 bool ControllerInput::shellCaptureEnabled() const
 {
     return m_shellCaptureEnabled;
+}
+
+bool ControllerInput::inputSuspended() const
+{
+    return m_inputSuspended;
+}
+
+void ControllerInput::setInputSuspended(bool suspended)
+{
+    if (m_inputSuspended == suspended) return;
+    if (suspended) publishConnectedGamepads(true);
+    m_inputSuspended = suspended;
+    for (auto *direction : {&m_left, &m_right, &m_up, &m_down})
+        *direction = RepeatingDirection{false, 0, 0, direction->key};
+    if (!suspended && !m_shellCaptureEnabled) {
+        for (int slot = 0; slot < static_cast<int>(m_slots.size()); ++slot)
+            updateSlotSnapshot(slot);
+        publishConnectedGamepads();
+    }
+    updatePollInterval();
+    emit inputSuspendedChanged();
 }
 
 void ControllerInput::setShellCaptureEnabled(bool enabled)
@@ -188,7 +210,7 @@ void ControllerInput::closeController(SDL_JoystickID id)
     if (!slot.gamepad) return;
     SDL_CloseGamepad(slot.gamepad);
     slot = {};
-    if (!m_shellCaptureEnabled) publishGamepad(slotIndex, true);
+    publishGamepad(slotIndex, true);
     for (auto *direction : {&m_left, &m_right, &m_up, &m_down}) {
         direction->active = false;
         direction->pressedAt = 0;
@@ -205,7 +227,7 @@ void ControllerInput::handleButton(const SDL_GamepadButtonEvent &event, bool pre
     if (slotIndex < 0) return;
     auto &slot = m_slots[static_cast<std::size_t>(slotIndex)];
     if (event.button == SDL_GAMEPAD_BUTTON_GUIDE) {
-        if (pressed && !m_shellCaptureEnabled)
+        if (pressed && !m_shellCaptureEnabled && !m_inputSuspended)
             emit localActionRequested(guideLocalAction);
     } else if (const auto mask = buttonMask(event.button); mask != 0) {
         if (pressed) slot.buttons |= mask;
@@ -213,7 +235,7 @@ void ControllerInput::handleButton(const SDL_GamepadButtonEvent &event, bool pre
         if (!m_shellCaptureEnabled) publishGamepad(slotIndex);
     }
 
-    if (!m_shellCaptureEnabled) return;
+    if (!m_shellCaptureEnabled || m_inputSuspended) return;
     const auto key = keyForButton(event.button);
     if (key != 0) {
         postKey(key, pressed);
@@ -236,7 +258,7 @@ void ControllerInput::handleAxis(const SDL_GamepadAxisEvent &event)
     default: return;
     }
     if (!m_shellCaptureEnabled) publishGamepad(slotIndex);
-    if (!m_shellCaptureEnabled) return;
+    if (!m_shellCaptureEnabled || m_inputSuspended) return;
 
     const auto value = event.value;
     bool activated = false;
@@ -262,6 +284,7 @@ quint16 ControllerInput::gamepadBitmap() const
 
 void ControllerInput::publishGamepad(int slotIndex, bool neutral)
 {
+    if (m_inputSuspended && !neutral) return;
     const auto &slot = m_slots[static_cast<std::size_t>(slotIndex)];
     const auto left = neutral ? QPair<qint16, qint16>{} : radialDeadzone(slot.rawLeftX, slot.rawLeftY);
     const auto right = neutral ? QPair<qint16, qint16>{} : radialDeadzone(slot.rawRightX, slot.rawRightY);
@@ -375,7 +398,7 @@ void ControllerInput::dispatchRepeats(qint64 now)
 
 void ControllerInput::postKey(int key, bool pressed, bool autoRepeat)
 {
-    if (!m_shellCaptureEnabled) return;
+    if (!m_shellCaptureEnabled || m_inputSuspended) return;
     auto *target = QGuiApplication::focusObject();
     if (!target) target = QCoreApplication::instance();
     const auto type = pressed ? QEvent::KeyPress : QEvent::KeyRelease;

--- a/opennow-qt/src/ControllerInput.h
+++ b/opennow-qt/src/ControllerInput.h
@@ -16,6 +16,7 @@ class ControllerInput final : public QObject
     Q_PROPERTY(int controllerCount READ controllerCount NOTIFY controllerCountChanged)
     Q_PROPERTY(QVariantList controllers READ controllers NOTIFY controllersChanged)
     Q_PROPERTY(bool shellCaptureEnabled READ shellCaptureEnabled WRITE setShellCaptureEnabled NOTIFY shellCaptureEnabledChanged)
+    Q_PROPERTY(bool inputSuspended READ inputSuspended WRITE setInputSuspended NOTIFY inputSuspendedChanged)
 
 public:
     static constexpr quint32 syntheticControllerScanCode = 0x4f504e57;
@@ -27,11 +28,14 @@ public:
     [[nodiscard]] QVariantList controllers() const;
     [[nodiscard]] bool shellCaptureEnabled() const;
     void setShellCaptureEnabled(bool enabled);
+    [[nodiscard]] bool inputSuspended() const;
+    void setInputSuspended(bool suspended);
 
 signals:
     void controllerCountChanged(int count);
     void controllersChanged();
     void shellCaptureEnabledChanged();
+    void inputSuspendedChanged();
     void controllerActivity();
     void controllerActivityDetailed(const QString &device, const QString &control, int value);
     void gamepadSnapshot(quint8 controllerId, quint16 bitmap, quint16 buttons,
@@ -89,6 +93,7 @@ private:
     std::array<GamepadSlot, 4> m_slots;
     bool m_sdlReady = false;
     bool m_shellCaptureEnabled = true;
+    bool m_inputSuspended = false;
     qint64 m_lastControllerMetadataAt = 0;
     qint64 m_lastGamepadSnapshotAt = 0;
     RepeatingDirection m_left{false, 0, 0, Qt::Key_Left};

--- a/opennow-qt/src/NativeStreamRuntime.cpp
+++ b/opennow-qt/src/NativeStreamRuntime.cpp
@@ -137,6 +137,8 @@ struct NativeStreamRuntime::Private {
     bool firstNotification = false;
     std::atomic<quint64> presentationGeneration{0};
     std::atomic_bool presentationAllowed{false};
+    std::atomic_bool inputAllowed{false};
+    bool inputAuthorizationPending = false;
     QString presentationStartId;
 };
 
@@ -208,6 +210,11 @@ bool NativeStreamRuntime::presentationAllowed() const
     return d->presentationAllowed.load(std::memory_order_acquire);
 }
 
+bool NativeStreamRuntime::inputAllowed() const
+{
+    return d->inputAllowed.load(std::memory_order_acquire);
+}
+
 void NativeStreamRuntime::invalidatePresentation()
 {
     d->presentationAllowed.store(false, std::memory_order_release);
@@ -221,6 +228,7 @@ void NativeStreamRuntime::reportPresentationError(const QString &message)
     const auto generation = presentationGeneration();
     QMetaObject::invokeMethod(this, [this, message, generation] {
         if (generation != presentationGeneration()) return;
+        resetInputCapture();
         invalidatePresentation();
         setLastError(message);
         qWarning("Stream presentation: %s", qUtf8Printable(message));
@@ -306,6 +314,10 @@ bool NativeStreamRuntime::sendBytes(const QByteArray &command)
     }
     const auto object = QJsonDocument::fromJson(command).object();
     const auto type = object.value(u"type"_s).toString();
+    const bool changesSession = type == u"start"_s || type == u"stop"_s;
+    const bool previousInputAllowed = inputAllowed();
+    const bool previousInputPending = d->inputAuthorizationPending;
+    if (changesSession) resetInputCapture();
 
     OpenNowStreamerStatus status = OPENNOW_STREAMER_CLOSED;
     {
@@ -319,6 +331,12 @@ bool NativeStreamRuntime::sendBytes(const QByteArray &command)
     handshakeLog(u"send %1 bytes=%2 queue_result=%3"_s
         .arg(handshakeSummary(object)).arg(command.size()).arg(int(status)));
     if (status != OPENNOW_STREAMER_OK) {
+        if (changesSession) {
+            d->inputAuthorizationPending = previousInputPending;
+            if (d->inputAllowed.exchange(previousInputAllowed, std::memory_order_acq_rel)
+                    != previousInputAllowed)
+                emit inputAllowedChanged();
+        }
         setLastError(statusText(status));
         return false;
     }
@@ -327,6 +345,7 @@ bool NativeStreamRuntime::sendBytes(const QByteArray &command)
         if (type == u"start"_s) {
             d->firstNotification = false;
             d->presentationStartId = object.value(u"id"_s).toString();
+            d->inputAuthorizationPending = true;
         }
     }
     setLastError({});
@@ -335,6 +354,7 @@ bool NativeStreamRuntime::sendBytes(const QByteArray &command)
 
 bool NativeStreamRuntime::shutdown(int timeoutMs)
 {
+    resetInputCapture();
     invalidatePresentation();
     OpenNowStreamer *handle = nullptr;
     std::shared_ptr<CallbackState> callbacks;
@@ -695,12 +715,18 @@ void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &s
         const auto status = document.object().value(u"status"_s).toString();
         if (message.event && (kind == u"error"_s
                 || (kind == u"status"_s && (status == u"stopped"_s || status == u"error"_s)))) {
+            resetInputCapture();
             invalidatePresentation();
             if (!current()) return;
         } else if (!message.event && !d->presentationStartId.isEmpty()
                 && document.object().value(u"id"_s).toString() == d->presentationStartId) {
             d->presentationStartId.clear();
             d->presentationAllowed.store(kind == u"ok"_s, std::memory_order_release);
+            const bool allowed = std::exchange(d->inputAuthorizationPending, false) && kind == u"ok"_s;
+            if (d->inputAllowed.exchange(allowed, std::memory_order_acq_rel) != allowed) {
+                emit inputAllowedChanged();
+                if (!current()) return;
+            }
             emit frameAvailable();
             if (!current()) return;
         }
@@ -713,6 +739,16 @@ void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &s
             emit responseReceived(document.object());
     }
     if (current() && reschedule) scheduleDrain(state);
+}
+
+void NativeStreamRuntime::resetInputCapture()
+{
+    const bool wasAllowed = d->inputAllowed.exchange(false, std::memory_order_acq_rel);
+    d->inputAuthorizationPending = false;
+    emit inputCaptureReset();
+    bool rawInput = false;
+    setCaptureActive(false, false, 0, &rawInput);
+    if (wasAllowed) emit inputAllowedChanged();
 }
 
 void NativeStreamRuntime::setLastError(const QString &error)

--- a/opennow-qt/src/NativeStreamRuntime.h
+++ b/opennow-qt/src/NativeStreamRuntime.h
@@ -85,6 +85,7 @@ public:
     [[nodiscard]] QString lastError() const;
     [[nodiscard]] quint64 presentationGeneration() const;
     [[nodiscard]] bool presentationAllowed() const;
+    [[nodiscard]] bool inputAllowed() const;
     // Called at most once per presentation failure from the scene-graph thread.
     void reportPresentationError(const QString &message);
 
@@ -120,6 +121,8 @@ public:
                                            bool *rawInputActive);
 
 signals:
+    void inputCaptureReset();
+    void inputAllowedChanged();
     void presentationError(const QString &message);
     void runningChanged();
     void lastErrorChanged();
@@ -147,6 +150,7 @@ private:
     void drainCallbacks(const std::shared_ptr<CallbackState> &state);
     void setLastError(const QString &error);
     void invalidatePresentation();
+    void resetInputCapture();
 
     std::unique_ptr<Private> d;
 };

--- a/opennow-qt/src/StreamVideoItem.cpp
+++ b/opennow-qt/src/StreamVideoItem.cpp
@@ -2,6 +2,7 @@
 
 #include "NativeStreamRuntime.h"
 #include "StreamVideoTextureRenderer.h"
+#include "WaylandPointerCapture.h"
 
 #include <QColor>
 #include <QSGRenderNode>
@@ -354,14 +355,30 @@ private:
 }
 
 StreamVideoItem::StreamVideoItem(QQuickItem *parent)
-    : QQuickItem(parent)
+    : QQuickItem(parent), m_waylandPointer(std::make_unique<WaylandPointerCapture>())
 {
+    connect(m_waylandPointer.get(), &WaylandPointerCapture::stateChanged, this, [this] {
+        syncCaptureState();
+        emit inputCaptureErrorChanged();
+    }, Qt::QueuedConnection);
+    connect(m_waylandPointer.get(), &WaylandPointerCapture::relativeMotion, this,
+            [this](qint16 x, qint16 y) {
+        if (m_captureActive && m_inputEnabled && m_relativeMouse && nativeRuntime)
+            nativeRuntime->submitMouseRelative(x, y);
+    });
     setFlag(ItemHasContents, true);
     setActiveFocusOnTab(true);
     setAcceptedMouseButtons(Qt::AllButtons);
     setKeepMouseGrab(true);
     setAcceptHoverEvents(true);
     if (nativeRuntime) {
+        connect(nativeRuntime, &NativeStreamRuntime::inputAllowedChanged,
+                this, &StreamVideoItem::syncCaptureState);
+        connect(nativeRuntime, &NativeStreamRuntime::inputCaptureReset, this, [this] {
+            releaseInput();
+            m_rawInputActive = false;
+            if (std::exchange(m_captureActive, false)) emit captureActiveChanged();
+        });
         setRenderCallback(std::make_shared<NativeStreamRenderCallback>(nativeRuntime));
         connect(nativeRuntime, &NativeStreamRuntime::frameAvailable,
                 this, &StreamVideoItem::requestFrame);
@@ -386,9 +403,11 @@ StreamVideoItem::StreamVideoItem(QQuickItem *parent)
             connect(currentWindow, &QWindow::yChanged,
                     this, &StreamVideoItem::updateCursorConfinement, Qt::UniqueConnection);
             connect(currentWindow, &QWindow::widthChanged,
-                    this, &StreamVideoItem::updateCursorConfinement, Qt::UniqueConnection);
+                    this, &StreamVideoItem::resynchronizeInput, Qt::UniqueConnection);
             connect(currentWindow, &QWindow::heightChanged,
-                    this, &StreamVideoItem::updateCursorConfinement, Qt::UniqueConnection);
+                    this, &StreamVideoItem::resynchronizeInput, Qt::UniqueConnection);
+            connect(currentWindow, &QWindow::screenChanged,
+                    this, &StreamVideoItem::resynchronizeInput, Qt::UniqueConnection);
         }
         syncCaptureState();
     });
@@ -396,11 +415,11 @@ StreamVideoItem::StreamVideoItem(QQuickItem *parent)
 
 StreamVideoItem::~StreamVideoItem()
 {
+    releaseInput();
     if (nativeRuntime && nativeRuntime->running()) {
         bool rawInput = false;
         nativeRuntime->setCaptureActive(false, false, 0, &rawInput);
     }
-    releaseInput();
 }
 
 QSize StreamVideoItem::videoSize() const
@@ -443,6 +462,11 @@ void StreamVideoItem::setInputEnabled(bool enabled)
 bool StreamVideoItem::captureActive() const
 {
     return m_captureActive;
+}
+
+QString StreamVideoItem::inputCaptureError() const
+{
+    return m_waylandPointer->error();
 }
 
 bool StreamVideoItem::relativeMouse() const
@@ -732,7 +756,7 @@ void StreamVideoItem::mouseMoveEvent(QMouseEvent *event)
         return;
     }
     if (m_relativeMouse) {
-        if (!m_rawInputActive) {
+        if (!m_rawInputActive && !WaylandPointerCapture::isWayland()) {
             const auto delta = event->position() - m_lastMousePosition;
             const auto deltaX = std::clamp(qRound(delta.x()), -32768, 32767);
             const auto deltaY = std::clamp(qRound(delta.y()), -32768, 32767);
@@ -811,7 +835,7 @@ void StreamVideoItem::itemChange(ItemChange change, const ItemChangeData &data)
 void StreamVideoItem::geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry)
 {
     QQuickItem::geometryChange(newGeometry, oldGeometry);
-    updateCursorConfinement();
+    resynchronizeInput();
 }
 
 QRect StreamVideoItem::scaledCaptureRect(const QRectF &itemRect,
@@ -909,7 +933,8 @@ QPoint StreamVideoItem::mapRemoteCursorPosition(const QPoint &normalizedPosition
 void StreamVideoItem::resynchronizeInput()
 {
     syncCaptureState();
-    if (m_captureActive && m_relativeMouse && !m_rawInputActive) {
+    if (m_captureActive && m_relativeMouse && !m_rawInputActive
+            && !WaylandPointerCapture::isWayland()) {
         const auto anchor = mapToGlobal(QPointF(width() / 2.0, height() / 2.0)).toPoint();
         QCursor::setPos(anchor);
     } else if (m_captureActive && !m_relativeMouse) {
@@ -934,14 +959,28 @@ void StreamVideoItem::submitAbsoluteMouse(const QPointF &position)
 
 void StreamVideoItem::syncCaptureState()
 {
-    const auto desired = m_inputEnabled && isVisible() && hasActiveFocus()
-        && window() && window()->isActive() && nativeRuntime && nativeRuntime->running();
-    if (!desired && m_captureActive) releaseInput();
+    auto desired = m_inputEnabled && isVisible() && hasActiveFocus()
+        && window() && window()->isActive() && nativeRuntime && nativeRuntime->running()
+        && nativeRuntime->inputAllowed();
+    if (m_captureActive && (!desired || (WaylandPointerCapture::isWayland()
+            && m_relativeMouse && !m_waylandPointer->locked())))
+        releaseInput();
+    if (WaylandPointerCapture::isWayland()) {
+        const auto viewport = aspectFitRect(m_videoSize, QSize(qRound(width()), qRound(height())));
+        auto region = mapRectToScene(QRectF(viewport)).toAlignedRect();
+        if (window()) region.translate(window()->frameMargins().left(), window()->frameMargins().top());
+        m_waylandPointer->setCapture(window(), desired && m_relativeMouse, region);
+        if (m_relativeMouse) desired = desired && m_waylandPointer->locked();
+    }
     bool rawInput = false;
     if (nativeRuntime && nativeRuntime->running()) {
         nativeRuntime->setCaptureActive(
             desired, m_relativeMouse,
-            window() ? static_cast<std::uintptr_t>(window()->winId()) : 0,
+            window() && !WaylandPointerCapture::isWayland()
+#if defined(Q_OS_LINUX)
+                && QGuiApplication::platformName() == QStringLiteral("xcb")
+#endif
+                ? static_cast<std::uintptr_t>(window()->winId()) : 0,
             &rawInput);
     }
     m_rawInputActive = desired && rawInput;
@@ -949,7 +988,7 @@ void StreamVideoItem::syncCaptureState()
     m_captureActive = desired;
     if (m_captureActive) {
         m_lastMousePosition = mapFromGlobal(QCursor::pos());
-        if (m_relativeMouse) grabMouse();
+        if (m_relativeMouse && !WaylandPointerCapture::isWayland()) grabMouse();
     } else {
         ungrabMouse();
     }
@@ -959,6 +998,7 @@ void StreamVideoItem::syncCaptureState()
 
 void StreamVideoItem::releaseInput()
 {
+    m_waylandPointer->release();
     const auto pendingRelativeMouse = m_pendingRelativeMouse;
     m_pendingRelativeMouse.reset();
     if (nativeRuntime) {
@@ -1073,7 +1113,7 @@ void StreamVideoItem::setRelativeMouse(bool relative)
     m_relativeMouse = relative;
     if (relative) {
         setCursor(Qt::BlankCursor);
-        if (m_captureActive) {
+        if (m_captureActive && !WaylandPointerCapture::isWayland()) {
             grabMouse();
             const auto anchor = mapToGlobal(QPointF(width() / 2.0, height() / 2.0)).toPoint();
             QCursor::setPos(anchor);
@@ -1103,7 +1143,7 @@ void StreamVideoItem::applyRemoteCursor(const QByteArray &bytes)
     if (hidden) return;
 
     if (reposition && metadata.normalizedPosition && m_pressedMouseButtons.isEmpty()
-        && m_captureActive) {
+        && m_captureActive && !WaylandPointerCapture::isWayland()) {
         const auto local = mapRemoteCursorPosition(
             *metadata.normalizedPosition, m_videoSize, QSizeF(width(), height()));
         QCursor::setPos(mapToGlobal(local).toPoint());

--- a/opennow-qt/src/StreamVideoItem.h
+++ b/opennow-qt/src/StreamVideoItem.h
@@ -45,6 +45,7 @@ class StreamVideoItem : public QQuickItem
     Q_PROPERTY(bool inputEnabled READ inputEnabled WRITE setInputEnabled
                    NOTIFY inputEnabledChanged)
     Q_PROPERTY(bool captureActive READ captureActive NOTIFY captureActiveChanged)
+    Q_PROPERTY(QString inputCaptureError READ inputCaptureError NOTIFY inputCaptureErrorChanged)
     Q_PROPERTY(bool relativeMouse READ relativeMouse WRITE setRelativeMouse
                    NOTIFY relativeMouseChanged)
     Q_PROPERTY(QVariantMap shortcutBindings READ shortcutBindings WRITE setShortcutBindings
@@ -69,6 +70,7 @@ public:
     [[nodiscard]] bool inputEnabled() const;
     void setInputEnabled(bool enabled);
     [[nodiscard]] bool captureActive() const;
+    [[nodiscard]] QString inputCaptureError() const;
     [[nodiscard]] bool relativeMouse() const;
     void setRelativeMouse(bool relative);
     [[nodiscard]] QVariantMap shortcutBindings() const;
@@ -104,6 +106,7 @@ signals:
     void renderCallbackAvailableChanged();
     void inputEnabledChanged();
     void captureActiveChanged();
+    void inputCaptureErrorChanged();
     void relativeMouseChanged();
     void shortcutBindingsChanged();
     void localShortcutRequested(const QString &action);
@@ -148,6 +151,7 @@ private:
     QSet<quint32> m_pressedShortcuts;
     QSet<quint8> m_pressedMouseButtons;
     QPointF m_lastMousePosition;
+    std::unique_ptr<class WaylandPointerCapture> m_waylandPointer;
     bool m_inputEnabled = true;
     bool m_captureActive = false;
     bool m_relativeMouse = false;

--- a/opennow-qt/src/WaylandPointerCapture.cpp
+++ b/opennow-qt/src/WaylandPointerCapture.cpp
@@ -1,0 +1,289 @@
+#include "WaylandPointerCapture.h"
+
+#include <QGuiApplication>
+#include <QPlatformSurfaceEvent>
+#include <QPointer>
+#include <QTimer>
+#include <QWindow>
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+#ifdef OPENNOW_WAYLAND_INPUT
+#include <QtGui/qguiapplication_platform.h>
+#include <qpa/qplatformnativeinterface.h>
+#include <wayland-client.h>
+#include "pointer-constraints-unstable-v1-client-protocol.h"
+#include "relative-pointer-unstable-v1-client-protocol.h"
+#endif
+
+struct WaylandPointerCapture::Private
+{
+    WaylandPointerCapture *q;
+    QPointer<QWindow> window;
+    QRect region;
+    QPointF remainder;
+    QString error;
+    QTimer refresh;
+    bool locked = false;
+    bool ready = false;
+#ifdef OPENNOW_WAYLAND_INPUT
+    wl_registry *registry = nullptr;
+    wl_callback *sync = nullptr;
+    zwp_relative_pointer_manager_v1 *relativeManager = nullptr;
+    zwp_pointer_constraints_v1 *constraints = nullptr;
+    zwp_relative_pointer_v1 *relative = nullptr;
+    zwp_locked_pointer_v1 *lock = nullptr;
+    wl_surface *surface = nullptr;
+    wl_pointer *pointer = nullptr;
+    uint32_t relativeName = 0;
+    uint32_t constraintsName = 0;
+
+    static QNativeInterface::QWaylandApplication *native()
+    {
+        return qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+    }
+
+    static void global(void *data, wl_registry *registry, uint32_t name,
+                       const char *interface, uint32_t)
+    {
+        auto *d = static_cast<Private *>(data);
+        if (QByteArrayView(interface) == zwp_relative_pointer_manager_v1_interface.name
+                && !d->relativeManager) {
+            d->relativeName = name;
+            d->relativeManager = static_cast<zwp_relative_pointer_manager_v1 *>(
+                wl_registry_bind(registry, name, &zwp_relative_pointer_manager_v1_interface, 1));
+        } else if (QByteArrayView(interface) == zwp_pointer_constraints_v1_interface.name
+                   && !d->constraints) {
+            d->constraintsName = name;
+            d->constraints = static_cast<zwp_pointer_constraints_v1 *>(
+                wl_registry_bind(registry, name, &zwp_pointer_constraints_v1_interface, 1));
+        }
+        if (d->ready) emit d->q->stateChanged();
+    }
+
+    static void globalRemoved(void *data, wl_registry *, uint32_t name)
+    {
+        auto *d = static_cast<Private *>(data);
+        if (name != d->relativeName && name != d->constraintsName) return;
+        d->clearLock();
+        if (name == d->relativeName && d->relativeManager) {
+            zwp_relative_pointer_manager_v1_destroy(d->relativeManager);
+            d->relativeManager = nullptr;
+        }
+        if (name == d->constraintsName && d->constraints) {
+            zwp_pointer_constraints_v1_destroy(d->constraints);
+            d->constraints = nullptr;
+        }
+        d->setError(QStringLiteral("The Wayland compositor withdrew relative pointer or pointer lock support."));
+    }
+
+    static void synchronized(void *data, wl_callback *callback, uint32_t)
+    {
+        auto *d = static_cast<Private *>(data);
+        wl_callback_destroy(callback);
+        d->sync = nullptr;
+        d->ready = true;
+        emit d->q->stateChanged();
+    }
+
+    static void pointerLocked(void *data, zwp_locked_pointer_v1 *)
+    {
+        auto *d = static_cast<Private *>(data);
+        d->locked = true;
+        d->remainder = {};
+        emit d->q->stateChanged();
+    }
+
+    static void pointerUnlocked(void *data, zwp_locked_pointer_v1 *)
+    {
+        auto *d = static_cast<Private *>(data);
+        d->locked = false;
+        d->remainder = {};
+        emit d->q->stateChanged();
+    }
+
+    static void motion(void *data, zwp_relative_pointer_v1 *, uint32_t, uint32_t,
+                       wl_fixed_t, wl_fixed_t, wl_fixed_t dx, wl_fixed_t dy)
+    {
+        auto *d = static_cast<Private *>(data);
+        if (!d->locked || !d->window || !d->window->isActive()) return;
+        const auto delta = boundedDelta(d->remainder,
+            QPointF(wl_fixed_to_double(dx), wl_fixed_to_double(dy)));
+        if (!delta.isNull()) emit d->q->relativeMotion(qint16(delta.x()), qint16(delta.y()));
+    }
+#endif
+
+    void clearLock()
+    {
+#ifdef OPENNOW_WAYLAND_INPUT
+        const bool hadCapture = lock || relative;
+        if (lock) zwp_locked_pointer_v1_destroy(lock);
+        if (relative) zwp_relative_pointer_v1_destroy(relative);
+        lock = nullptr;
+        relative = nullptr;
+        surface = nullptr;
+        pointer = nullptr;
+        if (hadCapture) {
+            if (auto *application = native(); application && application->display())
+                wl_display_flush(application->display());
+        }
+#endif
+        remainder = {};
+        if (std::exchange(locked, false)) emit q->stateChanged();
+    }
+
+    void setError(const QString &value)
+    {
+        if (error == value) return;
+        error = value;
+        if (!error.isEmpty()) qWarning("Wayland input capture: %s", qPrintable(error));
+        emit q->stateChanged();
+    }
+};
+
+WaylandPointerCapture::WaylandPointerCapture(QObject *parent)
+    : QObject(parent), d(std::make_unique<Private>())
+{
+    d->q = this;
+    d->refresh.setInterval(100);
+    connect(&d->refresh, &QTimer::timeout, this, [this] {
+        if (!d->window || !d->window->isActive()) {
+            release();
+            return;
+        }
+        setCapture(d->window, true, d->region);
+    });
+#ifdef OPENNOW_WAYLAND_INPUT
+    if (!isWayland()) return;
+    auto *native = Private::native();
+    if (!native || !native->display()) {
+        d->setError(QStringLiteral("Qt did not expose its native Wayland display."));
+        return;
+    }
+    static const wl_registry_listener registryListener{Private::global, Private::globalRemoved};
+    static const wl_callback_listener syncListener{Private::synchronized};
+    d->registry = wl_display_get_registry(native->display());
+    wl_registry_add_listener(d->registry, &registryListener, d.get());
+    d->sync = wl_display_sync(native->display());
+    wl_callback_add_listener(d->sync, &syncListener, d.get());
+    wl_display_flush(native->display());
+#endif
+}
+
+WaylandPointerCapture::~WaylandPointerCapture()
+{
+    release();
+#ifdef OPENNOW_WAYLAND_INPUT
+    if (d->sync) wl_callback_destroy(d->sync);
+    if (d->constraints) zwp_pointer_constraints_v1_destroy(d->constraints);
+    if (d->relativeManager) zwp_relative_pointer_manager_v1_destroy(d->relativeManager);
+    if (d->registry) wl_registry_destroy(d->registry);
+#endif
+}
+
+bool WaylandPointerCapture::isWayland()
+{
+    return QGuiApplication::platformName().startsWith(QStringLiteral("wayland"));
+}
+
+bool WaylandPointerCapture::locked() const { return d->locked; }
+QString WaylandPointerCapture::error() const { return d->error; }
+
+QPoint WaylandPointerCapture::boundedDelta(QPointF &remainder, const QPointF &delta)
+{
+    if (!std::isfinite(delta.x()) || !std::isfinite(delta.y())) {
+        remainder = {};
+        return {};
+    }
+    const auto sum = remainder + delta;
+    const QPoint result(int(std::clamp(sum.x(), -32768.0, 32767.0)),
+                        int(std::clamp(sum.y(), -32768.0, 32767.0)));
+    remainder = QPointF(std::abs(sum.x()) < 32767 ? sum.x() - result.x() : 0,
+                        std::abs(sum.y()) < 32767 ? sum.y() - result.y() : 0);
+    return result;
+}
+
+void WaylandPointerCapture::setCapture(QWindow *window, bool enabled, const QRect &surfaceRegion)
+{
+    if (!enabled || !window || !window->isVisible() || !window->isActive() || surfaceRegion.isEmpty()) {
+        release();
+        return;
+    }
+    if (!isWayland()) return;
+    if (d->window != window) {
+        release();
+        d->window = window;
+        window->installEventFilter(this);
+    }
+    const bool regionChanged = d->region != surfaceRegion;
+    d->region = surfaceRegion;
+    if (!d->refresh.isActive()) d->refresh.start();
+#ifdef OPENNOW_WAYLAND_INPUT
+    if (!d->ready) return;
+    if (!d->relativeManager || !d->constraints) {
+        d->clearLock();
+        d->refresh.stop();
+        d->setError(QStringLiteral("Relative mouse input requires Wayland relative-pointer-v1 and pointer-constraints-v1; the compositor does not provide both protocols."));
+        return;
+    }
+    auto *native = Private::native();
+    auto *surface = static_cast<wl_surface *>(QGuiApplication::platformNativeInterface()
+        ->nativeResourceForWindow("surface", window));
+    auto *pointer = native ? native->pointer() : nullptr;
+    if (!surface || !pointer || !native->compositor()) {
+        d->clearLock();
+        d->setError(QStringLiteral("The Qt Wayland window has no live surface or pointer device."));
+        return;
+    }
+    if (d->surface != surface || d->pointer != pointer) d->clearLock();
+    if (d->lock && !regionChanged) return;
+    d->setError({});
+    auto *region = wl_compositor_create_region(native->compositor());
+    wl_region_add(region, surfaceRegion.x(), surfaceRegion.y(),
+                  surfaceRegion.width(), surfaceRegion.height());
+    if (!d->lock) {
+        d->surface = surface;
+        d->pointer = pointer;
+        static const zwp_relative_pointer_v1_listener motionListener{Private::motion};
+        static const zwp_locked_pointer_v1_listener lockListener{
+            Private::pointerLocked, Private::pointerUnlocked};
+        d->relative = zwp_relative_pointer_manager_v1_get_relative_pointer(d->relativeManager, pointer);
+        zwp_relative_pointer_v1_add_listener(d->relative, &motionListener, d.get());
+        d->lock = zwp_pointer_constraints_v1_lock_pointer(d->constraints, surface, pointer,
+            region, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+        zwp_locked_pointer_v1_add_listener(d->lock, &lockListener, d.get());
+    } else {
+        zwp_locked_pointer_v1_set_region(d->lock, region);
+    }
+    wl_region_destroy(region);
+    window->requestUpdate();
+    wl_display_flush(native->display());
+#else
+    d->refresh.stop();
+    d->setError(QStringLiteral("This build has no native Wayland relative mouse backend."));
+#endif
+}
+
+void WaylandPointerCapture::release()
+{
+    d->refresh.stop();
+    d->clearLock();
+    if (d->window) d->window->removeEventFilter(this);
+    d->window.clear();
+    d->region = {};
+}
+
+bool WaylandPointerCapture::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == d->window) {
+        if (event->type() == QEvent::FocusOut || event->type() == QEvent::Hide
+                || event->type() == QEvent::Close)
+            release();
+        else if (event->type() == QEvent::PlatformSurface
+                 && static_cast<QPlatformSurfaceEvent *>(event)->surfaceEventType()
+                     == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed)
+            d->clearLock();
+    }
+    return QObject::eventFilter(watched, event);
+}

--- a/opennow-qt/src/WaylandPointerCapture.h
+++ b/opennow-qt/src/WaylandPointerCapture.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QObject>
+#include <QPointF>
+#include <QRect>
+#include <memory>
+
+class QWindow;
+
+class WaylandPointerCapture final : public QObject
+{
+    Q_OBJECT
+public:
+    explicit WaylandPointerCapture(QObject *parent = nullptr);
+    ~WaylandPointerCapture() override;
+
+    [[nodiscard]] static bool isWayland();
+    [[nodiscard]] bool locked() const;
+    [[nodiscard]] QString error() const;
+    void setCapture(QWindow *window, bool enabled, const QRect &surfaceRegion);
+    void release();
+    [[nodiscard]] static QPoint boundedDelta(QPointF &remainder, const QPointF &delta);
+
+signals:
+    void stateChanged();
+    void relativeMotion(qint16 x, qint16 y);
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    struct Private;
+    std::unique_ptr<Private> d;
+};

--- a/opennow-qt/src/main.cpp
+++ b/opennow-qt/src/main.cpp
@@ -475,7 +475,34 @@ int main(int argc, char *argv[])
         }
     } else {
         const auto screenshotIndex = arguments.indexOf(u"--screenshot"_s);
-        if (smokeTest && (arguments.contains(u"--smoke-backend-availability"_s)
+        if (smokeTest && arguments.contains(u"--smoke-input-capture-error"_s)) {
+            auto *store = engine.singletonInstance<QObject *>(u"OpenNOW"_s, u"ShellStore"_s);
+            if (!store) return EXIT_FAILURE;
+            store->setProperty("streamer", QVariantMap{{u"status"_s, u"streaming"_s}});
+            store->setProperty("streamState", u"streaming"_s);
+            QTimer::singleShot(150, &application, [&] {
+                auto *window = engine.rootObjects().isEmpty() ? nullptr
+                    : qobject_cast<QQuickWindow *>(engine.rootObjects().first());
+                auto *notice = window ? window->findChild<QQuickItem *>(u"streamInputCaptureNotice"_s) : nullptr;
+                auto *surface = window ? window->findChild<QQuickItem *>(u"streamSurfaceHost"_s) : nullptr;
+                if (!notice || !surface || !surface->isVisible()) {
+                    qCritical("Input capture fixture could not find the visible stream surface and notice");
+                    application.exit(EXIT_FAILURE);
+                    return;
+                }
+                notice->setProperty("message", u"Relative mouse input requires Wayland relative-pointer-v1 and pointer-constraints-v1; the compositor does not provide both protocols."_s);
+                QTimer::singleShot(250, &application, [&, window, notice, surface] {
+                    bool passed = !qmlWarningOccurred && notice->isVisible() && surface->isVisible()
+                        && window->findChild<QQuickItem *>(u"streamSurfaceHost"_s) == surface;
+                    const auto shot = arguments.indexOf(u"--screenshot"_s);
+                    if (shot >= 0 && shot + 1 < arguments.size())
+                        passed = passed && QFileInfo(arguments.at(shot + 1)).isAbsolute()
+                            && window->grabWindow().save(arguments.at(shot + 1));
+                    if (!passed) qCritical("Input capture fixture did not preserve the visible stream surface");
+                    application.exit(passed ? EXIT_SUCCESS : EXIT_FAILURE);
+                });
+            });
+        } else if (smokeTest && (arguments.contains(u"--smoke-backend-availability"_s)
                          || arguments.contains(u"--smoke-idle-mode"_s)
                          || arguments.contains(u"--smoke-stream-recovery"_s))) {
             QQmlComponent component(&engine, QUrl(arguments.contains(u"--smoke-idle-mode"_s)

--- a/opennow-qt/tests/tst_controllerinput.cpp
+++ b/opennow-qt/tests/tst_controllerinput.cpp
@@ -32,6 +32,49 @@ class ControllerInputTest final : public QObject
     Q_OBJECT
 
 private slots:
+    void suspendedInputNeutralizesAndStopsBackgroundGameplay()
+    {
+        ControllerInput input;
+        QSignalSpy snapshots(&input, &ControllerInput::gamepadSnapshot);
+        QSignalSpy activity(&input, &ControllerInput::controllerActivity);
+        SDL_VirtualJoystickDesc descriptor{};
+        SDL_INIT_INTERFACE(&descriptor);
+        descriptor.type = SDL_JOYSTICK_TYPE_GAMEPAD;
+        descriptor.naxes = SDL_GAMEPAD_AXIS_COUNT;
+        descriptor.nbuttons = SDL_GAMEPAD_BUTTON_COUNT;
+        descriptor.button_mask = 1u << SDL_GAMEPAD_BUTTON_SOUTH;
+        descriptor.name = "OpenNOW focus-loss controller";
+        const auto id = SDL_AttachVirtualJoystick(&descriptor);
+        QVERIFY2(id != 0, SDL_GetError());
+        QTRY_COMPARE_WITH_TIMEOUT(input.controllerCount(), 1, 2000);
+        input.setShellCaptureEnabled(false);
+        auto *joystick = SDL_GetJoystickFromID(id);
+        QVERIFY(joystick);
+        QVERIFY(SDL_SetJoystickVirtualButton(joystick, SDL_GAMEPAD_BUTTON_SOUTH, true));
+        SDL_UpdateJoysticks();
+        QTRY_VERIFY_WITH_TIMEOUT(snapshots.last().at(2).toUInt() == 0x1000, 1000);
+        input.setInputSuspended(true);
+        QCOMPARE(snapshots.last().at(2).toUInt(), 0u);
+        auto count = snapshots.size();
+        QTest::qWait(250);
+        QCOMPARE(snapshots.size(), count);
+        input.setShellCaptureEnabled(true);
+        count = snapshots.size();
+        QVERIFY(SDL_SetJoystickVirtualButton(joystick, SDL_GAMEPAD_BUTTON_SOUTH, false));
+        SDL_UpdateJoysticks();
+        QTest::qWait(150);
+        QCOMPARE(snapshots.size(), count);
+        QCOMPARE(activity.size(), 0);
+        input.setShellCaptureEnabled(false);
+        input.setInputSuspended(false);
+        QCOMPARE(snapshots.last().at(2).toUInt(), 0u);
+        input.setInputSuspended(true);
+        QVERIFY(SDL_DetachVirtualJoystick(id));
+        QTRY_COMPARE_WITH_TIMEOUT(input.controllerCount(), 0, 2000);
+        QCOMPARE(snapshots.last().at(1).toUInt(), 0u);
+        QCOMPARE(snapshots.last().at(2).toUInt(), 0u);
+    }
+
     void idleMetadataDoesNotInvalidateTheUi()
     {
         ControllerInput input;

--- a/opennow-qt/tests/tst_nativestreamruntime.cpp
+++ b/opennow-qt/tests/tst_nativestreamruntime.cpp
@@ -140,6 +140,79 @@ class NativeStreamRuntimeTest final : public QObject
     Q_OBJECT
 
 private slots:
+    void rejectedSessionCommandsRestorePreviousInputAuthorization()
+    {
+        NativeStreamRuntime runtime(fakeApi());
+        QVERIFY(runtime.start());
+        sendStatus = OPENNOW_STREAMER_QUEUE_FULL;
+        QVERIFY(!runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                               {QStringLiteral("id"), QStringLiteral("rejected-initial")}}));
+        QVERIFY(!runtime.inputAllowed());
+        sendStatus = OPENNOW_STREAMER_OK;
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("authorized-session")}}));
+        QTRY_VERIFY(runtime.inputAllowed());
+        QSignalSpy resets(&runtime, &NativeStreamRuntime::inputCaptureReset);
+        QSignalSpy authorization(&runtime, &NativeStreamRuntime::inputAllowedChanged);
+        for (const auto status : {OPENNOW_STREAMER_QUEUE_FULL, OPENNOW_STREAMER_CLOSED}) {
+            for (const auto &type : {QStringLiteral("start"), QStringLiteral("stop")}) {
+                sendStatus = status;
+                QVERIFY(!runtime.send({{QStringLiteral("type"), type},
+                                       {QStringLiteral("id"), QStringLiteral("rejected-command")}}));
+                QVERIFY(runtime.presentationAllowed());
+                QVERIFY(runtime.inputAllowed());
+            }
+        }
+        QCOMPARE(resets.size(), 4);
+        QCOMPARE(authorization.size(), 8);
+    }
+
+    void sessionTransitionsCloseInputBeforeSendingOrDestroying()
+    {
+        static QStringList calls;
+        static OpenNowStreamerConfig callbackConfig;
+        calls.clear();
+        auto api = fakeApi();
+        api.create = [](const OpenNowStreamerConfig *config, OpenNowStreamer **output) {
+            callbackConfig = *config;
+            return fakeCreate(config, output);
+        };
+        api.setCaptureActive = [](const OpenNowStreamer *, bool active, bool,
+                                  std::uintptr_t, bool *raw) {
+            calls.append(active ? QStringLiteral("open") : QStringLiteral("close"));
+            *raw = false;
+            return OPENNOW_STREAMER_OK;
+        };
+        api.send = [](const OpenNowStreamer *handle, const std::uint8_t *bytes, std::size_t size) {
+            calls.append(QStringLiteral("send"));
+            return fakeSend(handle, bytes, size);
+        };
+        api.destroy = [](OpenNowStreamer *handle) {
+            calls.append(QStringLiteral("destroy"));
+            return fakeDestroy(handle);
+        };
+        NativeStreamRuntime runtime(api);
+        connect(&runtime, &NativeStreamRuntime::inputCaptureReset, &runtime,
+                [] { calls.append(QStringLiteral("release")); });
+        QVERIFY(runtime.start());
+        bool raw = false;
+        for (const auto &type : {QStringLiteral("start"), QStringLiteral("stop")}) {
+            calls.clear();
+            QCOMPARE(runtime.setCaptureActive(true, false, 0, &raw), OPENNOW_STREAMER_OK);
+            QVERIFY(runtime.send({{QStringLiteral("type"), type}}));
+            QCOMPARE(calls, QStringList({QStringLiteral("open"), QStringLiteral("release"), QStringLiteral("close"),
+                                        QStringLiteral("send")}));
+        }
+        calls.clear();
+        const QByteArray terminal = R"({"type":"status","status":"error"})";
+        callbackConfig.event_callback(reinterpret_cast<const std::uint8_t *>(terminal.constData()),
+                                      terminal.size(), callbackConfig.user_data);
+        QTRY_COMPARE(calls, QStringList({QStringLiteral("release"), QStringLiteral("close")}));
+        calls.clear();
+        QVERIFY(runtime.shutdown());
+        QCOMPARE(calls, QStringList({QStringLiteral("release"), QStringLiteral("close"), QStringLiteral("destroy")}));
+    }
+
     void init()
     {
         nextDestroyDelayMs = 0;

--- a/opennow-qt/tests/tst_streamvideoitem.cpp
+++ b/opennow-qt/tests/tst_streamvideoitem.cpp
@@ -1,8 +1,10 @@
 #include "StreamVideoItem.h"
 #include "NativeStreamRuntime.h"
 #include "StreamVideoTextureRenderer.h"
+#include "WaylandPointerCapture.h"
 
 #include <QGuiApplication>
+#include <QJsonDocument>
 #include <QCursor>
 #include <QScopeGuard>
 #include <QtQml/qqml.h>
@@ -423,6 +425,212 @@ private slots:
 #else
         QSKIP("Windows cursor confinement test.");
 #endif
+    }
+
+    void waylandAbsoluteToPendingRelativeLockSurvivesUntilCompositorAcknowledges()
+    {
+        if (!WaylandPointerCapture::isWayland()
+                || !qEnvironmentVariableIsSet("OPENNOW_TEST_WAYLAND_CAPTURE"))
+            QSKIP("Requires an interactive Wayland compositor");
+        NativeStreamRuntime::Api api{};
+        static OpenNowStreamerConfig callbacks;
+        api.create = [](const OpenNowStreamerConfig *config, OpenNowStreamer **output) {
+            callbacks = *config;
+            *output = reinterpret_cast<OpenNowStreamer *>(new int(1));
+            return OPENNOW_STREAMER_OK;
+        };
+        api.destroy = [](OpenNowStreamer *handle) {
+            delete reinterpret_cast<int *>(handle);
+            return OPENNOW_STREAMER_OK;
+        };
+        api.send = [](const OpenNowStreamer *, const std::uint8_t *, std::size_t) {
+            return OPENNOW_STREAMER_OK;
+        };
+        api.setCaptureActive = [](const OpenNowStreamer *, bool, bool,
+                                  std::uintptr_t window, bool *raw) {
+            Q_ASSERT(window == 0);
+            *raw = false;
+            return OPENNOW_STREAMER_OK;
+        };
+        NativeStreamRuntime runtime(api);
+        QVERIFY(runtime.start());
+        StreamVideoItem::setNativeStreamRuntime(&runtime);
+        const auto reset = qScopeGuard([] { StreamVideoItem::setNativeStreamRuntime(nullptr); });
+        QQuickWindow window;
+        window.resize(640, 480);
+        auto *item = new StreamVideoItem(window.contentItem());
+        item->setRenderCallback({});
+        item->setSize(window.size());
+        item->setVideoSize(QSize(1920, 1080));
+        connect(&window, &QWindow::widthChanged, item, [&window, item] { item->setSize(window.size()); });
+        connect(&window, &QWindow::heightChanged, item, [&window, item] { item->setSize(window.size()); });
+        window.show();
+        QTRY_VERIFY_WITH_TIMEOUT(window.isActive(), 10000);
+        item->forceActiveFocus();
+        QVERIFY(!item->captureActive());
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("wayland-start")}}));
+        const QByteArray ready = R"({"id":"wayland-start","type":"ok"})";
+        callbacks.response_callback(reinterpret_cast<const std::uint8_t *>(ready.constData()),
+                                    ready.size(), callbacks.user_data);
+        QTRY_VERIFY(item->captureActive());
+        item->setRelativeMouse(true);
+        QVERIFY(!item->captureActive());
+        QTRY_VERIFY_WITH_TIMEOUT(item->m_waylandPointer->locked(), 10000);
+        QTRY_VERIFY(item->captureActive());
+        for (const bool fullscreen : {false, true}) {
+            if (fullscreen) window.showFullScreen();
+            else window.showNormal();
+            item->setSize(window.size());
+            item->setInputEnabled(false);
+            QVERIFY(!item->m_waylandPointer->locked());
+            QVERIFY(!item->captureActive());
+            item->setInputEnabled(true);
+            QTRY_VERIFY_WITH_TIMEOUT(item->m_waylandPointer->locked(), 10000);
+            QTRY_VERIFY(item->captureActive());
+        }
+        for (const bool failure : {false, true}) {
+            if (failure) {
+                const QByteArray error = R"({"type":"status","status":"error"})";
+                callbacks.event_callback(reinterpret_cast<const std::uint8_t *>(error.constData()),
+                                         error.size(), callbacks.user_data);
+            } else {
+                QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("stop")}}));
+            }
+            QTRY_VERIFY(!runtime.inputAllowed());
+            QVERIFY(item->isVisible());
+            QVERIFY(!item->m_waylandPointer->locked());
+            QVERIFY(!item->captureActive());
+            QMetaObject::invokeMethod(item->m_waylandPointer.get(), "stateChanged", Qt::QueuedConnection);
+            QTest::qWait(150);
+            QVERIFY(!item->m_waylandPointer->locked());
+            QVERIFY(!item->captureActive());
+            QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                                  {QStringLiteral("id"), QStringLiteral("wayland-start")}}));
+            callbacks.response_callback(reinterpret_cast<const std::uint8_t *>(ready.constData()),
+                                        ready.size(), callbacks.user_data);
+            QTRY_VERIFY_WITH_TIMEOUT(item->m_waylandPointer->locked(), 10000);
+            QTRY_VERIFY(item->captureActive());
+        }
+        window.hide();
+        QTRY_VERIFY(!item->m_waylandPointer->locked());
+        QTRY_VERIFY(!item->captureActive());
+    }
+
+    void sessionAuthorizationPreventsVisibleCaptureFromReopeningAfterReset()
+    {
+        static OpenNowStreamerConfig callbacks;
+        static QStringList inputCalls;
+        static OpenNowStreamerStatus commandStatus;
+        inputCalls.clear();
+        commandStatus = OPENNOW_STREAMER_OK;
+        NativeStreamRuntime::Api api{};
+        api.create = [](const OpenNowStreamerConfig *config, OpenNowStreamer **output) {
+            callbacks = *config;
+            *output = reinterpret_cast<OpenNowStreamer *>(new int(1));
+            return OPENNOW_STREAMER_OK;
+        };
+        api.destroy = [](OpenNowStreamer *handle) {
+            delete reinterpret_cast<int *>(handle);
+            return OPENNOW_STREAMER_OK;
+        };
+        api.send = [](const OpenNowStreamer *, const std::uint8_t *, std::size_t) {
+            return commandStatus;
+        };
+        api.setCaptureActive = [](const OpenNowStreamer *, bool active, bool, std::uintptr_t, bool *raw) {
+            inputCalls.append(active ? QStringLiteral("open") : QStringLiteral("close"));
+            *raw = false;
+            return OPENNOW_STREAMER_OK;
+        };
+        api.submitKey = [](const OpenNowStreamer *, std::uint16_t, std::uint16_t, bool pressed) {
+            inputCalls.append(pressed ? QStringLiteral("key-down") : QStringLiteral("key-up"));
+            return OPENNOW_STREAMER_OK;
+        };
+        NativeStreamRuntime runtime(api);
+        QVERIFY(runtime.start());
+        StreamVideoItem::setNativeStreamRuntime(&runtime);
+        const auto reset = qScopeGuard([] { StreamVideoItem::setNativeStreamRuntime(nullptr); });
+        QQuickWindow window;
+        window.resize(640, 480);
+        auto *item = new StreamVideoItem(window.contentItem());
+        item->setRenderCallback({});
+        item->setSize(window.size());
+        window.show();
+        window.requestActivate();
+        QTRY_VERIFY(window.isActive());
+        item->forceActiveFocus();
+        QVERIFY(!runtime.presentationAllowed());
+        QVERIFY(!item->captureActive());
+        QVERIFY(!inputCalls.contains(QStringLiteral("open")));
+        const auto reply = [](const QString &id) {
+            const auto bytes = QJsonDocument(QJsonObject{{QStringLiteral("id"), id},
+                {QStringLiteral("type"), QStringLiteral("ok")}}).toJson(QJsonDocument::Compact);
+            callbacks.response_callback(reinterpret_cast<const std::uint8_t *>(bytes.constData()),
+                                        bytes.size(), callbacks.user_data);
+        };
+        const auto delayedCaptureCallback = [item] {
+            QMetaObject::invokeMethod(item->m_waylandPointer.get(), "stateChanged", Qt::QueuedConnection);
+            QCoreApplication::sendPostedEvents();
+            QCoreApplication::processEvents();
+            item->resynchronizeInput();
+        };
+        for (const auto reason : {QStringLiteral("stop"), QStringLiteral("presentation-error"),
+                                  QStringLiteral("terminal-error"), QStringLiteral("rejected-stop")}) {
+            QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                                  {QStringLiteral("id"), reason}}));
+            QVERIFY(!item->captureActive());
+            delayedCaptureCallback();
+            QVERIFY(!item->captureActive());
+            reply(reason);
+            QTRY_VERIFY(runtime.inputAllowed());
+            QTRY_VERIFY(item->captureActive());
+            QKeyEvent press(QEvent::KeyPress, Qt::Key_W, Qt::NoModifier);
+            item->keyPressEvent(&press);
+            QVERIFY(inputCalls.contains(QStringLiteral("key-down")));
+            inputCalls.clear();
+            if (reason == QStringLiteral("presentation-error")) {
+                runtime.reportPresentationError(QStringLiteral("fixture presentation failure"));
+            } else if (reason == QStringLiteral("terminal-error")) {
+                const QByteArray bytes = R"({"type":"status","status":"error"})";
+                callbacks.event_callback(reinterpret_cast<const std::uint8_t *>(bytes.constData()),
+                                         bytes.size(), callbacks.user_data);
+            } else {
+                commandStatus = reason == QStringLiteral("rejected-stop")
+                    ? OPENNOW_STREAMER_QUEUE_FULL : OPENNOW_STREAMER_OK;
+                QCOMPARE(runtime.send({{QStringLiteral("type"), QStringLiteral("stop")}}),
+                         commandStatus == OPENNOW_STREAMER_OK);
+                commandStatus = OPENNOW_STREAMER_OK;
+            }
+            QTRY_COMPARE(runtime.inputAllowed(), reason == QStringLiteral("rejected-stop"));
+            QVERIFY(window.isVisible());
+            QVERIFY(item->isVisible());
+            QCOMPARE(item->captureActive(), reason == QStringLiteral("rejected-stop"));
+            QVERIFY(inputCalls.indexOf(QStringLiteral("key-up")) >= 0);
+            QVERIFY(inputCalls.indexOf(QStringLiteral("key-up")) < inputCalls.indexOf(QStringLiteral("close")));
+            inputCalls.clear();
+            reply(reason);
+            delayedCaptureCallback();
+            QCOMPARE(runtime.inputAllowed(), reason == QStringLiteral("rejected-stop"));
+            QCOMPARE(item->captureActive(), reason == QStringLiteral("rejected-stop"));
+            QCOMPARE(inputCalls.contains(QStringLiteral("open")), reason == QStringLiteral("rejected-stop"));
+        }
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("pending-start")}}));
+        commandStatus = OPENNOW_STREAMER_QUEUE_FULL;
+        QVERIFY(!runtime.send({{QStringLiteral("type"), QStringLiteral("stop")}}));
+        commandStatus = OPENNOW_STREAMER_OK;
+        delayedCaptureCallback();
+        QVERIFY(!runtime.inputAllowed());
+        QVERIFY(!item->captureActive());
+        reply(QStringLiteral("pending-start"));
+        QTRY_VERIFY(runtime.presentationAllowed());
+        delayedCaptureCallback();
+        QVERIFY(runtime.inputAllowed());
+        QVERIFY(item->captureActive());
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("fresh-start")}}));
+        reply(QStringLiteral("fresh-start"));
+        QTRY_VERIFY(item->captureActive());
     }
 
     void cursorModeChangesDoNotReleaseAnActiveDrag()

--- a/opennow-qt/tests/tst_waylandpointercapture.cpp
+++ b/opennow-qt/tests/tst_waylandpointercapture.cpp
@@ -1,0 +1,87 @@
+#include "WaylandPointerCapture.h"
+
+#include <QSignalSpy>
+#include <QTest>
+#include <QWindow>
+#include <QBackingStore>
+#include <QPainter>
+#include <limits>
+
+class InputTestWindow final : public QWindow
+{
+    QBackingStore m_buffer{this};
+    void exposeEvent(QExposeEvent *) override
+    {
+        if (!isExposed()) return;
+        m_buffer.resize(size());
+        const QRegion region(QRect(QPoint(), size()));
+        m_buffer.beginPaint(region);
+        QPainter painter(m_buffer.paintDevice());
+        painter.fillRect(QRect(QPoint(), size()), Qt::darkBlue);
+        painter.end();
+        m_buffer.endPaint();
+        m_buffer.flush(region);
+    }
+};
+
+class WaylandPointerCaptureTest final : public QObject
+{
+    Q_OBJECT
+private slots:
+    void relativeMotionIsBoundedAndPreservesSubpixelRemainders()
+    {
+        QPointF remainder;
+        QCOMPARE(WaylandPointerCapture::boundedDelta(remainder, {0.75, -0.75}), QPoint());
+        QCOMPARE(WaylandPointerCapture::boundedDelta(remainder, {0.75, -0.75}), QPoint(1, -1));
+        QCOMPARE(remainder, QPointF(0.5, -0.5));
+        QCOMPARE(WaylandPointerCapture::boundedDelta(remainder, {1e9, -1e9}), QPoint(32767, -32768));
+        QCOMPARE(remainder, QPointF());
+        QCOMPARE(WaylandPointerCapture::boundedDelta(remainder,
+            {std::numeric_limits<double>::infinity(), 1}), QPoint());
+    }
+
+    void inactiveWindowNeverLocks()
+    {
+        WaylandPointerCapture capture;
+        QWindow window;
+        capture.setCapture(&window, true, QRect(0, 0, 640, 480));
+        QVERIFY(!capture.locked());
+        capture.release();
+        capture.release();
+        QVERIFY(!capture.locked());
+    }
+
+    void compositorCaptureLifecycle()
+    {
+        if (!WaylandPointerCapture::isWayland()
+                || !qEnvironmentVariableIsSet("OPENNOW_TEST_WAYLAND_CAPTURE"))
+            QSKIP("Requires a Wayland compositor with an interactive pointer seat");
+        InputTestWindow window;
+        window.setTitle(QStringLiteral("OpenNOW Wayland input validation"));
+        window.resize(640, 480);
+        window.show();
+        WaylandPointerCapture capture;
+        QSignalSpy motion(&capture, &WaylandPointerCapture::relativeMotion);
+        QTRY_VERIFY_WITH_TIMEOUT(window.isActive(), 10000);
+        auto acquire = [&] {
+            capture.setCapture(&window, true, QRect(QPoint(), window.size()));
+            return capture.locked();
+        };
+        QTRY_VERIFY_WITH_TIMEOUT(acquire(), 10000);
+        QTRY_VERIFY_WITH_TIMEOUT(!motion.isEmpty(), 15000);
+        for (const auto fullscreen : {false, true}) {
+            if (fullscreen) window.showFullScreen();
+            else window.showNormal();
+            QTest::qWait(250);
+            QTRY_VERIFY_WITH_TIMEOUT(acquire(), 10000);
+            capture.release();
+            QVERIFY(!capture.locked());
+            QTRY_VERIFY_WITH_TIMEOUT(acquire(), 10000);
+        }
+        window.hide();
+        QTRY_VERIFY(!capture.locked());
+    }
+};
+
+QTEST_MAIN(WaylandPointerCaptureTest)
+#include "tst_waylandpointercapture.moc"


### PR DESCRIPTION
Suspend controller ownership on window deactivation and serialize native input closure with controller submissions. Reserve bounded, coalesced neutral snapshots so saturated queues cannot discard focus-loss releases, and preserve disconnect snapshots after capture closes.

Release Qt keys, buttons, and pointer locks before closing native capture. Session authorization prevents delayed compositor callbacks from reopening input after an accepted stop, error, or shutdown; rejected start/stop enqueue restores the old session’s authorization without changing media behavior.

Add Qt-owned native Wayland relative-pointer and persistent pointer-lock integration, including asynchronous lock acquisition, fullscreen/overlay transitions, and surface/device recreation. Native Wayland never activates XInput2 or cursor-warp fallback. A shared, localized stream banner reports unsupported capture without replacing the video item. Update Linux build prerequisites and test-runtime deployment.

Validation:
- Full Qt 6.8.3 build and 140/140 CTest tests passed, independently repeated in the parent’s combined four-fix tree.
- Combined feature-enabled native workspace: 317 passed, two ignored; affected native clippy, formatting, package capability, and localization checks passed.
- Real Weston tests passed for relative motion, lock/reacquisition, fullscreen, overlays, pending-lock transitions, visible stop/failure, rejected commands, and restart.
- Windows hardware input, physical controllers, representative GPU/DPR configurations, and authorized gameplay still require live acceptance. Weston ran nested on Xvfb, not a physical display.

Screenshots below use the public-safe smoke fixture to demonstrate the error notice, not a live gameplay session.

Desktop:
![Screenshot](https://api-nightly.capy.ai/pr-assets/O9OUFtcoRWZSo88OwITcK-cB80vryLJ_GH_ok8T3E1o)

Console:
![Screenshot](https://api-nightly.capy.ai/pr-assets/oM-B11Un3cAnph3-XjFxOPvfjpMVwxTVFphhdFBFZ_M)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1VZEFE3C8EJY5CGQDFA5M9D"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->