### PR TITLE
ci(qt): cache native builds and split 8-core Windows compilation from desktop tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,6 +10,7 @@ self-hosted-runner:
     - blacksmith-6vcpu-macos-latest
     - blacksmith-8vcpu-ubuntu-2404
     - blacksmith-8vcpu-ubuntu-2404-arm
+    - blacksmith-8vcpu-windows-2025
     - opennow-release-signer
 
 config-variables: null

--- a/.github/actions/sdl3/action.yml
+++ b/.github/actions/sdl3/action.yml
@@ -1,0 +1,58 @@
+name: Build and cache SDL3
+description: Cache the SDL installation by recipe, target, and native toolchain
+inputs:
+  version:
+    description: SDL release tag
+    required: true
+  target-arch:
+    description: Target architecture, x64 or arm64
+    required: true
+  parallel:
+    description: Maximum concurrent build jobs
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Identify SDL toolchain
+      id: toolchain
+      shell: python
+      run: |
+        import hashlib
+        import os
+        import subprocess
+
+        compiler = ["cl"] if os.name == "nt" else ["c++", "--version"]
+        identity = subprocess.run(compiler, stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout
+        identity += subprocess.check_output(["cmake", "--version"])
+        identity += os.environ.get("MACOSX_DEPLOYMENT_TARGET", "").encode()
+        with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+            output.write(f"digest={hashlib.sha256(identity).hexdigest()}\n")
+    - name: Cache SDL3 installation
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/SDL-install
+        key: sdl3-v2-${{ runner.os }}-${{ runner.arch }}-${{ inputs.target-arch }}-${{ inputs.version }}-${{ steps.toolchain.outputs.digest }}-${{ hashFiles('.github/actions/sdl3/action.yml') }}
+    - name: Build SDL3
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        SDL_VERSION: ${{ inputs.version }}
+        SDL_TARGET_ARCH: ${{ inputs.target-arch }}
+        SDL_BUILD_PARALLEL: ${{ inputs.parallel }}
+      run: |
+        args=()
+        if [[ "$RUNNER_OS" == Windows ]]; then
+          args+=(-G "Ninja Multi-Config" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl)
+          if [[ "$SDL_TARGET_ARCH" == arm64 ]]; then
+            args+=(-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=ARM64)
+          fi
+        elif [[ "$RUNNER_OS" == macOS ]]; then
+          args+=("-DCMAKE_OSX_ARCHITECTURES=$SDL_TARGET_ARCH" "-DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET" -DSDL_FRAMEWORK=OFF)
+        fi
+        git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
+        cmake -S "$RUNNER_TEMP/SDL" -B "$RUNNER_TEMP/SDL-build" \
+          -DCMAKE_BUILD_TYPE=Release -DSDL_SHARED=ON -DSDL_STATIC=OFF \
+          -DSDL_TEST_LIBRARY=OFF -DSDL_TESTS=OFF "${args[@]}"
+        cmake --build "$RUNNER_TEMP/SDL-build" --config Release --parallel "$SDL_BUILD_PARALLEL"
+        cmake --install "$RUNNER_TEMP/SDL-build" --config Release --prefix "$RUNNER_TEMP/SDL-install"

--- a/.github/scripts/map-windows-workspace.ps1
+++ b/.github/scripts/map-windows-workspace.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+
+if (Test-Path O:\) {
+    throw "The stable Windows CI workspace drive O: is already in use."
+}
+subst O: $env:GITHUB_WORKSPACE
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path O:\opennow-qt\CMakeLists.txt)) {
+    throw "Could not map the checkout to the stable Windows CI workspace O:."
+}

--- a/.github/scripts/windows-test-bundle.py
+++ b/.github/scripts/windows-test-bundle.py
@@ -1,0 +1,89 @@
+import argparse
+import json
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+import subprocess
+import zipfile
+
+
+MANIFEST = "windows-test-bundle.json"
+RUST_TARGET_DIRS = {"target", "rust-target", "streamer-rust-target"}
+
+
+def discover_tests(build):
+    result = subprocess.run(
+        ["ctest", "--test-dir", str(build), "-C", "Release", "--show-only=json-v1"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    names = sorted(test["name"] for test in json.loads(result.stdout)["tests"])
+    if not names:
+        raise ValueError("CTest discovered no tests")
+    return names
+
+
+def pack(build, output, revision):
+    build = Path(build)
+    runtime = build / "Release"
+    if not runtime.is_dir():
+        raise ValueError("Build is missing the Release runtime directory")
+    if not (build / "CTestTestfile.cmake").is_file():
+        raise ValueError("Build is missing the root CTestTestfile.cmake")
+    files = {path for path in runtime.rglob("*") if path.is_file()}
+    for directory, directories, filenames in os.walk(build):
+        directories[:] = [name for name in directories if name not in RUST_TARGET_DIRS]
+        if "CTestTestfile.cmake" in filenames:
+            files.add(Path(directory) / "CTestTestfile.cmake")
+    manifest = {"revision": revision, "tests": discover_tests(build)}
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=1) as archive:
+        archive.writestr(MANIFEST, json.dumps(manifest, indent=2) + "\n")
+        for path in sorted(files):
+            archive.write(path, path.relative_to(build).as_posix())
+
+
+def unpack(archive_path, build, revision):
+    build = Path(build)
+    with zipfile.ZipFile(archive_path) as archive:
+        manifest = json.loads(archive.read(MANIFEST))
+        if manifest["revision"] != revision:
+            raise ValueError("Bundle source revision does not match the checkout revision")
+        if not manifest["tests"]:
+            raise ValueError("Bundle test inventory is empty")
+        for entry in archive.infolist():
+            name = entry.filename
+            path = PurePosixPath(name)
+            windows_path = PureWindowsPath(name)
+            if (path.is_absolute() or windows_path.drive or windows_path.root
+                    or "\\" in name or ":" in name
+                    or any(part in {"", ".", ".."} or part.endswith((".", " "))
+                           for part in name.rstrip("/").split("/"))
+                    or not (build / path).resolve().is_relative_to(build.resolve())):
+                raise ValueError(f"Unsafe archive path: {name}")
+        archive.extractall(build)
+    actual = discover_tests(build)
+    expected = sorted(manifest["tests"])
+    if actual != expected:
+        raise ValueError(f"CTest test inventory mismatch: expected {expected!r}, got {actual!r}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transfer a prebuilt Windows Release CTest tree")
+    commands = parser.add_subparsers(dest="command", required=True)
+    pack_parser = commands.add_parser("pack")
+    pack_parser.add_argument("--build", required=True, type=Path)
+    pack_parser.add_argument("--output", required=True, type=Path)
+    pack_parser.add_argument("--revision", required=True)
+    unpack_parser = commands.add_parser("unpack")
+    unpack_parser.add_argument("--archive", required=True, type=Path)
+    unpack_parser.add_argument("--build", required=True, type=Path)
+    unpack_parser.add_argument("--revision", required=True)
+    args = parser.parse_args()
+    if args.command == "pack":
+        pack(args.build, args.output, args.revision)
+    else:
+        unpack(args.archive, args.build, args.revision)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -63,6 +63,7 @@ jobs:
           python3 -m unittest discover -s opennow-qt/tests -p test_macos_build.py
           python3 -m unittest discover -s opennow-qt/tests -p test_windows_test_bundle.py
           python3 -m unittest discover -s opennow-qt/tests -p test_ci_build_cache.py
+          python3 -m unittest discover -s opennow-qt/tests -p test_ci_release_trust.py
       - name: Record immutable nightly identity
         id: version
         shell: bash
@@ -202,8 +203,14 @@ jobs:
 
       - name: Bound Windows Rust compilation
         if: runner.os == 'Windows'
-        shell: bash
-        run: echo "CARGO_BUILD_JOBS=4" >> "$GITHUB_ENV"
+        shell: pwsh
+        run: |
+          "CARGO_BUILD_JOBS=4" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          if ($env:VSCMD_ARG_TGT_ARCH -eq "x64") {
+            $linker = Join-Path $env:VCToolsInstallDir "bin\Hostx64\x64\link.exe"
+            if (-not (Test-Path $linker)) { throw "The MSVC x64 linker is unavailable." }
+            "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
 
       - name: Install Windows LLVM
         if: runner.os == 'Windows'
@@ -522,7 +529,6 @@ jobs:
     needs: windows-build
     uses: ./.github/workflows/qt-windows-desktop-tests.yml
     with:
-      source-sha: ${{ github.sha }}
       artifact-name: windows-x64-tests
 
   macos-validate:

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -14,10 +14,10 @@ on:
     paths:
       - ".github/workflows/qt-ci.yml"
       - ".github/workflows/qt-release-candidate.yml"
+      - ".github/workflows/qt-windows-desktop-tests.yml"
       - ".github/actionlint.yaml"
-      - ".github/scripts/ensure-windows-media-foundation.ps1"
-      - ".github/scripts/ensure-windows-test-desktop.ps1"
-      - ".github/scripts/diagnose-windows-hdr-test.ps1"
+      - ".github/actions/**"
+      - ".github/scripts/**"
       - "opennow-qt/**"
       - "native/opennow-core/**"
       - "native/opennow-streamer/**"
@@ -25,13 +25,16 @@ on:
       - "scripts/**"
       - "package.json"
   push:
+    branches:
+      - dev
+      - main
     paths:
       - ".github/workflows/qt-ci.yml"
       - ".github/workflows/qt-release-candidate.yml"
+      - ".github/workflows/qt-windows-desktop-tests.yml"
       - ".github/actionlint.yaml"
-      - ".github/scripts/ensure-windows-media-foundation.ps1"
-      - ".github/scripts/ensure-windows-test-desktop.ps1"
-      - ".github/scripts/diagnose-windows-hdr-test.ps1"
+      - ".github/actions/**"
+      - ".github/scripts/**"
       - "opennow-qt/**"
       - "native/opennow-core/**"
       - "native/opennow-streamer/**"
@@ -58,6 +61,8 @@ jobs:
           python3 -m unittest discover -s opennow-qt/tests -p test_release_metadata.py
           python3 -m unittest discover -s opennow-qt/tests -p test_nightly_release.py
           python3 -m unittest discover -s opennow-qt/tests -p test_macos_build.py
+          python3 -m unittest discover -s opennow-qt/tests -p test_windows_test_bundle.py
+          python3 -m unittest discover -s opennow-qt/tests -p test_ci_build_cache.py
       - name: Record immutable nightly identity
         id: version
         shell: bash
@@ -109,29 +114,21 @@ jobs:
             linuxdeploy-sha256: 620095110d693282b8ebeb244a95b5e911cf8f65f76c88b4b47d16ae6346fcff
             qt-plugin-sha256: bf1c24aff6d749b5cf423afad6f15abd4440f81dec1aab95706b25f6667cdcf1
             appimage-runtime-sha256: 00cbdfcf917cc6c0ff6d3347d59e0ca1f7f45a6df1a428a0d6d8a78664d87444
-          - label: windows-x64
-            os: windows-2025
-            build-parallel: 4
-            qt-host: windows
-            qt-arch: win64_msvc2022_64
-            package-generator: ZIP
-            rust-target: ""
-            cmake-arch: ""
           - label: windows-arm64
-            os: blacksmith-4vcpu-windows-2025
-            build-parallel: 4
+            os: blacksmith-8vcpu-windows-2025
+            build-parallel: 8
             qt-host: windows
             qt-arch: win64_msvc2022_arm64_cross_compiled
             package-generator: ZIP
             rust-target: aarch64-pc-windows-msvc
             cmake-arch: ARM64
 
-    env:
+    env: &native-build-env
       CARGO_TERM_COLOR: always
       SDL_VERSION: release-3.2.20
       OPENNOW_BUILD_VERSION: ${{ needs.metadata.outputs.version }}
 
-    steps:
+    steps: &native-build-steps
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -142,10 +139,10 @@ jobs:
         shell: pwsh
         run: .github/scripts/ensure-windows-media-foundation.ps1
 
-      - name: Verify Windows test desktop
-        if: matrix.label == 'windows-x64'
+      - name: Map stable Windows workspace
+        if: runner.os == 'Windows'
         shell: pwsh
-        run: .github/scripts/ensure-windows-test-desktop.ps1
+        run: .github/scripts/map-windows-workspace.ps1
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -197,11 +194,16 @@ jobs:
           Write-Host "Using Windows ARM64 compiler: $($compiler.FullName)"
           Write-Host "Using Windows ARM64 linker: $linker"
 
-      - name: Setup Windows ARM64 build tools
-        if: matrix.label == 'windows-arm64'
+      - name: Setup Windows build tools
+        if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: amd64_arm64
+          arch: ${{ matrix.label == 'windows-arm64' && 'amd64_arm64' || 'x64' }}
+
+      - name: Bound Windows Rust compilation
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "CARGO_BUILD_JOBS=4" >> "$GITHUB_ENV"
 
       - name: Install Windows LLVM
         if: runner.os == 'Windows'
@@ -291,39 +293,17 @@ jobs:
             native/opennow-streamer -> ../../build/opennow-qt-release/streamer-rust-target
 
       - name: Cache Qt C++ compilation
-        if: runner.os != 'Windows'
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
         with:
           key: qt-ci-${{ matrix.os }}-${{ matrix.label }}
-          max-size: 500M
+          max-size: 1G
 
-      - name: Cache SDL3 installation
-        id: sdl-cache
-        uses: actions/cache@v4
+      - name: Build and cache SDL3
+        uses: ./.github/actions/sdl3
         with:
-          path: ${{ runner.temp }}/SDL-install
-          key: qt-ci-sdl-v1-${{ matrix.os }}-${{ matrix.label }}-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-ci.yml') }}
-
-      - name: Build SDL3
-        if: steps.sdl-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
-          SDL_CMAKE_ARGS=()
-          if [[ "${{ runner.os }}" == "Windows" && -n "${{ matrix.cmake-arch }}" ]]; then
-            SDL_CMAKE_ARGS+=("-A" "${{ matrix.cmake-arch }}")
-          elif [[ -n "${{ matrix.cmake-arch }}" ]]; then
-            SDL_CMAKE_ARGS+=("-DCMAKE_OSX_ARCHITECTURES=${{ matrix.cmake-arch }}")
-          fi
-          cmake -S "$RUNNER_TEMP/SDL" -B "$RUNNER_TEMP/SDL-build" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DSDL_SHARED=ON \
-            -DSDL_STATIC=OFF \
-            -DSDL_TEST_LIBRARY=OFF \
-            -DSDL_TESTS=OFF \
-            "${SDL_CMAKE_ARGS[@]}"
-          cmake --build "$RUNNER_TEMP/SDL-build" --config Release --parallel "${{ matrix.build-parallel }}"
-          cmake --install "$RUNNER_TEMP/SDL-build" --config Release --prefix "$RUNNER_TEMP/SDL-install"
+          version: ${{ env.SDL_VERSION }}
+          target-arch: ${{ endsWith(matrix.label, 'arm64') && 'arm64' || 'x64' }}
+          parallel: ${{ matrix.build-parallel }}
 
       - name: Rust format and lint
         if: runner.os == 'Linux'
@@ -359,7 +339,8 @@ jobs:
             | sha256sum --check --strict
           tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
           "$RUNNER_TEMP/actionlint" -color=false \
-            .github/workflows/qt-ci.yml .github/workflows/qt-release-candidate.yml
+            .github/workflows/qt-ci.yml .github/workflows/qt-release-candidate.yml \
+            .github/workflows/qt-windows-desktop-tests.yml
 
       - name: Rust tests
         if: runner.os == 'Linux'
@@ -377,10 +358,12 @@ jobs:
         shell: bash
         run: |
           OPENNOW_CMAKE_ARGS=()
-          if [[ "${{ runner.os }}" == "Windows" && -n "${{ matrix.cmake-arch }}" ]]; then
-            OPENNOW_CMAKE_ARGS+=("-A" "${{ matrix.cmake-arch }}")
-          elif [[ -n "${{ matrix.cmake-arch }}" ]]; then
-            OPENNOW_CMAKE_ARGS+=("-DCMAKE_OSX_ARCHITECTURES=${{ matrix.cmake-arch }}")
+          if [[ "$RUNNER_OS" == Windows ]]; then
+            cd /o
+            OPENNOW_CMAKE_ARGS+=(-G "Ninja Multi-Config" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl)
+            if [[ "${{ matrix.cmake-arch }}" == ARM64 ]]; then
+              OPENNOW_CMAKE_ARGS+=(-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=ARM64)
+            fi
           fi
           if [[ -n "${{ matrix.rust-target }}" ]]; then
             OPENNOW_CMAKE_ARGS+=("-DOPENNOW_RUST_TARGET=${{ matrix.rust-target }}")
@@ -388,48 +371,49 @@ jobs:
           if [[ -n "${OPENNOW_QT_HOST_PATH:-}" ]]; then
             OPENNOW_CMAKE_ARGS+=("-DQT_HOST_PATH=${OPENNOW_QT_HOST_PATH}")
           fi
-          if [[ "${{ runner.os }}" != "Windows" ]]; then
-            OPENNOW_CMAKE_ARGS+=("-DCMAKE_C_COMPILER_LAUNCHER=ccache" "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
-          fi
           cmake -S opennow-qt -B build/opennow-qt-release \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DOPENNOW_BUILD_VERSION="$OPENNOW_BUILD_VERSION" \
             -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install" \
             "${OPENNOW_CMAKE_ARGS[@]}"
 
       - name: Build Qt release
         shell: bash
-        run: cmake --build build/opennow-qt-release --config Release --parallel "${{ matrix.build-parallel }}"
+        run: |
+          if [[ "$RUNNER_OS" == Windows ]]; then cd /o; fi
+          cmake --build build/opennow-qt-release --config Release --parallel "${{ matrix.build-parallel }}"
+
+      - name: Bundle Windows desktop tests
+        if: matrix.label == 'windows-x64'
+        shell: bash
+        run: |
+          python .github/scripts/windows-test-bundle.py pack \
+            --build O:/build/opennow-qt-release --output "$RUNNER_TEMP/windows-tests.zip" \
+            --revision "$GITHUB_SHA"
+
+      - name: Upload Windows desktop tests
+        if: matrix.label == 'windows-x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-x64-tests
+          path: ${{ runner.temp }}/windows-tests.zip
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
 
       - name: Test Qt shell
         id: qt-tests
-        if: matrix.label != 'windows-arm64'
+        if: runner.os != 'Windows'
         shell: bash
         run: ctest --test-dir build/opennow-qt-release -C Release --output-on-failure --parallel 4
-
-      - name: Diagnose Windows HDR test failure
-        if: failure() && matrix.label == 'windows-x64' && steps.qt-tests.outcome == 'failure'
-        timeout-minutes: 6
-        shell: pwsh
-        run: .github/scripts/diagnose-windows-hdr-test.ps1
-
-      - name: Preserve Windows HDR failure diagnostics
-        if: failure() && matrix.label == 'windows-x64' && steps.qt-tests.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-hdr-test-failure
-          retention-days: 7
-          path: |
-            build/windows-hdr-diagnostics/
-            build/opennow-qt-release/Testing/Temporary/LastTest.log
-            build/opennow-qt-release/Release/opennow-hdrcolor-tests.exe
-            build/opennow-qt-release/Release/opennow-hdrcolor-tests.pdb
 
       - name: Create unsigned validation package
         shell: bash
         env:
           PACKAGE_GENERATOR: ${{ matrix.package-generator }}
         run: |
+          if [[ "$RUNNER_OS" == Windows ]]; then cd /o; fi
           mkdir -p build/qt-packages
           cpack --config build/opennow-qt-release/CPackConfig.cmake \
             -C Release \
@@ -512,6 +496,35 @@ jobs:
           retention-days: 14
           compression-level: 0
 
+  windows-build:
+    name: windows-x64
+    needs: metadata
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - label: windows-x64
+            os: blacksmith-8vcpu-windows-2025
+            build-parallel: 8
+            qt-host: windows
+            qt-arch: win64_msvc2022_64
+            package-generator: ZIP
+            rust-target: ""
+            cmake-arch: ""
+            linuxdeploy-arch: ""
+            linuxdeploy-sha256: ""
+            qt-plugin-sha256: ""
+            appimage-runtime-sha256: ""
+    env: *native-build-env
+    steps: *native-build-steps
+
+  windows-desktop-tests:
+    needs: windows-build
+    uses: ./.github/workflows/qt-windows-desktop-tests.yml
+    with:
+      source-sha: ${{ github.sha }}
+      artifact-name: windows-x64-tests
+
   macos-validate:
     name: macos-arm64
     needs: metadata
@@ -550,24 +563,17 @@ jobs:
             native/opennow-streamer -> target
             native/opennow-core -> ../../build/opennow-qt-release/rust-target
             native/opennow-streamer -> ../../build/opennow-qt-release/streamer-rust-target
-      - name: Cache SDL3 installation
-        id: sdl-cache
-        uses: actions/cache@v4
+      - name: Cache Qt C++ compilation
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
         with:
-          path: ${{ runner.temp }}/SDL-install
-          key: qt-ci-sdl-v1-macos-arm64-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-ci.yml') }}
-      - name: Build SDL3
-        if: steps.sdl-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
-          cmake -S "$RUNNER_TEMP/SDL" -B "$RUNNER_TEMP/SDL-build" \
-            -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET" \
-            -DSDL_SHARED=ON -DSDL_STATIC=OFF -DSDL_FRAMEWORK=OFF \
-            -DSDL_TEST_LIBRARY=OFF -DSDL_TESTS=OFF
-          cmake --build "$RUNNER_TEMP/SDL-build" --parallel 3
-          cmake --install "$RUNNER_TEMP/SDL-build" --prefix "$RUNNER_TEMP/SDL-install"
+          key: qt-ci-macos-arm64
+          max-size: 1G
+      - name: Build and cache SDL3
+        uses: ./.github/actions/sdl3
+        with:
+          version: ${{ env.SDL_VERSION }}
+          target-arch: arm64
+          parallel: 3
       - name: Test macOS native contracts
         shell: bash
         run: |
@@ -581,6 +587,7 @@ jobs:
         run: |
           cmake -S opennow-qt -B build/opennow-qt-release \
             -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET" \
             -DOPENNOW_BUILD_VERSION="$OPENNOW_BUILD_VERSION" \
             -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install"
@@ -683,7 +690,7 @@ jobs:
 
   nightly-inventory:
     name: Verify complete nightly artifact set
-    needs: [metadata, localization, validate]
+    needs: [metadata, localization, validate, windows-build, windows-desktop-tests]
     runs-on: ubuntu-24.04
     env:
       RELEASE_VERSION: ${{ needs.metadata.outputs.version }}

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -45,12 +45,16 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
           [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          if [[ "$SOURCE_COMMIT" != "$GITHUB_SHA" ]]; then
+            echo "Dispatch this workflow from a branch or tag pointing to source_commit." >&2
+            exit 1
+          fi
           [[ $(printf '%s' "$UPDATE_PUBLIC_KEY" | base64 --decode | wc -c) -eq 32 ]]
 
       - name: Resolve immutable source
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.source_commit }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Record source commit
@@ -89,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.preflight.outputs.source_sha }}
+          ref: ${{ github.sha }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -238,7 +242,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.preflight.outputs.source_sha }}
+          ref: ${{ github.sha }}
 
       - name: Map stable Windows workspace
         shell: pwsh
@@ -273,6 +277,14 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch == 'arm64' && 'amd64_arm64' || 'x64' }}
+
+      - name: Pin the Windows x64 Rust linker
+        if: matrix.arch == 'x64'
+        shell: pwsh
+        run: |
+          $linker = Join-Path $env:VCToolsInstallDir "bin\Hostx64\x64\link.exe"
+          if (-not (Test-Path $linker)) { throw "The MSVC x64 linker is unavailable." }
+          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install LLVM
         shell: pwsh
@@ -456,7 +468,6 @@ jobs:
     needs: [preflight, windows]
     uses: ./.github/workflows/qt-windows-desktop-tests.yml
     with:
-      source-sha: ${{ needs.preflight.outputs.source_sha }}
       artifact-name: windows-release-x64-tests
 
   inventory:

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -129,22 +129,12 @@ jobs:
           key: qt-release-${{ matrix.runner }}-${{ matrix.arch }}
           max-size: 500M
 
-      - name: Cache SDL3 installation
-        id: sdl-cache
-        uses: actions/cache@v4
+      - name: Build and cache SDL3
+        uses: ./.github/actions/sdl3
         with:
-          path: ${{ runner.temp }}/SDL-install
-          key: qt-release-sdl-v1-${{ matrix.runner }}-${{ matrix.arch }}-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-release-candidate.yml') }}
-
-      - name: Build SDL3
-        if: steps.sdl-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
-          cmake -S "$RUNNER_TEMP/SDL" -B "$RUNNER_TEMP/SDL-build" -DCMAKE_BUILD_TYPE=Release \
-            -DSDL_SHARED=ON -DSDL_STATIC=OFF -DSDL_TEST_LIBRARY=OFF -DSDL_TESTS=OFF
-          cmake --build "$RUNNER_TEMP/SDL-build" --config Release --parallel 6
-          cmake --install "$RUNNER_TEMP/SDL-build" --config Release --prefix "$RUNNER_TEMP/SDL-install"
+          version: ${{ env.SDL_VERSION }}
+          target-arch: ${{ matrix.arch }}
+          parallel: 6
 
       - name: Configure, build, and test release
         shell: bash
@@ -229,8 +219,10 @@ jobs:
   windows:
     name: windows-${{ matrix.arch }}
     needs: preflight
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     environment: qt-production-release
+    env:
+      CARGO_BUILD_JOBS: 4
     strategy:
       fail-fast: false
       matrix:
@@ -247,6 +239,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.preflight.outputs.source_sha }}
+
+      - name: Map stable Windows workspace
+        shell: pwsh
+        run: .github/scripts/map-windows-workspace.ps1
 
       - name: Enable Windows Media Foundation
         shell: pwsh
@@ -334,27 +330,21 @@ jobs:
           key: qt-release-windows-2025-${{ matrix.arch }}
           cache-bin: false
           workspaces: |
-            native/opennow-core -> ../../build/qt-release/rust-target
-            native/opennow-streamer -> ../../build/qt-release/streamer-rust-target
+            native/opennow-core -> ../../build/opennow-qt-release/rust-target
+            native/opennow-streamer -> ../../build/opennow-qt-release/streamer-rust-target
 
-      - name: Cache SDL3 installation
-        id: sdl-cache
-        uses: actions/cache@v4
+      - name: Cache Qt C++ compilation
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
         with:
-          path: ${{ runner.temp }}/SDL-install
-          key: qt-release-sdl-v1-windows-2025-${{ matrix.arch }}-${{ env.SDL_VERSION }}-${{ hashFiles('.github/workflows/qt-release-candidate.yml') }}
+          key: qt-release-windows-2025-${{ matrix.arch }}
+          max-size: 1G
 
-      - name: Build SDL3
-        if: steps.sdl-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git clone --depth 1 --branch "$SDL_VERSION" https://github.com/libsdl-org/SDL.git "$RUNNER_TEMP/SDL"
-          args=()
-          if [[ -n "${{ matrix.cmake_arch }}" ]]; then args+=("-A" "${{ matrix.cmake_arch }}"); fi
-          cmake -S "$RUNNER_TEMP/SDL" -B "$RUNNER_TEMP/SDL-build" -DCMAKE_BUILD_TYPE=Release \
-            -DSDL_SHARED=ON -DSDL_STATIC=OFF -DSDL_TEST_LIBRARY=OFF -DSDL_TESTS=OFF "${args[@]}"
-          cmake --build "$RUNNER_TEMP/SDL-build" --config Release --parallel
-          cmake --install "$RUNNER_TEMP/SDL-build" --config Release --prefix "$RUNNER_TEMP/SDL-install"
+      - name: Build and cache SDL3
+        uses: ./.github/actions/sdl3
+        with:
+          version: ${{ env.SDL_VERSION }}
+          target-arch: ${{ matrix.arch }}
+          parallel: 8
 
       - name: Configure and build release
         shell: bash
@@ -362,20 +352,39 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
           UPDATE_PUBLIC_KEY: ${{ inputs.update_public_key }}
         run: |
-          args=()
-          if [[ -n "${{ matrix.cmake_arch }}" ]]; then args+=("-A" "${{ matrix.cmake_arch }}"); fi
+          cd /o
+          args=(-G "Ninja Multi-Config" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl)
+          if [[ "${{ matrix.cmake_arch }}" == ARM64 ]]; then
+            args+=(-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=ARM64)
+          fi
           if [[ -n "${{ matrix.rust_target }}" ]]; then args+=("-DOPENNOW_RUST_TARGET=${{ matrix.rust_target }}"); fi
           if [[ -n "${OPENNOW_QT_HOST_PATH:-}" ]]; then args+=("-DQT_HOST_PATH=${OPENNOW_QT_HOST_PATH}"); fi
-          cmake -S opennow-qt -B build/qt-release -DCMAKE_BUILD_TYPE=Release \
+          cmake -S opennow-qt -B build/opennow-qt-release -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install" \
             -DOPENNOW_BUILD_VERSION="$RELEASE_VERSION" \
             -DOPENNOW_UPDATE_ED25519_PUBLIC_KEY="$UPDATE_PUBLIC_KEY" "${args[@]}"
-          cmake --build build/qt-release --config Release --parallel
+          cmake --build build/opennow-qt-release --config Release --parallel 8
 
-      - name: Test native x64 release
+      - name: Bundle Windows desktop tests
         if: matrix.arch == 'x64'
         shell: bash
-        run: ctest --test-dir build/qt-release -C Release --output-on-failure --parallel 4
+        env:
+          SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
+        run: |
+          python .github/scripts/windows-test-bundle.py pack \
+            --build O:/build/opennow-qt-release --output "$RUNNER_TEMP/windows-tests.zip" \
+            --revision "$SOURCE_SHA"
+
+      - name: Upload Windows desktop tests
+        if: matrix.arch == 'x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-release-x64-tests
+          path: ${{ runner.temp }}/windows-tests.zip
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
 
       - name: Authenticode-sign application binaries
         shell: pwsh
@@ -387,7 +396,7 @@ jobs:
           . ./opennow-qt/packaging/windows-release.ps1
           $pfx = Join-Path $env:RUNNER_TEMP "opennow-signing.pfx"
           [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_PFX_BASE64))
-          $files = @(Get-OpenNowReleaseBinaries -Root build/qt-release/Release)
+          $files = @(Get-OpenNowReleaseBinaries -Root build/opennow-qt-release/Release)
           foreach ($file in $files) {
             Invoke-OpenNowSignTool sign /f $pfx /p $env:WINDOWS_PFX_PASSWORD /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $file.FullName
             Invoke-OpenNowSignTool verify /pa /all $file.FullName
@@ -402,9 +411,9 @@ jobs:
           $ErrorActionPreference = "Stop"
           . ./opennow-qt/packaging/windows-release.ps1
           New-Item -ItemType Directory -Force build/release-artifacts | Out-Null
-          cpack --config build/qt-release/CPackConfig.cmake -C Release -G WIX -B build/release-artifacts
+          cpack --config build/opennow-qt-release/CPackConfig.cmake -C Release -G WIX -B build/release-artifacts
           if ($LASTEXITCODE -ne 0) { throw "MSI packaging failed with exit code $LASTEXITCODE" }
-          cpack --config build/qt-release/CPackConfig.cmake -C Release -G ZIP -B build/release-artifacts
+          cpack --config build/opennow-qt-release/CPackConfig.cmake -C Release -G ZIP -B build/release-artifacts
           if ($LASTEXITCODE -ne 0) { throw "ZIP packaging failed with exit code $LASTEXITCODE" }
           $pfx = Join-Path $env:RUNNER_TEMP "opennow-signing.pfx"
           $msi = Get-ChildItem build/release-artifacts -Filter *.msi
@@ -414,12 +423,12 @@ jobs:
           $msiExpanded = Join-Path $env:RUNNER_TEMP "msi-expanded"
           $process = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/a `"$($msi.FullName)`" /qn TARGETDIR=`"$msiExpanded`""
           if ($process.ExitCode -ne 0) { throw "MSI administrative extraction failed" }
-          Assert-OpenNowSignedPackage -Root $msiExpanded -SignedRoot build/qt-release/Release
+          Assert-OpenNowSignedPackage -Root $msiExpanded -SignedRoot build/opennow-qt-release/Release
           $zip = Get-ChildItem build/release-artifacts -Filter *.zip
           if ($zip.Count -ne 1) { throw "Expected one portable ZIP" }
           $expanded = Join-Path $env:RUNNER_TEMP "portable"
           Expand-Archive $zip.FullName $expanded
-          Assert-OpenNowSignedPackage -Root $expanded -SignedRoot build/qt-release/Release
+          Assert-OpenNowSignedPackage -Root $expanded -SignedRoot build/opennow-qt-release/Release
 
       - name: Record artifact checksums
         shell: pwsh
@@ -443,11 +452,18 @@ jobs:
             build/release-artifacts/SHA256SUMS
           if-no-files-found: error
 
+  windows-desktop-tests:
+    needs: [preflight, windows]
+    uses: ./.github/workflows/qt-windows-desktop-tests.yml
+    with:
+      source-sha: ${{ needs.preflight.outputs.source_sha }}
+      artifact-name: windows-release-x64-tests
+
   inventory:
     name: isolated-update-signing-and-inventory
     runs-on: [self-hosted, opennow-release-signer]
     environment: qt-update-signing
-    needs: [preflight, linux, windows]
+    needs: [preflight, linux, windows, windows-desktop-tests]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/qt-windows-desktop-tests.yml
+++ b/.github/workflows/qt-windows-desktop-tests.yml
@@ -1,0 +1,82 @@
+name: Qt Windows desktop tests
+
+on:
+  workflow_call:
+    inputs:
+      source-sha:
+        type: string
+        required: true
+      artifact-name:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  desktop-tests:
+    name: windows-x64-desktop-tests
+    runs-on: windows-2025
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source-sha }}
+      - name: Map stable Windows workspace
+        shell: pwsh
+        run: .github/scripts/map-windows-workspace.ps1
+      - name: Enable Windows Media Foundation
+        shell: pwsh
+        run: .github/scripts/ensure-windows-media-foundation.ps1
+      - name: Verify Windows test desktop
+        shell: pwsh
+        run: .github/scripts/ensure-windows-test-desktop.ps1
+      - name: Install Qt test dependencies
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.3"
+          host: windows
+          target: desktop
+          arch: win64_msvc2022_64
+          modules: qtmultimedia qtshadertools
+          cache: true
+          cache-key-prefix: qt-target-windows-x64
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ runner.temp }}/windows-tests
+      - name: Restore compiled tests and verify inventory
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source-sha }}
+        run: |
+          python .github/scripts/windows-test-bundle.py unpack \
+            --archive "$RUNNER_TEMP/windows-tests/windows-tests.zip" \
+            --build O:/build/opennow-qt-release --revision "$SOURCE_SHA"
+      - name: Test Qt shell
+        id: qt-tests
+        shell: bash
+        run: ctest --test-dir O:/build/opennow-qt-release -C Release --output-on-failure --no-tests=error --parallel 4
+      - name: Install Windows diagnostic tools
+        if: failure() && steps.qt-tests.outcome == 'failure'
+        shell: pwsh
+        run: |
+          choco install llvm -y --no-progress
+          "$env:ProgramFiles\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Diagnose Windows HDR test failure
+        if: failure() && steps.qt-tests.outcome == 'failure'
+        timeout-minutes: 6
+        shell: pwsh
+        run: .github/scripts/diagnose-windows-hdr-test.ps1
+      - name: Preserve Windows test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-hdr-test-failure
+          retention-days: 7
+          path: |
+            build/windows-hdr-diagnostics/
+            build/opennow-qt-release/Testing/Temporary/
+            build/opennow-qt-release/Release/opennow-hdrcolor-tests.exe
+            build/opennow-qt-release/Release/opennow-hdrcolor-tests.pdb
+

--- a/.github/workflows/qt-windows-desktop-tests.yml
+++ b/.github/workflows/qt-windows-desktop-tests.yml
@@ -3,9 +3,6 @@ name: Qt Windows desktop tests
 on:
   workflow_call:
     inputs:
-      source-sha:
-        type: string
-        required: true
       artifact-name:
         type: string
         required: true
@@ -21,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.source-sha }}
+          ref: ${{ github.sha }}
       - name: Map stable Windows workspace
         shell: pwsh
         run: .github/scripts/map-windows-workspace.ps1
@@ -48,7 +45,7 @@ jobs:
       - name: Restore compiled tests and verify inventory
         shell: bash
         env:
-          SOURCE_SHA: ${{ inputs.source-sha }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
           python .github/scripts/windows-test-bundle.py unpack \
             --archive "$RUNNER_TEMP/windows-tests/windows-tests.zip" \
@@ -79,4 +76,3 @@ jobs:
             build/opennow-qt-release/Testing/Temporary/
             build/opennow-qt-release/Release/opennow-hdrcolor-tests.exe
             build/opennow-qt-release/Release/opennow-hdrcolor-tests.pdb
-

--- a/docs/ci-performance.md
+++ b/docs/ci-performance.md
@@ -1,0 +1,74 @@
+# Qt CI performance and runner budget
+
+`qt-ci` runs on pull requests targeting `dev` or `main`, pushes to those two
+branches, and manual dispatches. Feature-branch pushes do not start a second
+copy of the pull-request matrix. Open a PR or dispatch the workflow to validate
+a feature branch. Superseded push/PR runs are cancelled; manual runs remain
+independent.
+
+## Windows builds and desktop tests
+
+Windows x64 and ARM64 compilation uses 8-vCPU Blacksmith Windows 2025 runners,
+MSVC, and Ninja Multi-Config. CMake is limited to eight build jobs and each Cargo
+invocation to four jobs, since the native core and streamer can build together.
+The existing Linux and macOS runner sizes are unchanged.
+
+Windows x64 tests run on an interactive GitHub-hosted `windows-2025` desktop.
+The build job uploads only the Release runtime and generated CTest files, not
+the Cargo targets or compiler objects. The desktop job does not rebuild. Both
+jobs map their checkout to `O:` so compiled-in fixture paths and generated test
+commands stay valid. The bundle records the source revision and complete test
+inventory; a different revision, empty inventory, or changed inventory fails
+the handoff. All CTest tests run, including native-window/HDR tests, and failures
+preserve diagnostics. Windows ARM64 remains cross-built, not runtime-tested.
+
+The x64 build is a separate job using the same anchored build steps as the
+matrix, so its desktop tests can start without waiting for Linux or ARM64.
+Unsigned nightly inventory and signed release inventory both require the
+desktop tests to pass. Signed release builds use the same transfer and test
+workflow, with the immutable release source revision.
+
+## Caches
+
+- C++ compiler caches are bounded to 1 GB per CI platform/architecture and per
+  Windows release architecture. The existing Linux release cache stays at
+  500 MB. Windows uses Ninja because CMake's compiler-launcher integration does
+  not apply to the Visual Studio generator. macOS now uses a compiler cache too.
+- Nightly version definitions apply only to the two C++ sources that consume
+  them. A new nightly identity no longer invalidates every application object.
+- SDL installations use one shared build recipe. Keys include the SDL release,
+  host and target architecture, compiler/CMake identity, macOS deployment
+  target, and recipe hash. Unrelated workflow edits no longer evict SDL, while
+  toolchain or recipe changes still invalidate it.
+- Rust dependency/build caching and Qt SDK caching remain enabled. The Windows
+  test-transfer artifact expires after one day; compiler caches do not retain
+  the transferred test archive.
+
+[Blacksmith's standard cache](https://docs.blacksmith.sh/blacksmith-caching/dependencies-actions)
+automatically accelerates upstream cache actions. There are no paid sticky
+disks or archived Blacksmith-specific action forks in this setup. Keep
+Blacksmith's branch-protected cache setting enabled, especially for release
+builds; this workflow does not change account settings.
+
+## Measuring the change
+
+The first run after a compiler, cache-key, or recipe change can be cold. Compare
+successful runs after the caches have been populated, checking the CCache
+Statistics job summaries, Rust build times, bundle transfer, and desktop-test
+duration. Do not infer end-to-end savings from compilation alone.
+
+Doubling runner cores doubles the per-minute usage rate, so it is only
+usage-neutral when the job time halves. Keep Windows at eight cores unless
+measured end-to-end savings justify another change under the sponsorship.
+
+Local checks for the transfer and cache contracts:
+
+```sh
+python3 -m unittest discover -s opennow-qt/tests -p test_windows_test_bundle.py
+python3 -m unittest discover -s opennow-qt/tests -p test_ci_build_cache.py
+actionlint .github/workflows/qt-ci.yml .github/workflows/qt-release-candidate.yml \
+  .github/workflows/qt-windows-desktop-tests.yml
+```
+
+The native Windows build, desktop tests, and packaging still need Windows CI.
+Production signing is not exercised by ordinary PR validation.

--- a/docs/ci-performance.md
+++ b/docs/ci-performance.md
@@ -27,6 +27,10 @@ matrix, so its desktop tests can start without waiting for Linux or ARM64.
 Unsigned nightly inventory and signed release inventory both require the
 desktop tests to pass. Signed release builds use the same transfer and test
 workflow, with the immutable release source revision.
+Release dispatches must select a branch or tag pointing to `source_commit`;
+preflight rejects a different revision. Build and desktop-test jobs check out
+the workflow's immutable `github.sha`, not an independently supplied ref, so a
+dispatch input cannot select code that writes into the caller's cache scope.
 
 ## Caches
 

--- a/opennow-qt/CMakeLists.txt
+++ b/opennow-qt/CMakeLists.txt
@@ -97,8 +97,9 @@ target_compile_definitions(opennow-qt PRIVATE
     QT_NO_CAST_FROM_ASCII
     QT_NO_CAST_TO_ASCII
     OPENNOW_EMBEDDED_STREAMER
-    OPENNOW_VERSION="${OPENNOW_BUILD_VERSION}"
 )
+set_source_files_properties(src/app/ApplicationStartup.cpp src/core/CoreClient.cpp
+    PROPERTIES COMPILE_DEFINITIONS "OPENNOW_VERSION=\"${OPENNOW_BUILD_VERSION}\"")
 
 include(cmake/NativeRuntime.cmake)
 

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -264,7 +264,6 @@ if(BUILD_TESTING)
     )
     target_include_directories(opennow-coreclient-tests PRIVATE src)
     target_link_libraries(opennow-coreclient-tests PRIVATE Qt6::Test Qt6::Core)
-    target_compile_definitions(opennow-coreclient-tests PRIVATE OPENNOW_VERSION="${OPENNOW_BUILD_VERSION}")
     add_dependencies(opennow-coreclient-tests opennow-fake-core)
     add_test(NAME opennow-coreclient-tests COMMAND opennow-coreclient-tests -o -,txt)
 

--- a/opennow-qt/tests/test_ci_build_cache.py
+++ b/opennow-qt/tests/test_ci_build_cache.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import time
+import unittest
+
+
+CMAKE_FILE = Path(__file__).resolve().parents[1] / "CMakeLists.txt"
+
+
+class CIBuildCacheTest(unittest.TestCase):
+    def run_command(self, *command):
+        result = subprocess.run(command, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result.stdout
+
+    def test_nightly_version_only_rebuilds_version_consumers(self):
+        statements = [
+            statement for statement in re.findall(
+                r"set_source_files_properties\s*\([^)]*\)", CMAKE_FILE.read_text()
+            )
+            if "OPENNOW_VERSION" in statement
+        ]
+        self.assertEqual(len(statements), 1, "Expected one source-specific OPENNOW_VERSION definition")
+        statement = statements[0]
+        self.assertIn("src/app/ApplicationStartup.cpp", statement)
+        self.assertIn("src/core/CoreClient.cpp", statement)
+        self.assertIn("${OPENNOW_BUILD_VERSION}", statement)
+
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source"
+            build = Path(directory) / "build"
+            files = {
+                "CMakeLists.txt": (
+                    "cmake_minimum_required(VERSION 3.24)\n"
+                    "project(BuildCacheContract LANGUAGES CXX)\n"
+                    "add_executable(cache-app main.cpp unrelated.cpp "
+                    "src/app/ApplicationStartup.cpp src/core/CoreClient.cpp)\n"
+                    "add_executable(cache-core-test test_main.cpp unrelated.cpp src/core/CoreClient.cpp)\n"
+                    + statement + "\n"
+                    'file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/executables.txt" CONTENT '
+                    '"$<TARGET_FILE:cache-app>\n$<TARGET_FILE:cache-core-test>\n")\n'
+                ),
+                "src/app/ApplicationStartup.cpp": (
+                    "const char *app_version() { return OPENNOW_VERSION; }\n"
+                ),
+                "src/core/CoreClient.cpp": (
+                    "const char *core_version() { return OPENNOW_VERSION; }\n"
+                ),
+                "unrelated.cpp": (
+                    "#ifdef OPENNOW_VERSION\n"
+                    '#error "Version definition leaked into an unrelated source"\n'
+                    "#endif\n"
+                    'const char *unrelated() { return "unrelated"; }\n'
+                ),
+                "main.cpp": (
+                    "#include <iostream>\n"
+                    "const char *app_version();\n"
+                    "const char *core_version();\n"
+                    "const char *unrelated();\n"
+                    "int main() { std::cout << app_version() << '\\n' "
+                    "<< core_version() << '\\n' << unrelated() << '\\n'; }\n"
+                ),
+                "test_main.cpp": (
+                    "#include <iostream>\n"
+                    "const char *core_version();\n"
+                    "const char *unrelated();\n"
+                    "int main() { std::cout << core_version() << '\\n' "
+                    "<< unrelated() << '\\n'; }\n"
+                ),
+            }
+            for name, content in files.items():
+                path = source / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content)
+
+            original_mtimes = None
+            for version in ("1.0.0-nightly.123.1", "1.0.0-nightly.124.1"):
+                with self.subTest(version=version):
+                    self.run_command(
+                        "cmake", "-S", str(source), "-B", str(build), "-G", "Ninja",
+                        "-DCMAKE_BUILD_TYPE=Release", f"-DOPENNOW_BUILD_VERSION={version}",
+                    )
+                    self.run_command("cmake", "--build", str(build))
+                    app, core_test = (build / "executables.txt").read_text().splitlines()
+                    self.assertEqual(self.run_command(app).splitlines(), [version, version, "unrelated"])
+                    self.assertEqual(self.run_command(core_test).splitlines(), [version, "unrelated"])
+                    objects = sorted(
+                        path for path in build.rglob("unrelated.cpp.*")
+                        if path.suffix in {".o", ".obj"}
+                    )
+                    self.assertEqual(len(objects), 2, "Expected an unrelated object for each target")
+                    mtimes = {path: path.stat().st_mtime_ns for path in objects}
+                    if original_mtimes is None:
+                        original_mtimes = mtimes
+                        time.sleep(1.1)
+                    else:
+                        self.assertEqual(mtimes, original_mtimes, "Nightly version rebuilt unrelated sources")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opennow-qt/tests/test_ci_release_trust.py
+++ b/opennow-qt/tests/test_ci_release_trust.py
@@ -1,0 +1,54 @@
+import base64
+import os
+from pathlib import Path
+import subprocess
+import textwrap
+import unittest
+
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github/workflows"
+
+
+class CIReleaseTrustTest(unittest.TestCase):
+    def validate(self, source_commit, workflow_sha):
+        workflow = (WORKFLOWS / "qt-release-candidate.yml").read_text()
+        step = workflow.split("      - name: Validate release inputs\n", 1)[1]
+        step = step.split("      - name:", 1)[0]
+        script = textwrap.dedent(step.split("        run: |\n", 1)[1])
+        return subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", script],
+            env={
+                **os.environ,
+                "RELEASE_VERSION": "1.0.0",
+                "SOURCE_COMMIT": source_commit,
+                "GITHUB_SHA": workflow_sha,
+                "UPDATE_PUBLIC_KEY": base64.b64encode(bytes(32)).decode(),
+            },
+            capture_output=True,
+            text=True,
+        )
+
+    def test_dispatched_revision_is_accepted(self):
+        result = self.validate("a" * 40, "a" * 40)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_independent_revision_is_rejected(self):
+        result = self.validate("a" * 40, "b" * 40)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("branch or tag pointing to source_commit", result.stderr)
+
+    def test_non_sha_revision_is_rejected(self):
+        result = self.validate("dev", "a" * 40)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_release_checkouts_do_not_use_input_refs(self):
+        for name in ("qt-release-candidate.yml", "qt-windows-desktop-tests.yml"):
+            with self.subTest(workflow=name):
+                refs = [line.strip() for line in (WORKFLOWS / name).read_text().splitlines()
+                        if line.strip().startswith("ref:")]
+                self.assertTrue(refs)
+                self.assertEqual(set(refs), {"ref: ${{ github.sha }}"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opennow-qt/tests/test_windows_test_bundle.py
+++ b/opennow-qt/tests/test_windows_test_bundle.py
@@ -1,0 +1,159 @@
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+import zipfile
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / ".github/scripts/windows-test-bundle.py"
+SPEC = importlib.util.spec_from_file_location("windows_test_bundle", SCRIPT)
+bundle = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bundle)
+
+
+class WindowsTestBundleTest(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.build = self.root / "original"
+        self.destination = self.root / "restored"
+        self.archive = self.root / "bundle.zip"
+        self.revision = "0123456789abcdef"
+        self.tests = ["embedded-orchestration", "stream-input"]
+        self.files = {
+            "Release/OpenNOW.exe": b"application\x00",
+            "Release/tst_streaminput.exe": b"test executable",
+            "Release/Qt6Core.dll": b"runtime library",
+            "Release/OpenNOW.pdb": b"debug symbols",
+            "Release/platforms/qwindows.dll": b"platform plugin",
+            "Release/qml/OpenNOW/qmldir": b"module OpenNOW",
+            "Release/resources/shader.bin": b"\x00\xff\x01",
+            "CTestTestfile.cmake": (
+                b'add_test(stream-input "O:/build/opennow-qt-release/Release/tst_streaminput.exe")\n'
+                b'subdirs("nested")\n'
+            ),
+            "nested/CTestTestfile.cmake": b"# generated nested test configuration\n",
+        }
+        for name, data in self.files.items():
+            self.write(name, data)
+        for name in (
+            "CMakeCache.txt", "build.ninja", "object.obj", "Debug/OpenNOW.exe",
+            "rust-target/CTestTestfile.cmake",
+            "streamer-rust-target/nested/CTestTestfile.cmake",
+            "nested/target/CTestTestfile.cmake",
+        ):
+            self.write(name, b"not bundled")
+        self.run = patch.object(bundle.subprocess, "run").start()
+        self.addCleanup(patch.stopall)
+        self.discovery(self.tests)
+
+    def write(self, name, data):
+        path = self.build / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+    def discovery(self, names):
+        self.run.return_value = subprocess.CompletedProcess(
+            [], 0, stdout=json.dumps({"tests": [{"name": name} for name in names]})
+        )
+
+    def pack(self):
+        bundle.pack(self.build, self.archive, self.revision)
+
+    def unpack(self):
+        bundle.unpack(self.archive, self.destination, self.revision)
+
+    def test_round_trip_preserves_all_runtime_files_and_generated_commands(self):
+        self.pack()
+        with zipfile.ZipFile(self.archive) as archive:
+            self.assertEqual(set(archive.namelist()), set(self.files) | {bundle.MANIFEST})
+            manifest = json.loads(archive.read(bundle.MANIFEST))
+            self.assertEqual(manifest, {"revision": self.revision, "tests": self.tests})
+        self.discovery(list(reversed(self.tests)))
+        self.unpack()
+        for name, data in self.files.items():
+            with self.subTest(name=name):
+                self.assertEqual((self.destination / name).read_bytes(), data)
+        self.assertEqual(self.run.call_count, 2)
+        for call, build in zip(self.run.call_args_list, [self.build, self.destination]):
+            self.assertEqual(call.args[0], [
+                "ctest", "--test-dir", str(build), "-C", "Release", "--show-only=json-v1",
+            ])
+            self.assertEqual(call.kwargs, {"check": True, "capture_output": True, "text": True})
+
+    def test_source_mismatch_is_rejected_before_extraction_or_discovery(self):
+        self.pack()
+        self.run.reset_mock()
+        with self.assertRaisesRegex(ValueError, "source revision"):
+            bundle.unpack(self.archive, self.destination, "different-revision")
+        self.assertFalse(self.destination.exists())
+        self.run.assert_not_called()
+
+    def test_empty_discovery_cannot_be_packed(self):
+        self.discovery([])
+        with self.assertRaisesRegex(ValueError, "no tests"):
+            self.pack()
+        self.assertFalse(self.archive.exists())
+
+    def test_empty_discovery_after_unpack_is_rejected(self):
+        self.pack()
+        self.discovery([])
+        with self.assertRaisesRegex(ValueError, "no tests"):
+            self.unpack()
+
+    def test_empty_manifest_inventory_is_rejected_before_extraction(self):
+        with zipfile.ZipFile(self.archive, "w") as archive:
+            archive.writestr(bundle.MANIFEST, json.dumps({"revision": self.revision, "tests": []}))
+        self.run.reset_mock()
+        with self.assertRaisesRegex(ValueError, "inventory is empty"):
+            self.unpack()
+        self.assertFalse(self.destination.exists())
+        self.run.assert_not_called()
+
+    def test_inventory_mismatch_is_rejected(self):
+        self.pack()
+        for names in (self.tests[:1], self.tests + ["extra"], ["renamed", self.tests[1]]):
+            with self.subTest(names=names):
+                self.discovery(names)
+                with self.assertRaisesRegex(ValueError, "inventory mismatch"):
+                    self.unpack()
+
+    def test_unsafe_archive_paths_are_rejected_before_any_extraction(self):
+        for name in (
+            "../escaped.txt", "Release/../../escaped.txt", "/absolute.txt",
+            "C:/absolute.txt", "C:relative.txt", "\\\\server\\share\\file",
+            "Release\\..\\escaped.txt", "Release/.. /escaped.txt",
+        ):
+            with self.subTest(name=name):
+                self.pack()
+                with zipfile.ZipFile(self.archive, "a") as archive:
+                    archive.writestr(name, "unsafe")
+                self.run.reset_mock()
+                with self.assertRaisesRegex(ValueError, "Unsafe archive path"):
+                    self.unpack()
+                self.assertFalse(self.destination.exists())
+                self.assertFalse((self.root / "escaped.txt").exists())
+                self.run.assert_not_called()
+
+    def test_ctest_failure_is_not_ignored(self):
+        self.run.side_effect = subprocess.CalledProcessError(1, "ctest")
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.pack()
+        self.assertFalse(self.archive.exists())
+
+    def test_missing_root_ctest_file_is_rejected(self):
+        (self.build / "CTestTestfile.cmake").unlink()
+        with self.assertRaisesRegex(ValueError, "root CTestTestfile"):
+            self.pack()
+
+    def test_missing_runtime_directory_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Release runtime"):
+            bundle.pack(self.root / "missing", self.archive, self.revision)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes

- Run Windows x64/ARM64 compilation on 8-vCPU Blacksmith runners using MSVC and Ninja Multi-Config, with eight CMake jobs and four jobs per Cargo invocation. Keep the full interactive x64 CTest suite on GitHub's Windows desktop, transferring the compiled binaries rather than rebuilding. Verify the source revision and exact test inventory; retain HDR failure diagnostics and gate nightly/release inventory on desktop-test success.
- Add bounded Windows and macOS C++ compiler caches. Limit the nightly version macro to its two source consumers so a new nightly identity does not invalidate the entire application cache.
- Share the SDL recipe across CI and releases, with cache keys based on SDL version, recipe, target, compiler/CMake identity, and macOS deployment target—not the whole workflow. Use upstream cache actions accelerated automatically by Blacksmith, without paid sticky disks or larger Linux/macOS runners.
- Restrict push builds to `dev`/`main`, retaining PR/manual validation without duplicate feature-branch push matrices.

Windows x64 has its own build dependency while sharing the matrix's steps through YAML anchors, so desktop tests can start without waiting for other platforms. Production signing is unchanged; signed release inventory also requires the shared desktop-test workflow. Release dispatches must select a branch/tag whose SHA equals `source_commit`; preflight rejects a mismatch, and release/test checkouts use the workflow SHA rather than an independently supplied ref. MSVC x64 Rust linking is pinned explicitly to avoid Git Bash’s unrelated `link.exe`.

## Verification

- Actionlint 1.7.12 with ShellCheck passes for all three affected workflows.
- 34 Python regression tests pass: release metadata, nightly inventory, macOS build contracts, Windows bundle transfer, nightly compile-cache invalidation, and release-source trust.
- Real CMake/Ninja cache regression builds verify two nightly versions and unchanged unrelated object timestamps, including a second target sharing CoreClient.
- SDL command fixtures pass for Linux x64/ARM64, Windows x64/ARM64, and macOS ARM64, covering compiler flags, target selection, install paths, and bounded parallelism.
- `git diff --check` passes.
- Native Windows compilation, packaging, binary transfer, and full desktop CTest execution await PR CI. Production signing is not exercised by PR validation. First runs may be cold; measured speedup requires successful warm-cache runs.

See `docs/ci-performance.md` for the runner budget and cache/test policy.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M22YQF1CF3FQXHTKP2EWWJ9W"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->