### PR TITLE
fix(qt): keep Tab and keyboard repeats from stealing stream focus

### DIFF
--- a/opennow-qt/src/streaming/StreamVideoItemInput.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItemInput.cpp
@@ -39,7 +39,8 @@ quint16 StreamVideoItem::windowsVirtualKey(int key, Qt::KeyboardModifiers modifi
     case Qt::Key_Enter: return 0x0d;
     case Qt::Key_Escape: return 0x1b;
     case Qt::Key_Backspace: return 0x08;
-    case Qt::Key_Tab: return 0x09;
+    case Qt::Key_Tab:
+    case Qt::Key_Backtab: return 0x09;
     case Qt::Key_Space: return 0x20;
     case Qt::Key_Exclam: return 0x31;
     case Qt::Key_At: return 0x32;
@@ -158,8 +159,12 @@ quint32 StreamVideoItem::keyIdentity(const QKeyEvent *event) const
 
 void StreamVideoItem::keyPressEvent(QKeyEvent *event)
 {
-    if (!m_captureActive || event->isAutoRepeat()) {
+    if (!m_captureActive) {
         event->ignore();
+        return;
+    }
+    if (event->isAutoRepeat()) {
+        event->accept();
         return;
     }
     const auto identity = keyIdentity(event);

--- a/opennow-qt/tests/tst_streamvideoitem.cpp
+++ b/opennow-qt/tests/tst_streamvideoitem.cpp
@@ -303,6 +303,104 @@ private slots:
         QCOMPARE(StreamVideoItem::inputModifiers(Qt::ShiftModifier, Qt::Key_Shift), quint16(0));
     }
 
+    void tabDoesNotStealGameplayFocus_data()
+    {
+        QTest::addColumn<int>("key");
+        QTest::addColumn<bool>("fullscreen");
+        for (const bool fullscreen : {false, true}) {
+            const auto mode = fullscreen ? "fullscreen" : "windowed";
+            QTest::newRow(qPrintable(QStringLiteral("tab-%1").arg(mode)))
+                << int(Qt::Key_Tab) << fullscreen;
+            QTest::newRow(qPrintable(QStringLiteral("backtab-%1").arg(mode)))
+                << int(Qt::Key_Backtab) << fullscreen;
+        }
+    }
+
+    void tabDoesNotStealGameplayFocus()
+    {
+        QFETCH(int, key);
+        QFETCH(bool, fullscreen);
+        static OpenNowStreamerConfig callbacks;
+        static QList<QList<quint16>> inputCalls;
+        inputCalls.clear();
+        NativeStreamRuntime::Api api{};
+        api.create = [](const OpenNowStreamerConfig *config, OpenNowStreamer **output) {
+            callbacks = *config;
+            *output = reinterpret_cast<OpenNowStreamer *>(new int(1));
+            return OPENNOW_STREAMER_OK;
+        };
+        api.destroy = [](OpenNowStreamer *handle) {
+            delete reinterpret_cast<int *>(handle);
+            return OPENNOW_STREAMER_OK;
+        };
+        api.send = [](const OpenNowStreamer *, const std::uint8_t *, std::size_t) {
+            return OPENNOW_STREAMER_OK;
+        };
+        api.setCaptureActive = [](const OpenNowStreamer *, bool, bool, std::uintptr_t, bool *raw) {
+            *raw = false;
+            return OPENNOW_STREAMER_OK;
+        };
+        api.submitKey = [](const OpenNowStreamer *, std::uint16_t vk,
+                           std::uint16_t modifiers, bool pressed) {
+            inputCalls.append(QList<quint16>{vk, modifiers, quint16(pressed)});
+            return OPENNOW_STREAMER_OK;
+        };
+        NativeStreamRuntime runtime(api);
+        QVERIFY(runtime.start());
+        StreamVideoItem::setNativeStreamRuntime(&runtime);
+        const auto reset = qScopeGuard([] { StreamVideoItem::setNativeStreamRuntime(nullptr); });
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("keyboard-focus")}}));
+        const QByteArray ready = R"({"id":"keyboard-focus","type":"ok"})";
+        callbacks.response_callback(reinterpret_cast<const std::uint8_t *>(ready.constData()),
+                                    ready.size(), callbacks.user_data);
+        QTRY_VERIFY(runtime.inputAllowed());
+        QQuickWindow window;
+        window.resize(640, 480);
+        auto *item = new StreamVideoItem(window.contentItem());
+        item->setRenderCallback({});
+        item->setSize(window.size());
+        auto *other = new QQuickItem(window.contentItem());
+        other->setActiveFocusOnTab(true);
+        if (fullscreen) window.showFullScreen();
+        else window.showNormal();
+        window.requestActivate();
+        QTRY_VERIFY(window.isActive());
+        item->forceActiveFocus();
+        QTRY_VERIFY(item->captureActive());
+        const auto modifiers = key == Qt::Key_Backtab ? Qt::ShiftModifier : Qt::NoModifier;
+        QKeyEvent press(QEvent::KeyPress, key, modifiers, 23, 0, 0);
+        QCoreApplication::sendEvent(&window, &press);
+        QCOMPARE(window.activeFocusItem(), item);
+        for (int i = 0; i < 3; ++i) {
+            QKeyEvent repeat(QEvent::KeyPress, key, modifiers, 23, 0, 0, {}, true);
+            QCoreApplication::sendEvent(&window, &repeat);
+            QCOMPARE(window.activeFocusItem(), item);
+            QVERIFY(item->captureActive());
+        }
+        QKeyEvent release(QEvent::KeyRelease, key, modifiers, 23, 0, 0);
+        QCoreApplication::sendEvent(&window, &release);
+        const auto wireModifiers = quint16(key == Qt::Key_Backtab ? 1 : 0);
+        QCOMPARE(inputCalls, (QList<QList<quint16>>{
+            {0x09, wireModifiers, 1}, {0x09, wireModifiers, 0}}));
+        for (const auto movement : {Qt::Key_W, Qt::Key_A, Qt::Key_S, Qt::Key_D}) {
+            inputCalls.clear();
+            QTest::keyClick(&window, movement);
+            QCOMPARE(inputCalls, (QList<QList<quint16>>{
+                {quint16(movement), 0, 1}, {quint16(movement), 0, 0}}));
+        }
+        item->setInputEnabled(false);
+        other->forceActiveFocus();
+        inputCalls.clear();
+        QTest::keyClick(&window, Qt::Key_W);
+        QVERIFY(inputCalls.isEmpty());
+        item->setInputEnabled(true);
+        item->forceActiveFocus();
+        QTRY_VERIFY(item->captureActive());
+        QTest::keyClick(&window, Qt::Key_W);
+        QCOMPARE(inputCalls, (QList<QList<quint16>>{{0x57, 0, 1}, {0x57, 0, 0}}));
+    }
+
     void forwardsShiftedPunctuation_data()
     {
         QTest::addColumn<int>("key");


### PR DESCRIPTION
Holding Tab caused StreamVideoItem to ignore its auto-repeat events, allowing Qt's default Tab navigation to move focus away from the stream and disable gameplay capture. Shift+Tab had the same effect immediately because Qt reports it as Key_Backtab, which was not mapped.

Consume auto-repeat presses while gameplay capture is active without sending duplicate remote key-downs, and map Backtab to the remote Tab virtual key. Input remains available to the shell when capture is inactive.

Add window-dispatched regression coverage for Tab and Shift+Tab in windowed/fullscreen modes, verifying that focus and capture stay on the stream, subsequent WASD presses reach the runtime, and disabling/re-enabling gameplay input still works. All four regression cases fail on the previous implementation and pass with this fix.

Validation:
- Built the stream-video, native-runtime, controller-input and embedded-orchestration Qt test targets with Qt 6.8.3.
- All four focused CTest suites pass.
- Full stream-video suite under X11/Xvfb: 52 passed, 0 failed, 2 platform-specific skips.
- Keyboard regression and shifted-punctuation checks under X11: 27 passed, no skips.
- `git diff --check` passes.

Live GFN gameplay and Windows/Wayland-specific acceptance were not run in this Linux/X11 environment. This fixes a reproduced keyboard-focus failure; the reporter's exact OS and triggering sequence are not yet confirmed.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M21GS3KC0EYHV6F8J8QEFHGK"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->