### PR TITLE
fix(streamer): preserve audio order through packet loss and RED recovery

### DIFF
--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -34,7 +34,7 @@ use str0m::config::Fingerprint;
 use str0m::format::{Codec, FormatParams};
 use str0m::media::{Frequency, MediaKind, Mid};
 use str0m::net::{Protocol as RtcProtocol, Receive};
-use str0m::rtp::Ssrc;
+use str0m::rtp::{RtpHeader as BundleRtpHeader, Ssrc};
 use str0m::{Candidate, Event, IceCreds, Input, Output, Rtc, RtcConfig};
 
 use super::nvst_control::{
@@ -4820,6 +4820,88 @@ fn matches_audio_track(track: &NvstAudioTrack, payload_type: u8, ssrc: u32) -> b
     matches_payload_type && track.ssrc.is_none_or(|expected| expected == ssrc)
 }
 
+#[derive(Default)]
+struct NvstAudioReceiver {
+    last_sequence: Option<(u32, u16)>,
+    discontinuity_pending: bool,
+}
+
+impl NvstAudioReceiver {
+    fn depacketize(
+        &mut self,
+        track: &NvstAudioTrack,
+        header: &BundleRtpHeader,
+        payload: Arc<[u8]>,
+        received_at_us: u64,
+    ) -> Result<Vec<EncodedMediaFrame>, NvstDropReason> {
+        let mut source_changed = false;
+        let missing_packets = match self.last_sequence {
+            Some((ssrc, previous)) if ssrc == *header.ssrc => {
+                let delta = header.sequence_number.wrapping_sub(previous);
+                if delta == 0 || delta >= 0x8000 {
+                    return Ok(Vec::new());
+                }
+                usize::from(delta - 1)
+            }
+            Some(_) => {
+                source_changed = true;
+                0
+            }
+            None => 0,
+        };
+        let mut frames = Vec::with_capacity(missing_packets.min(MAX_REDUNDANT_AUDIO_BLOCKS) + 1);
+        let mut append = |payload: Arc<[u8]>, timestamp: u32| {
+            frames.push(EncodedMediaFrame {
+                mid: track.mid.clone(),
+                codec: "opus".to_owned(),
+                payload,
+                frame_index: None,
+                rtp_timestamp: u64::from(timestamp),
+                clock_rate_hz: track.clock_rate_hz,
+                channels: Some(track.channels),
+                received_at_us,
+                keyframe: false,
+                contiguous: true,
+            });
+        };
+        let recovered_packets = if *header.payload_type == GFN_RED_PAYLOAD_TYPE {
+            let red = parse_red_opus(&payload).ok_or(NvstDropReason::MalformedRedAudio)?;
+            let recover_count = missing_packets.min(red.redundant.len());
+            for block in red
+                .redundant
+                .iter()
+                .skip(red.redundant.len() - recover_count)
+            {
+                append(
+                    Arc::from(block.payload),
+                    header
+                        .timestamp
+                        .wrapping_sub(u32::from(block.timestamp_offset)),
+                );
+            }
+            append(Arc::from(red.primary), header.timestamp);
+            recover_count
+        } else {
+            append(payload, header.timestamp);
+            0
+        };
+        frames[0].contiguous = !source_changed && missing_packets == recovered_packets;
+        self.last_sequence = Some((*header.ssrc, header.sequence_number));
+        Ok(frames)
+    }
+
+    fn deliver(
+        &mut self,
+        consumer: &MediaConsumer,
+        mut frame: EncodedMediaFrame,
+    ) -> Result<(), TransportError> {
+        frame.contiguous &= !self.discontinuity_pending;
+        let result = deliver_media_frame(consumer, frame);
+        self.discontinuity_pending = result.is_err();
+        result
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RedOpusBlock<'a> {
     timestamp_offset: u16,
@@ -4997,8 +5079,7 @@ fn run_nvst_webrtc_bundle(
     let mut cursor_capture_attempts = 0_u8;
     let mut control_keepalive_at = next_control_keepalive(Instant::now());
     let mut input_timeout_reported = false;
-    let mut last_audio_sequence: Option<(u32, u16)> = None;
-    let mut audio_discontinuity_pending = false;
+    let mut audio_receiver = NvstAudioReceiver::default();
     loop {
         loop {
             match commands.try_recv() {
@@ -5616,89 +5697,27 @@ fn run_nvst_webrtc_bundle(
                         });
                         if is_audio {
                             let audio = audio_track.as_ref().expect("audio track checked above");
-                            let audio_ssrc = *packet.header.ssrc;
-                            let missing_packets = last_audio_sequence
-                                .filter(|(ssrc, _)| *ssrc == audio_ssrc)
-                                .map(|(_, previous)| {
-                                    packet.header.sequence_number.wrapping_sub(previous)
-                                })
-                                .filter(|delta| {
-                                    (2..=u16::try_from(MAX_REDUNDANT_AUDIO_BLOCKS + 1)
-                                        .unwrap_or(u16::MAX))
-                                        .contains(delta)
-                                })
-                                .map_or(0, |delta| usize::from(delta - 1));
-                            last_audio_sequence = Some((audio_ssrc, packet.header.sequence_number));
                             let received_at_us = packet
                                 .timestamp
                                 .saturating_duration_since(transport_origin)
                                 .as_micros()
                                 .try_into()
                                 .unwrap_or(u64::MAX);
-                            let mut frames = Vec::with_capacity(missing_packets.saturating_add(1));
-                            let (primary, recovered_packets) =
-                                if outer_payload_type == GFN_RED_PAYLOAD_TYPE {
-                                    let Some(red) = parse_red_opus(&packet.payload) else {
-                                        let _ = event_sender.send(NvstReceiveEvent::Dropped(
-                                            NvstDropReason::MalformedRedAudio,
-                                        ));
-                                        audio_discontinuity_pending = true;
-                                        continue;
-                                    };
-                                    let recover_count = missing_packets.min(red.redundant.len());
-                                    for block in red
-                                        .redundant
-                                        .iter()
-                                        .skip(red.redundant.len().saturating_sub(recover_count))
-                                    {
-                                        frames.push(EncodedMediaFrame {
-                                            mid: audio.mid.clone(),
-                                            codec: "opus".to_owned(),
-                                            payload: Arc::from(block.payload),
-                                            frame_index: None,
-                                            rtp_timestamp: u64::from(
-                                                packet.header.timestamp.wrapping_sub(u32::from(
-                                                    block.timestamp_offset,
-                                                )),
-                                            ),
-                                            clock_rate_hz: audio.clock_rate_hz,
-                                            channels: Some(audio.channels),
-                                            received_at_us,
-                                            keyframe: false,
-                                            contiguous: true,
-                                        });
-                                    }
-                                    (Arc::from(red.primary), recover_count)
-                                } else {
-                                    (packet.payload, 0)
-                                };
-                            frames.push(EncodedMediaFrame {
-                                mid: audio.mid.clone(),
-                                codec: "opus".to_owned(),
-                                payload: primary,
-                                frame_index: None,
-                                rtp_timestamp: u64::from(packet.header.timestamp),
-                                clock_rate_hz: audio.clock_rate_hz,
-                                channels: Some(audio.channels),
+                            let frames = match audio_receiver.depacketize(
+                                audio,
+                                &packet.header,
+                                packet.payload,
                                 received_at_us,
-                                keyframe: false,
-                                contiguous: missing_packets == 0
-                                    || recovered_packets == missing_packets,
-                            });
-                            for (index, mut frame) in frames.into_iter().enumerate() {
-                                if audio_discontinuity_pending
-                                    && (recovered_packets == 0 || index > 0)
-                                {
-                                    frame.contiguous = false;
+                            ) {
+                                Ok(frames) => frames,
+                                Err(reason) => {
+                                    let _ = event_sender.send(NvstReceiveEvent::Dropped(reason));
+                                    continue;
                                 }
-                                match deliver_media_frame(&media_consumer, frame) {
-                                    Ok(()) => audio_discontinuity_pending = false,
-                                    Err(TransportError::MediaConsumerBackpressured) => {
-                                        // Mark the next accepted packet discontinuous so the
-                                        // Opus decoder performs PLC instead of clicking across
-                                        // a packet that vanished between transport and decode.
-                                        audio_discontinuity_pending = true;
-                                    }
+                            };
+                            for frame in frames {
+                                match audio_receiver.deliver(&media_consumer, frame) {
+                                    Ok(()) | Err(TransportError::MediaConsumerBackpressured) => {}
                                     Err(_) => {
                                         let _ = event_sender.send(NvstReceiveEvent::Dropped(
                                             NvstDropReason::MediaConsumerClosed,
@@ -6128,6 +6147,10 @@ fn forward_receive_event(
 
 #[cfg(test)]
 mod tests {
+    mod audio_tests {
+        include!("nvst_audio_tests.rs");
+    }
+
     mod recovery_tests {
         include!("nvst_recovery_tests.rs");
     }

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_audio_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_audio_tests.rs
@@ -1,0 +1,221 @@
+use super::super::*;
+
+fn track() -> NvstAudioTrack {
+    NvstAudioTrack {
+        payload_type: GFN_OPUS_PAYLOAD_TYPE,
+        clock_rate_hz: 48_000,
+        channels: 2,
+        mid: "audio".to_owned(),
+        ssrc: None,
+    }
+}
+
+fn header(sequence_number: u16) -> BundleRtpHeader {
+    BundleRtpHeader {
+        payload_type: GFN_OPUS_PAYLOAD_TYPE.into(),
+        sequence_number,
+        timestamp: u32::from(sequence_number) * 240,
+        ssrc: 42.into(),
+        ..BundleRtpHeader::default()
+    }
+}
+
+fn red_packet(
+    receiver: &mut NvstAudioReceiver,
+    sequence: u16,
+    timestamp: u32,
+    redundant_blocks: usize,
+) -> Vec<EncodedMediaFrame> {
+    let mut header = header(sequence);
+    header.payload_type = GFN_RED_PAYLOAD_TYPE.into();
+    header.timestamp = timestamp;
+    let mut payload = Vec::new();
+    for index in (1..=redundant_blocks).rev() {
+        let offset = index as u16 * 240;
+        payload.extend_from_slice(&[
+            0x80 | GFN_OPUS_PAYLOAD_TYPE,
+            (offset >> 6) as u8,
+            ((offset & 0x3f) << 2) as u8,
+            1,
+        ]);
+    }
+    payload.push(GFN_OPUS_PAYLOAD_TYPE);
+    payload.extend((0..=redundant_blocks).map(|index| index as u8));
+    receiver
+        .depacketize(&track(), &header, payload.into(), 123_456)
+        .unwrap()
+}
+
+#[test]
+fn ordered_audio_preserves_payload_and_sender_metadata() {
+    let mut receiver = NvstAudioReceiver::default();
+    let payload: Arc<[u8]> = Arc::from([0xf8, 0xff, 0xfe]);
+    for sequence in 10..13 {
+        let frames = receiver
+            .depacketize(&track(), &header(sequence), Arc::clone(&payload), 123_456)
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        let frame = &frames[0];
+        assert!(Arc::ptr_eq(&frame.payload, &payload));
+        assert_eq!(frame.mid, "audio");
+        assert_eq!(frame.codec, "opus");
+        assert_eq!(frame.frame_index, None);
+        assert_eq!(frame.rtp_timestamp, u64::from(sequence) * 240);
+        assert_eq!(frame.clock_rate_hz, 48_000);
+        assert_eq!(frame.channels, Some(2));
+        assert_eq!(frame.received_at_us, 123_456);
+        assert!(frame.contiguous);
+    }
+}
+
+#[test]
+fn late_originals_and_duplicates_never_replay_recovered_audio_or_rewind_sequence() {
+    let mut receiver = NvstAudioReceiver::default();
+    red_packet(&mut receiver, 10, 2_400, 1);
+    let recovered = red_packet(&mut receiver, 12, 2_880, 1);
+    assert_eq!(recovered.len(), 2);
+    assert!(recovered.iter().all(|frame| frame.contiguous));
+    for sequence in [11, 12, 10] {
+        assert!(red_packet(&mut receiver, sequence, u32::from(sequence) * 240, 1).is_empty());
+    }
+    let next = red_packet(&mut receiver, 13, 3_120, 1);
+    assert_eq!(next.len(), 1);
+    assert!(next[0].contiguous);
+}
+
+#[test]
+fn partial_red_recovery_marks_the_gap_before_the_first_recovered_packet() {
+    let mut receiver = NvstAudioReceiver::default();
+    red_packet(&mut receiver, 10, 2_400, 1);
+    let frames = red_packet(&mut receiver, 14, 3_360, 2);
+    assert_eq!(frames.len(), 3);
+    assert_eq!(
+        frames
+            .iter()
+            .map(|frame| frame.contiguous)
+            .collect::<Vec<_>>(),
+        [false, true, true]
+    );
+    assert_eq!(
+        frames
+            .iter()
+            .map(|frame| frame.rtp_timestamp)
+            .collect::<Vec<_>>(),
+        [2_880, 3_120, 3_360]
+    );
+    for (index, frame) in frames.iter().enumerate() {
+        assert_eq!(&*frame.payload, &[index as u8]);
+    }
+}
+
+#[test]
+fn gaps_beyond_red_capacity_remain_discontinuous_and_bounded() {
+    for redundant_blocks in [0, MAX_REDUNDANT_AUDIO_BLOCKS] {
+        let mut receiver = NvstAudioReceiver::default();
+        red_packet(&mut receiver, 10, 2_400, 0);
+        let frames = red_packet(&mut receiver, 20_000, 4_800_000, redundant_blocks);
+        assert_eq!(frames.len(), redundant_blocks + 1);
+        assert!(!frames[0].contiguous);
+        assert!(frames[1..].iter().all(|frame| frame.contiguous));
+    }
+}
+
+#[test]
+fn plain_opus_gaps_are_marked_without_fabricating_packets() {
+    let mut receiver = NvstAudioReceiver::default();
+    red_packet(&mut receiver, 10, 2_400, 0);
+    let frames = receiver
+        .depacketize(&track(), &header(30), Arc::from([0xf8]), 0)
+        .unwrap();
+    assert_eq!(frames.len(), 1);
+    assert!(!frames[0].contiguous);
+}
+
+#[test]
+fn sequence_and_timestamp_wrap_preserve_recovery_order() {
+    let mut receiver = NvstAudioReceiver::default();
+    red_packet(&mut receiver, u16::MAX - 1, u32::MAX - 239, 0);
+    let frames = red_packet(&mut receiver, 1, 480, 2);
+    assert_eq!(frames.len(), 3);
+    assert!(frames.iter().all(|frame| frame.contiguous));
+    assert_eq!(
+        frames
+            .iter()
+            .map(|frame| frame.rtp_timestamp)
+            .collect::<Vec<_>>(),
+        [0, 240, 480]
+    );
+    assert!(red_packet(&mut receiver, u16::MAX, 0, 0).is_empty());
+    assert_eq!(red_packet(&mut receiver, 2, 720, 1).len(), 1);
+
+    let mut receiver = NvstAudioReceiver::default();
+    red_packet(&mut receiver, 10, u32::MAX - 479, 0);
+    let frames = red_packet(&mut receiver, 12, 0, 1);
+    assert_eq!(frames[0].rtp_timestamp, u64::from(u32::MAX - 239));
+    assert_eq!(frames[1].rtp_timestamp, 0);
+    assert!(frames.iter().all(|frame| frame.contiguous));
+}
+
+#[test]
+fn malformed_red_does_not_prevent_recovery_from_the_next_packet() {
+    let mut receiver = NvstAudioReceiver::default();
+    red_packet(&mut receiver, 10, 2_400, 0);
+    let mut malformed_header = header(11);
+    malformed_header.payload_type = GFN_RED_PAYLOAD_TYPE.into();
+    assert!(matches!(
+        receiver.depacketize(&track(), &malformed_header, Arc::from([0xff]), 0),
+        Err(NvstDropReason::MalformedRedAudio)
+    ));
+    let frames = red_packet(&mut receiver, 12, 2_880, 1);
+    assert_eq!(frames.len(), 2);
+    assert!(frames.iter().all(|frame| frame.contiguous));
+    assert_eq!(frames[0].rtp_timestamp, 2_640);
+}
+
+#[test]
+fn consumer_backpressure_marks_the_next_recovered_frame_not_the_primary() {
+    let mut receiver = NvstAudioReceiver::default();
+    let (consumer, delivered) = mpsc::sync_channel(1);
+    for sequence in [10, 11] {
+        let frame = red_packet(&mut receiver, sequence, u32::from(sequence) * 240, 0)
+            .pop()
+            .unwrap();
+        let result = receiver.deliver(&consumer, frame);
+        if sequence == 10 {
+            assert!(result.is_ok());
+        } else {
+            assert!(matches!(
+                result,
+                Err(TransportError::MediaConsumerBackpressured)
+            ));
+        }
+    }
+    assert!(delivered.recv().unwrap().contiguous);
+    let frames = red_packet(&mut receiver, 13, 3_120, 1);
+    for (index, frame) in frames.into_iter().enumerate() {
+        receiver.deliver(&consumer, frame).unwrap();
+        let frame = delivered.recv().unwrap();
+        assert_eq!(frame.contiguous, index != 0);
+    }
+    drop(delivered);
+    let frame = red_packet(&mut receiver, 14, 3_360, 0).pop().unwrap();
+    assert!(matches!(
+        receiver.deliver(&consumer, frame),
+        Err(TransportError::MediaConsumerClosed)
+    ));
+}
+
+#[test]
+fn a_new_source_starts_a_discontinuous_sequence_baseline() {
+    let mut receiver = NvstAudioReceiver::default();
+    red_packet(&mut receiver, 100, 24_000, 0);
+    for sequence in [1, 2] {
+        let mut header = header(sequence);
+        header.ssrc = 43.into();
+        let frames = receiver
+            .depacketize(&track(), &header, Arc::from([0xf8]), 0)
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].contiguous, sequence == 2);
+    }
+}


### PR DESCRIPTION
The native audio receive path could decode a late original after its redundant copy had already played, rewind its sequence baseline, and recover the same audio again. Gaps larger than the RED recovery limit were treated as continuous, while partial recovery placed the discontinuity on the primary packet after the recovered audio. These are verified packet-handling defects that can cause glitches, not yet a confirmed diagnosis of the reported live-session audio.

Keep sequence tracking, RED depacketization, and delivery discontinuity state in one private receiver:
- Discard duplicate and late packets without rewinding the sequence baseline, including across sequence wraparound.
- Keep large gaps discontinuous while bounding recovered output to the existing RED block limit. Mark an unrecovered gap before the first recovered frame, not after it.
- Leave malformed RED packets out of the accepted sequence baseline so the next valid packet can recover them. Propagate consumer backpressure to the next delivered frame, including a redundant frame.
- Preserve payloads and sender timestamps, and establish a discontinuous baseline when the source changes. No bitrate, output-buffer, decoder, or playback-latency tuning.

Compared with OpenNOW-Mac at `9062711`: it negotiates RED/Opus and delegates audio jitter recovery to libwebrtc. OpenNOW's str0m RTP-mode path receives raw packets and must maintain this ordering itself; no second runtime or reference implementation was copied.

Validation:
- Nine new regression tests cover ordinary metadata/payload preservation, late originals and duplicates, partial RED recovery, bounded large gaps, plain Opus loss, sequence/timestamp wraparound, malformed packets, backpressure/consumer closure, and source changes.
- Transport crate tests: 121 passed.
- Native streamer `cargo test --workspace`: 423 passed, 8 ignored, 0 failed on Linux.
- Transport `cargo clippy --all-targets -- -D warnings`, workspace formatting, and `git diff --check` passed.

Live NVIDIA/GFN listening and Windows/macOS playback have not been verified. Native Linux/macOS output paths also do not currently consume the transport continuity flag; suppressing stale packets and recovering malformed RED apply to them, but this PR does not add native loss concealment or a jitter buffer.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M214WTWNXBKAXXKAEQNJKAVS"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->