### PR TITLE
fix(qt): remove persistent in-session shortcut hints

### DIFF
--- a/opennow-qt/qml/desktop/stream/DesktopStreamScreen.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopStreamScreen.qml
@@ -115,31 +115,6 @@ FocusScope {
         }
     }
 
-    Rectangle {
-        anchors.horizontalCenter: parent.horizontalCenter
-        layer.enabled: HdrOutput.chromeRequired
-        layer.effect: HdrChromeEffect {}
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 24
-        width: liveHints.implicitWidth + 28
-        height: 32
-        radius: 16
-        visible: root.streaming && AppController.overlay === ""
-        color: "#9904060A"
-        border.width: 1
-        border.color: "#24FFFFFF"
-        z: 2
-
-        Row {
-            id: liveHints
-            anchors.centerIn: parent
-            spacing: 18
-            DesktopKeyHint { keyText: "Ctrl G"; label: qsTr("Session") }
-            DesktopKeyHint { keyText: "F3"; label: qsTr("Stats") }
-            DesktopKeyHint { keyText: "F11"; label: qsTr("Fullscreen") }
-        }
-    }
-
     function restoreStreamFocus() {
         if (!root.visible || root.launchCovered
                 || ShellStore.streamOverlayBlocksGameplayInput(AppController.overlay))


### PR DESCRIPTION
Remove the always-visible Ctrl G / F3 / F11 hint strip from the desktop stream screen so it no longer covers gameplay. The shortcut bindings, session menu, statistics, fullscreen handling, and native video surface are unchanged.

Validation: `git diff --check` passed and the final diff is limited to removing the decorative QML rectangle. Local build, Qt tests, and visual verification could not run: `cmake -S opennow-qt -B build/opennow-qt -DCMAKE_BUILD_TYPE=Debug` fails at `find_package(Qt6 6.8)` because this machine has no Qt 6 SDK.

Runtime verification still needed: open a desktop stream in windowed and fullscreen modes, check that the strip is absent with overlays closed, and confirm Ctrl+G, F3, and F11 continue to work.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M213W8QFRSQHQKXMMFAKK6KX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->