### PR TITLE
fix(qt): handle Enter in the in-stream exit confirmation

### DIFF
--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -82,6 +82,12 @@ Useful development switches are `--route <name>`, `--overlay <name>`,
 `--reduced-motion`, `--core <path>` and `--screenshot <png-path>`. The test suite
 opens every route and overlay with QML warnings treated as failures.
 
+Run `ctest --test-dir build/opennow-qt --output-on-failure -R '^qml-stream-exit-'`
+to check the in-stream exit confirmation in desktop/console and windowed/fullscreen modes.
+The keyboard fixtures cover Return, keypad Enter, Tab+Space, Escape, safe default focus,
+auto-repeat suppression, and preserving the stream surface/input across cancellation.
+They use a smoke session, not a live GFN connection.
+
 ### Local frame generation (experimental)
 
 The desktop Streaming settings and console Video settings offer **Off** (default) or **2×**.

--- a/opennow-qt/cmake/Sources.cmake
+++ b/opennow-qt/cmake/Sources.cmake
@@ -30,6 +30,7 @@ qt_add_executable(opennow-qt
     src/acceptance/SmokeAcceptance.cpp
     src/acceptance/SmokeFixtures.cpp
     src/acceptance/FrameGenerationStatsAcceptance.cpp
+    src/acceptance/StreamExitAcceptance.cpp
     src/app/AppController.cpp
     src/app/AppController.h
     src/app/ApplicationStartup.cpp

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -448,6 +448,18 @@ if(BUILD_TESTING)
         set_tests_properties("qml-${surface}-input-capture-error" PROPERTIES
             ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT ${OPENNOW_QT_SMOKE_TIMEOUT})
     endforeach()
+    foreach(surface desktop console)
+        foreach(mode windowed fullscreen)
+            foreach(key return enter tab-space)
+                add_test(NAME "qml-stream-exit-${surface}-${mode}-${key}"
+                    COMMAND opennow-qt --smoke-test --allow-multiple-instances
+                        --${surface} --route stream --smoke-stream-exit
+                        --smoke-exit-${key} --smoke-exit-${mode} --reduced-motion)
+                set_tests_properties("qml-stream-exit-${surface}-${mode}-${key}" PROPERTIES
+                    ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
+            endforeach()
+        endforeach()
+    endforeach()
     add_test(NAME qml-fullscreen-stream-stats-shortcut
              COMMAND opennow-qt --smoke-test --allow-multiple-instances
                      --desktop --route stream --smoke-fullscreen-stats-shortcut --reduced-motion)

--- a/opennow-qt/qml/desktop/stream/DesktopStreamExitConfirm.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopStreamExitConfirm.qml
@@ -16,6 +16,14 @@ FocusScope {
     signal cancelRequested()
     signal confirmRequested()
 
+    Shortcut {
+        sequences: ["Return", "Enter"]
+        enabled: root.opened
+        context: Qt.WindowShortcut
+        autoRepeat: false
+        onActivated: root.confirmRequested()
+    }
+
     Rectangle {
         anchors.fill: parent
         color: "#A6000000"
@@ -75,6 +83,7 @@ FocusScope {
                 spacing: 10
                 DesktopButton {
                     id: keepPlayingButton
+                    objectName: "streamExitKeepPlaying"
                     text: qsTr("Keep playing")
                     shortcutText: qsTr("Esc")
                     primary: true
@@ -83,6 +92,7 @@ FocusScope {
                 }
                 DesktopButton {
                     id: endButton
+                    objectName: "streamExitEndSession"
                     text: qsTr("End session")
                     shortcutText: qsTr("Enter")
                     danger: true

--- a/opennow-qt/src/acceptance/AcceptanceSession.h
+++ b/opennow-qt/src/acceptance/AcceptanceSession.h
@@ -26,6 +26,7 @@ public:
 private:
     [[nodiscard]] int startSmokeWorkload();
     [[nodiscard]] int startFrameGenerationStatsWorkload();
+    [[nodiscard]] int startStreamExitWorkload();
 
     QGuiApplication &m_application;
     QQmlApplicationEngine &m_engine;

--- a/opennow-qt/src/acceptance/SmokeAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SmokeAcceptance.cpp
@@ -22,6 +22,8 @@ using namespace Qt::StringLiterals;
 int AcceptanceSession::startSmokeWorkload()
 {
     const auto screenshotIndex = m_arguments.indexOf(u"--screenshot"_s);
+    if (m_smokeTest && m_arguments.contains(u"--smoke-stream-exit"_s))
+        return startStreamExitWorkload();
     if (m_smokeTest && m_arguments.contains(u"--smoke-frame-generation-stats"_s))
         return startFrameGenerationStatsWorkload();
     if (m_smokeTest && m_arguments.contains(u"--smoke-frame-generation"_s)) {

--- a/opennow-qt/src/acceptance/StreamExitAcceptance.cpp
+++ b/opennow-qt/src/acceptance/StreamExitAcceptance.cpp
@@ -1,0 +1,126 @@
+#include "acceptance/AcceptanceSession.h"
+#include "app/AppController.h"
+
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QPointer>
+#include <QQmlApplicationEngine>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QTimer>
+#include <QVariantMap>
+
+#include <cstdlib>
+#include <memory>
+
+using namespace Qt::StringLiterals;
+
+int AcceptanceSession::startStreamExitWorkload()
+{
+    auto *window = m_engine.rootObjects().isEmpty() ? nullptr
+        : qobject_cast<QQuickWindow *>(m_engine.rootObjects().first());
+    auto *store = m_engine.singletonInstance<QObject *>(u"OpenNOW"_s, u"ShellStore"_s);
+    if (!window || !store) return EXIT_FAILURE;
+    store->setProperty("streamer", QVariantMap{{u"status"_s, u"streaming"_s}});
+    store->setProperty("streamState", u"streaming"_s);
+    const bool fullscreen = m_arguments.contains(u"--smoke-exit-fullscreen"_s);
+    if (fullscreen) window->showFullScreen();
+    window->requestActivate();
+    struct State {
+        int step = 0;
+        QPointer<QQuickItem> surface;
+    };
+    const auto state = std::make_shared<State>();
+    auto *timer = new QTimer(this);
+    timer->setInterval(150);
+    connect(timer, &QTimer::timeout, this, [this, window, store, fullscreen, state, timer] {
+        const auto require = [this, state, timer](bool ok, const char *message) {
+            if (!ok) {
+                qCritical("Stream exit step %d: %s", state->step, message);
+                timer->stop();
+                m_application.exit(EXIT_FAILURE);
+            }
+            return ok;
+        };
+        const auto keyClick = [window](Qt::Key key, Qt::KeyboardModifiers modifiers = Qt::NoModifier,
+                                      bool repeat = false) {
+            QKeyEvent press(QEvent::KeyPress, key, modifiers, {}, repeat);
+            QGuiApplication::sendEvent(window, &press);
+            QKeyEvent release(QEvent::KeyRelease, key, modifiers, {}, repeat);
+            QGuiApplication::sendEvent(window, &release);
+        };
+        const auto openConfirmation = [state] {
+            return QMetaObject::invokeMethod(state->surface, "localShortcutRequested",
+                Q_ARG(QString, u"stop-stream"_s));
+        };
+        if (!require(!m_qmlWarningOccurred, "QML warning")
+            || !require((window->visibility() == QWindow::FullScreen) == fullscreen,
+                        "confirmation changed fullscreen state")) return;
+        if (state->step == 0)
+            state->surface = window->findChild<QQuickItem *>(u"streamSurfaceHost"_s);
+        if (state->step < 6 && !require(state->surface && state->surface->isVisible()
+                && window->findChild<QQuickItem *>(u"streamSurfaceHost"_s) == state->surface
+                && m_controller.route() == u"stream"_s,
+                "confirmation recreated or left the stream surface")) return;
+        switch (state->step++) {
+        case 0:
+            if (!require(state->surface->property("inputEnabled").toBool(),
+                         "closed overlay blocked gameplay")) return;
+            if (!require(openConfirmation(), "stop-stream shortcut unavailable")) return;
+            break;
+        case 1:
+        case 3:
+        case 5: {
+            if (!require(m_controller.overlay() == u"desktop-stream-exit-confirm"_s
+                    && !state->surface->property("inputEnabled").toBool()
+                    && window->activeFocusItem()
+                    && window->activeFocusItem()->objectName() == u"streamExitKeepPlaying"_s,
+                    "confirmation did not own input with safe default focus")) return;
+            if (state->step == 2) {
+                keyClick(Qt::Key_Space);
+            } else if (state->step == 4) {
+                keyClick(Qt::Key_Escape);
+            } else {
+                keyClick(Qt::Key_Return, Qt::NoModifier, true);
+                if (!require(m_controller.overlay() == u"desktop-stream-exit-confirm"_s,
+                             "auto-repeat confirmed session exit")) return;
+                if (m_arguments.contains(u"--smoke-exit-tab-space"_s)) {
+                    keyClick(Qt::Key_Tab);
+                    if (!require(window->activeFocusItem()
+                            && window->activeFocusItem()->objectName() == u"streamExitEndSession"_s,
+                            "Tab did not focus End session")) return;
+                    keyClick(Qt::Key_Space);
+                } else if (m_arguments.contains(u"--smoke-exit-enter"_s)) {
+                    keyClick(Qt::Key_Enter, Qt::KeypadModifier);
+                } else {
+                    keyClick(Qt::Key_Return);
+                }
+            }
+            break;
+        }
+        case 2:
+        case 4:
+            if (!require(m_controller.overlay().isEmpty()
+                    && state->surface->property("inputEnabled").toBool()
+                    && store->property("streamState").toString() == u"streaming"_s,
+                    "cancel ended the session or failed to restore input")) return;
+            if (state->step == 3) {
+                m_controller.showOverlay(u"desktop-stream-menu"_s);
+                keyClick(Qt::Key_Q, Qt::ControlModifier | Qt::ShiftModifier);
+            } else {
+                m_controller.showOverlay(u"desktop-stream-stats"_s);
+                if (!require(openConfirmation(), "stop-stream shortcut unavailable over stats")) return;
+            }
+            break;
+        case 6:
+            if (!require(m_controller.overlay().isEmpty() && m_controller.route() != u"stream"_s
+                    && store->property("streamState").toString() == u"idle"_s,
+                    "confirmation key did not end the session")) return;
+            timer->stop();
+            m_application.exit(EXIT_SUCCESS);
+            break;
+        }
+    });
+    timer->start();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The in-stream exit confirmation advertised Enter but only handled Escape/Back. Add a window-scoped Return/keypad Enter shortcut enabled only while the confirmation is open, independent of button focus. Disable auto-repeat and preserve the default Keep playing focus, cancellation behavior, and existing stream surface/input ownership.

## Verification

- Reproduced the original bug with the new keyboard fixture: Return and keypad Enter failed; Tab+Space passed.
- All 12 new acceptance cases pass across desktop/console and windowed/fullscreen modes. Cover Return, keypad Enter, Tab+Space, Escape, Space on Keep playing, auto-repeat suppression, opening from the stream/menu/stats, and stable surface/input after cancellation.
- Full Debug Qt build and CTest: **159/159 passed**.
- QML lint target succeeded with warnings; `git diff --check` passed.
- Visually inspected the native dialog and confirmed it directly with Enter on XCB.

Acceptance uses smoke session state and the existing local shortcut signal for the native stream boundary; it does not validate live GFN gameplay or Windows/macOS runtime behavior.

![In-stream exit confirmation in a smoke fixture](https://api-nightly.capy.ai/pr-assets/KOSuZX6K5AG4cKlDxlNA0I52GLJ5EXXVWfiYyT1pKkc)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1YHBSCM1VFKVWVXTYCBP2GJ"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->