### PR TITLE
fix(qt): limit frame generation to 120 FPS targets and verify presented motion

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -121,6 +121,7 @@
     "localOutputFps": "LOCAL OUTPUT FPS",
     "frameGeneration": "FRAME GENERATION",
     "warmingUp": "Warming up",
+    "frameGenerationRateLimit": "120 FPS generation limit",
     "displayRefresh": "Display refresh",
     "overloaded": "Overloaded",
     "discontinuity": "Discontinuity",

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -90,6 +90,10 @@ stream FPS. A 60 FPS stream targets 120 displayed FPS only with a sufficiently f
 and a display running at approximately 120 Hz or higher. Input and game simulation remain at
 the source rate. Interpolation adds presentation latency and can artifact around fast motion,
 thin geometry, transparency, repeated textures, and the game's HUD.
+Generation is limited to a nominal 120 FPS target: source cadences faster than 60 FPS (with a
+small arrival-jitter margin) bypass interpolation and report `source-rate-limit`. In particular,
+a 120 FPS source is never doubled to 240, even on a 240 Hz or faster display. Normal source
+presentation is not capped or renegotiated by this guard.
 
 The Qt render-thread helper samples native GPU textures into two retained histories, estimates
 bidirectional motion through three reduced-resolution pyramids, and synthesizes one midpoint.
@@ -138,11 +142,16 @@ Xvfb. Without Xvfb, the offscreen platform can skip Vulkan coverage. Set
 resource use. The tests cover translated images versus a crossfade, cut fallback, 10-bit values,
 resource recreation, pacing, and the settings-to-surface bindings. Software Vulkan correctness
 does not establish a physical GPU's 8.33 ms presentation budget.
-The Linux `opennow-nativeframegeneration-tests` target drives the production native render
-callback with injected FFI frames and real adopted-device Vulkan textures. It checks absent,
+The Linux/Windows `opennow-nativeframegeneration-tests` target drives the production native render
+callback with injected FFI frames and real adopted-device Vulkan/D3D11 textures. It checks absent,
 repeated, and grouped PTS, generated/original scheduling across `frameSwapped`, pixel readback,
-Off, discontinuity diagnostics, metadata preservation, and resource release. It is not a network
-session, D3D11 integration test, or sustained output-FPS benchmark.
+Off, discontinuity diagnostics, metadata preservation, and resource release. Windows uses a
+D3D11 software device for deterministic CI coverage. It is not a network session, hardware
+swapchain test, or sustained output-FPS benchmark.
+Moving-image rows also require the presented midpoint to differ from the current source and
+approximate halfway motion, followed by an exact original. The shader suite separately checks
+pixel-scale detail at small motion offsets. These checks do not replace validation of a live
+Windows swapchain or establish that the submitted-output counter counts distinct motion frames.
 The `qml-frame-generation-stats-desktop` and `qml-frame-generation-stats-console` acceptance tests
 feed controlled snapshots through the render-callback boundary and the real item's timer, route
 facade, top-level overlay, and clipboard report. They check FPS-only changes, fallback/recovery,

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -143,7 +143,7 @@ if(BUILD_TESTING)
         target_link_libraries(opennow-streamvideo-tests PRIVATE Vulkan::Vulkan)
     endif()
     add_dependencies(opennow-streamvideo-tests opennow-streamer-ffi-build)
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
         qt_add_executable(opennow-nativeframegeneration-tests
             tests/tst_nativeframegeneration.cpp
             ${OPENNOW_STREAM_RUNTIME_SOURCES}
@@ -152,7 +152,10 @@ if(BUILD_TESTING)
             src/streaming/rendering/LinuxVulkanGraphics.cpp)
         target_include_directories(opennow-nativeframegeneration-tests PRIVATE src)
         target_link_libraries(opennow-nativeframegeneration-tests PRIVATE
-            Qt6::Test Qt6::GuiPrivate Qt6::Quick opennow-streamer-ffi Vulkan::Vulkan)
+            Qt6::Test Qt6::GuiPrivate Qt6::Quick opennow-streamer-ffi)
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            target_link_libraries(opennow-nativeframegeneration-tests PRIVATE Vulkan::Vulkan)
+        endif()
         add_dependencies(opennow-nativeframegeneration-tests opennow-streamer-ffi-build)
         qt_add_shaders(opennow-nativeframegeneration-tests "opennow-native-framegen-test-shaders"
             PREFIX "/opennow/shaders" BASE "shaders" FILES ${OPENNOW_STREAM_SHADERS})
@@ -165,6 +168,8 @@ if(BUILD_TESTING)
             set_tests_properties(opennow-nativeframegeneration-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
         endif()
         set_tests_properties(opennow-nativeframegeneration-tests PROPERTIES TIMEOUT 60)
+    endif()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         qt_add_executable(opennow-linuxvulkangraphics-tests
             tests/tst_linuxvulkangraphics.cpp
             src/streaming/rendering/LinuxVulkanGraphics.cpp
@@ -269,6 +274,7 @@ if(BUILD_TESTING)
         TIMEOUT 8
     )
     if(WIN32)
+        add_dependencies(opennow-nativeframegeneration-tests opennow-streamer-ffi-test-runtime)
         # Qt's executable helper defaults to the GUI subsystem on Windows. Keep
         # test runners as console programs so CTest captures QtTest failures.
         set_target_properties(
@@ -278,6 +284,7 @@ if(BUILD_TESTING)
             opennow-streamvideo-tests
             opennow-waylandpointer-tests
             opennow-nativestreamruntime-tests
+            opennow-nativeframegeneration-tests
             opennow-embedded-orchestration-tests
             opennow-singleinstance-tests
             opennow-thumbnail-tests
@@ -320,6 +327,7 @@ if(BUILD_TESTING)
                 opennow-streamvideo-tests
                 opennow-waylandpointer-tests
                 opennow-nativestreamruntime-tests
+                opennow-nativeframegeneration-tests
                 opennow-embedded-orchestration-tests
                 opennow-singleinstance-tests
                 opennow-thumbnail-tests

--- a/opennow-qt/qml/desktop/stream/DesktopStreamStats.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopStreamStats.qml
@@ -45,6 +45,7 @@ Item {
         case "warming-up": return qsTr("Warming up")
         case "active": return qsTr("Active")
         case "display-refresh": return qsTr("Display refresh")
+        case "source-rate-limit": return qsTr("120 FPS generation limit")
         case "overloaded": return qsTr("Overloaded")
         case "discontinuity": return qsTr("Discontinuity")
         default: return qsTr("Unavailable")

--- a/opennow-qt/src/streaming/rendering/NativeStreamRenderCallback.cpp
+++ b/opennow-qt/src/streaming/rendering/NativeStreamRenderCallback.cpp
@@ -38,7 +38,7 @@ private:
 
 class NativeStreamRenderCallback final : public StreamVideoRenderCallback
 {
-    enum class FrameGenerationState { Off, WarmingUp, Active, DisplayTooSlow, Overloaded, Unavailable, Discontinuity };
+    enum class FrameGenerationState { Off, WarmingUp, Active, DisplayTooSlow, Overloaded, Unavailable, Discontinuity, SourceRateLimit };
 public:
     explicit NativeStreamRenderCallback(NativeStreamRuntime *runtime)
         : m_runtime(runtime)
@@ -244,6 +244,7 @@ public:
         if (decision != StreamFramePacer::Result::Interpolate) {
             m_interpolator.reset();
             switch (decision) {
+            case StreamFramePacer::Result::SourceRateLimit: m_frameGenerationStatus.store(FrameGenerationState::SourceRateLimit); return;
             case StreamFramePacer::Result::DisplayTooSlow: m_frameGenerationStatus.store(FrameGenerationState::DisplayTooSlow); return;
             case StreamFramePacer::Result::Overloaded: m_frameGenerationStatus.store(FrameGenerationState::Overloaded); return;
             case StreamFramePacer::Result::Discontinuity: m_frameGenerationStatus.store(FrameGenerationState::Discontinuity); break;
@@ -311,7 +312,8 @@ public:
     {
         const QString states[] = {QStringLiteral("off"), QStringLiteral("warming-up"),
             QStringLiteral("active"), QStringLiteral("display-refresh"),
-            QStringLiteral("overloaded"), QStringLiteral("unavailable"), QStringLiteral("discontinuity")};
+            QStringLiteral("overloaded"), QStringLiteral("unavailable"), QStringLiteral("discontinuity"),
+            QStringLiteral("source-rate-limit")};
         const QString timing[] = {QStringLiteral("none"), QStringLiteral("source-timestamps"),
                                   QStringLiteral("arrival-cadence")};
         const QString rejections[] = {QStringLiteral("none"), QStringLiteral("sequence-gap"),

--- a/opennow-qt/src/streaming/rendering/StreamFramePacer.h
+++ b/opennow-qt/src/streaming/rendering/StreamFramePacer.h
@@ -8,7 +8,7 @@
 class StreamFramePacer
 {
 public:
-    enum class Result { Duplicate, WarmingUp, Interpolate, Discontinuity, DisplayTooSlow, Overloaded };
+    enum class Result { Duplicate, WarmingUp, Interpolate, Discontinuity, DisplayTooSlow, Overloaded, SourceRateLimit };
     enum class TimingSource { None, SourceTimestamps, ArrivalCadence };
     enum class Rejection { None, SequenceGap, TimestampRegression, TimestampJump, ArrivalGap, CadenceUnavailable };
 
@@ -72,6 +72,7 @@ public:
             m_rejection = Rejection::CadenceUnavailable;
             return Result::Discontinuity;
         }
+        if (m_interval < 16'000'000) return Result::SourceRateLimit;
         if (!std::isfinite(refreshRate) || refreshRate < 1.95e9 / double(m_interval))
             return Result::DisplayTooSlow;
         if (pending) m_cooldownUntil = now + 2'000'000'000;

--- a/opennow-qt/tests/FrameGenerationAcceptance.qml
+++ b/opennow-qt/tests/FrameGenerationAcceptance.qml
@@ -43,11 +43,25 @@ QtObject {
         stats.frameGenerationStats = {status: "overloaded", outputFps: 59}
         check(stats.cards.find(card => card.field === "frameGenerationOutputFps").value === 59,
             "fallback is reflected in the output measurement")
-        ShellStore.streamer = {status: "stopped"}
+        ShellStore.streamer = {status: "streaming", framesPerSecond: 120}
+        stats.frameGenerationStats = {status: "source-rate-limit", outputFps: 120}
+        check(stats.frameGenerationState() === qsTr("120 FPS generation limit"),
+            "the source-rate limit has an explicit status")
+        check(stats.cards.find(card => card.field === "framesPerSecond").value === 120
+            && stats.cards.find(card => card.field === "frameGenerationOutputFps").value === 120,
+            "a 120 FPS source stays at 120 rather than claiming 240")
+        if (Qt.application.arguments.indexOf("--screenshot") >= 0) {
+            stats.anchors.fill = parent
+            stats.z = 10000
+            stats.expanded = true
+            stats.visible = true
+        } else {
+            ShellStore.streamer = {status: "stopped"}
+            stats.destroy()
+        }
         ShellStore.lastError = ""
         desktop.destroy()
         console.destroy()
-        stats.destroy()
         return true
     }
 }

--- a/opennow-qt/tests/tst_frameinterpolator.cpp
+++ b/opennow-qt/tests/tst_frameinterpolator.cpp
@@ -163,6 +163,49 @@ private slots:
         QVERIFY(error(third, scene(size, translation * 3 / 2)) < actualError * 0.45);
     }
 
+    void detailedTextureProducesIntermediateMotion_data()
+    {
+        QTest::addColumn<int>("translation");
+        QTest::addColumn<QSize>("size");
+        for (const int shift : {2, 4, 8, 10, 16})
+            QTest::newRow(qPrintable(QString::number(shift))) << shift << QSize(640, 360);
+        QTest::newRow("1440p-small-motion") << 4 << QSize(2560, 1440);
+    }
+
+    void detailedTextureProducesIntermediateMotion()
+    {
+        QFETCH(int, translation);
+        QFETCH(QSize, size);
+        const auto detailed = [&](int shift) {
+            QImage image = scene(size, shift);
+            for (int y = 0; y < size.height(); ++y) {
+                auto *row = image.scanLine(y);
+                for (int x = 0; x < size.width(); ++x) {
+                    const auto px = std::uint32_t(x - shift);
+                    const auto hash = (px * 73856093u) ^ (std::uint32_t(y) * 19349663u);
+                    const int detail = int((hash ^ (hash >> 13)) % 97) - 48;
+                    for (int channel = 0; channel < 3; ++channel)
+                        row[x * 4 + channel] = uchar(qBound(0, int(row[x * 4 + channel]) + detail, 255));
+                }
+            }
+            return image;
+        };
+        auto source = std::unique_ptr<QRhiTexture>(m_rhi->newTexture(QRhiTexture::RGBA8, size));
+        QVERIFY(source->create());
+        StreamFrameInterpolator interpolator;
+        QVERIFY(interpolator.initialize(m_rhi.get()));
+        const auto previous = detailed(0);
+        const auto current = detailed(translation);
+        const auto expected = detailed(translation / 2);
+        QCOMPARE(submit(interpolator, source.get(), previous, false), previous);
+        const auto midpoint = submit(interpolator, source.get(), current, true);
+        QVERIFY(!midpoint.isNull());
+        const auto midpointError = error(midpoint, expected);
+        const auto sourceError = error(current, expected);
+        qInfo() << "Detailed midpoint/source errors:" << midpointError << sourceError;
+        QVERIFY(midpointError < sourceError * 0.45);
+    }
+
     void sceneCutUsesActualAndResetRetainsAllocation()
     {
         const QSize size(128, 96);

--- a/opennow-qt/tests/tst_framepacer.cpp
+++ b/opennow-qt/tests/tst_framepacer.cpp
@@ -63,6 +63,26 @@ private slots:
         QCOMPARE(pacer.source(130, 129 * 16'666'667ULL, 129 * 16'666'667LL, 120), Result::Interpolate);
     }
 
+    void doesNotGenerateAboveThe120FpsTarget()
+    {
+        for (const auto interval : {8'333'333ULL, 11'111'111ULL, 13'333'333ULL}) {
+            for (const bool timestamps : {false, true}) {
+                StreamFramePacer pacer;
+                pacer.source(1, 0, 0, 360);
+                for (std::uint64_t frame = 2; frame <= 20; ++frame) {
+                    QCOMPARE(pacer.source(frame, timestamps ? (frame - 1) * interval : 0,
+                                          (frame - 1) * interval, 360),
+                             StreamFramePacer::Result::SourceRateLimit);
+                    QVERIFY(!pacer.pending());
+                }
+                pacer.reset();
+                pacer.source(1, 0, 0, 360);
+                QCOMPARE(pacer.source(2, 16'666'667, 16'666'667, 360),
+                         StreamFramePacer::Result::Interpolate);
+            }
+        }
+    }
+
     void highRefreshDoesNotCompressTheOriginalPair()
     {
         StreamFramePacer pacer;

--- a/opennow-qt/tests/tst_nativeframegeneration.cpp
+++ b/opennow-qt/tests/tst_nativeframegeneration.cpp
@@ -3,6 +3,7 @@
 #include "streaming/rendering/StreamVideoRenderCallback.h"
 
 #include <QGuiApplication>
+#include <QImage>
 #include <QJsonDocument>
 #include <QScopeGuard>
 #include <QSignalSpy>
@@ -13,30 +14,38 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <optional>
 #include <thread>
 
-#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+#if defined(Q_OS_WIN)
+#include <d3d11.h>
+#elif QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
 #include <QVulkanFunctions>
+#endif
 
+#if defined(Q_OS_WIN) || (QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>))
 namespace {
 struct Producer {
+#if !defined(Q_OS_WIN)
     struct Image {
         VkImage image = VK_NULL_HANDLE;
         VkDeviceMemory memory = VK_NULL_HANDLE;
         bool initialized = false;
     };
+    QVulkanInstance *instance = nullptr;
+    QVulkanDeviceFunctions *functions = nullptr;
+    std::array<Image, 8> images{};
+#endif
     struct Frame {
         Producer *producer;
         OpenNowStreamerFrameInfo info;
     };
 
-    QVulkanInstance *instance = nullptr;
     OpenNowStreamerConfig config{};
     OpenNowStreamerGraphicsContext context{};
-    QVulkanDeviceFunctions *functions = nullptr;
-    std::array<Image, 8> images{};
+    QRhiTexture *sourceTexture = nullptr;
     std::optional<OpenNowStreamerFrameInfo> next;
     OpenNowStreamerFrameInfo acquired{};
     OpenNowStreamerFrameInfo recorded{};
@@ -46,19 +55,22 @@ struct Producer {
     int emptyCount = 0;
     int shutdownCount = 0;
 
-    VkDevice device() const { return reinterpret_cast<VkDevice>(context.device); }
-
     ~Producer() { clearImages(); }
 
     void clearImages()
     {
+#if !defined(Q_OS_WIN)
         if (!functions) return;
         for (auto &image : images) {
             if (image.image) functions->vkDestroyImage(device(), image.image, nullptr);
             if (image.memory) functions->vkFreeMemory(device(), image.memory, nullptr);
             image = {};
         }
+#endif
     }
+
+#if !defined(Q_OS_WIN)
+    VkDevice device() const { return reinterpret_cast<VkDevice>(context.device); }
 
     bool createImage(Image &image)
     {
@@ -92,6 +104,7 @@ struct Producer {
         }
         return false;
     }
+#endif
 };
 
 Producer *producerToCreate = nullptr;
@@ -119,10 +132,17 @@ NativeStreamRuntime::Api producerApi()
     api.setGraphicsContext = [](const OpenNowStreamer *handle,
                                 const OpenNowStreamerGraphicsContext *context) {
         auto *producer = reinterpret_cast<Producer *>(const_cast<OpenNowStreamer *>(handle));
+#if defined(Q_OS_WIN)
+        if (context->graphics_api != OPENNOW_STREAMER_GRAPHICS_API_D3D11
+            || !context->device || !context->queue)
+            return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
+        producer->context = *context;
+#else
         if (context->graphics_api != OPENNOW_STREAMER_GRAPHICS_API_VULKAN)
             return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
         producer->context = *context;
         producer->functions = producer->instance->deviceFunctions(producer->device());
+#endif
         return OPENNOW_STREAMER_OK;
     };
     api.acquireLatestFrame = [](const OpenNowStreamer *handle, OpenNowStreamerFrame **output,
@@ -145,9 +165,50 @@ NativeStreamRuntime::Api producerApi()
                          OpenNowStreamerRecordedFrame *output) {
         auto *producer = reinterpret_cast<Producer *>(const_cast<OpenNowStreamer *>(handle));
         const auto *frame = reinterpret_cast<const Producer::Frame *>(token);
+#if defined(Q_OS_WIN)
+        if (!producer->sourceTexture || !producer->context.device
+            || command->command_buffer != producer->context.queue)
+            return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
+        const auto native = producer->sourceTexture->nativeTexture();
+        if (!native.object) return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
+        auto *texture = reinterpret_cast<ID3D11Texture2D *>(native.object);
+        ID3D11Device *device = nullptr;
+        texture->GetDevice(&device);
+        const bool adoptedDevice = device == producer->context.device;
+        if (device) device->Release();
+        if (!adoptedDevice) return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
+        producer->recorded = frame->info;
+        *output = {native.object, 0, OPENNOW_STREAMER_GRAPHICS_API_D3D11,
+                   OPENNOW_STREAMER_TEXTURE_FORMAT_RGBA8, frame->info.width, frame->info.height,
+                   command->frame_slot, 1, frame->info.presentation_time_ns};
+        return OPENNOW_STREAMER_OK;
+#else
         if (!producer->functions || !command->command_buffer
             || command->frame_slot >= producer->images.size())
             return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
+        if (producer->sourceTexture) {
+            const auto native = producer->sourceTexture->nativeTexture();
+            VkImageMemoryBarrier barrier{};
+            barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT | VK_ACCESS_MEMORY_READ_BIT;
+            barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            barrier.oldLayout = VkImageLayout(native.layout);
+            barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            barrier.image = VkImage(native.object);
+            barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            producer->functions->vkCmdPipelineBarrier(
+                reinterpret_cast<VkCommandBuffer>(command->command_buffer),
+                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &barrier);
+            producer->sourceTexture->setNativeLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            producer->recorded = frame->info;
+            *output = {native.object, 0, OPENNOW_STREAMER_GRAPHICS_API_VULKAN,
+                       OPENNOW_STREAMER_TEXTURE_FORMAT_RGBA8, frame->info.width, frame->info.height,
+                       command->frame_slot, 1, frame->info.presentation_time_ns};
+            return OPENNOW_STREAMER_OK;
+        }
         auto &image = producer->images[command->frame_slot];
         if (!image.image && !producer->createImage(image))
             return OPENNOW_STREAMER_GRAPHICS_UNAVAILABLE;
@@ -183,6 +244,7 @@ NativeStreamRuntime::Api producerApi()
                    OPENNOW_STREAMER_TEXTURE_FORMAT_RGBA8, frame->info.width, frame->info.height,
                    command->frame_slot, 1, frame->info.presentation_time_ns};
         return OPENNOW_STREAMER_OK;
+#endif
     };
     api.releaseFrame = [](OpenNowStreamerFrame *token) {
         std::unique_ptr<Producer::Frame> frame(reinterpret_cast<Producer::Frame *>(token));
@@ -205,16 +267,58 @@ class NativeFrameGenerationTest final : public QObject
 {
     Q_OBJECT
 private:
-#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+#if !defined(Q_OS_WIN) && QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
     QVulkanInstance m_instance;
 #endif
     std::unique_ptr<QRhi> m_rhi;
     std::atomic<int> m_validationErrors = 0;
 
+    static QImage movingScene(QSize size, int shift)
+    {
+        QImage image(size, QImage::Format_RGBA8888);
+        for (int y = 0; y < size.height(); ++y) {
+            auto *row = image.scanLine(y);
+            for (int x = 0; x < size.width(); ++x) {
+                const double px = x - shift;
+                row[x * 4] = uchar(128 + 52 * std::sin(px * 0.091 + y * 0.033)
+                                      + 48 * std::cos(px * 0.047 - y * 0.077));
+                row[x * 4 + 1] = uchar(128 + 53 * std::cos(px * 0.067 + y * 0.059)
+                                          + 42 * std::sin(px * 0.029 - y * 0.113));
+                row[x * 4 + 2] = uchar(128 + 51 * std::sin(px * 0.053 - y * 0.043)
+                                          + 43 * std::cos(px * 0.107 + y * 0.023));
+                row[x * 4 + 3] = 255;
+            }
+        }
+        return image;
+    }
+
+    static double imageError(const QImage &actual, const QImage &expected)
+    {
+        double sum = 0;
+        int count = 0;
+        for (int y = 48; y < actual.height() - 48; ++y) {
+            for (int x = 64; x < actual.width() - 64; ++x) {
+                for (int c = 0; c < 3; ++c) {
+                    const int delta = int(actual.constScanLine(y)[x * 4 + c])
+                        - int(expected.constScanLine(y)[x * 4 + c]);
+                    sum += delta * delta;
+                    ++count;
+                }
+            }
+        }
+        return sum / count;
+    }
+
 private slots:
     void initTestCase()
     {
-#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+#if defined(Q_OS_WIN)
+        QRhiD3D11InitParams params;
+        params.enableDebugLayer = qEnvironmentVariableIsSet("OPENNOW_FRAMEGEN_VALIDATION");
+        m_rhi.reset(QRhi::create(QRhi::D3D11, &params, QRhi::PreferSoftwareRenderer));
+        QVERIFY2(m_rhi, "The Windows integration test requires a D3D11 software device");
+        QVERIFY(m_rhi->isTextureFormatSupported(QRhiTexture::RGBA16F, QRhiTexture::RenderTarget));
+#elif QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
         m_instance.setApiVersion(QVersionNumber(1, 1));
         m_instance.setExtensions(QRhiVulkanInitParams::preferredInstanceExtensions());
         if (qEnvironmentVariableIsSet("OPENNOW_FRAMEGEN_VALIDATION")) {
@@ -236,7 +340,7 @@ private slots:
         if (!m_rhi->isTextureFormatSupported(QRhiTexture::RGBA16F, QRhiTexture::RenderTarget))
             QSKIP("Renderable RGBA16F unavailable");
 #else
-        QSKIP("Native frame generation integration currently requires Vulkan");
+        QSKIP("Native frame generation integration requires D3D11 or Vulkan");
 #endif
     }
 
@@ -244,19 +348,26 @@ private slots:
     {
         QTest::addColumn<bool>("enabled");
         QTest::addColumn<int>("timestampMode");
-        QTest::newRow("absent-pts") << true << 0;
-        QTest::newRow("repeated-pts") << true << 1;
-        QTest::newRow("grouped-pts") << true << 2;
-        QTest::newRow("off-control") << false << 0;
+        QTest::addColumn<bool>("moving");
+        QTest::newRow("absent-pts") << true << 0 << false;
+        QTest::newRow("repeated-pts") << true << 1 << false;
+        QTest::newRow("grouped-pts") << true << 2 << false;
+        QTest::newRow("off-control") << false << 0 << false;
+        QTest::newRow("moving-repeated-pts") << true << 1 << true;
+        QTest::newRow("moving-grouped-pts") << true << 2 << true;
+        QTest::newRow("moving-off-control") << false << 1 << true;
     }
 
     void productionCallback()
     {
-#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+#if defined(Q_OS_WIN) || (QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>))
         QFETCH(bool, enabled);
         QFETCH(int, timestampMode);
+        QFETCH(bool, moving);
         Producer producer;
+#if !defined(Q_OS_WIN)
         producer.instance = &m_instance;
+#endif
         producerToCreate = &producer;
         const auto resetProducer = qScopeGuard([] { producerToCreate = nullptr; });
         NativeStreamRuntime runtime(producerApi());
@@ -266,7 +377,24 @@ private slots:
                               {QStringLiteral("id"), QStringLiteral("integration-start")}}));
         QTRY_VERIFY(runtime.presentationAllowed());
 
-        const QSize size(64, 64);
+        const QSize size = moving ? QSize(320, 224) : QSize(64, 64);
+        std::array<QImage, 17> sources;
+        std::array<QImage, 17> halfway;
+        std::unique_ptr<QRhiTexture> sourceTexture;
+        if (moving || m_rhi->backend() == QRhi::D3D11) {
+            for (int i = 0; i < int(sources.size()); ++i) {
+                if (moving) {
+                    sources[i] = movingScene(size, i * 8);
+                    halfway[i] = movingScene(size, i * 8 - 4);
+                } else {
+                    sources[i] = QImage(size, QImage::Format_RGBA8888);
+                    sources[i].fill(QColor(64, 128, 191, 255));
+                }
+            }
+            sourceTexture.reset(m_rhi->newTexture(QRhiTexture::RGBA8, size));
+            QVERIFY(sourceTexture->create());
+            producer.sourceTexture = sourceTexture.get();
+        }
         auto texture = std::unique_ptr<QRhiTexture>(m_rhi->newTexture(
             QRhiTexture::RGBA8, size, 1, QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource));
         QVERIFY(texture->create());
@@ -283,18 +411,25 @@ private slots:
         const auto release = qScopeGuard([&] { callback->releaseResources(); });
         callback->setFrameGeneration(enabled, 165.0);
         QMatrix4x4 matrix = m_rhi->clipSpaceCorrMatrix();
-        matrix.ortho(0, 64, 64, 0, -1, 1);
-        callback->setComposition(matrix, QRectF(0, 0, 64, 64), QRectF(0, 0, 64, 64), 1);
+        matrix.ortho(0, size.width(), size.height(), 0, -1, 1);
+        const QRectF bounds(QPointF(0, 0), QSizeF(size));
+        callback->setComposition(matrix, bounds, bounds, 1);
 
+        QImage presented;
         const auto present = [&](bool swapped = true) {
             QRhiCommandBuffer *cb = nullptr;
             if (m_rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess) return false;
+            if (sourceTexture && producer.next) {
+                auto *upload = m_rhi->nextResourceUpdateBatch();
+                upload->uploadTexture(sourceTexture.get(), sources[producer.next->sequence]);
+                cb->resourceUpdate(upload);
+            }
             callback->initialize(m_rhi.get(), cb, target.get());
             callback->prepareFrame(cb);
             cb->beginPass(target.get(), Qt::black, {1.0f, 0});
-            cb->setViewport(QRhiViewport(0, 0, 64, 64));
-            cb->setScissor(QRhiScissor(0, 0, 64, 64));
-            callback->recordFrame(cb, QRect(0, 0, 64, 64));
+            cb->setViewport(QRhiViewport(0, 0, size.width(), size.height()));
+            cb->setScissor(QRhiScissor(0, 0, size.width(), size.height()));
+            callback->recordFrame(cb, bounds.toRect());
             cb->endPass();
             QRhiReadbackResult readback;
             bool completed = false;
@@ -305,8 +440,12 @@ private slots:
             const auto ended = m_rhi->endOffscreenFrame();
             callback->finishFrame();
             if (swapped) callback->frameSwapped();
-            if (ended != QRhi::FrameOpSuccess || !completed || readback.data.size() != 64 * 64 * 4)
+            if (ended != QRhi::FrameOpSuccess || !completed
+                || readback.data.size() != size.width() * size.height() * 4)
                 return false;
+            presented = QImage(reinterpret_cast<const uchar *>(readback.data.constData()),
+                               size.width(), size.height(), QImage::Format_RGBA8888).copy();
+            if (moving) return true;
             const auto *pixel = reinterpret_cast<const unsigned char *>(readback.data.constData())
                 + (32 * 64 + 32) * 4;
             return qAbs(int(pixel[0]) - 64) <= 2 && qAbs(int(pixel[1]) - 128) <= 2
@@ -320,7 +459,8 @@ private slots:
             if (sequence > 1) std::this_thread::sleep_for(std::chrono::milliseconds(20));
             timestamp = timestampMode == 0 ? 0 : timestampMode == 1 ? 1'000'000'000
                 : 1'000'000'000 + ((sequence - 1) / 3) * 60'000'000;
-            producer.next = OpenNowStreamerFrameInfo{64, 64, sequence, timestamp};
+            producer.next = OpenNowStreamerFrameInfo{uint32_t(size.width()), uint32_t(size.height()),
+                                                     sequence, timestamp};
             QVERIFY2(present(false), qPrintable(runtime.lastError()));
             QCOMPARE(producer.acquired.sequence, sequence);
             QCOMPARE(producer.acquired.presentation_time_ns, timestamp);
@@ -336,31 +476,53 @@ private slots:
             if (!enabled) {
                 QCOMPARE(status, QStringLiteral("off"));
                 QVERIFY(!callback->needsFrame());
+                if (moving) QCOMPARE(presented, sources[sequence]);
                 callback->frameSwapped();
                 continue;
             }
             if (status != QStringLiteral("active")) {
+                if (moving) QCOMPARE(presented, sources[sequence]);
                 callback->frameSwapped();
                 continue;
             }
             QVERIFY(callback->needsFrame());
+            const QImage midpoint = presented;
+            if (moving) {
+                const double midpointError = imageError(midpoint, halfway[sequence]);
+                const double currentError = imageError(sources[sequence], halfway[sequence]);
+                QImage blend(size, QImage::Format_RGBA8888);
+                for (int y = 0; y < size.height(); ++y)
+                    for (int x = 0; x < size.width() * 4; ++x)
+                        blend.scanLine(y)[x] = (int(sources[sequence - 1].constScanLine(y)[x])
+                                                + int(sources[sequence].constScanLine(y)[x])) / 2;
+                const double blendError = imageError(blend, halfway[sequence]);
+                qInfo() << "Native callback midpoint/current halfway-motion error:"
+                        << midpointError << currentError;
+                QVERIFY(midpoint != sources[sequence]);
+                QVERIFY2(midpointError < currentError * 0.45,
+                         "Production callback output must move halfway, not repeat the current source");
+                QVERIFY2(midpointError < blendError * 0.70,
+                         "Production callback output must move texture features, not merely crossfade them");
+            }
             QCOMPARE(snapshot.value(QStringLiteral("timingSource")).toString(),
                      QStringLiteral("arrival-cadence"));
             QCOMPARE(snapshot.value(QStringLiteral("sequenceDelta")).toULongLong(), 1);
             QCOMPARE(snapshot.value(QStringLiteral("timestampDeltaMs")).toDouble(),
                      double(timestampDelta) / 1.0e6);
             QCOMPARE(snapshot.value(QStringLiteral("refreshRateHz")).toDouble(), 165.0);
-            const int sources = producer.sourceCount;
+            const int sourceCount = producer.sourceCount;
             const int empty = producer.emptyCount;
             std::this_thread::sleep_for(std::chrono::milliseconds(3));
             QVERIFY(present(false));
             QVERIFY(callback->needsFrame());
+            if (moving) QCOMPARE(presented, midpoint);
             callback->frameSwapped();
             std::this_thread::sleep_for(std::chrono::milliseconds(7));
             QVERIFY(present());
             QVERIFY(!callback->needsFrame());
-            QCOMPARE(producer.sourceCount, sources);
-            QCOMPARE(producer.releaseCount, sources);
+            if (moving) QCOMPARE(presented, sources[sequence]);
+            QCOMPARE(producer.sourceCount, sourceCount);
+            QCOMPARE(producer.releaseCount, sourceCount);
             QCOMPARE(producer.emptyCount, empty + 2);
             QCOMPARE(producer.released.sequence, sequence);
             QCOMPARE(producer.released.presentation_time_ns, timestamp);
@@ -374,7 +536,8 @@ private slots:
         if (enabled) {
             QVERIFY2(generatedPairs >= 3, "Production callback never sustained frame generation from native source arrivals");
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
-            producer.next = OpenNowStreamerFrameInfo{64, 64, 14, timestamp};
+            producer.next = OpenNowStreamerFrameInfo{uint32_t(size.width()), uint32_t(size.height()),
+                                                     14, timestamp};
             QVERIFY(present());
             QCOMPARE(callback->frameGenerationStats().value(QStringLiteral("status")).toString(),
                      QStringLiteral("discontinuity"));
@@ -382,7 +545,8 @@ private slots:
             QCOMPARE(callback->frameGenerationStats().value(QStringLiteral("rejectionReason")).toString(),
                      QStringLiteral("sequence-gap"));
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
-            producer.next = OpenNowStreamerFrameInfo{64, 64, 15, 2'000'000'000};
+            producer.next = OpenNowStreamerFrameInfo{uint32_t(size.width()), uint32_t(size.height()),
+                                                     15, 2'000'000'000};
             QVERIFY(present());
             if (callback->needsFrame()) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -390,7 +554,8 @@ private slots:
                 QVERIFY(!callback->needsFrame());
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
-            producer.next = OpenNowStreamerFrameInfo{64, 64, 16, 1'999'999'999};
+            producer.next = OpenNowStreamerFrameInfo{uint32_t(size.width()), uint32_t(size.height()),
+                                                     16, 1'999'999'999};
             QVERIFY(present());
             QCOMPARE(callback->frameGenerationStats().value(QStringLiteral("status")).toString(),
                      QStringLiteral("discontinuity"));


### PR DESCRIPTION
## Limit generation to the supported target

Bypass interpolation for source intervals below 16 ms, retaining a small jitter margin around 60 FPS. This blocks 120→240 generation even on faster displays without changing negotiated stream FPS or limiting normal source presentation. Expose `source-rate-limit` as “120 FPS generation limit” in the stats panel and add pacer/UI coverage.

## Verify pixels rather than only counters

Extend the production native render-callback integration test with moving textures and repeated/grouped PTS. Readbacks must show a distinct halfway-motion image, hold it until the swap notification, then present an exact original. The midpoint must outperform both source repetition and a crossfade. Existing static-frame, metadata, discontinuity, Off, and resource-lifetime assertions remain.

Run that integration target on Windows with a required D3D11 software device as well as Linux/Vulkan, including Windows console/offscreen and runtime deployment setup. Add shader tests for pixel-scale detail and small motion, including 2560×1440.

## Validation and remaining issue

- Full local build and Qt suite: **147/147 passed**; the subsequently updated screenshot fixture also passed its focused acceptance rerun.
- Validation-enabled Vulkan pacer/shader/callback suites pass. Moving callback rows render actual intermediate images; a scratch mutation selecting the current source instead fails the new moving checks while the old uniform-image checks still pass.
- Localization and whitespace checks pass. QML lint completes with warnings.
- Windows/D3D11 execution awaits CI.

**This does not resolve the reported live DX11 issue where the counter reaches 120 but visible motion remains at 60.** The tested Vulkan path does not reproduce it. No interpolation shader or normal presentation scheduling changes are included, and no live-GPU performance claim is made. The affected Windows device is offline; direct observation or a fresh high-frame-rate capture is still needed.

### Limit-state UI fixture

Controlled UI inputs, not live performance evidence:

![120 FPS generation limit in the statistics panel](https://api-nightly.capy.ai/pr-assets/uImvgUGBzMDRP4OGcAj-c-4morKr01pUFnmpXybhU34)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1Y04BBDEBR2CVPR9G7R1X4N"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->