### PR TITLE
fix(qt): tolerate grouped timestamps in local frame generation

### DIFF
--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -103,7 +103,11 @@ The helper accepts single-sample RGBA8 and RGB10A2 textures with renderable RGBA
 up to 4096 pixels per axis and 4096×2160 pixels total. Owned texture storage is approximately
 25 MiB at 1080p and 104 MiB at the maximum area. The motion grid is capped at 320×180. The pacer
 rejects missing, reordered, stalled, or substantially discontinuous sources; insufficient display
-refresh bypasses interpolation. An undrained original frame triggers a two-second cooldown
+refresh bypasses interpolation. Missing or grouped decoder timestamps alone are not missing
+frames: consecutive frame IDs can use the median of the last eight local source-arrival intervals
+when per-frame timestamps are unusable. Zero-duration arrivals remain in that bounded window;
+bursts without a usable cadence fall back rather than inventing a rate. Raw source timestamps and
+IDs are never rewritten. An undrained original frame triggers a two-second cooldown
 instead of growing a queue. Device/surface changes and toggling the mode clear interpolation
 history. Unsupported GPU resources leave normal streaming active.
 
@@ -116,13 +120,16 @@ warmup, insufficient refresh, overload, discontinuities, and unavailable resourc
 Both desktop and console routes pass the active video item's snapshot to the top-level statistics
 overlay and clipboard report. Sampled state changes are logged on the GUI thread to
 `diagnostics/native-streamer.log` as `shell-mode frame-generation state=... outputFps=...`;
-FPS-only updates do not produce log entries, and no file I/O is added to the render thread.
+The entries include the timing source, rejection reason, raw timestamp/arrival deltas, sequence
+delta, inferred interval, and Qt's display refresh rate. Changes to the timing source, rejection
+reason, or display refresh also produce an entry; FPS-only updates do not. `scope=acceptance`
+distinguishes smoke fixtures from `scope=stream`. No file I/O is added to the render thread.
 
 Run the focused checks with:
 
 ```sh
 ctest --test-dir build/opennow-qt --output-on-failure \
-  -R 'framepacer|frameinterpolator|frame-generation|streamvideo'
+  -R 'framepacer|frameinterpolator|nativeframegeneration|frame-generation|streamvideo'
 ```
 
 On Linux, installing `xvfb` and Mesa Vulkan drivers lets CTest run the actual shader tests through
@@ -131,6 +138,11 @@ Xvfb. Without Xvfb, the offscreen platform can skip Vulkan coverage. Set
 resource use. The tests cover translated images versus a crossfade, cut fallback, 10-bit values,
 resource recreation, pacing, and the settings-to-surface bindings. Software Vulkan correctness
 does not establish a physical GPU's 8.33 ms presentation budget.
+The Linux `opennow-nativeframegeneration-tests` target drives the production native render
+callback with injected FFI frames and real adopted-device Vulkan textures. It checks absent,
+repeated, and grouped PTS, generated/original scheduling across `frameSwapped`, pixel readback,
+Off, discontinuity diagnostics, metadata preservation, and resource release. It is not a network
+session, D3D11 integration test, or sustained output-FPS benchmark.
 The `qml-frame-generation-stats-desktop` and `qml-frame-generation-stats-console` acceptance tests
 feed controlled snapshots through the render-callback boundary and the real item's timer, route
 facade, top-level overlay, and clipboard report. They check FPS-only changes, fallback/recovery,

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -144,6 +144,27 @@ if(BUILD_TESTING)
     endif()
     add_dependencies(opennow-streamvideo-tests opennow-streamer-ffi-build)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        qt_add_executable(opennow-nativeframegeneration-tests
+            tests/tst_nativeframegeneration.cpp
+            ${OPENNOW_STREAM_RUNTIME_SOURCES}
+            src/streaming/rendering/NativeStreamRenderCallback.cpp
+            src/streaming/rendering/StreamFrameInterpolator.cpp
+            src/streaming/rendering/LinuxVulkanGraphics.cpp)
+        target_include_directories(opennow-nativeframegeneration-tests PRIVATE src)
+        target_link_libraries(opennow-nativeframegeneration-tests PRIVATE
+            Qt6::Test Qt6::GuiPrivate Qt6::Quick opennow-streamer-ffi Vulkan::Vulkan)
+        add_dependencies(opennow-nativeframegeneration-tests opennow-streamer-ffi-build)
+        qt_add_shaders(opennow-nativeframegeneration-tests "opennow-native-framegen-test-shaders"
+            PREFIX "/opennow/shaders" BASE "shaders" FILES ${OPENNOW_STREAM_SHADERS})
+        if(OPENNOW_XVFB_RUN)
+            add_test(NAME opennow-nativeframegeneration-tests
+                COMMAND "${OPENNOW_XVFB_RUN}" -a "$<TARGET_FILE:opennow-nativeframegeneration-tests>" -o -,txt)
+            set_tests_properties(opennow-nativeframegeneration-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=xcb")
+        else()
+            add_test(NAME opennow-nativeframegeneration-tests COMMAND opennow-nativeframegeneration-tests -o -,txt)
+            set_tests_properties(opennow-nativeframegeneration-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+        endif()
+        set_tests_properties(opennow-nativeframegeneration-tests PROPERTIES TIMEOUT 60)
         qt_add_executable(opennow-linuxvulkangraphics-tests
             tests/tst_linuxvulkangraphics.cpp
             src/streaming/rendering/LinuxVulkanGraphics.cpp

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -17,10 +17,21 @@ ApplicationWindow {
     readonly property var frameGenerationStats: activeRoute === "stream" && routeLoader.item
         ? (routeLoader.item.frameGenerationStats || ({})) : ({})
     readonly property string frameGenerationStatus: String(frameGenerationStats.status || "")
-    onFrameGenerationStatusChanged: {
+    readonly property string frameGenerationDiagnosticKey: [frameGenerationStatus,
+        frameGenerationStats.timingSource || "none", frameGenerationStats.rejectionReason || "none",
+        frameGenerationStats.refreshRateHz || 0].join(":")
+    onFrameGenerationDiagnosticKeyChanged: {
         if (frameGenerationStatus !== "")
             CoreClient.logShellDiagnostic("frame-generation state=" + frameGenerationStatus
-                + " outputFps=" + Number(frameGenerationStats.outputFps || 0).toFixed(1))
+                + " outputFps=" + Number(frameGenerationStats.outputFps || 0).toFixed(1)
+                + " timing=" + String(frameGenerationStats.timingSource || "none")
+                + " rejection=" + String(frameGenerationStats.rejectionReason || "none")
+                + " intervalMs=" + Number(frameGenerationStats.sourceIntervalMs || 0).toFixed(3)
+                + " ptsDeltaMs=" + Number(frameGenerationStats.timestampDeltaMs || 0).toFixed(3)
+                + " arrivalDeltaMs=" + Number(frameGenerationStats.arrivalDeltaMs || 0).toFixed(3)
+                + " sequenceDelta=" + Number(frameGenerationStats.sequenceDelta || 0)
+                + " refreshHz=" + Number(frameGenerationStats.refreshRateHz || 0).toFixed(2)
+                + " scope=" + (SmokeTestMode ? "acceptance" : "stream"))
     }
     property bool geometryRestored: false
     readonly property bool settingsLoaded: Object.keys(ShellStore.settings || {}).length > 0

--- a/opennow-qt/qml/desktop/stream/DesktopStreamStats.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopStreamStats.qml
@@ -181,6 +181,13 @@ Item {
                         Layout.fillWidth: true; spacing: 2
                         Text { text: root.telemetryActive ? qsTr("Stream statistics") : qsTr("Waiting for stream"); color: Theme.label; font.family: Theme.bodyFont; font.pixelSize: 14 * root.overlayScale; font.weight: Font.Bold }
                         Text { visible: root.shown("Region"); Layout.fillWidth: true; text: root.region + (root.rig ? " · " + root.rig : ""); elide: Text.ElideRight; color: Theme.textMuted; font.family: Theme.bodyFont; font.pixelSize: 12 * root.overlayScale }
+                        Text {
+                            objectName: "expandedFrameGenerationState"
+                            visible: root.frameGenerationEnabled; Layout.fillWidth: true
+                            text: qsTr("FRAME GENERATION") + " · " + root.frameGenerationState()
+                            wrapMode: Text.WordWrap; color: Theme.textMuted
+                            font.family: Theme.bodyFont; font.pixelSize: 12 * root.overlayScale
+                        }
                     }
                     Text { visible: root.shown("Clock"); text: root.elapsedText(); color: Theme.label; font.family: Theme.monoFont; font.pixelSize: 12 * root.overlayScale }
                 }

--- a/opennow-qt/src/streaming/rendering/NativeStreamRenderCallback.cpp
+++ b/opennow-qt/src/streaming/rendering/NativeStreamRenderCallback.cpp
@@ -230,6 +230,7 @@ public:
 
         const auto now = clockNs();
         const auto decision = m_pacer.source(info.sequence, info.presentation_time_ns, now, m_refreshRate);
+        updateTimingStats();
         if (decision == StreamFramePacer::Result::Duplicate) {
             m_outputDirty = false;
             if (m_pacer.pending())
@@ -282,6 +283,7 @@ public:
             m_resetFrameGeneration = true;
         m_frameGeneration = enabled;
         m_refreshRate = refreshRate;
+        m_reportedRefreshRate.store(refreshRate);
     }
 
     bool needsFrame() const override
@@ -310,7 +312,19 @@ public:
         const QString states[] = {QStringLiteral("off"), QStringLiteral("warming-up"),
             QStringLiteral("active"), QStringLiteral("display-refresh"),
             QStringLiteral("overloaded"), QStringLiteral("unavailable"), QStringLiteral("discontinuity")};
+        const QString timing[] = {QStringLiteral("none"), QStringLiteral("source-timestamps"),
+                                  QStringLiteral("arrival-cadence")};
+        const QString rejections[] = {QStringLiteral("none"), QStringLiteral("sequence-gap"),
+            QStringLiteral("timestamp-regression"), QStringLiteral("timestamp-jump"),
+            QStringLiteral("arrival-gap"), QStringLiteral("cadence-unavailable")};
         return {{QStringLiteral("status"), states[int(m_frameGenerationStatus.load())]},
+                {QStringLiteral("timingSource"), timing[int(m_timingSource.load())]},
+                {QStringLiteral("rejectionReason"), rejections[int(m_rejection.load())]},
+                {QStringLiteral("sourceIntervalMs"), double(m_sourceInterval.load()) / 1.0e6},
+                {QStringLiteral("timestampDeltaMs"), double(m_timestampDelta.load()) / 1.0e6},
+                {QStringLiteral("arrivalDeltaMs"), double(m_arrivalDelta.load()) / 1.0e6},
+                {QStringLiteral("sequenceDelta"), qulonglong(m_sequenceDelta.load())},
+                {QStringLiteral("refreshRateHz"), m_reportedRefreshRate.load()},
                 {QStringLiteral("outputFps"), clockNs() - m_sampleStart.load() < 2'000'000'000
                     ? m_outputFps.load() : 0.0}};
     }
@@ -351,6 +365,7 @@ public:
         m_textures.release();
         m_interpolator.release();
         m_pacer.reset();
+        updateTimingStats();
         m_needsFrame.store(false);
         m_submittedKind.store(0);
         m_outputCount.store(0);
@@ -387,6 +402,13 @@ private:
     std::atomic_uint64_t m_outputCount = 0;
     std::atomic_int64_t m_sampleStart = 0;
     std::atomic<double> m_outputFps = 0;
+    std::atomic<StreamFramePacer::TimingSource> m_timingSource = StreamFramePacer::TimingSource::None;
+    std::atomic<StreamFramePacer::Rejection> m_rejection = StreamFramePacer::Rejection::None;
+    std::atomic_uint64_t m_sourceInterval = 0;
+    std::atomic_uint64_t m_timestampDelta = 0;
+    std::atomic_uint64_t m_sequenceDelta = 0;
+    std::atomic_int64_t m_arrivalDelta = 0;
+    std::atomic<double> m_reportedRefreshRate = 0;
     OpenNowStreamerFrame *m_preparedFrame = nullptr;
     int m_stencilReference = 0;
     bool m_stencil = false;
@@ -399,11 +421,22 @@ private:
             std::chrono::steady_clock::now().time_since_epoch()).count();
     }
 
+    void updateTimingStats()
+    {
+        m_timingSource.store(m_pacer.timingSource());
+        m_rejection.store(m_pacer.rejection());
+        m_sourceInterval.store(m_pacer.interval());
+        m_timestampDelta.store(m_pacer.timestampDelta());
+        m_sequenceDelta.store(m_pacer.sequenceDelta());
+        m_arrivalDelta.store(m_pacer.arrivalDelta());
+    }
+
     void resetFrameGeneration()
     {
         m_textures.clearExternalTextures();
         m_interpolator.release();
         m_pacer.reset();
+        updateTimingStats();
         m_needsFrame.store(false);
         m_submittedKind.store(0);
         m_midpointSwapped.store(false);
@@ -417,6 +450,7 @@ private:
         m_textures.clearExternalTextures();
         m_interpolator.release();
         m_pacer.reset();
+        updateTimingStats();
         m_needsFrame.store(false);
         m_frameGenerationFailed = true;
         m_frameGenerationStatus.store(FrameGenerationState::Unavailable);

--- a/opennow-qt/src/streaming/rendering/StreamFramePacer.h
+++ b/opennow-qt/src/streaming/rendering/StreamFramePacer.h
@@ -2,24 +2,28 @@
 
 #include <cmath>
 #include <cstdint>
+#include <algorithm>
+#include <array>
 
 class StreamFramePacer
 {
 public:
     enum class Result { Duplicate, WarmingUp, Interpolate, Discontinuity, DisplayTooSlow, Overloaded };
+    enum class TimingSource { None, SourceTimestamps, ArrivalCadence };
+    enum class Rejection { None, SequenceGap, TimestampRegression, TimestampJump, ArrivalGap, CadenceUnavailable };
 
     Result source(std::uint64_t sequence, std::uint64_t timestamp,
                   std::int64_t now, double refreshRate)
     {
         if (m_hasSource && sequence == m_sequence && timestamp == m_timestamp)
             return Result::Duplicate;
-        const bool consecutive = m_hasSource && sequence == m_sequence + 1
-            && timestamp > m_timestamp;
-        const auto interval = consecutive ? timestamp - m_timestamp : 0;
-        const bool stable = interval >= 8'000'000 && interval <= 40'000'000
-            && (!m_interval || (interval * 4 >= m_interval * 3
-                               && interval * 4 <= m_interval * 5));
-        const bool delayed = stable && now - m_arrival > 2 * std::int64_t(interval);
+        const bool consecutive = sequence == m_sequence + 1;
+        m_sequenceDelta = sequence >= m_sequence ? sequence - m_sequence : 0;
+        const bool rewound = timestamp && m_timestamp && timestamp < m_timestamp;
+        m_timestampDelta = timestamp >= m_timestamp ? timestamp - m_timestamp : 0;
+        m_arrivalDelta = now >= m_arrival ? now - m_arrival : 0;
+        const bool jumped = m_timestamp && timestamp && m_timestampDelta > 250'000'000;
+        const auto gapLimit = m_interval ? std::max<std::int64_t>(50'000'000, m_interval * 2) : 75'000'000;
         const bool pending = m_pending;
         const bool first = !m_hasSource;
         m_hasSource = true;
@@ -27,10 +31,48 @@ public:
         m_timestamp = timestamp;
         m_arrival = now;
         m_pending = false;
-        m_interval = stable ? interval : 0;
-        if (first) return Result::WarmingUp;
-        if (!consecutive || !stable || delayed) return Result::Discontinuity;
-        if (!std::isfinite(refreshRate) || refreshRate < 1.95e9 / double(interval))
+        m_rejection = Rejection::None;
+        m_timingSource = TimingSource::None;
+        if (first) {
+            m_sequenceDelta = 0;
+            m_timestampDelta = 0;
+            m_arrivalDelta = 0;
+            return Result::WarmingUp;
+        }
+        const auto reject = [this](Rejection reason) {
+            m_rejection = reason;
+            m_interval = 0;
+            m_arrivalCount = 0;
+            m_arrivalSlot = 0;
+            return Result::Discontinuity;
+        };
+        if (!consecutive) return reject(Rejection::SequenceGap);
+        if (rewound) return reject(Rejection::TimestampRegression);
+        if (jumped) return reject(Rejection::TimestampJump);
+        if (m_arrivalDelta > gapLimit) return reject(Rejection::ArrivalGap);
+        m_arrivals[m_arrivalSlot] = m_arrivalDelta;
+        m_arrivalSlot = (m_arrivalSlot + 1) % m_arrivals.size();
+        m_arrivalCount = std::min(m_arrivalCount + 1, m_arrivals.size());
+        auto sorted = m_arrivals;
+        std::sort(sorted.begin(), sorted.begin() + m_arrivalCount);
+        const auto observed = m_arrivalCount
+            ? (sorted[(m_arrivalCount - 1) / 2] + sorted[m_arrivalCount / 2]) / 2 : 0;
+        const bool arrivalUsable = observed >= 8'000'000 && observed <= 40'000'000;
+        const bool sourceUsable = m_timestampDelta >= 8'000'000 && m_timestampDelta <= 40'000'000
+            && (!arrivalUsable || (m_timestampDelta * 4 >= std::uint64_t(observed) * 3
+                                  && m_timestampDelta * 4 <= std::uint64_t(observed) * 5));
+        if (sourceUsable) {
+            m_interval = m_timestampDelta;
+            m_timingSource = TimingSource::SourceTimestamps;
+        } else if (arrivalUsable) {
+            m_interval = observed;
+            m_timingSource = TimingSource::ArrivalCadence;
+        } else {
+            m_interval = 0;
+            m_rejection = Rejection::CadenceUnavailable;
+            return Result::Discontinuity;
+        }
+        if (!std::isfinite(refreshRate) || refreshRate < 1.95e9 / double(m_interval))
             return Result::DisplayTooSlow;
         if (pending) m_cooldownUntil = now + 2'000'000'000;
         if (now < m_cooldownUntil) return Result::Overloaded;
@@ -53,12 +95,26 @@ public:
     }
 
     bool pending() const { return m_pending; }
+    TimingSource timingSource() const { return m_timingSource; }
+    Rejection rejection() const { return m_rejection; }
+    std::uint64_t interval() const { return m_interval; }
+    std::uint64_t timestampDelta() const { return m_timestampDelta; }
+    std::int64_t arrivalDelta() const { return m_arrivalDelta; }
+    std::uint64_t sequenceDelta() const { return m_sequenceDelta; }
     void reset() { *this = {}; }
 
 private:
     std::uint64_t m_sequence = 0;
     std::uint64_t m_timestamp = 0;
     std::uint64_t m_interval = 0;
+    std::uint64_t m_timestampDelta = 0;
+    std::uint64_t m_sequenceDelta = 0;
+    std::int64_t m_arrivalDelta = 0;
+    std::array<std::int64_t, 8> m_arrivals{};
+    std::size_t m_arrivalCount = 0;
+    std::size_t m_arrivalSlot = 0;
+    TimingSource m_timingSource = TimingSource::None;
+    Rejection m_rejection = Rejection::None;
     std::int64_t m_arrival = 0;
     std::int64_t m_originalDue = 0;
     std::int64_t m_cooldownUntil = 0;

--- a/opennow-qt/tests/tst_framepacer.cpp
+++ b/opennow-qt/tests/tst_framepacer.cpp
@@ -72,6 +72,152 @@ private slots:
         QVERIFY(!pacer.takeOriginal(17'000'000, 360));
         QVERIFY(pacer.takeOriginal(22'000'000, 360));
     }
+
+    void distinctFramesWithMissingTimestampsStillInterpolate()
+    {
+        StreamFramePacer pacer;
+        using Result = StreamFramePacer::Result;
+        QCOMPARE(pacer.source(1, 0, 0, 165), Result::WarmingUp);
+        for (std::uint64_t frame = 2; frame <= 120; ++frame) {
+            const auto now = std::int64_t(frame - 1) * 16'666'667;
+            QCOMPARE(pacer.source(frame, 0, now, 165), Result::Interpolate);
+            QCOMPARE(pacer.timingSource(), StreamFramePacer::TimingSource::ArrivalCadence);
+            QCOMPARE(pacer.timestampDelta(), 0ULL);
+            QCOMPARE(pacer.arrivalDelta(), 16'666'667LL);
+            pacer.midpoint(now);
+            QVERIFY(pacer.takeOriginal(now + 8'333'334, 165));
+        }
+    }
+
+    void groupedTimestampsDoNotResetContinuousFrames()
+    {
+        StreamFramePacer pacer;
+        using Result = StreamFramePacer::Result;
+        QCOMPARE(pacer.source(1, 1'000'000'000, 0, 165), Result::WarmingUp);
+        for (std::uint64_t frame = 2; frame <= 120; ++frame) {
+            const auto now = std::int64_t(frame - 1) * 16'666'667;
+            const auto timestamp = 1'000'000'000ULL + ((frame - 1) / 3) * 50'000'001;
+            QCOMPARE(pacer.source(frame, timestamp, now, 165), Result::Interpolate);
+            pacer.midpoint(now);
+            QVERIFY(pacer.takeOriginal(now + 8'333'334, 165));
+        }
+    }
+
+    void missingTimestampsStillRejectGapsAndInsufficientRefresh()
+    {
+        StreamFramePacer pacer;
+        using Result = StreamFramePacer::Result;
+        pacer.source(1, 0, 0, 60);
+        QCOMPARE(pacer.source(2, 0, 16'666'667, 60), Result::DisplayTooSlow);
+        QCOMPARE(pacer.source(4, 0, 33'333'334, 165), Result::Discontinuity);
+        QCOMPARE(pacer.rejection(), StreamFramePacer::Rejection::SequenceGap);
+        QCOMPARE(pacer.source(5, 0, 200'000'000, 165), Result::Discontinuity);
+        QCOMPARE(pacer.rejection(), StreamFramePacer::Rejection::ArrivalGap);
+    }
+
+    void arrivalCadenceAbsorbsDisplayQuantizationWithoutChangingTimestamps()
+    {
+        StreamFramePacer pacer;
+        using Result = StreamFramePacer::Result;
+        std::int64_t now = 0;
+        pacer.source(1, 100, now, 165);
+        for (std::uint64_t frame = 2; frame <= 120; ++frame) {
+            now += frame % 4 == 0 ? 12'121'212 : 18'181'818;
+            QCOMPARE(pacer.source(frame, 100 + frame - 1, now, 165), Result::Interpolate);
+            QCOMPARE(pacer.timingSource(), StreamFramePacer::TimingSource::ArrivalCadence);
+            QCOMPARE(pacer.timestampDelta(), 1ULL);
+            pacer.midpoint(now);
+            QVERIFY(pacer.takeOriginal(now + 9'090'909, 165));
+        }
+    }
+
+    void sourceClockRemainsPreferredWhenUsable()
+    {
+        StreamFramePacer pacer;
+        pacer.source(1, 0, 0, 165);
+        QCOMPARE(pacer.source(2, 16'666'667, 18'181'818, 165), StreamFramePacer::Result::Interpolate);
+        QCOMPARE(pacer.timingSource(), StreamFramePacer::TimingSource::SourceTimestamps);
+        QCOMPARE(pacer.interval(), 16'666'667ULL);
+        pacer.reset();
+        QCOMPARE(pacer.timingSource(), StreamFramePacer::TimingSource::None);
+        QCOMPARE(pacer.interval(), 0ULL);
+    }
+
+    void alternatingBurstArrivalsConvergeWithoutHidingBackpressure()
+    {
+        StreamFramePacer pacer;
+        using Result = StreamFramePacer::Result;
+        std::int64_t now = 0;
+        pacer.source(1, 0, now, 165);
+        for (std::uint64_t frame = 2; frame <= 30; ++frame) {
+            now += frame % 2 ? 31'333'334 : 2'000'000;
+            const auto result = pacer.source(frame, 0, now, 165);
+            if (frame >= 10) {
+                QCOMPARE(result, Result::Interpolate);
+                QCOMPARE(pacer.interval(), 16'666'667ULL);
+            }
+        }
+        pacer.midpoint(now);
+        QCOMPARE(pacer.source(31, 0, now + 31'333'334, 165), Result::Overloaded);
+        QVERIFY(!pacer.pending());
+    }
+
+    void simultaneousArrivalsCannotMasqueradeAsSlowerInput()
+    {
+        StreamFramePacer pacer;
+        std::int64_t now = 0;
+        pacer.source(1, 0, now, 60);
+        for (std::uint64_t frame = 2; frame <= 30; ++frame) {
+            now += frame % 2 ? 33'333'334 : 0;
+            const auto result = pacer.source(frame, 0, now, 60);
+            if (frame >= 10)
+                QCOMPARE(result, StreamFramePacer::Result::DisplayTooSlow);
+        }
+    }
+
+    void clusteredBurstsWithoutUsableCadenceFallBack()
+    {
+        StreamFramePacer pacer;
+        std::int64_t now = 0;
+        pacer.source(1, 0, now, 165);
+        for (std::uint64_t frame = 2; frame <= 30; ++frame) {
+            now += frame % 3 ? 1'000'000 : 48'000'000;
+            const auto result = pacer.source(frame, 0, now, 165);
+            if (frame >= 10) {
+                QCOMPARE(result, StreamFramePacer::Result::Discontinuity);
+                QCOMPARE(pacer.rejection(), StreamFramePacer::Rejection::CadenceUnavailable);
+                QVERIFY(!pacer.pending());
+            }
+        }
+    }
+
+    void arrivalCadenceAdaptsToSourceRateChanges()
+    {
+        StreamFramePacer pacer;
+        std::int64_t now = 0;
+        pacer.source(1, 0, now, 60);
+        for (std::uint64_t frame = 2; frame <= 30; ++frame) {
+            now += frame <= 15 ? 16'666'667 : 33'333'334;
+            const auto result = pacer.source(frame, 0, now, 60);
+            if (frame <= 15)
+                QCOMPARE(result, StreamFramePacer::Result::DisplayTooSlow);
+            if (frame >= 24) {
+                QCOMPARE(result, StreamFramePacer::Result::Interpolate);
+                QCOMPARE(pacer.interval(), 33'333'334ULL);
+            }
+        }
+    }
+
+    void arrivalFallbackStillRejectsTimestampRewindsAndLargeJumps()
+    {
+        StreamFramePacer pacer;
+        pacer.source(1, 1'000'000'000, 0, 165);
+        QCOMPARE(pacer.source(2, 1'000'000'000, 16'666'667, 165), StreamFramePacer::Result::Interpolate);
+        QCOMPARE(pacer.source(3, 900'000'000, 33'333'334, 165), StreamFramePacer::Result::Discontinuity);
+        QCOMPARE(pacer.rejection(), StreamFramePacer::Rejection::TimestampRegression);
+        QCOMPARE(pacer.source(4, 2'000'000'000, 50'000'001, 165), StreamFramePacer::Result::Discontinuity);
+        QCOMPARE(pacer.rejection(), StreamFramePacer::Rejection::TimestampJump);
+    }
 };
 
 QTEST_APPLESS_MAIN(FramePacerTest)

--- a/opennow-qt/tests/tst_nativeframegeneration.cpp
+++ b/opennow-qt/tests/tst_nativeframegeneration.cpp
@@ -1,0 +1,419 @@
+#include "streaming/NativeStreamRuntime.h"
+#include "streaming/rendering/NativeStreamRenderCallback.h"
+#include "streaming/rendering/StreamVideoRenderCallback.h"
+
+#include <QGuiApplication>
+#include <QJsonDocument>
+#include <QScopeGuard>
+#include <QSignalSpy>
+#include <QTest>
+#include <rhi/qrhi.h>
+#include <rhi/qrhi_platform.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <thread>
+
+#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+#include <QVulkanFunctions>
+
+namespace {
+struct Producer {
+    struct Image {
+        VkImage image = VK_NULL_HANDLE;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        bool initialized = false;
+    };
+    struct Frame {
+        Producer *producer;
+        OpenNowStreamerFrameInfo info;
+    };
+
+    QVulkanInstance *instance = nullptr;
+    OpenNowStreamerConfig config{};
+    OpenNowStreamerGraphicsContext context{};
+    QVulkanDeviceFunctions *functions = nullptr;
+    std::array<Image, 8> images{};
+    std::optional<OpenNowStreamerFrameInfo> next;
+    OpenNowStreamerFrameInfo acquired{};
+    OpenNowStreamerFrameInfo recorded{};
+    OpenNowStreamerFrameInfo released{};
+    int sourceCount = 0;
+    int releaseCount = 0;
+    int emptyCount = 0;
+    int shutdownCount = 0;
+
+    VkDevice device() const { return reinterpret_cast<VkDevice>(context.device); }
+
+    ~Producer() { clearImages(); }
+
+    void clearImages()
+    {
+        if (!functions) return;
+        for (auto &image : images) {
+            if (image.image) functions->vkDestroyImage(device(), image.image, nullptr);
+            if (image.memory) functions->vkFreeMemory(device(), image.memory, nullptr);
+            image = {};
+        }
+    }
+
+    bool createImage(Image &image)
+    {
+        VkImageCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        info.imageType = VK_IMAGE_TYPE_2D;
+        info.format = VK_FORMAT_R8G8B8A8_UNORM;
+        info.extent = {64, 64, 1};
+        info.mipLevels = 1;
+        info.arrayLayers = 1;
+        info.samples = VK_SAMPLE_COUNT_1_BIT;
+        info.tiling = VK_IMAGE_TILING_OPTIMAL;
+        info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+        info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        if (functions->vkCreateImage(device(), &info, nullptr, &image.image) != VK_SUCCESS)
+            return false;
+        VkMemoryRequirements requirements{};
+        functions->vkGetImageMemoryRequirements(device(), image.image, &requirements);
+        VkPhysicalDeviceMemoryProperties properties{};
+        instance->functions()->vkGetPhysicalDeviceMemoryProperties(
+            reinterpret_cast<VkPhysicalDevice>(context.physical_device), &properties);
+        for (uint32_t i = 0; i < properties.memoryTypeCount; ++i) {
+            if (!(requirements.memoryTypeBits & (1u << i))) continue;
+            VkMemoryAllocateInfo allocation{};
+            allocation.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            allocation.allocationSize = requirements.size;
+            allocation.memoryTypeIndex = i;
+            if (functions->vkAllocateMemory(device(), &allocation, nullptr, &image.memory)
+                    != VK_SUCCESS) return false;
+            return functions->vkBindImageMemory(device(), image.image, image.memory, 0) == VK_SUCCESS;
+        }
+        return false;
+    }
+};
+
+Producer *producerToCreate = nullptr;
+
+NativeStreamRuntime::Api producerApi()
+{
+    NativeStreamRuntime::Api api;
+    api.create = [](const OpenNowStreamerConfig *config, OpenNowStreamer **output) {
+        producerToCreate->config = *config;
+        *output = reinterpret_cast<OpenNowStreamer *>(producerToCreate);
+        return OPENNOW_STREAMER_OK;
+    };
+    api.send = [](const OpenNowStreamer *handle, const uint8_t *bytes, size_t length) {
+        auto *producer = reinterpret_cast<const Producer *>(handle);
+        const auto command = QJsonDocument::fromJson(
+            QByteArray(reinterpret_cast<const char *>(bytes), qsizetype(length))).object();
+        const auto reply = QJsonDocument(QJsonObject{
+            {QStringLiteral("id"), command.value(QStringLiteral("id"))},
+            {QStringLiteral("type"), QStringLiteral("ok")}}).toJson(QJsonDocument::Compact);
+        producer->config.response_callback(reinterpret_cast<const uint8_t *>(reply.constData()),
+                                           size_t(reply.size()), producer->config.user_data);
+        return OPENNOW_STREAMER_OK;
+    };
+    api.destroy = [](OpenNowStreamer *) { return OPENNOW_STREAMER_OK; };
+    api.setGraphicsContext = [](const OpenNowStreamer *handle,
+                                const OpenNowStreamerGraphicsContext *context) {
+        auto *producer = reinterpret_cast<Producer *>(const_cast<OpenNowStreamer *>(handle));
+        if (context->graphics_api != OPENNOW_STREAMER_GRAPHICS_API_VULKAN)
+            return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
+        producer->context = *context;
+        producer->functions = producer->instance->deviceFunctions(producer->device());
+        return OPENNOW_STREAMER_OK;
+    };
+    api.acquireLatestFrame = [](const OpenNowStreamer *handle, OpenNowStreamerFrame **output,
+                                OpenNowStreamerFrameInfo *info) {
+        auto *producer = reinterpret_cast<Producer *>(const_cast<OpenNowStreamer *>(handle));
+        if (!producer->next) {
+            ++producer->emptyCount;
+            *output = nullptr;
+            return OPENNOW_STREAMER_NO_FRAME;
+        }
+        *info = *producer->next;
+        producer->acquired = *info;
+        producer->next.reset();
+        ++producer->sourceCount;
+        *output = reinterpret_cast<OpenNowStreamerFrame *>(new Producer::Frame{producer, *info});
+        return OPENNOW_STREAMER_OK;
+    };
+    api.recordFrame = [](const OpenNowStreamer *handle, const OpenNowStreamerFrame *token,
+                         const OpenNowStreamerRecordCommand *command,
+                         OpenNowStreamerRecordedFrame *output) {
+        auto *producer = reinterpret_cast<Producer *>(const_cast<OpenNowStreamer *>(handle));
+        const auto *frame = reinterpret_cast<const Producer::Frame *>(token);
+        if (!producer->functions || !command->command_buffer
+            || command->frame_slot >= producer->images.size())
+            return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
+        auto &image = producer->images[command->frame_slot];
+        if (!image.image && !producer->createImage(image))
+            return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
+        auto *f = producer->functions;
+        const auto cb = reinterpret_cast<VkCommandBuffer>(command->command_buffer);
+        VkImageMemoryBarrier barrier{};
+        barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.srcAccessMask = image.initialized ? VK_ACCESS_SHADER_READ_BIT : 0;
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.oldLayout = image.initialized ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+                                             : VK_IMAGE_LAYOUT_UNDEFINED;
+        barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.image = image.image;
+        barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        f->vkCmdPipelineBarrier(cb, image.initialized ? VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
+                                                     : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+        const VkClearColorValue color{{0.25f, 0.5f, 0.75f, 1.0f}};
+        f->vkCmdClearColorImage(cb, image.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                               &color, 1, &barrier.subresourceRange);
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        f->vkCmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr,
+                               0, nullptr, 1, &barrier);
+        image.initialized = true;
+        producer->recorded = frame->info;
+        *output = {quint64(image.image), 0, OPENNOW_STREAMER_GRAPHICS_API_VULKAN,
+                   OPENNOW_STREAMER_TEXTURE_FORMAT_RGBA8, frame->info.width, frame->info.height,
+                   command->frame_slot, 1, frame->info.presentation_time_ns};
+        return OPENNOW_STREAMER_OK;
+    };
+    api.releaseFrame = [](OpenNowStreamerFrame *token) {
+        std::unique_ptr<Producer::Frame> frame(reinterpret_cast<Producer::Frame *>(token));
+        frame->producer->released = frame->info;
+        ++frame->producer->releaseCount;
+        return OPENNOW_STREAMER_OK;
+    };
+    api.sceneGraphShutdown = [](const OpenNowStreamer *handle) {
+        auto *producer = reinterpret_cast<Producer *>(const_cast<OpenNowStreamer *>(handle));
+        producer->clearImages();
+        ++producer->shutdownCount;
+        return OPENNOW_STREAMER_OK;
+    };
+    return api;
+}
+}
+#endif
+
+class NativeFrameGenerationTest final : public QObject
+{
+    Q_OBJECT
+private:
+#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+    QVulkanInstance m_instance;
+#endif
+    std::unique_ptr<QRhi> m_rhi;
+    std::atomic<int> m_validationErrors = 0;
+
+private slots:
+    void initTestCase()
+    {
+#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+        m_instance.setApiVersion(QVersionNumber(1, 1));
+        m_instance.setExtensions(QRhiVulkanInitParams::preferredInstanceExtensions());
+        if (qEnvironmentVariableIsSet("OPENNOW_FRAMEGEN_VALIDATION")) {
+            QVERIFY2(m_instance.supportedLayers().contains("VK_LAYER_KHRONOS_validation"),
+                     "Vulkan validation requested but Khronos layer is unavailable");
+            m_instance.setLayers({"VK_LAYER_KHRONOS_validation"});
+            m_instance.installDebugOutputFilter(QVulkanInstance::DebugUtilsFilter(
+                [this](QVulkanInstance::DebugMessageSeverityFlags severity,
+                       QVulkanInstance::DebugMessageTypeFlags, const void *) {
+                    if (severity.testFlag(QVulkanInstance::ErrorSeverity)) ++m_validationErrors;
+                    return false;
+                }));
+        }
+        if (!m_instance.create()) QSKIP("Vulkan instance unavailable");
+        QRhiVulkanInitParams params;
+        params.inst = &m_instance;
+        m_rhi.reset(QRhi::create(QRhi::Vulkan, &params));
+        if (!m_rhi) QSKIP("Vulkan QRhi unavailable");
+        if (!m_rhi->isTextureFormatSupported(QRhiTexture::RGBA16F, QRhiTexture::RenderTarget))
+            QSKIP("Renderable RGBA16F unavailable");
+#else
+        QSKIP("Native frame generation integration currently requires Vulkan");
+#endif
+    }
+
+    void productionCallback_data()
+    {
+        QTest::addColumn<bool>("enabled");
+        QTest::addColumn<int>("timestampMode");
+        QTest::newRow("absent-pts") << true << 0;
+        QTest::newRow("repeated-pts") << true << 1;
+        QTest::newRow("grouped-pts") << true << 2;
+        QTest::newRow("off-control") << false << 0;
+    }
+
+    void productionCallback()
+    {
+#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+        QFETCH(bool, enabled);
+        QFETCH(int, timestampMode);
+        Producer producer;
+        producer.instance = &m_instance;
+        producerToCreate = &producer;
+        const auto resetProducer = qScopeGuard([] { producerToCreate = nullptr; });
+        NativeStreamRuntime runtime(producerApi());
+        QSignalSpy errors(&runtime, &NativeStreamRuntime::presentationError);
+        QVERIFY(runtime.start());
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("integration-start")}}));
+        QTRY_VERIFY(runtime.presentationAllowed());
+
+        const QSize size(64, 64);
+        auto texture = std::unique_ptr<QRhiTexture>(m_rhi->newTexture(
+            QRhiTexture::RGBA8, size, 1, QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource));
+        QVERIFY(texture->create());
+        auto depth = std::unique_ptr<QRhiRenderBuffer>(m_rhi->newRenderBuffer(
+            QRhiRenderBuffer::DepthStencil, size));
+        QVERIFY(depth->create());
+        QRhiTextureRenderTargetDescription description(QRhiColorAttachment(texture.get()));
+        description.setDepthStencilBuffer(depth.get());
+        auto target = std::unique_ptr<QRhiTextureRenderTarget>(m_rhi->newTextureRenderTarget(description));
+        auto pass = std::unique_ptr<QRhiRenderPassDescriptor>(target->newCompatibleRenderPassDescriptor());
+        target->setRenderPassDescriptor(pass.get());
+        QVERIFY(target->create());
+        auto callback = createNativeStreamRenderCallback(&runtime);
+        const auto release = qScopeGuard([&] { callback->releaseResources(); });
+        callback->setFrameGeneration(enabled, 165.0);
+        QMatrix4x4 matrix = m_rhi->clipSpaceCorrMatrix();
+        matrix.ortho(0, 64, 64, 0, -1, 1);
+        callback->setComposition(matrix, QRectF(0, 0, 64, 64), QRectF(0, 0, 64, 64), 1);
+
+        const auto present = [&](bool swapped = true) {
+            QRhiCommandBuffer *cb = nullptr;
+            if (m_rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess) return false;
+            callback->initialize(m_rhi.get(), cb, target.get());
+            callback->prepareFrame(cb);
+            cb->beginPass(target.get(), Qt::black, {1.0f, 0});
+            cb->setViewport(QRhiViewport(0, 0, 64, 64));
+            cb->setScissor(QRhiScissor(0, 0, 64, 64));
+            callback->recordFrame(cb, QRect(0, 0, 64, 64));
+            cb->endPass();
+            QRhiReadbackResult readback;
+            bool completed = false;
+            readback.completed = [&] { completed = true; };
+            auto *updates = m_rhi->nextResourceUpdateBatch();
+            updates->readBackTexture(QRhiReadbackDescription(texture.get()), &readback);
+            cb->resourceUpdate(updates);
+            const auto ended = m_rhi->endOffscreenFrame();
+            callback->finishFrame();
+            if (swapped) callback->frameSwapped();
+            if (ended != QRhi::FrameOpSuccess || !completed || readback.data.size() != 64 * 64 * 4)
+                return false;
+            const auto *pixel = reinterpret_cast<const unsigned char *>(readback.data.constData())
+                + (32 * 64 + 32) * 4;
+            return qAbs(int(pixel[0]) - 64) <= 2 && qAbs(int(pixel[1]) - 128) <= 2
+                && qAbs(int(pixel[2]) - 191) <= 2 && pixel[3] == 255;
+        };
+
+        int generatedPairs = 0;
+        quint64 timestamp = 0;
+        quint64 previousTimestamp = 0;
+        for (quint64 sequence = 1; sequence <= 12; ++sequence) {
+            if (sequence > 1) std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            timestamp = timestampMode == 0 ? 0 : timestampMode == 1 ? 1'000'000'000
+                : 1'000'000'000 + ((sequence - 1) / 3) * 60'000'000;
+            producer.next = OpenNowStreamerFrameInfo{64, 64, sequence, timestamp};
+            QVERIFY2(present(false), qPrintable(runtime.lastError()));
+            QCOMPARE(producer.acquired.sequence, sequence);
+            QCOMPARE(producer.acquired.presentation_time_ns, timestamp);
+            QCOMPARE(producer.recorded.sequence, sequence);
+            QCOMPARE(producer.recorded.presentation_time_ns, timestamp);
+            QCOMPARE(producer.released.sequence, sequence);
+            QCOMPARE(producer.released.presentation_time_ns, timestamp);
+            QCOMPARE(producer.releaseCount, producer.sourceCount);
+            const auto snapshot = callback->frameGenerationStats();
+            const auto status = snapshot.value(QStringLiteral("status")).toString();
+            const auto timestampDelta = sequence == 1 ? 0 : timestamp - previousTimestamp;
+            previousTimestamp = timestamp;
+            if (!enabled) {
+                QCOMPARE(status, QStringLiteral("off"));
+                QVERIFY(!callback->needsFrame());
+                callback->frameSwapped();
+                continue;
+            }
+            if (status != QStringLiteral("active")) {
+                callback->frameSwapped();
+                continue;
+            }
+            QVERIFY(callback->needsFrame());
+            QCOMPARE(snapshot.value(QStringLiteral("timingSource")).toString(),
+                     QStringLiteral("arrival-cadence"));
+            QCOMPARE(snapshot.value(QStringLiteral("sequenceDelta")).toULongLong(), 1);
+            QCOMPARE(snapshot.value(QStringLiteral("timestampDeltaMs")).toDouble(),
+                     double(timestampDelta) / 1.0e6);
+            QCOMPARE(snapshot.value(QStringLiteral("refreshRateHz")).toDouble(), 165.0);
+            const int sources = producer.sourceCount;
+            const int empty = producer.emptyCount;
+            std::this_thread::sleep_for(std::chrono::milliseconds(3));
+            QVERIFY(present(false));
+            QVERIFY(callback->needsFrame());
+            callback->frameSwapped();
+            std::this_thread::sleep_for(std::chrono::milliseconds(7));
+            QVERIFY(present());
+            QVERIFY(!callback->needsFrame());
+            QCOMPARE(producer.sourceCount, sources);
+            QCOMPARE(producer.releaseCount, sources);
+            QCOMPARE(producer.emptyCount, empty + 2);
+            QCOMPARE(producer.released.sequence, sequence);
+            QCOMPARE(producer.released.presentation_time_ns, timestamp);
+            const auto drained = callback->frameGenerationStats();
+            for (const auto &key : {QStringLiteral("timingSource"), QStringLiteral("sequenceDelta"),
+                                    QStringLiteral("timestampDeltaMs"), QStringLiteral("arrivalDeltaMs"),
+                                    QStringLiteral("sourceIntervalMs")})
+                QCOMPARE(drained.value(key), snapshot.value(key));
+            ++generatedPairs;
+        }
+        if (enabled) {
+            QVERIFY2(generatedPairs >= 3, "Production callback never sustained frame generation from native source arrivals");
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            producer.next = OpenNowStreamerFrameInfo{64, 64, 14, timestamp};
+            QVERIFY(present());
+            QCOMPARE(callback->frameGenerationStats().value(QStringLiteral("status")).toString(),
+                     QStringLiteral("discontinuity"));
+            QVERIFY(!callback->needsFrame());
+            QCOMPARE(callback->frameGenerationStats().value(QStringLiteral("rejectionReason")).toString(),
+                     QStringLiteral("sequence-gap"));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            producer.next = OpenNowStreamerFrameInfo{64, 64, 15, 2'000'000'000};
+            QVERIFY(present());
+            if (callback->needsFrame()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                QVERIFY(present());
+                QVERIFY(!callback->needsFrame());
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            producer.next = OpenNowStreamerFrameInfo{64, 64, 16, 1'999'999'999};
+            QVERIFY(present());
+            QCOMPARE(callback->frameGenerationStats().value(QStringLiteral("status")).toString(),
+                     QStringLiteral("discontinuity"));
+            QCOMPARE(callback->frameGenerationStats().value(QStringLiteral("rejectionReason")).toString(),
+                     QStringLiteral("timestamp-regression"));
+            QCOMPARE(producer.released.presentation_time_ns, 1'999'999'999);
+            QVERIFY(!callback->needsFrame());
+        }
+        callback->releaseResources();
+        QCOMPARE(producer.shutdownCount, 1);
+        QVERIFY(runtime.shutdown());
+        QCoreApplication::processEvents();
+        QCOMPARE(errors.size(), 0);
+        QCOMPARE(m_validationErrors.load(), 0);
+#endif
+    }
+
+    void cleanupTestCase()
+    {
+        m_rhi.reset();
+        QCOMPARE(m_validationErrors.load(), 0);
+    }
+};
+
+QTEST_MAIN(NativeFrameGenerationTest)
+#include "tst_nativeframegeneration.moc"


### PR DESCRIPTION
## Cadence and diagnostics

Keep consecutive decoded frames eligible for local 2× generation when decoder PTS is absent, repeated, or grouped. Prefer usable source timestamps and otherwise use a bounded eight-arrival median, including zero-duration arrivals. Preserve raw frame IDs/PTS and leave server FPS, transport feedback, input, audio, and recording unchanged. Sequence gaps, timestamp regression/large jumps, stalls, unusable cadence, insufficient refresh, and undrained-original backpressure still fall back.

Expose the timing source, rejection reason, timestamp/arrival/sequence deltas, inferred interval, and Qt display refresh in the native callback snapshot and sampled GUI-thread diagnostics. Mark smoke logs `scope=acceptance` so controlled FPS fixtures cannot be confused with gameplay. Show the current generation state in the expanded statistics panel.

## Verification

- Full Qt build and CTest: **147/147 passed**.
- Pacer regressions cover missing/grouped PTS, display quantization, alternating/clustered/zero-duration bursts, rate changes, discontinuities, refresh gates, and backpressure.
- New Linux/Vulkan integration test exercises the **production native render callback** with injected FFI source frames, adopted-device GPU textures, real shader passes and pixel readback. Checks active scheduling, swap-gated original draining, metadata preservation, Off, diagnostics, and resource release.
- The identical integration test against the original callback/pacer fails all three enabled PTS rows; the fixed version passes **6 cases, zero skips**, with Khronos validation enabled, including five consecutive registered-target runs.
- Validation-enabled shader/pacer/integration checks pass. QML lint target succeeds with warnings; localization and whitespace checks pass.

The supplied live logs show persistent discontinuity but contain no raw per-frame timing, so missing/grouped PTS is a reproduced defect, **not a confirmed diagnosis of that session**. These checks do not establish sustained 1440p60→120 on a physical GPU or D3D11 integration performance. A fresh Windows stream run must confirm the actual timing/rejection data and output cadence.

## UI evidence

Controlled statistics acceptance fixture, **not live generation or performance evidence**; the displayed FPS values are fixture inputs. The new state line is visible beneath the panel heading.

![Expanded statistics state in a controlled acceptance fixture](https://api-nightly.capy.ai/pr-assets/BKTLue8Bs74UY_R4zUQjBoYsyFrR9_4dE-X_34IWe1s)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1Y04BBDEBR2CVPR9G7R1X4N"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->