### PR TITLE
fix(streamer): preserve H.264 references through FEC and decoder recovery

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -358,6 +358,11 @@ jobs:
           cargo test --manifest-path native/opennow-core/Cargo.toml
           cargo test --manifest-path native/opennow-streamer/Cargo.toml --workspace
 
+      - name: Windows decoder regression tests
+        if: matrix.label == 'windows-x64'
+        shell: bash
+        run: cargo test --locked --manifest-path native/opennow-streamer/Cargo.toml -p opennow-streamer-platform-windows --lib
+
       - name: Configure Qt release
         shell: bash
         run: |

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/decoder.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/decoder.rs
@@ -27,10 +27,10 @@ use ::windows::Win32::Media::MediaFoundation::{
     MF_MT_PIXEL_ASPECT_RATIO, MF_MT_SUBTYPE, MF_MT_VIDEO_NOMINAL_RANGE, MF_SA_D3D11_AWARE,
     MF_TRANSFORM_ASYNC, MF_TRANSFORM_ASYNC_UNLOCK, MFCreateAttributes, MFCreateMediaType,
     MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video, MFNominalRange_0_255,
-    MFSampleExtension_CleanPoint, MFT_CATEGORY_VIDEO_DECODER, MFT_ENUM_ADAPTER_LUID, MFT_ENUM_FLAG,
-    MFT_ENUM_FLAG_ASYNCMFT, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER,
-    MFT_ENUM_FLAG_SYNCMFT, MFT_ENUM_HARDWARE_URL_Attribute, MFT_FRIENDLY_NAME_Attribute,
-    MFT_MESSAGE_COMMAND_FLUSH, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
+    MFSampleExtension_CleanPoint, MFSampleExtension_FrameCorruption, MFT_CATEGORY_VIDEO_DECODER,
+    MFT_ENUM_ADAPTER_LUID, MFT_ENUM_FLAG, MFT_ENUM_FLAG_ASYNCMFT, MFT_ENUM_FLAG_HARDWARE,
+    MFT_ENUM_FLAG_SORTANDFILTER, MFT_ENUM_FLAG_SYNCMFT, MFT_ENUM_HARDWARE_URL_Attribute,
+    MFT_FRIENDLY_NAME_Attribute, MFT_MESSAGE_COMMAND_FLUSH, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
     MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_END_STREAMING,
     MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER,
     MFT_OUTPUT_STREAM_CAN_PROVIDE_SAMPLES, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES,
@@ -75,6 +75,14 @@ impl DecodedVideoFrame {
         format: VideoFormat,
         aperture: VideoAperture,
     ) -> Result<Self, String> {
+        match unsafe { sample.GetUINT32(&MFSampleExtension_FrameCorruption) } {
+            Ok(corrupted) if corrupted != 0 => {
+                return Err("Media Foundation decoder reported a corrupted output frame".to_owned());
+            }
+            Ok(_) => {}
+            Err(error) if error.code() == MF_E_ATTRIBUTENOTFOUND => {}
+            Err(error) => return Err(format!("read decoder output corruption flag: {error}")),
+        }
         let (texture, subresource) = dxgi_surface(&sample)?;
         let timestamp_100ns = unsafe { sample.GetSampleTime().unwrap_or(0) };
         let duration_100ns = unsafe {
@@ -906,6 +914,62 @@ fn pack_pair(high: u32, low: u32) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn output_samples_reject_reported_corruption_before_surface_extraction() {
+        let _runtime = super::super::MediaRuntime::initialize().unwrap();
+        let format = VideoFormat {
+            codec: VideoCodec::H264,
+            width: 2560,
+            height: 1440,
+            frame_rate_numerator: std::num::NonZeroU32::new(60).unwrap(),
+            frame_rate_denominator: std::num::NonZeroU32::new(1).unwrap(),
+            average_bitrate: 78_000_000,
+            pixel_format: VideoPixelFormat::Nv12,
+            chroma_format: VideoChromaFormat::Cs420,
+            full_range: false,
+        };
+        let aperture = VideoAperture::new(format.width, format.height, None).unwrap();
+        for (corruption, discontinuity) in [
+            (None, false),
+            (Some(0), false),
+            (None, true),
+            (Some(0), true),
+            (Some(1), false),
+            (Some(1), true),
+        ] {
+            let sample = unsafe {
+                let sample = MFCreateSample().unwrap();
+                sample.AddBuffer(&MFCreateMemoryBuffer(1).unwrap()).unwrap();
+                if let Some(corruption) = corruption {
+                    sample
+                        .SetUINT32(&MFSampleExtension_FrameCorruption, corruption)
+                        .unwrap();
+                }
+                if discontinuity {
+                    sample
+                        .SetUINT32(
+                            &::windows::Win32::Media::MediaFoundation::MFSampleExtension_Discontinuity,
+                            1,
+                        )
+                        .unwrap();
+                }
+                sample
+            };
+            let error = DecodedVideoFrame::from_sample(sample, format, aperture)
+                .err()
+                .expect("system-memory output cannot be published as a decoded GPU frame");
+            assert_eq!(
+                error,
+                if corruption == Some(1) {
+                    "Media Foundation decoder reported a corrupted output frame"
+                } else {
+                    "hardware decoder returned a system-memory buffer instead of a D3D11 surface"
+                },
+                "corruption={corruption:?} discontinuity={discontinuity}"
+            );
+        }
+    }
 
     #[test]
     fn media_type_apertures_handle_padding_defaults_precedence_and_invalid_offsets() {

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/h264.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/h264.rs
@@ -1,0 +1,138 @@
+use std::collections::BTreeMap;
+
+#[derive(Default)]
+pub(crate) struct H264ParameterSets {
+    units: BTreeMap<(u8, u8), Vec<u8>>,
+}
+
+impl H264ParameterSets {
+    pub fn retain(&mut self, access_unit: &[u8]) -> Result<(), String> {
+        let mut updates = BTreeMap::new();
+        for unit in openh264::nal_units(access_unit) {
+            let Some(&header) = unit.get(3) else {
+                continue;
+            };
+            let kind = header & 0x1f;
+            if !matches!(kind, 7 | 8) {
+                continue;
+            }
+            if unit.len() > 64 * 1024 {
+                return Err("H.264 parameter set exceeds 64 KiB".to_owned());
+            }
+            let id = parameter_set_id(kind, &unit[4..])
+                .ok_or_else(|| "invalid H.264 parameter-set identifier".to_owned())?;
+            updates.insert((kind, id), unit);
+        }
+        for (key, unit) in updates {
+            if self.units.get(&key).is_none_or(|cached| cached != unit) {
+                self.units.insert(key, unit.to_vec());
+            }
+        }
+        Ok(())
+    }
+
+    pub fn replay(&self) -> Vec<u8> {
+        self.units.values().flatten().copied().collect()
+    }
+}
+
+fn parameter_set_id(kind: u8, bytes: &[u8]) -> Option<u8> {
+    let mut zeroes = 0;
+    let rbsp = bytes.iter().copied().filter(|&byte| {
+        if zeroes == 2 && byte == 3 {
+            zeroes = 0;
+            return false;
+        }
+        zeroes = if byte == 0 { (zeroes + 1).min(2) } else { 0 };
+        true
+    });
+    let mut bits = rbsp
+        .flat_map(|byte| (0..8).rev().map(move |shift| (byte >> shift) & 1))
+        .skip(if kind == 7 { 24 } else { 0 });
+    let mut leading_zeroes = 0;
+    while bits.next()? == 0 {
+        leading_zeroes += 1;
+        if leading_zeroes > 8 {
+            return None;
+        }
+    }
+    let mut value = 1_u16;
+    for _ in 0..leading_zeroes {
+        value = (value << 1) | u16::from(bits.next()?);
+    }
+    let id = u8::try_from(value - 1).ok()?;
+    (kind != 7 || id < 32).then_some(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parameter_sets_replace_only_matching_ids_and_replay_sequence_sets_first() {
+        let mut sets = H264ParameterSets::default();
+        sets.retain(&[0, 0, 1, 0x68, 0x80]).unwrap();
+        sets.retain(&[0, 0, 1, 0x67, 66, 0, 30, 0x80]).unwrap();
+        sets.retain(&[0, 0, 1, 0x68, 0x40]).unwrap();
+        sets.retain(&[0, 0, 1, 0x68, 0xa0]).unwrap();
+        assert_eq!(sets.units.len(), 3);
+        assert_eq!(
+            sets.replay(),
+            [
+                0, 0, 1, 0x67, 66, 0, 30, 0x80, 0, 0, 1, 0x68, 0xa0, 0, 0, 1, 0x68, 0x40
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_parameter_set_does_not_replace_cached_configuration() {
+        let mut sets = H264ParameterSets::default();
+        sets.retain(&[0, 0, 1, 0x68, 0x80]).unwrap();
+        let before = sets.replay();
+        assert!(sets.retain(&[0, 0, 1, 0x68, 0xa0, 0, 0, 1, 0x67]).is_err());
+        assert_eq!(sets.replay(), before);
+        assert!(sets.retain(&[0, 0, 1, 0x68, 0, 0, 0]).is_err());
+        assert_eq!(sets.replay(), before);
+    }
+
+    #[test]
+    fn parameter_set_ids_are_bounded_and_skip_emulation_prevention() {
+        assert_eq!(parameter_set_id(7, &[66, 0, 30, 0x80]), Some(0));
+        assert_eq!(parameter_set_id(7, &[0, 0, 3, 0, 0x80]), Some(0));
+        assert_eq!(parameter_set_id(7, &[66, 0, 30, 0x04, 0x00]), Some(31));
+        assert_eq!(parameter_set_id(7, &[66, 0, 30, 0x04, 0x20]), None);
+        assert_eq!(parameter_set_id(8, &[0, 0x80, 0]), Some(255));
+        assert_eq!(parameter_set_id(8, &[0, 0x80, 0x80]), None);
+    }
+
+    #[test]
+    fn oversized_parameter_set_does_not_change_the_cache() {
+        let mut sets = H264ParameterSets::default();
+        sets.retain(&[0, 0, 1, 0x68, 0x80]).unwrap();
+        let before = sets.replay();
+        let mut oversized = vec![0xff; 64 * 1024 + 1];
+        oversized[..5].copy_from_slice(&[0, 0, 1, 0x68, 0x80]);
+        assert!(sets.retain(&oversized).is_err());
+        assert_eq!(sets.replay(), before);
+    }
+
+    #[test]
+    fn mixed_annex_b_prefixes_retain_the_same_parameter_set_ids() {
+        let mut sets = H264ParameterSets::default();
+        sets.retain(&[0, 0, 0, 1, 0x68, 0x80, 0, 0, 1, 0x67, 66, 0, 30, 0x80])
+            .unwrap();
+        let expected = [0, 0, 1, 0x67, 66, 0, 30, 0x80, 0, 0, 1, 0x68, 0x80];
+        assert_eq!(sets.replay(), expected);
+        sets.retain(&[0, 0, 0, 1, 0x67, 66, 0, 30, 0x80]).unwrap();
+        sets.retain(&[0, 0, 1, 0x68, 0x80]).unwrap();
+        assert_eq!(sets.replay(), expected);
+        sets.retain(&[0, 0, 1, 0x67, 66, 0, 30, 0x80, 0, 0, 0, 1, 0x68, 0x80])
+            .unwrap();
+        assert_eq!(sets.units.len(), 2);
+        let replay = sets.replay();
+        let kinds: Vec<u8> = openh264::nal_units(&replay)
+            .map(|unit| unit[3] & 0x1f)
+            .collect();
+        assert_eq!(kinds, [7, 8]);
+    }
+}

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/lib.rs
@@ -1,6 +1,7 @@
 mod audio_playout;
 mod embedded_input;
 mod graphics;
+mod h264;
 #[cfg(target_os = "linux")]
 mod linux_backend;
 #[cfg(target_os = "linux")]

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
@@ -2270,6 +2270,7 @@ impl Drop for MediaSession {
 
 struct H264Decoder {
     decoder: OpenH264Decoder,
+    parameter_sets: crate::h264::H264ParameterSets,
 }
 
 impl H264Decoder {
@@ -2278,16 +2279,33 @@ impl H264Decoder {
             OpenH264API::from_source(),
             DecoderConfig::new().debug(false),
         )
-        .map(|decoder| Self { decoder })
+        .map(|decoder| Self {
+            decoder,
+            parameter_sets: crate::h264::H264ParameterSets::default(),
+        })
         .map_err(|error| format!("OpenH264 decoder initialization failed: {error}"))
     }
 
+    fn reset(&mut self) -> Result<(), String> {
+        let mut replacement = Self::new()?;
+        let parameter_sets = self.parameter_sets.replay();
+        if !parameter_sets.is_empty() {
+            replacement
+                .decoder
+                .decode(&parameter_sets)
+                .map_err(|error| format!("H.264 parameter-set replay failed: {error}"))?;
+        }
+        self.decoder = replacement.decoder;
+        Ok(())
+    }
+
     fn decode(&mut self, encoded: &[u8]) -> Result<Option<DecodedVideoFrame>, String> {
-        let Some(yuv) = self
+        let yuv = self
             .decoder
             .decode(encoded)
-            .map_err(|error| error.to_string())?
-        else {
+            .map_err(|error| error.to_string())?;
+        self.parameter_sets.retain(encoded)?;
+        let Some(yuv) = yuv else {
             return Ok(None);
         };
         let (width, height) = yuv.dimensions();
@@ -2370,12 +2388,15 @@ fn run_video_decoder_from(
         if shared.paused.load(Ordering::Acquire) {
             continue;
         }
+        if !frame.contiguous {
+            shared.video_desynced.store(true, Ordering::Release);
+        }
         if shared.video_desynced.load(Ordering::Acquire) {
             if !frame.keyframe {
                 continue;
             }
-            match H264Decoder::new() {
-                Ok(new_decoder) => decoder = new_decoder,
+            match decoder.reset() {
+                Ok(()) => {}
                 Err(message) => {
                     let _ = shared.feedback.send(MediaFeedback::DecoderError {
                         codec: "h264",
@@ -3152,7 +3173,9 @@ fn run_macos_h264_video(
                 }
             }
         } else if let Some(ref parameter_sets) = parameter_sets
-            && configured_parameter_sets.as_ref() != Some(parameter_sets)
+            && (configured_parameter_sets.as_ref() != Some(parameter_sets)
+                || !frame.contiguous
+                || shared.video_desynced.load(Ordering::Acquire))
             && frame.keyframe
         {
             let format = H264Format::new(parameter_sets.clone(), VideoColorSpace::Bt709);
@@ -3989,6 +4012,40 @@ mod tests {
     }
 
     #[test]
+    fn software_recovery_replays_parameter_sets_for_an_idr_only_access_unit() {
+        let rgb = vec![96_u8; 32 * 32 * 3];
+        let yuv = YUVBuffer::from_rgb_source(RgbSliceU8::new(&rgb, (32, 32)));
+        let mut encoder = Encoder::new().unwrap();
+        let initial = encoder.encode(&yuv).unwrap().to_vec();
+        encoder.force_intra_frame();
+        let recovery = encoder.encode(&yuv).unwrap().to_vec();
+        let idr_only: Vec<u8> = openh264::nal_units(&recovery)
+            .filter(|nal| nal.get(3).is_some_and(|header| header & 0x1f == 5))
+            .flatten()
+            .copied()
+            .collect();
+        assert!(!idr_only.is_empty());
+        assert!(H264Decoder::new().unwrap().decode(&idr_only).is_err());
+
+        let mut reference = H264Decoder::new().unwrap();
+        reference.decode(&initial).unwrap();
+        let expected = reference.decode(&idr_only).unwrap().unwrap();
+        let mut decoder = H264Decoder::new().unwrap();
+        assert!(decoder.decode(&initial).unwrap().is_some());
+        let parameter_sets = decoder.parameter_sets.replay();
+        assert!(!parameter_sets.is_empty());
+        assert!(decoder.decode(&[0, 0, 1, 0x67, 0xff]).is_err());
+        assert_eq!(decoder.parameter_sets.replay(), parameter_sets);
+        decoder.reset().unwrap();
+        let recovered = decoder.decode(&idr_only).unwrap().unwrap();
+        assert_eq!((recovered.width, recovered.height), (32, 32));
+        assert_eq!(recovered.rgb.len(), 32 * 32 * 3);
+        assert_eq!(recovered.rgb, expected.rgb);
+        decoder.reset().unwrap();
+        assert!(decoder.decode(&idr_only).unwrap().is_some());
+    }
+
+    #[test]
     fn captured_input_queue_preserves_raw_motion_and_fails_closed_on_control_overflow() {
         let queue = CapturedInputQueue::default();
         for _ in 0..3 {
@@ -4025,20 +4082,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn software_handoff_decodes_the_pending_h264_keyframe() {
-        let width = 32;
-        let height = 32;
-        let rgb = vec![96_u8; width * height * 3];
-        let yuv = YUVBuffer::from_rgb_source(RgbSliceU8::new(&rgb, (width, height)));
-        let mut encoder = Encoder::new().expect("encoder");
-        let encoded: Arc<[u8]> = encoder.encode(&yuv).expect("encode").to_vec().into();
-        let output = Arc::new(OutputBuffers::new());
-        let (feedback, _receiver) = std::sync::mpsc::channel();
+    fn software_test_pipeline() -> (Arc<SharedPipeline>, Receiver<MediaFeedback>) {
+        let (feedback, receiver) = std::sync::mpsc::channel();
         let shared = Arc::new(SharedPipeline {
             video: Arc::new(VideoQueue::new(VIDEO_QUEUE_CAPACITY)),
             audio: Arc::new(BoundedQueue::new(AUDIO_QUEUE_CAPACITY)),
-            output: Arc::clone(&output),
+            output: Arc::new(OutputBuffers::new()),
             feedback,
             paused: AtomicBool::new(false),
             video_desynced: AtomicBool::new(true),
@@ -4061,6 +4110,19 @@ mod tests {
             #[cfg(target_os = "linux")]
             linux_codec: MediaVideoCodec::H264,
         });
+        (shared, receiver)
+    }
+
+    #[test]
+    fn software_handoff_decodes_the_pending_h264_keyframe() {
+        let width = 32;
+        let height = 32;
+        let rgb = vec![96_u8; width * height * 3];
+        let yuv = YUVBuffer::from_rgb_source(RgbSliceU8::new(&rgb, (width, height)));
+        let mut encoder = Encoder::new().expect("encoder");
+        let encoded: Arc<[u8]> = encoder.encode(&yuv).expect("encode").to_vec().into();
+        let (shared, _receiver) = software_test_pipeline();
+        let output = Arc::clone(&shared.output);
         shared.video.close();
         run_video_decoder_from(
             shared,
@@ -4081,6 +4143,89 @@ mod tests {
             (decoded.width, decoded.height),
             (width as u32, height as u32)
         );
+    }
+
+    #[test]
+    fn software_worker_recovers_an_idr_without_repeated_parameter_sets() {
+        let rgb = vec![96_u8; 32 * 32 * 3];
+        let yuv = YUVBuffer::from_rgb_source(RgbSliceU8::new(&rgb, (32, 32)));
+        let mut encoder = Encoder::new().unwrap();
+        let initial = encoder.encode(&yuv).unwrap().to_vec();
+        encoder.force_intra_frame();
+        let recovery = encoder.encode(&yuv).unwrap().to_vec();
+        let idr_only: Vec<u8> = openh264::nal_units(&recovery)
+            .filter(|nal| nal.get(3).is_some_and(|header| header & 0x1f == 5))
+            .flatten()
+            .copied()
+            .collect();
+        let mut decoder = H264Decoder::new().unwrap();
+        assert!(decoder.decode(&initial).unwrap().is_some());
+        assert!(decoder.decode(&[0, 0, 1, 0x67, 0xff]).is_err());
+        let (shared, feedback) = software_test_pipeline();
+        let output = Arc::clone(&shared.output);
+        shared.video.close();
+        run_video_decoder_from(
+            shared,
+            decoder,
+            Some(EncodedFrame {
+                mid: "video".to_owned(),
+                codec: MediaCodec::H264,
+                data: idr_only.into(),
+                frame_index: Some(71),
+                timestamp: 4500,
+                clock_rate_hz: 90_000,
+                keyframe: true,
+                contiguous: false,
+            }),
+        );
+        let decoded = output.take_video().expect("recovered IDR");
+        assert_eq!((decoded.width, decoded.height), (32, 32));
+        assert!(matches!(
+            feedback.try_recv(),
+            Ok(MediaFeedback::VideoFrameAccepted {
+                frame_index: Some(71),
+                timestamp: 4500,
+                keyframe: true,
+                ..
+            })
+        ));
+        assert!(feedback.try_recv().is_err());
+    }
+
+    #[test]
+    fn software_worker_does_not_decode_a_discontinuous_delta_frame() {
+        let rgb = vec![96_u8; 32 * 32 * 3];
+        let yuv = YUVBuffer::from_rgb_source(RgbSliceU8::new(&rgb, (32, 32)));
+        let mut encoder = Encoder::new().unwrap();
+        let initial = encoder.encode(&yuv).unwrap().to_vec();
+        let delta = encoder.encode(&yuv).unwrap().to_vec();
+        assert!(!delta.is_empty());
+        assert!(
+            !openh264::nal_units(&delta)
+                .any(|nal| nal.get(3).is_some_and(|header| header & 0x1f == 5))
+        );
+        let mut decoder = H264Decoder::new().unwrap();
+        assert!(decoder.decode(&initial).unwrap().is_some());
+        let (shared, feedback) = software_test_pipeline();
+        shared.video_desynced.store(false, Ordering::Release);
+        shared.video.close();
+        run_video_decoder_from(
+            Arc::clone(&shared),
+            decoder,
+            Some(EncodedFrame {
+                mid: "video".to_owned(),
+                codec: MediaCodec::H264,
+                data: delta.into(),
+                frame_index: Some(72),
+                timestamp: 5250,
+                clock_rate_hz: 90_000,
+                keyframe: false,
+                contiguous: false,
+            }),
+        );
+        assert!(shared.video_desynced.load(Ordering::Acquire));
+        assert!(shared.output.take_video().is_none());
+        assert!(feedback.try_recv().is_err());
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -1522,6 +1522,13 @@ struct RtpPacket {
     index: u64,
     header: RtpHeader,
     plaintext: Vec<u8>,
+    origin: RtpPacketOrigin,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RtpPacketOrigin {
+    Authenticated,
+    RecoveredData,
 }
 
 #[derive(Clone)]
@@ -1685,6 +1692,7 @@ impl SrtpReceiver {
             index: packet_index,
             header,
             plaintext,
+            origin: RtpPacketOrigin::Authenticated,
         })
     }
 }
@@ -2976,6 +2984,7 @@ impl FecBlock {
                 index: self.base_index + index as u64,
                 header,
                 plaintext: std::mem::take(plaintext),
+                origin: RtpPacketOrigin::RecoveredData,
             };
             // Do not validate the reconstructed FEC word. NVIDIA's reference-compatible
             // receivers explicitly exclude fecInfo from recovered-packet validation because
@@ -3479,7 +3488,13 @@ impl NvstVideoReceiver {
             if layout.shard_index >= layout.data_shards {
                 self.fec_packets += 1;
             }
-            self.fec_reorder.push(packet, layout, now)
+            let result = self.fec_reorder.push(packet, layout, now);
+            if layout.shard_index < layout.data_shards
+                && matches!(result.dropped, Some(NvstDropReason::Unsupported(_)))
+            {
+                self.invalidate_picture();
+            }
+            result
         } else {
             self.reorder.push(packet, now)
         };
@@ -3498,37 +3513,34 @@ impl NvstVideoReceiver {
         }
         if let Some(recovery) = result.recovery {
             self.packet_gap_recoveries += 1;
-            self.assembler.reset();
-            self.next_frame_contiguous = false;
+            self.invalidate_picture();
             self.config.feedback.clear_nacks();
-            // A sequence gap breaks the decoder's reference chain; ask (via the
-            // bundle's rtcp1 channel) for a fresh keyframe to recover.
-            self.config.feedback.request_keyframe();
             events.push(NvstReceiveEvent::RecoveryNeeded(recovery));
         }
         for packet in result.ready {
             let payload = match packet.header.payload(&packet.plaintext) {
                 Ok(payload) => payload,
                 Err(error) => {
+                    self.invalidate_picture();
                     events.push(NvstReceiveEvent::Dropped(NvstDropReason::MalformedRtp(
                         error,
                     )));
                     continue;
                 }
             };
-            let (nv_packet, media) = match NvVideoPacket::parse(&packet.header, payload) {
+            let (mut nv_packet, media) = match NvVideoPacket::parse(&packet.header, payload) {
                 Ok(value) => value,
                 Err(error) => {
-                    self.assembler.reset();
-                    self.last_stream_packet_index = None;
-                    self.next_frame_contiguous = false;
-                    self.config.feedback.request_keyframe();
+                    self.invalidate_picture();
                     events.push(NvstReceiveEvent::Dropped(NvstDropReason::MalformedRtp(
                         error,
                     )));
                     continue;
                 }
             };
+            if packet.origin == RtpPacketOrigin::RecoveredData {
+                nv_packet.is_fec = false;
+            }
             if nv_packet.is_fec {
                 self.fec_packets += 1;
                 events.push(NvstReceiveEvent::Dropped(NvstDropReason::Unsupported(
@@ -3545,11 +3557,8 @@ impl NvstVideoReceiver {
                 // A new SOF before EOF means the previous reference frame was
                 // incomplete even when RTP sequence numbers were continuous.
                 // Never let the following P-frame look contiguous to the decoder.
-                self.assembler.reset();
-                self.last_stream_packet_index = None;
-                self.next_frame_contiguous = false;
+                self.invalidate_picture();
                 self.config.feedback.clear_nacks();
-                self.config.feedback.request_keyframe();
                 events.push(NvstReceiveEvent::Dropped(
                     NvstDropReason::FrameDiscontinuity,
                 ));
@@ -3561,10 +3570,7 @@ impl NvstVideoReceiver {
                     last.wrapping_add(1) & STREAM_PACKET_INDEX_MASK != nv_packet.stream_packet_index
                 })
             {
-                self.assembler.reset();
-                self.last_stream_packet_index = Some(nv_packet.stream_packet_index);
-                self.next_frame_contiguous = false;
-                self.config.feedback.request_keyframe();
+                self.invalidate_picture();
                 events.push(NvstReceiveEvent::Dropped(
                     NvstDropReason::FrameDiscontinuity,
                 ));
@@ -3584,19 +3590,19 @@ impl NvstVideoReceiver {
                 }
                 Ok(None) => {}
                 Err(reason) => {
-                    if matches!(
-                        reason,
-                        NvstDropReason::FrameDiscontinuity
-                            | NvstDropReason::InvalidLastPacketPayloadLength { .. }
-                    ) {
-                        self.next_frame_contiguous = false;
-                        self.config.feedback.request_keyframe();
-                    }
+                    self.invalidate_picture();
                     events.push(NvstReceiveEvent::Dropped(reason));
                 }
             }
         }
         events
+    }
+
+    fn invalidate_picture(&mut self) {
+        self.assembler.reset();
+        self.last_stream_packet_index = None;
+        self.next_frame_contiguous = false;
+        self.config.feedback.request_keyframe();
     }
 
     /// Returns an SRTCP Receiver Report to send to the video peer, at most once per
@@ -5971,6 +5977,9 @@ fn forward_receive_event(
 
 #[cfg(test)]
 mod tests {
+    mod recovery_tests {
+        include!("nvst_recovery_tests.rs");
+    }
     use super::*;
     use serde_json::json;
 
@@ -7719,6 +7728,7 @@ mod tests {
             index: base_index + shard_index as u64,
             header: RtpHeader::parse(&expected_middle).expect("template header"),
             plaintext,
+            origin: RtpPacketOrigin::Authenticated,
         };
         let mut block = FecBlock::new(layout(0), base_index);
         assert_eq!(block.insert(layout(0), packet(0, data[0].clone())), None);
@@ -7812,6 +7822,7 @@ mod tests {
             index: base_index + shard_index as u64,
             header: RtpHeader::parse(&plaintext).expect("parity RTP header"),
             plaintext,
+            origin: RtpPacketOrigin::Authenticated,
         };
         let mut block = FecBlock::new(layout(0), base_index);
         assert_eq!(block.insert(layout(1), packet(1, parity[0].clone())), None);
@@ -7868,6 +7879,7 @@ mod tests {
                 index,
                 header: RtpHeader::parse(&plaintext).expect("RTP header"),
                 plaintext,
+                origin: RtpPacketOrigin::Authenticated,
             }
         }
         fn layout(block_index: u8, shard_index: usize) -> FecPacketLayout {
@@ -7958,6 +7970,7 @@ mod tests {
                     gs_video_header: None,
                 },
                 plaintext: vec![0; RTP_FIXED_HEADER_LEN],
+                origin: RtpPacketOrigin::Authenticated,
             }
         }
 

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_recovery_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_recovery_tests.rs
@@ -1,0 +1,238 @@
+use super::*;
+
+fn reference_fec_block(
+    base: u16,
+    frame: u32,
+    count: usize,
+    percent: u32,
+    keyframe: bool,
+) -> Vec<Vec<u8>> {
+    const NANORS_INVERSE: [u8; 256] = [
+        0, 1, 142, 244, 71, 167, 122, 186, 173, 157, 221, 152, 61, 170, 93, 150, 216, 114, 192, 88,
+        224, 62, 76, 102, 144, 222, 85, 128, 160, 131, 75, 42, 108, 237, 57, 81, 96, 86, 44, 138,
+        112, 208, 31, 74, 38, 139, 51, 110, 72, 137, 111, 46, 164, 195, 64, 94, 80, 34, 207, 169,
+        171, 12, 21, 225, 54, 95, 248, 213, 146, 78, 166, 4, 48, 136, 43, 30, 22, 103, 69, 147, 56,
+        35, 104, 140, 129, 26, 37, 97, 19, 193, 203, 99, 151, 14, 55, 65, 36, 87, 202, 91, 185,
+        196, 23, 77, 82, 141, 239, 179, 32, 236, 47, 50, 40, 209, 17, 217, 233, 251, 218, 121, 219,
+        119, 6, 187, 132, 205, 254, 252, 27, 84, 161, 29, 124, 204, 228, 176, 73, 49, 39, 45, 83,
+        105, 2, 245, 24, 223, 68, 79, 155, 188, 15, 92, 11, 220, 189, 148, 172, 9, 199, 162, 28,
+        130, 159, 198, 52, 194, 70, 5, 206, 59, 13, 60, 156, 8, 190, 183, 135, 229, 238, 107, 235,
+        242, 191, 175, 197, 100, 7, 123, 149, 154, 174, 182, 18, 89, 165, 53, 101, 184, 163, 158,
+        210, 247, 98, 90, 133, 125, 168, 58, 41, 113, 200, 246, 249, 67, 215, 214, 16, 115, 118,
+        120, 153, 10, 25, 145, 20, 63, 230, 240, 134, 177, 226, 241, 250, 116, 243, 180, 109, 33,
+        178, 106, 227, 231, 181, 234, 3, 143, 211, 201, 66, 212, 232, 117, 127, 255, 126, 253,
+    ];
+    let parity_count = (count * percent as usize).div_ceil(100);
+    let mut packets = Vec::new();
+    for index in 0..count {
+        let mut payload = vec![0x55; 1264];
+        let mut flags = FLAG_CONTAINS_PIC_DATA;
+        if index == 0 {
+            flags |= FLAG_SOF;
+            payload[..5].copy_from_slice(&[0, 0, 0, 1, if keyframe { 0x65 } else { 0x61 }]);
+        }
+        if index == count - 1 {
+            flags |= FLAG_EOF;
+        }
+        let mut packet = build_plaintext_rtp(base + index as u16, flags, frame, &payload);
+        let fec_word = (percent << 4) | ((index as u32) << 12) | ((count as u32) << 22);
+        packet[28..32].copy_from_slice(&fec_word.to_le_bytes());
+        packets.push(packet);
+    }
+    for parity_index in 0..parity_count {
+        let mut parity = vec![0; 1296];
+        for (data_index, data) in packets[..count].iter().enumerate() {
+            let coefficient = NANORS_INVERSE[(parity_count + data_index) ^ parity_index];
+            for (target, source) in parity.iter_mut().zip(data) {
+                let mut value = *source;
+                let mut multiplier = coefficient;
+                while multiplier != 0 {
+                    if multiplier & 1 != 0 {
+                        *target ^= value;
+                    }
+                    let high_bit = value & 0x80 != 0;
+                    value <<= 1;
+                    if high_bit {
+                        value ^= 0x1d;
+                    }
+                    multiplier >>= 1;
+                }
+            }
+        }
+        parity[..16].copy_from_slice(&packets[0][..16]);
+        parity[2..4].copy_from_slice(&(base + (count + parity_index) as u16).to_be_bytes());
+        parity[20..24].copy_from_slice(&frame.to_le_bytes());
+        parity[27] = 0;
+        let fec_word =
+            (percent << 4) | (((count + parity_index) as u32) << 12) | ((count as u32) << 22);
+        parity[28..32].copy_from_slice(&fec_word.to_le_bytes());
+        packets.push(parity);
+    }
+    packets
+}
+
+#[test]
+fn recovered_sof_is_delivered_as_data_before_its_late_original() {
+    for (count, percent) in [(1, 200), (2, 100), (3, 66), (100, 20)] {
+        let mut config = config();
+        config.max_access_unit_bytes = DEFAULT_MAX_ACCESS_UNIT_BYTES;
+        let feedback = config.feedback();
+        let crypto = test_srtp(&config);
+        let mut receiver = NvstVideoReceiver::new(config);
+        let mut frames = Vec::new();
+        let initial = reference_fec_block(10, 5, 1, 200, true);
+        let reference = reference_fec_block(13, 6, count, percent, false);
+        let expected_reference = reference[..count]
+            .iter()
+            .flat_map(|packet| packet[32..].iter().copied())
+            .collect::<Vec<_>>();
+        let successor = reference_fec_block(13 + reference.len() as u16, 7, 1, 200, false);
+        let reordered_reference = reference[1..=count]
+            .iter()
+            .chain(std::iter::once(&reference[0]))
+            .chain(reference[count + 1..].iter());
+        for packet in initial.iter().chain(reordered_reference).chain(&successor) {
+            let encrypted = protect_for_test(&crypto, packet.clone(), 0);
+            for event in receiver.process_datagram(peer(), &encrypted, Instant::now()) {
+                let NvstReceiveEvent::Frame(frame) = event else {
+                    panic!("unexpected {count}-data FEC event: {event:?}");
+                };
+                assert!(frame.contiguous);
+                frames.push(frame);
+            }
+        }
+        assert_eq!(
+            frames
+                .iter()
+                .map(|frame| frame.frame_index)
+                .collect::<Vec<_>>(),
+            [5, 6, 7]
+        );
+        assert_eq!(frames[1].bytes, expected_reference);
+        assert_eq!(receiver.fec_repaired_packets, 1);
+        assert!(!feedback.keyframe_request_pending());
+        assert_eq!(feedback.network_metrics().unwrap().1, 0.0);
+    }
+}
+
+#[test]
+fn rejected_picture_requires_a_new_keyframe_and_marks_the_next_frame_discontinuous() {
+    let mut oversized = vec![0x55; 4097];
+    oversized[..5].copy_from_slice(&[0, 0, 0, 1, 0x61]);
+    for (flags, payload, reason) in [
+        (
+            FLAG_SOF | FLAG_EOF,
+            oversized,
+            NvstDropReason::AccessUnitTooLarge { limit: 4096 },
+        ),
+        (
+            FLAG_SOF | FLAG_EOF,
+            vec![0x55; 20],
+            NvstDropReason::MissingAnnexBStartCode,
+        ),
+        (
+            FLAG_EOF,
+            vec![0x55; 20],
+            NvstDropReason::AwaitingStartOfFrame,
+        ),
+    ] {
+        let config = config();
+        let feedback = config.feedback();
+        let crypto = test_srtp(&config);
+        let mut receiver = NvstVideoReceiver::new(config);
+        let initial = protect_for_test(
+            &crypto,
+            build_plaintext_rtp(10, FLAG_SOF | FLAG_EOF, 5, &[0, 0, 0, 1, 0x65]),
+            0,
+        );
+        assert!(
+            matches!(receiver.process_datagram(peer(), &initial, Instant::now()).as_slice(), [NvstReceiveEvent::Frame(frame)] if frame.keyframe)
+        );
+        let rejected = protect_for_test(&crypto, build_plaintext_rtp(11, flags, 6, &payload), 0);
+        assert_eq!(
+            receiver.process_datagram(peer(), &rejected, Instant::now()),
+            [NvstReceiveEvent::Dropped(reason)]
+        );
+        assert!(receiver.assembler.current_frame.is_none());
+        assert!(feedback.keyframe_request_pending());
+        let successor = protect_for_test(
+            &crypto,
+            build_plaintext_rtp(12, FLAG_SOF | FLAG_EOF, 7, &[0, 0, 0, 1, 0x61]),
+            0,
+        );
+        assert!(
+            matches!(receiver.process_datagram(peer(), &successor, Instant::now()).as_slice(), [NvstReceiveEvent::Frame(frame)] if !frame.contiguous && !frame.keyframe)
+        );
+        assert!(feedback.keyframe_request_pending());
+        assert_eq!(feedback.network_metrics().unwrap().1, 0.0);
+        let recovery = protect_for_test(
+            &crypto,
+            build_plaintext_rtp(13, FLAG_SOF | FLAG_EOF, 8, &[0, 0, 0, 1, 0x65]),
+            0,
+        );
+        assert!(
+            matches!(receiver.process_datagram(peer(), &recovery, Instant::now()).as_slice(), [NvstReceiveEvent::Frame(frame)] if frame.keyframe)
+        );
+        assert!(!feedback.keyframe_request_pending());
+    }
+}
+
+#[test]
+fn authenticated_unsupported_parity_and_replays_do_not_invalidate_picture_data() {
+    let config = config();
+    let feedback = config.feedback();
+    let crypto = test_srtp(&config);
+    let mut receiver = NvstVideoReceiver::new(config);
+    let first = protect_for_test(
+        &crypto,
+        build_plaintext_rtp(10, FLAG_SOF, 5, &[0, 0, 0, 1, 0x65]),
+        0,
+    );
+    assert!(
+        receiver
+            .process_datagram(peer(), &first, Instant::now())
+            .is_empty()
+    );
+    assert_eq!(
+        receiver.process_datagram(peer(), &first, Instant::now()),
+        [NvstReceiveEvent::Dropped(NvstDropReason::ReplayRejected)]
+    );
+    let mut parity = build_plaintext_rtp(11, FLAG_CONTAINS_PIC_DATA, 5, &[0x55]);
+    parity[28..32].copy_from_slice(&((100_u32 << 4) | (2_u32 << 12) | (1_u32 << 22)).to_le_bytes());
+    let parity = protect_for_test(&crypto, parity, 0);
+    assert_eq!(
+        receiver.process_datagram(peer(), &parity, Instant::now()),
+        [NvstReceiveEvent::Dropped(NvstDropReason::Unsupported(
+            NvstUnsupportedFeature::FecRepair
+        ))]
+    );
+    assert_eq!(receiver.assembler.current_frame, Some(5));
+    assert!(!feedback.keyframe_request_pending());
+}
+
+#[test]
+fn conflicting_fec_layout_invalidates_only_discarded_picture_data() {
+    for parity in [false, true] {
+        let config = config();
+        let feedback = config.feedback();
+        let crypto = test_srtp(&config);
+        let mut receiver = NvstVideoReceiver::new(config);
+        let block = reference_fec_block(10, 5, 2, 100, false);
+        let first = protect_for_test(&crypto, block[0].clone(), 0);
+        assert!(
+            receiver
+                .process_datagram(peer(), &first, Instant::now())
+                .is_empty()
+        );
+        let conflicting = reference_fec_block(10, 5, 3, 66, false);
+        let packet = protect_for_test(&crypto, conflicting[if parity { 3 } else { 1 }].clone(), 0);
+        assert_eq!(
+            receiver.process_datagram(peer(), &packet, Instant::now()),
+            [NvstReceiveEvent::Dropped(NvstDropReason::Unsupported(
+                NvstUnsupportedFeature::FecRepair
+            ))]
+        );
+        assert_eq!(feedback.keyframe_request_pending(), !parity);
+        assert_eq!(receiver.next_frame_contiguous, parity);
+    }
+}

--- a/opennow-qt/src/streaming/NativeStreamRuntime.cpp
+++ b/opennow-qt/src/streaming/NativeStreamRuntime.cpp
@@ -468,6 +468,10 @@ OpenNowStreamerStatus NativeStreamRuntime::recordLatestFrame(
     status = d->api.recordFrame(d->handle, *frame, &command, recorded);
     if (status != OPENNOW_STREAMER_OK) {
         d->api.releaseFrame(std::exchange(*frame, nullptr));
+    } else {
+        info->width = recorded->width;
+        info->height = recorded->height;
+        info->presentation_time_ns = recorded->presentation_time_ns;
     }
     return status;
 }

--- a/opennow-qt/tests/tst_nativestreamruntime.cpp
+++ b/opennow-qt/tests/tst_nativestreamruntime.cpp
@@ -1,4 +1,5 @@
 #include "streaming/NativeStreamRuntime.h"
+#include "streaming/rendering/StreamFramePacer.h"
 
 #include <QElapsedTimer>
 #include <QFile>
@@ -140,6 +141,51 @@ class NativeStreamRuntimeTest final : public QObject
     Q_OBJECT
 
 private slots:
+    void recordedFrameMetadataReplacesProvisionalNotificationMetadata()
+    {
+        static std::uint64_t sequence;
+        sequence = 0;
+        auto api = fakeApi();
+        api.acquireLatestFrame = [](const OpenNowStreamer *handle,
+                                     OpenNowStreamerFrame **frame,
+                                     OpenNowStreamerFrameInfo *info) {
+            const auto status = fakeAcquireLatestFrame(handle, frame, info);
+            if (status == OPENNOW_STREAMER_OK)
+                *info = {1920, 1088, ++sequence, 1'000'000'000};
+            return status;
+        };
+        api.recordFrame = [](const OpenNowStreamer *, const OpenNowStreamerFrame *,
+                               const OpenNowStreamerRecordCommand *,
+                               OpenNowStreamerRecordedFrame *recorded) {
+            *recorded = {1, 0, OPENNOW_STREAMER_GRAPHICS_API_D3D11,
+                         OPENNOW_STREAMER_TEXTURE_FORMAT_RGBA8, 1920, 1080, 0,
+                         sequence, 1'000'000'000 + (sequence - 1) * 16'666'667};
+            return OPENNOW_STREAMER_OK;
+        };
+        api.releaseFrame = &fakeReleaseFrame;
+        NativeStreamRuntime runtime(api);
+        QVERIFY(runtime.start());
+        StreamFramePacer pacer;
+        for (std::uint64_t index = 1; index <= 10; ++index) {
+            OpenNowStreamerRecordCommand command{};
+            OpenNowStreamerFrameInfo info{};
+            OpenNowStreamerRecordedFrame recorded{};
+            OpenNowStreamerFrame *frame = nullptr;
+            QCOMPARE(runtime.recordLatestFrame(command, &info, &recorded, &frame),
+                     OPENNOW_STREAMER_OK);
+            const auto release = qScopeGuard([&] { runtime.releaseFrame(frame); });
+            QVERIFY(frame);
+            QCOMPARE(info.width, 1920U);
+            QCOMPARE(info.height, 1080U);
+            QCOMPARE(info.sequence, index);
+            QCOMPARE(info.presentation_time_ns, recorded.presentation_time_ns);
+            QCOMPARE(pacer.source(info.sequence, info.presentation_time_ns,
+                                  (index - 1) * 16'666'667, 144),
+                     index == 1 ? StreamFramePacer::Result::WarmingUp
+                                : StreamFramePacer::Result::Interpolate);
+        }
+    }
+
     void bootstrapAndRuntimeShareTheInjectedDiagnosticsSink()
     {
         QTemporaryDir data;


### PR DESCRIPTION
Fix the reproduced reference-loss path where FEC correctly reconstructed picture bytes, but the receiver reclassified the recovered packet as parity using its reconstructed `fecInfo`. Recovered data now carries explicit provenance; genuine parity, duplicates, and late originals retain their existing handling. Picture parsing, assembly, and conflicting data-layout failures invalidate continuity and request keyframe recovery instead of silently admitting dependent frames.

Reject Media Foundation samples that explicitly report frame corruption before GPU surface extraction, using the existing decoder reset/keyframe recovery path. Missing corruption attributes remain supported, and discontinuity alone is not treated as corruption. Run the Windows platform unit tests on the Windows-x64 CI job so this MF-only regression executes on Windows.

Retain bounded, ID-keyed H.264 SPS/PPS configuration after successful software decoding and replay it when recreating the decoder. Honor software and H.264 VideoToolbox recovery discontinuities. Qt now uses the successfully recorded frame’s dimensions and presentation timestamp instead of stale notification metadata, restoring advancing timestamps to frame generation without an ABI change.

Regression coverage includes independent-parity 1+2, 2+2, 3+2 and 100+20 FEC layouts with late originals, exact recovered payloads, zero-loss reference continuity, malformed/oversized picture recovery, real H.264 IDR-only recovery with pixel comparison, bounded parameter-set updates, Windows sample corruption flags, and the Qt timestamp-to-pacer handoff.

Validation:
- Complete native streamer workspace: **342 passed, 2 explicitly ignored**; workspace rustfmt and strict all-target Clippy passed.
- Full Debug Qt application build and **146/146 Qt/acceptance tests passed**.
- Vulkan interpolation pixel tests: **12 passed, no skips**, also run with Khronos validation enabled using Mesa software Vulkan.
- Windows GNU target: decoder tests cross-compiled and strict Clippy passed.
- Workflow actionlint and staged diff checks passed.

This Linux environment cannot reproduce the affected Windows GPU/GFN session. Windows Media Foundation runtime coverage is enabled in CI; live Windows gameplay and macOS runtime confirmation remain required. No speculative video-processor-ID or color-matrix changes are included.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1YA7B2C17TVTJTWQJ18VPE9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->