### PR TITLE
fix(qt): make Steam Big Picture launch mode opt-in

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -977,6 +977,8 @@
       "experimentalL4SRequestHint": "Request the GeForce NOW L4S streaming feature on newly created sessions. This does not change browser WebRTC behavior by itself and may be ignored by the service or network path.",
       "identifyAsSteamDeck": "Identify as Steam Deck",
       "identifyAsSteamDeckHint": "Identify as the Steam Deck GFN client to unlock Deck-specific resolutions and 90 FPS. Video options refresh automatically.",
+      "steamBigPictureMode": "Steam Big Picture mode",
+      "steamBigPictureModeHint": "Request gamepad-friendly launchers such as Steam Big Picture. Applies to new GeForce NOW sessions only.",
       "identifyAsConsole": "Identify as Console",
       "identifyAsConsoleHint": "Ask GeForce NOW to launch streamed games in gamepad-friendly mode so launchers such as Steam can start in Big Picture. This affects new GFN sessions only; it does not fullscreen OpenNOW or enable its console shell."
     },

--- a/native/opennow-core/src/cloudmatch.rs
+++ b/native/opennow-core/src/cloudmatch.rs
@@ -1628,6 +1628,25 @@ mod tests {
     }
 
     #[test]
+    fn launch_mode_defaults_to_normal_and_maps_explicit_requests() {
+        for (mode, expected) in [
+            (Value::Null, 1),
+            (json!("default"), 1),
+            (json!("gamepadFriendly"), 2),
+            (json!("touchFriendly"), 3),
+            (json!("unknown"), 1),
+        ] {
+            let body = build_create_body(
+                "12345",
+                &json!({"appLaunchMode": mode}),
+                &json!({"controllerMode":true,"launchInConsoleMode":true}),
+                "device-id",
+            );
+            assert_eq!(body["sessionRequestData"]["appLaunchMode"], expected);
+        }
+    }
+
+    #[test]
     fn automatic_codec_delegates_selection_to_cloudmatch() {
         assert_eq!(codec_wire("auto"), 0);
         assert_eq!(codec_wire("unknown"), 0);

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -663,7 +663,8 @@ fn defaults() -> Map<String, Value> {
         "sessionClockShowEveryMinutes":60, "sessionClockShowDurationSeconds":30,
         "windowWidth":1400, "windowHeight":900, "keyboardLayout":"en-US",
         "gameLanguage":"en_US", "enablePersistingInGameSettings":false, "enableL4S":false,
-        "identifyAsSteamDeck":false, "enableCloudGsync":false, "discordRichPresence":false,
+        "identifyAsSteamDeck":false, "steamBigPictureMode":false,
+        "enableCloudGsync":false, "discordRichPresence":false,
         "autoCheckForUpdates":true, "updateChannel":"stable",
         "allowEscapeToExitFullscreen":false, "lastSeenReleaseHighlightsVersion":"",
         "videoShader":{"enabled":false,"sharpen":40,"saturation":100,"contrast":100,"brightness":100,"vibrance":0,"filmGrain":0},
@@ -679,6 +680,34 @@ fn defaults() -> Map<String, Value> {
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn steam_big_picture_is_opt_in_and_persists_independently() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = env::temp_dir().join(format!("opennow-big-picture-{unique}"));
+        let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["steamBigPictureMode"], false);
+        store.set("launchInConsoleMode", json!(true)).unwrap();
+        store.set("controllerMode", json!(true)).unwrap();
+        let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["steamBigPictureMode"], false);
+        store.set("steamBigPictureMode", json!(true)).unwrap();
+        let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["steamBigPictureMode"], true);
+        store.set("launchInConsoleMode", json!(false)).unwrap();
+        store.set("controllerMode", json!(false)).unwrap();
+        assert_eq!(store.all()["steamBigPictureMode"], true);
+        store.set("steamBigPictureMode", json!(false)).unwrap();
+        let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["steamBigPictureMode"], false);
+        store.set("steamBigPictureMode", json!(true)).unwrap();
+        store.reset().unwrap();
+        assert_eq!(store.all()["steamBigPictureMode"], false);
+        fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn console_switching_is_opt_in_and_manual_desktop_survives_reload() {

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -27,7 +27,11 @@ if(BUILD_TESTING)
     endif()
     set_tests_properties(opennow-frameinterpolator-tests PROPERTIES TIMEOUT 60)
     qt_add_resources(opennow-qt "region-ping-acceptance"
-        PREFIX "/acceptance" BASE tests FILES tests/RegionPingAcceptance.qml tests/StorePagingAcceptance.qml tests/BackendAvailabilityAcceptance.qml tests/StreamRecoveryAcceptance.qml tests/IdleModeAcceptance.qml tests/FrameGenerationAcceptance.qml)
+        PREFIX "/acceptance" BASE tests FILES tests/RegionPingAcceptance.qml tests/StorePagingAcceptance.qml tests/BackendAvailabilityAcceptance.qml tests/StreamRecoveryAcceptance.qml tests/IdleModeAcceptance.qml tests/FrameGenerationAcceptance.qml tests/SteamBigPictureAcceptance.qml)
+    add_test(NAME qml-steam-big-picture
+        COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
+            --route settings-streaming --smoke-steam-big-picture --reduced-motion)
+    set_tests_properties(qml-steam-big-picture PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
     add_test(NAME qml-frame-generation
         COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
             --route settings-streaming --smoke-frame-generation --reduced-motion)

--- a/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
+++ b/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
@@ -24,7 +24,7 @@ FocusScope {
     signal requestConsoleMode(bool enabled)
 
     readonly property var sections: [
-        {label: qsTr("Stream"), detail: qsTr("Picture, codec, bitrate"), icon: "monitor", page: 3, keywords: "resolution fps hdr color audio stats overlay bitrate codec reflex backend gpu directx vulkan"},
+        {label: qsTr("Stream"), detail: qsTr("Picture, codec, bitrate"), icon: "monitor", page: 3, keywords: "resolution fps hdr color audio stats overlay bitrate codec reflex backend gpu directx vulkan steam big picture launch gamepad"},
         {label: qsTr("Audio"), detail: qsTr("Output and stream audio"), icon: "wave", page: 4, keywords: "sound audio volume output microphone"},
         {label: qsTr("Controls"), detail: qsTr("Pads, mouse, shortcuts"), icon: "controller", page: 5, keywords: "controller gyroscope steam sensitivity keyboard language shortcuts"},
         {label: qsTr("Look"), detail: qsTr("Theme, accent, layout"), icon: "palette", page: 8, keywords: "theme accent interface language scale motion console sidebar tiles"},

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
@@ -11,6 +11,19 @@ Column {
     width: page.availableWidth; spacing: 20
     DesktopSettingsPanel {
         width: parent.width; paperStyle: true
+        DesktopSettingsRow {
+            width: parent.width; paperStyle: true; glyph: "controller"; title: qsTr("Steam Big Picture mode")
+            description: qsTr("Request gamepad-friendly launchers such as Steam Big Picture. Applies to new GeForce NOW sessions only.")
+            showDivider: false
+            DesktopSettingsToggle {
+                objectName: "steamBigPictureToggle"
+                checked: page.settingsScreen.boolSetting("steamBigPictureMode", false)
+                onValueChangedByUser: value => page.settingsScreen.setSetting("steamBigPictureMode", value)
+            }
+        }
+    }
+    DesktopSettingsPanel {
+        width: parent.width; paperStyle: true
         DesktopSettingsSection { text: qsTr("PICTURE") }
         DesktopSettingsResolution {
             width: parent.width; items: page.settingsScreen.resolutionItems()

--- a/opennow-qt/qml/screens/SettingsScreen.qml
+++ b/opennow-qt/qml/screens/SettingsScreen.qml
@@ -362,6 +362,7 @@ FocusScope {
             ]
             const shaderIndex = shader.enabled ? (Number(shader.filmGrain || 0) > 0 ? 3 : Number(shader.vibrance || 0) > 0 ? 2 : 1) : 0
             return [
+                toggle(qsTr("Steam Big Picture mode"), qsTr("Request gamepad-friendly launchers such as Steam Big Picture. Applies to new GeForce NOW sessions only."), "steamBigPictureMode"),
                 {t:"Display", d:"The Qt stream surface uses the current display", v:"Monitor 1 · current display", info:true},
                 choice("Resolution", "Exact stream size · up / down to browse, A to pick", "resolution", resolutions, resolutionLabels(resolutions)),
                 choice("Frame rate", root.fpsNote(), "fps", frameRates, frameRates.map(value => String(value)), "segments", root.fpsLockedValues()),

--- a/opennow-qt/qml/state/ShellStore.qml
+++ b/opennow-qt/qml/state/ShellStore.qml
@@ -964,7 +964,7 @@ QtObject {
             title: selectedGame.title || "GeForce NOW game",
             supportsInGameSettingsPersistence: Boolean(selectedVariant && selectedVariant.supportsInGameSettingsPersistence),
             accountLinked: Boolean(selectedVariant && selectedVariant.inLibrary),
-            appLaunchMode: Boolean(settings.controllerMode || settings.launchInConsoleMode || directConsoleMode)
+            appLaunchMode: settings.steamBigPictureMode === true
                 ? "gamepadFriendly" : "default"
         }
         const configuredRegion = String(settings.region || "")

--- a/opennow-qt/src/acceptance/SmokeAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SmokeAcceptance.cpp
@@ -74,9 +74,12 @@ int AcceptanceSession::startSmokeWorkload()
             });
         });
     } else if (m_smokeTest && (m_arguments.contains(u"--smoke-backend-availability"_s)
+                     || m_arguments.contains(u"--smoke-steam-big-picture"_s)
                      || m_arguments.contains(u"--smoke-idle-mode"_s)
                      || m_arguments.contains(u"--smoke-stream-recovery"_s))) {
-        QQmlComponent component(&m_engine, QUrl(m_arguments.contains(u"--smoke-idle-mode"_s)
+        QQmlComponent component(&m_engine, QUrl(m_arguments.contains(u"--smoke-steam-big-picture"_s)
+            ? u"qrc:/acceptance/SteamBigPictureAcceptance.qml"_s
+            : m_arguments.contains(u"--smoke-idle-mode"_s)
             ? u"qrc:/acceptance/IdleModeAcceptance.qml"_s
             : m_arguments.contains(u"--smoke-stream-recovery"_s)
             ? u"qrc:/acceptance/StreamRecoveryAcceptance.qml"_s
@@ -84,7 +87,8 @@ int AcceptanceSession::startSmokeWorkload()
         auto *fixture = component.create();
         if (!fixture) { qCritical() << component.errors(); return EXIT_FAILURE; }
         fixture->setParent(&m_engine);
-        if (m_arguments.contains(u"--smoke-stream-recovery"_s)) {
+        if (m_arguments.contains(u"--smoke-stream-recovery"_s)
+            || m_arguments.contains(u"--smoke-steam-big-picture"_s)) {
             auto *client = fixture->property("client").value<QObject *>();
             if (!client) return EXIT_FAILURE;
             m_engine.rootContext()->setContextProperty(u"CoreClient"_s, client);

--- a/opennow-qt/tests/SteamBigPictureAcceptance.qml
+++ b/opennow-qt/tests/SteamBigPictureAcceptance.qml
@@ -1,0 +1,82 @@
+import QtQuick
+import OpenNOW
+
+QtObject {
+    property Component consoleSettings: Component { SettingsScreen { visible: false; selectedSection: 2 } }
+    property QtObject client: QtObject {
+        property string state: "stopped"
+        property string lastError: ""
+        property var calls: []
+        signal responseReceived(string requestId, var result)
+        signal requestFailed(string requestId, string code, string message)
+        signal eventReceived(string name, var payload)
+        function logShellDiagnostic(message) {}
+        function request(method, params, timeout) {
+            const id = "fixture-" + (calls.length + 1)
+            calls = calls.concat([{id:id, method:method, params:params}])
+            return id
+        }
+        function cancel(id) { return true }
+    }
+    function check(ok, message) { if (!ok) throw new Error("Steam Big Picture: " + message) }
+    function find(item, name) {
+        if (item.objectName === name) return item
+        for (const child of item.children || []) {
+            const found = find(child, name)
+            if (found) return found
+        }
+        return null
+    }
+    function run(parent) {
+        client.state = "ready"
+        ShellStore.settings = {controllerMode:true, launchInConsoleMode:true}
+        const toggle = find(parent, "steamBigPictureToggle")
+        check(toggle && !toggle.checked, "desktop setting defaults off despite controller and console preferences")
+        toggle.clicked()
+        check(ShellStore.settings.steamBigPictureMode === true && toggle.checked, "desktop toggle opts in")
+        const write = client.calls[client.calls.length - 1]
+        check(write.method === "settings.set" && write.params.key === "steamBigPictureMode" && write.params.value === true,
+            "desktop toggle requests persistence")
+        toggle.clicked()
+        check(ShellStore.settings.steamBigPictureMode === false && !toggle.checked, "desktop toggle opts out")
+        const consolePage = consoleSettings.createObject(parent)
+        const row = consolePage.settingsModel().find(item => item.key === "steamBigPictureMode")
+        check(row && row.toggle && row.v === "Off", "console Video page exposes the same default-off preference")
+        consolePage.activate(row)
+        const consoleWrite = client.calls[client.calls.length - 1]
+        check(consoleWrite.method === "settings.set" && consoleWrite.params.key === "steamBigPictureMode"
+            && consoleWrite.params.value === true, "console toggle requests the same persisted opt-in")
+        client.eventReceived("settings.changed", {key:"steamBigPictureMode", value:true})
+        check(consolePage.settingsModel().find(item => item.key === "steamBigPictureMode").v === "On" && toggle.checked,
+            "both controls reflect the persisted value")
+        consolePage.destroy()
+
+        ShellStore.nativeRuntimeReady = true
+        ShellStore.authSession = {accountId:"fixture"}
+        ShellStore.selectedGame = {title:"Fixture", launchAppId:"12345", variants:[]}
+        for (const enabled of [undefined, false, true, false]) {
+            for (const controller of [false, true]) {
+                for (const consoleMode of [false, true]) {
+                    for (const directConsoleMode of [false, true]) {
+                        ShellStore.settings = {
+                            steamBigPictureMode:enabled,
+                            controllerMode:controller,
+                            launchInConsoleMode:consoleMode
+                        }
+                        ShellStore.launchSelectedGame(directConsoleMode)
+                        const request = client.calls[client.calls.length - 1]
+                        check(request.method === "session.remote.list", "launch checks existing sessions first")
+                        check(request.params.appLaunchMode === (enabled === true ? "gamepadFriendly" : "default"),
+                            "only explicit Big Picture opt-in selects gamepad-friendly mode")
+                        ShellStore.createPendingSession()
+                        const create = client.calls[client.calls.length - 1]
+                        check(create.method === "session.create" && create.params.appLaunchMode === request.params.appLaunchMode,
+                            "session creation preserves the selected launch mode")
+                        ShellStore.streamCreateRequestId = ""
+                    }
+                }
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
Game launches selected GFN's gamepad-friendly mode whenever controller support was enabled, which defaults to true. This also coupled the remote launcher mode to OpenNOW's console interface.

Add a persisted, default-off **Steam Big Picture mode** toggle in console **Video & display** and desktop **Stream** settings. Only this explicit preference selects `appLaunchMode: 2`; off or absent selects normal mode (`1`). Controller support and OpenNOW console/fullscreen preferences stay independent. The setting applies to new sessions, not an already-running or resumed session.

## Verification
- Full Qt 6.8.3 / SDL 3.2.20 Debug build passed.
- All **165 Qt tests passed**, including the new acceptance test covering both controls and 32 launch-policy combinations through discovery and session creation. Two graphics tests initially lacked X11 runtime libraries; after installing those dependencies, the full suite passed.
- Rust core tests, strict all-targets Clippy, and formatting passed. Added persistence/default/reset and CloudMatch wire-mode regressions.
- QML lint target passed with warnings; localization validation and all six validator tests passed.
- Captured and inspected both settings pages in the native X11 application using account-free smoke fixtures. No live GFN account or Steam session was used.

### Console Video settings
![Steam Big Picture mode defaults off in Video & display](https://api-nightly.capy.ai/pr-assets/wIVSIekPS7K3XeJd9EaYKWlc7M7bnqGMNMzjXpCX8Eo)

### Desktop Stream settings
![Steam Big Picture mode defaults off in desktop Stream settings](https://api-nightly.capy.ai/pr-assets/pP3pq9wGHqMsOEs_kF-ojzvc8B7NbseIu2KMFEKAOsY)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1YPAJAKE2GWKZEHKJ0J5Q6Z"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->