### PR TITLE
fix(qt): unify Home and Library poster play overlays

### DIFF
--- a/opennow-qt/cmake/QmlModule.cmake
+++ b/opennow-qt/cmake/QmlModule.cmake
@@ -37,6 +37,7 @@ qt_add_qml_module(opennow-qt
         qml/desktop/components/DesktopGlyph.qml
         qml/desktop/components/DesktopKeyHint.qml
         qml/desktop/components/DesktopPoster.qml
+        qml/desktop/components/DesktopPosterOverlay.qml
         qml/desktop/components/DesktopTokens.qml
         qml/desktop/friends/DesktopFriendsScreen.qml
         qml/desktop/home/DesktopHomePoster.qml
@@ -194,6 +195,7 @@ qt_add_qml_module(opennow-qt
         res/icons/desktop-nav-friends-active-on-light.svg
         res/icons/desktop-clock-on-light.svg
         res/icons/desktop-play.svg
+        res/icons/desktop-play-filled.svg
         res/icons/desktop-lock.svg
         res/icons/desktop-check.svg
         res/icons/desktop-shield.svg

--- a/opennow-qt/qml/desktop/components/DesktopPoster.qml
+++ b/opennow-qt/qml/desktop/components/DesktopPoster.qml
@@ -50,23 +50,13 @@ ItemDelegate {
                 ColorAnimation { duration: Theme.focusDuration }
             }
         }
-        Column {
+        DesktopPosterOverlay {
             x: root.artGutter + 9
             anchors.bottom: art.bottom
             anchors.bottomMargin: 12
             width: root.artWidth - 18
-            spacing: 7
+            game: root.game
             visible: root.cardLifted && !root.showTitle
-            Text { width: parent.width; text: root.game ? String(root.game.title || qsTr("Game")) : qsTr("Game"); color: DesktopTokens.text; elide: Text.ElideRight; font.family: DesktopTokens.bodyFont; font.pixelSize: 12; font.weight: Font.Bold }
-            Rectangle {
-                width: parent.width; height: 26; radius: 8; color: "#F2FFFFFF"
-                Row {
-                    anchors.centerIn: parent
-                    spacing: 6
-                    DesktopGlyph { width: 8; height: 10; icon: "desktop-play.svg" }
-                    Text { text: qsTr("Play"); color: DesktopTokens.shell; font.family: DesktopTokens.bodyFont; font.pixelSize: 11; font.weight: Font.Bold }
-                }
-            }
         }
         Column {
             x: root.artGutter; y: root.artGutter + root.artHeight + 6; width: root.artWidth; spacing: 5

--- a/opennow-qt/qml/desktop/components/DesktopPosterOverlay.qml
+++ b/opennow-qt/qml/desktop/components/DesktopPosterOverlay.qml
@@ -1,0 +1,48 @@
+import QtQuick
+import OpenNOW
+
+Column {
+    id: root
+    required property var game
+    spacing: 7
+
+    Text {
+        width: parent.width
+        text: root.game ? String(root.game.title || qsTr("Game")) : qsTr("Game")
+        color: Theme.mediaForeground
+        elide: Text.ElideRight
+        font.family: DesktopTokens.bodyFont
+        font.pixelSize: 12
+        font.weight: Font.Bold
+    }
+
+    Rectangle {
+        width: parent.width
+        height: 32
+        radius: 8
+        color: "#F2FFFFFF"
+
+        Row {
+            anchors.centerIn: parent
+            spacing: 6
+
+            DesktopGlyph {
+                anchors.verticalCenter: parent.verticalCenter
+                width: 18
+                height: 18
+                icon: "desktop-play-filled.svg"
+                sourceSize: Qt.size(Math.ceil(width * dpr * DesktopTokens.cardHoverScale),
+                                    Math.ceil(height * dpr * DesktopTokens.cardHoverScale))
+                smooth: true
+            }
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                text: qsTr("Play")
+                color: "#0B0F1A"
+                font.family: DesktopTokens.bodyFont
+                font.pixelSize: 12
+                font.weight: Font.Bold
+            }
+        }
+    }
+}

--- a/opennow-qt/qml/desktop/home/DesktopHomePoster.qml
+++ b/opennow-qt/qml/desktop/home/DesktopHomePoster.qml
@@ -35,7 +35,7 @@ Item {
         artwork: root.artwork
         fallbackColor: "#171B27"
         cornerRadius: 12
-        scrimStart: 1
+        scrimStart: root.highlighted ? 0.48 : 1
     }
 
     Rectangle {
@@ -51,6 +51,17 @@ Item {
         Behavior on border.color {
             ColorAnimation { duration: Theme.focusDuration }
         }
+    }
+
+    DesktopPosterOverlay {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: 9
+        anchors.rightMargin: 9
+        anchors.bottomMargin: 12
+        game: root.game
+        visible: root.highlighted
     }
 
     } // visual; hit-test handlers remain outside the transformed item

--- a/opennow-qt/res/icons/desktop-play-filled.svg
+++ b/opennow-qt/res/icons/desktop-play-filled.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#0B0F1A">
+  <path d="M6 4.5a1.5 1.5 0 0 1 2.25-1.3l12 7.5a1.5 1.5 0 0 1 0 2.6l-12 7.5A1.5 1.5 0 0 1 6 19.5z"/>
+</svg>


### PR DESCRIPTION
Home posters now show the same title and play overlay as Library posters when hovered or selected through keyboard/controller navigation. Both use a shared QML component, while existing card activation and hit-testing remain unchanged.

Replace the tiny outlined play glyph with an 18×18 filled SVG, smooth filtering, and raster sizing that accounts for display scaling and the hover zoom. Increase the play pill to 32px and keep its text/icon dark in both themes.

### Verification
- Passed focused Qt 6.8.3 runtime checks using the real poster/artwork/glyph components with fixture shell services: hover enter/leave, keyboard/controller selection, and clicking through the overlay.
- Passed at 1× and 2× DPI, light/dark themes, windowed/fullscreen, and normal/reduced motion, with no QML runtime warnings.
- Changed QML passes `qmllint` with context-property unqualified-access diagnostics set to informational; `git diff --check` passes.
- Full app configure/test suite unavailable locally: `cmake -S opennow-qt -B build/opennow-qt -DCMAKE_BUILD_TYPE=Debug` fails because the Qt 6.8 development SDK is absent. The focused check uses a separately installed Qt runtime.

### Visual check
Real Home and Library components in a focused QML harness, using the supplied cover crop (not a full-app screenshot):

![Home and Library share the larger, sharp play action](https://api-nightly.capy.ai/pr-assets/eOUcXlv2Fvp0VvFdk0OoaEGCFx3YxCP8E6rg0jNXIZk)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M215D2DMY83AF31MH5KK2AF3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->