### PR TITLE
fix(qt): use NVIDIA key art for square home tiles

### DIFF
--- a/docs/core-protocol.md
+++ b/docs/core-protocol.md
@@ -46,6 +46,16 @@ timeout still applies. Mutating operations already dispatched are not rolled bac
 
 ## Implemented core methods
 
+### Game artwork
+
+GraphQL-backed game objects expose nullable artwork URL strings: `imageUrl` prefers
+`GAME_BOX_ART`, `heroImageUrl` prefers hero/banner imagery, and `keyArtUrl` prefers
+NVIDIA `KEY_ART` with `KEY_IMAGE` as a fallback. Console Home uses `keyArtUrl` for
+square tiles while retaining hero imagery for wide tiles. If key art is absent,
+the shell falls back to `imageUrl`, then `heroImageUrl`. Older cached objects and
+public-catalog games may omit `keyArtUrl`; it is an optional, additive field in
+protocol 1 and does not change the handshake or existing artwork fields.
+
 ### Store pagination (`catalog.storePages.v1`)
 
 The protocol-1 envelope and 1 MiB limit are unchanged. This additive capability

--- a/native/opennow-core/src/gfn.rs
+++ b/native/opennow-core/src/gfn.rs
@@ -2120,6 +2120,7 @@ fn app_to_game(app: &Value) -> Option<Value> {
         ],
         1200,
     );
+    let key_art_url = first_image(&app["images"], &["KEY_ART", "KEY_IMAGE"], 900);
     let screenshots = image_values(&app["images"]["SCREENSHOTS"], 1200);
     let publisher = app["publisherName"].as_str().map(ToOwned::to_owned);
     let developer = app["developerName"].as_str().map(ToOwned::to_owned);
@@ -2152,6 +2153,7 @@ fn app_to_game(app: &Value) -> Option<Value> {
         "supportedControls":controls,
         "imageUrl":image_url,
         "heroImageUrl":hero_image_url,
+        "keyArtUrl":key_art_url,
         "screenshotUrl":screenshots.first(),
         "screenshotUrls":screenshots,
         "playType":app["gfn"]["playType"],
@@ -3026,6 +3028,52 @@ mod tests {
         assert_eq!(game["imageUrl"], "https://img.example/poster.jpg");
         assert_eq!(game["heroImageUrl"], "https://img.example/hero.jpg");
         assert!(STORE_PANELS_QUERY.contains("GAME_BOX_ART"));
+    }
+
+    #[test]
+    fn home_key_art_is_separate_from_posters_and_heroes() {
+        let game = app_to_game(&json!({
+            "id":"7","title":"Game","variants":[{"id":"7","appStore":"STEAM"}],
+            "images":{
+                "GAME_BOX_ART":"https://img.example/poster.jpg",
+                "KEY_IMAGE":"https://img.example/key-image.jpg",
+                "KEY_ART":"https://img.nvidiagrid.net/apps/game/ZZ/KEY_ART.jpg",
+                "HERO_IMAGE":"https://img.example/hero.jpg"
+            }
+        }))
+        .unwrap();
+        assert_eq!(game["imageUrl"], "https://img.example/poster.jpg");
+        assert_eq!(game["heroImageUrl"], "https://img.example/hero.jpg");
+        assert_eq!(
+            game["keyArtUrl"],
+            "https://img.nvidiagrid.net/apps/game/ZZ/KEY_ART.jpg;f=jpg;w=900"
+        );
+    }
+
+    #[test]
+    fn home_key_art_handles_missing_and_empty_images() {
+        for (images, expected) in [
+            (
+                json!({"KEY_ART":"  ", "KEY_IMAGE":"https://img.example/key.jpg"}),
+                json!("https://img.example/key.jpg"),
+            ),
+            (
+                json!({"KEY_ART":["", "https://img.example/key-art.jpg"]}),
+                json!("https://img.example/key-art.jpg"),
+            ),
+            (
+                json!({"GAME_BOX_ART":"https://img.example/poster.jpg"}),
+                Value::Null,
+            ),
+            (Value::Null, Value::Null),
+        ] {
+            let game = app_to_game(&json!({
+                "id":"7","title":"Game","variants":[{"id":"7","appStore":"STEAM"}],
+                "images":images
+            }))
+            .unwrap();
+            assert_eq!(game["keyArtUrl"], expected);
+        }
     }
 
     #[test]

--- a/opennow-qt/qml/components/GameTile.qml
+++ b/opennow-qt/qml/components/GameTile.qml
@@ -13,6 +13,7 @@ ItemDelegate {
     property bool addTile: false
     property string eyebrow: ""
     property bool currentItem: false
+    readonly property real cornerRadius: wide ? 34 : 12
     signal menuRequested()
     highlighted: activeFocus || currentItem
 
@@ -29,7 +30,7 @@ ItemDelegate {
     background: RoundedArtwork {
         artwork: root.addTile ? "" : root.artwork
         fallbackColor: root.storeColor
-        cornerRadius: 34
+        cornerRadius: root.cornerRadius
         scrimStart: 0.28
     }
 
@@ -94,7 +95,11 @@ ItemDelegate {
         }
     }
 
-    FocusFrame { focused: root.highlighted; opacity: root.addTile ? 0.55 : 1 }
+    FocusFrame {
+        focused: root.highlighted
+        frameRadius: root.cornerRadius
+        opacity: root.addTile ? 0.55 : 1
+    }
 
     TapHandler {
         acceptedButtons: Qt.RightButton

--- a/opennow-qt/qml/screens/HomeScreen.qml
+++ b/opennow-qt/qml/screens/HomeScreen.qml
@@ -291,7 +291,7 @@ FocusScope {
                     title: isAddTile ? qsTr("Add a game") : game.title
                     artwork: isAddTile ? "" : (modelData.wide
                         ? (game.heroImageUrl || game.imageUrl || "")
-                        : (game.imageUrl || game.heroImageUrl || ""))
+                        : (game.keyArtUrl || game.imageUrl || game.heroImageUrl || ""))
                     storeGlyph: isAddTile ? "+" : root.storeGlyph(game)
                     storeColor: isAddTile ? Theme.glassStrong : root.storeColor(storeGlyph)
                     addTile: isAddTile


### PR DESCRIPTION
Console Home's square tiles previously preferred portrait box art, cropping away much of the image. Expose NVIDIA `KEY_ART` (falling back to `KEY_IMAGE`) as the optional `keyArtUrl` field and prefer it on square home tiles. Keep existing poster and hero selections unchanged elsewhere, with the existing image/hero fallback for games without key art.

Reduce square game and Add a game tile corners from 34 px to 12 px, using the same radius for artwork masking and the focus outline. Wide tiles retain their existing styling. Square key art fills the existing square frame without stretching.

Validation:
- Core tests: 168 passed, including two new artwork regressions covering precedence, fallback, empty/missing values, and preservation of poster/hero URLs.
- `cargo clippy --manifest-path native/opennow-core/Cargo.toml --all-targets -- -D warnings`, `cargo fmt --manifest-path native/opennow-core/Cargo.toml --check`, and `git diff --check` passed.
- Loaded the actual HomeScreen and tile QML in an isolated PySide6 / Qt 6.11.2 harness with fixture shell services and the supplied public NVIDIA Trove image. Verified artwork selection/fallbacks, square/wide geometry, matching corner radii, focus, and windowed/fullscreen transitions with no QML warnings. Visually inspected the tiles and edit menu on the desktop.
- Full application build/CTest unavailable: CMake configuration stops at `find_package(Qt6 6.8)` because the Qt development SDK is absent. The standalone QML harness does not replace full application integration or authenticated catalog validation.

Preview from the actual QML with fixture data (the wide preview tile deliberately reuses the sample image; production wide-tile artwork selection is unchanged):

![Console Home square key art and subtler corners](https://api-nightly.capy.ai/pr-assets/_eJ9bUpohMeUI7vEyYMGU9xAw-KtDYxarjnK-U9O5zU)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M215WJC3MJSS9N0F246VWX89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->