### PR TITLE
fix(qt): recreate the swapchain when changing HDR formats

### DIFF
--- a/opennow-qt/src/streaming/rendering/HdrOutput.cpp
+++ b/opennow-qt/src/streaming/rendering/HdrOutput.cpp
@@ -141,6 +141,7 @@ void HdrOutput::updateOutput()
     const auto changeFormat = [&](QRhiSwapChain::Format format) {
         d->rhi->finish();
         auto *previousPass = d->rpDescForSwapchain;
+        sc->destroy();
         sc->setFormat(format);
         auto *nextPass = sc->newCompatibleRenderPassDescriptor();
         bool created = false;
@@ -149,6 +150,7 @@ void HdrOutput::updateOutput()
             created = sc->createOrResize();
         }
         if (!created) {
+            sc->destroy();
             delete nextPass;
             sc->setFormat(QRhiSwapChain::SDR);
             nextPass = sc->newCompatibleRenderPassDescriptor();


### PR DESCRIPTION
Qt 6.8.3's D3D11 backend chooses the backbuffer format and DXGI color space only when creating its native swapchain. Calling `setFormat()` followed by `createOrResize()` on an existing swapchain merely resizes buffers using the previous native format. OpenNOW consequently enabled HDR shader output while still presenting into an SDR backbuffer, clipping UI highlights.

Destroy the native swapchain after waiting for GPU work and before changing its format. Also destroy any partially created swapchain before retrying with SDR. Ordinary resizing and stream color conversion remain unchanged.

Validation: built `opennow-hdrcolor-tests` and `opennow-streamcolor-tests` with Qt 6.8.3; both passed on Linux/Vulkan (24 QtTest results, no failures or skips). `git diff --check` passed. Full application build and physical Windows HDR validation were not run.

Windows acceptance: launch with system HDR enabled and compare artwork and UI whites against SDR; toggle system HDR in both directions; resize and switch windowed/fullscreen with stream overlays open and closed. These checks still require an HDR-capable Windows display.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M200FHDYGT48KXD3XM12HA6Y"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->