### PR TITLE
feat(qt): add custom background images and opacity controls

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,18 @@
 {
+  "customBackground": {
+    "chooseTitle": "Choose a background image",
+    "imageFilter": "Images (*.png *.jpg *.jpeg *.webp *.bmp)",
+    "description": "Game art, a custom image, gradient or solid color",
+    "custom": "Custom",
+    "image": "Custom image",
+    "unavailable": "Image unavailable. Choose another file or remove it.",
+    "keepLocation": "Keep the image in its original location",
+    "formats": "Choose a local PNG, JPEG, WebP or BMP image",
+    "choose": "Choose image…",
+    "remove": "Remove",
+    "opacity": "Image opacity",
+    "opacityDescription": "0% hides the image · 100% shows the full image"
+  },
   "desktopRenewRemaining": {
     "languageJapanese": "Japanese",
     "languageKorean": "Korean",

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -137,9 +137,23 @@ impl SettingsStore {
         normalize_choice(
             &mut self.values,
             "desktopBackground",
-            &["art", "gradient", "solid"],
+            &["art", "gradient", "solid", "custom"],
             "art",
         );
+        clamp_integer(&mut self.values, "desktopBackgroundOpacity", 0, 100, 30);
+        let background_image = self.values["desktopBackgroundImage"].as_str().unwrap_or("");
+        if !background_image.is_empty()
+            && (background_image.len() > 8192
+                || !url::Url::parse(background_image).is_ok_and(|url| {
+                    url.scheme() == "file"
+                        && url.to_file_path().is_ok()
+                        && url.query().is_none()
+                        && url.fragment().is_none()
+                }))
+        {
+            self.values
+                .insert("desktopBackgroundImage".to_owned(), json!(""));
+        }
         normalize_choice(
             &mut self.values,
             "aspectRatio",
@@ -657,6 +671,7 @@ fn defaults() -> Map<String, Value> {
         "reducedMotion":false,
         "launchInConsoleMode":false, "consoleProfilePickerOnLaunch":true,
         "desktopRailCollapsed":true, "desktopSidebarHover":true, "desktopBackground":"art",
+        "desktopBackgroundImage":"", "desktopBackgroundOpacity":30,
         "switchToConsoleOnPad":false, "leaveConsoleOnPointer":true,
         "autoFullScreen":false, "favoriteGameIds":[], "hiddenGameIds":[], "homeTileSizes":{}, "sessionCounterEnabled":false,
         "showSessionReport":true, "showSessionTimeRemainingInStatsOverlay":false,
@@ -728,6 +743,72 @@ mod tests {
         let persisted: Value =
             serde_json::from_slice(&fs::read(directory.join("settings.json")).unwrap()).unwrap();
         assert_eq!(persisted["unrelatedLegacySetting"], json!("preserve"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn custom_background_preferences_are_bounded_and_persisted() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = env::temp_dir().join(format!("opennow-background-{unique}"));
+        let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["desktopBackgroundImage"], json!(""));
+        assert_eq!(store.all()["desktopBackgroundOpacity"], json!(30));
+        assert_eq!(
+            store.set("desktopBackground", json!("custom")).unwrap(),
+            json!("custom")
+        );
+
+        let image = url::Url::from_file_path(directory.join("写真 #1.png"))
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            store.set("desktopBackgroundImage", json!(image)).unwrap(),
+            json!(image)
+        );
+        for (input, expected) in [
+            (json!(-10), 0),
+            (json!(110), 100),
+            (json!(0), 0),
+            (json!(65), 65),
+            (json!(null), 30),
+            (json!("50"), 30),
+        ] {
+            assert_eq!(
+                store.set("desktopBackgroundOpacity", input).unwrap(),
+                json!(expected)
+            );
+        }
+        store.set("desktopBackgroundOpacity", json!(65)).unwrap();
+        let reloaded = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(reloaded.all()["desktopBackground"], json!("custom"));
+        assert_eq!(reloaded.all()["desktopBackgroundImage"], json!(image));
+        assert_eq!(reloaded.all()["desktopBackgroundOpacity"], json!(65));
+
+        for invalid in [
+            "https://example.com/image.png",
+            "qrc:/image.png",
+            "relative.png",
+            "file:///image.png?download=1",
+            "file:///image.png#fragment",
+        ] {
+            assert_eq!(
+                store.set("desktopBackgroundImage", json!(invalid)).unwrap(),
+                json!("")
+            );
+        }
+        assert_eq!(
+            store
+                .set("desktopBackgroundImage", json!("x".repeat(8193)))
+                .unwrap(),
+            json!("")
+        );
+        store.reset().unwrap();
+        assert_eq!(store.all()["desktopBackground"], json!("art"));
+        assert_eq!(store.all()["desktopBackgroundImage"], json!(""));
+        assert_eq!(store.all()["desktopBackgroundOpacity"], json!(30));
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -28,6 +28,15 @@ if(BUILD_TESTING)
     set_tests_properties(opennow-frameinterpolator-tests PROPERTIES TIMEOUT 60)
     qt_add_resources(opennow-qt "region-ping-acceptance"
         PREFIX "/acceptance" BASE tests FILES tests/RegionPingAcceptance.qml tests/StorePagingAcceptance.qml tests/BackendAvailabilityAcceptance.qml tests/StreamRecoveryAcceptance.qml tests/IdleModeAcceptance.qml tests/FrameGenerationAcceptance.qml)
+    qt_add_resources(opennow-qt "custom-background-acceptance"
+        PREFIX "/acceptance" BASE tests FILES tests/CustomBackgroundAcceptance.qml)
+    foreach(width 960 1600)
+        add_test(NAME qml-custom-background-${width}
+            COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
+                --route settings-themes --smoke-custom-background --smoke-width ${width} --reduced-motion)
+        set_tests_properties(qml-custom-background-${width} PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
+    endforeach()
     add_test(NAME qml-frame-generation
         COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
             --route settings-streaming --smoke-frame-generation --reduced-motion)

--- a/opennow-qt/qml/desktop/components/DesktopBackdrop.qml
+++ b/opennow-qt/qml/desktop/components/DesktopBackdrop.qml
@@ -3,9 +3,11 @@ import OpenNOW
 
 Item {
     id: root
+    objectName: root.signIn ? "signInBackdrop" : "desktopBackdrop"
     property string artwork: ShellStore.catalogGames.length
         ? DesktopTokens.artworkUrl(ShellStore.catalogGames[0], true) : ""
     property bool signIn: false
+    readonly property bool customBackground: !root.signIn && ShellStore.settings.desktopBackground === "custom"
     readonly property string normalizedArtwork: root.artwork !== ""
         ? DesktopTokens.decodeArtworkUrl(root.artwork)
         : root.signIn ? "qrc:/qt/qml/OpenNOW/res/brand/signin-hero.jpg" : "qrc:/qt/qml/OpenNOW/res/brand/desktop-renew.jpg"
@@ -13,7 +15,7 @@ Item {
     ArtworkSource {
         id: artworkSource
         sourceUrl: root.normalizedArtwork
-        active: root.visible
+        active: root.visible && (root.signIn || String(ShellStore.settings.desktopBackground || "art") === "art")
     }
 
     Rectangle { anchors.fill: parent; color: root.signIn ? Theme.shell : DesktopTokens.shell }
@@ -34,6 +36,16 @@ Item {
             opacity: status === Image.Ready && (root.signIn || String(ShellStore.settings.desktopBackground || "art") === "art") ? 1 : 0
             Behavior on opacity { NumberAnimation { duration: DesktopTokens.revealDuration } }
         }
+    }
+
+    Image {
+        objectName: "customDesktopBackground"
+        anchors.fill: parent
+        source: root.visible && root.customBackground ? String(ShellStore.settings.desktopBackgroundImage || "") : ""
+        sourceSize: Qt.size(1920, 1080)
+        asynchronous: true
+        fillMode: Image.PreserveAspectCrop
+        opacity: status === Image.Ready ? Number(ShellStore.settings.desktopBackgroundOpacity ?? 30) / 100 : 0
     }
 
     Rectangle {
@@ -58,7 +70,7 @@ Item {
 
     Rectangle {
         anchors.fill: parent
-        visible: !root.signIn && String(ShellStore.settings.desktopBackground || "art") !== "solid"
+        visible: !root.signIn && !root.customBackground && String(ShellStore.settings.desktopBackground || "art") !== "solid"
         // A gradient-only background must remain visible above the darkening
         // layers used for artwork. Solid mode has neither artwork nor tint.
         z: String(ShellStore.settings.desktopBackground || "art") === "gradient" ? 1 : 0
@@ -73,9 +85,9 @@ Item {
         anchors.fill: parent
         gradient: Gradient {
             orientation: Gradient.Horizontal
-            GradientStop { position: 0; color: Qt.rgba(Theme.shell.r, Theme.shell.g, Theme.shell.b, 0.92) }
-            GradientStop { position: 0.34; color: Qt.rgba(Theme.shell.r, Theme.shell.g, Theme.shell.b, 0.78) }
-            GradientStop { position: 1; color: Qt.rgba(Theme.shell.r, Theme.shell.g, Theme.shell.b, 0.94) }
+            GradientStop { position: 0; color: Qt.rgba(Theme.shell.r, Theme.shell.g, Theme.shell.b, root.customBackground ? 0.82 : 0.92) }
+            GradientStop { position: 0.34; color: Qt.rgba(Theme.shell.r, Theme.shell.g, Theme.shell.b, root.customBackground ? 0.12 : 0.78) }
+            GradientStop { position: 1; color: Qt.rgba(Theme.shell.r, Theme.shell.g, Theme.shell.b, root.customBackground ? 0.24 : 0.94) }
         }
     }
     Rectangle {
@@ -83,7 +95,7 @@ Item {
         anchors.fill: parent
         gradient: Gradient {
             GradientStop { position: 0; color: "#00000000" }
-            GradientStop { position: 1; color: Qt.rgba(Theme.shell.r, Theme.shell.g, Theme.shell.b, 0.55) }
+            GradientStop { position: 1; color: Qt.rgba(Theme.shell.r, Theme.shell.g, Theme.shell.b, root.customBackground ? 0.18 : 0.55) }
         }
     }
 }

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsLookPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsLookPage.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Dialogs
 import OpenNOW
 
 Column {
@@ -12,6 +13,21 @@ Column {
 
     width: page.availableWidth; spacing: 20
     property bool allThemes: false
+    readonly property string backgroundImage: String(page.settingsScreen.valueSetting("desktopBackgroundImage", ""))
+
+    FileDialog {
+        id: backgroundDialog
+        objectName: "customBackgroundDialog"
+        title: qsTr("Choose a background image")
+        fileMode: FileDialog.OpenFile
+        nameFilters: [qsTr("Images (*.png *.jpg *.jpeg *.webp *.bmp)")]
+        onAccepted: {
+            page.settingsScreen.setSetting("desktopBackgroundImage", selectedFile.toString())
+            page.settingsScreen.setSetting("desktopBackground", "custom")
+            chooseBackgroundButton.forceActiveFocus()
+        }
+        onRejected: chooseBackgroundButton.forceActiveFocus()
+    }
     DesktopSettingsPanel {
         width: parent.width; paperStyle: true
         DesktopSettingsSection { text: qsTr("THEME") }
@@ -47,11 +63,60 @@ Column {
             }
         }
         DesktopSettingsRow {
-            width: parent.width; paperStyle: true; glyph: "image"; title: qsTr("Background"); description: qsTr("Artwork, gradient or a solid theme color"); showDivider: false
+            width: parent.width; paperStyle: true; glyph: "image"; title: qsTr("Background"); description: qsTr("Game art, a custom image, gradient or solid color")
             DesktopSettingsSegmented {
-                options: [{label:qsTr("Game art"),value:"art"},{label:qsTr("Gradient"),value:"gradient"},{label:qsTr("Solid"),value:"solid"}]; optionWidth: 80
+                objectName: "desktopBackgroundChoice"
+                options: [{label:qsTr("Game art"),value:"art"},{label:qsTr("Gradient"),value:"gradient"},{label:qsTr("Solid"),value:"solid"},{label:qsTr("Custom"),value:"custom"}]; optionWidth: 80
                 selectedIndex: options.findIndex(item => item.value === page.settingsScreen.valueSetting("desktopBackground","art"))
                 onSelected: (index,item) => page.settingsScreen.setSetting("desktopBackground",item.value)
+            }
+        }
+        DesktopSettingsRow {
+            width: parent.width; paperStyle: true; glyph: "image"; title: qsTr("Custom image")
+            description: backgroundPreview.status === Image.Error
+                ? qsTr("Image unavailable. Choose another file or remove it.")
+                : page.backgroundImage !== "" ? qsTr("Keep the image in its original location") : qsTr("Choose a local PNG, JPEG, WebP or BMP image")
+            Row {
+                spacing: 10
+                Image {
+                    id: backgroundPreview
+                    objectName: "customBackgroundPreview"
+                    width: 60; height: 40
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: page.backgroundImage !== ""
+                    source: page.backgroundImage
+                    sourceSize: Qt.size(120, 80)
+                    fillMode: Image.PreserveAspectCrop
+                    asynchronous: true
+                }
+                DesktopSettingsButton {
+                    id: chooseBackgroundButton
+                    objectName: "chooseCustomBackground"
+                    text: qsTr("Choose image…")
+                    onClicked: backgroundDialog.open()
+                }
+                DesktopSettingsButton {
+                    objectName: "removeCustomBackground"
+                    text: qsTr("Remove")
+                    visible: page.backgroundImage !== ""
+                    onClicked: {
+                        page.settingsScreen.setSetting("desktopBackgroundImage", "")
+                        if (page.settingsScreen.valueSetting("desktopBackground", "art") === "custom")
+                            page.settingsScreen.setSetting("desktopBackground", "art")
+                        chooseBackgroundButton.forceActiveFocus()
+                    }
+                }
+            }
+        }
+        DesktopSettingsRow {
+            width: parent.width; paperStyle: true; glyph: "sun"; title: qsTr("Image opacity")
+            description: qsTr("0% hides the image · 100% shows the full image"); showDivider: false
+            DesktopSettingsSlider {
+                objectName: "customBackgroundOpacity"
+                enabled: page.settingsScreen.valueSetting("desktopBackground", "art") === "custom" && page.backgroundImage !== ""
+                from: 0; to: 100; stepSize: 1
+                value: Number(page.settingsScreen.valueSetting("desktopBackgroundOpacity", 30))
+                onCommitted: value => page.settingsScreen.setSetting("desktopBackgroundOpacity", value)
             }
         }
     }

--- a/opennow-qt/src/acceptance/SmokeAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SmokeAcceptance.cpp
@@ -11,6 +11,7 @@
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QTimer>
+#include <QTemporaryFile>
 #include <QVariantMap>
 
 #include <cstdio>
@@ -28,22 +29,45 @@ int AcceptanceSession::startSmokeWorkload()
         return startStreamExitWorkload();
     if (m_smokeTest && m_arguments.contains(u"--smoke-frame-generation-stats"_s))
         return startFrameGenerationStatsWorkload();
-    if (m_smokeTest && m_arguments.contains(u"--smoke-frame-generation"_s)) {
-        QQmlComponent component(&m_engine, QUrl(u"qrc:/acceptance/FrameGenerationAcceptance.qml"_s));
+    if (m_smokeTest && (m_arguments.contains(u"--smoke-frame-generation"_s)
+                       || m_arguments.contains(u"--smoke-custom-background"_s))) {
+        const bool customBackground = m_arguments.contains(u"--smoke-custom-background"_s);
+        QQmlComponent component(&m_engine, QUrl(customBackground
+            ? u"qrc:/acceptance/CustomBackgroundAcceptance.qml"_s
+            : u"qrc:/acceptance/FrameGenerationAcceptance.qml"_s));
         auto *fixture = component.create();
         if (!fixture) { qCritical() << component.errors(); return EXIT_FAILURE; }
         fixture->setParent(&m_engine);
-        QTimer::singleShot(150, this, [this, fixture] {
+        if (customBackground) {
+            QFile image(u":/qt/qml/OpenNOW/res/brand/desktop-renew.jpg"_s);
+            auto *localImage = new QTemporaryFile(&m_engine);
+            if (!image.open(QIODevice::ReadOnly) || !localImage->open()) return EXIT_FAILURE;
+            const auto data = image.readAll();
+            if (localImage->write(data) != data.size() || !localImage->flush()) return EXIT_FAILURE;
+            fixture->setProperty("imageUrl", QUrl::fromLocalFile(localImage->fileName()).toString());
+            localImage->close();
+        }
+        QTimer::singleShot(150, this, [this, fixture, customBackground] {
             auto *window = qobject_cast<QQuickWindow *>(m_engine.rootObjects().first());
             QVariant passed;
             const bool ok = window && QMetaObject::invokeMethod(fixture, "run", Q_RETURN_ARG(QVariant, passed),
                 Q_ARG(QVariant, QVariant::fromValue(window->contentItem()))) && passed.toBool() && !m_qmlWarningOccurred;
             if (!ok) { m_application.exit(EXIT_FAILURE); return; }
-            QTimer::singleShot(150, this, [this, window] {
-                const auto shot = m_arguments.indexOf(u"--screenshot"_s);
-                const bool saved = shot < 0 || (shot + 1 < m_arguments.size()
-                    && window->grabWindow().save(m_arguments.at(shot + 1)));
-                m_application.exit(saved && !m_qmlWarningOccurred ? EXIT_SUCCESS : EXIT_FAILURE);
+            QTimer::singleShot(150, this, [this, window, fixture, customBackground] {
+                if (customBackground) {
+                    QVariant verified;
+                    if (!QMetaObject::invokeMethod(fixture, "verify", Q_RETURN_ARG(QVariant, verified))
+                        || !verified.toBool() || m_qmlWarningOccurred) {
+                        m_application.exit(EXIT_FAILURE);
+                        return;
+                    }
+                }
+                QTimer::singleShot(150, this, [this, window] {
+                    const auto shot = m_arguments.indexOf(u"--screenshot"_s);
+                    const bool saved = shot < 0 || (shot + 1 < m_arguments.size()
+                        && window->grabWindow().save(m_arguments.at(shot + 1)));
+                    m_application.exit(saved && !m_qmlWarningOccurred ? EXIT_SUCCESS : EXIT_FAILURE);
+                });
             });
         });
     } else if (m_smokeTest && m_arguments.contains(u"--smoke-input-capture-error"_s)) {

--- a/opennow-qt/tests/CustomBackgroundAcceptance.qml
+++ b/opennow-qt/tests/CustomBackgroundAcceptance.qml
@@ -1,0 +1,63 @@
+import QtQuick
+import OpenNOW
+
+QtObject {
+    property var background
+    property var slider
+    property var removeButton
+    property var dialog
+    property string imageUrl: ""
+
+    function check(ok, message) { if (!ok) throw new Error("Custom background: " + message) }
+    function find(item, name) {
+        if (!item) return null
+        if (item.objectName === name) return item
+        for (const child of [...(item.children || []), ...(item.resources || [])]) {
+            const result = find(child, name)
+            if (result) return result
+        }
+        return null
+    }
+    function run(parent) {
+        background = find(find(parent, "desktopBackdrop"), "customDesktopBackground")
+        slider = find(parent, "customBackgroundOpacity")
+        removeButton = find(parent, "removeCustomBackground")
+        dialog = find(parent, "customBackgroundDialog")
+        check(background && slider && removeButton && dialog, "background controls exist")
+        check(!slider.enabled, "opacity is disabled without a custom image")
+        dialog.selectedFile = imageUrl
+        dialog.accepted()
+        check(ShellStore.settings.desktopBackground === "custom", "selection activates custom mode")
+        check(ShellStore.settings.desktopBackgroundImage === imageUrl, "selection stores the image URL")
+        check(background.source.toString() === imageUrl && slider.enabled, "selection reaches the backdrop")
+        slider.committed(65)
+        check(ShellStore.settings.desktopBackgroundOpacity === 65, "opacity control updates settings")
+        dialog.rejected()
+        check(ShellStore.settings.desktopBackgroundImage === imageUrl, "cancel preserves the image")
+        ShellStore.lastError = ""
+        return true
+    }
+    function verify() {
+        check(background.status === Image.Ready, "image loads asynchronously")
+        check(background.opacity === 0.65, "image uses the selected opacity")
+        slider.committed(0)
+        check(background.opacity === 0, "zero opacity hides the image")
+        slider.committed(100)
+        check(background.opacity === 1, "full opacity shows the unmodified image")
+        ShellStore.applySetting("desktopBackground", "solid")
+        check(background.source.toString() === "", "other modes release the custom image")
+        check(ShellStore.settings.desktopBackgroundImage === imageUrl, "mode changes retain the selection")
+        ShellStore.applySetting("desktopBackground", "custom")
+        removeButton.clicked()
+        check(ShellStore.settings.desktopBackgroundImage === "", "remove clears the image")
+        check(ShellStore.settings.desktopBackground === "art", "remove restores game art")
+        check(!slider.enabled, "remove disables opacity")
+        if (Qt.application.arguments.indexOf("--screenshot") >= 0) {
+            dialog.selectedFile = imageUrl
+            dialog.accepted()
+            slider.committed(65)
+        }
+        ShellStore.lastError = ""
+        return true
+    }
+}


### PR DESCRIPTION
Adds a **Custom** background option in desktop Settings → Look, with a native image picker, thumbnail, remove action, and a saved 0–100% image-opacity setting (30% by default).

- Supports local PNG, JPEG, WebP, and BMP files. The image stays in its original location; unavailable or unreadable files fall back to the theme background with an explanatory message.
- Loads the backdrop asynchronously at a bounded resolution and releases its source while hidden or using another mode. Theme-colored scrims preserve navigation contrast in light and dark modes. Sign-in and stream presentation are unchanged.
- Validates local file URLs and clamps opacity in the Rust settings owner. Adds persistence/reset coverage and Qt acceptance tests for selection, cancellation, opacity endpoints, mode switching, and removal at 960px and 1600px.

### Verification
- Full Qt Debug build and **166/166 Qt tests passed**.
- Rust core test suite passed; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` passed.
- `npm run locales:check` passed.
- Visually checked desktop/compact layouts and light/dark modes. Exercised the native file picker with spaces and `#` in the filename, opacity adjustment, and an unreadable-image fallback in an interactive Qt smoke session.

### Screenshots
![Desktop custom background at 65% opacity](https://api-nightly.capy.ai/pr-assets/opysdEFyAmOzGSuyKDfsBOTEnaPIHTgtt4v_gj30WNo)
![Compact custom background controls](https://api-nightly.capy.ai/pr-assets/fpOHsXAEO2FEz863Q0lDiyQrFK9gyupZvOK0BOYBNCM)
![Light-mode custom background](https://api-nightly.capy.ai/pr-assets/vfczkzlURuHMfk_3aF2MoW-fDGbCEmwOU17xljaw9AM)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1YPSKW8PXRFZ7CPYQPGGK7B"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->