### PR TITLE
fix(macos): harden embedded native streaming and app bundles

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           python3 -m unittest discover -s opennow-qt/tests -p test_release_metadata.py
           python3 -m unittest discover -s opennow-qt/tests -p test_nightly_release.py
+          python3 -m unittest discover -s opennow-qt/tests -p test_macos_build.py
       - name: Record immutable nightly identity
         id: version
         shell: bash
@@ -507,6 +508,173 @@ jobs:
             build/qt-packages/*.deb
             build/qt-packages/*.dmg
             build/qt-packages/*.zip
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+
+  macos-validate:
+    name: macos-arm64
+    needs: metadata
+    runs-on: macos-15
+    timeout-minutes: 60
+    env:
+      CARGO_TERM_COLOR: always
+      SDL_VERSION: release-3.2.20
+      OPENNOW_BUILD_VERSION: ${{ needs.metadata.outputs.version }}
+      MACOSX_DEPLOYMENT_TARGET: "13.0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.3"
+          host: mac
+          target: desktop
+          arch: clang_64
+          modules: qtmultimedia qtshadertools
+          cache: true
+          cache-key-prefix: qt-target-macos-arm64
+      - name: Cache Rust dependencies and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          key: qt-ci-macos-arm64
+          cache-bin: false
+          workspaces: |
+            native/opennow-core -> target
+            native/opennow-streamer -> target
+            native/opennow-core -> ../../build/opennow-qt-release/rust-target
+            native/opennow-streamer -> ../../build/opennow-qt-release/streamer-rust-target
+      - name: Cache SDL3 installation
+        id: sdl-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/SDL-install
+          key: qt-ci-sdl-v1-macos-arm64-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-ci.yml') }}
+      - name: Build SDL3
+        if: steps.sdl-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
+          cmake -S "$RUNNER_TEMP/SDL" -B "$RUNNER_TEMP/SDL-build" \
+            -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET" \
+            -DSDL_SHARED=ON -DSDL_STATIC=OFF -DSDL_FRAMEWORK=OFF \
+            -DSDL_TEST_LIBRARY=OFF -DSDL_TESTS=OFF
+          cmake --build "$RUNNER_TEMP/SDL-build" --parallel 3
+          cmake --install "$RUNNER_TEMP/SDL-build" --prefix "$RUNNER_TEMP/SDL-install"
+      - name: Test macOS native contracts
+        shell: bash
+        run: |
+          [[ "$(uname -m)" == arm64 ]]
+          python3 -m unittest discover -s opennow-qt/tests -p test_macos_build.py
+          cargo test --manifest-path native/opennow-core/Cargo.toml --locked
+          cargo test --manifest-path native/opennow-streamer/Cargo.toml --locked \
+            -p opennow-streamer-platform-macos -p opennow-streamer-protocol -p opennow-streamer-ffi
+      - name: Configure and build Qt native release
+        shell: bash
+        run: |
+          cmake -S opennow-qt -B build/opennow-qt-release \
+            -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET" \
+            -DOPENNOW_BUILD_VERSION="$OPENNOW_BUILD_VERSION" \
+            -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install"
+          cmake --build build/opennow-qt-release --parallel 3
+      - name: Test Qt shell and embedded runtime offscreen
+        shell: bash
+        run: |
+          ctest --test-dir build/opennow-qt-release --output-on-failure --parallel 2 \
+            -R '^opennow-.*-tests$|^opennow-acceptance-verifier-help$|^qml-(desktop-route-(home|settings|stream)|fullscreen-.*stats-shortcut|desktop-stream-.*|streamer-event-contract)$'
+      - name: Package unsigned macOS validation bundle
+        shell: bash
+        run: |
+          mkdir -p build/qt-packages
+          cpack --config build/opennow-qt-release/CPackConfig.cmake \
+            -G ZIP -B build/qt-packages
+      - name: Test relocated bundle without development libraries
+        shell: bash
+        run: |
+          packages=(build/qt-packages/OpenNOW-Qt-*-Darwin-arm64.zip)
+          [[ ${#packages[@]} -eq 1 && -f "${packages[0]}" ]]
+          ditto -x -k "${packages[0]}" "$RUNNER_TEMP/relocated"
+          app=$(find "$RUNNER_TEMP/relocated" -name OpenNOW.app -type d -print -quit)
+          [[ -n "$app" ]]
+          bin="$app/Contents/MacOS"
+          for executable in OpenNOW opennow-core opennow-acceptance-verify opennow-streamer; do
+            test -x "$bin/$executable"
+            lipo -verify_arch arm64 "$bin/$executable"
+          done
+          test -f "$bin/libopennow_streamer_ffi.dylib"
+          lipo -verify_arch arm64 "$bin/libopennow_streamer_ffi.dylib"
+          otool -D build/opennow-qt-release/OpenNOW.app/Contents/MacOS/libopennow_streamer_ffi.dylib \
+            | grep -Fx '@rpath/libopennow_streamer_ffi.dylib'
+          test -f "$app/Contents/Resources/licenses/THIRD_PARTY_NOTICES"
+          restore() {
+            for path in "$PWD/build/opennow-qt-release" "$QT_ROOT_DIR" "$RUNNER_TEMP/SDL-install"; do
+              if [[ -d "$path.unavailable" ]]; then mv "$path.unavailable" "$path"; fi
+            done
+          }
+          trap restore EXIT
+          mv build/opennow-qt-release build/opennow-qt-release.unavailable
+          mv "$QT_ROOT_DIR" "$QT_ROOT_DIR.unavailable"
+          mv "$RUNNER_TEMP/SDL-install" "$RUNNER_TEMP/SDL-install.unavailable"
+          unset QT_PLUGIN_PATH QT_QPA_PLATFORM_PLUGIN_PATH QML2_IMPORT_PATH QML_IMPORT_PATH
+          unset DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_FALLBACK_LIBRARY_PATH DYLD_FALLBACK_FRAMEWORK_PATH
+          "$bin/opennow-acceptance-verify" --help
+          python3 - "$bin" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import select
+          import subprocess
+          import sys
+          import tempfile
+
+          bin_dir = Path(sys.argv[1])
+          for name in ("OpenNOW", "opennow-core", "opennow-acceptance-verify",
+                       "opennow-streamer", "libopennow_streamer_ffi.dylib"):
+              dependencies = subprocess.check_output(["otool", "-L", bin_dir / name], text=True)
+              for line in dependencies.splitlines()[1:]:
+                  dependency = line.strip().split(" (", 1)[0]
+                  assert not dependency.startswith("/") or dependency.startswith(
+                      ("/System/Library/", "/usr/lib/")), (name, dependency)
+          probe = subprocess.run(
+              [bin_dir / "opennow-streamer"],
+              input='{"id":"package-probe","type":"hello","protocolVersion":6}\n'
+                    '{"id":"package-shutdown","type":"shutdown"}\n',
+              text=True, capture_output=True, check=True, timeout=30)
+          messages = [json.loads(line) for line in probe.stdout.splitlines()]
+          ready = next(m for m in messages if m.get("id") == "package-probe")
+          assert ready.get("type") == "ready", ready
+          assert any(b.get("backend") == "videotoolbox" for b in ready["capabilities"]["videoBackends"])
+          with tempfile.TemporaryDirectory() as data_dir:
+              core = subprocess.Popen(
+                  [bin_dir / "opennow-core", "--data-dir", data_dir],
+                  stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+              try:
+                  core.stdin.write('{"type":"request","id":"package-core","method":"core.hello",'
+                                   '"params":{"protocolVersion":1}}\n')
+                  core.stdin.flush()
+                  assert select.select([core.stdout], [], [], 30)[0], "Core handshake timed out"
+                  response = json.loads(core.stdout.readline())
+                  assert response.get("id") == "package-core" and response.get("ok") is True, response
+              finally:
+                  core.kill()
+                  core.communicate(timeout=5)
+          subprocess.run(
+              [bin_dir / "OpenNOW", "--smoke-test", "--allow-multiple-instances",
+               "--desktop", "--route", "home", "--reduced-motion"],
+              env={**os.environ, "QT_QPA_PLATFORM": "cocoa"}, check=True, timeout=30)
+          PY
+      - name: Upload macOS validation package
+        uses: actions/upload-artifact@v4
+        with:
+          name: opennow-macos-arm64-validation
+          path: build/qt-packages/*.zip
           if-no-files-found: error
           retention-days: 14
           compression-level: 0

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -544,6 +544,7 @@ jobs:
         with:
           key: qt-ci-macos-arm64
           cache-bin: false
+          cache-on-failure: true
           workspaces: |
             native/opennow-core -> target
             native/opennow-streamer -> target

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -614,6 +614,7 @@ jobs:
           otool -D build/opennow-qt-release/OpenNOW.app/Contents/MacOS/libopennow_streamer_ffi.dylib \
             | grep -Fx '@rpath/libopennow_streamer_ffi.dylib'
           test -f "$app/Contents/Resources/licenses/THIRD_PARTY_NOTICES"
+          test -f "$app/Contents/PlugIns/imageformats/libqsvg.dylib"
           restore() {
             for path in "$PWD/build/opennow-qt-release" "$QT_ROOT_DIR" "$RUNNER_TEMP/SDL-install"; do
               if [[ -d "$path.unavailable" ]]; then mv "$path.unavailable" "$path"; fi

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -607,10 +607,10 @@ jobs:
           bin="$app/Contents/MacOS"
           for executable in OpenNOW opennow-core opennow-acceptance-verify opennow-streamer; do
             test -x "$bin/$executable"
-            lipo -verify_arch arm64 "$bin/$executable"
+            lipo "$bin/$executable" -verify_arch arm64
           done
           test -f "$bin/libopennow_streamer_ffi.dylib"
-          lipo -verify_arch arm64 "$bin/libopennow_streamer_ffi.dylib"
+          lipo "$bin/libopennow_streamer_ffi.dylib" -verify_arch arm64
           otool -D build/opennow-qt-release/OpenNOW.app/Contents/MacOS/libopennow_streamer_ffi.dylib \
             | grep -Fx '@rpath/libopennow_streamer_ffi.dylib'
           test -f "$app/Contents/Resources/licenses/THIRD_PARTY_NOTICES"

--- a/native/opennow-core/src/cloudmatch.rs
+++ b/native/opennow-core/src/cloudmatch.rs
@@ -739,7 +739,7 @@ fn build_create_body(app_id: &str, params: &Value, settings: &Value, device_id: 
         json!({"key":"ClientImeSupport","value":"0"}),
         json!({"key":"SubSessionId","value":random_uuid()}),
         json!({"key":"clientPhysicalResolution","value":physical_resolution}),
-        json!({"key":"networkType","value":if cfg!(target_os = "macos") { "WiFi5.0" } else { "Unknown" }}),
+        json!({"key":"networkType","value":"Unknown"}),
         json!({"key":"wssignaling","value":"1"}),
         json!({"key":"surroundAudioInfo","value":"2"}),
     ];
@@ -1778,6 +1778,18 @@ mod tests {
             );
             assert_eq!(body["sessionRequestData"]["appLaunchMode"], expected);
         }
+    }
+
+    #[test]
+    fn native_request_does_not_invent_the_clients_network_type() {
+        let body = build_create_body("12345", &json!({}), &json!({}), "device-id");
+        let network = body["sessionRequestData"]["metaData"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["key"] == "networkType")
+            .unwrap();
+        assert_eq!(network["value"], "Unknown");
     }
 
     #[test]

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -1556,27 +1556,39 @@ mod tests {
             .as_nanos();
         let root = env::temp_dir().join(format!("opennow-core-profile-{unique}"));
         let primary = root.join("OpenNOW");
-        let legacy = root.join("opennow");
+        let legacy = root.join("legacy-opennow");
 
         fs::create_dir_all(&legacy).unwrap();
-        #[cfg(not(windows))]
         assert_eq!(
             select_existing_data_dir(primary.clone(), [legacy.clone()]),
             legacy
         );
-        // Windows resolves these two historical spellings to the same directory,
-        // so the preferred spelling is already considered present.
-        #[cfg(windows)]
-        assert_eq!(
-            select_existing_data_dir(primary.clone(), [legacy.clone()]),
-            primary
-        );
 
         fs::create_dir_all(&primary).unwrap();
-        assert_eq!(
-            select_existing_data_dir(primary.clone(), [root.join("opennow")]),
-            primary
-        );
+        assert_eq!(select_existing_data_dir(primary.clone(), [legacy]), primary);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn historical_profile_spelling_respects_filesystem_case_sensitivity() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = env::temp_dir().join(format!("opennow-core-profile-case-{unique}"));
+        let primary = root.join("OpenNOW");
+        let legacy = root.join("opennow");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("settings.json"), b"{}").unwrap();
+
+        let expected = if primary.canonicalize().is_ok() {
+            primary.clone()
+        } else {
+            legacy.clone()
+        };
+        let selected = select_existing_data_dir(primary, [legacy.clone()]);
+        assert_eq!(selected, expected);
+        assert_eq!(fs::read(selected.join("settings.json")).unwrap(), b"{}");
         let _ = fs::remove_dir_all(root);
     }
 

--- a/native/opennow-core/src/streamer.rs
+++ b/native/opennow-core/src/streamer.rs
@@ -351,14 +351,27 @@ impl StreamerService {
                 ),
             });
         }
+        let videotoolbox = backends.iter().any(|backend| {
+            backend["backend"] == "videotoolbox"
+                && backend["platform"] == "macos"
+                && backend["available"].as_bool() == Some(true)
+        });
         let color = if hdr {
             "10bit_420"
         } else {
             settings["colorQuality"].as_str().unwrap_or("8bit_420")
         };
+        if videotoolbox && !matches!(color, "8bit_420" | "10bit_420") {
+            return Err(StreamerError {
+                code: "streamer_color_unavailable",
+                message: "The macOS embedded streamer supports 8-bit and 10-bit 4:2:0 SDR. Select 4:2:0 in Stream settings.".to_owned(),
+            });
+        }
         for backend in backends.iter_mut() {
-            let requires_profiles =
-                hdr || backend["backend"] == "vulkan" || backend["platform"] == "linux";
+            let requires_profiles = hdr
+                || backend["backend"] == "vulkan"
+                || backend["platform"] == "linux"
+                || backend["backend"] == "videotoolbox";
             for codec in backend["codecs"].as_array_mut().into_iter().flatten() {
                 let hdr_supported = codec
                     .get("hdrSupported")
@@ -398,6 +411,8 @@ impl StreamerService {
             let candidates: &[&str] = match color {
                 _ if hdr => &["h265", "av1"],
                 "8bit_444" | "10bit_444" => &["h265"],
+                "10bit_420" if videotoolbox => &["h265", "av1"],
+                _ if videotoolbox => macos_auto_codec_candidates(settings),
                 "10bit_420" => &["av1", "h265"],
                 _ => &["av1", "h265", "h264"],
             };
@@ -460,8 +475,14 @@ impl StreamerService {
         if !params["runtimeCapabilities"].is_null() {
             // Re-check the server's negotiated codec on resume/attachment as well. Never
             // reinterpret compressed AV1 bytes as H.264 when a persisted session is resumed.
+            let mut negotiated_settings = context["settings"].clone();
+            if let Some(color) =
+                context["session"]["negotiatedStreamProfile"]["colorQuality"].as_str()
+            {
+                negotiated_settings["colorQuality"] = json!(color);
+            }
             let resolved = Self::embedded_session_settings(
-                &context["settings"],
+                &negotiated_settings,
                 &params["runtimeCapabilities"],
             )?;
             context["settings"]["nativeHdrSupported"] = resolved["nativeHdrSupported"].clone();
@@ -904,6 +925,29 @@ fn available_codecs(capabilities: &Value) -> Vec<&'static str> {
         .into_iter()
         .filter(|codec| codec_available(capabilities, codec))
         .collect()
+}
+
+fn macos_auto_codec_candidates(settings: &Value) -> &'static [&'static str] {
+    let (width, height) = settings["resolution"]
+        .as_str()
+        .and_then(|value| value.split_once('x'))
+        .and_then(|(width, height)| Some((width.parse::<u64>().ok()?, height.parse::<u64>().ok()?)))
+        .filter(|(width, height)| *width > 0 && *height > 0)
+        .unwrap_or((1920, 1080));
+    let pixels = width.saturating_mul(height);
+    let fps = settings["fps"].as_u64().unwrap_or(60);
+    let bitrate = settings["maxBitrateMbps"].as_u64().unwrap_or(75);
+    if fps >= 144 {
+        &["h264", "h265", "av1"]
+    } else if pixels >= 3840 * 2160 || ((1..=30).contains(&bitrate) && pixels >= 2560 * 1440) {
+        &["av1", "h265", "h264"]
+    } else if (1..=30).contains(&bitrate) {
+        &["av1", "h264", "h265"]
+    } else if pixels >= 2560 * 1440 || bitrate >= 75 {
+        &["h265", "h264", "av1"]
+    } else {
+        &["h264", "h265", "av1"]
+    }
 }
 
 fn codec_available(capabilities: &Value, codec: &str) -> bool {
@@ -1883,6 +1927,135 @@ mod tests {
         let prepared = service.prepare_embedded(&params, &stale_hdr).unwrap();
         assert_eq!(prepared["context"]["settings"]["enableHdr"], false);
         assert_eq!(prepared["context"]["settings"]["nativeHdrSupported"], false);
+    }
+
+    #[test]
+    fn embedded_macos_auto_matches_hardware_stream_quality_policy() {
+        let caps = json!({"protocolVersion":STREAMER_PROTOCOL_VERSION,"videoBackends":[{
+            "backend":"videotoolbox","platform":"macos","available":true,"codecs":[
+                {"codec":"h264","available":true,"colorQualities":["8bit_420"]}, {"codec":"h265","available":true,"colorQualities":["8bit_420","10bit_420"]},
+                {"codec":"av1","available":true,"colorQualities":["8bit_420","10bit_420"]}]}]});
+        for (resolution, fps, bitrate, color, expected) in [
+            ("1920x1080", 60, 75, "8bit_420", "h265"),
+            ("1920x1080", 60, 50, "8bit_420", "h264"),
+            ("2560x1440", 60, 80, "8bit_420", "h265"),
+            ("1920x1080", 60, 30, "8bit_420", "av1"),
+            ("1920x1080", 60, 31, "8bit_420", "h264"),
+            ("3840x2160", 120, 80, "8bit_420", "av1"),
+            ("3840x2160", 144, 20, "8bit_420", "h264"),
+            ("1920x1080", 240, 75, "8bit_420", "h264"),
+            ("1920x1080", 60, 20, "10bit_420", "h265"),
+            ("1920x1080", 144, 75, "10bit_420", "h265"),
+        ] {
+            let settings = json!({"codec":"auto", "resolution":resolution,
+                "fps":fps, "maxBitrateMbps":bitrate, "colorQuality":color,
+                "transportMode":"nvst"});
+            let resolved = StreamerService::embedded_session_settings(&settings, &caps).unwrap();
+            assert_eq!(resolved["codec"], expected, "{settings}");
+            assert_eq!(resolved["colorQuality"], color);
+            assert_eq!(resolved["transportMode"], "nvst");
+            assert_eq!(settings["codec"], "auto");
+        }
+        assert_eq!(
+            StreamerService::embedded_session_settings(&json!({"codec":"auto"}), &caps).unwrap()["codec"],
+            "h265"
+        );
+    }
+
+    #[test]
+    fn embedded_macos_codec_policy_never_falls_back_to_unsupported_hardware() {
+        let mut caps = json!({"protocolVersion":STREAMER_PROTOCOL_VERSION,"videoBackends":[{
+            "backend":"videotoolbox","platform":"macos","available":true,"codecs":[
+                {"codec":"h264","available":true,"colorQualities":["8bit_420"]}, {"codec":"h265","available":true,"colorQualities":["8bit_420","10bit_420"]},
+                {"codec":"av1","available":false}]},
+            {"backend":"software","available":true,"codecs":[
+                {"codec":"av1","available":true,"colorQualities":["8bit_420","10bit_420"]}]}]});
+        let settings = json!({"codec":"auto", "maxBitrateMbps":20});
+        assert_eq!(
+            StreamerService::embedded_session_settings(&settings, &caps).unwrap()["codec"],
+            "h264"
+        );
+        assert_eq!(
+            StreamerService::embedded_session_settings(
+                &json!({"codec":"auto", "maxBitrateMbps":20, "resolution":"3840x2160"}),
+                &caps
+            )
+            .unwrap()["codec"],
+            "h265"
+        );
+        assert_eq!(
+            StreamerService::embedded_session_settings(&json!({"codec":"av1"}), &caps)
+                .unwrap_err()
+                .code,
+            "streamer_codec_unavailable"
+        );
+        assert_eq!(
+            StreamerService::embedded_session_settings(&json!({"codec":"h264"}), &caps).unwrap()["codec"],
+            "h264"
+        );
+        caps["videoBackends"][0]["codecs"][1]["available"] = json!(false);
+        assert_eq!(
+            StreamerService::embedded_session_settings(&settings, &caps).unwrap()["codec"],
+            "h264"
+        );
+        for codec in ["auto", "h264", "h265"] {
+            assert_eq!(
+                StreamerService::embedded_session_settings(
+                    &json!({"codec":codec,"colorQuality":"10bit_420"}),
+                    &caps,
+                )
+                .unwrap_err()
+                .code,
+                "streamer_codec_unavailable",
+            );
+        }
+        for codec in ["auto", "h264", "h265"] {
+            for color in ["8bit_444", "10bit_444"] {
+                assert_eq!(
+                    StreamerService::embedded_session_settings(
+                        &json!({"codec":codec,"colorQuality":color}),
+                        &caps
+                    )
+                    .unwrap_err()
+                    .code,
+                    "streamer_color_unavailable"
+                );
+            }
+        }
+        caps["videoBackends"][0]["available"] = json!(false);
+        assert_eq!(
+            StreamerService::embedded_session_settings(&settings, &caps)
+                .unwrap_err()
+                .code,
+            "streamer_backend_unavailable"
+        );
+    }
+
+    #[test]
+    fn embedded_macos_prepare_checks_negotiated_color_before_attachment() {
+        let service = StreamerService::new();
+        for color in ["8bit_444", "10bit_444"] {
+            let result = service.prepare_embedded(
+                &json!({"session": {
+                    "sessionId":"resume", "status":2,
+                    "negotiatedStreamProfile":{"codec":"H265", "colorQuality":color}
+                }, "runtimeCapabilities":{"protocolVersion":STREAMER_PROTOCOL_VERSION,"videoBackends":[{
+                    "backend":"videotoolbox","platform":"macos","available":true,
+                    "codecs":[{"codec":"h265","available":true,"colorQualities":["8bit_420","10bit_420"]}]}]}}),
+                &json!({"codec":"auto", "colorQuality":"8bit_420"}),
+            );
+            assert_eq!(result.unwrap_err().code, "streamer_color_unavailable");
+        }
+        let prepared = service.prepare_embedded(
+            &json!({"session": {
+                "sessionId":"resume-ten-bit", "status":2,
+                "negotiatedStreamProfile":{"codec":"H265", "colorQuality":"10bit_420"}
+            }, "runtimeCapabilities":{"protocolVersion":STREAMER_PROTOCOL_VERSION,"videoBackends":[{
+                "backend":"videotoolbox","platform":"macos","available":true,
+                "codecs":[{"codec":"h265","available":true,"colorQualities":["8bit_420","10bit_420"]}]}]}}),
+            &json!({"codec":"auto", "colorQuality":"8bit_420"}),
+        ).unwrap();
+        assert_eq!(prepared["context"]["settings"]["colorQuality"], "10bit_420");
     }
 
     #[test]

--- a/native/opennow-streamer/Cargo.lock
+++ b/native/opennow-streamer/Cargo.lock
@@ -1655,6 +1655,7 @@ name = "opennow-streamer-platform"
 version = "0.2.0"
 dependencies = [
  "base64",
+ "cc",
  "image",
  "libc",
  "objc2",

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/README.md
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/README.md
@@ -17,7 +17,34 @@ This isolated crate implements the macOS media path without GStreamer or FFmpeg:
 
 The crate is a member of the native-streamer workspace and is linked only on macOS.
 
-## Integration API
+## Qt embedded integration
+
+`MacOsBackend::start_embedded_with_publisher` runs on a session-owned worker and creates no
+AppKit window, Metal device, command queue, or display link. Hardware VideoToolbox decoding is
+required; the real-time property is requested as a best-effort latency hint. The single-frame
+mailbox drops obsolete decoded frames without blocking the decoder. Qt owns composition,
+fullscreen, overlays, and the graphics device throughout the session.
+
+The pixel buffer and its CoreVideo/Metal textures remain retained until Qt's command buffer
+completes, including when the stream item's graphics resources are retired before completion.
+`video_metal_completed` measures completion of this GPU work, separately from the standalone
+presenter's `video_presented` scanout count. Both paths can signal playback readiness. Persistent
+embedded decoder or GPU failure is reported rather than switching to an invisible SDL/software
+presenter.
+
+The core adapts the SDR Auto codec policy from
+[OpenNOW-Mac's stream settings](https://github.com/OpenCloudGaming/OpenNOW-Mac/blob/0a68e94c58b8190bbe3f789beb14a35c9ae99c6d/OPN/Stream/WebRTCMediaStreamSettings.swift):
+prefer H.264 at 144 FPS or higher; otherwise prefer hardware AV1 for constrained bitrate or 4K,
+and HEVC for 1440p or high bitrate. Selection stays within codecs actually supported by the Mac.
+The decoder's real-time hint follows its `NvstVideoToolboxDecoder.swift`. These settings do not
+import the reference's Swift/WebRTC runtime or change OpenNOW's NVST transport.
+
+The current Qt path supports SDR 8-bit 4:2:0 and preserves the main application's ten-bit
+HEVC/AV1 path through P010 and RGB10A2 textures. Ten-bit Auto selection stays on HEVC/AV1;
+H.264 remains eight-bit. Unsupported 4:4:4 requests, including resumed sessions, are rejected
+rather than silently reduced to 4:2:0. macOS HDR output is not advertised.
+
+## Standalone integration API
 
 Create `H264ParameterSets` from the current SPS and PPS (or `H265ParameterSets` from VPS, SPS and
 PPS) and start the backend on AppKit's main thread. OpenNOW's native host creates a standalone SDL/AppKit window and supplies its dedicated
@@ -165,6 +192,19 @@ On macOS, run:
 cargo test
 cargo clippy --all-targets -- -D warnings
 ```
+
+On a Mac with working VideoToolbox hardware decoding and Metal, also run this offline acceptance
+test from the repository root (no GFN account is needed):
+
+```sh
+cargo test --manifest-path native/opennow-streamer/Cargo.toml \
+  -p opennow-streamer-platform-macos \
+  hardware_decode_to_embedded_metal_survives_surface_retirement -- --ignored --nocapture
+```
+
+It decodes a synthetic black H.264 frame in hardware, imports the IOSurface on an adopted Metal
+device, and retires/recreates graphics resources before GPU completion. Live gameplay still needs
+the Qt windowed/fullscreen, overlay, reconnect, and input checks in `docs/qt-acceptance.md`.
 
 Both Apple architectures can be type-checked from a non-macOS host when Rust's targets are
 installed. A real build still requires the Apple SDK and a matching C compiler because vendored

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
@@ -4,6 +4,7 @@ use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use block2::RcBlock;
 use objc2::Message;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
@@ -20,13 +21,14 @@ use objc2_core_video::{
 };
 use objc2_foundation::NSString;
 use objc2_metal::{
-    MTLCommandBuffer, MTLCommandEncoder, MTLDevice, MTLLibrary, MTLLoadAction, MTLPixelFormat,
-    MTLPrimitiveType, MTLRenderCommandEncoder, MTLRenderPassDescriptor,
-    MTLRenderPipelineDescriptor, MTLRenderPipelineState, MTLStorageMode, MTLStoreAction,
-    MTLTexture, MTLTextureDescriptor, MTLTextureUsage, MTLViewport,
+    MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder, MTLDevice, MTLLibrary,
+    MTLLoadAction, MTLPixelFormat, MTLPrimitiveType, MTLRenderCommandEncoder,
+    MTLRenderPassDescriptor, MTLRenderPipelineDescriptor, MTLRenderPipelineState, MTLStorageMode,
+    MTLStoreAction, MTLTexture, MTLTextureDescriptor, MTLTextureUsage, MTLViewport,
 };
 
 use crate::color::ConversionParameters;
+use crate::failure::FailureReporter;
 use crate::format::{MetalFrameFormat, VideoBitDepth, VideoColorSpace};
 
 use super::mailbox::LatestMailbox;
@@ -203,6 +205,7 @@ pub struct MetalFrame {
     frame: DecodedFrame,
     state: Arc<Mutex<Option<MetalState>>>,
     counters: Arc<Counters>,
+    failures: Arc<FailureReporter>,
     sequence: u64,
 }
 
@@ -270,6 +273,8 @@ impl MetalFrame {
             self.frame.clone(),
             command_buffer,
             frame_slot,
+            Arc::clone(&self.counters),
+            Arc::clone(&self.failures),
         )?;
         self.counters
             .video_metal_submitted
@@ -287,15 +292,21 @@ pub struct EmbeddedFrameProducer {
     state: Arc<Mutex<Option<MetalState>>>,
     sequence: Arc<AtomicU64>,
     counters: Arc<Counters>,
+    failures: Arc<FailureReporter>,
 }
 
 impl EmbeddedFrameProducer {
-    pub(super) fn new(mailbox: Arc<LatestMailbox<DecodedFrame>>, counters: Arc<Counters>) -> Self {
+    pub(super) fn new(
+        mailbox: Arc<LatestMailbox<DecodedFrame>>,
+        counters: Arc<Counters>,
+        failures: Arc<FailureReporter>,
+    ) -> Self {
         Self {
             mailbox,
             state: Arc::new(Mutex::new(None)),
             sequence: Arc::new(AtomicU64::new(0)),
             counters,
+            failures,
         }
     }
 
@@ -306,6 +317,7 @@ impl EmbeddedFrameProducer {
             frame,
             state: Arc::clone(&self.state),
             counters: Arc::clone(&self.counters),
+            failures: Arc::clone(&self.failures),
             sequence,
         })
     }
@@ -331,8 +343,8 @@ impl EmbeddedFrameProducer {
     }
 }
 
-struct SlotResources {
-    output: Retained<ProtocolObject<dyn MTLTexture>>,
+struct InFlightResources {
+    _output: Retained<ProtocolObject<dyn MTLTexture>>,
     _frame: DecodedFrame,
     _luma_cv_texture: CFRetained<CVMetalTexture>,
     _chroma_cv_texture: CFRetained<CVMetalTexture>,
@@ -346,7 +358,7 @@ struct MetalState {
     library: Retained<ProtocolObject<dyn MTLLibrary>>,
     pipelines: [Option<Retained<ProtocolObject<dyn MTLRenderPipelineState>>>; 2],
     texture_cache: CFRetained<CVMetalTextureCache>,
-    slots: HashMap<u32, SlotResources>,
+    slots: HashMap<u32, Retained<ProtocolObject<dyn MTLTexture>>>,
     generation: u64,
 }
 
@@ -392,6 +404,8 @@ impl MetalState {
         frame: DecodedFrame,
         command_buffer: &ProtocolObject<dyn MTLCommandBuffer>,
         frame_slot: u32,
+        counters: Arc<Counters>,
+        failures: Arc<FailureReporter>,
     ) -> Result<MetalRecordedFrame, BackendError> {
         if CVPixelBufferGetPlaneCount(&frame.image) != 2 {
             return Err(BackendError::Metal(
@@ -427,7 +441,6 @@ impl MetalState {
         let output = self
             .slots
             .remove(&frame_slot)
-            .map(|resources| resources.output)
             .filter(|texture| {
                 texture.width() == width
                     && texture.height() == height
@@ -493,17 +506,37 @@ impl MetalState {
         encoder.endEncoding();
 
         let texture = Retained::as_ptr(&output).cast_mut().cast::<c_void>();
-        self.slots.insert(
-            frame_slot,
-            SlotResources {
-                output,
-                _frame: frame,
-                _luma_cv_texture: luma_cv_texture,
-                _chroma_cv_texture: chroma_cv_texture,
-                _luma_texture: luma_texture,
-                _chroma_texture: chroma_texture,
+        self.slots.insert(frame_slot, output.clone());
+        let resources = InFlightResources {
+            _output: output,
+            _frame: frame,
+            _luma_cv_texture: luma_cv_texture,
+            _chroma_cv_texture: chroma_cv_texture,
+            _luma_texture: luma_texture,
+            _chroma_texture: chroma_texture,
+        };
+        let completed = RcBlock::new(
+            move |command: NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
+                let _retained_until_completion = &resources;
+                let command = unsafe { command.as_ref() };
+                if command.status() == MTLCommandBufferStatus::Completed {
+                    counters
+                        .video_metal_completed
+                        .fetch_add(1, Ordering::Relaxed);
+                    failures.metal_succeeded();
+                } else {
+                    counters
+                        .video_present_errors
+                        .fetch_add(1, Ordering::Relaxed);
+                    let message = command.error().map_or_else(
+                        || "Qt Metal command buffer failed without an error description".to_owned(),
+                        |error| error.localizedDescription().to_string(),
+                    );
+                    failures.metal_failed(message);
+                }
             },
         );
+        unsafe { command_buffer.addCompletedHandler(RcBlock::as_ptr(&completed)) };
         self.generation = self.generation.wrapping_add(1);
         Ok(MetalRecordedFrame {
             texture,

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/mod.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/mod.rs
@@ -157,6 +157,7 @@ pub struct BackendStats {
     pub video_frames_dropped: u64,
     pub video_decoded_queue_dropped: u64,
     pub video_metal_submitted: u64,
+    pub video_metal_completed: u64,
     pub video_display_underflows: u64,
     pub video_scanout_skipped: u64,
     pub video_presented: u64,
@@ -178,6 +179,7 @@ pub(super) struct Counters {
     video_frames_dropped: AtomicU64,
     video_decoded_queue_dropped: AtomicU64,
     video_metal_submitted: AtomicU64,
+    video_metal_completed: AtomicU64,
     video_display_underflows: AtomicU64,
     video_scanout_skipped: AtomicU64,
     video_presented: AtomicU64,
@@ -200,6 +202,7 @@ impl Counters {
             video_frames_dropped: self.video_frames_dropped.load(Ordering::Relaxed),
             video_decoded_queue_dropped: self.video_decoded_queue_dropped.load(Ordering::Relaxed),
             video_metal_submitted: self.video_metal_submitted.load(Ordering::Relaxed),
+            video_metal_completed: self.video_metal_completed.load(Ordering::Relaxed),
             video_display_underflows: self.video_display_underflows.load(Ordering::Relaxed),
             video_scanout_skipped: self.video_scanout_skipped.load(Ordering::Relaxed),
             video_presented: self.video_presented.load(Ordering::Relaxed),
@@ -595,7 +598,8 @@ impl MacOsBackend {
         let counters = Arc::new(Counters::default());
         let failures = Arc::new(FailureReporter::default());
         let mailbox = Arc::new(LatestMailbox::new());
-        let frame_producer = EmbeddedFrameProducer::new(mailbox, Arc::clone(&counters));
+        let frame_producer =
+            EmbeddedFrameProducer::new(mailbox, Arc::clone(&counters), Arc::clone(&failures));
         let frame_available = publish.map(|publish| {
             let producer = frame_producer.clone();
             Arc::new(move || {

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/video.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/video.rs
@@ -24,7 +24,8 @@ use objc2_core_video::{
 };
 use objc2_video_toolbox::{
     VTDecodeFrameFlags, VTDecodeInfoFlags, VTDecompressionOutputCallbackRecord,
-    VTDecompressionSession, kVTVideoDecoderSpecification_RequireHardwareAcceleratedVideoDecoder,
+    VTDecompressionSession, VTSessionSetProperty, kVTDecompressionPropertyKey_RealTime,
+    kVTVideoDecoderSpecification_RequireHardwareAcceleratedVideoDecoder,
 };
 
 use crate::failure::{BackendSubsystem, FailureReporter};
@@ -205,6 +206,18 @@ impl VideoDecoder {
             status: -1,
         })?;
         let session = unsafe { CFRetained::from_raw(session_ptr) };
+        let realtime_status = unsafe {
+            VTSessionSetProperty(
+                session.as_ref(),
+                kVTDecompressionPropertyKey_RealTime,
+                Some(true_value.as_ref()),
+            )
+        };
+        if realtime_status != 0 {
+            eprintln!(
+                "VideoToolbox declined the real-time decode hint: OSStatus {realtime_status}"
+            );
+        }
 
         Ok(Self {
             session: Some(session),
@@ -588,5 +601,96 @@ mod tests {
             epoch: 0,
         };
         assert_eq!(time_to_100ns(time), 10_000_000);
+    }
+
+    #[test]
+    #[ignore = "requires a Mac with VideoToolbox hardware decode and a Metal device"]
+    fn hardware_decode_to_embedded_metal_survives_surface_retirement() {
+        use super::*;
+        use crate::{AdoptedMetalContext, EmbeddedFrameProducer, H264ParameterSets};
+        use objc2::rc::Retained;
+        use objc2_metal::{
+            MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
+            MTLCreateSystemDefaultDevice, MTLDevice,
+        };
+
+        let sps = [
+            0x67, 0x42, 0xc0, 0x0a, 0xd9, 0x04, 0x26, 0xc0, 0x44, 0x00, 0x00, 0x03, 0x00, 0x04,
+            0x00, 0x00, 0x03, 0x01, 0xe2, 0x3c, 0x48, 0x99, 0x20,
+        ];
+        let pps = [0x68, 0xcb, 0x83, 0xcb, 0x20];
+        let idr = [
+            0x65, 0x88, 0x84, 0x04, 0xbc, 0x98, 0xa0, 0x00, 0x38, 0xa3, 0x27, 0x27, 0x27, 0x5d,
+            0x75, 0xd7, 0x5d, 0x75, 0xd7, 0x5d, 0x75, 0xd7, 0x80,
+        ];
+        let format = H264Format::new(
+            H264ParameterSets::new(sps, pps).unwrap(),
+            VideoColorSpace::Bt709,
+        )
+        .into();
+        let device = MTLCreateSystemDefaultDevice().expect("Metal device");
+        let queue = device.newCommandQueue().expect("Metal command queue");
+        let mailbox = Arc::new(LatestMailbox::new());
+        let counters = Arc::new(Counters::default());
+        let failures = Arc::new(FailureReporter::default());
+        let producer = EmbeddedFrameProducer::new(
+            Arc::clone(&mailbox),
+            Arc::clone(&counters),
+            Arc::clone(&failures),
+        );
+        let decoder = VideoDecoder::new(
+            &format,
+            DecodedFrameOutput::EmbeddedMailbox {
+                mailbox,
+                frame_available: None,
+            },
+            Arc::clone(&counters),
+            Arc::clone(&failures),
+            3,
+        )
+        .expect("hardware VideoToolbox session");
+        let mut sample = (idr.len() as u32).to_be_bytes().to_vec();
+        sample.extend_from_slice(&idr);
+        for _ in 0..3 {
+            assert!(
+                decoder
+                    .submit(&sample, FrameTiming::from_90khz(90_000, 1500))
+                    .unwrap()
+            );
+            assert_eq!(
+                unsafe {
+                    decoder
+                        .session
+                        .as_ref()
+                        .unwrap()
+                        .wait_for_asynchronous_frames()
+                },
+                0
+            );
+            let frame = producer.acquire_latest().expect("decoded hardware frame");
+            assert_eq!((frame.width(), frame.height()), (64, 64));
+            assert_eq!(frame.presentation_time_ns(), 1_000_000_000);
+            let command = queue.commandBuffer().expect("Metal command buffer");
+            let recorded = unsafe {
+                frame.record(
+                    AdoptedMetalContext {
+                        device: Retained::as_ptr(&device).cast_mut().cast(),
+                        command_buffer: Retained::as_ptr(&command).cast_mut().cast(),
+                    },
+                    0,
+                )
+            }
+            .expect("zero-copy IOSurface import and Metal conversion");
+            assert!(!recorded.texture.is_null());
+            assert_eq!((recorded.width, recorded.height), (64, 64));
+            producer.release_graphics_resources();
+            drop(frame);
+            command.commit();
+            command.waitUntilCompleted();
+            assert_eq!(command.status(), MTLCommandBufferStatus::Completed);
+        }
+        assert_eq!(counters.snapshot().video_metal_completed, 3);
+        assert_eq!(counters.snapshot().video_present_errors, 0);
+        assert!(failures.fatal_failure().is_none());
     }
 }

--- a/native/opennow-streamer/crates/opennow-streamer-platform/Cargo.toml
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[build-dependencies]
+cc = "1"
+
 [features]
 default = []
 test-runtime = []

--- a/native/opennow-streamer/crates/opennow-streamer-platform/build.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/build.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+
+    let output = cc::Build::new()
+        .get_compiler()
+        .to_command()
+        .arg("--print-resource-dir")
+        .output()
+        .expect("query the macOS C compiler's runtime directory");
+    assert!(
+        output.status.success(),
+        "could not locate the macOS Clang runtime: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let resource_dir = String::from_utf8(output.stdout).expect("UTF-8 Clang resource directory");
+    let runtime_dir = PathBuf::from(resource_dir.trim()).join("lib/darwin");
+    assert!(
+        runtime_dir.join("libclang_rt.osx.a").is_file(),
+        "macOS Clang runtime is missing from {}; install the Xcode command-line tools",
+        runtime_dir.display()
+    );
+    println!("cargo:rustc-link-search=native={}", runtime_dir.display());
+    println!("cargo:rustc-link-lib=static=clang_rt.osx");
+}

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/lib.rs
@@ -312,24 +312,24 @@ fn hardware_backend() -> VideoBackendCapability {
         platform: "macos",
         codecs: vec![
             CodecCapability {
-                hdr_supported: None,
-                color_qualities: None,
+                hdr_supported: Some(false),
+                color_qualities: Some(vec!["8bit_420"]),
                 codec: "h264",
                 available: h264_available,
                 reason: (!h264_available)
                     .then_some("H.264 VideoToolbox hardware decode or Metal is unavailable"),
             },
             CodecCapability {
-                hdr_supported: None,
-                color_qualities: None,
+                hdr_supported: Some(false),
+                color_qualities: Some(vec!["8bit_420", "10bit_420"]),
                 codec: "h265",
                 available: h265_available,
                 reason: (!h265_available)
                     .then_some("H.265 VideoToolbox hardware decode or Metal is unavailable"),
             },
             CodecCapability {
-                hdr_supported: None,
-                color_qualities: None,
+                hdr_supported: Some(false),
+                color_qualities: Some(vec!["8bit_420", "10bit_420"]),
                 codec: "av1",
                 available: av1_available,
                 reason: (!av1_available)

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
@@ -870,7 +870,7 @@ impl MediaSession {
             ))
             .spawn(move || match stream.codec {
                 MediaVideoCodec::H264 => {
-                    run_macos_h264_video(video_shared, video_commands, stream.fps);
+                    run_macos_h264_video(video_shared, video_commands, stream.fps, true);
                 }
                 MediaVideoCodec::H265 => {
                     run_macos_h265_video(video_shared, video_commands, stream.fps);
@@ -1331,7 +1331,7 @@ impl MediaSession {
             ))
             .spawn(move || match stream.codec {
                 MediaVideoCodec::H264 => {
-                    run_macos_h264_video(video_shared, video_commands, stream.fps);
+                    run_macos_h264_video(video_shared, video_commands, stream.fps, false);
                 }
                 MediaVideoCodec::H265 => {
                     run_macos_h265_video(video_shared, video_commands, stream.fps);
@@ -3102,6 +3102,7 @@ fn run_macos_h264_video(
     shared: Arc<SharedPipeline>,
     host_commands: Sender<HostCommand>,
     stream_fps: u32,
+    allow_software_fallback: bool,
 ) {
     use std::sync::mpsc;
     use std::time::Duration;
@@ -3138,6 +3139,16 @@ fn run_macos_h264_video(
                 mark_macos_video_desynced(&shared, &frame.mid, reason);
             }
             if let Some(failure) = sink.fatal_failure() {
+                if !allow_software_fallback {
+                    let _ = shared.feedback.send(MediaFeedback::DecoderError {
+                        codec: "h264",
+                        message: format!(
+                            "{}; the Qt Metal stream view requires hardware decoding",
+                            failure.message
+                        ),
+                    });
+                    return;
+                }
                 shared.mac_software_fallback.store(true, Ordering::Release);
                 mark_macos_video_desynced(
                     &shared,
@@ -3307,7 +3318,8 @@ fn run_macos_h264_video(
                 );
             }
         }
-        if !playback_started && sink.stats().video_presented > 0 {
+        let stats = sink.stats();
+        if !playback_started && (stats.video_presented > 0 || stats.video_metal_completed > 0) {
             playback_started = true;
             let _ = shared.feedback.send(MediaFeedback::PlaybackStarted {
                 backend: "VideoToolbox/Metal",
@@ -3489,7 +3501,8 @@ fn run_macos_h265_video(
                 );
             }
         }
-        if !playback_started && sink.stats().video_presented > 0 {
+        let stats = sink.stats();
+        if !playback_started && (stats.video_presented > 0 || stats.video_metal_completed > 0) {
             playback_started = true;
             let _ = shared.feedback.send(MediaFeedback::PlaybackStarted {
                 backend: "VideoToolbox HEVC/Metal",
@@ -3686,7 +3699,8 @@ fn run_macos_av1_video(
                 );
             }
         }
-        if !playback_started && sink.stats().video_presented > 0 {
+        let stats = sink.stats();
+        if !playback_started && (stats.video_presented > 0 || stats.video_metal_completed > 0) {
             playback_started = true;
             let _ = shared.feedback.send(MediaFeedback::PlaybackStarted {
                 backend: "VideoToolbox AV1/Metal",

--- a/opennow-qt/CMakeLists.txt
+++ b/opennow-qt/CMakeLists.txt
@@ -19,6 +19,9 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOMOC_COMPILER_PREDEFINES OFF)
 
 find_package(Qt6 6.8 REQUIRED COMPONENTS Quick QuickControls2 Gui Network Multimedia Test ShaderTools)
+if(APPLE)
+    find_package(Qt6 ${Qt6_VERSION} EXACT REQUIRED COMPONENTS Svg)
+endif()
 # Qt 6.8 exports GuiPrivate with Gui; newer Qt versions package it separately.
 # Require the actual target on both layouts without requesting a 6.8 package
 # that does not exist. Private headers remain a mandatory build dependency.
@@ -84,6 +87,8 @@ target_link_libraries(opennow-qt PRIVATE
 )
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(opennow-qt PRIVATE Vulkan::Vulkan)
+elseif(APPLE)
+    target_link_libraries(opennow-qt PRIVATE Qt6::Svg)
 endif()
 
 include(cmake/WindowsRuntime.cmake)

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -91,6 +91,40 @@ cmake --build build/opennow-qt
 ctest --test-dir build/opennow-qt --output-on-failure
 ```
 
+### macOS
+
+Use Xcode command-line tools, CMake 3.24+, Rust, Qt 6.8+ (including Quick,
+Multimedia, ShaderTools, and the Gui private headers), and a shared SDL3 build.
+Point `CMAKE_PREFIX_PATH` at Qt and SDL3 if they are not already discoverable.
+Build one architecture at a time; universal Qt bundles are not supported.
+
+```sh
+arch=$(uname -m)
+case "$arch" in
+  arm64) rustup target add aarch64-apple-darwin ;;
+  x86_64) rustup target add x86_64-apple-darwin ;;
+esac
+cmake -S opennow-qt -B build/opennow-qt -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_OSX_ARCHITECTURES="$arch"
+cmake --build build/opennow-qt --parallel 4
+ctest --test-dir build/opennow-qt --output-on-failure --parallel 2
+./build/opennow-qt/OpenNOW.app/Contents/MacOS/OpenNOW
+cpack --config build/opennow-qt/CPackConfig.cmake -G ZIP -B build/qt-packages
+```
+
+CMake selects the matching Rust target; an explicitly supplied
+`OPENNOW_RUST_TARGET` must agree with the Qt architecture. The app bundle carries
+the core, acceptance verifier, standalone capability probe, embedded streamer
+dylib, and deployed Qt/SDL3 libraries. The FFI dylib uses an `@rpath` install name
+so it can load outside the build tree.
+
+The separate `macos-validate` CI job builds and tests the native Apple Silicon
+stack, then checks a relocated ZIP with the development dependencies hidden.
+These are unsigned validation artifacts, not notarized releases, and are not
+part of the Linux/Windows nightly inventory. Offscreen tests cover shell and FFI
+contracts; real VideoToolbox/Metal presentation, audio, input capture, and login
+still require macOS hardware and a GFN account.
+
 Run with the offscreen Qt platform plugin for a startup smoke test:
 
 ```sh

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -94,7 +94,7 @@ ctest --test-dir build/opennow-qt --output-on-failure
 ### macOS
 
 Use Xcode command-line tools, CMake 3.24+, Rust, Qt 6.8+ (including Quick,
-Multimedia, ShaderTools, and the Gui private headers), and a shared SDL3 build.
+Multimedia, ShaderTools, Svg, and the Gui private headers), and a shared SDL3 build.
 Point `CMAKE_PREFIX_PATH` at Qt and SDL3 if they are not already discoverable.
 Build one architecture at a time; universal Qt bundles are not supported.
 
@@ -117,6 +117,8 @@ CMake selects the matching Rust target; an explicitly supplied
 the core, acceptance verifier, standalone capability probe, embedded streamer
 dylib, and deployed Qt/SDL3 libraries. The FFI dylib uses an `@rpath` install name
 so it can load outside the build tree.
+The app explicitly links Qt Svg so macdeployqt includes the SVG image plugin used
+by the QML icons; the relocated-bundle check requires that plugin to be present.
 
 The separate `macos-validate` CI job builds and tests the native Apple Silicon
 stack, then checks a relocated ZIP with the development dependencies hidden.

--- a/opennow-qt/cmake/NativeRuntime.cmake
+++ b/opennow-qt/cmake/NativeRuntime.cmake
@@ -1,6 +1,17 @@
 set(OPENNOW_CORE_TARGET_DIR "${CMAKE_BINARY_DIR}/rust-target")
 set(OPENNOW_CORE_PROFILE "$<IF:$<CONFIG:Release>,release,debug>")
 set(OPENNOW_CORE_SUFFIX "$<IF:$<PLATFORM_ID:Windows>,.exe,>")
+if(APPLE)
+    if(OPENNOW_PACKAGE_ARCH STREQUAL "arm64")
+        set(OPENNOW_MACOS_RUST_TARGET "aarch64-apple-darwin")
+    else()
+        set(OPENNOW_MACOS_RUST_TARGET "x86_64-apple-darwin")
+    endif()
+    if(OPENNOW_RUST_TARGET AND NOT OPENNOW_RUST_TARGET STREQUAL OPENNOW_MACOS_RUST_TARGET)
+        message(FATAL_ERROR "OPENNOW_RUST_TARGET must match the macOS Qt architecture: ${OPENNOW_MACOS_RUST_TARGET}")
+    endif()
+    set(OPENNOW_RUST_TARGET "${OPENNOW_MACOS_RUST_TARGET}")
+endif()
 set(OPENNOW_RUST_TARGET_ARGS)
 set(OPENNOW_CORE_ARTIFACT_ROOT "${OPENNOW_CORE_TARGET_DIR}")
 if(OPENNOW_RUST_TARGET)
@@ -153,6 +164,12 @@ set(OPENNOW_STREAMER_FFI_LINK_LIBRARY
 set(OPENNOW_STREAMER_FFI_ARTIFACTS
     "${OPENNOW_STREAMER_FFI_RUNTIME}" "${OPENNOW_STREAMER_FFI_LINK_LIBRARY}")
 list(REMOVE_DUPLICATES OPENNOW_STREAMER_FFI_ARTIFACTS)
+set(OPENNOW_STREAMER_FFI_CARGO_COMMAND build)
+set(OPENNOW_STREAMER_FFI_RUSTC_ARGS)
+if(APPLE)
+    set(OPENNOW_STREAMER_FFI_CARGO_COMMAND rustc)
+    set(OPENNOW_STREAMER_FFI_RUSTC_ARGS -- -C rpath=yes)
+endif()
 file(GLOB_RECURSE OPENNOW_STREAMER_RUST_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/../native/opennow-streamer/crates/*.rs"
     "${CMAKE_CURRENT_SOURCE_DIR}/../native/opennow-streamer/crates/*/Cargo.toml")
@@ -160,7 +177,7 @@ add_custom_command(
     OUTPUT ${OPENNOW_STREAMER_FFI_ARTIFACTS}
     COMMAND "${CMAKE_COMMAND}" -E env --unset=MAKEFLAGS --unset=MFLAGS
             "CMAKE=${CMAKE_COMMAND}"
-            "${CARGO_EXECUTABLE}" build
+            "${CARGO_EXECUTABLE}" ${OPENNOW_STREAMER_FFI_CARGO_COMMAND}
             --manifest-path "${CMAKE_CURRENT_SOURCE_DIR}/../native/opennow-streamer/Cargo.toml"
             --target-dir "${OPENNOW_STREAMER_TARGET_DIR}"
             --package opennow-streamer-ffi
@@ -168,6 +185,7 @@ add_custom_command(
             ${OPENNOW_RUST_TARGET_ARGS}
             ${OPENNOW_STREAMER_CARGO_FEATURE_ARGS}
             --release
+            ${OPENNOW_STREAMER_FFI_RUSTC_ARGS}
     DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/../native/opennow-streamer/Cargo.lock"
         "${CMAKE_CURRENT_SOURCE_DIR}/../native/opennow-streamer/Cargo.toml"

--- a/opennow-qt/cmake/Packaging.cmake
+++ b/opennow-qt/cmake/Packaging.cmake
@@ -27,6 +27,10 @@ elseif(NOT APPLE)
     install(PROGRAMS "${OPENNOW_STREAMER_BIN_ARTIFACT}"
         DESTINATION "${CMAKE_INSTALL_BINDIR}")
 else()
+    install(PROGRAMS
+        "${OPENNOW_CORE_ARTIFACT_ROOT}/${OPENNOW_CORE_PROFILE}/opennow-core${OPENNOW_CORE_SUFFIX}"
+        "${OPENNOW_CORE_ARTIFACT_ROOT}/${OPENNOW_CORE_PROFILE}/opennow-acceptance-verify${OPENNOW_CORE_SUFFIX}"
+        DESTINATION "${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS")
     install(FILES "${OPENNOW_STREAMER_FFI_RUNTIME}"
         DESTINATION "${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS")
     install(PROGRAMS "${OPENNOW_STREAMER_BIN_ARTIFACT}"
@@ -56,6 +60,13 @@ if(UNIX AND NOT APPLE)
         DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo")
     install(FILES packaging/io.github.opencloudgaming.OpenNOW.svg
         DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps")
+endif()
+
+if(APPLE)
+    set(OPENNOW_QT_DEPLOY_TOOL_ARGS DEPLOY_TOOL_OPTIONS
+        "-executable=${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS/opennow-core"
+        "-executable=${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS/opennow-acceptance-verify"
+        "-executable=${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS/opennow-streamer")
 endif()
 
 if(WIN32 OR APPLE)

--- a/opennow-qt/tests/test_macos_build.py
+++ b/opennow-qt/tests/test_macos_build.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import shlex
 import subprocess
 import tempfile
 import unittest
@@ -8,6 +9,17 @@ QT_SOURCE = Path(__file__).resolve().parents[1]
 
 
 class MacOSBuildContractTest(unittest.TestCase):
+    def test_architecture_validation_places_input_before_architecture_list(self):
+        workflow = QT_SOURCE.parent / ".github/workflows/qt-ci.yml"
+        commands = [shlex.split(line.strip()) for line in workflow.read_text().splitlines()
+                    if line.strip().startswith("lipo ")]
+        self.assertEqual(len(commands), 2)
+        self.assertEqual(
+            commands,
+            [["lipo", "$bin/$executable", "-verify_arch", "arm64"],
+             ["lipo", "$bin/libopennow_streamer_ffi.dylib", "-verify_arch", "arm64"]],
+        )
+
     def configure(self, arch="arm64", rust_target=""):
         directory = tempfile.TemporaryDirectory()
         self.addCleanup(directory.cleanup)

--- a/opennow-qt/tests/test_macos_build.py
+++ b/opennow-qt/tests/test_macos_build.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+QT_SOURCE = Path(__file__).resolve().parents[1]
+
+
+class MacOSBuildContractTest(unittest.TestCase):
+    def configure(self, arch="arm64", rust_target=""):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        source = Path(directory.name)
+        build = source / "build"
+        (source / "main.cpp").write_text("int main() { return 0; }\n")
+        (source / "CMakeLists.txt").write_text(
+            f'''cmake_minimum_required(VERSION 3.24)
+project(MacOSBuildContract VERSION 1.0.0 LANGUAGES CXX)
+include(GNUInstallDirs)
+add_executable(opennow-qt main.cpp)
+set(APPLE TRUE)
+set(WIN32 FALSE)
+set(CMAKE_SYSTEM_NAME Darwin)
+set(CMAKE_OSX_ARCHITECTURES "{arch}")
+set(CMAKE_CURRENT_SOURCE_DIR "{QT_SOURCE.as_posix()}")
+set(OPENNOW_RUST_TARGET "{rust_target}")
+set(CARGO_EXECUTABLE cargo)
+include("{QT_SOURCE.as_posix()}/cmake/BuildMetadata.cmake")
+include("{QT_SOURCE.as_posix()}/cmake/NativeRuntime.cmake")
+set(OPENNOW_EXECUTABLE_NAME OpenNOW)
+set(OPENNOW_SDL3_RUNTIME_TARGET SDL3-runtime)
+add_library(SDL3-runtime SHARED IMPORTED)
+set_target_properties(SDL3-runtime PROPERTIES
+    IMPORTED_LOCATION "${{CMAKE_BINARY_DIR}}/libSDL3.dylib")
+function(qt_generate_deploy_qml_app_script)
+    file(WRITE "${{CMAKE_BINARY_DIR}}/deploy.cmake" "")
+    file(WRITE "${{CMAKE_BINARY_DIR}}/deploy-args.txt" "${{ARGV}}")
+    set(opennow_deploy_script "${{CMAKE_BINARY_DIR}}/deploy.cmake" PARENT_SCOPE)
+endfunction()
+include("{QT_SOURCE.as_posix()}/cmake/Packaging.cmake")
+get_target_property(build_rpath opennow-qt BUILD_RPATH)
+get_target_property(install_rpath opennow-qt INSTALL_RPATH)
+file(GENERATE OUTPUT "${{CMAKE_BINARY_DIR}}/contract.txt" CONTENT
+"${{OPENNOW_RUST_TARGET}}\n${{OPENNOW_CORE_ARTIFACT_ROOT}}\n${{OPENNOW_STREAMER_FFI_RUNTIME}}\n${{build_rpath}}\n${{install_rpath}}\n")
+'''
+        )
+        result = subprocess.run(
+            ["cmake", "-S", str(source), "-B", str(build),
+             "-G", "Unix Makefiles", "-DCMAKE_BUILD_TYPE=Release"],
+            capture_output=True, text=True,
+        )
+        return result, build
+
+    def test_rust_target_follows_qt_architecture(self):
+        for arch, target in (("arm64", "aarch64-apple-darwin"),
+                             ("x86_64", "x86_64-apple-darwin")):
+            with self.subTest(arch=arch):
+                result, build = self.configure(arch)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                contract = (build / "contract.txt").read_text().splitlines()
+                self.assertEqual(contract[0], target)
+                self.assertTrue(contract[1].endswith(f"rust-target/{target}"))
+                self.assertTrue(contract[2].endswith(
+                    f"streamer-rust-target/{target}/release/libopennow_streamer_ffi.dylib"))
+                self.assertIn("@loader_path", contract[3])
+                self.assertIn("@loader_path", contract[4])
+
+    def test_matching_explicit_rust_target_is_accepted(self):
+        result, _ = self.configure(rust_target="aarch64-apple-darwin")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_mismatched_rust_target_is_rejected(self):
+        result, _ = self.configure(rust_target="x86_64-apple-darwin")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must match the macOS Qt architecture", result.stderr)
+
+    def test_ffi_requests_relocatable_install_name(self):
+        result, build = self.configure()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        rule = (build / "CMakeFiles/opennow-streamer-ffi-build.dir/build.make").read_text()
+        self.assertIn("cargo rustc", rule)
+        self.assertIn("-- -C rpath=yes", rule)
+        self.assertIn("--target aarch64-apple-darwin", rule)
+
+    def test_bundle_explicitly_installs_native_helpers(self):
+        result, build = self.configure()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        install = (build / "cmake_install.cmake").read_text()
+        self.assertIn("OpenNOW.app/Contents/MacOS", install)
+        for helper in ("opennow-core", "opennow-acceptance-verify"):
+            self.assertIn(f"rust-target/aarch64-apple-darwin/release/{helper}", install)
+        for runtime in ("opennow-streamer", "libopennow_streamer_ffi.dylib"):
+            self.assertIn(f"streamer-rust-target/aarch64-apple-darwin/release/{runtime}", install)
+
+    def test_deployment_scans_helper_dependencies(self):
+        result, build = self.configure()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        arguments = (build / "deploy-args.txt").read_text().split(";")
+        for helper in ("opennow-core", "opennow-acceptance-verify", "opennow-streamer"):
+            self.assertIn(f"-executable=OpenNOW.app/Contents/MacOS/{helper}", arguments)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Native macOS streaming

Adapt the hardware-aware SDR Auto codec policy and VideoToolbox real-time hint from [OpenNOW-Mac](https://github.com/OpenCloudGaming/OpenNOW-Mac/tree/0a68e94c58b8190bbe3f789beb14a35c9ae99c6d), retaining the Qt/native NVST runtime. Report the network type as unknown instead of assuming Wi-Fi.

Retain decoded IOSurfaces and Metal textures through completion of Qt's adopted command buffer, including graphics-resource retirement. Track embedded GPU completion separately from standalone scanout for playback readiness, and report fatal embedded H.264 errors instead of entering a software path without a Qt presenter.

Preserve latest dev's macOS P010/RGB10A2 pipeline and color conversion. Advertise SDR 8-bit 4:2:0 for H.264 and 8-/10-bit 4:2:0 for HEVC/AV1. Ten-bit Auto stays on HEVC/AV1; unsupported 4:4:4 requests and resumed profiles fail explicitly. macOS HDR output is not advertised. Latest audio-device, microphone, and Windows/Linux HDR changes remain intact.

## Build and validation

Match Rust artifacts to the Qt architecture, link SDL's required Clang runtime, use a relocatable FFI install name, deploy all native helpers and their dependencies, and include Qt SVG support for packaged QML icons. Add a separate Apple Silicon CI job covering Rust/Qt tests and a relocated unsigned ZIP with development dependencies hidden; the existing nightly publication inventory is unchanged. Package probing uses the current protocol version 6.

Added codec/color-policy, filesystem, and CMake/workflow contract tests, plus an opt-in offline VideoToolbox-to-Metal hardware test covering graphics-resource retirement.

Verified after rebasing onto dev at **502cff45**:
- 166 core tests passed.
- 409 native streamer tests passed; eight environment-dependent tests were ignored.
- Apple Silicon macOS backend Clippy/typechecking, core/platform Clippy, targeted formatting, seven Mac build-contract tests, actionlint, localization, and diff checks passed.

**CI was fully green on the previous head (4613c80); it is rerunning on this rebase.** That included Mac compilation, selected Qt tests, packaging, relocated helper handshakes, and Cocoa app startup. Real hardware decode, windowed/fullscreen/overlay, audio/input, and GFN gameplay acceptance remain unverified, so the PR remains draft. No hardware zero-copy runtime acceptance is claimed.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1XMH03J0SVS6DRBWPK849XB"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->