### PR TITLE
fix(qt): group server regions and simplify network settings

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,7 @@
 {
   "desktopRenewRemaining": {
+    "regionAfrica": "AFRICA",
+    "searchRegions": "Search regions…",
     "languageJapanese": "Japanese",
     "languageKorean": "Korean",
     "languageChinese": "Chinese",

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -27,7 +27,7 @@ if(BUILD_TESTING)
     endif()
     set_tests_properties(opennow-frameinterpolator-tests PROPERTIES TIMEOUT 60)
     qt_add_resources(opennow-qt "region-ping-acceptance"
-        PREFIX "/acceptance" BASE tests FILES tests/RegionPingAcceptance.qml tests/StorePagingAcceptance.qml tests/BackendAvailabilityAcceptance.qml tests/StreamRecoveryAcceptance.qml tests/IdleModeAcceptance.qml tests/FrameGenerationAcceptance.qml tests/SteamBigPictureAcceptance.qml)
+        PREFIX "/acceptance" BASE tests FILES tests/RegionPingAcceptance.qml tests/RegionChoicesAcceptance.qml tests/StorePagingAcceptance.qml tests/BackendAvailabilityAcceptance.qml tests/StreamRecoveryAcceptance.qml tests/IdleModeAcceptance.qml tests/FrameGenerationAcceptance.qml tests/SteamBigPictureAcceptance.qml)
     add_test(NAME qml-steam-big-picture
         COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
             --route settings-streaming --smoke-steam-big-picture --reduced-motion)

--- a/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
+++ b/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
@@ -29,7 +29,7 @@ FocusScope {
         {label: qsTr("Controls"), detail: qsTr("Pads, mouse, shortcuts"), icon: "controller", page: 5, keywords: "controller gyroscope steam sensitivity keyboard language shortcuts"},
         {label: qsTr("Look"), detail: qsTr("Theme, accent, layout"), icon: "palette", page: 8, keywords: "theme accent interface language scale motion console sidebar tiles"},
         {label: qsTr("Console mode"), detail: qsTr("Gamepad-first interface"), icon: "controller", page: 9, keywords: "console fullscreen gamepad startup"},
-        {label: qsTr("Network"), detail: qsTr("Region, ping, proxy"), icon: "globe", page: 6, keywords: "server region ping proxy bandwidth l4s"},
+        {label: qsTr("Network"), detail: qsTr("Region, ping, proxy"), icon: "globe", page: 6, keywords: "server region ping proxy l4s"},
         {label: qsTr("Account"), detail: qsTr("NVIDIA, stores, privacy"), icon: "person", page: 0, keywords: "profile subscription stores steam epic xbox ubisoft battle gaijin privacy"},
         {label: qsTr("About"), detail: qsTr("Updates, diagnostics"), icon: "info", page: 11, keywords: "version release update diagnostics"}
     ]
@@ -161,40 +161,43 @@ FocusScope {
     }
 
     function regionGroup(name) {
-        const n = String(name || "").toLowerCase()
-        if (n.indexOf("us ") === 0 || n.indexOf("us-") === 0 || n.indexOf("ca ") === 0 || n.indexOf("canada") >= 0 || n.indexOf("north america") >= 0)
+        const n = String(name || "").trim().toLowerCase()
+        if (/^(us|ca)\b|\b(usa|canada|north america)\b/.test(n))
             return qsTr("NORTH AMERICA")
-        if (n.indexOf("eu ") === 0 || n.indexOf("eu-") === 0 || n.indexOf("uk") === 0 || n.indexOf("europe") >= 0 || n.indexOf("london") >= 0 || n.indexOf("frankfurt") >= 0 || n.indexOf("amsterdam") >= 0)
+        if (/^(eu|uk|tr)\b|\b(europe|united kingdom|sweden|netherlands|germany|france|poland|bulgaria|turkey|türkiye|london|frankfurt|amsterdam)\b/.test(n))
             return qsTr("EUROPE")
-        if (n.indexOf("jp") === 0 || n.indexOf("kr") === 0 || n.indexOf("sg") === 0 || n.indexOf("au") === 0 || n.indexOf("asia") >= 0 || n.indexOf("tokyo") >= 0 || n.indexOf("seoul") >= 0 || n.indexOf("singapore") >= 0 || n.indexOf("sydney") >= 0 || n.indexOf("india") >= 0)
+        if (/^(jp|kr|sg|au|tw|my|th)\b|\b(asia|japan|korea|taiwan|malaysia|thailand|australia|new zealand|tokyo|seoul|singapore|sydney|india)\b/.test(n))
             return qsTr("ASIA PACIFIC")
-        if (n.indexOf("br") === 0 || n.indexOf("south america") >= 0 || n.indexOf("brazil") >= 0 || n.indexOf("sao") >= 0)
+        if (/^br\b|\b(latam|south america|brazil|sao|são|chile|colombia|uruguay)\b/.test(n))
             return qsTr("SOUTH AMERICA")
-        if (n.indexOf("me ") === 0 || n.indexOf("middle") >= 0 || n.indexOf("uae") >= 0)
+        if (/^me\b|\b(middle east|uae|saudi|riyadh)\b/.test(n))
             return qsTr("MIDDLE EAST")
+        if (/\b(africa|johannesburg)\b/.test(n))
+            return qsTr("AFRICA")
         return qsTr("OTHER")
     }
 
     function regionChoiceItems() {
         const items = [{ kind: "choice", label: qsTr("Automatic"), detail: qsTr("Lowest latency"), value: "" }]
-        const regions = (ShellStore.regions || []).slice()
-        let lastGroup = ""
-        for (let i = 0; i < regions.length; ++i) {
-            const region = regions[i]
-            const group = root.regionGroup(region.name)
-            if (group !== lastGroup) {
-                items.push({ kind: "heading", label: group })
-                lastGroup = group
+        const groups = [qsTr("EUROPE"), qsTr("NORTH AMERICA"), qsTr("ASIA PACIFIC"),
+                        qsTr("SOUTH AMERICA"), qsTr("MIDDLE EAST"), qsTr("AFRICA"), qsTr("OTHER")]
+        const regions = (ShellStore.regions || []).slice().sort((a, b) => String(a.name).localeCompare(String(b.name)))
+        for (const group of groups) {
+            const members = regions.filter(region => root.regionGroup(region.name) === group)
+            if (!members.length)
+                continue
+            items.push({ kind: "heading", label: group })
+            for (const region of members) {
+                const ping = root.regionPingMs(region.url)
+                items.push({
+                    kind: "choice",
+                    label: region.name,
+                    detail: ShellStore.regionPingBusy ? qsTr("Measuring…") : ping !== null ? (ping + " ms")
+                        : ShellStore.regionPingResults[region.url] === null ? qsTr("No response") : qsTr("Not measured"),
+                    detailColor: ping === null ? "" : root.pingRankColor(ping),
+                    value: region.url
+                })
             }
-            const ping = root.regionPingMs(region.url)
-            items.push({
-                kind: "choice",
-                label: region.name,
-                detail: ShellStore.regionPingBusy ? qsTr("Measuring…") : ping !== null ? (ping + " ms")
-                    : ShellStore.regionPingResults[region.url] === null ? qsTr("No response") : qsTr("Not measured"),
-                detailColor: ping === null ? "" : root.pingRankColor(ping),
-                value: region.url
-            })
         }
         return items
     }

--- a/opennow-qt/qml/desktop/settings/controls/DesktopSettingsChoice.qml
+++ b/opennow-qt/qml/desktop/settings/controls/DesktopSettingsChoice.qml
@@ -14,6 +14,9 @@ Item {
     property string valueLabel: ""
     property bool expanded: false
     property bool showDivider: true
+    property int maximumColumns: 0
+    property real maximumOptionsHeight: DesktopTokens.px(260)
+    property string filterPlaceholder: qsTr("Filter options…")
     signal selected(var value)
     readonly property var current: items.find(item => item.kind !== "heading" && String(item.value) === String(root.value))
     readonly property var groups: {
@@ -28,7 +31,7 @@ Item {
         return groups.filter(group => group.items.length)
     }
     readonly property real revealProgress: reveal.progress
-    readonly property real optionsHeight: Math.min(DesktopTokens.px(260), grid.implicitHeight + 12)
+    readonly property real optionsHeight: Math.min(maximumOptionsHeight, grid.implicitHeight + 12)
     implicitHeight: header.height + (search.height + optionsHeight + 28) * reveal.progress
     clip: true
     MotionProgress { id: reveal; shown: root.expanded; enterDuration: 200; exitDuration: 160 }
@@ -65,7 +68,8 @@ Item {
         enabled: root.expanded
         opacity: reveal.progress
         x: 20; y: header.height; width: parent.width - 40
-        placeholderText: qsTr("Filter options…")
+        placeholderText: root.filterPlaceholder
+        onTextChanged: scroll.contentY = 0
         Accessible.name: root.title + ": " + placeholderText
         Keys.onEscapePressed: event => { root.expanded = false; event.accepted = true }
     }
@@ -78,11 +82,11 @@ Item {
         height: root.optionsHeight
         contentWidth: width; contentHeight: grid.implicitHeight
         clip: true; boundsBehavior: Flickable.StopAtBounds
-        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+        ScrollBar.vertical: ScrollBar { policy: scroll.contentHeight > scroll.height ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff }
         Keys.onEscapePressed: event => { root.expanded = false; event.accepted = true }
         Column {
             id: grid
-            width: parent.width; spacing: 14
+            width: parent.width - 12; spacing: 14
             Repeater {
                 model: root.groups
                 delegate: Column {
@@ -96,7 +100,7 @@ Item {
                     }
                     Flow {
                         width: parent.width; spacing: 8
-                        readonly property int columns: Math.max(1, Math.floor((width+8)/(DesktopTokens.px(200)+8)))
+                        readonly property int columns: Math.max(1, Math.min(root.maximumColumns || 1000, Math.floor((width+8)/(DesktopTokens.px(200)+8))))
                         Repeater {
                             model: modelData.items
                             delegate: AbstractButton {

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsNetworkPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsNetworkPage.qml
@@ -17,6 +17,9 @@ Column {
             objectName: "renewNetworkRegion"
             width: parent.width; glyph: "globe"; title: qsTr("Server region")
             description: ShellStore.regions.length ? qsTr("%1 streaming regions from your account").arg(ShellStore.regions.length) : qsTr("Sign in to discover available regions")
+            maximumColumns: 4
+            maximumOptionsHeight: DesktopTokens.px(420)
+            filterPlaceholder: qsTr("Search regions…")
             items: page.settingsScreen.regionChoiceItems()
             value: {
                 const selected = String(page.settingsScreen.valueSetting("region",""))
@@ -29,6 +32,7 @@ Column {
         DesktopSettingsRow {
             objectName: "renewRegionLatency"
             width: parent.width; paperStyle: true; glyph: "speed"; title: qsTr("Region latency")
+            showDivider: false
             description: ShellStore.regionPingMessage || qsTr("Measure available regions before your next session")
             value: ShellStore.regionPingBusy || page.settingsScreen.currentRegionPing() === null ? ""
                 : page.settingsScreen.valueSetting("region", "") === "" ? qsTr("Best: %1 ms").arg(page.settingsScreen.currentRegionPing())
@@ -38,17 +42,6 @@ Column {
                 text: ShellStore.regionPingPending ? qsTr("Loading…") : ShellStore.regionPingBusy ? qsTr("Pinging…") : qsTr("Ping regions")
                 enabled: !ShellStore.regionPingBusy
                 onClicked: ShellStore.pingRegions()
-            }
-        }
-        DesktopSettingsRow {
-            id: bandwidthRow
-            width: parent.width; paperStyle: true; glyph: "wave"; title: qsTr("Bandwidth ceiling")
-            description: qsTr("Maximum requested bitrate"); showDivider: false
-            DesktopSettingsSlider {
-                trackWidth: Math.max(DesktopTokens.px(160), bandwidthRow.width-DesktopTokens.px(460))
-                from: 10; to: 200; stepSize: 5; suffix: " Mbps"
-                value: Number(page.settingsScreen.valueSetting("maxBitrateMbps",75))
-                onCommitted: value => page.settingsScreen.setSetting("maxBitrateMbps",Math.round(value))
             }
         }
     }

--- a/opennow-qt/tests/RegionChoicesAcceptance.qml
+++ b/opennow-qt/tests/RegionChoicesAcceptance.qml
@@ -1,0 +1,83 @@
+import QtQuick
+import OpenNOW
+
+QtObject {
+    function check(condition, message) {
+        if (!condition) throw new Error("Region choices acceptance: " + message)
+    }
+
+    readonly property var locations: [
+        {group: "EUROPE", names: ["United Kingdom 1", "United Kingdom 2", "Sweden", "Netherlands North", "Netherlands South", "Germany", "France 1", "France 2", "Poland", "Bulgaria"]},
+        {group: "NORTH AMERICA", names: ["Northern California (USA)", "Southern California (USA)", "Oregon (USA)", "Arizona (USA)", "Texas (USA)", "Illinois (USA)", "Florida (USA)", "Georgia (USA)", "Virginia (USA)", "New Jersey (USA)", "Ontario (Canada)", "Quebec (Canada)"]},
+        {group: "ASIA PACIFIC", names: ["India", "Japan"]}
+    ]
+
+    function run(screen, picker) {
+        const original = ShellStore.regions
+        const fixtures = []
+        for (const location of locations) {
+            for (const name of location.names) {
+                check(screen.regionGroup(name) === location.group, name + " has the wrong continent")
+                check(screen.regionGroup(name + " [RTX 5080]") === location.group, name + " with a hardware suffix")
+                fixtures.push({name: name, url: "https://region-" + fixtures.length + ".example.invalid/"})
+            }
+        }
+        for (const sample of [
+            ["EU West", "EUROPE"], ["EU-Central", "EUROPE"], ["US East", "NORTH AMERICA"],
+            ["TW TWM 1", "ASIA PACIFIC"], ["KR GFN1", "ASIA PACIFIC"], ["MY YES", "ASIA PACIFIC"],
+            ["TH BPC", "ASIA PACIFIC"], ["AU East 1", "ASIA PACIFIC"], ["TR Central 1", "EUROPE"],
+            ["LATAM North", "SOUTH AMERICA"], ["LATAM South", "SOUTH AMERICA"],
+            ["Africa South", "AFRICA"], ["ME Central", "MIDDLE EAST"],
+            ["Unknown location", "OTHER"], ["Auburn", "OTHER"], ["Brand new location", "OTHER"]
+        ])
+            check(screen.regionGroup(sample[0]) === sample[1], "legacy/partner/boundary match: " + sample[0])
+
+        fixtures.push({name: "A new location", url: "https://new.example.invalid/"})
+        fixtures.push({name: "Z new location", url: "https://another.example.invalid/"})
+        fixtures.sort((a, b) => a.name.localeCompare(b.name))
+        ShellStore.regions = fixtures
+        const items = screen.regionChoiceItems()
+        check(items[0].value === "" && items[0].label === "Automatic", "automatic remains first")
+        const headings = items.filter(item => item.kind === "heading").map(item => item.label)
+        check(JSON.stringify(headings) === JSON.stringify(["EUROPE", "NORTH AMERICA", "ASIA PACIFIC", "OTHER"]), "one contiguous section per continent, with unknown locations last")
+        const choices = items.filter(item => item.kind === "choice" && item.value !== "")
+        check(choices.length === fixtures.length, "every account region remains selectable")
+        let group = ""
+        let previousName = ""
+        for (const item of items.slice(1)) {
+            if (item.kind === "heading") {
+                group = item.label
+                previousName = ""
+            } else {
+                check(screen.regionGroup(item.label) === group, "choice under wrong heading")
+                check(previousName.localeCompare(item.label) <= 0, "alphabetical order within a section")
+                check(fixtures.some(region => region.name === item.label && region.url === item.value), "account name and endpoint must be preserved")
+                previousName = item.label
+            }
+        }
+        check(ShellStore.regions === fixtures, "grouping must not replace account data")
+        check(fixtures[0].name === "A new location", "grouping must not reorder account data")
+        check(picker.maximumColumns === 4 && picker.maximumOptionsHeight > 260, "readable grid with more room for regions")
+        const search = picker.children.find(child => child.placeholderText === picker.filterPlaceholder)
+        check(Boolean(search), "region search is available")
+        search.text = "europe"
+        check(picker.groups.length === 1 && picker.groups[0].items.length === 10, "continent search keeps the complete European group")
+        search.text = "japan"
+        check(picker.groups.length === 1 && picker.groups[0].label === "ASIA PACIFIC"
+              && picker.groups[0].items.length === 1, "country search keeps its heading")
+        search.text = "no such region"
+        check(picker.groups.length === 0, "unmatched search has no orphan headings")
+        search.text = ""
+        check(picker.groups.length === 5, "clearing search restores Automatic and every group")
+        const pending = [screen]
+        while (pending.length) {
+            const item = pending.pop()
+            check(item.title !== "Bandwidth ceiling", "Network must not duplicate the stream bitrate setting")
+            for (const child of item.children || []) pending.push(child)
+        }
+        ShellStore.regions = []
+        check(screen.regionChoiceItems().length === 1, "empty discovery keeps only Automatic")
+        ShellStore.regions = original
+        return true
+    }
+}

--- a/opennow-qt/tests/RegionPingAcceptance.qml
+++ b/opennow-qt/tests/RegionPingAcceptance.qml
@@ -5,6 +5,7 @@ import OpenNOW
 // unchanged, but no request can reach an account or the network.
 QtObject {
     id: test
+    property RegionChoicesAcceptance regionChoices: RegionChoicesAcceptance {}
     property QtObject client: QtObject {
         property string state: "ready"
         property string lastError: ""
@@ -38,6 +39,7 @@ QtObject {
         return false
     }
     function run(screen, row, button, picker) {
+        regionChoices.run(screen, picker)
         ShellStore.resetRegionPing()
         ShellStore.regionsRequestId = ""
         ShellStore.regions = []


### PR DESCRIPTION
## Changes
- Recognize NVIDIA’s current country/state region names from [GeForce NOW Status](https://status.geforcenow.com/), alongside legacy and alliance region labels. Emit each geographical heading once, alphabetize within groups, and keep unknown locations at the end without changing account names or endpoints.
- Give the region selector a maximum of four columns, a taller options area, a region-specific search placeholder, and a persistent scrollbar when the list overflows. Reset scrolling when filtering and leave space beside tiles for the scrollbar.
- Remove the duplicate **Bandwidth ceiling** row from Network. The existing Stream bitrate control and saved setting are unchanged.
- Add grouping and search regression coverage to the existing region-ping acceptance workload, including all 24 current NVIDIA locations, legacy/partner names, unknown locations, empty results, and the removed duplicate control.

## Verification
- Passed the new `RegionChoicesAcceptance.qml` checks against the actual settings-screen, network-page, and choice-control QML in a Qt 6.8.3/PySide6 source-module harness at widths 960, 1440, and 2000. The harness used an isolated ShellStore fixture, not a live account.
- Visually inspected the rendered Qt controls and exercised country search, selection, and Escape dismissal.
- Passed QML parsing for all changed QML files, `npm run locales:check`, and `git diff --check`.
- Standalone `qmllint` reports the existing unqualified delegate-access/missing-parent-type warning classes, including the new column-limit access; it is not warning-clean.
- Full CMake build/CTest could not run: `cmake -S opennow-qt -B build/opennow-qt -DCMAKE_BUILD_TYPE=Debug` stops at `find_package(Qt6 6.8)` because the sandbox has no Qt development SDK. The installed PySide runtime permits isolated QML verification only.

## Preview
Actual production QML with synthetic account endpoints and NVIDIA’s current location names; no live latency results.

![Grouped server region selector](https://api-nightly.capy.ai/pr-assets/WV3AkQvmmxy-fG_PTj1ZW6ZIw9uEgUSr-R6QghLusuY)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1YPX2G64HG9N6VGRYK1B5E5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->