### PR TITLE
fix(core): cache server metadata and restore full store pages

### DIFF
--- a/docs/core-protocol.md
+++ b/docs/core-protocol.md
@@ -63,9 +63,9 @@ advertises cursor pagination and separate storefront presentation. The existing
 `catalog.store.list` method now caps `limit` at 100 (default 100), returning one
 complete upstream page instead of aggregating thousands of games.
 
-Fresh upstream pages request at most 50 games, even when the requested limit is
-larger; existing cached pages may still contain up to 100. Always follow the
-returned cursor rather than assuming a full page has the requested count.
+Fresh upstream pages request up to 100 games. Existing cached pages may contain
+fewer games; always follow the returned cursor rather than assuming a full page
+has the requested count.
 
 Request: `{ "limit":100, "cursor":"", "searchQuery":"" }`. Cursor is an opaque
 string (at most 4096 UTF-8 bytes); search is at most 512 UTF-8 bytes. Response:
@@ -100,6 +100,13 @@ HTTP 429 starts a core-wide Store cooldown using `Retry-After` (seconds or HTTP
 date), or 60 seconds when it is absent or invalid. Uncached requests during the
 cooldown return `rate_limited` without network traffic; cached responses remain
 available. The core does not automatically retry a rate-limited request.
+
+Server metadata lookups share one bounded, in-memory cache across Store, library,
+and subscription requests. A successful lookup is reused for five minutes, scoped
+by provider endpoint, account, and token fingerprint; concurrent callers share
+the lookup. Ordinary failures use the same context's last known value (or
+`GFN-PC` when none exists) for 30 seconds before retrying. Rate-limit and
+cancellation errors propagate instead of becoming cached fallback values.
 
 The shell serializes game requests, merges by stable game identity, and retains
 loaded games and the failed cursor on error. Retries resume that page.

--- a/native/opennow-core/src/gfn.rs
+++ b/native/opennow-core/src/gfn.rs
@@ -373,6 +373,7 @@ pub struct GfnService {
     account_connections: AccountConnectionsService,
     persistent_storage: PersistentStorageService,
     store_cache: crate::store_cache::StoreCache,
+    server_vpc_cache: crate::server_vpc_cache::ServerVpcCache,
     auth_operation: Mutex<()>,
     state: Mutex<ServiceState>,
 }
@@ -409,6 +410,7 @@ impl GfnService {
             vault,
             profiles: ConsoleProfiles::load(&data_dir),
             store_cache: crate::store_cache::StoreCache::new(data_dir),
+            server_vpc_cache: crate::server_vpc_cache::ServerVpcCache::default(),
             auth_operation: Mutex::new(()),
             state: Mutex::new(ServiceState::default()),
         }
@@ -1282,56 +1284,53 @@ impl GfnService {
             let vpc_id = self.vpc_id(&session, token, Some(&self.store_cache.requests))?;
             // Each retry starts at the SAME cursor. Never truncate a fetched page:
             // doing so would skip games when returning NVIDIA's end cursor.
-            crate::store_catalog_page::fetch_bounded_page(
-                page.limit.min(crate::store_requests::PAGE_SIZE),
-                |fetch_count| {
-                    let searching = !page.search.is_empty();
-                    let query = if searching {
-                        STORE_SEARCH_QUERY
-                    } else {
-                        STORE_BROWSE_QUERY
-                    };
-                    let mut variables = json!({
-                        "vpcId":vpc_id, "locale":"en_US",
-                        "sortString":"itemMetadata.relevance:DESC,sortName:ASC",
-                        "fetchCount":fetch_count, "cursor":page.cursor, "filters":{}
+            crate::store_catalog_page::fetch_bounded_page(page.limit, |fetch_count| {
+                let searching = !page.search.is_empty();
+                let query = if searching {
+                    STORE_SEARCH_QUERY
+                } else {
+                    STORE_BROWSE_QUERY
+                };
+                let mut variables = json!({
+                    "vpcId":vpc_id, "locale":"en_US",
+                    "sortString":"itemMetadata.relevance:DESC,sortName:ASC",
+                    "fetchCount":fetch_count, "cursor":page.cursor, "filters":{}
+                });
+                if searching {
+                    variables["searchString"] = Value::String(page.search.clone());
+                }
+                let response = self.store_cache.requests.send(
+                    client
+                        .post(GRAPHQL_URL)
+                        .headers(graphql_headers(token)?)
+                        .json(&json!({"query":query,"variables":variables})),
+                    "GFN store query failed",
+                )?;
+                if !response.status().is_success() {
+                    return Err(ServiceError::response("GFN store query failed", response));
+                }
+                let payload = response
+                    .json::<Value>()
+                    .map_err(|error| ServiceError::network("Invalid GFN store response", error))?;
+                if let Some(message) = graphql_error_message(&payload) {
+                    return Err(ServiceError {
+                        code: "graphql_error",
+                        message,
                     });
-                    if searching {
-                        variables["searchString"] = Value::String(page.search.clone());
-                    }
-                    let response = self.store_cache.requests.send(
-                        client
-                            .post(GRAPHQL_URL)
-                            .headers(graphql_headers(token)?)
-                            .json(&json!({"query":query,"variables":variables})),
-                        "GFN store query failed",
-                    )?;
-                    if !response.status().is_success() {
-                        return Err(ServiceError::response("GFN store query failed", response));
-                    }
-                    let payload = response.json::<Value>().map_err(|error| {
-                        ServiceError::network("Invalid GFN store response", error)
-                    })?;
-                    if let Some(message) = graphql_error_message(&payload) {
-                        return Err(ServiceError {
-                            code: "graphql_error",
-                            message,
-                        });
-                    }
-                    let apps = &payload["data"]["apps"];
-                    let items = apps["items"].as_array().ok_or_else(|| ServiceError {
-                        code: "invalid_upstream_response",
-                        message: "Store response has no games array".to_owned(),
-                    })?;
-                    let games: Vec<Value> = items.iter().filter_map(app_to_game).collect();
-                    crate::store_catalog_page::page_result(
-                        &page.cursor,
-                        games,
-                        &apps["pageInfo"],
-                        now_ms(),
-                    )
-                },
-            )
+                }
+                let apps = &payload["data"]["apps"];
+                let items = apps["items"].as_array().ok_or_else(|| ServiceError {
+                    code: "invalid_upstream_response",
+                    message: "Store response has no games array".to_owned(),
+                })?;
+                let games: Vec<Value> = items.iter().filter_map(app_to_game).collect();
+                crate::store_catalog_page::page_result(
+                    &page.cursor,
+                    games,
+                    &apps["pageInfo"],
+                    now_ms(),
+                )
+            })
         })
     }
 
@@ -1674,30 +1673,31 @@ impl GfnService {
         let Ok(headers) = lcars_headers(token, "NATIVE", "NVIDIA-CLASSIC", false) else {
             return Ok("GFN-PC".to_owned());
         };
-        let request = self.client.get(url).headers(headers);
-        let response = match requests {
-            Some(requests) => requests.send(request, "Store server info failed"),
-            None => request
-                .send()
-                .map_err(|error| ServiceError::network("Server info failed", error)),
-        };
-        let response = match response {
-            Ok(response) => response,
-            Err(error) if matches!(error.code, "rate_limited" | "cancelled") => return Err(error),
-            Err(_) => return Ok("GFN-PC".to_owned()),
-        };
-        if !response.status().is_success() {
-            return Ok("GFN-PC".to_owned());
-        }
-        Ok(response
-            .json::<Value>()
-            .ok()
-            .and_then(|payload| {
-                payload["requestStatus"]["serverId"]
-                    .as_str()
-                    .map(ToOwned::to_owned)
+        self.server_vpc_cache
+            .resolve(base.as_str(), &session.user.user_id, token, || {
+                let request = self.client.get(url).headers(headers);
+                let response = match requests {
+                    Some(requests) => requests.send(request, "Store server info failed"),
+                    None => request
+                        .send()
+                        .map_err(|error| ServiceError::network("Server info failed", error)),
+                };
+                let response = match response {
+                    Ok(response) => response,
+                    Err(error) if matches!(error.code, "rate_limited" | "cancelled") => {
+                        return Err(error);
+                    }
+                    Err(_) => return Ok(None),
+                };
+                if !response.status().is_success() {
+                    return Ok(None);
+                }
+                Ok(response.json::<Value>().ok().and_then(|payload| {
+                    payload["requestStatus"]["serverId"]
+                        .as_str()
+                        .map(ToOwned::to_owned)
+                }))
             })
-            .unwrap_or_else(|| "GFN-PC".to_owned()))
     }
 
     fn fetch_user_info(&self, tokens: &AuthTokens) -> Result<AuthUser, ServiceError> {

--- a/native/opennow-core/src/main.rs
+++ b/native/opennow-core/src/main.rs
@@ -14,6 +14,7 @@ mod network;
 mod persistent_storage;
 mod proxy;
 mod requests;
+mod server_vpc_cache;
 mod settings;
 mod store_cache;
 mod store_catalog_page;

--- a/native/opennow-core/src/server_vpc_cache.rs
+++ b/native/opennow-core/src/server_vpc_cache.rs
@@ -1,0 +1,219 @@
+use crate::gfn::ServiceError;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+const FRESHNESS: Duration = Duration::from_secs(5 * 60);
+const FAILURE_BACKOFF: Duration = Duration::from_secs(30);
+
+struct Entry {
+    scope: [u8; 32],
+    vpc_id: String,
+    expires: Instant,
+}
+
+#[derive(Default)]
+pub struct ServerVpcCache(Mutex<Option<Entry>>);
+
+impl ServerVpcCache {
+    pub fn resolve(
+        &self,
+        provider: &str,
+        account: &str,
+        token: &str,
+        fetch: impl FnOnce() -> Result<Option<String>, ServiceError>,
+    ) -> Result<String, ServiceError> {
+        let scope = Sha256::digest(json!([provider, account, token]).to_string().as_bytes()).into();
+        let mut cached = crate::store_requests::lock(&self.0)?;
+        if let Some(entry) = cached
+            .as_ref()
+            .filter(|entry| entry.scope == scope && entry.expires > Instant::now())
+        {
+            return Ok(entry.vpc_id.clone());
+        }
+        let result = fetch()?;
+        crate::requests::check()?;
+        let (vpc_id, freshness) = match result.filter(|value| !value.is_empty()) {
+            Some(value) => (value, FRESHNESS),
+            None => (
+                cached
+                    .as_ref()
+                    .filter(|entry| entry.scope == scope)
+                    .map(|entry| entry.vpc_id.clone())
+                    .unwrap_or_else(|| "GFN-PC".into()),
+                FAILURE_BACKOFF,
+            ),
+        };
+        *cached = Some(Entry {
+            scope,
+            vpc_id: vpc_id.clone(),
+            expires: Instant::now() + freshness,
+        });
+        Ok(vpc_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    #[test]
+    fn concurrent_lookups_share_one_fetch_and_reuse_it_for_five_minutes() {
+        let cache = ServerVpcCache::default();
+        let ready = Barrier::new(4);
+        let calls = AtomicUsize::new(0);
+        let started = Instant::now();
+        std::thread::scope(|threads| {
+            for _ in 0..4 {
+                let cache = &cache;
+                let ready = &ready;
+                let calls = &calls;
+                threads.spawn(move || {
+                    ready.wait();
+                    let result = cache
+                        .resolve("provider", "account", "token", || {
+                            calls.fetch_add(1, Ordering::SeqCst);
+                            std::thread::sleep(Duration::from_millis(100));
+                            Ok(Some("region-a".into()))
+                        })
+                        .unwrap();
+                    assert_eq!(result, "region-a");
+                });
+            }
+        });
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            cache
+                .resolve("provider", "account", "token", || panic!(
+                    "fresh metadata refetched"
+                ))
+                .unwrap(),
+            "region-a"
+        );
+        let mut cached = cache.0.lock().unwrap();
+        let entry = cached.as_mut().unwrap();
+        assert!(entry.expires >= started + FRESHNESS);
+        assert!(entry.expires <= Instant::now() + FRESHNESS);
+        entry.expires = Instant::now() - Duration::from_secs(1);
+        drop(cached);
+        assert_eq!(
+            cache
+                .resolve("provider", "account", "token", || Ok(Some(
+                    "region-b".into()
+                )))
+                .unwrap(),
+            "region-b"
+        );
+    }
+
+    #[test]
+    fn providers_accounts_and_refreshed_tokens_do_not_share_metadata() {
+        let cache = ServerVpcCache::default();
+        for (index, (provider, account, token)) in [
+            ("provider-a", "account-a", "token-a"),
+            ("provider-b", "account-a", "token-a"),
+            ("provider-b", "account-b", "token-a"),
+            ("provider-b", "account-b", "token-b"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let expected = format!("region-{index}");
+            assert_eq!(
+                cache
+                    .resolve(provider, account, token, || Ok(Some(expected.clone())))
+                    .unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn failures_preserve_known_metadata_with_a_short_retry_backoff() {
+        let cache = ServerVpcCache::default();
+        assert_eq!(cache.resolve("p", "a", "t", || Ok(None)).unwrap(), "GFN-PC");
+        assert!(
+            cache
+                .0
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .expires
+                .duration_since(Instant::now())
+                <= FAILURE_BACKOFF
+        );
+        cache
+            .resolve("p", "a", "t", || {
+                panic!("failed lookup retried immediately")
+            })
+            .unwrap();
+        cache.0.lock().unwrap().as_mut().unwrap().expires = Instant::now() - Duration::from_secs(1);
+        assert_eq!(
+            cache
+                .resolve("p", "a", "t", || Ok(Some("known".into())))
+                .unwrap(),
+            "known"
+        );
+        cache.0.lock().unwrap().as_mut().unwrap().expires = Instant::now() - Duration::from_secs(1);
+        assert_eq!(cache.resolve("p", "a", "t", || Ok(None)).unwrap(), "known");
+        assert_eq!(
+            cache.resolve("other", "a", "t", || Ok(None)).unwrap(),
+            "GFN-PC"
+        );
+    }
+
+    #[test]
+    fn rate_limit_errors_are_not_cached_as_successful_metadata() {
+        let cache = ServerVpcCache::default();
+        let error = cache
+            .resolve("p", "a", "t", || {
+                Err(ServiceError {
+                    code: "rate_limited",
+                    message: "Try later".into(),
+                })
+            })
+            .unwrap_err();
+        assert_eq!(error.code, "rate_limited");
+        assert!(cache.0.lock().unwrap().is_none());
+        assert_eq!(
+            cache
+                .resolve("p", "a", "t", || Ok(Some("recovered".into())))
+                .unwrap(),
+            "recovered"
+        );
+    }
+
+    #[test]
+    fn cancelled_lookups_neither_wait_for_the_cache_nor_publish_results() {
+        let cache = ServerVpcCache::default();
+        let requests = Arc::new(crate::requests::Requests::default());
+        let permit = requests.admit("lookup", "catalog.store.local").unwrap();
+        crate::requests::scope(permit.token.clone(), || {
+            assert_eq!(
+                cache
+                    .resolve("p", "a", "t", || {
+                        requests.cancel("lookup");
+                        Ok(Some("cancelled".into()))
+                    })
+                    .unwrap_err()
+                    .code,
+                "cancelled"
+            );
+            let held = cache.0.lock().unwrap();
+            assert!(held.is_none());
+            assert_eq!(
+                cache
+                    .resolve("p", "a", "t", || panic!("cancelled fetch started"))
+                    .unwrap_err()
+                    .code,
+                "cancelled"
+            );
+        });
+    }
+}

--- a/native/opennow-core/src/store_catalog_page.rs
+++ b/native/opennow-core/src/store_catalog_page.rs
@@ -122,6 +122,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn normal_sized_pages_keep_the_full_hundred_game_batch() {
+        let request = PageRequest::parse(&json!({"limit": 100})).unwrap();
+        let mut calls = 0;
+        let page = fetch_bounded_page(request.limit, |count| {
+            calls += 1;
+            assert_eq!(count, 100);
+            page_result(
+                "",
+                (0..count).map(|id| json!({"id": id})).collect(),
+                &json!({"hasNextPage": true, "endCursor": "after-100", "totalCount": 2500}),
+                0,
+            )
+        })
+        .unwrap();
+        assert_eq!(calls, 1);
+        assert_eq!(page["count"], 100);
+        assert_eq!(page["nextCursor"], "after-100");
+    }
+
+    #[test]
     fn cancelled_fetch_does_not_retry_an_oversized_page() {
         let requests = std::sync::Arc::new(crate::requests::Requests::default());
         let permit = requests.admit("page", "catalog.store.browse").unwrap();

--- a/native/opennow-core/src/store_requests.rs
+++ b/native/opennow-core/src/store_requests.rs
@@ -5,7 +5,6 @@ use std::time::{Duration, Instant, SystemTime};
 
 const REQUEST_INTERVAL: Duration = Duration::from_millis(50);
 const DEFAULT_COOLDOWN: Duration = Duration::from_secs(60);
-pub const PAGE_SIZE: usize = 50;
 
 pub fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, ServiceError> {
     loop {


### PR DESCRIPTION
Follow up to #845 after comparing the native macOS catalog implementation. Reduce unnecessary requests through shared metadata caching rather than halving the catalog page size.

- Restore fresh upstream pages of up to 100 games, preserving existing cursor and response-size handling. Keep the 50 ms Store request pacing, concurrent page-fetch deduplication, and HTTP 429 cooldown unchanged.
- Reuse server metadata for five minutes across Store, library, and subscription requests. A single bounded in-memory entry is scoped by provider endpoint, account, and token fingerprint, and concurrent callers share the lookup through cancellation-aware locking.
- On ordinary lookup failures, retain the same context's last known value (or the existing GFN-PC fallback) for 30 seconds before retrying. Rate-limit and cancellation errors propagate without being cached as successful lookups.

Validation: all 169 core unit tests passed, including new tests for shared lookups, expiry, context isolation, failure backoff, cancellation, and 100-game pages. Strict Clippy across all core targets, formatting, and `git diff --check` passed. Live authenticated NVIDIA/GFN browsing was not tested.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M21EEZVS622DE4Z3SSC63PQN"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->