### PR TITLE
fix(qt): forward shifted punctuation to the native stream

### DIFF
--- a/opennow-qt/src/streaming/StreamVideoItem.h
+++ b/opennow-qt/src/streaming/StreamVideoItem.h
@@ -87,7 +87,8 @@ public:
     [[nodiscard]] static QPoint mapRemoteCursorPosition(const QPoint &normalizedPosition,
                                                         const QSize &videoSize,
                                                         const QSizeF &itemSize);
-    [[nodiscard]] static quint16 windowsVirtualKey(int key);
+    [[nodiscard]] static quint16 windowsVirtualKey(
+        int key, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
     [[nodiscard]] static quint16 inputModifiers(Qt::KeyboardModifiers modifiers, int key);
     [[nodiscard]] static QString shortcutActionForInput(
         const QVariantMap &bindings, int key, Qt::KeyboardModifiers modifiers);

--- a/opennow-qt/src/streaming/StreamVideoItemInput.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItemInput.cpp
@@ -28,7 +28,7 @@
 #include <windows.h>
 #endif
 
-quint16 StreamVideoItem::windowsVirtualKey(int key)
+quint16 StreamVideoItem::windowsVirtualKey(int key, Qt::KeyboardModifiers modifiers)
 {
     if (key >= Qt::Key_A && key <= Qt::Key_Z) return static_cast<quint16>(key);
     if (key >= Qt::Key_0 && key <= Qt::Key_9) return static_cast<quint16>(key);
@@ -41,16 +41,37 @@ quint16 StreamVideoItem::windowsVirtualKey(int key)
     case Qt::Key_Backspace: return 0x08;
     case Qt::Key_Tab: return 0x09;
     case Qt::Key_Space: return 0x20;
+    case Qt::Key_Exclam: return 0x31;
+    case Qt::Key_At: return 0x32;
+    case Qt::Key_NumberSign: return 0x33;
+    case Qt::Key_Dollar: return 0x34;
+    case Qt::Key_Percent: return 0x35;
+    case Qt::Key_AsciiCircum: return 0x36;
+    case Qt::Key_Ampersand: return 0x37;
+    case Qt::Key_Asterisk: return modifiers.testFlag(Qt::KeypadModifier) ? 0x6a : 0x38;
+    case Qt::Key_ParenLeft: return 0x39;
+    case Qt::Key_ParenRight: return 0x30;
+    case Qt::Key_Plus: return modifiers.testFlag(Qt::KeypadModifier) ? 0x6b : 0xbb;
+    case Qt::Key_Underscore:
     case Qt::Key_Minus: return 0xbd;
     case Qt::Key_Equal: return 0xbb;
+    case Qt::Key_BraceLeft:
     case Qt::Key_BracketLeft: return 0xdb;
+    case Qt::Key_BraceRight:
     case Qt::Key_BracketRight: return 0xdd;
+    case Qt::Key_Bar:
     case Qt::Key_Backslash: return 0xdc;
+    case Qt::Key_Colon:
     case Qt::Key_Semicolon: return 0xba;
+    case Qt::Key_QuoteDbl:
     case Qt::Key_Apostrophe: return 0xde;
+    case Qt::Key_AsciiTilde:
     case Qt::Key_QuoteLeft: return 0xc0;
+    case Qt::Key_Less:
     case Qt::Key_Comma: return 0xbc;
+    case Qt::Key_Greater:
     case Qt::Key_Period: return 0xbe;
+    case Qt::Key_Question:
     case Qt::Key_Slash: return 0xbf;
     case Qt::Key_Right: return 0x27;
     case Qt::Key_Left: return 0x25;
@@ -72,8 +93,6 @@ quint16 StreamVideoItem::windowsVirtualKey(int key)
     case Qt::Key_ScrollLock: return 0x91;
     case Qt::Key_Pause: return 0x13;
     case Qt::Key_Menu: return 0x5d;
-    case Qt::Key_Plus: return 0x6b;
-    case Qt::Key_Asterisk: return 0x6a;
     default: return 0;
     }
 }
@@ -132,8 +151,9 @@ void StreamVideoItem::focusOutEvent(QFocusEvent *event)
 
 quint32 StreamVideoItem::keyIdentity(const QKeyEvent *event) const
 {
-    return event->nativeScanCode() != 0 ? event->nativeScanCode()
-                                        : static_cast<quint32>(event->key());
+    if (event->nativeScanCode() != 0) return event->nativeScanCode();
+    const auto virtualKey = windowsVirtualKey(event->key(), event->modifiers());
+    return virtualKey != 0 ? virtualKey : static_cast<quint32>(event->key());
 }
 
 void StreamVideoItem::keyPressEvent(QKeyEvent *event)
@@ -156,7 +176,7 @@ void StreamVideoItem::keyPressEvent(QKeyEvent *event)
         event->accept();
         return;
     }
-    const auto virtualKey = windowsVirtualKey(event->key());
+    const auto virtualKey = windowsVirtualKey(event->key(), event->modifiers());
     if (virtualKey == 0) {
         event->ignore();
         return;

--- a/opennow-qt/tests/tst_streamvideoitem.cpp
+++ b/opennow-qt/tests/tst_streamvideoitem.cpp
@@ -7,6 +7,7 @@
 #include <QGuiApplication>
 #include <QBuffer>
 #include <QJsonDocument>
+#include <QKeyEvent>
 #include <QCursor>
 #include <QPixmap>
 #include <QScopeGuard>
@@ -300,6 +301,153 @@ private slots:
         QCOMPARE(StreamVideoItem::inputModifiers(
                      Qt::ShiftModifier | Qt::ControlModifier, Qt::Key_W), quint16(0x03));
         QCOMPARE(StreamVideoItem::inputModifiers(Qt::ShiftModifier, Qt::Key_Shift), quint16(0));
+    }
+
+    void forwardsShiftedPunctuation_data()
+    {
+        QTest::addColumn<int>("key");
+        QTest::addColumn<int>("baseKey");
+        QTest::addColumn<quint16>("virtualKey");
+        const struct {
+            const char *name;
+            Qt::Key key;
+            Qt::Key baseKey;
+            quint16 virtualKey;
+        } cases[] = {
+            {"!", Qt::Key_Exclam, Qt::Key_1, 0x31},
+            {"@", Qt::Key_At, Qt::Key_2, 0x32},
+            {"#", Qt::Key_NumberSign, Qt::Key_3, 0x33},
+            {"$", Qt::Key_Dollar, Qt::Key_4, 0x34},
+            {"%", Qt::Key_Percent, Qt::Key_5, 0x35},
+            {"^", Qt::Key_AsciiCircum, Qt::Key_6, 0x36},
+            {"&", Qt::Key_Ampersand, Qt::Key_7, 0x37},
+            {"*", Qt::Key_Asterisk, Qt::Key_8, 0x38},
+            {"(", Qt::Key_ParenLeft, Qt::Key_9, 0x39},
+            {")", Qt::Key_ParenRight, Qt::Key_0, 0x30},
+            {"_", Qt::Key_Underscore, Qt::Key_Minus, 0xbd},
+            {"+", Qt::Key_Plus, Qt::Key_Equal, 0xbb},
+            {"{", Qt::Key_BraceLeft, Qt::Key_BracketLeft, 0xdb},
+            {"}", Qt::Key_BraceRight, Qt::Key_BracketRight, 0xdd},
+            {"|", Qt::Key_Bar, Qt::Key_Backslash, 0xdc},
+            {":", Qt::Key_Colon, Qt::Key_Semicolon, 0xba},
+            {"\"", Qt::Key_QuoteDbl, Qt::Key_Apostrophe, 0xde},
+            {"<", Qt::Key_Less, Qt::Key_Comma, 0xbc},
+            {">", Qt::Key_Greater, Qt::Key_Period, 0xbe},
+            {"?", Qt::Key_Question, Qt::Key_Slash, 0xbf},
+            {"~", Qt::Key_AsciiTilde, Qt::Key_QuoteLeft, 0xc0},
+        };
+        for (const auto &entry : cases)
+            QTest::newRow(entry.name) << int(entry.key) << int(entry.baseKey) << entry.virtualKey;
+    }
+
+    void forwardsShiftedPunctuation()
+    {
+        QFETCH(int, key);
+        QFETCH(int, baseKey);
+        QFETCH(quint16, virtualKey);
+        QCOMPARE(StreamVideoItem::windowsVirtualKey(key, Qt::ShiftModifier), virtualKey);
+        QCOMPARE(StreamVideoItem::windowsVirtualKey(baseKey), virtualKey);
+
+        static OpenNowStreamerConfig callbacks;
+        static QList<QList<quint16>> inputCalls;
+        inputCalls.clear();
+        NativeStreamRuntime::Api api{};
+        api.create = [](const OpenNowStreamerConfig *config, OpenNowStreamer **output) {
+            callbacks = *config;
+            *output = reinterpret_cast<OpenNowStreamer *>(new int(1));
+            return OPENNOW_STREAMER_OK;
+        };
+        api.destroy = [](OpenNowStreamer *handle) {
+            delete reinterpret_cast<int *>(handle);
+            return OPENNOW_STREAMER_OK;
+        };
+        api.send = [](const OpenNowStreamer *, const std::uint8_t *, std::size_t) {
+            return OPENNOW_STREAMER_OK;
+        };
+        api.setCaptureActive = [](const OpenNowStreamer *, bool, bool, std::uintptr_t, bool *raw) {
+            *raw = false;
+            return OPENNOW_STREAMER_OK;
+        };
+        api.submitKey = [](const OpenNowStreamer *, std::uint16_t vk,
+                           std::uint16_t modifiers, bool pressed) {
+            inputCalls.append(QList<quint16>{vk, modifiers, quint16(pressed)});
+            return OPENNOW_STREAMER_OK;
+        };
+        NativeStreamRuntime runtime(api);
+        QVERIFY(runtime.start());
+        StreamVideoItem::setNativeStreamRuntime(&runtime);
+        const auto reset = qScopeGuard([] { StreamVideoItem::setNativeStreamRuntime(nullptr); });
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("punctuation")}}));
+        const QByteArray ready = R"({"id":"punctuation","type":"ok"})";
+        callbacks.response_callback(reinterpret_cast<const std::uint8_t *>(ready.constData()),
+                                    ready.size(), callbacks.user_data);
+        QTRY_VERIFY(runtime.inputAllowed());
+        QQuickWindow window;
+        window.resize(640, 480);
+        auto *item = new StreamVideoItem(window.contentItem());
+        item->setRenderCallback({});
+        item->setSize(window.size());
+        auto *overlay = new QQuickItem(window.contentItem());
+        overlay->setVisible(false);
+        for (const bool fullscreen : {false, true}) {
+            if (fullscreen) window.showFullScreen();
+            else window.showNormal();
+            window.requestActivate();
+            QTRY_VERIFY(window.isActive());
+            item->forceActiveFocus();
+            QTRY_VERIFY(item->captureActive());
+            for (const quint32 scanCode : {0u, 39u}) {
+                for (const bool shiftReleasedFirst : {false, true}) {
+                    inputCalls.clear();
+                    QKeyEvent press(QEvent::KeyPress, key, Qt::ShiftModifier, scanCode, 0, 0);
+                    QCoreApplication::sendEvent(&window, &press);
+                    QVERIFY(press.isAccepted());
+                    QCOMPARE(inputCalls, (QList<QList<quint16>>{{virtualKey, 1, 1}}));
+                    QKeyEvent repeat(QEvent::KeyPress, key, Qt::ShiftModifier,
+                                     scanCode, 0, 0, {}, true);
+                    QCoreApplication::sendEvent(&window, &repeat);
+                    QCOMPARE(inputCalls.size(), 1);
+                    const auto modifiers = shiftReleasedFirst ? Qt::NoModifier : Qt::ShiftModifier;
+                    QKeyEvent release(QEvent::KeyRelease, shiftReleasedFirst ? baseKey : key,
+                                      modifiers, scanCode, 0, 0);
+                    QCoreApplication::sendEvent(&window, &release);
+                    QVERIFY(release.isAccepted());
+                    QCOMPARE(inputCalls, (QList<QList<quint16>>{
+                        {virtualKey, 1, 1}, {virtualKey, quint16(shiftReleasedFirst ? 0 : 1), 0}}));
+                    QVERIFY(item->m_pressedKeys.isEmpty());
+                }
+            }
+            inputCalls.clear();
+            QKeyEvent held(QEvent::KeyPress, key, Qt::ShiftModifier);
+            QCoreApplication::sendEvent(&window, &held);
+            overlay->setVisible(true);
+            overlay->forceActiveFocus();
+            QTRY_VERIFY(!item->captureActive());
+            QCOMPARE(inputCalls, (QList<QList<quint16>>{{virtualKey, 1, 1}, {virtualKey, 0, 0}}));
+            QVERIFY(item->m_pressedKeys.isEmpty());
+            QKeyEvent blocked(QEvent::KeyPress, key, Qt::ShiftModifier);
+            QCoreApplication::sendEvent(&window, &blocked);
+            QCOMPARE(inputCalls.size(), 2);
+            overlay->setVisible(false);
+            item->forceActiveFocus();
+            QTRY_VERIFY(item->captureActive());
+            QKeyEvent resumed(QEvent::KeyPress, key, Qt::ShiftModifier);
+            QCoreApplication::sendEvent(&window, &resumed);
+            QCOMPARE(inputCalls.last(), (QList<quint16>{virtualKey, 1, 1}));
+            item->releaseInput();
+            QCOMPARE(inputCalls.size(), 4);
+        }
+    }
+
+    void keepsKeypadOperatorsSeparateFromShiftedNumberRow()
+    {
+        QCOMPARE(StreamVideoItem::windowsVirtualKey(Qt::Key_Plus, Qt::KeypadModifier), quint16(0x6b));
+        QCOMPARE(StreamVideoItem::windowsVirtualKey(Qt::Key_Asterisk, Qt::KeypadModifier), quint16(0x6a));
+        QCOMPARE(StreamVideoItem::windowsVirtualKey(
+                     Qt::Key_Plus, Qt::KeypadModifier | Qt::ShiftModifier), quint16(0x6b));
+        QCOMPARE(StreamVideoItem::windowsVirtualKey(
+                     Qt::Key_Asterisk, Qt::KeypadModifier | Qt::ShiftModifier), quint16(0x6a));
     }
 
     void inputEnablementIsExplicitAndObservable()


### PR DESCRIPTION
Qt reports shifted punctuation as symbol keys (`Key_Colon`, `Key_Exclam`, etc.), but the stream translator only handled their unshifted counterparts. Those events were discarded before reaching the native streamer; number-row `*` and `+` were incorrectly sent as keypad operators.

Map all 21 shifted US punctuation symbols to their underlying Windows virtual keys while preserving the existing modifier encoding. Keep keypad `*` and `+` distinct, and normalize the key identity fallback when native scan codes are unavailable so releasing Shift before the symbol cannot leave the remote key held. Native scan-code identity and local-shortcut precedence remain unchanged.

Compared with [OpenNOW-Mac at 9062711](https://github.com/OpenCloudGaming/OpenNOW-Mac/tree/90627114383501dd18ef165baa005d9ea603fdf3): its input path forwards hardware key codes and modifiers separately, and its transport maps those codes to the underlying Windows virtual keys.

Validation:
- An isolated reproduction using the original translator confirmed 19 dropped symbols and two incorrect keypad mappings.
- Added regression coverage for all 21 symbols through Qt window event routing to the native API, with/without native scan codes, both Shift release orders, repeat suppression, and overlay focus loss/recovery in windowed/fullscreen modes. Added keypad operator checks.
- Full Debug Qt 6.8.3 application/test build passed.
- `ctest --test-dir build/opennow-qt --output-on-failure -j 4`: **194/194 passed**, after installing the missing software Vulkan driver on the test machine.
- Native X11 stream-video suite under Xvfb: **48 passed, 2 platform-specific skips**.
- `git diff --check` passed.

Live typing in an authenticated GFN session and Windows/macOS runtime validation were not available on this Linux machine. This change fixes the existing US-style symbol mapping; it does not introduce general international-layout or IME support.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M215R1CTK0X1WK6AJCTFEE5E"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->