### PR TITLE
fix(linux): temporarily disable HDR output

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1006,6 +1006,7 @@
       "frameGenerationHint": "Targets 120 displayed FPS from a 60 FPS stream. Requires a fast GPU and 120 Hz display; adds latency and artifacts.",
       "frameGeneration2x": "2×",
       "hdrOutputReady": "HDR output ready. Applies to the next stream.",
+      "hdrOutputDisabledLinux": "HDR is temporarily disabled on Linux.",
       "hdrOutputUnavailable": "HDR unavailable on this display. Enable HDR in your operating system and use a supported GPU and compositor.",
       "hdrDecoderUnavailable": "HDR requires a supported 10-bit H.265 or AV1 hardware decoder.",
       "hdrFrameGenerationUnavailable": "Unavailable with HDR",

--- a/opennow-qt/src/streaming/rendering/HdrOutput.cpp
+++ b/opennow-qt/src/streaming/rendering/HdrOutput.cpp
@@ -74,8 +74,12 @@ HdrOutput::State HdrOutput::renderState()
 
 QString HdrOutput::status() const
 {
+#if defined(Q_OS_LINUX)
+    return tr("HDR is temporarily disabled on Linux.");
+#else
     return m_supported ? tr("HDR output ready. Applies to the next stream.")
                        : tr("HDR unavailable on this display. Enable HDR in your operating system and use a supported GPU and compositor.");
+#endif
 }
 
 void HdrOutput::publish(State state)
@@ -127,12 +131,14 @@ void HdrOutput::updateOutput()
             && (sc->format() != QRhiSwapChain::HDR10
                 || (m_outputPass && m_outputPass->matches(d->rhi, sc)))) return;
     auto desired = QRhiSwapChain::SDR;
+#if !defined(Q_OS_LINUX)
     if (d->rhi->backend() == QRhi::D3D11 || d->rhi->backend() == QRhi::Vulkan) {
         if (sc->isFormatSupported(QRhiSwapChain::HDRExtendedSrgbLinear))
             desired = QRhiSwapChain::HDRExtendedSrgbLinear;
         else if (sc->isFormatSupported(QRhiSwapChain::HDR10))
             desired = QRhiSwapChain::HDR10;
     }
+#endif
     if (desired != QRhiSwapChain::SDR && !m_chromeSynchronized) {
         requestChrome(true);
         m_probeRequested.store(true);

--- a/opennow-qt/tests/tst_hdrcolor.cpp
+++ b/opennow-qt/tests/tst_hdrcolor.cpp
@@ -1,5 +1,6 @@
 #include <QFile>
 #include "streaming/rendering/HdrOutputPass.h"
+#include "streaming/rendering/HdrOutput.h"
 #include "streaming/rendering/HdrChromeEffect.h"
 #include <QQmlEngine>
 #include <QQmlComponent>
@@ -112,6 +113,41 @@ private slots:
     }
 
     void cleanupTestCase() { m_rhi.reset(); }
+
+    void linuxOutputRemainsSdr()
+    {
+#if defined(Q_OS_LINUX)
+        QQuickWindow window;
+        window.setVulkanInstance(&m_instance);
+        window.resize(96, 80);
+        HdrOutput output;
+        output.attach(&window);
+        window.show();
+        QVERIFY(QTest::qWaitForWindowExposed(&window));
+        const auto verifySdr = [&] {
+            QVERIFY(!window.grabWindow().isNull());
+            QCoreApplication::processEvents();
+            QVERIFY(!output.supported());
+            QCOMPARE(output.outputMode(), 0);
+            QVERIFY(!output.chromeRequired());
+            const auto state = HdrOutput::renderState();
+            QCOMPARE(state.mode, 0);
+            QVERIFY(!state.supported);
+        };
+        verifySdr();
+        QCOMPARE(output.status(), QStringLiteral("HDR is temporarily disabled on Linux."));
+        window.showFullScreen();
+        QTRY_COMPARE(window.visibility(), QWindow::FullScreen);
+        verifySdr();
+        window.showNormal();
+        window.resize(128, 96);
+        verifySdr();
+        QTest::qWait(1600);
+        verifySdr();
+#else
+        QSKIP("Linux-only HDR output policy");
+#endif
+    }
 
     void sdrRoundTripsAndWhiteLevel()
     {


### PR DESCRIPTION
Temporarily keep Linux Qt output in SDR instead of treating Vulkan HDR surface-format support as evidence that the compositor is driving an HDR display. This prevents false HDR readiness on SDR Hyprland outputs, even when an attached monitor advertises HDR capability.

- Skip HDR swapchain selection on Linux; Windows and macOS behavior is unchanged.
- Show “HDR is temporarily disabled on Linux.” rather than suggesting that enabling OS HDR will make the option available.
- Keep the existing core capability gate: Linux cannot start an HDR stream. Persisted HDR preferences are not silently rewritten; users who previously enabled HDR must switch it off before launching.
- Add Linux coverage for SDR output, disabled HDR chrome, fullscreen transitions, resizing, and periodic rechecks.

Validation:
- Built the repository's `opennow-hdrcolor-tests` and `opennow-coreclient-tests` targets with Qt 6.8.3.
- Focused `linuxOutputRemainsSdr` test passed under Xvfb/Vulkan.
- `ctest --test-dir build/opennow-qt -R '^opennow-(hdrcolor|coreclient)-tests$' --output-on-failure` passed (2/2 suites).
- `cargo test --manifest-path native/opennow-core/Cargo.toml --locked hdr_` passed (6 tests).
- `npm run locales:check`, localization-tool tests (6/6), and `git diff --check` passed.

No live Hyprland or hardware HDR validation was performed; this is a temporary Linux disable, not a compositor-state detection implementation.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M213Z1N57Y74PHCZHY41SHTB"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->