### PR TITLE
fix(streaming): preserve 10-bit color through Qt composition

### DIFF
--- a/docs/linux-vulkan-acceptance.md
+++ b/docs/linux-vulkan-acceptance.md
@@ -68,9 +68,12 @@ after decoder destruction. They complement, rather than replace, the live Qt pla
 ## Color and recovery
 
 Repeat playback with H.265 10-bit 4:2:0 when it is offered by the device and service. Confirm the
-decoder and presentation preserve 10-bit output rather than silently converting it to 8-bit
-NV12. Check dark gradients and limited/full-range black and white levels. This is an SDR
-bit-depth check, not HDR certification. Unsupported chroma/bit-depth combinations must fail
+decoder preserves P010 and the native conversion publishes RGB10A2 rather than an 8-bit
+intermediate. Qt's SDR swapchain is 8-bit: the final video draw applies centered spatial
+dithering after scaling, including to generated frames, without changing the transfer function.
+Check `qt-native.log` for `SDR video composition: textureBits=10 outputBits=8 dither=ordered-8x8`.
+Check dark gradients and limited/full-range black and white levels. This is an SDR
+precision check, not a claim of 10-bit scan-out or HDR certification. Unsupported chroma/bit-depth combinations must fail
 before session creation instead of silently changing the selected quality.
 
 Interrupt the network briefly, then restore it. Recovery must discard unusable reference frames

--- a/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/frame_producer.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/frame_producer.rs
@@ -37,9 +37,51 @@ pub struct RecordedGpuFrame {
     pub generation: u64,
     pub image: u64,
     pub image_view: u64,
+    pub texture_format: GpuTextureFormat,
     pub width: u32,
     pub height: u32,
     pub timestamp_us: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GpuTextureFormat {
+    Rgba8,
+    Rgb10A2,
+}
+
+impl GpuTextureFormat {
+    fn for_pixel_format(format: PixelFormat) -> Result<Self> {
+        match format {
+            PixelFormat::Nv12 => Ok(Self::Rgba8),
+            PixelFormat::P010 => Ok(Self::Rgb10A2),
+            _ => Err(Error::InvalidFormat(format!(
+                "unsupported embedded conversion source format {format:?}"
+            ))),
+        }
+    }
+
+    fn vulkan_format(self) -> vk::Format {
+        match self {
+            Self::Rgba8 => vk::Format::R8G8B8A8_UNORM,
+            Self::Rgb10A2 => vk::Format::A2B10G10R10_UNORM_PACK32,
+        }
+    }
+
+    fn validate_features(self, features: vk::FormatFeatureFlags) -> Result<()> {
+        let required = vk::FormatFeatureFlags::COLOR_ATTACHMENT
+            | vk::FormatFeatureFlags::SAMPLED_IMAGE
+            | vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_LINEAR;
+        if !features.contains(required) {
+            return Err(Error::unavailable(
+                Subsystem::Vulkan,
+                format!(
+                    "embedded {self:?} output ({:?}) requires optimal-tiling color attachment and linearly filtered sampling support; available features: {features:?}",
+                    self.vulkan_format()
+                ),
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -387,7 +429,7 @@ pub struct LinuxFrameProducer {
     render: VulkanRenderDevice,
     dmabuf_import_supported: bool,
     imported: HashMap<DmaBufKey, Weak<ImportedNv12Frame>>,
-    renderer: Option<RendererResources>,
+    renderers: HashMap<GpuTextureFormat, RendererResources>,
     slots: Vec<Option<FrameSlotResources>>,
     generation: u64,
     device_lost: bool,
@@ -420,12 +462,19 @@ struct CpuUploadResources {
 struct FrameSlotResources {
     width: u32,
     height: u32,
+    texture_format: GpuTextureFormat,
     output: GpuImage,
     output_initialized: bool,
     framebuffer: vk::Framebuffer,
     cpu: Option<CpuUploadResources>,
     owned_input_views: Vec<vk::ImageView>,
     frame: Option<PreparedLinuxFrame>,
+}
+
+impl FrameSlotResources {
+    fn reusable(&self, width: u32, height: u32, texture_format: GpuTextureFormat) -> bool {
+        self.width == width && self.height == height && self.texture_format == texture_format
+    }
 }
 
 impl LinuxFrameProducer {
@@ -480,7 +529,7 @@ impl LinuxFrameProducer {
             render,
             dmabuf_import_supported,
             imported: HashMap::new(),
-            renderer: None,
+            renderers: HashMap::new(),
             slots: (0..slot_count).map(|_| None).collect(),
             generation: 0,
             device_lost: false,
@@ -519,9 +568,10 @@ impl LinuxFrameProducer {
         let color_matrix = frame.format.color_matrix;
         let full_range = frame.format.color_range == crate::ColorRange::Full;
         let chroma_location = frame.format.chroma_location;
+        let texture_format = GpuTextureFormat::for_pixel_format(frame.format.pixel_format)?;
         let prepared = self.prepare(frame)?;
-        self.ensure_renderer()?;
-        self.ensure_slot(slot_index, width, height)?;
+        self.ensure_renderer(texture_format)?;
+        self.ensure_slot(slot_index, width, height, texture_format)?;
         let command_buffer = vk::CommandBuffer::from_raw(command_buffer as u64);
         let (luma_view, chroma_view) =
             self.prepare_input(slot_index, command_buffer, &prepared, width, height)?;
@@ -564,6 +614,7 @@ impl LinuxFrameProducer {
             generation,
             image: slot_resources.output.image.as_raw(),
             image_view: slot_resources.output.view.as_raw(),
+            texture_format: slot_resources.texture_format,
             width,
             height,
             timestamp_us,
@@ -722,12 +773,19 @@ impl LinuxFrameProducer {
         Ok(imported)
     }
 
-    fn ensure_renderer(&mut self) -> Result<()> {
-        if self.renderer.is_some() {
+    fn ensure_renderer(&mut self, texture_format: GpuTextureFormat) -> Result<()> {
+        if self.renderers.contains_key(&texture_format) {
             return Ok(());
         }
+        let properties = unsafe {
+            self.instance.get_physical_device_format_properties(
+                self.physical_device,
+                texture_format.vulkan_format(),
+            )
+        };
+        texture_format.validate_features(properties.optimal_tiling_features)?;
         let attachment = [vk::AttachmentDescription::default()
-            .format(vk::Format::R8G8B8A8_UNORM)
+            .format(texture_format.vulkan_format())
             .samples(vk::SampleCountFlags::TYPE_1)
             .load_op(vk::AttachmentLoadOp::DONT_CARE)
             .store_op(vk::AttachmentStoreOp::STORE)
@@ -878,24 +936,63 @@ impl LinuxFrameProducer {
             )
         }
         .map_err(|error| vk_error("allocate embedded NV12 descriptor sets", error))?;
-        self.renderer = Some(RendererResources {
-            render_pass,
-            descriptor_set_layout,
-            pipeline_layout,
-            pipeline,
-            descriptor_pool,
-            descriptor_sets,
-            sampler,
-        });
+        self.renderers.insert(
+            texture_format,
+            RendererResources {
+                render_pass,
+                descriptor_set_layout,
+                pipeline_layout,
+                pipeline,
+                descriptor_pool,
+                descriptor_sets,
+                sampler,
+            },
+        );
         Ok(())
     }
 
-    fn ensure_slot(&mut self, slot: usize, width: u32, height: u32) -> Result<()> {
+    fn ensure_slot(
+        &mut self,
+        slot: usize,
+        width: u32,
+        height: u32,
+        texture_format: GpuTextureFormat,
+    ) -> Result<()> {
         if self.slots[slot]
             .as_ref()
-            .is_some_and(|resources| resources.width == width && resources.height == height)
+            .is_some_and(|resources| resources.reusable(width, height, texture_format))
         {
             return Ok(());
+        }
+        let usage = vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::SAMPLED;
+        let properties = unsafe {
+            self.instance.get_physical_device_image_format_properties(
+                self.physical_device,
+                texture_format.vulkan_format(),
+                vk::ImageType::TYPE_2D,
+                vk::ImageTiling::OPTIMAL,
+                usage,
+                vk::ImageCreateFlags::empty(),
+            )
+        }
+        .map_err(|error| {
+            vk_error(
+                &format!("query embedded {texture_format:?} output support"),
+                error,
+            )
+        })?;
+        if width > properties.max_extent.width
+            || height > properties.max_extent.height
+            || !properties
+                .sample_counts
+                .contains(vk::SampleCountFlags::TYPE_1)
+        {
+            return Err(Error::unavailable(
+                Subsystem::Vulkan,
+                format!(
+                    "embedded {texture_format:?} output does not support {width}x{height} single-sample images"
+                ),
+            ));
         }
         if let Some(resources) = self.slots[slot].take() {
             self.destroy_slot(resources);
@@ -906,10 +1003,10 @@ impl LinuxFrameProducer {
             &self.device,
             width,
             height,
-            vk::Format::R8G8B8A8_UNORM,
-            vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::SAMPLED,
+            texture_format.vulkan_format(),
+            usage,
         )?;
-        let renderer = self.renderer.as_ref().expect("renderer initialized");
+        let renderer = &self.renderers[&texture_format];
         let attachments = [output.view];
         let framebuffer = unsafe {
             self.device.create_framebuffer(
@@ -926,6 +1023,7 @@ impl LinuxFrameProducer {
         self.slots[slot] = Some(FrameSlotResources {
             width,
             height,
+            texture_format,
             output,
             output_initialized: false,
             framebuffer,
@@ -982,7 +1080,8 @@ impl LinuxFrameProducer {
         luma_view: vk::ImageView,
         chroma_view: vk::ImageView,
     ) {
-        let renderer = self.renderer.as_ref().expect("renderer initialized");
+        let resources = self.slots[slot].as_ref().expect("slot initialized");
+        let renderer = &self.renderers[&resources.texture_format];
         let luma = [vk::DescriptorImageInfo::default()
             .sampler(renderer.sampler)
             .image_view(luma_view)
@@ -1019,7 +1118,7 @@ impl LinuxFrameProducer {
         chroma_location: crate::ChromaLocation,
     ) -> Result<()> {
         let resources = self.slots[slot].as_mut().expect("slot initialized");
-        let renderer = self.renderer.as_ref().expect("renderer initialized");
+        let renderer = &self.renderers[&resources.texture_format];
         let mut acquire = Vec::new();
         match prepared {
             PreparedLinuxFrame::Vulkan(frame) => {
@@ -1240,7 +1339,7 @@ impl Drop for LinuxFrameProducer {
         for resources in std::mem::take(&mut self.slots).into_iter().flatten() {
             self.destroy_slot(resources);
         }
-        if let Some(renderer) = self.renderer.take() {
+        for (_, renderer) in self.renderers.drain() {
             unsafe {
                 self.device
                     .destroy_descriptor_pool(renderer.descriptor_pool, None);
@@ -1979,7 +2078,7 @@ fn create_plane_view(
         .map_err(|error| vk_error("create DMA-BUF plane image view", error))
 }
 
-fn vk_error(context: &'static str, error: vk::Result) -> Error {
+fn vk_error(context: &str, error: vk::Result) -> Error {
     if error == vk::Result::ERROR_DEVICE_LOST {
         return Error::DeviceLost {
             subsystem: Subsystem::Vulkan,
@@ -2002,6 +2101,165 @@ fn decode_readiness(result: std::result::Result<(), vk::Result>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn embedded_output_format_preserves_source_precision() {
+        assert_eq!(
+            GpuTextureFormat::for_pixel_format(PixelFormat::Nv12).unwrap(),
+            GpuTextureFormat::Rgba8
+        );
+        assert_eq!(
+            GpuTextureFormat::for_pixel_format(PixelFormat::P010).unwrap(),
+            GpuTextureFormat::Rgb10A2
+        );
+        assert_eq!(
+            GpuTextureFormat::Rgba8.vulkan_format(),
+            vk::Format::R8G8B8A8_UNORM
+        );
+        assert_eq!(
+            GpuTextureFormat::Rgb10A2.vulkan_format(),
+            vk::Format::A2B10G10R10_UNORM_PACK32
+        );
+        assert!(GpuTextureFormat::for_pixel_format(PixelFormat::I420).is_err());
+    }
+
+    #[test]
+    fn embedded_output_requires_attachment_and_filtered_sampling_support() {
+        let required = vk::FormatFeatureFlags::COLOR_ATTACHMENT
+            | vk::FormatFeatureFlags::SAMPLED_IMAGE
+            | vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_LINEAR;
+        for format in [GpuTextureFormat::Rgba8, GpuTextureFormat::Rgb10A2] {
+            assert!(format.validate_features(required).is_ok());
+            for missing in [
+                vk::FormatFeatureFlags::COLOR_ATTACHMENT,
+                vk::FormatFeatureFlags::SAMPLED_IMAGE,
+                vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_LINEAR,
+            ] {
+                let error = format.validate_features(required & !missing).unwrap_err();
+                assert!(error.to_string().contains(&format!("{format:?}")));
+            }
+        }
+    }
+
+    #[test]
+    fn embedded_slot_reuse_requires_matching_extent_and_precision() {
+        for texture_format in [GpuTextureFormat::Rgba8, GpuTextureFormat::Rgb10A2] {
+            let resources = FrameSlotResources {
+                width: 1920,
+                height: 1080,
+                texture_format,
+                output: GpuImage {
+                    image: vk::Image::null(),
+                    memory: vk::DeviceMemory::null(),
+                    view: vk::ImageView::null(),
+                },
+                output_initialized: false,
+                framebuffer: vk::Framebuffer::null(),
+                cpu: None,
+                owned_input_views: Vec::new(),
+                frame: None,
+            };
+            assert!(resources.reusable(1920, 1080, texture_format));
+            assert!(!resources.reusable(1280, 1080, texture_format));
+            assert!(!resources.reusable(1920, 720, texture_format));
+            let other_format = match texture_format {
+                GpuTextureFormat::Rgba8 => GpuTextureFormat::Rgb10A2,
+                GpuTextureFormat::Rgb10A2 => GpuTextureFormat::Rgba8,
+            };
+            assert!(!resources.reusable(1920, 1080, other_format));
+        }
+    }
+
+    #[test]
+    #[ignore = "requires a Vulkan implementation; runs with Mesa lavapipe without /dev/dri"]
+    fn embedded_precision_switch_recreates_only_the_recycled_slot() {
+        unsafe {
+            let entry = ash::Entry::load().unwrap();
+            let application = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
+            let instance = entry
+                .create_instance(
+                    &vk::InstanceCreateInfo::default().application_info(&application),
+                    None,
+                )
+                .unwrap();
+            let physical = instance.enumerate_physical_devices().unwrap()[0];
+            let family = instance
+                .get_physical_device_queue_family_properties(physical)
+                .iter()
+                .position(|family| family.queue_flags.contains(vk::QueueFlags::GRAPHICS))
+                .unwrap() as u32;
+            let priorities = [1.0];
+            let queues = [vk::DeviceQueueCreateInfo::default()
+                .queue_family_index(family)
+                .queue_priorities(&priorities)];
+            let device = instance
+                .create_device(
+                    physical,
+                    &vk::DeviceCreateInfo::default().queue_create_infos(&queues),
+                    None,
+                )
+                .unwrap();
+            let render = VulkanRenderDevice {
+                instance: instance.handle().as_raw() as usize,
+                physical_device: physical.as_raw() as usize,
+                device: device.handle().as_raw() as usize,
+                queue: device.get_device_queue(family, 0).as_raw() as usize,
+                queue_family: family,
+                dmabuf_import_enabled: false,
+            };
+            let mut producer = LinuxFrameProducer::new_with_slots(render, 2).unwrap();
+            producer.ensure_renderer(GpuTextureFormat::Rgba8).unwrap();
+            for slot in 0..2 {
+                producer
+                    .ensure_slot(slot, 4, 4, GpuTextureFormat::Rgba8)
+                    .unwrap();
+                producer.slots[slot].as_mut().unwrap().output_initialized = true;
+            }
+            let other_image = producer.slots[1].as_ref().unwrap().output.image;
+            let rgba8_pipeline = producer.renderers[&GpuTextureFormat::Rgba8].pipeline;
+            producer.ensure_renderer(GpuTextureFormat::Rgb10A2).unwrap();
+            let rgb10_pipeline = producer.renderers[&GpuTextureFormat::Rgb10A2].pipeline;
+            assert_ne!(rgba8_pipeline, rgb10_pipeline);
+            for texture_format in [
+                GpuTextureFormat::Rgb10A2,
+                GpuTextureFormat::Rgba8,
+                GpuTextureFormat::Rgb10A2,
+            ] {
+                producer.ensure_renderer(texture_format).unwrap();
+                producer.ensure_slot(0, 4, 4, texture_format).unwrap();
+                let slot = producer.slots[0].as_mut().unwrap();
+                assert_eq!(slot.texture_format, texture_format);
+                assert!(!slot.output_initialized);
+                let image = slot.output.image;
+                slot.output_initialized = true;
+                producer.ensure_slot(0, 4, 4, texture_format).unwrap();
+                let slot = producer.slots[0].as_ref().unwrap();
+                assert_eq!(slot.output.image, image);
+                assert!(slot.output_initialized);
+                let other_slot = producer.slots[1].as_ref().unwrap();
+                assert_eq!(other_slot.output.image, other_image);
+                assert_eq!(other_slot.texture_format, GpuTextureFormat::Rgba8);
+                assert!(other_slot.output_initialized);
+                assert_eq!(producer.renderers.len(), 2);
+                assert_eq!(
+                    producer.renderers[&GpuTextureFormat::Rgba8].pipeline,
+                    rgba8_pipeline
+                );
+                assert_eq!(
+                    producer.renderers[&GpuTextureFormat::Rgb10A2].pipeline,
+                    rgb10_pipeline
+                );
+            }
+            producer
+                .ensure_slot(0, 8, 4, GpuTextureFormat::Rgb10A2)
+                .unwrap();
+            assert_eq!(producer.slots[0].as_ref().unwrap().width, 8);
+            assert!(!producer.slots[0].as_ref().unwrap().output_initialized);
+            drop(producer);
+            device.destroy_device(None);
+            instance.destroy_instance(None);
+        }
+    }
 
     #[test]
     #[ignore = "requires a Vulkan implementation; runs with Mesa lavapipe without /dev/dri"]
@@ -2459,6 +2717,10 @@ mod tests {
                 let output = frame.record(render, command.as_raw() as usize, 0).unwrap();
                 assert_ne!(output.image, 0);
                 assert_eq!((output.width, output.height), (4, 4));
+                assert_eq!(
+                    output.texture_format,
+                    GpuTextureFormat::for_pixel_format(pixel_format).unwrap()
+                );
                 device.end_command_buffer(command).unwrap();
                 device
                     .queue_submit(

--- a/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/lib.rs
@@ -45,9 +45,9 @@ pub use format::{
 };
 #[cfg(all(target_os = "linux", feature = "vulkan"))]
 pub use frame_producer::{
-    CpuNv12Frame, ImportedNv12Frame, LinuxFrameProducer, LinuxGpuFrame, LinuxGpuFrameProducer,
-    LinuxGpuRenderResources, PreparedLinuxFrame, PreparedVulkanFrame, PreparedVulkanImage,
-    RecordedGpuFrame, VulkanRenderDevice,
+    CpuNv12Frame, GpuTextureFormat, ImportedNv12Frame, LinuxFrameProducer, LinuxGpuFrame,
+    LinuxGpuFrameProducer, LinuxGpuRenderResources, PreparedLinuxFrame, PreparedVulkanFrame,
+    PreparedVulkanImage, RecordedGpuFrame, VulkanRenderDevice,
 };
 #[cfg(all(target_os = "linux", feature = "vulkan"))]
 pub use presentation::{NativeSurface, VulkanPresenter};

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/README.md
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/README.md
@@ -6,9 +6,10 @@ This isolated crate implements the macOS media path without GStreamer or FFmpeg:
   temporal units, are copied into CoreMedia sample buffers and decoded asynchronously by
   VideoToolbox. AV1 starts only after a keyframe supplies a valid sequence-header OBU from which
   the `av1C` codec configuration can be derived.
-- VideoToolbox is asked for Metal-compatible, IOSurface-backed NV12 (`420v`) pixel buffers. A
-  `CVMetalTextureCache` maps both planes into Metal without a CPU pixel copy, and a
-  `CAMetalLayer` presents them through a small BT.601/BT.709 conversion shader.
+- VideoToolbox is asked for Metal-compatible, IOSurface-backed NV12 (`420v`) or ten-bit P010
+  (`x420`) pixel buffers. A `CVMetalTextureCache` maps both planes into Metal without a CPU
+  pixel copy. The embedded Qt path records conversion into Qt's Metal command buffer; the
+  standalone `CAMetalLayer` presenter remains limited to eight-bit NV12.
 - Opus packets are decoded to interleaved `f32` PCM by the reference libopus decoder. The
   dependency builds libopus statically on macOS, so it adds no runtime media-framework
   dependency. A default-output Audio Unit pulls PCM from a fixed-size SPSC ring in its real-time
@@ -87,6 +88,32 @@ the pending keyframe plus the same bounded H.264/Opus queues to the OpenH264/sof
 HEVC and AV1 have no bundled macOS software decoder, so initialization or fatal decode failure for
 either codec stops that media path and disables that codec in later capability replies instead of
 silently mis-negotiating a fallback.
+
+## Embedded SDR color precision
+
+H.264/H.265 callers pass negotiated precision with
+`with_bit_depth(VideoBitDepth::Ten)` on initial configuration and reconfiguration. Their existing
+constructors default to eight-bit. AV1 reads precision from its `av1C` record. CoreMedia's
+`BitsPerComponent` metadata can raise the requested output to ten-bit but cannot lower a
+ten-bit request. Unsupported bit depths fail configuration, and a decoder that returns an
+eight-bit buffer for a ten-bit request reports a fatal VideoToolbox failure.
+
+The embedded converter maps NV12 to `MetalFrameFormat::Rgba8Unorm` and P010 to
+`MetalFrameFormat::Rgb10a2Unorm`; `MetalRecordedFrame.format` tells Qt which texture format to
+import. The output format does not select HDR or a wide-gamut color space. Conversion honors
+BT.601/BT.709 YCbCr matrix attachments on each decoded buffer; when the attachment is absent,
+it uses the explicitly configured `VideoColorSpace` (the streamer supplies BT.709). Other
+matrix attachments are rejected instead of being treated as BT.709. The pixel-buffer format
+determines full versus video range, independently of bit depth and matrix. This path performs
+SDR matrix conversion, not transfer-function conversion, HDR tone mapping, or gamut mapping.
+
+P010's high-aligned ten-bit values are normalized from R16Unorm before applying the exact
+luma endpoints, chroma midpoint, and range-specific chroma gain. The output pool retains at
+most eight frame slots and two format-specific pipelines. Reusing a slot requires Qt to
+retire its previous GPU work. Slot textures are
+reused only when both dimensions and pixel format match; changing depth does not release
+other slots' in-flight resources. RGB10A2 allocation or pipeline failure is returned as an
+error, never silently retried as RGBA8. Qt owns the final SDR display conversion.
 
 ## Queue and lifecycle behavior
 

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/color.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/color.rs
@@ -1,0 +1,168 @@
+use crate::format::{VideoBitDepth, VideoColorSpace};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ConversionParameters {
+    pub sample_scale: f32,
+    pub luma_offset: f32,
+    pub luma_scale: f32,
+    pub chroma_offset: f32,
+    pub chroma_scale: f32,
+    pub red_cr: f32,
+    pub green_cb: f32,
+    pub green_cr: f32,
+    pub blue_cb: f32,
+}
+
+impl ConversionParameters {
+    pub(crate) fn new(
+        bit_depth: VideoBitDepth,
+        full_range: bool,
+        color_space: VideoColorSpace,
+    ) -> Self {
+        let (maximum, black, luma_range, midpoint, chroma_range, sample_scale) = match bit_depth {
+            VideoBitDepth::Eight => (255.0, 16.0, 219.0, 128.0, 224.0, 1.0),
+            VideoBitDepth::Ten => (1023.0, 64.0, 876.0, 512.0, 896.0, 65535.0 / 65472.0),
+        };
+        let (kr, kb) = match color_space {
+            VideoColorSpace::Bt601 => (0.299, 0.114),
+            VideoColorSpace::Bt709 => (0.2126, 0.0722),
+        };
+        let kg = 1.0 - kr - kb;
+        Self {
+            sample_scale,
+            luma_offset: if full_range { 0.0 } else { black / maximum },
+            luma_scale: if full_range {
+                1.0
+            } else {
+                maximum / luma_range
+            },
+            chroma_offset: midpoint / maximum,
+            chroma_scale: if full_range {
+                1.0
+            } else {
+                maximum / chroma_range
+            },
+            red_cr: 2.0 * (1.0 - kr),
+            green_cb: -2.0 * kb * (1.0 - kb) / kg,
+            green_cr: -2.0 * kr * (1.0 - kr) / kg,
+            blue_cb: 2.0 * (1.0 - kb),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn convert_codes(
+        parameters: ConversionParameters,
+        depth: VideoBitDepth,
+        codes: [f32; 3],
+    ) -> [f32; 3] {
+        let storage_scale = match depth {
+            VideoBitDepth::Eight => 1.0 / 255.0,
+            VideoBitDepth::Ten => 64.0 / 65535.0,
+        };
+        let samples = codes.map(|code| code * storage_scale * parameters.sample_scale);
+        let y = (samples[0] - parameters.luma_offset) * parameters.luma_scale;
+        let cb = (samples[1] - parameters.chroma_offset) * parameters.chroma_scale;
+        let cr = (samples[2] - parameters.chroma_offset) * parameters.chroma_scale;
+        [
+            y + parameters.red_cr * cr,
+            y + parameters.green_cb * cb + parameters.green_cr * cr,
+            y + parameters.blue_cb * cb,
+        ]
+    }
+
+    fn assert_rgb(actual: [f32; 3], expected: [f32; 3]) {
+        for (actual, expected) in actual.into_iter().zip(expected) {
+            assert!(
+                (actual - expected).abs() < 0.000002,
+                "{actual} != {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_neutral_chroma_and_black_white_endpoints_in_both_ranges_and_depths() {
+        for depth in [VideoBitDepth::Eight, VideoBitDepth::Ten] {
+            for full_range in [false, true] {
+                let (black, white, midpoint) = match (depth, full_range) {
+                    (VideoBitDepth::Eight, false) => (16.0, 235.0, 128.0),
+                    (VideoBitDepth::Eight, true) => (0.0, 255.0, 128.0),
+                    (VideoBitDepth::Ten, false) => (64.0, 940.0, 512.0),
+                    (VideoBitDepth::Ten, true) => (0.0, 1023.0, 512.0),
+                };
+                for matrix in [VideoColorSpace::Bt601, VideoColorSpace::Bt709] {
+                    let parameters = ConversionParameters::new(depth, full_range, matrix);
+                    for level in [0.0, 0.25, 0.5, 0.75, 1.0] {
+                        assert_rgb(
+                            convert_codes(
+                                parameters,
+                                depth,
+                                [black + level * (white - black), midpoint, midpoint],
+                            ),
+                            [level; 3],
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bt709_color_vectors_use_range_specific_chroma_gain() {
+        for depth in [VideoBitDepth::Eight, VideoBitDepth::Ten] {
+            for full_range in [false, true] {
+                let (maximum, midpoint, black, y_range, c_range) = match (depth, full_range) {
+                    (VideoBitDepth::Eight, false) => (255.0, 128.0, 16.0, 219.0, 224.0),
+                    (VideoBitDepth::Eight, true) => (255.0, 128.0, 0.0, 255.0, 255.0),
+                    (VideoBitDepth::Ten, false) => (1023.0, 512.0, 64.0, 876.0, 896.0),
+                    (VideoBitDepth::Ten, true) => (1023.0, 512.0, 0.0, 1023.0, 1023.0),
+                };
+                let parameters =
+                    ConversionParameters::new(depth, full_range, VideoColorSpace::Bt709);
+                for rgb in [[0.8, 0.1, 0.2], [0.1, 0.8, 0.2], [0.2, 0.1, 0.8]] {
+                    let y = 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+                    let cb = (rgb[2] - y) / 1.8556;
+                    let cr = (rgb[0] - y) / 1.5748;
+                    let codes = [
+                        black + y * y_range,
+                        midpoint + cb * c_range,
+                        midpoint + cr * c_range,
+                    ];
+                    assert!(codes.iter().all(|code| (0.0..=maximum).contains(code)));
+                    assert_rgb(convert_codes(parameters, depth, codes), rgb);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn p010_retains_every_legal_luma_step_in_rgb10_output() {
+        for (full_range, black, white) in [(false, 64, 940), (true, 0, 1023)] {
+            let parameters =
+                ConversionParameters::new(VideoBitDepth::Ten, full_range, VideoColorSpace::Bt709);
+            let mut previous = None;
+            for code in black..=white {
+                let rgb =
+                    convert_codes(parameters, VideoBitDepth::Ten, [code as f32, 512.0, 512.0]);
+                let expected = (code - black) as f32 / (white - black) as f32;
+                assert_rgb(rgb, [expected; 3]);
+                let quantized = (rgb[0] * 1023.0).round() as u32;
+                if let Some(previous) = previous {
+                    assert!(quantized > previous);
+                }
+                previous = Some(quantized);
+            }
+            assert_eq!(previous, Some(1023));
+        }
+    }
+
+    #[test]
+    fn metal_uniform_layout_is_nine_packed_floats() {
+        assert_eq!(std::mem::size_of::<ConversionParameters>(), 9 * 4);
+        assert_eq!(std::mem::align_of::<ConversionParameters>(), 4);
+    }
+}

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/format.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/format.rs
@@ -19,6 +19,18 @@ pub enum VideoColorSpace {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VideoBitDepth {
+    Eight,
+    Ten,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MetalFrameFormat {
+    Rgba8Unorm,
+    Rgb10a2Unorm,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FrameTiming {
     pub presentation_value: i64,
     pub duration_value: i64,
@@ -75,6 +87,7 @@ impl H264ParameterSets {
 pub struct H264Format {
     pub parameter_sets: H264ParameterSets,
     pub color_space: VideoColorSpace,
+    pub bit_depth: VideoBitDepth,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -114,6 +127,7 @@ impl H265ParameterSets {
 pub struct H265Format {
     pub parameter_sets: H265ParameterSets,
     pub color_space: VideoColorSpace,
+    pub bit_depth: VideoBitDepth,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -121,6 +135,7 @@ pub struct Av1Format {
     codec_configuration: Vec<u8>,
     width: i32,
     height: i32,
+    bit_depth: VideoBitDepth,
     pub color_space: VideoColorSpace,
 }
 
@@ -138,6 +153,12 @@ impl Av1Format {
         {
             return Err(FormatError::InvalidAv1Configuration);
         }
+        let bit_depth = match codec_configuration[2] & 0x60 {
+            0 => VideoBitDepth::Eight,
+            0x40 => VideoBitDepth::Ten,
+            0x60 => return Err(FormatError::UnsupportedVideoBitDepth(12)),
+            _ => return Err(FormatError::InvalidAv1Configuration),
+        };
         let width = i32::try_from(width)
             .ok()
             .filter(|value| *value > 0)
@@ -150,6 +171,7 @@ impl Av1Format {
             codec_configuration: codec_configuration.to_vec(),
             width,
             height,
+            bit_depth,
             color_space,
         })
     }
@@ -165,6 +187,10 @@ impl Av1Format {
     pub const fn height(&self) -> i32 {
         self.height
     }
+
+    pub const fn bit_depth(&self) -> VideoBitDepth {
+        self.bit_depth
+    }
 }
 
 impl H265Format {
@@ -172,7 +198,13 @@ impl H265Format {
         Self {
             parameter_sets,
             color_space,
+            bit_depth: VideoBitDepth::Eight,
         }
+    }
+
+    pub const fn with_bit_depth(mut self, bit_depth: VideoBitDepth) -> Self {
+        self.bit_depth = bit_depth;
+        self
     }
 }
 
@@ -184,6 +216,25 @@ pub enum VideoFormat {
 }
 
 impl VideoFormat {
+    pub(crate) fn destination_bit_depth(
+        &self,
+        bitstream_depth: Option<i32>,
+    ) -> Result<VideoBitDepth, FormatError> {
+        match bitstream_depth {
+            Some(10) => Ok(VideoBitDepth::Ten),
+            Some(8) | None => Ok(self.bit_depth()),
+            Some(depth) => Err(FormatError::UnsupportedVideoBitDepth(depth)),
+        }
+    }
+
+    pub const fn bit_depth(&self) -> VideoBitDepth {
+        match self {
+            Self::H264(format) => format.bit_depth,
+            Self::H265(format) => format.bit_depth,
+            Self::Av1(format) => format.bit_depth(),
+        }
+    }
+
     pub const fn color_space(&self) -> VideoColorSpace {
         match self {
             Self::H264(format) => format.color_space,
@@ -216,7 +267,13 @@ impl H264Format {
         Self {
             parameter_sets,
             color_space,
+            bit_depth: VideoBitDepth::Eight,
         }
+    }
+
+    pub const fn with_bit_depth(mut self, bit_depth: VideoBitDepth) -> Self {
+        self.bit_depth = bit_depth;
+        self
     }
 }
 
@@ -528,6 +585,8 @@ pub enum FormatError {
     NalUnitTooLarge,
     #[error("AV1 codec configuration is not a bounded version-1 av1C record")]
     InvalidAv1Configuration,
+    #[error("unsupported video bit depth {0}")]
+    UnsupportedVideoBitDepth(i32),
     #[error("encoded video dimensions must fit positive signed 32-bit values")]
     InvalidVideoDimensions,
     #[error("frame timescale must be positive")]
@@ -761,6 +820,71 @@ mod tests {
             Av1Format::new([0x81, 0, 0, 0], 0, 1080, VideoColorSpace::Bt709),
             Err(FormatError::InvalidVideoDimensions)
         );
+    }
+
+    #[test]
+    fn av1_depth_comes_from_configuration_and_rejects_twelve_bit() {
+        for (flags, expected) in [(0x0c, VideoBitDepth::Eight), (0x4c, VideoBitDepth::Ten)] {
+            let format =
+                Av1Format::new([0x81, 0x0d, flags, 0], 1920, 1080, VideoColorSpace::Bt709).unwrap();
+            assert_eq!(format.bit_depth(), expected);
+            assert_eq!(VideoFormat::Av1(format).bit_depth(), expected);
+        }
+        assert_eq!(
+            Av1Format::new([0x81, 0x4d, 0x6c, 0], 1920, 1080, VideoColorSpace::Bt709),
+            Err(FormatError::UnsupportedVideoBitDepth(12))
+        );
+        assert_eq!(
+            Av1Format::new([0x81, 0x0d, 0x2c, 0], 1920, 1080, VideoColorSpace::Bt709),
+            Err(FormatError::InvalidAv1Configuration)
+        );
+    }
+
+    #[test]
+    fn h26x_depth_is_explicit_and_bitstream_metadata_cannot_downgrade_it() {
+        let h264 = H264Format::new(
+            H264ParameterSets::new([0x67, 0x64, 0x00], [0x68, 0xee]).unwrap(),
+            VideoColorSpace::Bt709,
+        );
+        let h265 = H265Format::new(
+            H265ParameterSets::new([0x40, 0x01], [0x42, 0x01], [0x44, 0x01]).unwrap(),
+            VideoColorSpace::Bt709,
+        );
+        for format in [
+            VideoFormat::H264(h264.clone()),
+            VideoFormat::H265(h265.clone()),
+        ] {
+            assert_eq!(format.bit_depth(), VideoBitDepth::Eight);
+            assert_eq!(format.destination_bit_depth(None), Ok(VideoBitDepth::Eight));
+            assert_eq!(
+                format.destination_bit_depth(Some(8)),
+                Ok(VideoBitDepth::Eight)
+            );
+            assert_eq!(
+                format.destination_bit_depth(Some(10)),
+                Ok(VideoBitDepth::Ten)
+            );
+            assert_eq!(
+                format.destination_bit_depth(Some(12)),
+                Err(FormatError::UnsupportedVideoBitDepth(12))
+            );
+        }
+        for format in [
+            VideoFormat::H264(h264.with_bit_depth(VideoBitDepth::Ten)),
+            VideoFormat::H265(h265.with_bit_depth(VideoBitDepth::Ten)),
+        ] {
+            assert_eq!(format.bit_depth(), VideoBitDepth::Ten);
+            for metadata in [None, Some(8), Some(10)] {
+                assert_eq!(
+                    format.destination_bit_depth(metadata),
+                    Ok(VideoBitDepth::Ten)
+                );
+            }
+            assert_eq!(
+                format.destination_bit_depth(Some(12)),
+                Err(FormatError::UnsupportedVideoBitDepth(12))
+            );
+        }
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/lib.rs
@@ -29,6 +29,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(target_os = "macos"), allow(dead_code))]
 
+mod color;
 mod failure;
 mod format;
 mod lifecycle;
@@ -42,8 +43,8 @@ pub use failure::{BackendFailure, BackendSubsystem, VideoDecodeLoss};
 pub use format::{
     AudioFormat, Av1Format, BackendConfig, BorrowedNsView, BorrowedNsWindow, EmbeddedBackendConfig,
     FrameTiming, H264Format, H264Framing, H264ParameterSets, H265Format, H265ParameterSets,
-    OwnedOverlayConfig, QueueLimits, RendererRect, ScreenRect, SurfaceTarget, VideoColorSpace,
-    VideoFormat, WindowSurfaceConfig,
+    MetalFrameFormat, OwnedOverlayConfig, QueueLimits, RendererRect, ScreenRect, SurfaceTarget,
+    VideoBitDepth, VideoColorSpace, VideoFormat, WindowSurfaceConfig,
 };
 pub use lifecycle::BackendState;
 

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
@@ -11,8 +11,8 @@ use objc2_core_foundation::{CFRetained, CFString};
 use objc2_core_video::{
     CVMetalTexture, CVMetalTextureCache, CVMetalTextureGetTexture, CVPixelBufferGetHeightOfPlane,
     CVPixelBufferGetIOSurface, CVPixelBufferGetPixelFormatType, CVPixelBufferGetPlaneCount,
-    CVPixelBufferGetWidthOfPlane, kCVImageBufferYCbCrMatrixKey,
-    kCVImageBufferYCbCrMatrix_ITU_R_601_4, kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+    CVPixelBufferGetWidthOfPlane, kCVImageBufferYCbCrMatrix_ITU_R_601_4,
+    kCVImageBufferYCbCrMatrix_ITU_R_709_2, kCVImageBufferYCbCrMatrixKey,
     kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
     kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
     kCVPixelFormatType_420YpCbCr10BiPlanarFullRange,
@@ -597,13 +597,13 @@ impl Drop for MetalState {
 mod tests {
     use super::{BiPlanarFormat, MAX_RETAINED_FRAME_SLOTS, validate_frame_slot};
     use crate::format::MetalFrameFormat;
-    use objc2_metal::MTLPixelFormat;
     use objc2_core_video::{
         kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
         kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
         kCVPixelFormatType_420YpCbCr10BiPlanarFullRange,
         kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
     };
+    use objc2_metal::MTLPixelFormat;
 
     #[test]
     fn accepts_nv12_and_p010_ranges_only() {

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
@@ -7,11 +7,13 @@ use std::sync::{Arc, Mutex};
 use objc2::Message;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
-use objc2_core_foundation::CFRetained;
+use objc2_core_foundation::{CFRetained, CFString};
 use objc2_core_video::{
     CVMetalTexture, CVMetalTextureCache, CVMetalTextureGetTexture, CVPixelBufferGetHeightOfPlane,
     CVPixelBufferGetIOSurface, CVPixelBufferGetPixelFormatType, CVPixelBufferGetPlaneCount,
-    CVPixelBufferGetWidthOfPlane, kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+    CVPixelBufferGetWidthOfPlane, kCVImageBufferYCbCrMatrixKey,
+    kCVImageBufferYCbCrMatrix_ITU_R_601_4, kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+    kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
     kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
     kCVPixelFormatType_420YpCbCr10BiPlanarFullRange,
     kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
@@ -24,7 +26,8 @@ use objc2_metal::{
     MTLTexture, MTLTextureDescriptor, MTLTextureUsage, MTLViewport,
 };
 
-use crate::format::VideoColorSpace;
+use crate::color::ConversionParameters;
+use crate::format::{MetalFrameFormat, VideoBitDepth, VideoColorSpace};
 
 use super::mailbox::LatestMailbox;
 use super::video::DecodedFrame;
@@ -52,9 +55,15 @@ struct VertexOut {
 };
 
 struct ConversionParameters {
-    uint color_space;
-    uint sample_format;
-    uint full_range;
+    float sample_scale;
+    float luma_offset;
+    float luma_scale;
+    float chroma_offset;
+    float chroma_scale;
+    float red_cr;
+    float green_cb;
+    float green_cr;
+    float blue_cb;
 };
 
 vertex VertexOut embedded_video_vertex(uint vertex_id [[vertex_id]]) {
@@ -72,33 +81,14 @@ fragment float4 embedded_video_fragment(
     texture2d<float> chroma [[texture(1)]],
     constant ConversionParameters &parameters [[buffer(0)]]) {
     constexpr sampler linear_sampler(coord::normalized, address::clamp_to_edge, filter::linear);
-    float y = luma.sample(linear_sampler, in.texcoord).r;
-    float2 cbcr = chroma.sample(linear_sampler, in.texcoord).rg;
-    if (parameters.full_range == 0) {
-        if (parameters.sample_format == 0) {
-            y = (y - (16.0 / 255.0)) * (255.0 / 219.0);
-            cbcr -= float2(0.5);
-        } else {
-            y = (y - (64.0 / 1023.0)) * (1023.0 / 876.0);
-            cbcr -= float2(512.0 / 1023.0);
-        }
-    } else {
-        cbcr -= parameters.sample_format == 0
-            ? float2(128.0 / 255.0)
-            : float2(512.0 / 1023.0);
-    }
-    float3 rgb;
-    if (parameters.color_space == 0) {
-        rgb = float3(
-            y + 1.596027 * cbcr.y,
-            y - 0.391762 * cbcr.x - 0.812968 * cbcr.y,
-            y + 2.017232 * cbcr.x);
-    } else {
-        rgb = float3(
-            y + 1.792741 * cbcr.y,
-            y - 0.213249 * cbcr.x - 0.532909 * cbcr.y,
-            y + 2.112402 * cbcr.x);
-    }
+    float y = luma.sample(linear_sampler, in.texcoord).r * parameters.sample_scale;
+    float2 cbcr = chroma.sample(linear_sampler, in.texcoord).rg * parameters.sample_scale;
+    y = (y - parameters.luma_offset) * parameters.luma_scale;
+    cbcr = (cbcr - parameters.chroma_offset) * parameters.chroma_scale;
+    float3 rgb = float3(
+        y + parameters.red_cr * cbcr.y,
+        y + parameters.green_cb * cbcr.x + parameters.green_cr * cbcr.y,
+        y + parameters.blue_cb * cbcr.x);
     return float4(saturate(rgb), 1.0);
 }
 "#;
@@ -135,30 +125,61 @@ impl BiPlanarFormat {
         }
     }
 
-    const fn parameters(self, color_space: VideoColorSpace) -> ConversionParameters {
-        ConversionParameters {
-            color_space: match color_space {
-                VideoColorSpace::Bt601 => 0,
-                VideoColorSpace::Bt709 => 1,
+    const fn output_format(self) -> MetalFrameFormat {
+        match self {
+            Self::Nv12Video | Self::Nv12Full => MetalFrameFormat::Rgba8Unorm,
+            Self::P010Video | Self::P010Full => MetalFrameFormat::Rgb10a2Unorm,
+        }
+    }
+
+    fn parameters(self, color_space: VideoColorSpace) -> ConversionParameters {
+        ConversionParameters::new(
+            match self {
+                Self::Nv12Video | Self::Nv12Full => VideoBitDepth::Eight,
+                Self::P010Video | Self::P010Full => VideoBitDepth::Ten,
             },
-            sample_format: match self {
-                Self::Nv12Video | Self::Nv12Full => 0,
-                Self::P010Video | Self::P010Full => 1,
-            },
-            full_range: match self {
-                Self::Nv12Video | Self::P010Video => 0,
-                Self::Nv12Full | Self::P010Full => 1,
-            },
+            matches!(self, Self::Nv12Full | Self::P010Full),
+            color_space,
+        )
+    }
+}
+
+impl MetalFrameFormat {
+    const fn pixel_format(self) -> MTLPixelFormat {
+        match self {
+            Self::Rgba8Unorm => MTLPixelFormat::RGBA8Unorm,
+            Self::Rgb10a2Unorm => MTLPixelFormat::RGB10A2Unorm,
+        }
+    }
+
+    const fn pipeline_index(self) -> usize {
+        match self {
+            Self::Rgba8Unorm => 0,
+            Self::Rgb10a2Unorm => 1,
         }
     }
 }
 
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct ConversionParameters {
-    color_space: u32,
-    sample_format: u32,
-    full_range: u32,
+fn frame_color_space(frame: &DecodedFrame) -> Result<VideoColorSpace, BackendError> {
+    let Some(attachment) = (unsafe {
+        frame
+            .image
+            .attachment(kCVImageBufferYCbCrMatrixKey, ptr::null_mut())
+    }) else {
+        return Ok(frame.color_space);
+    };
+    let matrix = attachment.downcast_ref::<CFString>().ok_or_else(|| {
+        BackendError::Metal("VideoToolbox returned an invalid YCbCr matrix attachment".into())
+    })?;
+    if matrix == unsafe { kCVImageBufferYCbCrMatrix_ITU_R_601_4 } {
+        Ok(VideoColorSpace::Bt601)
+    } else if matrix == unsafe { kCVImageBufferYCbCrMatrix_ITU_R_709_2 } {
+        Ok(VideoColorSpace::Bt709)
+    } else {
+        Err(BackendError::Metal(format!(
+            "unsupported VideoToolbox YCbCr matrix: {matrix}"
+        )))
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -170,6 +191,7 @@ pub struct AdoptedMetalContext {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MetalRecordedFrame {
     pub texture: *mut c_void,
+    pub format: MetalFrameFormat,
     pub width: u32,
     pub height: u32,
     pub frame_slot: u32,
@@ -321,7 +343,8 @@ struct SlotResources {
 struct MetalState {
     device_identity: usize,
     _device: Retained<ProtocolObject<dyn MTLDevice>>,
-    pipeline: Retained<ProtocolObject<dyn MTLRenderPipelineState>>,
+    library: Retained<ProtocolObject<dyn MTLLibrary>>,
+    pipelines: [Option<Retained<ProtocolObject<dyn MTLRenderPipelineState>>>; 2],
     texture_cache: CFRetained<CVMetalTextureCache>,
     slots: HashMap<u32, SlotResources>,
     generation: u64,
@@ -339,24 +362,6 @@ impl MetalState {
         let library = device
             .newLibraryWithSource_options_error(&source, None)
             .map_err(|error| BackendError::Metal(error.localizedDescription().to_string()))?;
-        let vertex = library
-            .newFunctionWithName(&NSString::from_str("embedded_video_vertex"))
-            .ok_or_else(|| BackendError::Metal("embedded_video_vertex shader is missing".into()))?;
-        let fragment = library
-            .newFunctionWithName(&NSString::from_str("embedded_video_fragment"))
-            .ok_or_else(|| {
-                BackendError::Metal("embedded_video_fragment shader is missing".into())
-            })?;
-        let descriptor = MTLRenderPipelineDescriptor::new();
-        descriptor.setVertexFunction(Some(&vertex));
-        descriptor.setFragmentFunction(Some(&fragment));
-        let attachments = descriptor.colorAttachments();
-        let attachment = unsafe { attachments.objectAtIndexedSubscript(0) };
-        attachment.setPixelFormat(MTLPixelFormat::RGBA8Unorm);
-        let pipeline = device
-            .newRenderPipelineStateWithDescriptor_error(&descriptor)
-            .map_err(|error| BackendError::Metal(error.localizedDescription().to_string()))?;
-
         let mut cache_ptr = ptr::null_mut();
         let status = unsafe {
             CVMetalTextureCache::create(None, None, &device, None, NonNull::from(&mut cache_ptr))
@@ -374,7 +379,8 @@ impl MetalState {
         Ok(Self {
             device_identity,
             _device: device,
-            pipeline,
+            library,
+            pipelines: [None, None],
             texture_cache: unsafe { CFRetained::from_raw(cache_ptr) },
             slots: HashMap::with_capacity(3),
             generation: 0,
@@ -402,6 +408,9 @@ impl MetalState {
                 .ok_or_else(|| {
                     BackendError::Metal("VideoToolbox returned neither NV12 nor P010".into())
                 })?;
+        let output_format = format.output_format();
+        let parameters = format.parameters(frame_color_space(&frame)?);
+        self.ensure_pipeline(output_format)?;
         let width = CVPixelBufferGetWidthOfPlane(&frame.image, 0);
         let height = CVPixelBufferGetHeightOfPlane(&frame.image, 0);
         let chroma_width = CVPixelBufferGetWidthOfPlane(&frame.image, 1);
@@ -419,12 +428,16 @@ impl MetalState {
             .slots
             .remove(&frame_slot)
             .map(|resources| resources.output)
-            .filter(|texture| texture.width() == width && texture.height() == height)
+            .filter(|texture| {
+                texture.width() == width
+                    && texture.height() == height
+                    && texture.pixelFormat() == output_format.pixel_format()
+            })
             .map_or_else(
                 || {
                     let descriptor = unsafe {
                         MTLTextureDescriptor::texture2DDescriptorWithPixelFormat_width_height_mipmapped(
-                            MTLPixelFormat::RGBA8Unorm,
+                            output_format.pixel_format(),
                             width,
                             height,
                             false,
@@ -437,7 +450,7 @@ impl MetalState {
                     self._device
                         .newTextureWithDescriptor(&descriptor)
                         .ok_or_else(|| {
-                            BackendError::Metal("failed to create embedded RGBA texture".into())
+                            BackendError::Metal(format!("failed to create embedded {output_format:?} texture"))
                         })
                 },
                 Ok,
@@ -452,12 +465,15 @@ impl MetalState {
         let encoder = command_buffer
             .renderCommandEncoderWithDescriptor(&render_pass)
             .ok_or_else(|| BackendError::Metal("failed to create embedded Metal encoder".into()))?;
-        encoder.setRenderPipelineState(&self.pipeline);
+        encoder.setRenderPipelineState(
+            self.pipelines[output_format.pipeline_index()]
+                .as_ref()
+                .expect("initialized pipeline"),
+        );
         unsafe {
             encoder.setFragmentTexture_atIndex(Some(&luma_texture), 0);
             encoder.setFragmentTexture_atIndex(Some(&chroma_texture), 1);
         }
-        let parameters = format.parameters(frame.color_space);
         unsafe {
             encoder.setFragmentBytes_length_atIndex(
                 NonNull::from(&parameters).cast::<c_void>(),
@@ -491,12 +507,47 @@ impl MetalState {
         self.generation = self.generation.wrapping_add(1);
         Ok(MetalRecordedFrame {
             texture,
+            format: output_format,
             width: u32::try_from(width).unwrap_or(u32::MAX),
             height: u32::try_from(height).unwrap_or(u32::MAX),
             frame_slot,
             generation: self.generation,
             presentation_time_ns: 0,
         })
+    }
+
+    fn ensure_pipeline(&mut self, format: MetalFrameFormat) -> Result<(), BackendError> {
+        let pipeline = &mut self.pipelines[format.pipeline_index()];
+        if pipeline.is_some() {
+            return Ok(());
+        }
+        let vertex = self
+            .library
+            .newFunctionWithName(&NSString::from_str("embedded_video_vertex"))
+            .ok_or_else(|| BackendError::Metal("embedded_video_vertex shader is missing".into()))?;
+        let fragment = self
+            .library
+            .newFunctionWithName(&NSString::from_str("embedded_video_fragment"))
+            .ok_or_else(|| {
+                BackendError::Metal("embedded_video_fragment shader is missing".into())
+            })?;
+        let descriptor = MTLRenderPipelineDescriptor::new();
+        descriptor.setVertexFunction(Some(&vertex));
+        descriptor.setFragmentFunction(Some(&fragment));
+        let attachments = descriptor.colorAttachments();
+        let attachment = unsafe { attachments.objectAtIndexedSubscript(0) };
+        attachment.setPixelFormat(format.pixel_format());
+        *pipeline = Some(
+            self._device
+                .newRenderPipelineStateWithDescriptor_error(&descriptor)
+                .map_err(|error| {
+                    BackendError::Metal(format!(
+                        "failed to create {format:?} pipeline: {}",
+                        error.localizedDescription()
+                    ))
+                })?,
+        );
+        Ok(())
     }
 
     fn make_plane_texture(
@@ -545,6 +596,8 @@ impl Drop for MetalState {
 #[cfg(test)]
 mod tests {
     use super::{BiPlanarFormat, MAX_RETAINED_FRAME_SLOTS, validate_frame_slot};
+    use crate::format::MetalFrameFormat;
+    use objc2_metal::MTLPixelFormat;
     use objc2_core_video::{
         kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
         kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
@@ -579,5 +632,33 @@ mod tests {
         assert!(validate_frame_slot(0).is_ok());
         assert!(validate_frame_slot(7).is_ok());
         assert!(validate_frame_slot(8).is_err());
+    }
+
+    #[test]
+    fn ten_bit_planes_always_select_rgb10a2_texture_and_pipeline() {
+        for format in [BiPlanarFormat::Nv12Video, BiPlanarFormat::Nv12Full] {
+            assert_eq!(format.output_format(), MetalFrameFormat::Rgba8Unorm);
+            assert_eq!(
+                format.output_format().pixel_format(),
+                MTLPixelFormat::RGBA8Unorm
+            );
+            assert_eq!(format.output_format().pipeline_index(), 0);
+            assert_eq!(
+                format.plane_formats(),
+                (MTLPixelFormat::R8Unorm, MTLPixelFormat::RG8Unorm)
+            );
+        }
+        for format in [BiPlanarFormat::P010Video, BiPlanarFormat::P010Full] {
+            assert_eq!(format.output_format(), MetalFrameFormat::Rgb10a2Unorm);
+            assert_eq!(
+                format.output_format().pixel_format(),
+                MTLPixelFormat::RGB10A2Unorm
+            );
+            assert_eq!(format.output_format().pipeline_index(), 1);
+            assert_eq!(
+                format.plane_formats(),
+                (MTLPixelFormat::R16Unorm, MTLPixelFormat::RG16Unorm)
+            );
+        }
     }
 }

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/video.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/video.rs
@@ -11,20 +11,26 @@ use objc2_core_media::{
     CMBlockBuffer, CMFormatDescription, CMSampleBuffer, CMSampleTimingInfo, CMTime,
     CMVideoFormatDescriptionCreate, CMVideoFormatDescriptionCreateFromH264ParameterSets,
     CMVideoFormatDescriptionCreateFromHEVCParameterSets,
+    kCMFormatDescriptionExtension_BitsPerComponent,
     kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms, kCMTimeInvalid,
     kCMVideoCodecType_AV1,
 };
 use objc2_core_video::{
-    CVImageBuffer, kCVPixelBufferIOSurfacePropertiesKey, kCVPixelBufferMetalCompatibilityKey,
-    kCVPixelBufferPixelFormatTypeKey, kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+    CVImageBuffer, CVPixelBufferGetPixelFormatType, kCVPixelBufferIOSurfacePropertiesKey,
+    kCVPixelBufferMetalCompatibilityKey, kCVPixelBufferPixelFormatTypeKey,
+    kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+    kCVPixelFormatType_420YpCbCr10BiPlanarFullRange,
+    kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
 };
 use objc2_video_toolbox::{
     VTDecodeFrameFlags, VTDecodeInfoFlags, VTDecompressionOutputCallbackRecord,
     VTDecompressionSession, kVTVideoDecoderSpecification_RequireHardwareAcceleratedVideoDecoder,
 };
 
-use crate::failure::FailureReporter;
-use crate::format::{Av1Format, FrameTiming, H264Format, H265Format, VideoColorSpace, VideoFormat};
+use crate::failure::{BackendSubsystem, FailureReporter};
+use crate::format::{
+    Av1Format, FrameTiming, H264Format, H265Format, VideoBitDepth, VideoColorSpace, VideoFormat,
+};
 use crate::queue::{BoundedQueue, PushResult};
 
 use super::mailbox::LatestMailbox;
@@ -105,6 +111,7 @@ struct CallbackContext {
     failures: Arc<FailureReporter>,
     in_flight: Arc<InFlight>,
     color_space: VideoColorSpace,
+    bit_depth: VideoBitDepth,
 }
 
 pub(super) struct VideoDecoder {
@@ -127,6 +134,10 @@ impl VideoDecoder {
         maximum_in_flight: usize,
     ) -> Result<Self, BackendError> {
         let format_description = create_format_description(format)?;
+        let bitstream_depth =
+            unsafe { format_description.extension(kCMFormatDescriptionExtension_BitsPerComponent) }
+                .and_then(|value| value.downcast_ref::<CFNumber>().and_then(CFNumber::as_i32));
+        let bit_depth = format.destination_bit_depth(bitstream_depth)?;
         let in_flight = Arc::new(InFlight {
             count: AtomicUsize::new(0),
             maximum: maximum_in_flight,
@@ -137,13 +148,17 @@ impl VideoDecoder {
             failures,
             in_flight: Arc::clone(&in_flight),
             color_space: format.color_space(),
+            bit_depth,
         });
         let callback = VTDecompressionOutputCallbackRecord {
             decompressionOutputCallback: Some(decompression_callback),
             decompressionOutputRefCon: (&mut *callback_context as *mut CallbackContext).cast(),
         };
 
-        let pixel_format = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange as i32;
+        let pixel_format = match bit_depth {
+            VideoBitDepth::Eight => kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+            VideoBitDepth::Ten => kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
+        } as i32;
         let pixel_format_number = unsafe {
             CFNumber::new(
                 None,
@@ -323,6 +338,22 @@ unsafe extern "C-unwind" fn decompression_callback(
     if status == 0 {
         if let Some(image_buffer) = NonNull::new(image_buffer) {
             let image = unsafe { CFRetained::retain(image_buffer) };
+            let pixel_format = CVPixelBufferGetPixelFormatType(&image);
+            if context.bit_depth == VideoBitDepth::Ten
+                && pixel_format != kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
+                && pixel_format != kCVPixelFormatType_420YpCbCr10BiPlanarFullRange
+            {
+                context
+                    .counters
+                    .video_decode_errors
+                    .fetch_add(1, Ordering::Relaxed);
+                context.failures.report_fatal(
+                    BackendSubsystem::VideoToolbox,
+                    format!("VideoToolbox did not preserve ten-bit output: pixel format {pixel_format:#010x}"),
+                );
+                context.in_flight.release();
+                return;
+            }
             let frame = DecodedFrame {
                 image,
                 color_space: context.color_space,

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/README.md
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/README.md
@@ -20,6 +20,24 @@ capability is reported only when its selected decoder class and the complete pre
 operation succeed. `WindowsBackend::probe` remains the D3D11 compatibility entry point.
 Non-Windows builds expose the same typed API but report the backend as unavailable.
 
+## Embedded Qt SDR conversion
+
+The embedded frame producer converts NV12/AYUV to RGBA8 and P010/Y410 to RGB10A2,
+preserving ten-bit precision until Qt's final SDR composition pass. RGB10A2 is an SDR
+intermediate, not an HDR or ten-bit scan-out guarantee. Both full- and limited-range
+BT.709 decoder output are converted to full-range BT.709 RGB.
+
+Embedded conversion requires `ID3D11VideoContext1` for explicit color-space selection and
+`ID3D11VideoProcessorEnumerator1` to validate the input/output format and color-space pair.
+Unsupported conversions fail explicitly; the producer does not silently replace RGB10A2
+with RGBA8 or rely on legacy driver color defaults. Format, range, and extent changes
+invalidate the processor, cached input views, and frame slots before conversion resumes.
+
+Media Foundation may temporarily negotiate a lower-precision output type before reading
+the first sequence header. That startup compatibility does not permit downgraded frames:
+each decoded surface must match its output media type and preserve at least the negotiated
+bit depth and chroma before entering the decoded queue.
+
 ## HEVC availability in Qt
 
 The embedded Qt stream view uses the same Media Foundation decoder configuration as the

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/decoder.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/decoder.rs
@@ -8,8 +8,8 @@ use ::windows::Win32::Foundation::{E_NOTIMPL, LUID};
 use ::windows::Win32::Graphics::Direct3D11::{
     D3D11_DECODER_PROFILE_AV1_VLD_PROFILE0, D3D11_DECODER_PROFILE_H264_VLD_FGT,
     D3D11_DECODER_PROFILE_H264_VLD_NOFGT, D3D11_DECODER_PROFILE_HEVC_VLD_MAIN,
-    D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10, D3D11_VIDEO_DECODER_DESC, ID3D11Texture2D,
-    ID3D11VideoDevice,
+    D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10, D3D11_TEXTURE2D_DESC, D3D11_VIDEO_DECODER_DESC,
+    ID3D11Texture2D, ID3D11VideoDevice,
 };
 use ::windows::Win32::Graphics::Dxgi::Common::{
     DXGI_FORMAT, DXGI_FORMAT_AYUV, DXGI_FORMAT_NV12, DXGI_FORMAT_P010, DXGI_FORMAT_Y410,
@@ -76,6 +76,7 @@ impl DecodedVideoFrame {
         sample: IMFSample,
         format: VideoFormat,
         aperture: VideoAperture,
+        preferred_pixel_format: VideoPixelFormat,
     ) -> Result<Self, String> {
         match unsafe { sample.GetUINT32(&MFSampleExtension_FrameCorruption) } {
             Ok(corrupted) if corrupted != 0 => {
@@ -86,6 +87,15 @@ impl DecodedVideoFrame {
             Err(error) => return Err(format!("read decoder output corruption flag: {error}")),
         }
         let (texture, subresource) = dxgi_surface(&sample)?;
+        let mut description = D3D11_TEXTURE2D_DESC::default();
+        unsafe {
+            texture.GetDesc(&mut description);
+        }
+        validate_decoded_output_format(
+            description.Format,
+            format.pixel_format,
+            preferred_pixel_format,
+        )?;
         let timestamp_100ns = unsafe { sample.GetSampleTime().unwrap_or(0) };
         let duration_100ns = unsafe {
             sample
@@ -359,7 +369,12 @@ impl Decoder {
                 "hardware decoder requires caller-allocated output samples".to_owned()
             }
         })?;
-        let frame = DecodedVideoFrame::from_sample(sample, self.format, self.aperture)?;
+        let frame = DecodedVideoFrame::from_sample(
+            sample,
+            self.format,
+            self.aperture,
+            self.preferred_pixel_format,
+        )?;
         if decoded_frames.len() == ADAPTIVE_VIDEO_QUEUE_CAPACITY {
             decoded_frames.pop_front();
             let _ = event_queue.push(BackendEvent::QueueOverflow(Subsystem::VideoPresentation));
@@ -691,12 +706,7 @@ fn ensure_hardware_format<G: DecoderDevice>(
         }
         ID3D11VideoDevice::from_raw(service)
     };
-    let output: DXGI_FORMAT = match format.pixel_format {
-        VideoPixelFormat::Nv12 => DXGI_FORMAT_NV12,
-        VideoPixelFormat::P010 => DXGI_FORMAT_P010,
-        VideoPixelFormat::Ayuv => DXGI_FORMAT_AYUV,
-        VideoPixelFormat::Y410 => DXGI_FORMAT_Y410,
-    };
+    let output = decoder_surface_format(format.pixel_format);
     let candidates = hardware_profiles(format.codec, format.pixel_format);
     unsafe {
         for index in 0..device.GetVideoDecoderProfileCount() {
@@ -803,6 +813,37 @@ fn output_format_preferences(preferred: VideoPixelFormat) -> &'static [VideoPixe
             VideoPixelFormat::Nv12,
         ],
     }
+}
+
+fn decoder_surface_format(pixel_format: VideoPixelFormat) -> DXGI_FORMAT {
+    match pixel_format {
+        VideoPixelFormat::Nv12 => DXGI_FORMAT_NV12,
+        VideoPixelFormat::P010 => DXGI_FORMAT_P010,
+        VideoPixelFormat::Ayuv => DXGI_FORMAT_AYUV,
+        VideoPixelFormat::Y410 => DXGI_FORMAT_Y410,
+    }
+}
+
+fn validate_decoded_output_format(
+    surface_format: DXGI_FORMAT,
+    output: VideoPixelFormat,
+    preferred: VideoPixelFormat,
+) -> Result<(), String> {
+    if surface_format != decoder_surface_format(output) {
+        return Err(format!(
+            "Media Foundation decoder surface format {} does not match output media format {output:?}",
+            surface_format.0
+        ));
+    }
+    if output.bit_depth() < preferred.bit_depth()
+        || (chroma_format(preferred) == VideoChromaFormat::Cs444
+            && chroma_format(output) != VideoChromaFormat::Cs444)
+    {
+        return Err(format!(
+            "Media Foundation decoder produced {output:?} output below negotiated {preferred:?} precision or chroma"
+        ));
+    }
+    Ok(())
 }
 
 fn pixel_format_from_subtype(subtype: ::windows::core::GUID) -> Option<VideoPixelFormat> {
@@ -1049,9 +1090,10 @@ mod tests {
                 }
                 sample
             };
-            let error = DecodedVideoFrame::from_sample(sample, format, aperture)
-                .err()
-                .expect("system-memory output cannot be published as a decoded GPU frame");
+            let error =
+                DecodedVideoFrame::from_sample(sample, format, aperture, format.pixel_format)
+                    .err()
+                    .expect("system-memory output cannot be published as a decoded GPU frame");
             assert_eq!(
                 error,
                 if corruption == Some(1) {
@@ -1226,5 +1268,65 @@ mod tests {
             output_format_preferences(VideoPixelFormat::Nv12),
             &[VideoPixelFormat::Nv12]
         );
+    }
+
+    #[test]
+    fn decoded_output_rejects_depth_or_chroma_loss_after_startup() {
+        for (preferred, accepted) in [
+            (VideoPixelFormat::Nv12, [true, true, true, true]),
+            (VideoPixelFormat::P010, [false, true, false, true]),
+            (VideoPixelFormat::Ayuv, [false, false, true, true]),
+            (VideoPixelFormat::Y410, [false, false, false, true]),
+        ] {
+            for (output, accepted) in [
+                VideoPixelFormat::Nv12,
+                VideoPixelFormat::P010,
+                VideoPixelFormat::Ayuv,
+                VideoPixelFormat::Y410,
+            ]
+            .into_iter()
+            .zip(accepted)
+            {
+                let result = validate_decoded_output_format(
+                    decoder_surface_format(output),
+                    output,
+                    preferred,
+                );
+                assert_eq!(
+                    result.is_ok(),
+                    accepted,
+                    "requested={preferred:?} output={output:?}: {result:?}"
+                );
+                if !accepted {
+                    let error = result.unwrap_err();
+                    assert!(error.contains(&format!("produced {output:?}")));
+                    assert!(error.contains(&format!("negotiated {preferred:?}")));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn decoded_surface_must_match_media_type_before_precision_validation() {
+        for surface in [
+            DXGI_FORMAT_NV12,
+            DXGI_FORMAT_P010,
+            DXGI_FORMAT_AYUV,
+            DXGI_FORMAT_Y410,
+            ::windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R8G8B8A8_UNORM,
+        ] {
+            for output in [
+                VideoPixelFormat::Nv12,
+                VideoPixelFormat::P010,
+                VideoPixelFormat::Ayuv,
+                VideoPixelFormat::Y410,
+            ] {
+                let result = validate_decoded_output_format(surface, output, output);
+                assert_eq!(result.is_ok(), surface == decoder_surface_format(output));
+                if let Err(error) = result {
+                    assert!(error.contains("does not match output media format"));
+                }
+            }
+        }
     }
 }

--- a/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/embedded.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-windows/src/windows/embedded.rs
@@ -12,10 +12,11 @@ use ::windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
 use ::windows::Win32::Graphics::Direct3D11::{
     D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_TEX2D_VPIV, D3D11_TEX2D_VPOV,
     D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE,
-    D3D11_VIDEO_PROCESSOR_CONTENT_DESC, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT,
-    D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC, D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0,
-    D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC, D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0,
-    D3D11_VIDEO_PROCESSOR_STREAM, D3D11_VIDEO_USAGE_OPTIMAL_SPEED, D3D11_VPIV_DIMENSION_TEXTURE2D,
+    D3D11_VIDEO_PROCESSOR_CONTENT_DESC, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT,
+    D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT, D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC,
+    D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0, D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC,
+    D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0, D3D11_VIDEO_PROCESSOR_STREAM,
+    D3D11_VIDEO_USAGE_OPTIMAL_SPEED, D3D11_VPIV_DIMENSION_TEXTURE2D,
     D3D11_VPOV_DIMENSION_TEXTURE2D, ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D,
     ID3D11VideoContext, ID3D11VideoContext1, ID3D11VideoDevice, ID3D11VideoProcessor,
     ID3D11VideoProcessorEnumerator, ID3D11VideoProcessorEnumerator1, ID3D11VideoProcessorInputView,
@@ -255,7 +256,7 @@ struct AdoptedResources {
     device: ID3D11Device,
     video_device: ID3D11VideoDevice,
     video_context: ID3D11VideoContext,
-    video_context_1: Option<ID3D11VideoContext1>,
+    video_context_1: ID3D11VideoContext1,
     manager: IMFDXGIDeviceManager,
     format: VideoFormat,
     generation: u64,
@@ -286,7 +287,9 @@ impl AdoptedResources {
         let video_context: ID3D11VideoContext = context
             .cast()
             .map_err(|error| format!("Qt immediate context has no video interface: {error}"))?;
-        let video_context_1 = video_context.cast().ok();
+        let video_context_1 = video_context.cast().map_err(|error| {
+            format!("Qt D3D11 context cannot configure explicit SDR color spaces: {error}")
+        })?;
         let mut reset_token = 0;
         let mut manager = None;
         unsafe {
@@ -537,18 +540,16 @@ impl AdoptedResources {
                 .CreateVideoProcessor(&enumerator, 0)
                 .map_err(|error| format!("CreateVideoProcessor: {error}"))?
         };
-        if let Some(context) = self.video_context_1.as_ref() {
-            unsafe {
-                context.VideoProcessorSetStreamColorSpace1(
-                    &processor,
-                    0,
-                    input_color_space(self.format),
-                );
-                context.VideoProcessorSetOutputColorSpace1(
-                    &processor,
-                    DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
-                );
-            }
+        unsafe {
+            self.video_context_1.VideoProcessorSetStreamColorSpace1(
+                &processor,
+                0,
+                input_color_space(self.format),
+            );
+            self.video_context_1.VideoProcessorSetOutputColorSpace1(
+                &processor,
+                DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
+            );
         }
         // QRhi owns slot reuse. Allocate only the slots it actually visits;
         // reserving the ABI maximum would waste seven 4K textures on D3D11.
@@ -1285,6 +1286,15 @@ fn validate_conversion(
 ) -> Result<(), String> {
     unsafe {
         let support = enumerator
+            .CheckVideoProcessorFormat(input_format)
+            .map_err(|error| format!("query decoder video-processor input: {error}"))?;
+        if support & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT.0 as u32 == 0 {
+            return Err(format!(
+                "D3D11 video processor does not support input format {}",
+                input_format.0
+            ));
+        }
+        let support = enumerator
             .CheckVideoProcessorFormat(output_format)
             .map_err(|error| format!("query RGB video-processor output: {error}"))?;
         if support & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT.0 as u32 == 0 {
@@ -1293,33 +1303,38 @@ fn validate_conversion(
                 output_format.0
             ));
         }
-        if let Ok(enumerator_1) = enumerator.cast::<ID3D11VideoProcessorEnumerator1>() {
-            let supported = enumerator_1
-                .CheckVideoProcessorFormatConversion(
-                    input_format,
-                    input_color_space(format),
-                    output_format,
-                    DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
-                )
-                .map_err(|error| format!("query D3D11 embedded conversion: {error}"))?;
-            if !supported.as_bool() {
-                return Err(format!(
-                    "D3D11 driver rejects embedded video conversion {} -> {}",
-                    input_format.0, output_format.0
-                ));
-            }
+        let enumerator_1 = enumerator
+            .cast::<ID3D11VideoProcessorEnumerator1>()
+            .map_err(|error| format!("D3D11 cannot validate explicit SDR conversion: {error}"))?;
+        let supported = enumerator_1
+            .CheckVideoProcessorFormatConversion(
+                input_format,
+                input_color_space(format),
+                output_format,
+                DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
+            )
+            .map_err(|error| format!("query D3D11 embedded conversion: {error}"))?;
+        if !supported.as_bool() {
+            return Err(format!(
+                "D3D11 driver rejects embedded SDR video conversion {} ({}) -> {} (full-range RGB BT.709)",
+                input_format.0,
+                if format.full_range {
+                    "full-range BT.709"
+                } else {
+                    "limited-range BT.709"
+                },
+                output_format.0
+            ));
         }
     }
     Ok(())
 }
 
-fn output_dxgi_format(_format: VideoPixelFormat) -> DXGI_FORMAT {
-    // The embedded Qt window currently presents through an SDR 8-bit swapchain. Publishing an
-    // RGB10A2 intermediate therefore cannot produce 10-bit scan-out, but it does add a second
-    // cross-owned 10-bit render target between the D3D11 video processor and QRhi. Keep the
-    // negotiated ten-bit bitstream and P010/Y410 decode surface, then let the video processor
-    // perform the final SDR conversion into Qt's native RGBA8 composition format.
-    DXGI_FORMAT_R8G8B8A8_UNORM
+fn output_dxgi_format(format: VideoPixelFormat) -> DXGI_FORMAT {
+    match format {
+        VideoPixelFormat::Nv12 | VideoPixelFormat::Ayuv => DXGI_FORMAT_R8G8B8A8_UNORM,
+        VideoPixelFormat::P010 | VideoPixelFormat::Y410 => DXGI_FORMAT_R10G10B10A2_UNORM,
+    }
 }
 
 fn d3d11_texture_format(format: DXGI_FORMAT) -> D3d11TextureFormat {
@@ -1443,7 +1458,9 @@ mod tests {
                 sample.SetSampleDuration(166_667).unwrap();
                 sample
             };
-            let frame = DecodedVideoFrame::from_sample(sample, format, aperture).unwrap();
+            let frame =
+                DecodedVideoFrame::from_sample(sample, format, aperture, format.pixel_format)
+                    .unwrap();
             let first = resources.record(0, &frame).unwrap();
             let processor = resources.processor.as_ref().unwrap().processor.clone();
             for _ in 0..3 {
@@ -1713,10 +1730,40 @@ mod tests {
             sample
         };
         let baseline_refs = sample_ref_count(&sample);
+        for preferred in [
+            VideoPixelFormat::P010,
+            VideoPixelFormat::Ayuv,
+            VideoPixelFormat::Y410,
+        ] {
+            let error = DecodedVideoFrame::from_sample(
+                sample.clone(),
+                format,
+                crate::aperture::VideoAperture::new(format.width, format.height, None).unwrap(),
+                preferred,
+            )
+            .err()
+            .expect("startup fallback must not publish a downgraded frame");
+            assert!(error.contains("produced Nv12 output below negotiated"));
+            assert_eq!(sample_ref_count(&sample), baseline_refs);
+        }
+        let error = DecodedVideoFrame::from_sample(
+            sample.clone(),
+            VideoFormat {
+                pixel_format: VideoPixelFormat::P010,
+                ..format
+            },
+            crate::aperture::VideoAperture::new(format.width, format.height, None).unwrap(),
+            VideoPixelFormat::P010,
+        )
+        .err()
+        .expect("an eight-bit surface cannot claim ten-bit output");
+        assert!(error.contains("does not match output media format P010"));
+        assert_eq!(sample_ref_count(&sample), baseline_refs);
         let frame = DecodedVideoFrame::from_sample(
             sample.clone(),
             format,
             crate::aperture::VideoAperture::new(format.width, format.height, None).unwrap(),
+            format.pixel_format,
         )
         .unwrap();
         assert_eq!(
@@ -1770,6 +1817,119 @@ mod tests {
                 .iter()
                 .all(Option::is_none)
         );
+        let enumerator = resources.processor.as_ref().unwrap().enumerator.clone();
+        let enumerator_1: ID3D11VideoProcessorEnumerator1 = enumerator.cast().unwrap();
+        let mut previous_texture = None;
+        for (input_format, pixel_format, chroma_format) in [
+            (
+                DXGI_FORMAT_NV12,
+                VideoPixelFormat::Nv12,
+                VideoChromaFormat::Cs420,
+            ),
+            (
+                DXGI_FORMAT_P010,
+                VideoPixelFormat::P010,
+                VideoChromaFormat::Cs420,
+            ),
+            (
+                DXGI_FORMAT_Y410,
+                VideoPixelFormat::Y410,
+                VideoChromaFormat::Cs444,
+            ),
+            (
+                DXGI_FORMAT_AYUV,
+                VideoPixelFormat::Ayuv,
+                VideoChromaFormat::Cs444,
+            ),
+            (
+                DXGI_FORMAT_NV12,
+                VideoPixelFormat::Nv12,
+                VideoChromaFormat::Cs420,
+            ),
+        ] {
+            for full_range in [true, false] {
+                let format = VideoFormat {
+                    width: 128,
+                    pixel_format,
+                    chroma_format,
+                    full_range,
+                    ..format
+                };
+                resources.reconfigure(format);
+                assert!(resources.processor.is_none());
+                let output_format = output_dxgi_format(pixel_format);
+                let supported = unsafe {
+                    enumerator.CheckVideoProcessorFormat(input_format).unwrap()
+                        & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT.0 as u32
+                        != 0
+                        && enumerator.CheckVideoProcessorFormat(output_format).unwrap()
+                            & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT.0 as u32
+                            != 0
+                        && enumerator_1
+                            .CheckVideoProcessorFormatConversion(
+                                input_format,
+                                input_color_space(format),
+                                output_format,
+                                DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
+                            )
+                            .unwrap()
+                            .as_bool()
+                };
+                let result = resources.ensure_processor(128, 64, input_format, 128, 64);
+                if !supported {
+                    assert!(
+                        result.is_err(),
+                        "unsupported conversion must not fall back to RGBA8"
+                    );
+                    assert!(resources.processor.is_none());
+                    continue;
+                }
+                result.unwrap();
+                let processor = resources.processor.as_mut().unwrap();
+                assert_eq!(processor.output_format, output_format);
+                assert!(processor.input_views.is_empty());
+                assert!(processor.slots.iter().all(Option::is_none));
+                unsafe {
+                    assert_eq!(
+                        resources
+                            .video_context_1
+                            .VideoProcessorGetStreamColorSpace1(&processor.processor, 0,),
+                        input_color_space(format)
+                    );
+                    assert_eq!(
+                        resources
+                            .video_context_1
+                            .VideoProcessorGetOutputColorSpace1(&processor.processor,),
+                        DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709
+                    );
+                }
+                let slot = FrameSlot::new(
+                    &device,
+                    &resources.video_device,
+                    &processor.enumerator,
+                    128,
+                    64,
+                    processor.output_format,
+                )
+                .unwrap();
+                let mut description = D3D11_TEXTURE2D_DESC::default();
+                unsafe {
+                    slot.texture.GetDesc(&mut description);
+                }
+                assert_eq!(description.Format, output_format);
+                if let Some(previous) = previous_texture.as_ref() {
+                    assert_ne!(&slot.texture, previous);
+                }
+                previous_texture = Some(slot.texture.clone());
+                processor.slots[0] = Some(slot);
+                let identity = processor.processor.clone();
+                resources
+                    .ensure_processor(128, 64, input_format, 128, 64)
+                    .unwrap();
+                assert_eq!(resources.processor.as_ref().unwrap().processor, identity);
+                assert!(resources.processor.as_ref().unwrap().slots[0].is_some());
+            }
+        }
     }
 
     #[test]
@@ -1856,12 +2016,66 @@ mod tests {
 
         let ten_bit =
             frame_slot_description(2560, 1440, output_dxgi_format(VideoPixelFormat::P010));
-        assert_eq!(ten_bit.Format, DXGI_FORMAT_R8G8B8A8_UNORM);
+        assert_eq!(ten_bit.Format, DXGI_FORMAT_R10G10B10A2_UNORM);
         assert_eq!(output_dxgi_format(VideoPixelFormat::Y410), ten_bit.Format);
         assert_eq!(
             d3d11_texture_format(ten_bit.Format),
-            D3d11TextureFormat::Rgba8
+            D3d11TextureFormat::Rgb10A2
         );
+    }
+
+    #[test]
+    fn sdr_conversion_preserves_decoder_precision_and_expands_only_limited_range() {
+        for (pixel_format, chroma_format, output_format, texture_format) in [
+            (
+                VideoPixelFormat::Nv12,
+                VideoChromaFormat::Cs420,
+                DXGI_FORMAT_R8G8B8A8_UNORM,
+                D3d11TextureFormat::Rgba8,
+            ),
+            (
+                VideoPixelFormat::Ayuv,
+                VideoChromaFormat::Cs444,
+                DXGI_FORMAT_R8G8B8A8_UNORM,
+                D3d11TextureFormat::Rgba8,
+            ),
+            (
+                VideoPixelFormat::P010,
+                VideoChromaFormat::Cs420,
+                DXGI_FORMAT_R10G10B10A2_UNORM,
+                D3d11TextureFormat::Rgb10A2,
+            ),
+            (
+                VideoPixelFormat::Y410,
+                VideoChromaFormat::Cs444,
+                DXGI_FORMAT_R10G10B10A2_UNORM,
+                D3d11TextureFormat::Rgb10A2,
+            ),
+        ] {
+            for full_range in [false, true] {
+                let format = VideoFormat {
+                    codec: crate::VideoCodec::H265,
+                    width: 64,
+                    height: 64,
+                    frame_rate_numerator: std::num::NonZeroU32::new(60).unwrap(),
+                    frame_rate_denominator: std::num::NonZeroU32::new(1).unwrap(),
+                    average_bitrate: 10_000_000,
+                    pixel_format,
+                    chroma_format,
+                    full_range,
+                };
+                assert_eq!(output_dxgi_format(pixel_format), output_format);
+                assert_eq!(d3d11_texture_format(output_format), texture_format);
+                assert_eq!(
+                    input_color_space(format),
+                    if full_range {
+                        DXGI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P709
+                    } else {
+                        DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P709
+                    }
+                );
+            }
+        }
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/graphics.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/graphics.rs
@@ -167,7 +167,14 @@ impl GraphicsFrame for opennow_streamer_platform_linux::LinuxGpuFrame {
         Ok(GraphicsRecordedFrame {
             resource: frame.image,
             resource_view: frame.image_view,
-            texture_format: GraphicsTextureFormat::Rgba8,
+            texture_format: match frame.texture_format {
+                opennow_streamer_platform_linux::GpuTextureFormat::Rgba8 => {
+                    GraphicsTextureFormat::Rgba8
+                }
+                opennow_streamer_platform_linux::GpuTextureFormat::Rgb10A2 => {
+                    GraphicsTextureFormat::Rgb10A2
+                }
+            },
             width: frame.width,
             height: frame.height,
             frame_slot: frame.slot,
@@ -213,7 +220,14 @@ impl GraphicsFrame for opennow_streamer_platform_macos::MetalFrame {
         Ok(GraphicsRecordedFrame {
             resource: frame.texture as usize as u64,
             resource_view: 0,
-            texture_format: GraphicsTextureFormat::Rgba8,
+            texture_format: match frame.format {
+                opennow_streamer_platform_macos::MetalFrameFormat::Rgba8Unorm => {
+                    GraphicsTextureFormat::Rgba8
+                }
+                opennow_streamer_platform_macos::MetalFrameFormat::Rgb10a2Unorm => {
+                    GraphicsTextureFormat::Rgb10A2
+                }
+            },
             width: frame.width,
             height: frame.height,
             frame_slot: frame.frame_slot,

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/lib.rs
@@ -144,6 +144,18 @@ pub(crate) fn embedded_video_backends_with_device(
     };
     #[cfg(target_os = "macos")]
     let mut backends = vec![hardware_backend()];
+    #[cfg(target_os = "macos")]
+    for backend in &mut backends {
+        for codec in &mut backend.codecs {
+            codec.color_qualities = Some(if !codec.available {
+                Vec::new()
+            } else if codec.codec == "h264" {
+                vec!["8bit_420"]
+            } else {
+                vec!["8bit_420", "10bit_420"]
+            });
+        }
+    }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     let mut backends = Vec::new();
     apply_backend_policy(
@@ -587,6 +599,25 @@ mod tests {
                     assert!(backend.zero_copy_modes.is_empty());
                 } else {
                     assert!(colors.iter().all(|color| *color == "8bit_420"));
+                }
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn embedded_macos_reports_only_biplanar_color_profiles() {
+        for backend in embedded_video_backends() {
+            for codec in backend.codecs {
+                let colors = codec
+                    .color_qualities
+                    .expect("embedded macOS color profiles");
+                if !codec.available {
+                    assert!(colors.is_empty());
+                } else if codec.codec == "h264" {
+                    assert_eq!(colors, ["8bit_420"]);
+                } else {
+                    assert_eq!(colors, ["8bit_420", "10bit_420"]);
                 }
             }
         }

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
@@ -330,6 +330,15 @@ impl MediaColorQuality {
     pub const fn is_444(self) -> bool {
         matches!(self, Self::EightBit444 | Self::TenBit444)
     }
+
+    #[cfg(target_os = "macos")]
+    const fn macos_bit_depth(self) -> opennow_streamer_platform_macos::VideoBitDepth {
+        use opennow_streamer_platform_macos::VideoBitDepth;
+        match self {
+            Self::EightBit420 | Self::EightBit444 => VideoBitDepth::Eight,
+            Self::TenBit420 | Self::TenBit444 => VideoBitDepth::Ten,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1145,6 +1154,11 @@ impl MediaSession {
         stream: MediaStreamConfig,
         frames: crate::GraphicsFramePublisher,
     ) -> Result<Self, String> {
+        if stream.color_quality.is_444() {
+            return Err(
+                "embedded VideoToolbox decode does not support negotiated 4:4:4 color".to_owned(),
+            );
+        }
         let shared = Arc::new(SharedPipeline {
             video: Arc::new(VideoQueue::new(macos_video_queue_capacity(stream.fps))),
             audio: Arc::new(BoundedQueue::new(AUDIO_QUEUE_CAPACITY)),
@@ -1218,7 +1232,9 @@ impl MediaSession {
                             reply,
                         } => {
                             let result = start(
-                                H265Format::new(parameter_sets, VideoColorSpace::Bt709).into(),
+                                H265Format::new(parameter_sets, VideoColorSpace::Bt709)
+                                    .with_bit_depth(stream.color_quality.macos_bit_depth())
+                                    .into(),
                             )
                             .and_then(|mut started| {
                                 started.set_paused(paused)?;
@@ -3359,7 +3375,8 @@ fn run_macos_h265_video(
             && configured_parameter_sets.as_ref() != Some(parameter_sets)
             && frame.keyframe
         {
-            let format = H265Format::new(parameter_sets.clone(), VideoColorSpace::Bt709);
+            let format = H265Format::new(parameter_sets.clone(), VideoColorSpace::Bt709)
+                .with_bit_depth(shared.stream.color_quality.macos_bit_depth());
             let Some(sink) = backend_sink.as_ref() else {
                 return;
             };

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -56,6 +56,26 @@ Raw session contexts, credentials, URLs, SDP and media payloads are excluded fro
 the new handshake trace. Logs rotate during use, and exports retain readable lines.
 No per-packet or per-input file logging is added to the gameplay path.
 
+## Video color precision
+
+The color-depth setting selects the stream's encoded and decoded precision, not HDR.
+Ten-bit video stays ten-bit through native YUV-to-RGB conversion and GPU texture import;
+frame-generation history and generated output retain that texture format. The normal Qt SDR
+window uses an 8-bit swapchain. Its final video draw applies centered, static 8×8 spatial
+dithering after scaling so lower bits contribute to the displayed gradient instead of being
+discarded before composition. Black, white, neutral balance, and the SDR transfer function
+are preserved. High-precision texture render targets do not receive the 8-bit dither.
+
+`qt-native.log` reports `SDR video composition` when the imported or output format changes,
+including `textureBits`, `outputBits`, and the dither policy. A ten-bit stream with
+`textureBits=10 outputBits=8 dither=ordered-8x8` is the expected SDR path, not native ten-bit
+scan-out. HDR10 swapchains are not used to display unconverted SDR pixels.
+
+Run `ctest --test-dir build/opennow-qt -R opennow-streamcolor-tests --output-on-failure`
+for GPU readback checks of ten-bit gradients, endpoint and neutral colors, final quantization,
+and high-precision render targets. Live acceptance still requires checking gradients and
+black/white levels on the intended GPU and display in windowed and fullscreen modes.
+
 ## Build
 
 Install the Qt ShaderTools development module with Qt Quick and Multimedia; CMake

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -26,6 +26,24 @@ if(BUILD_TESTING)
         endif()
     endif()
     set_tests_properties(opennow-frameinterpolator-tests PROPERTIES TIMEOUT 60)
+    qt_add_executable(opennow-streamcolor-tests tests/tst_streamcolor.cpp)
+    target_include_directories(opennow-streamcolor-tests PRIVATE src)
+    target_link_libraries(opennow-streamcolor-tests PRIVATE
+        Qt6::Test Qt6::Core Qt6::Gui Qt6::GuiPrivate)
+    qt_add_shaders(opennow-streamcolor-tests "opennow-streamcolor-test-shaders"
+        PREFIX "/opennow/shaders" BASE "shaders"
+        FILES shaders/streamvideo.vert shaders/streamvideo.frag)
+    if(OPENNOW_XVFB_RUN)
+        add_test(NAME opennow-streamcolor-tests
+            COMMAND "${OPENNOW_XVFB_RUN}" -a "$<TARGET_FILE:opennow-streamcolor-tests>" -o -,txt)
+        set_tests_properties(opennow-streamcolor-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=xcb")
+    else()
+        add_test(NAME opennow-streamcolor-tests COMMAND opennow-streamcolor-tests -o -,txt)
+        if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            set_tests_properties(opennow-streamcolor-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+        endif()
+    endif()
+    set_tests_properties(opennow-streamcolor-tests PROPERTIES TIMEOUT 60)
     qt_add_resources(opennow-qt "region-ping-acceptance"
         PREFIX "/acceptance" BASE tests FILES tests/RegionPingAcceptance.qml tests/StorePagingAcceptance.qml tests/BackendAvailabilityAcceptance.qml tests/StreamRecoveryAcceptance.qml tests/IdleModeAcceptance.qml tests/FrameGenerationAcceptance.qml)
     add_test(NAME qml-frame-generation

--- a/opennow-qt/shaders/streamvideo.frag
+++ b/opennow-qt/shaders/streamvideo.frag
@@ -12,7 +12,14 @@ void main()
 {
     vec2 uv = (itemPosition - videoRect.xy) / max(videoRect.zw, vec2(1.0));
     vec3 color = vec3(0.0);
-    if (all(greaterThanEqual(uv, vec2(0.0))) && all(lessThanEqual(uv, vec2(1.0))))
+    if (all(greaterThanEqual(uv, vec2(0.0))) && all(lessThanEqual(uv, vec2(1.0)))) {
         color = texture(videoTexture, uv).rgb;
+        uvec2 pixel = uvec2(gl_FragCoord.xy) & uvec2(7u);
+        uint rank = ((pixel.x ^ pixel.y) & 1u) * 32u + (pixel.y & 1u) * 16u
+                  + ((pixel.x ^ pixel.y) & 2u) * 4u + (pixel.y & 2u) * 2u
+                  + ((pixel.x ^ pixel.y) & 4u) / 2u + (pixel.y & 4u) / 4u;
+        float dither = ((float(rank) + 0.5) / 64.0 - 0.5) * parameters.y;
+        color = clamp(color + vec3(dither), 0.0, 1.0);
+    }
     fragColor = vec4(color * parameters.x, parameters.x);
 }

--- a/opennow-qt/src/streaming/rendering/NativeStreamRenderCallback.cpp
+++ b/opennow-qt/src/streaming/rendering/NativeStreamRenderCallback.cpp
@@ -9,6 +9,7 @@
 
 #include <rhi/qrhi.h>
 #include <rhi/qrhi_platform.h>
+#include <QDebug>
 
 #include <utility>
 #include <atomic>
@@ -224,6 +225,14 @@ public:
             reportFailure(QStringLiteral("Could not import the decoded video texture into Qt. The decoder and graphics backend must use compatible GPU resources."));
             return;
         }
+        if (m_reportedColorFormat != recorded.texture_format
+                || m_reportedOutputBits != m_textures.outputBits()) {
+            m_reportedColorFormat = recorded.texture_format;
+            m_reportedOutputBits = m_textures.outputBits();
+            qInfo("SDR video composition: textureBits=%u outputBits=%d dither=%s",
+                  recorded.texture_format == OPENNOW_STREAMER_TEXTURE_FORMAT_RGB10A2 ? 10u : 8u,
+                  m_reportedOutputBits, m_reportedOutputBits == 8 ? "ordered-8x8" : "none");
+        }
         m_outputDirty = true;
         m_outputKind = 1;
         if (!m_frameGeneration || m_frameGenerationFailed) return;
@@ -380,12 +389,16 @@ public:
         if (m_graphicsReady && m_runtime) m_runtime->sceneGraphShutdown();
         m_graphicsReady = false;
         m_reportedFailure = false;
+        m_reportedColorFormat = 0;
+        m_reportedOutputBits = 0;
         m_rhi = nullptr;
     }
 
 private:
     NativeStreamRuntime *m_runtime;
     QRhi *m_rhi = nullptr;
+    std::uint32_t m_reportedColorFormat = 0;
+    int m_reportedOutputBits = 0;
     StreamVideoTextureRenderer m_textures;
     StreamFrameInterpolator m_interpolator;
     StreamFramePacer m_pacer;

--- a/opennow-qt/src/streaming/rendering/StreamVideoTextureRenderer.h
+++ b/opennow-qt/src/streaming/rendering/StreamVideoTextureRenderer.h
@@ -27,7 +27,29 @@ public:
         m_target = target;
         m_passFormat = format;
         m_sampleCount = target->sampleCount();
+        m_outputBits = 0;
+        if (target->resourceType() == QRhiResource::SwapChainRenderTarget) {
+            const auto *swapChain = static_cast<QRhiSwapChainRenderTarget *>(target)->swapChain();
+            if (swapChain->format() == QRhiSwapChain::SDR) m_outputBits = 8;
+        } else if (target->resourceType() == QRhiResource::TextureRenderTarget) {
+            const auto description = static_cast<QRhiTextureRenderTarget *>(target)->description();
+            if (description.colorAttachmentCount() > 0) {
+                const auto *texture = description.colorAttachmentAt(0)->texture();
+                if (texture) {
+                    switch (texture->format()) {
+                    case QRhiTexture::RGBA8:
+                    case QRhiTexture::BGRA8: m_outputBits = 8; break;
+                    case QRhiTexture::RGB10A2: m_outputBits = 10; break;
+                    case QRhiTexture::RGBA16F: m_outputBits = 16; break;
+                    default: break;
+                    }
+                }
+            }
+        }
+        m_composition[25] = m_outputBits == 8 ? 1.0f / 255.0f : 0.0f;
     }
+
+    int outputBits() const { return m_outputBits; }
 
     void setComposition(const QMatrix4x4 &matrix, const QRectF &bounds,
                         const QRectF &video, float opacity)
@@ -231,4 +253,5 @@ private:
     size_t m_currentSlot = 0;
     int m_externalSlot = -1;
     int m_sampleCount = 1;
+    int m_outputBits = 0;
 };

--- a/opennow-qt/tests/tst_streamcolor.cpp
+++ b/opennow-qt/tests/tst_streamcolor.cpp
@@ -1,0 +1,278 @@
+#include "streaming/rendering/StreamVideoTextureRenderer.h"
+
+#include <QGuiApplication>
+#include <QTest>
+#include <rhi/qrhi.h>
+#include <rhi/qrhi_platform.h>
+#include <atomic>
+#include <cmath>
+#include <cstring>
+#include <memory>
+
+class StreamColorTest : public QObject
+{
+    Q_OBJECT
+private:
+#if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+    QVulkanInstance m_instance;
+#endif
+    std::unique_ptr<QRhi> m_rhi;
+    std::atomic<int> m_validationErrors = 0;
+    static constexpr int tileSize = 8;
+
+    struct Target {
+        std::unique_ptr<QRhiTexture> texture;
+        std::unique_ptr<QRhiRenderBuffer> depthStencil;
+        std::unique_ptr<QRhiRenderPassDescriptor> pass;
+        std::unique_ptr<QRhiTextureRenderTarget> target;
+    };
+
+    std::unique_ptr<Target> makeTarget(QRhiTexture::Format format, QSize size)
+    {
+        auto result = std::make_unique<Target>();
+        result->texture.reset(m_rhi->newTexture(
+            format, size, 1, QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource));
+        if (!result->texture->create()) return {};
+        result->depthStencil.reset(m_rhi->newRenderBuffer(QRhiRenderBuffer::DepthStencil, size));
+        if (!result->depthStencil->create()) return {};
+        QRhiTextureRenderTargetDescription description(QRhiColorAttachment(result->texture.get()));
+        description.setDepthStencilBuffer(result->depthStencil.get());
+        result->target.reset(m_rhi->newTextureRenderTarget(description));
+        result->pass.reset(result->target->newCompatibleRenderPassDescriptor());
+        result->target->setRenderPassDescriptor(result->pass.get());
+        if (!result->target->create()) return {};
+        return result;
+    }
+
+    static QByteArray patches(const QList<int> &codes, bool tenBit)
+    {
+        const int width = int(codes.size()) * tileSize;
+        QByteArray data(width * tileSize * 4, Qt::Uninitialized);
+        for (int y = 0; y < tileSize; ++y) {
+            for (int x = 0; x < width; ++x) {
+                const quint32 code = quint32(codes[x / tileSize]);
+                char *pixel = data.data() + (y * width + x) * 4;
+                if (tenBit) {
+                    const quint32 packed = code | (code << 10) | (code << 20) | (3u << 30);
+                    std::memcpy(pixel, &packed, sizeof(packed));
+                } else {
+                    pixel[0] = pixel[1] = pixel[2] = char(code);
+                    pixel[3] = char(255);
+                }
+            }
+        }
+        return data;
+    }
+
+    std::unique_ptr<QRhiTexture> makeSource(const QList<int> &codes, bool tenBit = true)
+    {
+        const QSize size(int(codes.size()) * tileSize, tileSize);
+        auto texture = std::unique_ptr<QRhiTexture>(m_rhi->newTexture(
+            tenBit ? QRhiTexture::RGB10A2 : QRhiTexture::RGBA8, size, 1,
+            QRhiTexture::UsedAsTransferSource));
+        if (!texture->create()) return {};
+        QRhiCommandBuffer *cb = nullptr;
+        if (m_rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess) return {};
+        auto *updates = m_rhi->nextResourceUpdateBatch();
+        updates->uploadTexture(texture.get(), QRhiTextureUploadDescription({
+            QRhiTextureUploadEntry(0, 0, QRhiTextureSubresourceUploadDescription(patches(codes, tenBit)))
+        }));
+        cb->resourceUpdate(updates);
+        if (m_rhi->endOffscreenFrame() != QRhi::FrameOpSuccess) return {};
+        return texture;
+    }
+
+    QByteArray render(StreamVideoTextureRenderer &renderer, QRhiTexture *source,
+                      Target &target, QRhiTexture *external = nullptr)
+    {
+        const QSize size = target.texture->pixelSize();
+        renderer.initialize(m_rhi.get(), target.target.get());
+        QMatrix4x4 projection;
+        projection.ortho(0.0f, float(size.width()), float(size.height()), 0.0f, -1.0f, 1.0f);
+        const QRectF bounds(QPointF(0, 0), QSizeF(size));
+        renderer.setComposition(m_rhi->clipSpaceCorrMatrix() * projection, bounds, bounds, 1.0f);
+        QRhiCommandBuffer *cb = nullptr;
+        if (m_rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess) return {};
+        const bool ready = renderer.prepare(cb)
+            && renderer.importFrame(0, source->nativeTexture(), source->format(), source->pixelSize())
+            && (!external || renderer.selectTexture(external));
+        QRhiReadbackResult result;
+        bool completed = false;
+        if (ready) {
+            cb->beginPass(target.target.get(), QColor(255, 0, 255), {1.0f, 0});
+            cb->setViewport(QRhiViewport(0, 0, float(size.width()), float(size.height())));
+            cb->setScissor(QRhiScissor(0, 0, size.width(), size.height()));
+            renderer.render(cb, false, 0);
+            cb->endPass();
+            result.completed = [&completed] { completed = true; };
+            auto *readback = m_rhi->nextResourceUpdateBatch();
+            readback->readBackTexture(QRhiReadbackDescription(target.texture.get()), &result);
+            cb->resourceUpdate(readback);
+        }
+        const auto ended = m_rhi->endOffscreenFrame();
+        if (!ready || ended != QRhi::FrameOpSuccess || !completed
+            || result.pixelSize != size || result.format != target.texture->format()) return {};
+        return result.data;
+    }
+
+    static double mean(const QByteArray &data, int patch, int patchCount)
+    {
+        int sum = 0;
+        for (int y = 0; y < tileSize; ++y)
+            for (int x = 0; x < tileSize; ++x)
+                sum += quint8(data[(y * patchCount * tileSize + patch * tileSize + x) * 4]);
+        return double(sum) / (tileSize * tileSize);
+    }
+
+private slots:
+    void initTestCase()
+    {
+#if defined(Q_OS_WIN)
+        QRhiD3D11InitParams params;
+        m_rhi.reset(QRhi::create(QRhi::D3D11, &params));
+#elif QT_CONFIG(metal)
+        QRhiMetalInitParams params;
+        m_rhi.reset(QRhi::create(QRhi::Metal, &params));
+#elif QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
+        m_instance.setApiVersion(QVersionNumber(1, 1));
+        m_instance.setExtensions(QRhiVulkanInitParams::preferredInstanceExtensions());
+        if (qEnvironmentVariableIsSet("OPENNOW_STREAMCOLOR_VALIDATION")) {
+            QVERIFY2(m_instance.supportedLayers().contains("VK_LAYER_KHRONOS_validation"),
+                     "Vulkan validation requested but Khronos layer is unavailable");
+            m_instance.setLayers({"VK_LAYER_KHRONOS_validation"});
+            m_instance.installDebugOutputFilter(QVulkanInstance::DebugUtilsFilter(
+                [this](QVulkanInstance::DebugMessageSeverityFlags severity,
+                       QVulkanInstance::DebugMessageTypeFlags, const void *) {
+                    if (severity.testFlag(QVulkanInstance::ErrorSeverity)) ++m_validationErrors;
+                    return false;
+                }));
+        }
+        if (!m_instance.create()) QSKIP("Vulkan instance unavailable");
+        QRhiVulkanInitParams params;
+        params.inst = &m_instance;
+        m_rhi.reset(QRhi::create(QRhi::Vulkan, &params));
+#endif
+        if (!m_rhi) QSKIP("No supported GPU backend available");
+        if (!m_rhi->isTextureFormatSupported(QRhiTexture::RGB10A2))
+            QSKIP("RGB10A2 source textures unavailable");
+    }
+
+    void cleanupTestCase()
+    {
+        m_rhi.reset();
+        QCOMPARE(m_validationErrors.load(), 0);
+    }
+
+    void fractionalGrayPreservesMeanAndAdjacentCodes()
+    {
+        const QList<int> codes{1, 2, 3, 4, 127, 128, 255, 256, 510, 511, 512, 513, 514, 768, 1020, 1021, 1022};
+        auto source = makeSource(codes);
+        QVERIFY(source);
+        auto target = makeTarget(QRhiTexture::RGBA8, source->pixelSize());
+        QVERIFY(target);
+        StreamVideoTextureRenderer renderer;
+        const auto data = render(renderer, source.get(), *target);
+        QCOMPARE(data.size(), source->pixelSize().width() * tileSize * 4);
+        for (int patch = 0; patch < codes.size(); ++patch) {
+            const double expected = codes[patch] * 255.0 / 1023.0;
+            const double actual = mean(data, patch, int(codes.size()));
+            QVERIFY2(std::abs(actual - expected) <= 0.025,
+                     qPrintable(QString("10-bit code %1: mean %2, expected %3")
+                                    .arg(codes[patch]).arg(actual).arg(expected)));
+            if (patch > 0 && codes[patch] == codes[patch - 1] + 1)
+                QVERIFY(actual > mean(data, patch - 1, int(codes.size())) + 0.20);
+            for (int y = 0; y < tileSize; ++y) {
+                for (int x = 0; x < tileSize; ++x) {
+                    const int offset = (y * source->pixelSize().width() + patch * tileSize + x) * 4;
+                    const int value = quint8(data[offset]);
+                    QVERIFY(value == int(std::floor(expected)) || value == int(std::ceil(expected)));
+                    QCOMPARE(quint8(data[offset + 1]), value);
+                    QCOMPARE(quint8(data[offset + 2]), value);
+                    QCOMPARE(quint8(data[offset + 3]), 255);
+                }
+            }
+        }
+    }
+
+    void blackAndWhiteAreExact()
+    {
+        auto source = makeSource({0, 1023});
+        QVERIFY(source);
+        auto target = makeTarget(QRhiTexture::RGBA8, source->pixelSize());
+        QVERIFY(target);
+        StreamVideoTextureRenderer renderer;
+        QCOMPARE(render(renderer, source.get(), *target), patches({0, 255}, false));
+    }
+
+    void exactEightBitInputsAreUnchanged()
+    {
+        QList<int> codes;
+        for (int code = 0; code <= 255; ++code) codes.append(code);
+        auto source = makeSource(codes, false);
+        QVERIFY(source);
+        auto target = makeTarget(QRhiTexture::RGBA8, source->pixelSize());
+        QVERIFY(target);
+        StreamVideoTextureRenderer renderer;
+        QCOMPARE(render(renderer, source.get(), *target), patches(codes, false));
+    }
+
+    void highPrecisionTargetRetainsCodesWithoutDither()
+    {
+        if (!m_rhi->isTextureFormatSupported(QRhiTexture::RGB10A2, QRhiTexture::RenderTarget))
+            QSKIP("Renderable RGB10A2 unavailable");
+        const QList<int> codes{0, 1, 2, 3, 4, 127, 128, 255, 256, 510, 511, 512, 513, 514, 768, 1021, 1022, 1023};
+        auto source = makeSource(codes);
+        QVERIFY(source);
+        auto target = makeTarget(QRhiTexture::RGB10A2, source->pixelSize());
+        QVERIFY(target);
+        StreamVideoTextureRenderer renderer;
+        QCOMPARE(render(renderer, source.get(), *target), patches(codes, true));
+    }
+
+    void targetFormatSwitchingUpdatesDither()
+    {
+        if (!m_rhi->isTextureFormatSupported(QRhiTexture::RGB10A2, QRhiTexture::RenderTarget))
+            QSKIP("Renderable RGB10A2 unavailable");
+        const QList<int> codes{511, 512, 513};
+        auto source = makeSource(codes);
+        QVERIFY(source);
+        auto eightBit = makeTarget(QRhiTexture::RGBA8, source->pixelSize());
+        auto tenBit = makeTarget(QRhiTexture::RGB10A2, source->pixelSize());
+        QVERIFY(eightBit);
+        QVERIFY(tenBit);
+        StreamVideoTextureRenderer renderer;
+        const auto first = render(renderer, source.get(), *eightBit);
+        QCOMPARE(first.size(), patches(codes, false).size());
+        QVERIFY(std::abs(mean(first, 1, 3) - 512.0 * 255.0 / 1023.0) <= 0.025);
+        QCOMPARE(render(renderer, source.get(), *tenBit), patches(codes, true));
+        QCOMPARE(render(renderer, source.get(), *eightBit), first);
+        QCOMPARE(render(renderer, source.get(), *tenBit), patches(codes, true));
+    }
+
+    void externalTextureMatchesImportWithoutAccumulation()
+    {
+        const QList<int> codes{1, 128, 511, 512, 513, 1022};
+        auto source = makeSource(codes);
+        auto external = makeSource(codes);
+        QVERIFY(source);
+        QVERIFY(external);
+        auto target = makeTarget(QRhiTexture::RGBA8, source->pixelSize());
+        QVERIFY(target);
+        StreamVideoTextureRenderer renderer;
+        const auto imported = render(renderer, source.get(), *target);
+        QCOMPARE(imported.size(), patches(codes, false).size());
+        QVERIFY(std::abs(mean(imported, 3, int(codes.size())) - 512.0 * 255.0 / 1023.0) <= 0.025);
+        for (int frame = 0; frame < 8; ++frame)
+            QCOMPARE(render(renderer, source.get(), *target, external.get()), imported);
+        renderer.clearExternalTextures();
+        QCOMPARE(render(renderer, source.get(), *target), imported);
+        if (m_rhi->isTextureFormatSupported(QRhiTexture::RGB10A2, QRhiTexture::RenderTarget)) {
+            auto highPrecision = makeTarget(QRhiTexture::RGB10A2, source->pixelSize());
+            QVERIFY(highPrecision);
+            QCOMPARE(render(renderer, source.get(), *highPrecision, external.get()), patches(codes, true));
+        }
+    }
+};
+
+QTEST_MAIN(StreamColorTest)
+#include "tst_streamcolor.moc"


### PR DESCRIPTION
Ten-bit streams were reduced to RGBA8 before reaching Qt, and VideoToolbox always requested eight-bit decoder output. Preserve precision through native conversion and texture import, then quantize deliberately at the final SDR draw.

## Native color handling
- Publish RGB10A2 for P010/Y410 on Windows, P010 on Vulkan, and ten-bit VideoToolbox frames on Metal. Keep eight-bit inputs in RGBA8 and propagate the actual texture format through the existing graphics ABI.
- Keep format-dependent resources bounded and recreate only appropriate resources on precision changes. Reject unsupported GPU conversions and decoded precision/chroma loss rather than silently downgrading.
- Select VideoToolbox depth from negotiated configuration and bitstream metadata, preserve it across HEVC reconfiguration, and advertise only supported embedded 4:2:0 profiles.
- Correct Metal full-range chroma gain, the exact NV12 chroma midpoint, and P010's 16-bit texture normalization. Honor supplied BT.601/BT.709 matrix metadata and reject unsupported supplied matrices.

## Qt SDR presentation
- Apply centered, static 8×8 spatial dithering in the final video draw after scaling, including the generated-frame texture path. Preserve exact black/white and neutral balance; do not dither high-precision texture render targets.
- Log the imported texture depth, output depth, and dither policy when formats change.
- Qt's SDR swapchain remains eight-bit. This preserves ten-bit information until final quantization; it does **not** claim native ten-bit scan-out or HDR, and does not tag SDR pixels as HDR10.

## Verification
- New real-GPU color readback suite: 8 passed, 0 skipped, with Vulkan validation enabled. Covers adjacent ten-bit levels, neutral/endpoints, unchanged exact eight-bit values, ten-bit target round-trips, target-format changes, and external/generated texture binding behavior.
- Existing GPU frame-interpolator suite passed with Vulkan validation enabled.
- Native streamer workspace tests passed; Linux producer GPU tests and platform-specific numerical/format tests passed. Strict all-targets Clippy passed for the changed platform crates.
- Windows and Apple-target checks/strict Clippy passed for their platform crates. These are cross-compilation checks, not D3D11/Metal hardware execution.
- Full Qt 6.8.3 / SDL 3.2.20 Debug application and native runtime build passed; all **165 CTest cases passed**. Real Vulkan window/fullscreen/overlay composition checks also passed separately (5 QtTest passes, no skips).
- Final native workspace rerun passed (451 tests, plus three normally ignored Linux GPU tests exercised separately). Workspace formatting passes after correcting macOS import order found by CI. All CI checks now pass on `a4e34210`, including Linux and Windows x64/ARM64 validation jobs.
- No live GFN session, Windows GPU, or Mac display was available. Apple-target validation covers the platform-macos crate only and uses an Opus discovery override for non-linking type-checking; it does not validate Apple linking or Metal shader execution.

### Actual GPU readback
A 1,024-code RGB10A2 gradient rendered by the production Qt shader into an RGBA8 target:

![Production GPU gradient after final SDR dithering](https://api-nightly.capy.ai/pr-assets/5TwLOW_xue4L51QhA8aVyPBBtRXbR9K7pluQ2OqH5RA)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M1YPPPKCVCNSSWPPNRS4YJAX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->