### PR TITLE
fix(qt): keep held-button cursor updates aligned with input mode

### DIFF
--- a/opennow-qt/src/streaming/StreamVideoItem.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItem.cpp
@@ -53,6 +53,7 @@ StreamVideoItem::StreamVideoItem(QQuickItem *parent)
             if (!s_nativeRuntime || !s_nativeRuntime->running()) {
                 m_remoteCursorKnown = false;
                 m_remoteCursorVisible = false;
+                m_remoteCursor = QCursor();
                 if (m_relativeMouse) setRelativeMouse(false);
                 else unsetCursor();
             }

--- a/opennow-qt/src/streaming/StreamVideoItem.h
+++ b/opennow-qt/src/streaming/StreamVideoItem.h
@@ -3,6 +3,7 @@
 #include "streaming/rendering/StreamVideoRenderCallback.h"
 
 #include <QQuickItem>
+#include <QCursor>
 #include <QHash>
 #include <QPoint>
 #include <QPointer>
@@ -126,6 +127,7 @@ private:
     };
 
     void applyRemoteCursor(const QByteArray &bytes);
+    void setRemoteCursorShape(const QCursor &cursor);
     void syncCaptureState();
     void connectFrameSwaps();
     void releaseInput();
@@ -158,6 +160,7 @@ private:
     bool m_cursorConfined = false;
     bool m_remoteCursorKnown = false;
     bool m_remoteCursorVisible = false;
+    QCursor m_remoteCursor;
     std::optional<bool> m_pendingRelativeMouse;
 };
 

--- a/opennow-qt/src/streaming/StreamVideoItemInput.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItemInput.cpp
@@ -320,6 +320,7 @@ void StreamVideoItem::itemChange(ItemChange change, const ItemChangeData &data)
     if (change == ItemVisibleHasChanged && !isVisible()) {
         m_remoteCursorKnown = false;
         m_remoteCursorVisible = false;
+        m_remoteCursor = QCursor();
         if (m_relativeMouse) setRelativeMouse(false);
         else unsetCursor();
     }
@@ -511,7 +512,7 @@ void StreamVideoItem::releaseInput()
     if (pendingRelativeMouse && m_relativeMouse != *pendingRelativeMouse) {
         m_relativeMouse = *pendingRelativeMouse;
         if (m_relativeMouse) setCursor(Qt::BlankCursor);
-        else unsetCursor();
+        else setCursor(m_remoteCursor);
         emit relativeMouseChanged();
     }
 }
@@ -617,10 +618,16 @@ void StreamVideoItem::setRelativeMouse(bool relative)
     } else {
         ungrabMouse();
         releaseCursorConfinement();
-        unsetCursor();
+        setCursor(m_remoteCursor);
     }
     syncCaptureState();
     emit relativeMouseChanged();
+}
+
+void StreamVideoItem::setRemoteCursorShape(const QCursor &cursor)
+{
+    m_remoteCursor = cursor;
+    if (!m_relativeMouse) setCursor(m_remoteCursor);
 }
 
 void StreamVideoItem::applyRemoteCursor(const QByteArray &bytes)
@@ -661,20 +668,20 @@ void StreamVideoItem::applyRemoteCursor(const QByteArray &bytes)
                            0, pixmap.width() - 1),
                 std::clamp(qRound(static_cast<quint8>(bytes[3]) / metadata.scale),
                            0, pixmap.height() - 1));
-            setCursor(QCursor(pixmap, hotspot.x(), hotspot.y()));
+            setRemoteCursorShape(QCursor(pixmap, hotspot.x(), hotspot.y()));
             return;
         }
     }
     switch (cursorId) {
-    case 2: setCursor(Qt::IBeamCursor); break;
-    case 3: setCursor(Qt::WaitCursor); break;
-    case 4: setCursor(Qt::CrossCursor); break;
-    case 6: setCursor(Qt::SizeFDiagCursor); break;
-    case 7: setCursor(Qt::SizeBDiagCursor); break;
-    case 8: setCursor(Qt::SizeHorCursor); break;
-    case 9: setCursor(Qt::SizeVerCursor); break;
-    case 10: setCursor(Qt::SizeAllCursor); break;
-    case 12: setCursor(Qt::PointingHandCursor); break;
-    default: setCursor(Qt::ArrowCursor); break;
+    case 2: setRemoteCursorShape(Qt::IBeamCursor); break;
+    case 3: setRemoteCursorShape(Qt::WaitCursor); break;
+    case 4: setRemoteCursorShape(Qt::CrossCursor); break;
+    case 6: setRemoteCursorShape(Qt::SizeFDiagCursor); break;
+    case 7: setRemoteCursorShape(Qt::SizeBDiagCursor); break;
+    case 8: setRemoteCursorShape(Qt::SizeHorCursor); break;
+    case 9: setRemoteCursorShape(Qt::SizeVerCursor); break;
+    case 10: setRemoteCursorShape(Qt::SizeAllCursor); break;
+    case 12: setRemoteCursorShape(Qt::PointingHandCursor); break;
+    default: setRemoteCursorShape(Qt::ArrowCursor); break;
     }
 }

--- a/opennow-qt/tests/tst_streamvideoitem.cpp
+++ b/opennow-qt/tests/tst_streamvideoitem.cpp
@@ -5,8 +5,10 @@
 #include "input/platform/WaylandPointerCapture.h"
 
 #include <QGuiApplication>
+#include <QBuffer>
 #include <QJsonDocument>
 #include <QCursor>
+#include <QPixmap>
 #include <QScopeGuard>
 #include <QtQml/qqml.h>
 #include <QQuickWindow>
@@ -782,6 +784,91 @@ private slots:
         QVERIFY(item.relativeMouse());
         QVERIFY(item.m_pressedMouseButtons.isEmpty());
         QVERIFY(!item.m_pendingRelativeMouse.has_value());
+    }
+
+    void visibleCursorUpdatesStayHiddenUntilRelativeButtonRelease()
+    {
+        StreamVideoItem item;
+        item.applyRemoteCursor(QByteArray::fromHex("0000"));
+        QVERIFY(item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+        item.m_pressedMouseButtons.insert(1);
+        item.m_pressedMouseButtons.insert(3);
+        for (const auto &cursor : {"000c", "0002", "0000", "000c"}) {
+            item.applyRemoteCursor(QByteArray::fromHex(cursor));
+            QVERIFY(item.relativeMouse());
+            QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+            QCOMPARE(item.m_pressedMouseButtons.size(), 2);
+        }
+        item.m_captureActive = true;
+        item.m_rawInputActive = true;
+        QMouseEvent leftRelease(QEvent::MouseButtonRelease, QPointF(), QPointF(),
+                                Qt::LeftButton, Qt::RightButton, Qt::NoModifier);
+        item.mouseReleaseEvent(&leftRelease);
+        QVERIFY(item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+        QMouseEvent rightRelease(QEvent::MouseButtonRelease, QPointF(), QPointF(),
+                                 Qt::RightButton, Qt::NoButton, Qt::NoModifier);
+        item.mouseReleaseEvent(&rightRelease);
+        QVERIFY(!item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::PointingHandCursor);
+        QVERIFY(item.m_pressedMouseButtons.isEmpty());
+        QVERIFY(!item.m_pendingRelativeMouse.has_value());
+    }
+
+    void deferredCursorUpdatesSurviveInputRelease()
+    {
+        StreamVideoItem item;
+        item.applyRemoteCursor(QByteArray::fromHex("0002"));
+        QCOMPARE(item.cursor().shape(), Qt::IBeamCursor);
+        item.m_pressedMouseButtons.insert(1);
+        item.applyRemoteCursor(QByteArray::fromHex("0000"));
+        QVERIFY(!item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::IBeamCursor);
+        item.releaseInput();
+        QVERIFY(item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+        item.m_pressedMouseButtons.insert(1);
+        item.applyRemoteCursor(QByteArray::fromHex("000c"));
+        item.applyRemoteCursor(QByteArray::fromHex("0002"));
+        QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+        item.releaseInput();
+        QVERIFY(!item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::IBeamCursor);
+        QVERIFY(item.m_pressedMouseButtons.isEmpty());
+        QVERIFY(!item.m_pendingRelativeMouse.has_value());
+    }
+
+    void deferredBitmapCursorRetainsItsShapeAndHotspot()
+    {
+        QPixmap image(8, 8);
+        image.fill(Qt::red);
+        QByteArray png;
+        QBuffer buffer(&png);
+        QVERIFY(buffer.open(QIODevice::WriteOnly));
+        QVERIFY(image.save(&buffer, "PNG"));
+        const auto encoded = png.toBase64();
+        auto message = QByteArray::fromHex("0100020300");
+        message.append(static_cast<char>(encoded.size() & 0xff));
+        message.append(static_cast<char>((encoded.size() >> 8) & 0xff));
+        message.append(encoded);
+
+        StreamVideoItem item;
+        item.applyRemoteCursor(QByteArray::fromHex("0000"));
+        item.m_pressedMouseButtons.insert(1);
+        item.applyRemoteCursor(message);
+        QVERIFY(item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+        item.releaseInput();
+        QVERIFY(!item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::BitmapCursor);
+        QCOMPARE(item.cursor().hotSpot(), QPoint(2, 3));
+        QCOMPARE(item.cursor().pixmap().toImage(), image.toImage());
+        item.setVisible(false);
+        item.setVisible(true);
+        item.setRelativeMouse(true);
+        item.setRelativeMouse(false);
+        QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
     }
 
     void directVideoPreservesPixelsClippingOpacityAndOverlays()


### PR DESCRIPTION
Server cursor messages could display a local cursor while a held mouse button kept the stream in relative input mode. Subsequent hidden-cursor messages did not clear that cursor because the mode transition was still deferred; releasing the button could then discard the server cursor shape and fall back to the local arrow.

Cache the latest server cursor separately from the displayed cursor. Keep it hidden while relative mode is active, restore its shape and hotspot when a deferred transition completes, and clear the cache when the stream item hides or the runtime stops. Button ownership, drag deferral, and streaming/rendering lifecycles are unchanged.

Validation:
- Three new regression tests fail against the original implementation and pass with the fix, covering multiple held buttons, alternating server updates, input release, and bitmap cursor restoration/reset.
- Built `opennow-streamvideo-tests` and `opennow-embedded-orchestration-tests` with Qt 6.8.3; both CTest suites pass.
- Native-window stream suite under Xvfb: 26 passed, 2 platform-specific skips. Orchestration suite: 30 passed.
- Windows confinement and real GFN gameplay have not been exercised on this Linux machine. Windows CI and live reproduction are still needed to confirm the reported Windows symptom.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M213SP967T0W9K5EJCMKG5MJ"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->