### PR TITLE
fix(core): pace and deduplicate store requests

### DIFF
--- a/docs/core-protocol.md
+++ b/docs/core-protocol.md
@@ -63,6 +63,10 @@ advertises cursor pagination and separate storefront presentation. The existing
 `catalog.store.list` method now caps `limit` at 100 (default 100), returning one
 complete upstream page instead of aggregating thousands of games.
 
+Fresh upstream pages request at most 50 games, even when the requested limit is
+larger; existing cached pages may still contain up to 100. Always follow the
+returned cursor rather than assuming a full page has the requested count.
+
 Request: `{ "limit":100, "cursor":"", "searchQuery":"" }`. Cursor is an opaque
 string (at most 4096 UTF-8 bytes); search is at most 512 UTF-8 bytes. Response:
 `{ "games":[], "count":0, "totalCount":0, "hasNextPage":false,
@@ -88,6 +92,14 @@ and 512 entries. Missing or corrupt entries refetch normally. There is no timed
 catalog invalidation: an optional `refresh:true` on a first-page request clears
 that account/context's pages and presentation before fetching. Continuations
 must omit it or send false. Other accounts' entries are unaffected.
+
+Concurrent misses for the same cache key and refresh epoch share one successful
+fetch. Store network requests (including server metadata, presentation fallbacks,
+and oversized-page retries) are serialized with at least 50 ms between them.
+HTTP 429 starts a core-wide Store cooldown using `Retry-After` (seconds or HTTP
+date), or 60 seconds when it is absent or invalid. Uncached requests during the
+cooldown return `rate_limited` without network traffic; cached responses remain
+available. The core does not automatically retry a rate-limited request.
 
 The shell serializes game requests, merges by stable game identity, and retains
 loaded games and the failed cursor on error. Retries resume that page.

--- a/native/opennow-core/Cargo.lock
+++ b/native/opennow-core/Cargo.lock
@@ -746,6 +746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1155,7 @@ version = "1.0.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
+ "httpdate",
  "keyring",
  "md5",
  "qrcode",

--- a/native/opennow-core/Cargo.toml
+++ b/native/opennow-core/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.85"
 [dependencies]
 base64 = "0.22"
 ed25519-dalek = "2.2"
+httpdate = "1"
 md5 = "0.7"
 keyring = { version = "3.6", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust"] }
 qrcode = { version = "0.14", default-features = false }

--- a/native/opennow-core/src/gfn.rs
+++ b/native/opennow-core/src/gfn.rs
@@ -325,7 +325,7 @@ pub struct ServiceError {
 }
 
 impl ServiceError {
-    fn network(context: &str, error: reqwest::Error) -> Self {
+    pub(crate) fn network(context: &str, error: reqwest::Error) -> Self {
         Self {
             code: "network_error",
             message: format!("{context}: {}", error.without_url()),
@@ -1155,7 +1155,7 @@ impl GfnService {
             .id_token
             .as_deref()
             .unwrap_or(&session.tokens.access_token);
-        let vpc_id = self.vpc_id(&session, token);
+        let vpc_id = self.vpc_id(&session, token, None)?;
         let limit = params["limit"].as_u64().unwrap_or(600).clamp(1, 2000) as usize;
         let search = params["searchQuery"]
             .as_str()
@@ -1279,55 +1279,59 @@ impl GfnService {
         let key = json!(["page", page.limit, page.cursor, page.search]);
         let refresh = params["refresh"].as_bool() == Some(true) && page.cursor.is_empty();
         self.store_cache.load_or_fetch(&scope, &key, refresh, || {
-            let vpc_id = self.vpc_id(&session, token);
+            let vpc_id = self.vpc_id(&session, token, Some(&self.store_cache.requests))?;
             // Each retry starts at the SAME cursor. Never truncate a fetched page:
             // doing so would skip games when returning NVIDIA's end cursor.
-            crate::store_catalog_page::fetch_bounded_page(page.limit, |fetch_count| {
-                let searching = !page.search.is_empty();
-                let query = if searching {
-                    STORE_SEARCH_QUERY
-                } else {
-                    STORE_BROWSE_QUERY
-                };
-                let mut variables = json!({
-                    "vpcId":vpc_id, "locale":"en_US",
-                    "sortString":"itemMetadata.relevance:DESC,sortName:ASC",
-                    "fetchCount":fetch_count, "cursor":page.cursor, "filters":{}
-                });
-                if searching {
-                    variables["searchString"] = Value::String(page.search.clone());
-                }
-                let response = client
-                    .post(GRAPHQL_URL)
-                    .headers(graphql_headers(token)?)
-                    .json(&json!({"query":query,"variables":variables}))
-                    .send()
-                    .map_err(|error| ServiceError::network("GFN store query failed", error))?;
-                if !response.status().is_success() {
-                    return Err(ServiceError::response("GFN store query failed", response));
-                }
-                let payload = response
-                    .json::<Value>()
-                    .map_err(|error| ServiceError::network("Invalid GFN store response", error))?;
-                if let Some(message) = graphql_error_message(&payload) {
-                    return Err(ServiceError {
-                        code: "graphql_error",
-                        message,
+            crate::store_catalog_page::fetch_bounded_page(
+                page.limit.min(crate::store_requests::PAGE_SIZE),
+                |fetch_count| {
+                    let searching = !page.search.is_empty();
+                    let query = if searching {
+                        STORE_SEARCH_QUERY
+                    } else {
+                        STORE_BROWSE_QUERY
+                    };
+                    let mut variables = json!({
+                        "vpcId":vpc_id, "locale":"en_US",
+                        "sortString":"itemMetadata.relevance:DESC,sortName:ASC",
+                        "fetchCount":fetch_count, "cursor":page.cursor, "filters":{}
                     });
-                }
-                let apps = &payload["data"]["apps"];
-                let items = apps["items"].as_array().ok_or_else(|| ServiceError {
-                    code: "invalid_upstream_response",
-                    message: "Store response has no games array".to_owned(),
-                })?;
-                let games: Vec<Value> = items.iter().filter_map(app_to_game).collect();
-                crate::store_catalog_page::page_result(
-                    &page.cursor,
-                    games,
-                    &apps["pageInfo"],
-                    now_ms(),
-                )
-            })
+                    if searching {
+                        variables["searchString"] = Value::String(page.search.clone());
+                    }
+                    let response = self.store_cache.requests.send(
+                        client
+                            .post(GRAPHQL_URL)
+                            .headers(graphql_headers(token)?)
+                            .json(&json!({"query":query,"variables":variables})),
+                        "GFN store query failed",
+                    )?;
+                    if !response.status().is_success() {
+                        return Err(ServiceError::response("GFN store query failed", response));
+                    }
+                    let payload = response.json::<Value>().map_err(|error| {
+                        ServiceError::network("Invalid GFN store response", error)
+                    })?;
+                    if let Some(message) = graphql_error_message(&payload) {
+                        return Err(ServiceError {
+                            code: "graphql_error",
+                            message,
+                        });
+                    }
+                    let apps = &payload["data"]["apps"];
+                    let items = apps["items"].as_array().ok_or_else(|| ServiceError {
+                        code: "invalid_upstream_response",
+                        message: "Store response has no games array".to_owned(),
+                    })?;
+                    let games: Vec<Value> = items.iter().filter_map(app_to_game).collect();
+                    crate::store_catalog_page::page_result(
+                        &page.cursor,
+                        games,
+                        &apps["pageInfo"],
+                        now_ms(),
+                    )
+                },
+            )
         })
     }
 
@@ -1372,7 +1376,7 @@ impl GfnService {
                     .id_token
                     .as_deref()
                     .unwrap_or(&session.tokens.access_token);
-                let vpc_id = self.vpc_id(&session, token);
+                let vpc_id = self.vpc_id(&session, token, Some(&self.store_cache.requests))?;
                 let (variables, request_type, sha, query) = match section {
                     "panels" => (
                         json!({"vpcId":vpc_id,"locale":"en_US","panelNames":["MAIN"]}),
@@ -1398,14 +1402,13 @@ impl GfnService {
                     // Execute our document so GAME_BOX_ART is actually requested, just
                     // like Library/browse, rather than silently ignoring these fields.
                     crate::requests::check()?;
-                    let response = client
-                        .post(GRAPHQL_URL)
-                        .headers(graphql_headers(token)?)
-                        .json(&json!({"query":query,"variables":variables}))
-                        .send()
-                        .map_err(|error| {
-                            ServiceError::network("GFN storefront query failed", error)
-                        })?;
+                    let response = self.store_cache.requests.send(
+                        client
+                            .post(GRAPHQL_URL)
+                            .headers(graphql_headers(token)?)
+                            .json(&json!({"query":query,"variables":variables})),
+                        "GFN storefront query failed",
+                    )?;
                     if !response.status().is_success() {
                         return Err(ServiceError::response(
                             "GFN storefront query failed",
@@ -1424,13 +1427,13 @@ impl GfnService {
                     payload
                 } else {
                     fetch_panels_document(
+                        &self.store_cache.requests,
                         &client,
                         token,
                         variables,
                         request_type,
                         sha,
                         query,
-                        "GFN storefront query",
                     )?
                 };
                 crate::requests::check()?;
@@ -1502,7 +1505,7 @@ impl GfnService {
             .id_token
             .as_deref()
             .unwrap_or(&session.tokens.access_token);
-        let vpc_id = self.vpc_id(&session, token);
+        let vpc_id = self.vpc_id(&session, token, None)?;
         let steam_deck = settings["identifyAsSteamDeck"].as_bool().unwrap_or(false);
         let mut url = url::Url::parse(MES_URL).expect("MES URL is valid");
         url.query_pairs_mut()
@@ -1656,23 +1659,37 @@ impl GfnService {
         })
     }
 
-    fn vpc_id(&self, session: &AuthSession, token: &str) -> String {
+    fn vpc_id(
+        &self,
+        session: &AuthSession,
+        token: &str,
+        requests: Option<&crate::store_requests::StoreRequests>,
+    ) -> Result<String, ServiceError> {
         let Ok(base) = trusted_streaming_base(&session.provider.streaming_service_url) else {
-            return "GFN-PC".to_owned();
+            return Ok("GFN-PC".to_owned());
         };
         let Ok(url) = base.join("v2/serverInfo") else {
-            return "GFN-PC".to_owned();
+            return Ok("GFN-PC".to_owned());
         };
         let Ok(headers) = lcars_headers(token, "NATIVE", "NVIDIA-CLASSIC", false) else {
-            return "GFN-PC".to_owned();
+            return Ok("GFN-PC".to_owned());
         };
-        let Ok(response) = self.client.get(url).headers(headers).send() else {
-            return "GFN-PC".to_owned();
+        let request = self.client.get(url).headers(headers);
+        let response = match requests {
+            Some(requests) => requests.send(request, "Store server info failed"),
+            None => request
+                .send()
+                .map_err(|error| ServiceError::network("Server info failed", error)),
+        };
+        let response = match response {
+            Ok(response) => response,
+            Err(error) if matches!(error.code, "rate_limited" | "cancelled") => return Err(error),
+            Err(_) => return Ok("GFN-PC".to_owned()),
         };
         if !response.status().is_success() {
-            return "GFN-PC".to_owned();
+            return Ok("GFN-PC".to_owned());
         }
-        response
+        Ok(response
             .json::<Value>()
             .ok()
             .and_then(|payload| {
@@ -1680,7 +1697,7 @@ impl GfnService {
                     .as_str()
                     .map(ToOwned::to_owned)
             })
-            .unwrap_or_else(|| "GFN-PC".to_owned())
+            .unwrap_or_else(|| "GFN-PC".to_owned()))
     }
 
     fn fetch_user_info(&self, tokens: &AuthTokens) -> Result<AuthUser, ServiceError> {
@@ -2246,14 +2263,15 @@ fn game_identity(value: &Value) -> Option<String> {
 /// mirroring Electron's fetchLcarsGraphQl). Used for the storefront
 /// marquee hero and the official Main shelves.
 fn fetch_panels_document(
+    requests: &crate::store_requests::StoreRequests,
     client: &Client,
     token: &str,
     variables: Value,
     request_type: &str,
     sha: &str,
     fallback_query: &str,
-    context: &str,
 ) -> Result<Value, ServiceError> {
+    let context = "GFN storefront query";
     crate::requests::check()?;
     let extensions = json!({"persistedQuery":{"sha256Hash":sha}}).to_string();
     let variables_text = variables.to_string();
@@ -2269,11 +2287,10 @@ fn fetch_panels_document(
         reqwest::header::CONTENT_TYPE,
         HeaderValue::from_static("application/graphql"),
     );
-    let response = client
-        .get(url.clone())
-        .headers(headers)
-        .send()
-        .map_err(|error| ServiceError::network(&format!("{context} failed"), error))?;
+    let response = requests.send(
+        client.get(url.clone()).headers(headers),
+        &format!("{context} failed"),
+    )?;
     let payload = if response.status().as_u16() == 400 {
         crate::requests::check()?;
         url.query_pairs_mut().append_pair("query", fallback_query);
@@ -2282,11 +2299,17 @@ fn fetch_panels_document(
             reqwest::header::CONTENT_TYPE,
             HeaderValue::from_static("application/graphql"),
         );
-        client
-            .get(url)
-            .headers(retry_headers)
-            .send()
-            .map_err(|error| ServiceError::network(&format!("{context} failed"), error))?
+        let response = requests.send(
+            client.get(url).headers(retry_headers),
+            &format!("{context} failed"),
+        )?;
+        if !response.status().is_success() {
+            return Err(ServiceError::response(
+                &format!("{context} failed"),
+                response,
+            ));
+        }
+        response
             .json::<Value>()
             .map_err(|error| ServiceError::network(&format!("Invalid {context} response"), error))?
     } else {

--- a/native/opennow-core/src/main.rs
+++ b/native/opennow-core/src/main.rs
@@ -18,6 +18,7 @@ mod settings;
 mod store_cache;
 mod store_catalog_page;
 mod store_index;
+mod store_requests;
 mod streamer;
 mod telemetry;
 mod thanks;

--- a/native/opennow-core/src/store_cache.rs
+++ b/native/opennow-core/src/store_cache.rs
@@ -3,13 +3,16 @@
 use crate::{gfn::ServiceError, store_catalog_page::RESULT_BUDGET};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, Weak};
 
 const MAX_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_ENTRIES: usize = 512;
+
+type FetchLocks = HashMap<(PathBuf, u64), Weak<Mutex<()>>>;
 
 pub struct StoreCache {
     root: PathBuf,
@@ -17,6 +20,8 @@ pub struct StoreCache {
     // IO is serialized, but network work never holds the lock. Invalidation
     // advances the epoch so an older in-flight fetch cannot refill cleared data.
     epoch: Mutex<u64>,
+    fetches: Mutex<FetchLocks>,
+    pub requests: crate::store_requests::StoreRequests,
 }
 
 fn digest(value: &Value) -> String {
@@ -29,6 +34,8 @@ impl StoreCache {
             root: data_dir.join("store-cache-v1"),
             index: Mutex::new(None),
             epoch: Mutex::new(0),
+            fetches: Mutex::new(HashMap::new()),
+            requests: crate::store_requests::StoreRequests::default(),
         }
     }
 
@@ -62,6 +69,24 @@ impl StoreCache {
             }
             *epoch
         };
+        let fetch_lock = {
+            let mut fetches = self.fetches.lock().expect("Store fetches poisoned");
+            fetches.retain(|_, lock| lock.strong_count() > 0);
+            let entry = fetches.entry((path.clone(), epoch)).or_default();
+            match entry.upgrade() {
+                Some(lock) => lock,
+                None => {
+                    let lock = Arc::new(Mutex::new(()));
+                    *entry = Arc::downgrade(&lock);
+                    lock
+                }
+            }
+        };
+        let _fetch = crate::store_requests::lock(&fetch_lock)?;
+        if let Some(mut value) = self.read(&path) {
+            value["cacheHit"] = Value::Bool(true);
+            return Ok(value);
+        }
         let mut value = fetch()?;
         crate::requests::check()?;
         value["cacheHit"] = Value::Bool(false);
@@ -234,6 +259,71 @@ mod tests {
             .unwrap();
         assert_eq!(hit["games"][0]["id"], "saved");
         assert_eq!(hit["cacheHit"], true);
+        fs::remove_dir_all(cache.root.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn simultaneous_cache_misses_fetch_each_page_only_once() {
+        let cache = cache();
+        let ready = std::sync::Barrier::new(4);
+        let calls = std::sync::atomic::AtomicUsize::new(0);
+        std::thread::scope(|threads| {
+            let mut workers = Vec::new();
+            for _ in 0..4 {
+                workers.push(threads.spawn(|| {
+                    ready.wait();
+                    cache
+                        .load_or_fetch(&json!("a"), &json!("first"), false, || {
+                            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            std::thread::sleep(std::time::Duration::from_millis(100));
+                            Ok(page("shared"))
+                        })
+                        .unwrap()
+                }));
+            }
+            let results: Vec<_> = workers
+                .into_iter()
+                .map(|worker| worker.join().unwrap())
+                .collect();
+            assert_eq!(
+                results
+                    .iter()
+                    .filter(|value| value["cacheHit"] == false)
+                    .count(),
+                1
+            );
+            assert!(
+                results
+                    .iter()
+                    .all(|value| value["games"][0]["id"] == "shared")
+            );
+        });
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        fs::remove_dir_all(cache.root.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn failed_fetches_leave_saved_pages_available() {
+        let cache = cache();
+        cache
+            .load_or_fetch(&json!("a"), &json!("saved"), false, || Ok(page("saved")))
+            .unwrap();
+        assert!(
+            cache
+                .load_or_fetch(&json!("a"), &json!("missing"), false, || {
+                    Err(ServiceError {
+                        code: "rate_limited",
+                        message: "Try later".into(),
+                    })
+                })
+                .is_err()
+        );
+        let result = cache
+            .load_or_fetch(&json!("a"), &json!("saved"), false, || {
+                panic!("cached page fetched again")
+            })
+            .unwrap();
+        assert_eq!(result["cacheHit"], true);
         fs::remove_dir_all(cache.root.parent().unwrap()).unwrap();
     }
     #[test]

--- a/native/opennow-core/src/store_requests.rs
+++ b/native/opennow-core/src/store_requests.rs
@@ -1,0 +1,212 @@
+use crate::gfn::ServiceError;
+use reqwest::blocking::{RequestBuilder, Response};
+use std::sync::{Mutex, MutexGuard, TryLockError};
+use std::time::{Duration, Instant, SystemTime};
+
+const REQUEST_INTERVAL: Duration = Duration::from_millis(50);
+const DEFAULT_COOLDOWN: Duration = Duration::from_secs(60);
+pub const PAGE_SIZE: usize = 50;
+
+pub fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, ServiceError> {
+    loop {
+        crate::requests::check()?;
+        match mutex.try_lock() {
+            Ok(guard) => return Ok(guard),
+            Err(TryLockError::WouldBlock) => std::thread::sleep(REQUEST_INTERVAL),
+            Err(TryLockError::Poisoned(_)) => panic!("Store request state poisoned"),
+        }
+    }
+}
+
+#[derive(Default)]
+struct Schedule {
+    next_request: Option<Instant>,
+    cooldown: Option<Instant>,
+}
+
+#[derive(Default)]
+pub struct StoreRequests(Mutex<Schedule>);
+
+fn rate_limited(remaining: Duration) -> ServiceError {
+    ServiceError {
+        code: "rate_limited",
+        message: format!(
+            "The Store is rate limited. Try again in {} seconds.",
+            remaining.as_secs().saturating_add(1)
+        ),
+    }
+}
+
+impl StoreRequests {
+    pub fn send(&self, request: RequestBuilder, context: &str) -> Result<Response, ServiceError> {
+        let mut schedule = lock(&self.0)?;
+        if let Some(remaining) = schedule
+            .cooldown
+            .and_then(|until| until.checked_duration_since(Instant::now()))
+        {
+            return Err(rate_limited(remaining));
+        }
+        while let Some(remaining) = schedule
+            .next_request
+            .and_then(|until| until.checked_duration_since(Instant::now()))
+        {
+            crate::requests::check()?;
+            std::thread::sleep(remaining.min(REQUEST_INTERVAL));
+        }
+        crate::requests::check()?;
+        let response = request.send();
+        schedule.next_request = Some(Instant::now() + REQUEST_INTERVAL);
+        let response = response.map_err(|error| ServiceError::network(context, error))?;
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let delay = response
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| {
+                    value
+                        .parse::<u64>()
+                        .ok()
+                        .map(Duration::from_secs)
+                        .or_else(|| {
+                            httpdate::parse_http_date(value)
+                                .ok()
+                                .and_then(|date| date.duration_since(SystemTime::now()).ok())
+                        })
+                })
+                .unwrap_or(DEFAULT_COOLDOWN)
+                .max(REQUEST_INTERVAL);
+            let now = Instant::now();
+            schedule.cooldown = Some(now.checked_add(delay).unwrap_or(now + DEFAULT_COOLDOWN));
+            return Err(rate_limited(delay));
+        }
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+    use std::sync::Arc;
+
+    fn server(responses: Vec<String>) -> (String, std::thread::JoinHandle<Vec<Instant>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let worker = std::thread::spawn(move || {
+            let mut arrivals = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let mut reader = BufReader::new(&mut stream);
+                let mut request = Vec::new();
+                while !request.ends_with(b"\r\n\r\n") {
+                    assert!(reader.read_until(b'\n', &mut request).unwrap() > 0);
+                    assert!(request.len() <= 4096);
+                }
+                arrivals.push(Instant::now());
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+            arrivals
+        });
+        (url, worker)
+    }
+
+    #[test]
+    fn concurrent_store_requests_are_paced() {
+        let (url, server) = server(
+            vec!["HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".into(); 4],
+        );
+        let requests = Arc::new(StoreRequests::default());
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap();
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                scope.spawn(|| requests.send(client.get(&url), "test").unwrap());
+            }
+        });
+        let arrivals = server.join().unwrap();
+        assert!(
+            arrivals
+                .windows(2)
+                .all(|pair| pair[1].duration_since(pair[0]) >= REQUEST_INTERVAL)
+        );
+    }
+
+    #[test]
+    fn rate_limits_stop_subsequent_requests_including_retries() {
+        for header in [
+            "Retry-After: 120\r\n".to_owned(),
+            format!(
+                "Retry-After: {}\r\n",
+                httpdate::fmt_http_date(SystemTime::now() + Duration::from_secs(120))
+            ),
+            "Retry-After: invalid\r\n".to_owned(),
+            String::new(),
+        ] {
+            let (url, server) = server(vec![format!(
+                "HTTP/1.1 429 Too Many Requests\r\n{header}Content-Length: 0\r\nConnection: close\r\n\r\n"
+            )]);
+            let requests = StoreRequests::default();
+            let client = reqwest::blocking::Client::builder()
+                .no_proxy()
+                .build()
+                .unwrap();
+            assert_eq!(
+                requests.send(client.get(&url), "test").unwrap_err().code,
+                "rate_limited"
+            );
+            server.join().unwrap();
+            for _ in 0..100 {
+                assert_eq!(
+                    requests.send(client.get(&url), "test").unwrap_err().code,
+                    "rate_limited"
+                );
+            }
+            let remaining = requests
+                .0
+                .lock()
+                .unwrap()
+                .cooldown
+                .unwrap()
+                .duration_since(Instant::now());
+            assert!(
+                remaining
+                    >= Duration::from_secs(if header.contains("120") || header.contains("GMT") {
+                        118
+                    } else {
+                        58
+                    })
+            );
+        }
+    }
+
+    #[test]
+    fn cooldown_expires_and_cancelled_waiters_never_send() {
+        let (url, server) = server(vec![
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".into(),
+        ]);
+        let requests = StoreRequests::default();
+        requests.0.lock().unwrap().cooldown = Some(Instant::now() - Duration::from_secs(1));
+        let client = reqwest::blocking::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap();
+        requests.send(client.get(&url), "test").unwrap();
+        server.join().unwrap();
+        let active = Arc::new(crate::requests::Requests::default());
+        let permit = active.admit("cancelled", "catalog.store.local").unwrap();
+        active.cancel("cancelled");
+        let _held = requests.0.lock().unwrap();
+        crate::requests::scope(permit.token.clone(), || {
+            assert_eq!(
+                requests.send(client.get(&url), "test").unwrap_err().code,
+                "cancelled"
+            );
+        });
+    }
+}


### PR DESCRIPTION
Store cache misses could fetch the same page concurrently, and upstream Store traffic had no shared pacing or rate-limit cooldown.

- Fetch at most 50 games per fresh upstream page, preserving opaque cursors and compatibility with existing cached pages.
- Share successful concurrent cache misses by cache key and refresh epoch, with cancellation-aware waits and unchanged invalidation protection.
- Serialize Store HTTP requests with a 50 ms gap, including server metadata, presentation fallbacks, and oversized-page retries. Honor HTTP 429 `Retry-After` values in seconds or HTTP-date form, falling back to a 60-second cooldown; cached pages remain available and uncached retries fail locally during the cooldown.

Validation: all 163 core unit tests passed; strict Clippy across all core targets, formatting, and `git diff --check` passed. Added local HTTP regression tests for pacing, cooldowns, recovery, and cancellation, plus concurrent cache-miss coverage. Live NVIDIA/GFN browsing was not tested with an authenticated account.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M21EEZVS622DE4Z3SSC63PQN"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->