### PR TITLE
fix(qt): connect live frame-generation stats to stream overlays

### DIFF
--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -113,6 +113,10 @@ boundary, not twice the stream FPS and not unrelated overlay redraws. It is a pr
 measurement, not a hardware scanout measurement; generated slots rejected by the scene-cut or
 confidence checks can contain the actual source image. The frame-generation status reports
 warmup, insufficient refresh, overload, discontinuities, and unavailable resources.
+Both desktop and console routes pass the active video item's snapshot to the top-level statistics
+overlay and clipboard report. Sampled state changes are logged on the GUI thread to
+`diagnostics/native-streamer.log` as `shell-mode frame-generation state=... outputFps=...`;
+FPS-only updates do not produce log entries, and no file I/O is added to the render thread.
 
 Run the focused checks with:
 
@@ -127,6 +131,11 @@ Xvfb. Without Xvfb, the offscreen platform can skip Vulkan coverage. Set
 resource use. The tests cover translated images versus a crossfade, cut fallback, 10-bit values,
 resource recreation, pacing, and the settings-to-surface bindings. Software Vulkan correctness
 does not establish a physical GPU's 8.33 ms presentation budget.
+The `qml-frame-generation-stats-desktop` and `qml-frame-generation-stats-console` acceptance tests
+feed controlled snapshots through the render-callback boundary and the real item's timer, route
+facade, top-level overlay, and clipboard report. They check FPS-only changes, fallback/recovery,
+compact/expanded/hidden overlays, fullscreen transitions, and clearing stats after leaving a stream;
+they do not inject values into the statistics component.
 
 Before treating a GPU/backend as performance-validated, test a real 1080p60 stream on a 120 Hz+
 display with Off and 2× in both windowed and fullscreen modes. Check output cadence, GPU time,

--- a/opennow-qt/cmake/Sources.cmake
+++ b/opennow-qt/cmake/Sources.cmake
@@ -29,6 +29,7 @@ qt_add_executable(opennow-qt
     src/acceptance/MotionAcceptance.h
     src/acceptance/SmokeAcceptance.cpp
     src/acceptance/SmokeFixtures.cpp
+    src/acceptance/FrameGenerationStatsAcceptance.cpp
     src/app/AppController.cpp
     src/app/AppController.h
     src/app/ApplicationStartup.cpp

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -32,6 +32,13 @@ if(BUILD_TESTING)
         COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
             --route settings-streaming --smoke-frame-generation --reduced-motion)
     set_tests_properties(qml-frame-generation PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
+    foreach(surface desktop console)
+        add_test(NAME qml-frame-generation-stats-${surface}
+            COMMAND opennow-qt --smoke-test --allow-multiple-instances --${surface}
+                --route stream --smoke-frame-generation-stats --reduced-motion)
+        set_tests_properties(qml-frame-generation-stats-${surface} PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 15)
+    endforeach()
     add_test(NAME qml-idle-mode
         COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
             --route settings-streaming --smoke-idle-mode --reduced-motion)

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -14,6 +14,14 @@ ApplicationWindow {
     title: qsTr("OpenNOW")
 
     property string activeRoute: AppController.route
+    readonly property var frameGenerationStats: activeRoute === "stream" && routeLoader.item
+        ? (routeLoader.item.frameGenerationStats || ({})) : ({})
+    readonly property string frameGenerationStatus: String(frameGenerationStats.status || "")
+    onFrameGenerationStatusChanged: {
+        if (frameGenerationStatus !== "")
+            CoreClient.logShellDiagnostic("frame-generation state=" + frameGenerationStatus
+                + " outputFps=" + Number(frameGenerationStats.outputFps || 0).toFixed(1))
+    }
     property bool geometryRestored: false
     readonly property bool settingsLoaded: Object.keys(ShellStore.settings || {}).length > 0
     property bool consoleHeldByPad: false
@@ -547,6 +555,7 @@ ApplicationWindow {
     DesktopStreamOverlayHost {
         id: desktopStreamOverlay
         anchors.fill: parent
+        frameGenerationStats: window.frameGenerationStats
         pointerLocked: window.activeRoute === "stream" && routeLoader.item
             && routeLoader.item.streamPointerLocked === true
         overlay: AppController.overlay

--- a/opennow-qt/qml/desktop/shell/DesktopApp.qml
+++ b/opennow-qt/qml/desktop/shell/DesktopApp.qml
@@ -20,6 +20,7 @@ FocusScope {
     readonly property bool sessionStartingVisible: !signInVisible && route === "inserting"
     readonly property bool streamVisible: !signInVisible && route === "stream"
     readonly property bool streamPointerLocked: streamVisible && desktopStream.streamPointerLocked
+    readonly property var frameGenerationStats: streamVisible ? desktopStream.frameGenerationStats : ({})
     readonly property bool shellVisible: !signInVisible && !sessionStartingVisible && !streamVisible
 
     function titleForRoute(value) {

--- a/opennow-qt/qml/desktop/stream/DesktopStreamOverlayHost.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopStreamOverlayHost.qml
@@ -3,11 +3,13 @@ import OpenNOW
 
 FocusScope {
     id: root
+    objectName: "desktopStreamOverlayHost"
     width: 1440
     height: 900
     property string overlay: ""
     property bool inputBlocking: false
     property bool pointerLocked: false
+    property var frameGenerationStats: ({})
     focus: visible && inputBlocking
     readonly property bool present: menuView.present || exitView.present || statsVisible
 
@@ -70,6 +72,7 @@ FocusScope {
         id: statsView
         anchors.fill: parent
         visible: root.statsVisible
+        frameGenerationStats: root.frameGenerationStats
         pointerLocked: root.pointerLocked
         focus: false
         expanded: root.overlay === "desktop-stream-stats-expanded"

--- a/opennow-qt/src/acceptance/AcceptanceSession.h
+++ b/opennow-qt/src/acceptance/AcceptanceSession.h
@@ -25,6 +25,7 @@ public:
 
 private:
     [[nodiscard]] int startSmokeWorkload();
+    [[nodiscard]] int startFrameGenerationStatsWorkload();
 
     QGuiApplication &m_application;
     QQmlApplicationEngine &m_engine;

--- a/opennow-qt/src/acceptance/FrameGenerationStatsAcceptance.cpp
+++ b/opennow-qt/src/acceptance/FrameGenerationStatsAcceptance.cpp
@@ -1,0 +1,137 @@
+#include "acceptance/AcceptanceSession.h"
+#include "app/AppController.h"
+#include "streaming/StreamVideoItem.h"
+
+#include <QGuiApplication>
+#include <QJSValue>
+#include <QPointer>
+#include <QQmlApplicationEngine>
+#include <QQuickWindow>
+#include <QTimer>
+
+#include <cstdlib>
+#include <memory>
+
+using namespace Qt::StringLiterals;
+
+namespace {
+class StatsRenderCallback final : public StreamVideoRenderCallback
+{
+public:
+    QVariantMap snapshot;
+    void initialize(QRhi *, QRhiCommandBuffer *, QRhiRenderTarget *) override {}
+    void prepareFrame(QRhiCommandBuffer *) override {}
+    void recordFrame(QRhiCommandBuffer *, const QRect &) override {}
+    void finishFrame() override {}
+    void releaseResources() override {}
+    QVariantMap frameGenerationStats() const override { return snapshot; }
+};
+
+QVariantMap statsFor(QObject *object)
+{
+    if (!object) return {};
+    const auto value = object->property("frameGenerationStats");
+    return value.canConvert<QJSValue>() ? value.value<QJSValue>().toVariant().toMap() : value.toMap();
+}
+}
+
+int AcceptanceSession::startFrameGenerationStatsWorkload()
+{
+    auto *store = m_engine.singletonInstance<QObject *>(u"OpenNOW"_s, u"ShellStore"_s);
+    if (!store) return EXIT_FAILURE;
+    store->setProperty("settings", QVariantMap{{u"fps"_s, 60}, {u"frameGeneration"_s, u"2x"_s}});
+    store->setProperty("streamer", QVariantMap{{u"status"_s, u"streaming"_s}, {u"framesPerSecond"_s, 60}});
+    store->setProperty("streamState", u"streaming"_s);
+    QTimer::singleShot(150, this, [this] {
+        auto *window = m_engine.rootObjects().isEmpty() ? nullptr
+            : qobject_cast<QQuickWindow *>(m_engine.rootObjects().first());
+        QPointer<StreamVideoItem> surface;
+        if (window) {
+            for (auto *item : window->findChildren<StreamVideoItem *>(u"streamSurfaceHost"_s)) {
+                if (item->isVisible()) surface = item;
+            }
+        }
+        auto *host = window ? window->findChild<QQuickItem *>(u"desktopStreamOverlayHost"_s) : nullptr;
+        auto *stats = host ? host->findChild<QQuickItem *>(u"desktopStreamStats"_s) : nullptr;
+        auto *loader = window ? window->findChild<QObject *>(u"mainRouteLoader"_s) : nullptr;
+        if (!surface || !surface->frameGeneration() || !host || !stats || !loader) {
+            qCritical("Frame generation stats acceptance could not locate the production surface and overlay");
+            m_application.exit(EXIT_FAILURE);
+            return;
+        }
+        const QList<QVariantMap> snapshots{
+            {{u"status"_s, u"warming-up"_s}, {u"outputFps"_s, 0}},
+            {{u"status"_s, u"active"_s}, {u"outputFps"_s, 117}},
+            {{u"status"_s, u"active"_s}, {u"outputFps"_s, 113}},
+            {{u"status"_s, u"overloaded"_s}, {u"outputFps"_s, 59}},
+            {{u"status"_s, u"unavailable"_s}, {u"outputFps"_s, 0}},
+            {{u"status"_s, u"active"_s}, {u"outputFps"_s, 119}}
+        };
+        const auto callback = std::make_shared<StatsRenderCallback>();
+        callback->snapshot = snapshots.first();
+        surface->setRenderCallback(callback);
+        const auto sampled = std::make_shared<bool>(false);
+        connect(surface, &StreamVideoItem::frameGenerationStatsChanged, this,
+                [sampled] { *sampled = true; });
+        const auto phase = std::make_shared<qsizetype>(0);
+        const QString prefix = window->property("desktopSurfaceActive").toBool()
+            ? u"desktop-stream-stats"_s : u"stream-stats"_s;
+        m_controller.showOverlay(prefix + u"-expanded"_s);
+        auto *timer = new QTimer(this);
+        timer->setInterval(50);
+        connect(timer, &QTimer::timeout, this,
+                [this, window, host, stats, loader, surface, callback, snapshots, sampled, phase, prefix, timer] {
+            if (!*sampled) return;
+            *sampled = false;
+            const auto expected = snapshots.at(*phase);
+            auto *route = loader->property("item").value<QObject *>();
+            if (!surface || surface->renderCallback() != callback || !surface->isVisible()
+                || statsFor(route) != expected || statsFor(host) != expected || statsFor(stats) != expected) {
+                qCritical() << "Production frame-generation stats did not follow the render callback:"
+                            << "route" << statsFor(route) << "host" << statsFor(host)
+                            << "overlay" << statsFor(stats) << "expected" << expected;
+                m_application.exit(EXIT_FAILURE);
+                return;
+            }
+            QVariant report;
+            const QString output = u"LOCAL OUTPUT FPS: %1 fps"_s.arg(expected.value(u"outputFps"_s).toInt());
+            if (!QMetaObject::invokeMethod(host, "copyStatsSummary", Q_RETURN_ARG(QVariant, report))
+                || !report.toString().contains(output)
+                || !report.toString().contains(u"STREAM FPS: 60 fps"_s) || m_qmlWarningOccurred) {
+                qCritical("Production frame-generation statistics report is stale or conflates source/output FPS");
+                m_application.exit(EXIT_FAILURE);
+                return;
+            }
+            if (*phase == 0) m_controller.showOverlay(prefix);
+            else if (*phase == 1) m_controller.showOverlay({});
+            else m_controller.showOverlay(prefix + u"-expanded"_s);
+            if (*phase == 3) window->showFullScreen();
+            else if (*phase == 4) window->showNormal();
+            ++*phase;
+            if (*phase < snapshots.size()) {
+                callback->snapshot = snapshots.at(*phase);
+                return;
+            }
+            timer->stop();
+            const auto shot = m_arguments.indexOf(u"--screenshot"_s);
+            if (shot >= 0 && (shot + 1 >= m_arguments.size()
+                || !window->grabWindow().save(m_arguments.at(shot + 1)))) {
+                m_application.exit(EXIT_FAILURE);
+                return;
+            }
+            m_controller.showOverlay({});
+            m_controller.navigate(u"home"_s);
+            QTimer::singleShot(100, this, [this, host] {
+                const bool passed = statsFor(host).isEmpty() && !m_qmlWarningOccurred;
+                if (!passed) qCritical("Frame-generation stats survived leaving the stream route");
+                m_application.exit(passed ? EXIT_SUCCESS : EXIT_FAILURE);
+            });
+        });
+        timer->start();
+    });
+    QTimer::singleShot(10'000, this, [this] {
+        qCritical("Production frame-generation stats acceptance timed out waiting for the surface sampler");
+        m_application.exit(EXIT_FAILURE);
+    });
+    return EXIT_SUCCESS;
+}

--- a/opennow-qt/src/acceptance/SmokeAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SmokeAcceptance.cpp
@@ -22,6 +22,8 @@ using namespace Qt::StringLiterals;
 int AcceptanceSession::startSmokeWorkload()
 {
     const auto screenshotIndex = m_arguments.indexOf(u"--screenshot"_s);
+    if (m_smokeTest && m_arguments.contains(u"--smoke-frame-generation-stats"_s))
+        return startFrameGenerationStatsWorkload();
     if (m_smokeTest && m_arguments.contains(u"--smoke-frame-generation"_s)) {
         QQmlComponent component(&m_engine, QUrl(u"qrc:/acceptance/FrameGenerationAcceptance.qml"_s));
         auto *fixture = component.create();


### PR DESCRIPTION
## Production statistics wiring

- Forward the desktop stream's live `frameGenerationStats` through `DesktopApp`, select the active desktop/console route snapshot in `Main`, and pass it through `DesktopStreamOverlayHost` to the actual `DesktopStreamStats` instance. Clear the overlay snapshot when leaving the stream route.
- Fix LOCAL OUTPUT FPS and frame-generation state falling back to N/A/Unavailable because the top-level overlay received an empty object. Keep source FPS separate and preserve the existing video surface.
- Log sampled state changes through the existing GUI-thread diagnostic sink (`diagnostics/native-streamer.log`, `shell-mode frame-generation state=... outputFps=...`). FPS-only updates do not produce log entries; no render-thread file I/O or transport/decoder/interpolation changes.

## Regression coverage and verification

- Add desktop and console acceptance tests that supply controlled snapshots at the **render-callback boundary**, then wait for the real `StreamVideoItem` timer and check the route facade, top-level overlay, and clipboard summary. They do not assign stats to the overlay/component.
- Both new tests failed on the original wiring with empty route/host/overlay snapshots, then passed with the fix. Cover warmup, FPS-only updates, overload, unavailable/recovery, compact/expanded/hidden overlays, fullscreen transitions, presenter identity, and clearing stats on route exit.
- Full Qt build and CTest: **146/146 passed**. QML lint target and localization validation passed; lint emits warnings.
- Desktop and console XCB acceptance runs passed. Diagnostic inspection confirmed active → overloaded → unavailable → active entries, with no entry for an FPS-only 117 → 113 update.

The screenshot is a controlled acceptance fixture showing **60 source FPS / 119 local output FPS**, not a live-game performance measurement.

![Production statistics overlay receiving the controlled render-callback snapshot](https://api-nightly.capy.ai/pr-assets/NEmocw8v-qxSvrsz_X4CNBCM-Ehg6AeqVoadTvV3RKo)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1Y04BBDEBR2CVPR9G7R1X4N"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->