### PR TITLE
fix(streaming): measure live ping and hide unavailable timing stats

### DIFF
--- a/native/opennow-streamer/README.md
+++ b/native/opennow-streamer/README.md
@@ -175,15 +175,25 @@ reception loss since stream start). Values are null before a stream is known.
 Reading these measurements does not advance RTCP report intervals. Qt forwards
 measured values without converting nulls into zeros.
 
-The optional `pingMs` field measures round-trip time using the existing authenticated
-STUN/NATT keepalives to the negotiated streaming peer. Replies must match an outstanding
-transaction, the peer address, fingerprint, and message integrity. The dedicated video
-path takes priority; a fresh control/audio bundle sample is used when no fresh video
-sample exists. Each receiver tracks at most 64 probes, and both outstanding probes and
-measurements expire after five seconds. New sessions start without a measurement, and
-missing or expired ping is emitted as null. No extra probes, discovery-server ping,
-remote-clock assumptions, or synthesized ICE replies are used for this measurement.
-Ping is transport RTT, not one-way video or input-to-display latency. Decode duration
+The optional `pingMs` field measures round-trip time on the active session. It prefers
+the nominated ICE candidate pair's measured RTT, then authenticated STUN/NATT replies
+on the dedicated video socket or control/audio bundle, then a timed RTSPS keepalive.
+STUN replies must match an outstanding transaction, the peer address, fingerprint, and
+message integrity. Each receiver tracks at most 64 probes. ICE statistics only refresh
+the sample when the pair's response count changes; rereading old statistics cannot keep
+an old measurement alive.
+
+The control fallback follows [OpenNOW-Mac's live-tested keepalive method](https://github.com/OpenCloudGaming/OpenNOW-Mac/blob/90627114383501dd18ef165baa005d9ea603fdf3/GFN/NVST/Rtsp/NvstRtspConnection.swift#L161-L234):
+send `GET_PARAMETER` with the RTSP Session header every two seconds over the existing
+RTSPS WebSocket, and time the matching response. A `551 Option Not Supported` response
+still measures a real round trip. Some seats do not answer STUN/ICE probes and close the
+connection on client WebSocket pings, so those pings are replaced by session-scoped
+RTSP keepalives. Server-initiated WebSocket pings are still answered with pongs.
+
+Measurements expire after five seconds, and new sessions start without a sample.
+Missing or expired ping is emitted as null. No discovery-server ping, remote-clock
+assumptions, stale handshake timing, or synthesized ICE replies supply this metric.
+Ping is network/control-path RTT, not one-way video or input-to-display latency. Decode duration
 and end-to-end latency remain unavailable without a measurement source; Qt hides those
 two metrics when unavailable in the panel, compact bar, and copied statistics.
 

--- a/native/opennow-streamer/README.md
+++ b/native/opennow-streamer/README.md
@@ -173,8 +173,19 @@ Protocol 5 telemetry includes optional `jitterMs` (RTP interarrival jitter on
 the video 90 kHz clock) and `packetLossPercent` (cumulative authenticated RTP
 reception loss since stream start). Values are null before a stream is known.
 Reading these measurements does not advance RTCP report intervals. Qt forwards
-measured values without converting nulls into zeros; RTT, decode duration and
-end-to-end latency remain unavailable when no measurement source provides them.
+measured values without converting nulls into zeros.
+
+The optional `pingMs` field measures round-trip time using the existing authenticated
+STUN/NATT keepalives to the negotiated streaming peer. Replies must match an outstanding
+transaction, the peer address, fingerprint, and message integrity. The dedicated video
+path takes priority; a fresh control/audio bundle sample is used when no fresh video
+sample exists. Each receiver tracks at most 64 probes, and both outstanding probes and
+measurements expire after five seconds. New sessions start without a measurement, and
+missing or expired ping is emitted as null. No extra probes, discovery-server ping,
+remote-clock assumptions, or synthesized ICE replies are used for this measurement.
+Ping is transport RTT, not one-way video or input-to-display latency. Decode duration
+and end-to-end latency remain unavailable without a measurement source; Qt hides those
+two metrics when unavailable in the panel, compact bar, and copied statistics.
 
 During Windows decoder recreation, the worker retains one pending recovery
 keyframe outside the bounded input queue. Already-queued descendants remain in

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
@@ -80,6 +80,9 @@ const NVST_RECOVERY_ATTEMPT_LIMIT: usize = 1;
 const NATIVE_INPUT_POLL_INTERVAL: Duration = Duration::from_micros(250);
 
 trait NvstSessionResources {
+    fn ping_ms(&self) -> Option<f64> {
+        None
+    }
     fn network_metrics(&self) -> Option<(f64, f64)> {
         None
     }
@@ -99,6 +102,9 @@ struct ActiveNvstResources {
 }
 
 impl NvstSessionResources for ActiveNvstResources {
+    fn ping_ms(&self) -> Option<f64> {
+        self.feedback.ping_ms(Instant::now())
+    }
     fn network_metrics(&self) -> Option<(f64, f64)> {
         self.feedback.network_metrics()
     }
@@ -1803,6 +1809,7 @@ fn forward_nvst_media_feedback<R: NvstSessionResources>(
                         "framesPerSecond": frames_per_second,
                         "bitrateMbps": bitrate_mbps,
                         "peakBitrateMbps": state.peak_bitrate_mbps,
+                        "pingMs": resources.ping_ms(),
                         "jitterMs": network.map(|metrics| metrics.0),
                         "packetLossPercent": network.map(|metrics| metrics.1),
                     }),
@@ -2434,6 +2441,7 @@ mod tests {
 
     #[derive(Default)]
     struct TestNvstResources {
+        ping_ms: Option<f64>,
         keyframe_requests: AtomicUsize,
         acknowledged_frames: AtomicUsize,
         acknowledged_frame_data: Mutex<Vec<(u32, u32)>>,
@@ -2443,6 +2451,10 @@ mod tests {
     }
 
     impl NvstSessionResources for TestNvstResources {
+        fn ping_ms(&self) -> Option<f64> {
+            self.ping_ms
+        }
+
         fn request_keyframe(&self) {
             self.keyframe_requests.fetch_add(1, Ordering::Relaxed);
         }
@@ -2586,6 +2598,37 @@ mod tests {
                 .is_some_and(|value| (0.9..=1.0).contains(&value))
         );
         assert_eq!(telemetry["peakBitrateMbps"], telemetry["bitrateMbps"]);
+    }
+
+    #[test]
+    fn accepted_video_telemetry_preserves_measured_and_unavailable_ping() {
+        for ping_ms in [None, Some(0.0), Some(25.5)] {
+            let (sender, receiver) = std::sync::mpsc::channel();
+            let sender = EventSender::unbounded(sender);
+            let resources = TestNvstResources {
+                ping_ms,
+                ..Default::default()
+            };
+            let mut state = NvstMediaFeedbackState::new(true);
+            state.telemetry_window_started = Instant::now() - Duration::from_secs(1);
+            forward_nvst_media_feedback(
+                &sender,
+                &connected_lifecycle(),
+                7,
+                &resources,
+                MediaFeedback::VideoFrameAccepted {
+                    frame_index: Some(72),
+                    timestamp: 90_000,
+                    bytes: 125_000,
+                    keyframe: false,
+                },
+                &mut state,
+            );
+            let telemetry = receiver.recv().unwrap();
+            assert_eq!(telemetry["type"], "telemetry");
+            assert!(telemetry.get("pingMs").is_some());
+            assert_eq!(telemetry["pingMs"], json!(ping_ms));
+        }
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
@@ -30,7 +30,7 @@ mod nvst_rtsp;
 
 use microphone::MicrophoneController;
 
-use nvst_rtsp::{ActiveNvstRtspSession, prepare_owned_nvst};
+use nvst_rtsp::{ActiveNvstRtspSession, NvstControlPing, prepare_owned_nvst};
 
 pub use opennow_streamer_transport::{EncodedMediaFrame, MediaConsumer};
 
@@ -98,12 +98,18 @@ struct ActiveNvstResources {
     bundle: NvstUdpReceiverControl,
     mjolnir: Option<NvstUdpReceiverControl>,
     feedback: SharedNvstFeedback,
+    control_ping: Option<NvstControlPing>,
     media: Option<MediaControl>,
 }
 
 impl NvstSessionResources for ActiveNvstResources {
     fn ping_ms(&self) -> Option<f64> {
-        self.feedback.ping_ms(Instant::now())
+        let now = Instant::now();
+        self.feedback.ping_ms(now).or_else(|| {
+            self.control_ping
+                .as_ref()
+                .and_then(|ping| ping.ping_ms(now))
+        })
     }
     fn network_metrics(&self) -> Option<(f64, f64)> {
         self.feedback.network_metrics()
@@ -840,6 +846,9 @@ impl Engine {
                 bundle: bundle_control,
                 mjolnir: mjolnir_control,
                 feedback,
+                control_ping: prepared_nvst
+                    .as_ref()
+                    .map(|prepared| prepared.control_ping.clone()),
                 media: self.media_session.as_ref().map(MediaSession::control),
             });
             nvst_events = Some(event_receiver);

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::net::{IpAddr, TcpStream};
 use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -15,6 +16,9 @@ use tungstenite::{Message, WebSocket, connect};
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(2);
+const CONTROL_PING_EXPIRY: Duration = Duration::from_secs(5);
+const CONTROL_IO_TIMEOUT: Duration = Duration::from_millis(100);
+const MAX_CONTROL_RESPONSE_BYTES: usize = 64 * 1024;
 const MAX_STREAM_BITRATE_MBPS: u64 = 200;
 // GeForce NOW 2.0.87.131 reports video[0].timeoutLengthMs=8000 and
 // video[0].sendFrameTimeoutMs=7000. Waiting sixty seconds left a dead Mjolnir media leg on screen
@@ -48,6 +52,37 @@ struct RtspClient {
     socket: WebSocket<MaybeTlsStream<TcpStream>>,
     cseq: u64,
     buffer: String,
+}
+
+#[derive(Clone, Default)]
+pub struct NvstControlPing {
+    sample: Arc<Mutex<Option<(Instant, Duration)>>>,
+}
+
+impl NvstControlPing {
+    pub fn ping_ms(&self, now: Instant) -> Option<f64> {
+        let mut sample = self.sample.lock().ok()?;
+        let (received_at, elapsed) = (*sample)?;
+        if now.checked_duration_since(received_at)? >= CONTROL_PING_EXPIRY {
+            *sample = None;
+            return None;
+        }
+        Some(elapsed.as_secs_f64() * 1000.0)
+    }
+
+    fn record(&self, sent_at: Instant, received_at: Instant) {
+        if let Ok(mut sample) = self.sample.lock() {
+            *sample = received_at
+                .checked_duration_since(sent_at)
+                .map(|elapsed| (received_at, elapsed));
+        }
+    }
+
+    fn clear(&self) {
+        if let Ok(mut sample) = self.sample.lock() {
+            *sample = None;
+        }
+    }
 }
 
 impl RtspClient {
@@ -91,7 +126,7 @@ impl RtspClient {
             opennow_streamer_protocol::log::log_line("WARN", "rtsp", &failure.message);
             failure
         })?;
-        set_read_timeout(&mut socket, REQUEST_TIMEOUT);
+        set_io_timeout(&mut socket, REQUEST_TIMEOUT);
         Ok((
             Self {
                 socket,
@@ -121,7 +156,7 @@ impl RtspClient {
         timeout: Duration,
     ) -> Result<RtspResponse, NvstRtspError> {
         let mut stage = opennow_streamer_protocol::log::Stage::begin("rtsps.request");
-        self.cseq += 1;
+        self.send_request(method, uri, headers, body)?;
         opennow_streamer_protocol::log::log_line(
             "INFO",
             "rtsps",
@@ -132,24 +167,30 @@ impl RtspClient {
                 body.len()
             ),
         );
-        let mut request = format!(
-            "{method} {uri} RTSP/1.0\r\nCSeq: {}\r\nRequest-Id: {}\r\n",
-            self.cseq, self.cseq
-        );
-        for (name, value) in headers {
-            request.push_str(&format!("{name}: {value}\r\n"));
-        }
-        if !body.is_empty() {
-            request.push_str(&format!("Content-Length: {}\r\n", body.len()));
-        }
-        request.push_str("\r\n");
-        request.push_str(body);
-        self.socket
-            .send(Message::Text(request.into()))
-            .map_err(|error| NvstRtspError::new("nvst-rtsp-failed", error.to_string()))?;
         let deadline = Instant::now() + timeout;
         loop {
-            if let Some(response) = take_rtsp_response(&mut self.buffer, self.cseq)? {
+            if self.buffer.len() > MAX_CONTROL_RESPONSE_BYTES {
+                return Err(NvstRtspError::new(
+                    "nvst-rtsp-failed",
+                    "RTSPS response exceeds control buffer limit",
+                ));
+            }
+            if Instant::now() >= deadline {
+                return Err(NvstRtspError::new(
+                    "nvst-rtsp-timeout",
+                    format!("RTSPS {method} timed out"),
+                ));
+            }
+            let response = match take_rtsp_response(&mut self.buffer, self.cseq) {
+                Ok(response) => response,
+                Err(error)
+                    if method == "TEARDOWN" && error.code == "nvst-rtsp-sequence-mismatch" =>
+                {
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            if let Some(response) = response {
                 opennow_streamer_protocol::log::log_line(
                     "INFO",
                     "rtsps",
@@ -160,12 +201,6 @@ impl RtspClient {
                 );
                 stage.complete();
                 return Ok(response);
-            }
-            if Instant::now() >= deadline {
-                return Err(NvstRtspError::new(
-                    "nvst-rtsp-timeout",
-                    format!("RTSPS {method} timed out"),
-                ));
             }
             match self.socket.read() {
                 Ok(Message::Text(text)) => self.buffer.push_str(text.as_str()),
@@ -189,6 +224,32 @@ impl RtspClient {
                 }
             }
         }
+    }
+
+    fn send_request(
+        &mut self,
+        method: &str,
+        uri: &str,
+        headers: &[(&str, String)],
+        body: &str,
+    ) -> Result<u64, NvstRtspError> {
+        self.cseq += 1;
+        let mut request = format!(
+            "{method} {uri} RTSP/1.0\r\nCSeq: {}\r\nRequest-Id: {}\r\n",
+            self.cseq, self.cseq
+        );
+        for (name, value) in headers {
+            request.push_str(&format!("{name}: {value}\r\n"));
+        }
+        if !body.is_empty() {
+            request.push_str(&format!("Content-Length: {}\r\n", body.len()));
+        }
+        request.push_str("\r\n");
+        request.push_str(body);
+        self.socket
+            .send(Message::Text(request.into()))
+            .map_err(|error| NvstRtspError::new("nvst-rtsp-failed", error.to_string()))?;
+        Ok(self.cseq)
     }
 }
 
@@ -215,6 +276,7 @@ fn rtsp_connect_error(error: &tungstenite::Error) -> NvstRtspError {
 }
 
 pub struct PreparedNvstRtspSession {
+    pub control_ping: NvstControlPing,
     client: Option<RtspClient>,
     target: String,
     common_headers: Vec<(&'static str, String)>,
@@ -280,6 +342,7 @@ impl PreparedNvstRtspSession {
             self.target.clone(),
             self.common_headers.clone(),
             self.rtsp_session.clone(),
+            self.control_ping.clone(),
         )
     }
 }
@@ -292,7 +355,7 @@ impl Drop for PreparedNvstRtspSession {
         let Some(client) = self.client.as_mut() else {
             return;
         };
-        set_read_timeout(&mut client.socket, Duration::from_millis(100));
+        set_io_timeout(&mut client.socket, CONTROL_IO_TIMEOUT);
         let mut headers = self.common_headers.clone();
         headers.push(("Session", self.rtsp_session.clone()));
         let _ = client.request_with_timeout(
@@ -321,17 +384,24 @@ impl ActiveNvstRtspSession {
         target: String,
         common_headers: Vec<(&'static str, String)>,
         rtsp_session: String,
+        control_ping: NvstControlPing,
     ) -> Result<Self, NvstRtspError> {
-        set_read_timeout(&mut client.socket, Duration::from_millis(100));
+        set_io_timeout(&mut client.socket, CONTROL_IO_TIMEOUT);
+        client.socket.set_config(|config| {
+            config.max_message_size = Some(MAX_CONTROL_RESPONSE_BYTES);
+            config.max_frame_size = Some(MAX_CONTROL_RESPONSE_BYTES);
+        });
         let (control, receiver) = mpsc::channel();
         let worker = thread::Builder::new()
             .name("opennow-nvst-rtsps".to_owned())
             .spawn(move || {
                 let mut last_ping = Instant::now();
+                let mut outstanding: Option<(u64, Instant)> = None;
+                let mut headers = common_headers;
+                headers.push(("Session", rtsp_session));
                 loop {
                     if receiver.try_recv().is_ok() {
-                        let mut headers = common_headers.clone();
-                        headers.push(("Session", rtsp_session.clone()));
+                        control_ping.clear();
                         let _ = client.request_with_timeout(
                             "TEARDOWN",
                             &target,
@@ -342,19 +412,30 @@ impl ActiveNvstRtspSession {
                         let _ = client.socket.close(None);
                         break;
                     }
-                    if last_ping.elapsed() >= KEEPALIVE_INTERVAL {
-                        if client
-                            .socket
-                            .send(Message::Ping(Vec::new().into()))
-                            .is_err()
-                        {
-                            break;
+                    let now = Instant::now();
+                    if outstanding.is_some_and(|(_, sent_at)| {
+                        now.duration_since(sent_at) >= KEEPALIVE_INTERVAL
+                    }) {
+                        outstanding = None;
+                        control_ping.clear();
+                    }
+                    if outstanding.is_none() && now.duration_since(last_ping) >= KEEPALIVE_INTERVAL
+                    {
+                        match client.send_request("GET_PARAMETER", &target, &headers, "") {
+                            Ok(cseq) => outstanding = Some((cseq, now)),
+                            Err(_) => break,
                         }
-                        last_ping = Instant::now();
+                        last_ping = now;
                     }
                     match client.socket.read() {
+                        Ok(Message::Text(text)) => client.buffer.push_str(text.as_str()),
+                        Ok(Message::Binary(bytes)) => {
+                            client.buffer.push_str(&String::from_utf8_lossy(&bytes));
+                        }
                         Ok(Message::Ping(bytes)) => {
-                            let _ = client.socket.send(Message::Pong(bytes));
+                            if client.socket.send(Message::Pong(bytes)).is_err() {
+                                break;
+                            }
                         }
                         Ok(Message::Close(_)) => break,
                         Ok(_) => {}
@@ -365,7 +446,32 @@ impl ActiveNvstRtspSession {
                             ) => {}
                         Err(_) => break,
                     }
+                    if client.buffer.len() > MAX_CONTROL_RESPONSE_BYTES {
+                        break;
+                    }
+                    while !client.buffer.is_empty() {
+                        let expected_cseq = outstanding.map_or(client.cseq, |(cseq, _)| cseq);
+                        match take_rtsp_response(&mut client.buffer, expected_cseq) {
+                            Ok(Some(_)) => {
+                                if let Some((_, sent_at)) = outstanding.take() {
+                                    let received_at = Instant::now();
+                                    if received_at.duration_since(sent_at) < KEEPALIVE_INTERVAL {
+                                        control_ping.record(sent_at, received_at);
+                                    } else {
+                                        control_ping.clear();
+                                    }
+                                }
+                            }
+                            Ok(None) => break,
+                            Err(error) if error.code == "nvst-rtsp-sequence-mismatch" => {}
+                            Err(_) => {
+                                control_ping.clear();
+                                return;
+                            }
+                        }
+                    }
                 }
+                control_ping.clear();
             })
             .map_err(|error| NvstRtspError::new("nvst-control-failed", error.to_string()))?;
         Ok(Self {
@@ -640,6 +746,7 @@ pub fn prepare_owned_nvst(
         },
     );
     Ok(PreparedNvstRtspSession {
+        control_ping: NvstControlPing::default(),
         client: Some(client),
         target,
         common_headers,
@@ -997,9 +1104,17 @@ fn take_rtsp_response(
                 .and_then(|(_, value)| value.trim().parse::<usize>().ok())
         })
         .unwrap_or(0);
-    let total = header_end + separator + content_length;
+    let total = (header_end + separator)
+        .checked_add(content_length)
+        .ok_or_else(|| NvstRtspError::new("nvst-rtsp-failed", "Invalid RTSPS content length"))?;
     if buffer.len() < total {
         return Ok(None);
+    }
+    if !buffer.is_char_boundary(total) {
+        return Err(NvstRtspError::new(
+            "nvst-rtsp-failed",
+            "Invalid RTSPS body encoding",
+        ));
     }
     let raw = buffer[..total].to_owned();
     buffer.drain(..total);
@@ -1048,7 +1163,7 @@ fn take_rtsp_response(
     };
     if !sequence_matches {
         return Err(NvstRtspError::new(
-            "nvst-rtsp-failed",
+            "nvst-rtsp-sequence-mismatch",
             format!(
                 "RTSPS response sequence mismatch: expected {expected_cseq}, CSeq={}, Request-Id={}",
                 response_cseq
@@ -1212,17 +1327,23 @@ fn random_runtime_key() -> Result<(String, u32), NvstRtspError> {
     ))
 }
 
-fn set_read_timeout(socket: &mut WebSocket<MaybeTlsStream<TcpStream>>, timeout: Duration) {
+fn set_io_timeout(socket: &mut WebSocket<MaybeTlsStream<TcpStream>>, timeout: Duration) {
     match socket.get_mut() {
         MaybeTlsStream::Plain(stream) => {
             let _ = stream.set_read_timeout(Some(timeout));
+            let _ = stream.set_write_timeout(Some(timeout));
         }
         MaybeTlsStream::Rustls(stream) => {
             let _ = stream.get_mut().set_read_timeout(Some(timeout));
+            let _ = stream.get_mut().set_write_timeout(Some(timeout));
         }
         _ => {}
     }
 }
+
+#[cfg(test)]
+#[path = "nvst_rtsp_control_ping_tests.rs"]
+mod control_ping_tests;
 
 #[cfg(test)]
 mod tests {

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp_control_ping_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp_control_ping_tests.rs
@@ -1,0 +1,241 @@
+use super::*;
+use std::net::TcpListener;
+
+fn socket_pair() -> (RtspClient, WebSocket<TcpStream>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(6)))
+            .unwrap();
+        stream
+            .set_write_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        tungstenite::accept(stream).unwrap()
+    });
+    let stream = TcpStream::connect(address).unwrap();
+    stream.set_nodelay(true).unwrap();
+    let (socket, _) = tungstenite::client(
+        format!("ws://{address}/rtsp"),
+        MaybeTlsStream::Plain(stream),
+    )
+    .unwrap();
+    (
+        RtspClient {
+            socket,
+            cseq: 7,
+            buffer: String::new(),
+        },
+        server.join().unwrap(),
+    )
+}
+
+fn active_session(client: RtspClient, ping: &NvstControlPing) -> ActiveNvstRtspSession {
+    ActiveNvstRtspSession::spawn(
+        client,
+        "rtsps://seat.nvidiagrid.net:322".to_owned(),
+        vec![
+            ("X-GS-Version", "14.2".to_owned()),
+            ("x-nv-sessionid", "nv-session".to_owned()),
+        ],
+        "rtsp-session".to_owned(),
+        ping.clone(),
+    )
+    .unwrap()
+}
+
+fn read_request(server: &mut WebSocket<TcpStream>, method: &str) -> u64 {
+    let message = server.read().unwrap();
+    let Message::Text(text) = message else {
+        panic!("expected RTSP request, received {message:?}");
+    };
+    assert!(text.starts_with(&format!(
+        "{method} rtsps://seat.nvidiagrid.net:322 RTSP/1.0\r\n"
+    )));
+    assert!(text.contains("\r\nSession: rtsp-session\r\n"));
+    assert!(text.contains("\r\nX-GS-Version: 14.2\r\n"));
+    assert!(text.contains("\r\nx-nv-sessionid: nv-session\r\n"));
+    let cseq = text
+        .lines()
+        .find_map(|line| line.strip_prefix("CSeq: "))
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(text.contains(&format!("\r\nRequest-Id: {cseq}\r\n")));
+    cseq
+}
+
+fn response(server: &mut WebSocket<TcpStream>, cseq: u64, status: u16) {
+    server
+        .send(Message::Text(
+            format!("RTSP/1.0 {status} Response\r\nCSeq: {cseq}\r\n\r\n").into(),
+        ))
+        .unwrap();
+}
+
+fn server_ping(server: &mut WebSocket<TcpStream>) {
+    server.send(Message::Ping(vec![1, 2, 3].into())).unwrap();
+    assert_eq!(server.read().unwrap(), Message::Pong(vec![1, 2, 3].into()));
+}
+
+fn wait_until(mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !condition() {
+        assert!(Instant::now() < deadline, "worker did not respond promptly");
+        thread::sleep(Duration::from_millis(2));
+    }
+}
+
+#[test]
+fn control_ping_parser_rejects_overflowing_and_invalid_body_boundaries() {
+    let mut overflowing = format!(
+        "RTSP/1.0 551 Response\r\nCSeq: 8\r\nContent-Length: {}\r\n\r\n",
+        usize::MAX
+    );
+    assert!(take_rtsp_response(&mut overflowing, 8).is_err());
+    let mut invalid = "RTSP/1.0 551 Response\r\nCSeq: 8\r\nContent-Length: 1\r\n\r\né".to_owned();
+    assert!(take_rtsp_response(&mut invalid, 8).is_err());
+}
+
+#[test]
+fn control_ping_samples_are_shared_expiring_and_clearable() {
+    let ping = NvstControlPing::default();
+    let clone = ping.clone();
+    let sent = Instant::now();
+    let received = sent + Duration::from_micros(4_750);
+    assert_eq!(ping.ping_ms(sent), None);
+    ping.record(sent, received);
+    assert_eq!(clone.ping_ms(received), Some(4.75));
+    assert_eq!(clone.ping_ms(sent), None);
+    assert_eq!(ping.ping_ms(received + Duration::from_secs(4)), Some(4.75));
+    assert_eq!(ping.ping_ms(received + CONTROL_PING_EXPIRY), None);
+    assert_eq!(clone.ping_ms(received), None);
+    ping.record(sent, received);
+    clone.clear();
+    assert_eq!(ping.ping_ms(received), None);
+    ping.record(sent, sent);
+    assert_eq!(ping.ping_ms(sent), Some(0.0));
+}
+
+#[test]
+fn live_control_ping_uses_session_rtsp_and_accepts_551_not_wrong_sequences() {
+    let (client, mut server) = socket_pair();
+    let ping = NvstControlPing::default();
+    let mut active = active_session(client, &ping);
+    server_ping(&mut server);
+    let cseq = read_request(&mut server, "GET_PARAMETER");
+    assert_eq!(cseq, 8);
+    response(&mut server, cseq + 1, 551);
+    server_ping(&mut server);
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+    server
+        .send(Message::Binary(
+            format!("RTSP/1.0 551 Option Not Supported\r\nRequest-Id: {cseq}\r\n")
+                .into_bytes()
+                .into(),
+        ))
+        .unwrap();
+    server
+        .send(Message::Binary(b"\r\n".to_vec().into()))
+        .unwrap();
+    wait_until(|| ping.ping_ms(Instant::now()).is_some());
+    assert!(ping.ping_ms(Instant::now()).unwrap() < 1000.0);
+    server_ping(&mut server);
+    server.close(None).unwrap();
+    wait_until(|| active.worker.as_ref().unwrap().is_finished());
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+    let shutdown_started = Instant::now();
+    active.shutdown();
+    assert!(shutdown_started.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn live_control_ping_times_out_without_accepting_late_replies() {
+    let (client, mut server) = socket_pair();
+    let ping = NvstControlPing::default();
+    let mut active = active_session(client, &ping);
+    let first = read_request(&mut server, "GET_PARAMETER");
+    response(&mut server, first, 200);
+    wait_until(|| ping.ping_ms(Instant::now()).is_some());
+    let missing = read_request(&mut server, "GET_PARAMETER");
+    assert_eq!(missing, first + 1);
+    let next = read_request(&mut server, "GET_PARAMETER");
+    assert_eq!(next, missing + 1);
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+    response(&mut server, missing, 551);
+    server_ping(&mut server);
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+    response(&mut server, next, 551);
+    wait_until(|| ping.ping_ms(Instant::now()).is_some());
+    drop(server);
+    wait_until(|| active.worker.as_ref().unwrap().is_finished());
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+    active.shutdown();
+}
+
+#[test]
+fn live_control_ping_shutdown_sends_teardown_with_pending_probe() {
+    let (client, mut server) = socket_pair();
+    let ping = NvstControlPing::default();
+    let mut active = active_session(client, &ping);
+    let cseq = read_request(&mut server, "GET_PARAMETER");
+    let shutdown_started = Instant::now();
+    let shutdown = thread::spawn(move || active.shutdown());
+    assert_eq!(read_request(&mut server, "TEARDOWN"), cseq + 1);
+    shutdown.join().unwrap();
+    assert!(shutdown_started.elapsed() < Duration::from_secs(2));
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+}
+
+#[test]
+fn live_control_ping_shutdown_waits_past_pending_probe_reply_for_teardown() {
+    let (client, mut server) = socket_pair();
+    let ping = NvstControlPing::default();
+    let mut active = active_session(client, &ping);
+    let probe = read_request(&mut server, "GET_PARAMETER");
+    let shutdown_started = Instant::now();
+    let shutdown = thread::spawn(move || active.shutdown());
+    let teardown = read_request(&mut server, "TEARDOWN");
+    response(&mut server, probe, 551);
+    server_ping(&mut server);
+    assert!(!shutdown.is_finished());
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+    response(&mut server, teardown, 200);
+    shutdown.join().unwrap();
+    assert!(shutdown_started.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn live_control_ping_shutdown_clears_sample_and_accepts_teardown_response() {
+    let (client, mut server) = socket_pair();
+    let ping = NvstControlPing::default();
+    let mut active = active_session(client, &ping);
+    let cseq = read_request(&mut server, "GET_PARAMETER");
+    response(&mut server, cseq, 551);
+    wait_until(|| ping.ping_ms(Instant::now()).is_some());
+    let shutdown_started = Instant::now();
+    let shutdown = thread::spawn(move || active.shutdown());
+    let teardown = read_request(&mut server, "TEARDOWN");
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+    response(&mut server, teardown, 200);
+    shutdown.join().unwrap();
+    assert!(shutdown_started.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn live_control_ping_rejects_unbounded_partial_response() {
+    let (client, mut server) = socket_pair();
+    let ping = NvstControlPing::default();
+    let mut active = active_session(client, &ping);
+    let cseq = read_request(&mut server, "GET_PARAMETER");
+    response(&mut server, cseq, 551);
+    wait_until(|| ping.ping_ms(Instant::now()).is_some());
+    server
+        .send(Message::Text("x".repeat(MAX_CONTROL_RESPONSE_BYTES).into()))
+        .unwrap();
+    server.send(Message::Text("x".into())).unwrap();
+    wait_until(|| active.worker.as_ref().unwrap().is_finished());
+    assert_eq!(ping.ping_ms(Instant::now()), None);
+    active.shutdown();
+}

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -35,6 +35,7 @@ use str0m::format::{Codec, FormatParams};
 use str0m::media::{Frequency, MediaKind, Mid};
 use str0m::net::{Protocol as RtcProtocol, Receive};
 use str0m::rtp::{RtpHeader as BundleRtpHeader, Ssrc};
+use str0m::stats::CandidatePairStats;
 use str0m::{Candidate, Event, IceCreds, Input, Output, Rtc, RtcConfig};
 
 use super::nvst_control::{
@@ -380,6 +381,7 @@ pub struct NvstFeedbackState {
     received_packets: AtomicU32,
     report_prior: Mutex<(u32, u32)>,
     reception_timing: Mutex<ReceptionTiming>,
+    ice_ping: Mutex<Option<(Instant, Duration)>>,
     video_ping: Mutex<Option<(Instant, Duration)>>,
     bundle_ping: Mutex<Option<(Instant, Duration)>>,
     /// Remains set through send attempts until assembly receives a fresh keyframe.
@@ -401,6 +403,7 @@ impl Default for NvstFeedbackState {
             received_packets: AtomicU32::new(0),
             report_prior: Mutex::new((0, 0)),
             reception_timing: Mutex::new(ReceptionTiming::default()),
+            ice_ping: Mutex::new(None),
             video_ping: Mutex::new(None),
             bundle_ping: Mutex::new(None),
             keyframe_needed: AtomicBool::new(false),
@@ -414,6 +417,27 @@ impl Default for NvstFeedbackState {
 }
 
 impl NvstFeedbackState {
+    fn update_ice_ping(
+        &self,
+        pair: Option<&CandidatePairStats>,
+        previous_responses: &mut u64,
+        now: Instant,
+    ) {
+        let mut sample = self
+            .ice_ping
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(pair) = pair else {
+            *previous_responses = 0;
+            *sample = None;
+            return;
+        };
+        if pair.responses_received != *previous_responses {
+            *previous_responses = pair.responses_received;
+            *sample = pair.current_round_trip_time.map(|elapsed| (now, elapsed));
+        }
+    }
+
     fn publish_ping(&self, video: bool, now: Instant, elapsed: Duration) {
         let sample = if video {
             &self.video_ping
@@ -426,7 +450,7 @@ impl NvstFeedbackState {
     }
 
     pub fn ping_ms(&self, now: Instant) -> Option<f64> {
-        [&self.video_ping, &self.bundle_ping]
+        [&self.ice_ping, &self.video_ping, &self.bundle_ping]
             .into_iter()
             .find_map(|sample| {
                 sample
@@ -4339,6 +4363,7 @@ fn create_nvst_bundle_rtc(socket: &UdpSocket) -> Result<Rtc, NvstUdpReceiverErro
     // str0m's default 16-char ufrag is rejected by Bifrost length checks.
     let mut rtc_config = RtcConfig::new()
         .set_rtp_mode(true)
+        .set_stats_interval(Some(Duration::from_secs(1)))
         .set_send_buffer_audio(MICROPHONE_QUEUE_CAPACITY);
     rtc_config.codec_config().add_config(
         GFN_RED_PAYLOAD_TYPE.into(),
@@ -5117,6 +5142,7 @@ fn run_nvst_webrtc_bundle(
     let mut outbound_datagrams = 0_u64;
     let mut hole_punch_pings = 0_u64;
     let mut ping_tracker = StreamPingTracker::default();
+    let mut ice_ping_responses = 0;
     let mut last_hole_punch = Instant::now() - PING_INTERVAL_BEFORE_CONNECTION;
     let mut seen_ssrcs = HashSet::new();
     let mut dtls_ready = false;
@@ -5584,6 +5610,11 @@ fn run_nvst_webrtc_bundle(
                     // unblocks str0m and sends ClientHello before GFN has a pair.
                 }
                 Ok(Output::Event(event)) => match event {
+                    Event::PeerStats(stats) => feedback.update_ice_ping(
+                        stats.selected_candidate_pair.as_ref(),
+                        &mut ice_ping_responses,
+                        Instant::now(),
+                    ),
                     Event::IceConnectionStateChange(state) => {
                         opennow_streamer_protocol::log::log_async(
                             "INFO",

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -76,6 +76,50 @@ const MAX_NACK_ATTEMPTS: u8 = 3;
 const KEYFRAME_REQUEST_COOLDOWN: Duration = Duration::from_millis(250);
 const MAX_PENDING_NACK_RANGES: usize = 16;
 const MAX_PENDING_FRAME_ACKS: usize = 512;
+const STREAM_PING_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_PENDING_STREAM_PINGS: usize = 64;
+
+#[derive(Default)]
+struct StreamPingTracker {
+    pending: VecDeque<([u8; 12], Instant)>,
+}
+
+impl StreamPingTracker {
+    fn sent(&mut self, transaction_id: [u8; 12], now: Instant) {
+        self.pending
+            .retain(|(_, sent)| now.saturating_duration_since(*sent) < STREAM_PING_TIMEOUT);
+        if self.pending.len() == MAX_PENDING_STREAM_PINGS {
+            self.pending.pop_front();
+        }
+        self.pending.push_back((transaction_id, now));
+    }
+
+    fn receive(
+        &mut self,
+        packet: &[u8],
+        source: SocketAddr,
+        credentials: &NvstStunCredentials,
+        now: Instant,
+    ) -> Option<Duration> {
+        if packet.get(..2)? != STUN_BINDING_SUCCESS_RESPONSE.to_be_bytes() {
+            return None;
+        }
+        let transaction_id = packet.get(8..20)?;
+        let index = self
+            .pending
+            .iter()
+            .position(|(id, _)| id == transaction_id)?;
+        if !matches!(
+            handle_stun_datagram(packet, source, credentials),
+            StunDatagram::Handled(None)
+        ) {
+            return None;
+        }
+        let (_, sent) = self.pending.remove(index)?;
+        let elapsed = now.checked_duration_since(sent)?;
+        (elapsed < STREAM_PING_TIMEOUT).then_some(elapsed)
+    }
+}
 
 fn verbose_diagnostics_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
@@ -336,6 +380,8 @@ pub struct NvstFeedbackState {
     received_packets: AtomicU32,
     report_prior: Mutex<(u32, u32)>,
     reception_timing: Mutex<ReceptionTiming>,
+    video_ping: Mutex<Option<(Instant, Duration)>>,
+    bundle_ping: Mutex<Option<(Instant, Duration)>>,
     /// Remains set through send attempts until assembly receives a fresh keyframe.
     keyframe_needed: AtomicBool,
     /// Missing extended RTP sequence ranges awaiting RFC 4585 generic NACK.
@@ -355,6 +401,8 @@ impl Default for NvstFeedbackState {
             received_packets: AtomicU32::new(0),
             report_prior: Mutex::new((0, 0)),
             reception_timing: Mutex::new(ReceptionTiming::default()),
+            video_ping: Mutex::new(None),
+            bundle_ping: Mutex::new(None),
             keyframe_needed: AtomicBool::new(false),
             pending_nacks: Mutex::new(VecDeque::new()),
             completed_frames: AtomicU32::new(0),
@@ -366,6 +414,31 @@ impl Default for NvstFeedbackState {
 }
 
 impl NvstFeedbackState {
+    fn publish_ping(&self, video: bool, now: Instant, elapsed: Duration) {
+        let sample = if video {
+            &self.video_ping
+        } else {
+            &self.bundle_ping
+        };
+        *sample
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some((now, elapsed));
+    }
+
+    pub fn ping_ms(&self, now: Instant) -> Option<f64> {
+        [&self.video_ping, &self.bundle_ping]
+            .into_iter()
+            .find_map(|sample| {
+                sample
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .filter(|(received, _)| {
+                        now.saturating_duration_since(*received) < STREAM_PING_TIMEOUT
+                    })
+                    .map(|(_, elapsed)| elapsed.as_secs_f64() * 1000.0)
+            })
+    }
+
     fn publish_stream(&self, ssrc: u32, highest_sequence: u32, rtp_timestamp: u32, now: Instant) {
         self.video_ssrc.store(ssrc, Ordering::Release);
         let _ = self.base_sequence.compare_exchange(
@@ -5043,6 +5116,7 @@ fn run_nvst_webrtc_bundle(
     let mut inbound_datagrams = 0_u64;
     let mut outbound_datagrams = 0_u64;
     let mut hole_punch_pings = 0_u64;
+    let mut ping_tracker = StreamPingTracker::default();
     let mut last_hole_punch = Instant::now() - PING_INTERVAL_BEFORE_CONNECTION;
     let mut seen_ssrcs = HashSet::new();
     let mut dtls_ready = false;
@@ -5265,11 +5339,13 @@ fn run_nvst_webrtc_bundle(
                     &credentials.remote_password,
                     &natt_tid,
                 );
+                let sent_at = Instant::now();
                 if let Err(error) = socket.send_to(&natt, bundle_peer) {
                     eprintln!("NVST NATT send failed: {error}");
                     forward_optional(&event_sender, receiver.stop());
                     return;
                 }
+                ping_tracker.sent(natt_tid, sent_at);
                 Some(natt)
             } else {
                 None
@@ -5801,6 +5877,17 @@ fn run_nvst_webrtc_bundle(
                     if source != bundle_peer {
                         continue;
                     }
+                    if let Some(credentials) = stun_credentials.as_ref() {
+                        let received_at = Instant::now();
+                        if let Some(elapsed) = ping_tracker.receive(
+                            &datagram[..length],
+                            source,
+                            credentials,
+                            received_at,
+                        ) {
+                            feedback.publish_ping(false, received_at, elapsed);
+                        }
+                    }
                     if datagram[..length] == *b"PING" {
                         if let Err(error) = socket.send_to(b"PONG", source) {
                             eprintln!("NVST PONG send failed: {error}");
@@ -5903,6 +5990,7 @@ fn run_nvst_udp_receiver(
     let mut peer_seen = false;
     let mut last_ping = Instant::now() - PING_INTERVAL_BEFORE_CONNECTION;
     let mut pings_sent = 0_u64;
+    let mut ping_tracker = StreamPingTracker::default();
     let mut inbound_datagrams = 0_u64;
     let mut handled_stun = 0_u64;
     let mut invalid_stun = 0_u64;
@@ -5957,12 +6045,14 @@ fn run_nvst_udp_receiver(
                     &credentials.remote_password,
                     &transaction_id,
                 );
+                let sent_at = Instant::now();
                 if let Err(error) = socket.send_to(&ping, receiver.config.video_peer) {
                     log_udp_error("video-natt-send", local_port, &error);
                     eprintln!("NVST NATT send failed: {error}");
                     forward_optional(&event_sender, receiver.stop());
                     return;
                 }
+                ping_tracker.sent(transaction_id, sent_at);
                 pings_sent += 1;
             } else {
                 if let Err(error) =
@@ -6001,6 +6091,15 @@ fn run_nvst_udp_receiver(
                 if source == receiver.config.video_peer
                     && let Some(credentials) = stun_credentials.as_ref()
                 {
+                    let received_at = Instant::now();
+                    if let Some(elapsed) =
+                        ping_tracker.receive(&datagram[..length], source, credentials, received_at)
+                    {
+                        receiver
+                            .config
+                            .feedback()
+                            .publish_ping(true, received_at, elapsed);
+                    }
                     match handle_stun_datagram(&datagram[..length], source, credentials) {
                         StunDatagram::Handled(response) => {
                             handled_stun += 1;
@@ -6154,6 +6253,9 @@ mod tests {
         include!("nvst_audio_tests.rs");
     }
 
+    mod ping_tests {
+        include!("nvst_ping_tests.rs");
+    }
     mod recovery_tests {
         include!("nvst_recovery_tests.rs");
     }

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
@@ -199,3 +199,55 @@ fn bundle_receiver_publishes_ping_from_its_real_udp_keepalive_reply() {
     assert!(measured.is_some_and(|value| (0.0..2000.0).contains(&value)));
     assert!(feedback.video_ping.lock().unwrap().is_none());
 }
+
+#[test]
+fn selected_ice_pair_ping_takes_priority_without_refreshing_old_samples() {
+    let feedback = NvstFeedbackState::default();
+    let now = Instant::now();
+    let mut previous_responses = 0;
+    let mut pair = CandidatePairStats {
+        protocol: RtcProtocol::Udp,
+        local: str0m::stats::CandidateStats {
+            addr: "127.0.0.1:5000".parse().unwrap(),
+        },
+        remote: str0m::stats::CandidateStats { addr: peer() },
+        current_round_trip_time: None,
+        total_round_trip_time: Duration::ZERO,
+        responses_received: 0,
+    };
+    feedback.update_ice_ping(Some(&pair), &mut previous_responses, now);
+    assert_eq!(feedback.ping_ms(now), None);
+    feedback.publish_ping(true, now, Duration::from_millis(40));
+    pair.responses_received = 1;
+    pair.current_round_trip_time = Some(Duration::from_micros(25_500));
+    feedback.update_ice_ping(Some(&pair), &mut previous_responses, now);
+    assert_eq!(feedback.ping_ms(now), Some(25.5));
+    feedback.publish_ping(
+        true,
+        now + Duration::from_secs(1),
+        Duration::from_millis(30),
+    );
+    feedback.update_ice_ping(
+        Some(&pair),
+        &mut previous_responses,
+        now + STREAM_PING_TIMEOUT,
+    );
+    assert_eq!(feedback.ping_ms(now + STREAM_PING_TIMEOUT), Some(30.0));
+    pair.responses_received = 2;
+    pair.current_round_trip_time = Some(Duration::ZERO);
+    feedback.update_ice_ping(
+        Some(&pair),
+        &mut previous_responses,
+        now + STREAM_PING_TIMEOUT,
+    );
+    assert_eq!(feedback.ping_ms(now + STREAM_PING_TIMEOUT), Some(0.0));
+    feedback.update_ice_ping(None, &mut previous_responses, now + STREAM_PING_TIMEOUT);
+    assert_eq!(feedback.ping_ms(now + STREAM_PING_TIMEOUT), Some(30.0));
+    assert_eq!(previous_responses, 0);
+    feedback.update_ice_ping(
+        Some(&pair),
+        &mut previous_responses,
+        now + STREAM_PING_TIMEOUT,
+    );
+    assert_eq!(feedback.ping_ms(now + STREAM_PING_TIMEOUT), Some(0.0));
+}

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
@@ -1,0 +1,201 @@
+use super::*;
+
+fn success(transaction_id: [u8; 12]) -> Vec<u8> {
+    build_authenticated_stun_packet(
+        STUN_BINDING_SUCCESS_RESPONSE,
+        &transaction_id,
+        stun_credentials().remote_password.as_bytes(),
+        &[],
+    )
+}
+
+#[test]
+fn stream_ping_matches_authenticated_transactions_once_and_handles_reordering() {
+    let mut tracker = StreamPingTracker::default();
+    let start = Instant::now();
+    let credentials = stun_credentials();
+    tracker.sent([1; 12], start);
+    tracker.sent([2; 12], start + Duration::from_millis(100));
+    let received = start + Duration::from_micros(125_500);
+    assert_eq!(
+        tracker.receive(&success([3; 12]), peer(), &credentials, received),
+        None
+    );
+    assert_eq!(
+        tracker.receive(&success([2; 12]), peer(), &credentials, received),
+        Some(Duration::from_micros(25_500))
+    );
+    assert_eq!(
+        tracker.receive(&success([2; 12]), peer(), &credentials, received),
+        None
+    );
+    assert_eq!(
+        tracker.receive(&success([1; 12]), peer(), &credentials, received),
+        Some(Duration::from_micros(125_500))
+    );
+    assert!(tracker.pending.is_empty());
+}
+
+#[test]
+fn stream_ping_rejects_invalid_packets_without_consuming_the_request() {
+    let mut tracker = StreamPingTracker::default();
+    let start = Instant::now();
+    let credentials = stun_credentials();
+    tracker.sent([1; 12], start);
+    let mut bad_fingerprint = success([1; 12]);
+    *bad_fingerprint.last_mut().unwrap() ^= 1;
+    let bad_integrity =
+        build_authenticated_stun_packet(STUN_BINDING_SUCCESS_RESPONSE, &[1; 12], b"wrong-key", &[]);
+    let request = build_stun_binding_request(&credentials, &[1; 12]);
+    let error_response = build_authenticated_stun_packet(
+        0x0111,
+        &[1; 12],
+        credentials.remote_password.as_bytes(),
+        &[],
+    );
+    for packet in [
+        vec![],
+        vec![1; 19],
+        bad_fingerprint,
+        bad_integrity,
+        request,
+        error_response,
+    ] {
+        assert_eq!(tracker.receive(&packet, peer(), &credentials, start), None);
+        assert_eq!(tracker.pending.len(), 1);
+    }
+    assert_eq!(
+        tracker.receive(&success([1; 12]), peer(), &credentials, start),
+        Some(Duration::ZERO)
+    );
+}
+
+#[test]
+fn stream_ping_bounds_pending_requests_and_expires_late_replies() {
+    let mut tracker = StreamPingTracker::default();
+    let start = Instant::now();
+    let credentials = stun_credentials();
+    for id in 0..=MAX_PENDING_STREAM_PINGS {
+        tracker.sent([id as u8; 12], start);
+    }
+    assert_eq!(tracker.pending.len(), MAX_PENDING_STREAM_PINGS);
+    assert_eq!(
+        tracker.receive(&success([0; 12]), peer(), &credentials, start),
+        None
+    );
+    assert_eq!(
+        tracker.receive(
+            &success([1; 12]),
+            peer(),
+            &credentials,
+            start + STREAM_PING_TIMEOUT
+        ),
+        None
+    );
+    tracker.sent([99; 12], start + STREAM_PING_TIMEOUT);
+    assert_eq!(tracker.pending.len(), 1);
+    assert_eq!(tracker.pending.front().unwrap().0, [99; 12]);
+}
+
+#[test]
+fn stream_ping_prefers_video_with_fresh_bundle_fallback_and_resets_per_session() {
+    let feedback = NvstFeedbackState::default();
+    let start = Instant::now();
+    assert_eq!(feedback.ping_ms(start), None);
+    feedback.publish_ping(false, start, Duration::from_micros(22_500));
+    assert_eq!(feedback.ping_ms(start), Some(22.5));
+    feedback.publish_ping(true, start, Duration::from_millis(30));
+    assert_eq!(feedback.ping_ms(start), Some(30.0));
+    feedback.publish_ping(
+        false,
+        start + Duration::from_secs(1),
+        Duration::from_millis(24),
+    );
+    assert_eq!(feedback.ping_ms(start + STREAM_PING_TIMEOUT), Some(24.0));
+    assert_eq!(
+        feedback.ping_ms(start + STREAM_PING_TIMEOUT + Duration::from_secs(1)),
+        None
+    );
+    assert_eq!(NvstFeedbackState::default().ping_ms(start), None);
+}
+
+#[test]
+fn mjolnir_receiver_publishes_ping_from_its_real_udp_keepalive_reply() {
+    let server = UdpSocket::bind("127.0.0.1:0").unwrap();
+    server
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    let client = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut config = config();
+    config.video_peer = server.local_addr().unwrap();
+    config.stun_credentials = Some(stun_credentials());
+    let feedback = config.feedback();
+    let (media_consumer, _media_receiver) = mpsc::sync_channel(1);
+    let (event_sender, _event_receiver) = mpsc::channel();
+    let session =
+        spawn_nvst_mjolnir_receiver(client, config, media_consumer, event_sender).unwrap();
+    let mut packet = [0; 512];
+    let (length, source) = server.recv_from(&mut packet).unwrap();
+    assert!(length >= STUN_HEADER_LEN);
+    let transaction_id = packet[8..20].try_into().unwrap();
+    let response = success(transaction_id);
+    let unexpected_peer = UdpSocket::bind("127.0.0.1:0").unwrap();
+    unexpected_peer.send_to(&response, source).unwrap();
+    server.recv_from(&mut packet).unwrap();
+    assert_eq!(feedback.ping_ms(Instant::now()), None);
+    server.send_to(&response, source).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while feedback.ping_ms(Instant::now()).is_none() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(5));
+    }
+    let measured = feedback.ping_ms(Instant::now());
+    session.stop();
+    assert!(measured.is_some_and(|value| value > 0.0 && value < 2000.0));
+}
+
+#[test]
+fn bundle_receiver_publishes_ping_from_its_real_udp_keepalive_reply() {
+    let server = UdpSocket::bind("127.0.0.1:0").unwrap();
+    server
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    let client = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut config = config();
+    config.video_peer = server.local_addr().unwrap();
+    config.stun_credentials = Some(stun_credentials());
+    config.remote_dtls_fingerprint = Some(["00"; 32].join(":"));
+    config.ping_payload = b"ping-fixture".to_vec();
+    let feedback = config.feedback();
+    let (media_consumer, _media_receiver) = mpsc::sync_channel(1);
+    let (event_sender, _event_receiver) = mpsc::channel();
+    let session = spawn_nvst_udp_receiver_with_socket(
+        config,
+        media_consumer,
+        event_sender,
+        Some(client),
+        None,
+    )
+    .unwrap();
+    let mut packet = [0; 2048];
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut replied = false;
+    while Instant::now() < deadline {
+        let (length, source) = server.recv_from(&mut packet).unwrap();
+        if find_stun_attribute(&packet[..length], STUN_ATTR_USERNAME)
+            .is_some_and(|(_, username)| username == b"ping-fixture:loc1")
+        {
+            let transaction_id = packet[8..20].try_into().unwrap();
+            server.send_to(&success(transaction_id), source).unwrap();
+            replied = true;
+            break;
+        }
+    }
+    while feedback.ping_ms(Instant::now()).is_none() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(5));
+    }
+    let measured = feedback.ping_ms(Instant::now());
+    session.stop();
+    assert!(replied);
+    assert!(measured.is_some_and(|value| (0.0..2000.0).contains(&value)));
+    assert!(feedback.video_ping.lock().unwrap().is_none());
+}

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -135,6 +135,15 @@ if(BUILD_TESTING)
     set_tests_properties(qml-controller-metadata PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
     qt_add_resources(opennow-qt "custom-background-acceptance"
         PREFIX "/acceptance" BASE tests FILES tests/CustomBackgroundAcceptance.qml)
+    qt_add_resources(opennow-qt "stream-stats-acceptance"
+        PREFIX "/acceptance" BASE tests FILES tests/StreamStatsAcceptance.qml)
+    foreach(mode compact expanded)
+        add_test(NAME qml-stream-stats-${mode}
+            COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
+                --route stream --smoke-stream-stats --smoke-stats-${mode} --reduced-motion)
+        set_tests_properties(qml-stream-stats-${mode} PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
+    endforeach()
     foreach(width 960 1600)
         add_test(NAME qml-custom-background-${width}
             COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop

--- a/opennow-qt/qml/desktop/stream/DesktopStreamStats.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopStreamStats.qml
@@ -91,7 +91,8 @@ Item {
         ]
         if (frameGenerationEnabled)
             cards.push({key:"LocalOutputFps", label:qsTr("LOCAL OUTPUT FPS"), value:frameGenerationOutputFps(), unit:"fps", field:"frameGenerationOutputFps"})
-        return cards.filter(item => shown(item.key))
+        return cards.filter(item => shown(item.key)
+            && ((item.key !== "Decode" && item.key !== "Latency") || item.value !== null))
     }
     function compactItems() {
         const items = cards.map(item => ({text:item.label + " " + format(item.value, item.decimals) + " " + item.unit}))

--- a/opennow-qt/src/acceptance/SmokeAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SmokeAcceptance.cpp
@@ -35,14 +35,18 @@ int AcceptanceSession::startSmokeWorkload()
     if (m_smokeTest && m_arguments.contains(u"--smoke-frame-generation-stats"_s))
         return startFrameGenerationStatsWorkload();
     if (m_smokeTest && (m_arguments.contains(u"--smoke-frame-generation"_s)
+                       || m_arguments.contains(u"--smoke-stream-stats"_s)
                        || m_arguments.contains(u"--smoke-controller-metadata"_s)
                        || m_arguments.contains(u"--smoke-custom-background"_s))) {
         const bool controllerMetadata = m_arguments.contains(u"--smoke-controller-metadata"_s);
         const bool customBackground = m_arguments.contains(u"--smoke-custom-background"_s);
+        const bool streamStats = m_arguments.contains(u"--smoke-stream-stats"_s);
         QQmlComponent component(&m_engine, QUrl(controllerMetadata
             ? u"qrc:/acceptance/ControllerMetadataAcceptance.qml"_s
             : customBackground
             ? u"qrc:/acceptance/CustomBackgroundAcceptance.qml"_s
+            : streamStats
+            ? u"qrc:/acceptance/StreamStatsAcceptance.qml"_s
             : u"qrc:/acceptance/FrameGenerationAcceptance.qml"_s));
         auto *fixture = component.create();
         if (!fixture) { qCritical() << component.errors(); return EXIT_FAILURE; }

--- a/opennow-qt/tests/StreamStatsAcceptance.qml
+++ b/opennow-qt/tests/StreamStatsAcceptance.qml
@@ -1,0 +1,94 @@
+import QtQuick
+import OpenNOW
+
+QtObject {
+    property Component statsComponent: Component { DesktopStreamStats { visible: false } }
+
+    function check(ok, message) { if (!ok) throw new Error("Stream stats: " + message) }
+    function checkMetric(stats, key, label, expected) {
+        const card = stats.cards.find(item => item.key === key)
+        const compact = stats.compactMetrics.find(item => item.text.startsWith(label + " "))
+        const line = stats.report().split("\n").find(item => item.startsWith(label + ": "))
+        if (expected === null) {
+            check(!card && !compact && !line, key + " is absent from cards, compact text, and report")
+        } else {
+            check(card && card.value === expected, key + " preserves its measured value")
+            const value = stats.format(expected, card.decimals) + " " + card.unit
+            check(compact && compact.text === label + " " + value, key + " compact value")
+            check(line === label + ": " + value, key + " report value")
+        }
+    }
+    function run(parent) {
+        ShellStore.settings = Object.assign({}, ShellStore.settings, {
+            statsShowPing: true, statsShowDecode: true, statsShowLatency: true,
+            statsShowGraphs: false, frameGeneration: "off"
+        })
+        ShellStore.activeSession = null
+        ShellStore.streamer = {status: "streaming"}
+        const stats = statsComponent.createObject(parent)
+        check(stats !== null, "overlay created")
+        stats.expanded = Qt.application.arguments.indexOf("--smoke-stats-expanded") >= 0
+        checkMetric(stats, "Decode", qsTr("DECODE"), null)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), null)
+        check(stats.cards.find(item => item.key === "Ping").value === null,
+            "missing ping remains unavailable rather than a fabricated value")
+        ShellStore.acceptNativeEvent({type: "telemetry", pingMs: 23, decodeTimeMs: null, latencyMs: null})
+        check(ShellStore.streamer.pingMs === 23, "native ping reaches ShellStore")
+        checkMetric(stats, "Ping", qsTr("PING"), 23)
+        checkMetric(stats, "Decode", qsTr("DECODE"), null)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), null)
+        ShellStore.acceptNativeEvent({type: "telemetry", pingMs: 0, decodeTimeMs: 0, latencyMs: 0})
+        checkMetric(stats, "Ping", qsTr("PING"), 0)
+        checkMetric(stats, "Decode", qsTr("DECODE"), 0)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), 0)
+        ShellStore.acceptNativeEvent({type: "telemetry", decodeTimeMs: 2.5, latencyMs: 18})
+        checkMetric(stats, "Decode", qsTr("DECODE"), 2.5)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), 18)
+        ShellStore.settings = Object.assign({}, ShellStore.settings, {
+            statsShowPing: false, statsShowDecode: false, statsShowLatency: false
+        })
+        checkMetric(stats, "Ping", qsTr("PING"), null)
+        checkMetric(stats, "Decode", qsTr("DECODE"), null)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), null)
+        ShellStore.settings = Object.assign({}, ShellStore.settings, {
+            statsShowPing: true, statsShowDecode: true, statsShowLatency: true
+        })
+        checkMetric(stats, "Decode", qsTr("DECODE"), 2.5)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), 18)
+        ShellStore.acceptNativeEvent({type: "telemetry", decodeTimeMs: null})
+        checkMetric(stats, "Decode", qsTr("DECODE"), null)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), 18)
+        ShellStore.acceptNativeEvent({type: "telemetry", decodeTimeMs: 1.5, latencyMs: null})
+        checkMetric(stats, "Decode", qsTr("DECODE"), 1.5)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), null)
+        ShellStore.acceptNativeEvent({type: "telemetry", pingMs: null, decodeTimeMs: "invalid", latencyMs: "invalid"})
+        check(ShellStore.streamer.pingMs === null, "an unavailable native ping clears the previous sample")
+        check(stats.cards.find(item => item.key === "Ping").value === null,
+            "an unavailable native ping clears the displayed value")
+        checkMetric(stats, "Decode", qsTr("DECODE"), null)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), null)
+        ShellStore.streamer = {status: "starting", pingMs: 23, decodeTimeMs: 2.5, latencyMs: 18}
+        checkMetric(stats, "Decode", qsTr("DECODE"), null)
+        checkMetric(stats, "Latency", qsTr("LATENCY"), null)
+        check(stats.cards.find(item => item.key === "Ping").value === null,
+            "non-streaming telemetry is unavailable")
+        ShellStore.acceptStreamerSnapshot({status: "streaming", pingMs: 31})
+        checkMetric(stats, "Ping", qsTr("PING"), 31)
+        ShellStore.acceptStreamerSnapshot({status: "streaming"})
+        check(stats.cards.find(item => item.key === "Ping").value === null,
+            "replacement snapshots without ping do not retain an old measurement")
+        ShellStore.acceptNativeEvent({type: "telemetry", pingMs: 23, framesPerSecond: 60,
+            bitrateMbps: 24.5, jitterMs: 0.4, packetLossPercent: 0, decodeTimeMs: null, latencyMs: null})
+        ShellStore.activeSession = {regionName: "SYNTHETIC FIXTURE · NOT LIVE",
+            negotiatedStreamProfile: {codec: "h264", width: 1920, height: 1080}}
+        checkMetric(stats, "Ping", qsTr("PING"), 23)
+        if (Qt.application.arguments.indexOf("--screenshot") >= 0) {
+            stats.anchors.fill = parent
+            stats.z = 10000
+            stats.visible = true
+        } else {
+            stats.destroy()
+        }
+        return true
+    }
+}


### PR DESCRIPTION
The stats UI already accepted `pingMs`, but native telemetry never supplied it. Measure live session round-trip time and forward it through native telemetry. Follow [OpenNOW-Mac’s current implementation](https://github.com/OpenCloudGaming/OpenNOW-Mac/blob/90627114383501dd18ef165baa005d9ea603fdf3/GFN/NVST/Rtsp/NvstRtspConnection.swift#L161-L234), which documents seats that do not answer STUN/ICE and close the connection on client WebSocket pings.

- Match replies to outstanding transactions from the negotiated peer, verifying the STUN fingerprint and message integrity. Track at most 64 requests per receiver, reject duplicates/late replies, and expire samples after five seconds.
- Prefer the nominated ICE candidate pair’s measured RTT, then authenticated video/bundle STUN samples, then the existing RTSPS control connection. ICE statistics only refresh a sample when a new response arrives.
- Replace client WebSocket pings with session-scoped `GET_PARAMETER` every two seconds, matching the Mac method. Time matching CSeq/Request-Id replies, including `551 Option Not Supported`; continue answering server WebSocket pings. Keep one outstanding probe, bounded I/O/buffers, stale-response rejection, and prompt TEARDOWN even with a pending keepalive.
- Clear control samples on timeout, disconnect, or shutdown. Do not substitute discovery ping, stale handshake timing, or remote-clock estimates.
- Hide unavailable Decode and Latency in the expanded panel, compact bar, and copied report. Preserve measured zeroes and visibility settings. Missing ping remains unavailable rather than fabricated.
- Add deterministic tracking/expiry tests, real loopback UDP reply tests for both native receive paths, TCP/WebSocket GET_PARAMETER and shutdown regressions, native telemetry coverage, and compact/expanded QML acceptance coverage.

Validation:
- `cargo test --manifest-path native/opennow-streamer/Cargo.toml -p opennow-streamer-transport` — 115 passed.
- `cargo test --manifest-path native/opennow-streamer/Cargo.toml -p opennow-streamer-core` — 54 passed.
- Full native streamer workspace tests — 425 passed; 8 existing manual/hardware tests ignored.
- Native workspace Clippy (`--workspace --all-targets -- -D warnings`), Rust formatting, and `git diff --check` passed.
- Built the Qt 6.8.3 application; focused Qt statistics, recovery, frame-generation, fullscreen-shortcut, shell, and embedded-orchestration checks passed. Final focused CTest rerun: 12/12 passed.
- `opennow-qt_qmllint` passed with existing context-property warnings. The full unrelated Qt suite was not run.

The Mac source and its recorded live-calibration notes were inspected; the Mac application was not run on this Linux host. No live GFN account/gameplay validation was performed. Ping measures network/control-path RTT, not input-to-display latency. These screenshots are rendered by the built application using explicitly labeled synthetic telemetry; 23 ms is a fixture value, not a live measurement.

### Expanded statistics
![Expanded statistics with synthetic ping and unavailable decode/latency hidden](https://api-nightly.capy.ai/pr-assets/t3UWLg-6_TM-3V11oaf4m_OVtbt1hyr58-UKal4tviw)

### Compact statistics
![Compact statistics with synthetic ping and unavailable decode/latency hidden](https://api-nightly.capy.ai/pr-assets/q0VI4dhhaVzzsKgQPB4lbTsbDwJw3i_l-Z6PfKlo9dE)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M213VMZBYGDS73MGD07HTMNT"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->