### PR TITLE
fix(qt): keep fullscreen controls available after session exit

### DIFF
--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -88,6 +88,10 @@ The keyboard fixtures cover Return, keypad Enter, Tab+Space, Escape, safe defaul
 auto-repeat suppression, and preserving the stream surface/input across cancellation.
 They use a smoke session, not a live GFN connection.
 
+Run `ctest --test-dir build/opennow-qt --output-on-failure -R '^qml-session-fullscreen-'`
+to verify that F11 can leave and re-enter fullscreen after confirming session exit,
+in desktop/console mode, restoring either the normal or maximized window state.
+
 ### Local frame generation (experimental)
 
 The desktop Streaming settings and console Video settings offer **Off** (default) or **2×**.

--- a/opennow-qt/cmake/Sources.cmake
+++ b/opennow-qt/cmake/Sources.cmake
@@ -31,6 +31,7 @@ qt_add_executable(opennow-qt
     src/acceptance/SmokeFixtures.cpp
     src/acceptance/FrameGenerationStatsAcceptance.cpp
     src/acceptance/StreamExitAcceptance.cpp
+    src/acceptance/SessionFullscreenAcceptance.cpp
     src/app/AppController.cpp
     src/app/AppController.h
     src/app/ApplicationStartup.cpp

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -468,6 +468,16 @@ if(BUILD_TESTING)
             endforeach()
         endforeach()
     endforeach()
+    foreach(surface desktop console)
+        foreach(mode windowed maximized)
+            add_test(NAME "qml-session-fullscreen-${surface}-${mode}"
+                COMMAND opennow-qt --smoke-test --allow-multiple-instances
+                    --${surface} --route stream --smoke-session-fullscreen
+                    --smoke-fullscreen-restore-${mode} --reduced-motion)
+            set_tests_properties("qml-session-fullscreen-${surface}-${mode}" PROPERTIES
+                ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
+        endforeach()
+    endforeach()
     add_test(NAME qml-fullscreen-stream-stats-shortcut
              COMMAND opennow-qt --smoke-test --allow-multiple-instances
                      --desktop --route stream --smoke-fullscreen-stats-shortcut --reduced-motion)

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -135,6 +135,14 @@ ApplicationWindow {
     onActiveChanged: syncInputOwnership()
     onDesktopSurfaceActiveChanged: ShellStore.desktopUiActive = desktopSurfaceActive
 
+    Shortcut {
+        objectName: "shellFullscreenShortcut"
+        sequence: "F11"
+        context: Qt.ApplicationShortcut
+        enabled: window.activeRoute !== "stream"
+        onActivated: window.toggleFullscreen()
+    }
+
     Connections {
         target: ShellStore
         function onFullscreenToggleRequested() {

--- a/opennow-qt/src/acceptance/AcceptanceSession.h
+++ b/opennow-qt/src/acceptance/AcceptanceSession.h
@@ -27,6 +27,7 @@ private:
     [[nodiscard]] int startSmokeWorkload();
     [[nodiscard]] int startFrameGenerationStatsWorkload();
     [[nodiscard]] int startStreamExitWorkload();
+    [[nodiscard]] int startSessionFullscreenWorkload();
 
     QGuiApplication &m_application;
     QQmlApplicationEngine &m_engine;

--- a/opennow-qt/src/acceptance/SessionFullscreenAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SessionFullscreenAcceptance.cpp
@@ -1,0 +1,99 @@
+#include "acceptance/AcceptanceSession.h"
+#include "app/AppController.h"
+
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QQmlApplicationEngine>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QTimer>
+#include <QVariantMap>
+
+#include <cstdlib>
+#include <memory>
+
+using namespace Qt::StringLiterals;
+
+int AcceptanceSession::startSessionFullscreenWorkload()
+{
+    auto *window = m_engine.rootObjects().isEmpty() ? nullptr
+        : qobject_cast<QQuickWindow *>(m_engine.rootObjects().first());
+    auto *store = m_engine.singletonInstance<QObject *>(u"OpenNOW"_s, u"ShellStore"_s);
+    if (!window || !store) return EXIT_FAILURE;
+    store->setProperty("streamer", QVariantMap{{u"status"_s, u"streaming"_s}});
+    store->setProperty("streamState", u"streaming"_s);
+    const auto restoredVisibility = m_arguments.contains(u"--smoke-fullscreen-restore-maximized"_s)
+        ? QWindow::Maximized : QWindow::Windowed;
+    if (restoredVisibility == QWindow::Maximized) window->showMaximized();
+    window->requestActivate();
+    const auto step = std::make_shared<int>(0);
+    auto *timer = new QTimer(this);
+    timer->setInterval(150);
+    connect(timer, &QTimer::timeout, this, [this, window, store, restoredVisibility, step, timer] {
+        const auto require = [this, step, timer](bool ok, const char *message) {
+            if (!ok) {
+                qCritical("Session fullscreen step %d: %s", *step, message);
+                timer->stop();
+                m_application.exit(EXIT_FAILURE);
+            }
+            return ok;
+        };
+        const auto keyClick = [window](Qt::Key key) {
+            QKeyEvent press(QEvent::KeyPress, key, Qt::NoModifier);
+            QGuiApplication::sendEvent(window, &press);
+            QKeyEvent release(QEvent::KeyRelease, key, Qt::NoModifier);
+            QGuiApplication::sendEvent(window, &release);
+        };
+        if (!require(!m_qmlWarningOccurred, "QML warning")) return;
+        switch ((*step)++) {
+        case 0:
+            if (!require(window->visibility() == restoredVisibility,
+                         "initial window state not applied")) return;
+            if (!require(QMetaObject::invokeMethod(window, "toggleFullscreen"),
+                         "fullscreen toggle unavailable")) return;
+            break;
+        case 1: {
+            auto *shortcut = window->findChild<QObject *>(u"shellFullscreenShortcut"_s);
+            if (!require(!shortcut || !shortcut->property("enabled").toBool(),
+                         "shell shortcut competed with stream input")) return;
+            if (!require(window->visibility() == QWindow::FullScreen,
+                         "stream did not enter fullscreen")) return;
+            if (!require(QMetaObject::invokeMethod(store, "requestStreamExitConfirmation"),
+                         "exit confirmation unavailable")) return;
+            break;
+        }
+        case 2:
+            if (!require(m_controller.overlay() == u"desktop-stream-exit-confirm"_s
+                    && window->visibility() == QWindow::FullScreen,
+                    "exit confirmation changed fullscreen state")) return;
+            keyClick(Qt::Key_Return);
+            break;
+        case 3:
+            if (!require(m_controller.route() != u"stream"_s
+                    && store->property("streamState").toString() == u"idle"_s
+                    && window->visibility() == QWindow::FullScreen,
+                    "session exit did not preserve the fullscreen shell")) return;
+            keyClick(Qt::Key_F11);
+            break;
+        case 4:
+            if (!require(window->visibility() == restoredVisibility,
+                         "F11 did not restore the shell window after session exit")) return;
+            keyClick(Qt::Key_F11);
+            break;
+        case 5:
+            if (!require(window->visibility() == QWindow::FullScreen,
+                         "F11 did not re-enter fullscreen from the shell")) return;
+            window->contentItem()->forceActiveFocus();
+            keyClick(Qt::Key_F11);
+            break;
+        case 6:
+            if (!require(window->visibility() == restoredVisibility,
+                         "F11 depended on the shell page focus")) return;
+            timer->stop();
+            m_application.exit(EXIT_SUCCESS);
+            break;
+        }
+    });
+    timer->start();
+    return EXIT_SUCCESS;
+}

--- a/opennow-qt/src/acceptance/SmokeAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SmokeAcceptance.cpp
@@ -22,6 +22,8 @@ using namespace Qt::StringLiterals;
 int AcceptanceSession::startSmokeWorkload()
 {
     const auto screenshotIndex = m_arguments.indexOf(u"--screenshot"_s);
+    if (m_smokeTest && m_arguments.contains(u"--smoke-session-fullscreen"_s))
+        return startSessionFullscreenWorkload();
     if (m_smokeTest && m_arguments.contains(u"--smoke-stream-exit"_s))
         return startStreamExitWorkload();
     if (m_smokeTest && m_arguments.contains(u"--smoke-frame-generation-stats"_s))


### PR DESCRIPTION
F11 was only handled on the stream route. Ending a fullscreen session removed that input owner but left the application fullscreen, with no way to toggle back from the shell.

Add an application-scoped F11 shortcut on non-stream routes, reusing the existing fullscreen toggle and normal/maximized restoration. Keep it disabled during streaming so it cannot compete with native gameplay input or change existing overlay behavior.

Add four smoke acceptance cases covering confirmed session exit in desktop/console modes, restoration to normal/maximized windows, repeated toggling, and focus-independent shell handling.

Validation:
- Qt Debug build passed.
- All four new cases fail without the fix at `F11 did not restore the shell window after session exit`, and pass with it.
- Complete 163-test Qt suite exercised: 161 passed initially; the two graphics tests failed because X11 runtime libraries were absent, then both passed after installing those libraries.
- All four new cases also passed on the X11 desktop, not just offscreen.
- `opennow-qt_qmllint` passed with warnings; `git diff --check` passed.
- No live GFN session was used; session teardown uses the smoke fixture.

[Desktop recording: F11 toggling outside the stream screen](https://api-nightly.capy.ai/pr-assets/v_Iwc3iE0_Yi-Hs5VWLGKMym9UMGHJAJiUgOF8EUTP1bQ)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1YKGJBRCRJ4SJGD4NVMYRQ2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->