### PR TITLE
fix(qt): restore the pre-session window mode on exit

### DIFF
--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -160,8 +160,11 @@ When Xvfb is available, the video variants also render a synthetic GPU texture t
 production video material and check that it stays covered until the first-frame handoff.
 
 Run `ctest --test-dir build/opennow-qt --output-on-failure -R '^qml-session-fullscreen-'`
-to verify that F11 can leave and re-enter fullscreen after confirming session exit,
-in desktop/console mode, restoring either the normal or maximized window state.
+to verify that session exit restores the pre-session windowed, maximized, or fullscreen
+mode in both desktop and console shells, and F11 still toggles correctly afterward.
+The fixture also checks exit cancellation, launch/reconnect route transitions, and a
+subsequent aborted launch with a different initial window mode, and automatic fullscreen
+on direct launch.
 
 ### Local frame generation (experimental)
 

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -637,7 +637,7 @@ if(BUILD_TESTING)
         endforeach()
     endforeach()
     foreach(surface desktop console)
-        foreach(mode windowed maximized)
+        foreach(mode windowed maximized fullscreen)
             add_test(NAME "qml-session-fullscreen-${surface}-${mode}"
                 COMMAND opennow-qt --smoke-test --allow-multiple-instances
                     --${surface} --route stream --smoke-session-fullscreen

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -53,6 +53,9 @@ ApplicationWindow {
     property bool streamSurfaceLocked: false
     property bool lockedStreamDesktopSurface: true
     property int visibilityBeforeFullscreen: ApplicationWindow.Windowed
+    property bool sessionWindowModeSaved: false
+    property int visibilityBeforeSession: ApplicationWindow.Windowed
+    property int fullscreenRestoreVisibilityBeforeSession: ApplicationWindow.Windowed
     readonly property string configuredStatsShortcut: String(
         ShellStore.settings.shortcutToggleStats || "Ctrl+N")
     readonly property bool streamStatsShortcutEnabled: activeRoute === "stream"
@@ -210,6 +213,33 @@ ApplicationWindow {
             || (event.key === Qt.Key_F1 && AppController.inputMode === "controller")
     }
 
+    function saveSessionWindowMode() {
+        if (window.sessionWindowModeSaved)
+            return
+        window.visibilityBeforeSession = window.visibility
+        window.fullscreenRestoreVisibilityBeforeSession = window.visibilityBeforeFullscreen
+        window.sessionWindowModeSaved = true
+    }
+
+    function updateSessionWindowMode() {
+        if (["inserting", "joining", "stream"].indexOf(AppController.route) >= 0) {
+            window.saveSessionWindowMode()
+            return
+        }
+        if (!window.sessionWindowModeSaved)
+            return
+        window.sessionWindowModeSaved = false
+        window.visibilityBeforeFullscreen = window.fullscreenRestoreVisibilityBeforeSession
+        if (window.visibility === window.visibilityBeforeSession)
+            return
+        if (window.visibilityBeforeSession === ApplicationWindow.FullScreen)
+            window.showFullScreen()
+        else if (window.visibilityBeforeSession === ApplicationWindow.Maximized)
+            window.showMaximized()
+        else
+            window.showNormal()
+    }
+
     function toggleFullscreen() {
         const enteringFullscreen = window.visibility !== ApplicationWindow.FullScreen
         if (enteringFullscreen) {
@@ -359,6 +389,7 @@ ApplicationWindow {
 
     Component.onCompleted: {
         initializeStartupMode()
+        updateSessionWindowMode()
         updateStreamSurfaceLock()
         modeInitialized = true
         window.synchronizeRenderedSurface()
@@ -500,6 +531,7 @@ ApplicationWindow {
         Connections {
             target: AppController
             function onRouteChanged() {
+                window.updateSessionWindowMode()
                 window.updateStreamSurfaceLock()
                 // The desktop shell and embedded video stay opaque. Animate
                 // the entering panel, never flash the entire app on navigation.
@@ -521,8 +553,12 @@ ApplicationWindow {
                     Qt.callLater(() => routeLoader.item.forceActiveFocus())
             }
             function onDirectLaunchRequested(appId, title) {
-                if (ShellStore.settings.autoFullScreen)
+                if (ShellStore.settings.autoFullScreen) {
+                    window.saveSessionWindowMode()
+                    if (window.visibility !== ApplicationWindow.FullScreen)
+                        window.visibilityBeforeFullscreen = window.visibility
                     window.showFullScreen()
+                }
                 ShellStore.acceptDirectLaunch(appId, title)
             }
         }

--- a/opennow-qt/src/acceptance/SessionFullscreenAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SessionFullscreenAcceptance.cpp
@@ -20,16 +20,26 @@ int AcceptanceSession::startSessionFullscreenWorkload()
         : qobject_cast<QQuickWindow *>(m_engine.rootObjects().first());
     auto *store = m_engine.singletonInstance<QObject *>(u"OpenNOW"_s, u"ShellStore"_s);
     if (!window || !store) return EXIT_FAILURE;
+    m_controller.navigate(u"home"_s);
     store->setProperty("streamer", QVariantMap{{u"status"_s, u"streaming"_s}});
     store->setProperty("streamState", u"streaming"_s);
     const auto restoredVisibility = m_arguments.contains(u"--smoke-fullscreen-restore-maximized"_s)
-        ? QWindow::Maximized : QWindow::Windowed;
+        ? QWindow::Maximized
+        : m_arguments.contains(u"--smoke-fullscreen-restore-fullscreen"_s)
+            ? QWindow::FullScreen : QWindow::Windowed;
     if (restoredVisibility == QWindow::Maximized) window->showMaximized();
+    if (restoredVisibility == QWindow::FullScreen
+        && !QMetaObject::invokeMethod(window, "toggleFullscreen")) return EXIT_FAILURE;
+    const auto sessionVisibility = restoredVisibility == QWindow::FullScreen
+        ? QWindow::Windowed : QWindow::FullScreen;
+    const auto nextSessionVisibility = restoredVisibility == QWindow::Windowed
+        ? QWindow::Maximized : QWindow::Windowed;
     window->requestActivate();
     const auto step = std::make_shared<int>(0);
     auto *timer = new QTimer(this);
     timer->setInterval(150);
-    connect(timer, &QTimer::timeout, this, [this, window, store, restoredVisibility, step, timer] {
+    connect(timer, &QTimer::timeout, this,
+            [this, window, store, restoredVisibility, sessionVisibility, nextSessionVisibility, step, timer] {
         const auto require = [this, step, timer](bool ok, const char *message) {
             if (!ok) {
                 qCritical("Session fullscreen step %d: %s", *step, message);
@@ -49,46 +59,101 @@ int AcceptanceSession::startSessionFullscreenWorkload()
         case 0:
             if (!require(window->visibility() == restoredVisibility,
                          "initial window state not applied")) return;
+            m_controller.navigate(u"inserting"_s);
             if (!require(QMetaObject::invokeMethod(window, "toggleFullscreen"),
                          "fullscreen toggle unavailable")) return;
             break;
-        case 1: {
+        case 1:
+            if (!require(window->visibility() == sessionVisibility,
+                         "launch screen did not toggle fullscreen")) return;
+            m_controller.navigate(u"stream"_s);
+            break;
+        case 2: {
             auto *shortcut = window->findChild<QObject *>(u"shellFullscreenShortcut"_s);
             if (!require(!shortcut || !shortcut->property("enabled").toBool(),
                          "shell shortcut competed with stream input")) return;
-            if (!require(window->visibility() == QWindow::FullScreen,
-                         "stream did not enter fullscreen")) return;
+            if (!require(window->visibility() == sessionVisibility,
+                         "stream entry changed the session window mode")) return;
             if (!require(QMetaObject::invokeMethod(store, "requestStreamExitConfirmation"),
                          "exit confirmation unavailable")) return;
             break;
         }
-        case 2:
-            if (!require(m_controller.overlay() == u"desktop-stream-exit-confirm"_s
-                    && window->visibility() == QWindow::FullScreen,
-                    "exit confirmation changed fullscreen state")) return;
-            keyClick(Qt::Key_Return);
-            break;
         case 3:
-            if (!require(m_controller.route() != u"stream"_s
-                    && store->property("streamState").toString() == u"idle"_s
-                    && window->visibility() == QWindow::FullScreen,
-                    "session exit did not preserve the fullscreen shell")) return;
-            keyClick(Qt::Key_F11);
+            if (!require(m_controller.overlay() == u"desktop-stream-exit-confirm"_s
+                    && window->visibility() == sessionVisibility,
+                    "exit confirmation changed fullscreen state")) return;
+            keyClick(Qt::Key_Escape);
             break;
         case 4:
-            if (!require(window->visibility() == restoredVisibility,
-                         "F11 did not restore the shell window after session exit")) return;
-            keyClick(Qt::Key_F11);
+            if (!require(m_controller.overlay().isEmpty()
+                    && m_controller.route() == u"stream"_s
+                    && window->visibility() == sessionVisibility,
+                    "cancelling exit changed the session window mode")) return;
+            if (!require(QMetaObject::invokeMethod(store, "requestStreamExitConfirmation"),
+                         "exit confirmation unavailable")) return;
             break;
         case 5:
-            if (!require(window->visibility() == QWindow::FullScreen,
-                         "F11 did not re-enter fullscreen from the shell")) return;
+            keyClick(Qt::Key_Return);
+            break;
+        case 6:
+            if (!require(m_controller.route() != u"stream"_s
+                    && store->property("streamState").toString() == u"idle"_s
+                    && window->visibility() == restoredVisibility,
+                    "session exit did not restore the pre-session window mode")) return;
+            keyClick(Qt::Key_F11);
+            break;
+        case 7:
+            if (!require(window->visibility() == sessionVisibility,
+                         "F11 did not toggle fullscreen from the restored shell")) return;
             window->contentItem()->forceActiveFocus();
             keyClick(Qt::Key_F11);
             break;
-        case 6:
+        case 8:
             if (!require(window->visibility() == restoredVisibility,
                          "F11 depended on the shell page focus")) return;
+            if (nextSessionVisibility == QWindow::Maximized) window->showMaximized();
+            else window->showNormal();
+            break;
+        case 9:
+            m_controller.navigate(u"inserting"_s);
+            if (!require(QMetaObject::invokeMethod(window, "toggleFullscreen"),
+                         "second session fullscreen toggle unavailable")) return;
+            break;
+        case 10:
+            m_controller.navigate(u"joining"_s);
+            break;
+        case 11:
+            m_controller.navigate(u"stream"_s);
+            break;
+        case 12:
+            m_controller.navigate(u"inserting"_s);
+            break;
+        case 13:
+            if (!require(window->visibility() == QWindow::FullScreen,
+                         "session route transitions restored the window prematurely")) return;
+            m_controller.navigate(u"home"_s);
+            break;
+        case 14:
+            if (!require(window->visibility() == nextSessionVisibility,
+                         "aborted session reused the previous session's window mode")) return;
+            store->setProperty("catalogState", u"loading"_s);
+            store->setProperty("settings", QVariantMap{{u"autoFullScreen"_s, true}});
+            m_controller.directLaunchRequested(u"12345"_s, u"Fullscreen acceptance fixture"_s);
+            break;
+        case 15:
+            if (!require(window->visibility() == QWindow::FullScreen,
+                         "direct launch did not apply automatic fullscreen")) return;
+            m_controller.navigate(u"inserting"_s);
+            break;
+        case 16:
+            m_controller.navigate(u"stream"_s);
+            break;
+        case 17:
+            m_controller.navigate(u"home"_s);
+            break;
+        case 18:
+            if (!require(window->visibility() == nextSessionVisibility,
+                         "direct launch captured its automatic fullscreen as the initial mode")) return;
             timer->stop();
             m_application.exit(EXIT_SUCCESS);
             break;

--- a/opennow-qt/src/acceptance/StreamExitAcceptance.cpp
+++ b/opennow-qt/src/acceptance/StreamExitAcceptance.cpp
@@ -54,8 +54,9 @@ int AcceptanceSession::startStreamExitWorkload()
                 Q_ARG(QString, u"stop-stream"_s));
         };
         if (!require(!m_qmlWarningOccurred, "QML warning")
-            || !require((window->visibility() == QWindow::FullScreen) == fullscreen,
-                        "confirmation changed fullscreen state")) return;
+            || !require(window->visibility() == (fullscreen && state->step < 6
+                            ? QWindow::FullScreen : QWindow::Windowed),
+                        "confirmation or completed exit has the wrong window mode")) return;
         if (state->step == 0)
             state->surface = window->findChild<QQuickItem *>(u"streamSurfaceHost"_s);
         if (state->step < 6 && !require(state->surface && state->surface->isVisible()


### PR DESCRIPTION
Save the shell's window mode at session entry separately from the F11 restore state. Returning from a session now restores its original windowed, maximized, or fullscreen mode, including when direct launch automatically entered fullscreen.

Keep that snapshot across launch/join/stream transitions and leave exit-confirmation cancellation unchanged. Clear it when returning to the shell so subsequent sessions capture their own initial mode.

Extend the desktop/console fullscreen acceptance fixture to cover all three initial modes, F11 after exit, cancellation, reconnect route transitions, repeated/aborted launches, and direct-launch auto fullscreen. Update exit-confirmation assertions to expect restoration only after confirmed exit.

Validation:
- Debug Qt/native build passed with Qt 6.8.3.
- Complete Qt suite: **196/196 passed**, including six fullscreen-restoration cases and twelve exit-confirmation cases.
- `opennow-qt_qmllint` passed (context-property/unqualified-access warnings remain).
- Visible X11 smoke fixture passed. No live GFN account/gameplay validation.

[Automated fullscreen restoration and F11 regression recording (one-third speed; smoke session)](https://api-nightly.capy.ai/pr-assets/v_9Ag4Wfgm4_1uPSOLvT4SfFAFDoYmgqd1MX-hbzFgif8)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2151HWW4BCN6TJ109P15KVZ"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->