### PR TITLE
fix(streamer): allow large RTSPS session descriptions

### DIFF
--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
@@ -18,6 +18,7 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(2);
 const CONTROL_PING_EXPIRY: Duration = Duration::from_secs(5);
 const CONTROL_IO_TIMEOUT: Duration = Duration::from_millis(100);
+const MAX_REQUEST_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_CONTROL_RESPONSE_BYTES: usize = 64 * 1024;
 const MAX_STREAM_BITRATE_MBPS: u64 = 200;
 // GeForce NOW 2.0.87.131 reports video[0].timeoutLengthMs=8000 and
@@ -156,6 +157,10 @@ impl RtspClient {
         timeout: Duration,
     ) -> Result<RtspResponse, NvstRtspError> {
         let mut stage = opennow_streamer_protocol::log::Stage::begin("rtsps.request");
+        self.socket.set_config(|config| {
+            config.max_message_size = Some(MAX_REQUEST_RESPONSE_BYTES);
+            config.max_frame_size = Some(MAX_REQUEST_RESPONSE_BYTES);
+        });
         self.send_request(method, uri, headers, body)?;
         opennow_streamer_protocol::log::log_line(
             "INFO",
@@ -169,10 +174,13 @@ impl RtspClient {
         );
         let deadline = Instant::now() + timeout;
         loop {
-            if self.buffer.len() > MAX_CONTROL_RESPONSE_BYTES {
+            if self.buffer.len() > MAX_REQUEST_RESPONSE_BYTES {
                 return Err(NvstRtspError::new(
                     "nvst-rtsp-failed",
-                    "RTSPS response exceeds control buffer limit",
+                    format!(
+                        "RTSPS {method} response exceeds request buffer limit: {} bytes (limit {MAX_REQUEST_RESPONSE_BYTES})",
+                        self.buffer.len()
+                    ),
                 ));
             }
             if Instant::now() >= deadline {
@@ -195,8 +203,10 @@ impl RtspClient {
                     "INFO",
                     "rtsps",
                     &format!(
-                        "response method={method} cseq={} status={}",
-                        self.cseq, response.status
+                        "response method={method} cseq={} status={} body_bytes={}",
+                        self.cseq,
+                        response.status,
+                        response.body.len()
                     ),
                 );
                 stage.complete();
@@ -1107,6 +1117,14 @@ fn take_rtsp_response(
     let total = (header_end + separator)
         .checked_add(content_length)
         .ok_or_else(|| NvstRtspError::new("nvst-rtsp-failed", "Invalid RTSPS content length"))?;
+    if total > MAX_REQUEST_RESPONSE_BYTES {
+        return Err(NvstRtspError::new(
+            "nvst-rtsp-failed",
+            format!(
+                "RTSPS response exceeds request buffer limit: {total} bytes (limit {MAX_REQUEST_RESPONSE_BYTES})"
+            ),
+        ));
+    }
     if buffer.len() < total {
         return Ok(None);
     }

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp_control_ping_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp_control_ping_tests.rs
@@ -88,6 +88,120 @@ fn wait_until(mut condition: impl FnMut() -> bool) {
 }
 
 #[test]
+fn describe_accepts_large_text_binary_and_split_responses() {
+    for (binary, chunk_size) in [
+        (false, usize::MAX),
+        (true, usize::MAX),
+        (false, 16 * 1024),
+        (true, 16 * 1024),
+    ] {
+        let (mut client, mut server) = socket_pair();
+        let body = "a=x-nv-test:description\r\n".repeat(12_000);
+        assert!(body.len() > MAX_CONTROL_RESPONSE_BYTES);
+        let expected_body = body.clone();
+        let sender = thread::spawn(move || {
+            let Message::Text(request) = server.read().unwrap() else {
+                panic!("expected DESCRIBE request");
+            };
+            assert!(request.starts_with("DESCRIBE "));
+            assert!(request.contains("\r\nCSeq: 8\r\n"));
+            let response = format!(
+                "RTSP/1.0 200 OK\r\nCSeq: 8\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            for chunk in response.as_bytes().chunks(chunk_size) {
+                let message = if binary {
+                    Message::Binary(chunk.to_vec().into())
+                } else {
+                    Message::Text(String::from_utf8(chunk.to_vec()).unwrap().into())
+                };
+                server.send(message).unwrap();
+            }
+        });
+        let response = client
+            .request("DESCRIBE", "rtsps://seat.nvidiagrid.net:322", &[], "")
+            .unwrap();
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, expected_body);
+        assert!(client.buffer.is_empty());
+        sender.join().unwrap();
+    }
+}
+
+#[test]
+fn request_rejects_unbounded_partial_response() {
+    let (mut client, mut server) = socket_pair();
+    let sender = thread::spawn(move || {
+        server.read().unwrap();
+        server
+            .send(Message::Text("x".repeat(MAX_REQUEST_RESPONSE_BYTES).into()))
+            .unwrap();
+        server.send(Message::Text("x".into())).unwrap();
+    });
+    let error = client
+        .request("DESCRIBE", "rtsps://seat.nvidiagrid.net:322", &[], "")
+        .err()
+        .unwrap();
+    assert_eq!(error.code, "nvst-rtsp-failed");
+    assert!(
+        error
+            .message
+            .contains("DESCRIBE response exceeds request buffer limit")
+    );
+    sender.join().unwrap();
+}
+
+#[test]
+fn request_bounds_websocket_message_size() {
+    let (mut client, mut server) = socket_pair();
+    let sender = thread::spawn(move || {
+        server.read().unwrap();
+        let _ = server.send(Message::Text(
+            "x".repeat(MAX_REQUEST_RESPONSE_BYTES + 1).into(),
+        ));
+    });
+    let error = client
+        .request("DESCRIBE", "rtsps://seat.nvidiagrid.net:322", &[], "")
+        .err()
+        .unwrap();
+    assert_eq!(error.code, "nvst-rtsp-failed");
+    assert!(error.message.contains("Space limit exceeded"));
+    assert!(client.buffer.is_empty());
+    sender.join().unwrap();
+}
+
+#[test]
+fn rtsp_parser_accepts_response_at_request_size_limit() {
+    let prefix = "RTSP/1.0 200 OK\r\nCSeq: 8\r\nContent-Length: ";
+    let body_length = MAX_REQUEST_RESPONSE_BYTES
+        - prefix.len()
+        - MAX_REQUEST_RESPONSE_BYTES.to_string().len()
+        - 4;
+    let body = "x".repeat(body_length);
+    let mut buffer = format!("{prefix}{body_length}\r\n\r\n{body}");
+    assert_eq!(buffer.len(), MAX_REQUEST_RESPONSE_BYTES);
+    let response = take_rtsp_response(&mut buffer, 8).unwrap().unwrap();
+    assert_eq!(response.body, body);
+    assert!(buffer.is_empty());
+}
+
+#[test]
+fn rtsp_parser_bounds_declared_response_size_before_receiving_body() {
+    let mut oversized = format!(
+        "RTSP/1.0 200 OK\r\nCSeq: 8\r\nContent-Length: {MAX_REQUEST_RESPONSE_BYTES}\r\n\r\n"
+    );
+    let error = take_rtsp_response(&mut oversized, 8).err().unwrap();
+    assert!(
+        error
+            .message
+            .contains("response exceeds request buffer limit")
+    );
+
+    let mut bounded = "RTSP/1.0 200 OK\r\nCSeq: 8\r\nContent-Length: 262144\r\n\r\n".to_owned();
+    assert!(take_rtsp_response(&mut bounded, 8).unwrap().is_none());
+}
+
+#[test]
 fn control_ping_parser_rejects_overflowing_and_invalid_body_boundaries() {
     let mut overflowing = format!(
         "RTSP/1.0 551 Response\r\nCSeq: 8\r\nContent-Length: {}\r\n\r\n",


### PR DESCRIPTION
The live-ping change in #836 also applied its 64 KiB control-response guard to synchronous RTSPS requests. This rejects larger DESCRIBE replies during session setup; the supplied diagnostics show OPTIONS succeeding followed by repeated DESCRIBE failures.

Give synchronous request responses a separate 4 MiB budget, including WebSocket frame/message limits, while retaining the 64 KiB live keepalive limits. Reject declared responses larger than the request budget before waiting for their bodies. Log successful response body sizes and include byte counts in request-buffer limit errors without logging response content.

Add local WebSocket regression coverage for 300 KB DESCRIBE replies delivered as text, binary, and multiple messages. Cover oversized partial responses, the WebSocket size limit, early rejection of excessive Content-Length, and acceptance at the exact request-size boundary. The large-response regression fails when the original 64 KiB guard is restored and passes with this fix; existing live-control bounded-buffer tests remain unchanged.

Validation:
- Focused RTSPS tests: 29 passed.
- Native-streamer workspace tests: 456 passed, 8 ignored.
- Workspace formatting and strict Clippy across all targets passed.
- `git diff --check` passed.

The logs do not include the original response body or its exact size. Live authenticated GFN session startup was not tested; the regression uses synthetic protocol replies.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M22E54DXB5FV5FH6C98GMCGH"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->