### PR TITLE
fix(qt): show image opacity only for custom backgrounds

### DIFF
--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsLookPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsLookPage.qml
@@ -123,6 +123,7 @@ Column {
         }
         DesktopSettingsRow {
             width: parent.width; paperStyle: true; glyph: "sun"; title: qsTr("Image opacity")
+            visible: page.settingsScreen.valueSetting("desktopBackground", "art") === "custom"
             description: qsTr("0% hides the image · 100% shows the full image"); showDivider: false
             DesktopSettingsSlider {
                 objectName: "customBackgroundOpacity"


### PR DESCRIPTION
Hide the entire Image opacity row in Game art, Gradient, and Solid background modes. Custom mode continues showing the slider, with its existing requirement to select an image before adjusting it. The hidden row no longer occupies layout space; artwork rendering and saved settings are unchanged.

Validation: loaded the actual Look page and settings controls in a focused Qt 6.8.3/PySide6 harness with mocked settings. Verified visibility and layout collapse at 960 and 1600 px, mode changes, disabled state without an image, and mouse-driven opacity commits with an image. QML syntax parsing and `git diff --check` passed. The full app build/CTest suite was not run because the C++ Qt SDK is unavailable.

Game art (row hidden):
![Game art mode](https://api-nightly.capy.ai/pr-assets/CWmOMA2Y92DbCjdoFXc8zU1k2qzvjOcrR0J-XjMMQGQ)

Custom (row visible):
![Custom mode](https://api-nightly.capy.ai/pr-assets/cb7ePbsIesDKHehiH8qOZU2cgvcIBY1W-aR9eFy1VOM)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2155ZMC7F6JG3PQJCJPG26S"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->