### PR TITLE
fix(streamer): size NVST video packets for VPN interface MTUs

### DIFF
--- a/docs/qt-acceptance.md
+++ b/docs/qt-acceptance.md
@@ -109,11 +109,16 @@ ten minutes. Exercise the following without restarting the app:
 12. For VPN compatibility, start fresh sessions with Cloudflare WARP off and on, keeping the
     same game and stream settings. Record the OS, WARP version, and tunnel mode (WireGuard or
     MASQUE). Confirm first-frame playback, audio, and input with WARP still enabled. The native
-    `nvst-udp` log reports the video peer's `interface_mtu`, `mtu_fallback`, and `packet_size`;
-    a 1,280-byte IPv4 interface should select 1,216, while a 1,500-byte interface retains 1,280.
+    `nvst-udp` log reports the video peer's `interface_mtu`, `vpn_detected`, and `packet_size`;
+    a detected VPN's 1,280-byte IPv4 interface should select 1,216, while a 1,500-byte interface
+    retains 1,280. Non-VPN and unrecognized routes always retain the original 1,280-byte packet
+    size, even with a smaller MTU. Verify a split-tunnel route that bypasses the VPN also retains it.
     These are NVST payload sizes, not complete IP packet sizes: sizing reserves IP, UDP, RTP/FEC,
-    and the largest supported SRTP authentication tag, then rounds down to 16 bytes. If interface
-    discovery fails, sizing assumes a 1,280-byte IP MTU. This queries the local outgoing interface,
+    and the largest supported SRTP authentication tag, then rounds down to 16 bytes. Detection
+    uses Linux TUN/TAP metadata and known VPN interface names, macOS tunnel interface names,
+    and known VPN driver descriptions on Windows. It is conservative, not an exhaustive VPN
+    inventory; if route discovery or VPN identification fails, packet sizing stays unchanged.
+    This queries the local outgoing interface,
     not the full Internet path, and does not bypass a VPN or a firewall blocking UDP. Keep paired
     diagnostic exports if video still fails; changing WARP during a live session is a separate
     route-change/recovery test, not evidence that fresh-session negotiation passed.

--- a/docs/qt-acceptance.md
+++ b/docs/qt-acceptance.md
@@ -106,7 +106,18 @@ ten minutes. Exercise the following without restarting the app:
 11. Force one recoverable network interruption and one graphics-device or native-runtime failure.
    Confirm bounded reconnect/reinitialization behavior, no stuck input, and a usable error if
    recovery is exhausted.
-12. Export both the redacted diagnostic report and **live evidence** from the Diagnostics screen
+12. For VPN compatibility, start fresh sessions with Cloudflare WARP off and on, keeping the
+    same game and stream settings. Record the OS, WARP version, and tunnel mode (WireGuard or
+    MASQUE). Confirm first-frame playback, audio, and input with WARP still enabled. The native
+    `nvst-udp` log reports the video peer's `interface_mtu`, `mtu_fallback`, and `packet_size`;
+    a 1,280-byte IPv4 interface should select 1,216, while a 1,500-byte interface retains 1,280.
+    These are NVST payload sizes, not complete IP packet sizes: sizing reserves IP, UDP, RTP/FEC,
+    and the largest supported SRTP authentication tag, then rounds down to 16 bytes. If interface
+    discovery fails, sizing assumes a 1,280-byte IP MTU. This queries the local outgoing interface,
+    not the full Internet path, and does not bypass a VPN or a firewall blocking UDP. Keep paired
+    diagnostic exports if video still fails; changing WARP during a live session is a separate
+    route-change/recovery test, not evidence that fresh-session negotiation passed.
+13. Export both the redacted diagnostic report and **live evidence** from the Diagnostics screen
    after the run. The live export is direct machine-readable JSON and must report
    `observedPass: true`; it includes hashed screenshot/recording/thumbnail metadata and bounded
    NVST transport, first-frame, input ownership, guide, recovery and error checks without

--- a/docs/streamer-comparison/README.md
+++ b/docs/streamer-comparison/README.md
@@ -34,7 +34,7 @@ OpenNOW also uses a dedicated Raw Input thread plus SDL grab. Official logs `acc
 
 ## Shared shape
 
-Both clients run OPTIONS, DESCRIBE, SETUP, ANNOUNCE, then optional PLAY over WebSocket-carried RTSP. Video is raw SRTP on Mjolnir. Audio and input ride the bundle. NACK envelope numbers match. 1024-packet wait queue, 2048 pending NACKs, 3 retries, 1280-byte packets.
+Both clients run OPTIONS, DESCRIBE, SETUP, ANNOUNCE, then optional PLAY over WebSocket-carried RTSP. Video is raw SRTP on Mjolnir. Audio and input ride the bundle. NACK envelope numbers match. 1024-packet wait queue, 2048 pending NACKs, 3 retries. OpenNOW retains the 1280-byte video packet baseline when the outgoing interface MTU allows it and negotiates smaller packets on constrained routes.
 
 The differences start after that shared envelope. Color, recovery extras, audio jitter, host mouse settings, and what CloudMatch is allowed to request.
 

--- a/docs/streamer-comparison/README.md
+++ b/docs/streamer-comparison/README.md
@@ -34,7 +34,7 @@ OpenNOW also uses a dedicated Raw Input thread plus SDL grab. Official logs `acc
 
 ## Shared shape
 
-Both clients run OPTIONS, DESCRIBE, SETUP, ANNOUNCE, then optional PLAY over WebSocket-carried RTSP. Video is raw SRTP on Mjolnir. Audio and input ride the bundle. NACK envelope numbers match. 1024-packet wait queue, 2048 pending NACKs, 3 retries. OpenNOW retains the 1280-byte video packet baseline when the outgoing interface MTU allows it and negotiates smaller packets on constrained routes.
+Both clients run OPTIONS, DESCRIBE, SETUP, ANNOUNCE, then optional PLAY over WebSocket-carried RTSP. Video is raw SRTP on Mjolnir. Audio and input ride the bundle. NACK envelope numbers match. 1024-packet wait queue, 2048 pending NACKs, 3 retries. OpenNOW retains the 1280-byte video packet baseline except on detected VPN routes whose outgoing interface MTU requires smaller packets.
 
 The differences start after that shared envelope. Color, recovery extras, audio jitter, host mouse settings, and what CloudMatch is allowed to request.
 

--- a/docs/streamer-comparison/video.md
+++ b/docs/streamer-comparison/video.md
@@ -56,7 +56,7 @@ Official also has named profiles, AI prefilter, HUD sharpness, and upscaling. Op
 ## How OpenNOW plays video
 
 1. Prefer NVST. Reserve Mjolnir then bundle+1. The child owns RTSPS.
-2. ANNOUNCE viewport, fps, bitrate, NACK, FEC 20–35%, packet size up to 1280 (OpenNOW reduces it for the video route's interface MTU).
+2. ANNOUNCE viewport, fps, bitrate, NACK, FEC 20–35%, packet size 1280 (OpenNOW reduces it for the video route's interface MTU only when that route uses a detected VPN).
 3. `NvstVideoReceiver` unprotects SRTP, reorders up to 1024 packets, waits up to 150 ms for a gap, NACKs, assembles access units from the GS header.
 4. Keyframe rules. H.264 NAL type 5. H.265 IRAP 16–21. AV1 SOF header byte `[3]==2`.
 5. `MediaSink` encoded video queue capacity 2. Overflow marks desync and requests a keyframe. Windows MF overflow uses `push_or_clear_on_overflow`, which dumps the whole reference chain.

--- a/docs/streamer-comparison/video.md
+++ b/docs/streamer-comparison/video.md
@@ -56,7 +56,7 @@ Official also has named profiles, AI prefilter, HUD sharpness, and upscaling. Op
 ## How OpenNOW plays video
 
 1. Prefer NVST. Reserve Mjolnir then bundle+1. The child owns RTSPS.
-2. ANNOUNCE viewport, fps, bitrate, NACK, FEC 20–35%, packet size 1280.
+2. ANNOUNCE viewport, fps, bitrate, NACK, FEC 20–35%, packet size up to 1280 (OpenNOW reduces it for the video route's interface MTU).
 3. `NvstVideoReceiver` unprotects SRTP, reorders up to 1024 packets, waits up to 150 ms for a gap, NACKs, assembles access units from the GS header.
 4. Keyframe rules. H.264 NAL type 5. H.265 IRAP 16–21. AV1 SOF header byte `[3]==2`.
 5. `MediaSink` encoded video queue capacity 2. Overflow marks desync and requests a keyframe. Windows MF overflow uses `push_or_clear_on_overflow`, which dumps the whole reference chain.

--- a/native/opennow-streamer/Cargo.lock
+++ b/native/opennow-streamer/Cargo.lock
@@ -358,6 +358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1225,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mtu"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6915088ba81d679b0a07ecc674f31d66af5e7edaeb0c34782669be38cdf67b5"
+dependencies = [
+ "bindgen 0.72.1",
+ "cfg_aliases 0.2.2",
+ "libc",
+ "static_assertions",
+ "windows",
+]
+
+[[package]]
 name = "nasm-rs"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,7 +1254,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
 ]
 
@@ -1743,6 +1762,7 @@ dependencies = [
  "getrandom 0.3.4",
  "ghash",
  "hmac",
+ "mtu",
  "opennow-streamer-protocol",
  "serde_json",
  "sha1",

--- a/native/opennow-streamer/Cargo.toml
+++ b/native/opennow-streamer/Cargo.toml
@@ -30,6 +30,7 @@ getrandom = "0.3"
 ghash = "0.5"
 hmac = "0.12"
 image = { version = "0.25", default-features = false, features = ["bmp", "ico", "png"] }
+mtu = "0.3"
 openh264 = { version = "0.9.8", default-features = false, features = ["source"] }
 oxideav-core = "0.1.34"
 oxideav-mkv = "0.0.9"

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
@@ -6,7 +6,7 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use opennow_streamer_protocol::SessionContext;
-use opennow_streamer_transport::ReservedNvstBundle;
+use opennow_streamer_transport::{ReservedNvstBundle, nvst_video_packet_size};
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;
 use tungstenite::http::{HeaderValue, Uri};
@@ -523,6 +523,10 @@ pub fn prepare_owned_nvst(
                 format!("Could not select the local route to the NVST media peer: {error}"),
             )
         })?;
+    let video_packet_size = nvst_video_packet_size(video_peer_ip.parse().map_err(|_| {
+        NvstRtspError::new("invalid-media-peer", "NVST video peer is not an IP address")
+    })?)
+    .map_err(|error| NvstRtspError::new("nvst-video-mtu-invalid", error.to_string()))?;
     opennow_streamer_protocol::log::log_line(
         "INFO",
         "transport",
@@ -569,7 +573,7 @@ pub fn prepare_owned_nvst(
 
     let mut handoff = json!({
         "clientUdpPort":client_port,
-        "packetSize":1280,
+        "packetSize":video_packet_size,
         "mjolnirUdpPort":mjolnir_port,
         "videoPeerIp":video_peer_ip,
         "videoPeerPort":video_peer_port,
@@ -630,6 +634,7 @@ pub fn prepare_owned_nvst(
             password: handoff["localIcePassword"].as_str().unwrap_or_default(),
             fingerprint: handoff["localDtlsFingerprint"].as_str().unwrap_or_default(),
             video_port: video_peer_port,
+            video_packet_size,
             rtcp_on_sctp,
             microphone_available,
         },
@@ -669,6 +674,7 @@ struct AnnounceParams<'a> {
     password: &'a str,
     fingerprint: &'a str,
     video_port: u16,
+    video_packet_size: usize,
     rtcp_on_sctp: bool,
     microphone_available: bool,
 }
@@ -709,7 +715,7 @@ fn build_announce(context: &SessionContext, params: AnnounceParams<'_>) -> Strin
         format!("a=x-nv-video[0].clientViewportHt:{height}"),
         "a=x-nv-video[0].videoSplitEncodeStripsPerFrame:64".to_owned(),
         "a=x-nv-video[0].updateSplitEncodeStateDynamically:1".to_owned(),
-        "a=x-nv-video[0].packetSize:1280".to_owned(),
+        format!("a=x-nv-video[0].packetSize:{}", params.video_packet_size),
         "a=x-nv-video[0].enableRtpNack:1".to_owned(),
         "a=x-nv-video[0].rtpNackQueueLength:2048".to_owned(),
         "a=x-nv-video[0].rtpNackQueueMaxPackets:1024".to_owned(),
@@ -1280,6 +1286,7 @@ mod tests {
                 password: "abcdefghijklmnopqrstuv",
                 fingerprint: "AA:BB",
                 video_port: 5004,
+                video_packet_size: 1280,
                 rtcp_on_sctp: true,
                 microphone_available: false,
             },
@@ -1293,6 +1300,32 @@ mod tests {
         assert!(sdp.contains("a=x-nv-general.rtcDataChannelOnNativeBundle:1"));
         assert!(sdp.contains("a=x-nv-runtime.encryptionKey:"));
         assert!(sdp.contains("m=video 5004"));
+    }
+
+    #[test]
+    fn announce_preserves_the_route_selected_video_packet_size() {
+        for video_packet_size in [1280, 1216, 1200, 1136] {
+            let sdp = build_announce(
+                &context(),
+                AnnounceParams {
+                    key: &"01".repeat(32),
+                    key_id: 7,
+                    port: 49006,
+                    address: "192.0.2.10",
+                    ufrag: "abcd",
+                    password: "abcdefghijklmnopqrstuv",
+                    fingerprint: "AA:BB",
+                    video_port: 5004,
+                    video_packet_size,
+                    rtcp_on_sctp: true,
+                    microphone_available: false,
+                },
+            );
+            assert_eq!(
+                sdp_attribute(&sdp, "video[0].packetSize"),
+                Some(video_packet_size.to_string())
+            );
+        }
     }
 
     #[test]
@@ -1318,6 +1351,7 @@ mod tests {
                     password: "abcdefghijklmnopqrstuv",
                     fingerprint: "AA:BB",
                     video_port: 5004,
+                    video_packet_size: 1280,
                     rtcp_on_sctp: true,
                     microphone_available: false,
                 },
@@ -1343,6 +1377,7 @@ mod tests {
                 password: "abcdefghijklmnopqrstuv",
                 fingerprint: "AA:BB",
                 video_port: 5004,
+                video_packet_size: 1280,
                 rtcp_on_sctp: true,
                 microphone_available: false,
             },
@@ -1379,6 +1414,7 @@ mod tests {
                         password: "abcdefghijklmnopqrstuv",
                         fingerprint: "AA:BB",
                         video_port: 5004,
+                        video_packet_size: 1280,
                         rtcp_on_sctp: true,
                         microphone_available: available,
                     },

--- a/native/opennow-streamer/crates/opennow-streamer-transport/Cargo.toml
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/Cargo.toml
@@ -22,7 +22,7 @@ thiserror.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 str0m = { workspace = true, features = ["wincrypto-dimpl"] }
-windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock"] }
+windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Keep transport crypto architecture-independent. The Apple/Swift provider's

--- a/native/opennow-streamer/crates/opennow-streamer-transport/Cargo.toml
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/Cargo.toml
@@ -12,6 +12,7 @@ crc32fast.workspace = true
 getrandom.workspace = true
 ghash.workspace = true
 hmac.workspace = true
+mtu.workspace = true
 opennow-streamer-protocol = { path = "../opennow-streamer-protocol" }
 serde_json.workspace = true
 sha1.workspace = true

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/lib.rs
@@ -15,9 +15,9 @@ pub use nvst::{
     NvstReceiveEvent, NvstReceiverState, NvstRecovery, NvstSrtpProfile, NvstUdpReceiverControl,
     NvstUdpReceiverError, NvstUdpReceiverSession, NvstUnsupportedFeature, NvstVideoCodec,
     NvstVideoConfig, NvstVideoReceiver, ReservedNvstBundle, SharedNvstFeedback,
-    advertised_nvst_ipv4, parse_nvst_video_handoff, reserve_nvst_mjolnir_udp_socket,
-    reserve_nvst_udp_socket, spawn_nvst_mjolnir_receiver, spawn_nvst_udp_receiver,
-    spawn_nvst_udp_receiver_with_socket,
+    advertised_nvst_ipv4, nvst_video_packet_size, parse_nvst_video_handoff,
+    reserve_nvst_mjolnir_udp_socket, reserve_nvst_udp_socket, spawn_nvst_mjolnir_receiver,
+    spawn_nvst_udp_receiver, spawn_nvst_udp_receiver_with_socket,
 };
 
 static INSTALL_CRYPTO: Once = Once::new();

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/lib.rs
@@ -9,6 +9,7 @@ pub mod nvst;
 mod nvst_control;
 mod nvst_input;
 mod nvst_microphone;
+mod nvst_network;
 
 pub use nvst::{
     BoundedFrameQueue, EncodedVideoAccessUnit, NvstBundleIdentity, NvstConfigError, NvstDropReason,

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -28,6 +28,7 @@ use subtle::ConstantTimeEq;
 use thiserror::Error;
 
 use super::nvst_microphone::{MICROPHONE_QUEUE_CAPACITY, MicrophoneQueue};
+use super::nvst_network::is_vpn_interface;
 use str0m::channel::ChannelId;
 use str0m::config::Fingerprint;
 use str0m::format::{Codec, FormatParams};
@@ -96,7 +97,6 @@ const NVST_FEC_RTP_HEADER_ALLOWANCE: usize = 16;
 const DEFAULT_NVST_VIDEO_PACKET_SIZE: usize = 1_280;
 const MIN_NVST_VIDEO_PACKET_SIZE: usize = 256;
 const MAX_NVST_VIDEO_PACKET_SIZE: usize = 65_519;
-const FALLBACK_NVST_IP_MTU: usize = 1_280;
 // Match the official client's bounded NACK/dejitter envelope: it keeps up to
 // 1,024 RTP packets available for late or retransmitted packets and permits a
 // 2,048-entry NACK queue. A 32-packet window is only a few milliseconds at
@@ -4112,33 +4112,35 @@ pub fn advertised_nvst_ipv4() -> Option<IpAddr> {
 }
 
 pub fn nvst_video_packet_size(peer: IpAddr) -> std::io::Result<usize> {
-    let route_mtu = match mtu::interface_and_mtu(peer) {
-        Ok((_, mtu)) => Some(mtu),
+    let (interface, route_mtu) = match mtu::interface_and_mtu(peer) {
+        Ok(route) => route,
         Err(error) => {
             opennow_streamer_protocol::log::log_line(
                 "WARN",
                 "nvst-udp",
                 &format!(
-                    "video route MTU lookup failed: {error}; using IP MTU {FALLBACK_NVST_IP_MTU}"
+                    "video route lookup failed: {error}; VPN unverified, retaining packet_size={DEFAULT_NVST_VIDEO_PACKET_SIZE}"
                 ),
             );
-            None
+            return Ok(DEFAULT_NVST_VIDEO_PACKET_SIZE);
         }
     };
-    let packet_size = video_packet_size_for_mtu(peer, route_mtu)?;
+    let vpn_detected = is_vpn_interface(&interface);
+    let packet_size = video_packet_size_for_vpn_mtu(peer, vpn_detected.then_some(route_mtu))?;
     opennow_streamer_protocol::log::log_line(
         "INFO",
         "nvst-udp",
         &format!(
-            "video route peer={peer} interface_mtu={} mtu_fallback={} packet_size={packet_size}",
-            route_mtu.unwrap_or(FALLBACK_NVST_IP_MTU),
-            route_mtu.is_none(),
+            "video route peer={peer} interface_mtu={route_mtu} vpn_detected={vpn_detected} packet_size={packet_size}",
         ),
     );
     Ok(packet_size)
 }
 
-fn video_packet_size_for_mtu(peer: IpAddr, route_mtu: Option<usize>) -> std::io::Result<usize> {
+fn video_packet_size_for_vpn_mtu(peer: IpAddr, route_mtu: Option<usize>) -> std::io::Result<usize> {
+    let Some(route_mtu) = route_mtu else {
+        return Ok(DEFAULT_NVST_VIDEO_PACKET_SIZE);
+    };
     let ip_header_bytes = if peer.is_ipv4() { 20 } else { 40 };
     let udp_header_bytes = 8;
     let overhead = ip_header_bytes
@@ -4146,7 +4148,6 @@ fn video_packet_size_for_mtu(peer: IpAddr, route_mtu: Option<usize>) -> std::io:
         + NVST_FEC_RTP_HEADER_ALLOWANCE
         + SRTP_AEAD_AES_GCM_TAG_LEN;
     let packet_size = route_mtu
-        .unwrap_or(FALLBACK_NVST_IP_MTU)
         .saturating_sub(overhead)
         .min(DEFAULT_NVST_VIDEO_PACKET_SIZE)
         / 16
@@ -6869,26 +6870,30 @@ mod tests {
             ("192.0.2.1", Some(1500), 1280),
             ("192.0.2.1", Some(1280), 1216),
             ("192.0.2.1", Some(1200), 1136),
-            ("192.0.2.1", None, 1216),
+            ("192.0.2.1", None, 1280),
             ("2001:db8::1", Some(1280), 1200),
-            ("2001:db8::1", None, 1200),
+            ("2001:db8::1", None, 1280),
             ("127.0.0.1", Some(65536), 1280),
         ] {
             let peer = address.parse().unwrap();
-            let packet_size = video_packet_size_for_mtu(peer, mtu).unwrap();
+            let packet_size = video_packet_size_for_vpn_mtu(peer, mtu).unwrap();
             assert_eq!(packet_size, expected);
             let ip_header_bytes = if peer.is_ipv4() { 20 } else { 40 };
-            assert!(packet_size + 16 + 16 + 8 + ip_header_bytes <= mtu.unwrap_or(1280));
+            if let Some(mtu) = mtu {
+                assert!(packet_size + 16 + 16 + 8 + ip_header_bytes <= mtu);
+            }
         }
         for mtu in [0, 59, 60, 300] {
-            assert!(video_packet_size_for_mtu("192.0.2.1".parse().unwrap(), Some(mtu)).is_err());
+            assert!(
+                video_packet_size_for_vpn_mtu("192.0.2.1".parse().unwrap(), Some(mtu)).is_err()
+            );
         }
     }
 
     #[test]
     fn tunnel_packet_size_is_preserved_by_the_handoff_and_fec_receiver() {
         let mut handoff = legacy_handoff();
-        let packet_size = video_packet_size_for_mtu(peer().ip(), Some(1280)).unwrap();
+        let packet_size = video_packet_size_for_vpn_mtu(peer().ip(), Some(1280)).unwrap();
         handoff["packetSize"] = serde_json::json!(packet_size);
         let config = NvstVideoConfig::from_legacy_handoff(&handoff, None).unwrap();
         assert_eq!(config.video_packet_size, packet_size);

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -96,6 +96,7 @@ const NVST_FEC_RTP_HEADER_ALLOWANCE: usize = 16;
 const DEFAULT_NVST_VIDEO_PACKET_SIZE: usize = 1_280;
 const MIN_NVST_VIDEO_PACKET_SIZE: usize = 256;
 const MAX_NVST_VIDEO_PACKET_SIZE: usize = 65_519;
+const FALLBACK_NVST_IP_MTU: usize = 1_280;
 // Match the official client's bounded NACK/dejitter envelope: it keeps up to
 // 1,024 RTP packets available for late or retransmitted packets and permits a
 // 2,048-entry NACK queue. A 32-packet window is only a few milliseconds at
@@ -4110,6 +4111,55 @@ pub fn advertised_nvst_ipv4() -> Option<IpAddr> {
     discover_routed_ipv4()
 }
 
+pub fn nvst_video_packet_size(peer: IpAddr) -> std::io::Result<usize> {
+    let route_mtu = match mtu::interface_and_mtu(peer) {
+        Ok((_, mtu)) => Some(mtu),
+        Err(error) => {
+            opennow_streamer_protocol::log::log_line(
+                "WARN",
+                "nvst-udp",
+                &format!(
+                    "video route MTU lookup failed: {error}; using IP MTU {FALLBACK_NVST_IP_MTU}"
+                ),
+            );
+            None
+        }
+    };
+    let packet_size = video_packet_size_for_mtu(peer, route_mtu)?;
+    opennow_streamer_protocol::log::log_line(
+        "INFO",
+        "nvst-udp",
+        &format!(
+            "video route peer={peer} interface_mtu={} mtu_fallback={} packet_size={packet_size}",
+            route_mtu.unwrap_or(FALLBACK_NVST_IP_MTU),
+            route_mtu.is_none(),
+        ),
+    );
+    Ok(packet_size)
+}
+
+fn video_packet_size_for_mtu(peer: IpAddr, route_mtu: Option<usize>) -> std::io::Result<usize> {
+    let ip_header_bytes = if peer.is_ipv4() { 20 } else { 40 };
+    let udp_header_bytes = 8;
+    let overhead = ip_header_bytes
+        + udp_header_bytes
+        + NVST_FEC_RTP_HEADER_ALLOWANCE
+        + SRTP_AEAD_AES_GCM_TAG_LEN;
+    let packet_size = route_mtu
+        .unwrap_or(FALLBACK_NVST_IP_MTU)
+        .saturating_sub(overhead)
+        .min(DEFAULT_NVST_VIDEO_PACKET_SIZE)
+        / 16
+        * 16;
+    if packet_size < MIN_NVST_VIDEO_PACKET_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "video route MTU is too small for an NVST video packet",
+        ));
+    }
+    Ok(packet_size)
+}
+
 /// ICE + DTLS identity that already owns the reserved bundle socket.
 #[derive(Debug, Clone)]
 pub struct NvstBundleIdentity {
@@ -6811,6 +6861,43 @@ mod tests {
                 .unwrap(),
             "127.0.0.1"
         );
+    }
+
+    #[test]
+    fn video_packet_sizing_reserves_wire_overhead_on_tunnel_routes() {
+        for (address, mtu, expected) in [
+            ("192.0.2.1", Some(1500), 1280),
+            ("192.0.2.1", Some(1280), 1216),
+            ("192.0.2.1", Some(1200), 1136),
+            ("192.0.2.1", None, 1216),
+            ("2001:db8::1", Some(1280), 1200),
+            ("2001:db8::1", None, 1200),
+            ("127.0.0.1", Some(65536), 1280),
+        ] {
+            let peer = address.parse().unwrap();
+            let packet_size = video_packet_size_for_mtu(peer, mtu).unwrap();
+            assert_eq!(packet_size, expected);
+            let ip_header_bytes = if peer.is_ipv4() { 20 } else { 40 };
+            assert!(packet_size + 16 + 16 + 8 + ip_header_bytes <= mtu.unwrap_or(1280));
+        }
+        for mtu in [0, 59, 60, 300] {
+            assert!(video_packet_size_for_mtu("192.0.2.1".parse().unwrap(), Some(mtu)).is_err());
+        }
+    }
+
+    #[test]
+    fn tunnel_packet_size_is_preserved_by_the_handoff_and_fec_receiver() {
+        let mut handoff = legacy_handoff();
+        let packet_size = video_packet_size_for_mtu(peer().ip(), Some(1280)).unwrap();
+        handoff["packetSize"] = serde_json::json!(packet_size);
+        let config = NvstVideoConfig::from_legacy_handoff(&handoff, None).unwrap();
+        assert_eq!(config.video_packet_size, packet_size);
+        let receiver = NvstVideoReceiver::new(config.clone());
+        assert_eq!(receiver.fec_reorder.shard_len, packet_size + 16);
+        let plaintext = build_plaintext_rtp(1, FLAG_SOF | FLAG_EOF, 1, &vec![0; packet_size - 16]);
+        assert_eq!(plaintext.len(), receiver.fec_reorder.shard_len);
+        let encrypted = protect_for_test(&test_srtp(&config), plaintext, 0);
+        assert!(encrypted.len() + 20 + 8 <= 1280);
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_network.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_network.rs
@@ -1,0 +1,112 @@
+fn known_vpn_adapter(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    [
+        "cloudflarewarp",
+        "cloudflare warp",
+        "wireguard",
+        "wintun",
+        "tap-windows",
+        "openvpn",
+        "tailscale",
+        "zerotier",
+        "nordlynx",
+    ]
+    .iter()
+    .any(|marker| name.contains(marker))
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
+fn numbered_interface(name: &str, prefix: &str) -> bool {
+    name.strip_prefix(prefix).is_some_and(|suffix| {
+        !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn is_vpn_interface(name: &str) -> bool {
+    known_vpn_adapter(name)
+        || numbered_interface(name, "wg")
+        || std::path::Path::new("/sys/class/net")
+            .join(name)
+            .join("tun_flags")
+            .is_file()
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn is_vpn_interface(name: &str) -> bool {
+    known_vpn_adapter(name)
+        || ["utun", "tun", "tap", "wg"]
+            .iter()
+            .any(|prefix| numbered_interface(name, prefix))
+}
+
+#[cfg(windows)]
+pub(super) fn is_vpn_interface(name: &str) -> bool {
+    use windows_sys::Win32::NetworkManagement::IpHelper::{
+        ConvertInterfaceNameToLuidA, GetIfEntry2, MIB_IF_ROW2,
+    };
+
+    let Ok(name) = std::ffi::CString::new(name) else {
+        return false;
+    };
+    let mut row = MIB_IF_ROW2::default();
+    if unsafe { ConvertInterfaceNameToLuidA(name.as_ptr().cast(), &mut row.InterfaceLuid) } != 0
+        || unsafe { GetIfEntry2(&mut row) } != 0
+    {
+        return false;
+    }
+    let end = row
+        .Description
+        .iter()
+        .position(|value| *value == 0)
+        .unwrap_or(row.Description.len());
+    known_vpn_adapter(&String::from_utf16_lossy(&row.Description[..end]))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+pub(super) fn is_vpn_interface(_name: &str) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vpn_adapter_detection_recognizes_tunnel_drivers_not_generic_virtual_adapters() {
+        for name in [
+            "CloudflareWARP",
+            "Cloudflare WARP Interface Tunnel",
+            "WireGuard Tunnel",
+            "Wintun Userspace Tunnel",
+            "TAP-Windows Adapter V9",
+            "OpenVPN Data Channel Offload",
+            "Tailscale Tunnel",
+            "ZeroTier Virtual Port",
+            "NordLynx Tunnel",
+        ] {
+            assert!(known_vpn_adapter(name), "{name}");
+        }
+        for name in [
+            "Ethernet",
+            "Wi-Fi",
+            "Intel Ethernet Controller",
+            "Hyper-V Virtual Ethernet Adapter",
+            "lo",
+            "en0",
+            "eth0",
+            "wg-home-ethernet",
+        ] {
+            assert!(!known_vpn_adapter(name), "{name}");
+        }
+    }
+
+    #[test]
+    fn numbered_tunnel_names_require_an_exact_prefix_and_numeric_suffix() {
+        assert!(numbered_interface("utun4", "utun"));
+        assert!(numbered_interface("wg0", "wg"));
+        assert!(!numbered_interface("wg", "wg"));
+        assert!(!numbered_interface("wg-office", "wg"));
+        assert!(!numbered_interface("ethernet0", "wg"));
+    }
+}


### PR DESCRIPTION
NVST always advertised `packetSize:1280`, excluding RTP/SRTP and IP/UDP overhead. That exceeds a 1280-byte interface MTU such as WARP's and can leave video dependent on fragmentation that the tunnel/path does not deliver. This is a verified compatibility defect and a likely explanation for the reported WARP-on black screen, not yet a confirmed diagnosis of that user's connection.

- Enable adaptive sizing **only when the video peer's outgoing route is recognized as a VPN**. Non-VPN routes, unrecognized adapters, and failed route/VPN detection retain the original packetSize 1280, regardless of MTU. A VPN connected elsewhere does not affect split-tunnel video traffic bypassing it.
- Detect Linux TUN/TAP metadata and known VPN interface names, macOS tunnel interface names, and Windows VPN driver descriptions resolved from the selected interface's native identity. Detection is conservative, not an exhaustive VPN inventory.
- On detected VPN routes, reserve IP, UDP, RTP/FEC, and maximum SRTP tag overhead and align payloads down to 16 bytes, capped at 1280. Reject unusably small VPN MTUs. Pass one selected size to RTSP ANNOUNCE and the native handoff so FEC shard sizing remains consistent.
- Log the interface MTU, VPN detection result, and selected size. Document WARP-on/off acceptance and split-tunnel behavior; no VPN bypass or network-setting changes.

Validation:
- Streamer `cargo fmt --all -- --check` passed.
- `cargo clippy -p opennow-streamer-transport -p opennow-streamer-core --all-targets -- -D warnings` passed.
- Streamer `cargo test --workspace`: 414 passed, 8 ignored, 0 failed on Linux.
- `cargo check -p opennow-streamer-transport --target x86_64-pc-windows-msvc --all-targets` passed.
- Isolated Linux TUN with a custom name: at MTU 1280, selected packetSize 1216; old 1340-byte IP packet rejected with EMSGSIZE, new 1276-byte packet accepted. MTU 1500 retained packetSize 1280. Separate policy-routing table at MTU 1200 selected packetSize 1136 and accepted the resulting 1196-byte packet.
- Non-VPN loopback route with MTU 1280 retained packetSize 1280 both with the VPN interface present on another route and after removing it. Scratch probes remain outside the commit.

Live NVIDIA/GFN playback with Cloudflare WARP, and Windows/macOS runtime behavior, have not been verified here. This discovers the local interface MTU, not the complete Internet path MTU, and cannot fix a firewall that blocks UDP or guarantee recovery when WARP is toggled mid-session.