### PR TITLE
fix(streamer): configure Windows HEVC profiles and log probe failures

### DIFF
--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/README.md
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/README.md
@@ -20,6 +20,23 @@ capability is reported only when its selected decoder class and the complete pre
 operation succeed. `WindowsBackend::probe` remains the D3D11 compatibility entry point.
 Non-Windows builds expose the same typed API but report the backend as unavailable.
 
+## HEVC availability in Qt
+
+The embedded Qt stream view uses the same Media Foundation decoder configuration as the
+Windows capability probe. HEVC input types explicitly carry the profile matching the negotiated
+bit depth and chroma before the decoder selects its output type. Hardware profile checks and
+D3D11 surface requirements still apply; setting a profile does not enable an unsupported GPU.
+
+Windows must have a registered, activatable HEVC Media Foundation decoder, such as Microsoft's
+HEVC Video Extensions, in addition to a compatible GPU and driver. The app does not bundle a
+separate Windows HEVC decoder. An installed extension alone does not prove that decoder
+activation or D3D11 configuration succeeds.
+
+When Qt disables H.265, `%APPDATA%\OpenNOW\diagnostics\native-streamer.log` records
+`Windows hardware decoder probe failed` with `codec=H.265` and the decoder error, even if H.264
+remains available. `OPENNOW_DATA_DIR` overrides the data directory. Configuration failures include
+the MFT name and activation, D3D manager, or input-type stage where applicable.
+
 ## Integration API
 
 ```rust,no_run

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/decoder.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/decoder.rs
@@ -23,20 +23,22 @@ use ::windows::Win32::Media::MediaFoundation::{
     MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE,
     MF_EVENT_FLAG_NO_WAIT, MF_LOW_LATENCY, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE,
     MF_MT_GEOMETRIC_APERTURE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE,
-    MF_MT_MINIMUM_DISPLAY_APERTURE, MF_MT_PAN_SCAN_APERTURE, MF_MT_PAN_SCAN_ENABLED,
-    MF_MT_PIXEL_ASPECT_RATIO, MF_MT_SUBTYPE, MF_MT_VIDEO_NOMINAL_RANGE, MF_SA_D3D11_AWARE,
-    MF_TRANSFORM_ASYNC, MF_TRANSFORM_ASYNC_UNLOCK, MFCreateAttributes, MFCreateMediaType,
-    MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video, MFNominalRange_0_255,
-    MFSampleExtension_CleanPoint, MFSampleExtension_FrameCorruption, MFT_CATEGORY_VIDEO_DECODER,
-    MFT_ENUM_ADAPTER_LUID, MFT_ENUM_FLAG, MFT_ENUM_FLAG_ASYNCMFT, MFT_ENUM_FLAG_HARDWARE,
-    MFT_ENUM_FLAG_SORTANDFILTER, MFT_ENUM_FLAG_SYNCMFT, MFT_ENUM_HARDWARE_URL_Attribute,
-    MFT_FRIENDLY_NAME_Attribute, MFT_MESSAGE_COMMAND_FLUSH, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
-    MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_END_STREAMING,
-    MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER,
-    MFT_OUTPUT_STREAM_CAN_PROVIDE_SAMPLES, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES,
-    MFT_REGISTER_TYPE_INFO, MFTEnum2, MFVideoArea, MFVideoFormat_AV1, MFVideoFormat_AYUV,
-    MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoFormat_P010,
-    MFVideoFormat_Y410, MFVideoInterlace_MixedInterlaceOrProgressive,
+    MF_MT_MINIMUM_DISPLAY_APERTURE, MF_MT_MPEG2_PROFILE, MF_MT_PAN_SCAN_APERTURE,
+    MF_MT_PAN_SCAN_ENABLED, MF_MT_PIXEL_ASPECT_RATIO, MF_MT_SUBTYPE, MF_MT_VIDEO_NOMINAL_RANGE,
+    MF_SA_D3D11_AWARE, MF_TRANSFORM_ASYNC, MF_TRANSFORM_ASYNC_UNLOCK, MFCreateAttributes,
+    MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video,
+    MFNominalRange_0_255, MFSampleExtension_CleanPoint, MFSampleExtension_FrameCorruption,
+    MFT_CATEGORY_VIDEO_DECODER, MFT_ENUM_ADAPTER_LUID, MFT_ENUM_FLAG, MFT_ENUM_FLAG_ASYNCMFT,
+    MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER, MFT_ENUM_FLAG_SYNCMFT,
+    MFT_ENUM_HARDWARE_URL_Attribute, MFT_FRIENDLY_NAME_Attribute, MFT_MESSAGE_COMMAND_FLUSH,
+    MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_END_OF_STREAM,
+    MFT_MESSAGE_NOTIFY_END_STREAMING, MFT_MESSAGE_NOTIFY_START_OF_STREAM,
+    MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_CAN_PROVIDE_SAMPLES,
+    MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnum2, MFVideoArea,
+    MFVideoFormat_AV1, MFVideoFormat_AYUV, MFVideoFormat_H264, MFVideoFormat_HEVC,
+    MFVideoFormat_NV12, MFVideoFormat_P010, MFVideoFormat_Y410,
+    MFVideoInterlace_MixedInterlaceOrProgressive, eAVEncH265VProfile_Main_420_8,
+    eAVEncH265VProfile_Main_420_10, eAVEncH265VProfile_Main_444_8, eAVEncH265VProfile_Main_444_10,
 };
 use ::windows::Win32::System::Com::CoTaskMemFree;
 use ::windows::core::Interface;
@@ -147,6 +149,8 @@ impl Decoder {
         let activations = enumerate_decoders(graphics.adapter_luid()?, format.codec, mode)?;
         let mut failures = Vec::new();
         for activation in activations {
+            let friendly_name = activation_string(&activation, &MFT_FRIENDLY_NAME_Attribute)
+                .unwrap_or_else(|| "unknown".to_owned());
             match configure_transform(&activation, graphics, format) {
                 Ok((
                     transform,
@@ -159,9 +163,6 @@ impl Decoder {
                     aperture,
                 )) => {
                     let input_credits = u32::from(events.is_none());
-                    let friendly_name =
-                        activation_string(&activation, &MFT_FRIENDLY_NAME_Attribute)
-                            .unwrap_or_else(|| "unknown".to_owned());
                     let hardware_registered =
                         activation_string(&activation, &MFT_ENUM_HARDWARE_URL_Attribute).is_some();
                     video_log!(
@@ -194,7 +195,7 @@ impl Decoder {
                     });
                 }
                 Err(error) => {
-                    failures.push(error);
+                    failures.push(format!("{friendly_name}: {error}"));
                     unsafe {
                         let _ = activation.ShutdownObject();
                     }
@@ -434,7 +435,7 @@ fn configure_transform<G: DecoderDevice>(
     unsafe {
         let transform: IMFTransform = activation
             .ActivateObject()
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| format!("ActivateObject: {error}"))?;
         let attributes = transform
             .GetAttributes()
             .map_err(|error| error.to_string())?;
@@ -456,43 +457,13 @@ fn configure_transform<G: DecoderDevice>(
                 MFT_MESSAGE_SET_D3D_MANAGER,
                 graphics.device_manager().as_raw() as usize,
             )
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| format!("MFT_MESSAGE_SET_D3D_MANAGER: {error}"))?;
 
         let (input_stream, output_stream) = stream_ids(&transform)?;
-        let input_type = MFCreateMediaType().map_err(|error| error.to_string())?;
-        input_type
-            .SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Video)
-            .map_err(|error| error.to_string())?;
-        input_type
-            .SetGUID(&MF_MT_SUBTYPE, video_subtype(format.codec))
-            .map_err(|error| error.to_string())?;
-        input_type
-            .SetUINT64(&MF_MT_FRAME_SIZE, pack_pair(format.width, format.height))
-            .map_err(|error| error.to_string())?;
-        input_type
-            .SetUINT64(
-                &MF_MT_FRAME_RATE,
-                pack_pair(
-                    format.frame_rate_numerator.get(),
-                    format.frame_rate_denominator.get(),
-                ),
-            )
-            .map_err(|error| error.to_string())?;
-        input_type
-            .SetUINT64(&MF_MT_PIXEL_ASPECT_RATIO, pack_pair(1, 1))
-            .map_err(|error| error.to_string())?;
-        input_type
-            .SetUINT32(
-                &MF_MT_INTERLACE_MODE,
-                MFVideoInterlace_MixedInterlaceOrProgressive.0 as u32,
-            )
-            .map_err(|error| error.to_string())?;
-        input_type
-            .SetUINT32(&MF_MT_AVG_BITRATE, format.average_bitrate)
-            .map_err(|error| error.to_string())?;
+        let input_type = video_input_type(format)?;
         transform
             .SetInputType(input_stream, &input_type, 0)
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| format!("SetInputType: {error}"))?;
         let pixel_format =
             select_video_output_type(&transform, output_stream, format.pixel_format)?;
         let (aperture, full_range) = output_format(&transform, output_stream, format)?;
@@ -525,6 +496,54 @@ fn configure_transform<G: DecoderDevice>(
             full_range,
             aperture,
         ))
+    }
+}
+
+fn video_input_type(format: VideoFormat) -> Result<IMFMediaType, String> {
+    unsafe {
+        let input_type = MFCreateMediaType().map_err(|error| error.to_string())?;
+        input_type
+            .SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Video)
+            .map_err(|error| error.to_string())?;
+        input_type
+            .SetGUID(&MF_MT_SUBTYPE, video_subtype(format.codec))
+            .map_err(|error| error.to_string())?;
+        if format.codec == VideoCodec::H265 {
+            let profile = match format.pixel_format {
+                VideoPixelFormat::Nv12 => eAVEncH265VProfile_Main_420_8,
+                VideoPixelFormat::P010 => eAVEncH265VProfile_Main_420_10,
+                VideoPixelFormat::Ayuv => eAVEncH265VProfile_Main_444_8,
+                VideoPixelFormat::Y410 => eAVEncH265VProfile_Main_444_10,
+            };
+            input_type
+                .SetUINT32(&MF_MT_MPEG2_PROFILE, profile.0 as u32)
+                .map_err(|error| format!("HEVC input profile: {error}"))?;
+        }
+        input_type
+            .SetUINT64(&MF_MT_FRAME_SIZE, pack_pair(format.width, format.height))
+            .map_err(|error| error.to_string())?;
+        input_type
+            .SetUINT64(
+                &MF_MT_FRAME_RATE,
+                pack_pair(
+                    format.frame_rate_numerator.get(),
+                    format.frame_rate_denominator.get(),
+                ),
+            )
+            .map_err(|error| error.to_string())?;
+        input_type
+            .SetUINT64(&MF_MT_PIXEL_ASPECT_RATIO, pack_pair(1, 1))
+            .map_err(|error| error.to_string())?;
+        input_type
+            .SetUINT32(
+                &MF_MT_INTERLACE_MODE,
+                MFVideoInterlace_MixedInterlaceOrProgressive.0 as u32,
+            )
+            .map_err(|error| error.to_string())?;
+        input_type
+            .SetUINT32(&MF_MT_AVG_BITRATE, format.average_bitrate)
+            .map_err(|error| error.to_string())?;
+        Ok(input_type)
     }
 }
 
@@ -914,6 +933,80 @@ fn pack_pair(high: u32, low: u32) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hevc_input_types_set_the_negotiated_profile_before_decoder_configuration() {
+        let _runtime = super::super::MediaRuntime::initialize().unwrap();
+        for (pixel_format, profile) in [
+            (VideoPixelFormat::Nv12, eAVEncH265VProfile_Main_420_8),
+            (VideoPixelFormat::P010, eAVEncH265VProfile_Main_420_10),
+            (VideoPixelFormat::Ayuv, eAVEncH265VProfile_Main_444_8),
+            (VideoPixelFormat::Y410, eAVEncH265VProfile_Main_444_10),
+        ] {
+            let format = VideoFormat {
+                codec: VideoCodec::H265,
+                width: 2560,
+                height: 1440,
+                frame_rate_numerator: std::num::NonZeroU32::new(120).unwrap(),
+                frame_rate_denominator: std::num::NonZeroU32::new(1).unwrap(),
+                average_bitrate: 75_000_000,
+                pixel_format,
+                chroma_format: chroma_format(pixel_format),
+                full_range: false,
+            };
+            let input_type = video_input_type(format).unwrap();
+            unsafe {
+                assert_eq!(
+                    input_type.GetGUID(&MF_MT_MAJOR_TYPE).unwrap(),
+                    MFMediaType_Video
+                );
+                assert_eq!(
+                    input_type.GetGUID(&MF_MT_SUBTYPE).unwrap(),
+                    MFVideoFormat_HEVC
+                );
+                assert_eq!(
+                    input_type.GetUINT32(&MF_MT_MPEG2_PROFILE).unwrap(),
+                    profile.0 as u32
+                );
+                assert_eq!(
+                    input_type.GetUINT64(&MF_MT_FRAME_SIZE).unwrap(),
+                    pack_pair(2560, 1440)
+                );
+                assert_eq!(
+                    input_type.GetUINT64(&MF_MT_FRAME_RATE).unwrap(),
+                    pack_pair(120, 1)
+                );
+                assert_eq!(
+                    input_type.GetUINT32(&MF_MT_AVG_BITRATE).unwrap(),
+                    75_000_000
+                );
+                assert_eq!(
+                    input_type.GetUINT64(&MF_MT_PIXEL_ASPECT_RATIO).unwrap(),
+                    pack_pair(1, 1)
+                );
+                assert_eq!(
+                    input_type.GetUINT32(&MF_MT_INTERLACE_MODE).unwrap(),
+                    MFVideoInterlace_MixedInterlaceOrProgressive.0 as u32
+                );
+            }
+            for codec in [VideoCodec::H264, VideoCodec::Av1] {
+                let input_type = video_input_type(VideoFormat { codec, ..format }).unwrap();
+                unsafe {
+                    assert_eq!(
+                        input_type.GetGUID(&MF_MT_SUBTYPE).unwrap(),
+                        *video_subtype(codec)
+                    );
+                    assert_eq!(
+                        input_type
+                            .GetUINT32(&MF_MT_MPEG2_PROFILE)
+                            .unwrap_err()
+                            .code(),
+                        MF_E_ATTRIBUTENOTFOUND
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn output_samples_reject_reported_corruption_before_surface_extraction() {

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/mod.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/mod.rs
@@ -339,6 +339,18 @@ pub(super) fn probe(api: WindowsGraphicsApi) -> CapabilityProbe {
             Decoder::probe(graphics, VideoCodec::Av1, WindowsDecoderMode::Hardware)
                 .map_err(|error| error.to_string())
         });
+    for (codec, result) in [
+        (VideoCodec::H264, &h264_decoder),
+        (VideoCodec::H265, &h265_decoder),
+        (VideoCodec::Av1, &av1_decoder),
+    ] {
+        if let Err(error) = result {
+            video_log!(
+                "Windows hardware decoder probe failed api={api:?} codec={}: {error}",
+                codec.label()
+            );
+        }
+    }
     let h264_software_decoder = graphics
         .as_ref()
         .map_err(Clone::clone)


### PR DESCRIPTION
## Windows HEVC initialization

Set `MF_MT_MPEG2_PROFILE` on HEVC input media types before `SetInputType`, using the negotiated output depth/chroma to select Main 4:2:0 8/10-bit or Main 4:4:4 8/10-bit. Both the Qt capability probe and live decoding use this path. H.264/AV1 input attributes, hardware profile validation, and D3D11 surface requirements remain unchanged.

Microsoft's [HEVC decoder contract](https://learn.microsoft.com/en-us/windows/win32/medfound/h-265---hevc-video-decoder) expects the source to specify the input profile. OpenNOW previously omitted it.

Preserve hardware decoder probe errors in `native-streamer.log`, including when another codec remains available. Decoder configuration failures now identify the MFT and activation, D3D manager, or input-type stage where applicable. Document the Windows HEVC dependency and diagnostic location.

## Validation

- Passed: 23 platform-independent Windows-crate unit tests on Linux.
- Passed: Windows x64 and ARM64 `cargo clippy --all-targets -- -D warnings` (includes cross-compilation of the new Windows-only regression test).
- Passed: streamer workspace formatting and `git diff --check`.
- Added a Windows Media Foundation regression test covering all four HEVC profiles, preserved stream attributes, and unchanged H.264/AV1 profile behavior. Execution is covered by the existing Windows CI job; it has not run locally.

The reported RTX 3080 has HEVC Video Extensions 2.5.33.0 installed. This fixes a concrete initialization omission, but the exact failure on that machine has not been reproduced. Actual H.265 availability and playback still need validation there; the retained probe diagnostics will identify any remaining failure.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1YHHT5J7FC0R42EVYWPJFW4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->