### PR TITLE
ci(qt): separate native platform checks from manual packaging

### DIFF
--- a/.github/actions/qt-unit-tests/action.yml
+++ b/.github/actions/qt-unit-tests/action.yml
@@ -1,0 +1,136 @@
+name: Qt and Rust unit tests
+description: Run native platform checks without compiling or packaging the desktop application
+inputs:
+  label:
+    description: Platform cache identity
+    required: true
+  qt-host:
+    description: Qt installer host
+    required: true
+  qt-arch:
+    description: Qt installer architecture
+    required: true
+  target-arch:
+    description: SDL target architecture
+    required: true
+  parallel:
+    description: Maximum concurrent build jobs
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Prepare Windows test desktop
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        .github/scripts/map-windows-workspace.ps1
+        .github/scripts/ensure-windows-media-foundation.ps1
+        .github/scripts/ensure-windows-test-desktop.ps1
+    - name: Setup Windows build tools
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+    - name: Install Windows native test dependencies
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        choco install llvm nasm -y --no-progress
+        $llvmBin = Join-Path $env:ProgramFiles "LLVM\bin"
+        if (-not (Test-Path (Join-Path $llvmBin "libclang.dll"))) {
+          throw "LLVM installation is missing libclang.dll"
+        }
+        $llvmBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        (Join-Path $env:ProgramFiles "NASM") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        "LIBCLANG_PATH=$llvmBin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        $linker = Join-Path $env:VCToolsInstallDir "bin\Hostx64\x64\link.exe"
+        if (-not (Test-Path $linker)) { throw "MSVC linker is unavailable" }
+        "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
+    - name: Check Rust formatting
+      shell: bash
+      working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      run: |
+        cargo fmt --manifest-path native/opennow-core/Cargo.toml -- --check
+        cargo fmt --manifest-path native/opennow-streamer/Cargo.toml --all -- --check
+    - name: Install Linux test dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          clang libclang-dev libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev libgl1-mesa-dev \
+          libpulse-dev libsecret-1-dev libva-dev libvulkan-dev libwayland-dev \
+          libx11-dev libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcursor-dev libxext-dev libxfixes-dev \
+          libxi-dev libxkbcommon-dev libxkbcommon-x11-0 libxrandr-dev libxrender-dev libxss-dev \
+          mesa-vulkan-drivers nasm ninja-build pkg-config wayland-protocols xvfb
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+      with:
+        key: qt-checks-${{ inputs.label }}
+        cache-bin: false
+        workspaces: |
+          native/opennow-core -> target
+          native/opennow-streamer -> target
+    - name: Lint Rust
+      shell: bash
+      working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      run: |
+        cargo clippy --locked --manifest-path native/opennow-core/Cargo.toml --all-targets -- -D warnings
+        cargo clippy --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace --all-targets -- -D warnings
+    - name: Test Rust
+      shell: bash
+      working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      run: |
+        cargo test --locked --manifest-path native/opennow-core/Cargo.toml
+        cargo test --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: "6.8.3"
+        host: ${{ inputs.qt-host }}
+        target: desktop
+        arch: ${{ inputs.qt-arch }}
+        modules: qtmultimedia qtshadertools
+        cache: true
+        cache-key-prefix: qt-target-${{ inputs.label }}
+    - uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
+      with:
+        key: qt-checks-${{ inputs.label }}
+        max-size: 1G
+    - name: Build and cache SDL3 test dependency
+      uses: ./.github/actions/sdl3
+      with:
+        version: release-3.2.20
+        target-arch: ${{ inputs.target-arch }}
+        parallel: ${{ inputs.parallel }}
+    - name: Check QML syntax
+      shell: bash
+      working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      run: find opennow-qt/qml -name '*.qml' -print0 | xargs -0 -n1 "$QT_ROOT_DIR/bin/qmlformat" > /dev/null
+    - name: Compile Qt unit tests only
+      shell: bash
+      working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      env:
+        BUILD_PARALLEL: ${{ inputs.parallel }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
+      run: |
+        args=()
+        if [[ "$RUNNER_OS" == Windows ]]; then
+          args+=(-DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl)
+        elif [[ "$RUNNER_OS" == macOS ]]; then
+          args+=("-DCMAKE_OSX_ARCHITECTURES=$TARGET_ARCH" "-DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET")
+        fi
+        cmake -S opennow-qt -B build/opennow-qt-checks -G Ninja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install" "${args[@]}"
+        cmake --build build/opennow-qt-checks --target opennow-ci-unit-tests --parallel "$BUILD_PARALLEL"
+    - name: Run Qt unit tests
+      shell: bash
+      working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      env:
+        BUILD_PARALLEL: ${{ inputs.parallel }}
+      run: ctest --test-dir build/opennow-qt-checks --output-on-failure --no-tests=error -L ci-unit --parallel "$BUILD_PARALLEL"

--- a/.github/actions/qt-unit-tests/action.yml
+++ b/.github/actions/qt-unit-tests/action.yml
@@ -19,13 +19,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Prepare Windows test desktop
+    - name: Prepare Windows test dependencies
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
         .github/scripts/map-windows-workspace.ps1
         .github/scripts/ensure-windows-media-foundation.ps1
-        .github/scripts/ensure-windows-test-desktop.ps1
     - name: Setup Windows build tools
       if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@v1
@@ -69,8 +68,9 @@ runs:
           mesa-vulkan-drivers nasm ninja-build pkg-config wayland-protocols xvfb
     - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
       with:
-        key: qt-checks-${{ inputs.label }}
+        shared-key: qt-checks-${{ inputs.label }}
         cache-bin: false
+        cache-on-failure: true
         workspaces: |
           native/opennow-core -> target
           native/opennow-streamer -> target

--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   metadata:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -43,6 +43,7 @@ jobs:
     name: Package ${{ matrix.label }}
     needs: metadata
     runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.label == 'macos-arm64' && 60 || 360 }}
     strategy:
       fail-fast: false
       matrix:
@@ -91,11 +92,20 @@ jobs:
             linuxdeploy-sha256: ""
             qt-plugin-sha256: ""
             appimage-runtime-sha256: ""
+          - label: macos-arm64
+            os: blacksmith-6vcpu-macos-15
+            build-parallel: 3
+            qt-host: mac
+            qt-arch: clang_64
+            package-generator: ZIP
+            rust-target: aarch64-apple-darwin
+            cmake-arch: ""
 
     env:
       CARGO_TERM_COLOR: always
       SDL_VERSION: release-3.2.20
       OPENNOW_BUILD_VERSION: ${{ needs.metadata.outputs.version }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.label == 'macos-arm64' && '13.0' || '' }}
 
     steps:
       - name: Checkout
@@ -258,8 +268,9 @@ jobs:
       - name: Cache Rust dependencies and build artifacts
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
-          key: qt-ci-${{ matrix.os }}-${{ matrix.label }}
+          key: ${{ runner.os == 'macOS' && 'qt-ci-macos-arm64' || format('qt-ci-{0}-{1}', matrix.os, matrix.label) }}
           cache-bin: false
+          cache-on-failure: ${{ runner.os == 'macOS' }}
           workspaces: |
             native/opennow-core -> target
             native/opennow-streamer -> target
@@ -269,7 +280,7 @@ jobs:
       - name: Cache Qt C++ compilation
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
         with:
-          key: qt-ci-${{ matrix.os }}-${{ matrix.label }}
+          key: ${{ runner.os == 'macOS' && 'qt-ci-macos-arm64' || format('qt-ci-{0}-{1}', matrix.os, matrix.label) }}
           max-size: 1G
 
       - name: Build and cache SDL3
@@ -285,6 +296,7 @@ jobs:
         run: cargo test --locked --manifest-path native/opennow-streamer/Cargo.toml -p opennow-streamer-platform-windows --lib
 
       - name: Configure Qt release
+        if: runner.os != 'macOS'
         shell: bash
         run: |
           OPENNOW_CMAKE_ARGS=()
@@ -309,6 +321,7 @@ jobs:
             "${OPENNOW_CMAKE_ARGS[@]}"
 
       - name: Build Qt release
+        if: runner.os != 'macOS'
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == Windows ]]; then cd /o; fi
@@ -316,11 +329,12 @@ jobs:
 
       - name: Test Qt shell
         id: qt-tests
-        if: runner.os != 'Windows'
+        if: runner.os == 'Linux'
         shell: bash
         run: ctest --test-dir build/opennow-qt-release -C Release --output-on-failure --parallel 4
 
       - name: Create unsigned package
+        if: runner.os != 'macOS'
         shell: bash
         env:
           PACKAGE_GENERATOR: ${{ matrix.package-generator }}
@@ -396,6 +410,7 @@ jobs:
             --smoke-test --allow-multiple-instances --route home --reduced-motion
 
       - name: Upload unsigned package
+        if: runner.os != 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: opennow-qt-${{ matrix.label }}-unsigned
@@ -408,56 +423,8 @@ jobs:
           retention-days: 14
           compression-level: 0
 
-  macos-package:
-    name: Package macos-arm64
-    needs: metadata
-    runs-on: macos-15
-    timeout-minutes: 60
-    env:
-      CARGO_TERM_COLOR: always
-      SDL_VERSION: release-3.2.20
-      OPENNOW_BUILD_VERSION: ${{ needs.metadata.outputs.version }}
-      MACOSX_DEPLOYMENT_TARGET: "13.0"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: "6.8.3"
-          host: mac
-          target: desktop
-          arch: clang_64
-          modules: qtmultimedia qtshadertools
-          cache: true
-          cache-key-prefix: qt-target-macos-arm64
-      - name: Cache Rust dependencies and build artifacts
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
-        with:
-          key: qt-ci-macos-arm64
-          cache-bin: false
-          cache-on-failure: true
-          workspaces: |
-            native/opennow-core -> target
-            native/opennow-streamer -> target
-            native/opennow-core -> ../../build/opennow-qt-release/rust-target
-            native/opennow-streamer -> ../../build/opennow-qt-release/streamer-rust-target
-      - name: Cache Qt C++ compilation
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
-        with:
-          key: qt-ci-macos-arm64
-          max-size: 1G
-      - name: Build and cache SDL3
-        uses: ./.github/actions/sdl3
-        with:
-          version: ${{ env.SDL_VERSION }}
-          target-arch: arm64
-          parallel: 3
       - name: Test macOS native contracts
+        if: runner.os == 'macOS'
         shell: bash
         run: |
           [[ "$(uname -m)" == arm64 ]]
@@ -466,6 +433,7 @@ jobs:
           cargo test --manifest-path native/opennow-streamer/Cargo.toml --locked \
             -p opennow-streamer-platform-macos -p opennow-streamer-protocol -p opennow-streamer-ffi
       - name: Configure and build Qt native release
+        if: runner.os == 'macOS'
         shell: bash
         run: |
           cmake -S opennow-qt -B build/opennow-qt-release \
@@ -476,17 +444,20 @@ jobs:
             -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install"
           cmake --build build/opennow-qt-release --parallel 3
       - name: Test Qt shell and embedded runtime offscreen
+        if: runner.os == 'macOS'
         shell: bash
         run: |
           ctest --test-dir build/opennow-qt-release --output-on-failure --parallel 2 \
             -R '^opennow-.*-tests$|^opennow-acceptance-verifier-help$|^qml-(desktop-route-(home|settings|stream)|fullscreen-.*stats-shortcut|desktop-stream-.*|streamer-event-contract)$'
       - name: Package unsigned macOS validation bundle
+        if: runner.os == 'macOS'
         shell: bash
         run: |
           mkdir -p build/qt-packages
           cpack --config build/opennow-qt-release/CPackConfig.cmake \
             -G ZIP -B build/qt-packages
       - name: Test relocated bundle without development libraries
+        if: runner.os == 'macOS'
         shell: bash
         run: |
           packages=(build/qt-packages/OpenNOW-Qt-*-Darwin-arm64.zip)
@@ -563,6 +534,7 @@ jobs:
               env={**os.environ, "QT_QPA_PLATFORM": "cocoa"}, check=True, timeout=30)
           PY
       - name: Upload macOS validation package
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: opennow-macos-arm64-validation
@@ -574,7 +546,7 @@ jobs:
   artifact-inventory:
     name: Verify complete unsigned artifact set
     needs: [metadata, packages]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       RELEASE_VERSION: ${{ needs.metadata.outputs.version }}
       BUILD_CHANNEL: ${{ inputs.channel }}

--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -268,9 +268,9 @@ jobs:
       - name: Cache Rust dependencies and build artifacts
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
-          key: ${{ runner.os == 'macOS' && 'qt-ci-macos-arm64' || format('qt-ci-{0}-{1}', matrix.os, matrix.label) }}
+          shared-key: ${{ runner.os == 'macOS' && 'qt-ci-macos-arm64' || format('qt-ci-{0}-{1}', matrix.os, matrix.label) }}
           cache-bin: false
-          cache-on-failure: ${{ runner.os == 'macOS' }}
+          cache-on-failure: true
           workspaces: |
             native/opennow-core -> target
             native/opennow-streamer -> target
@@ -331,7 +331,7 @@ jobs:
         id: qt-tests
         if: runner.os == 'Linux'
         shell: bash
-        run: ctest --test-dir build/opennow-qt-release -C Release --output-on-failure --parallel 4
+        run: ctest --test-dir build/opennow-qt-release -C Release --output-on-failure --parallel 4 --no-tests=error -LE interactive-desktop
 
       - name: Create unsigned package
         if: runner.os != 'macOS'
@@ -447,7 +447,7 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          ctest --test-dir build/opennow-qt-release --output-on-failure --parallel 2 \
+          ctest --test-dir build/opennow-qt-release --output-on-failure --parallel 2 --no-tests=error -LE interactive-desktop \
             -R '^opennow-.*-tests$|^opennow-acceptance-verifier-help$|^qml-(desktop-route-(home|settings|stream)|fullscreen-.*stats-shortcut|desktop-stream-.*|streamer-event-contract)$'
       - name: Package unsigned macOS validation bundle
         if: runner.os == 'macOS'

--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -21,21 +21,12 @@ permissions:
 
 jobs:
   metadata:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
-      - name: Test release metadata and artifact inventory
-        run: |
-          python3 -m unittest discover -s opennow-qt/tests -p test_release_metadata.py
-          python3 -m unittest discover -s opennow-qt/tests -p test_nightly_release.py
-          python3 -m unittest discover -s opennow-qt/tests -p test_supporter_build.py
-          python3 -m unittest discover -s opennow-qt/tests -p test_macos_build.py
-          python3 -m unittest discover -s opennow-qt/tests -p test_ffmpeg_build.py
-          python3 -m unittest discover -s opennow-qt/tests -p test_windows_test_bundle.py
-          python3 -m unittest discover -s opennow-qt/tests -p test_ci_build_cache.py
-          python3 -m unittest discover -s opennow-qt/tests -p test_ci_release_trust.py
       - name: Record immutable build identity
         id: version
         shell: bash
@@ -48,18 +39,8 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]]
 
-  localization:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-      - run: npm run locales:check
-      - run: node --test scripts/check-translations.test.mjs
-
-  validate:
-    name: ${{ matrix.label }}
+  packages:
+    name: Package ${{ matrix.label }}
     needs: metadata
     runs-on: ${{ matrix.os }}
     strategy:
@@ -98,13 +79,25 @@ jobs:
             package-generator: ZIP
             rust-target: aarch64-pc-windows-msvc
             cmake-arch: ARM64
+          - label: windows-x64
+            os: blacksmith-8vcpu-windows-2025
+            build-parallel: 8
+            qt-host: windows
+            qt-arch: win64_msvc2022_64
+            package-generator: ZIP
+            rust-target: ""
+            cmake-arch: ""
+            linuxdeploy-arch: ""
+            linuxdeploy-sha256: ""
+            qt-plugin-sha256: ""
+            appimage-runtime-sha256: ""
 
-    env: &native-build-env
+    env:
       CARGO_TERM_COLOR: always
       SDL_VERSION: release-3.2.20
       OPENNOW_BUILD_VERSION: ${{ needs.metadata.outputs.version }}
 
-    steps: &native-build-steps
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -129,11 +122,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: opennow-qt/tests/test_windows_release.ps1
-
-      - name: Test Linux package capability checks
-        if: runner.os == 'Linux'
-        shell: bash
-        run: python3 -m unittest discover -s opennow-qt/tests -p test_linux_package.py
 
       - name: Add package Rust target
         if: matrix.rust-target != ''
@@ -291,50 +279,6 @@ jobs:
           target-arch: ${{ endsWith(matrix.label, 'arm64') && 'arm64' || 'x64' }}
           parallel: ${{ matrix.build-parallel }}
 
-      - name: Rust format and lint
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          cargo fmt --manifest-path native/opennow-core/Cargo.toml -- --check
-          cargo clippy --manifest-path native/opennow-core/Cargo.toml --all-targets -- -D warnings
-          cargo fmt --manifest-path native/opennow-streamer/Cargo.toml --all -- --check
-          cargo clippy --manifest-path native/opennow-streamer/Cargo.toml --workspace --all-targets -- -D warnings
-
-      - name: Lint GitHub workflows
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          case "$(uname -m)" in
-            x86_64)
-              actionlint_arch=amd64
-              actionlint_sha256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
-              ;;
-            aarch64)
-              actionlint_arch=arm64
-              actionlint_sha256=325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6
-              ;;
-            *)
-              echo "Unsupported actionlint architecture: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-          curl --fail --location --retry 3 \
-            "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_${actionlint_arch}.tar.gz" \
-            --output "$RUNNER_TEMP/actionlint.tar.gz"
-          echo "$actionlint_sha256  $RUNNER_TEMP/actionlint.tar.gz" \
-            | sha256sum --check --strict
-          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
-          "$RUNNER_TEMP/actionlint" -color=false \
-            .github/workflows/qt-ci.yml .github/workflows/qt-build.yml \
-            .github/workflows/qt-release-candidate.yml
-
-      - name: Rust tests
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          cargo test --manifest-path native/opennow-core/Cargo.toml
-          cargo test --manifest-path native/opennow-streamer/Cargo.toml --workspace
-
       - name: Windows decoder regression tests
         if: matrix.label == 'windows-x64'
         shell: bash
@@ -376,7 +320,7 @@ jobs:
         shell: bash
         run: ctest --test-dir build/opennow-qt-release -C Release --output-on-failure --parallel 4
 
-      - name: Create unsigned validation package
+      - name: Create unsigned package
         shell: bash
         env:
           PACKAGE_GENERATOR: ${{ matrix.package-generator }}
@@ -451,7 +395,7 @@ jobs:
             "${appimages[0]}" \
             --smoke-test --allow-multiple-instances --route home --reduced-motion
 
-      - name: Upload unsigned validation package
+      - name: Upload unsigned package
         uses: actions/upload-artifact@v4
         with:
           name: opennow-qt-${{ matrix.label }}-unsigned
@@ -464,30 +408,8 @@ jobs:
           retention-days: 14
           compression-level: 0
 
-  windows-build:
-    name: windows-x64
-    needs: metadata
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - label: windows-x64
-            os: blacksmith-8vcpu-windows-2025
-            build-parallel: 8
-            qt-host: windows
-            qt-arch: win64_msvc2022_64
-            package-generator: ZIP
-            rust-target: ""
-            cmake-arch: ""
-            linuxdeploy-arch: ""
-            linuxdeploy-sha256: ""
-            qt-plugin-sha256: ""
-            appimage-runtime-sha256: ""
-    env: *native-build-env
-    steps: *native-build-steps
-
-  macos-validate:
-    name: macos-arm64
+  macos-package:
+    name: Package macos-arm64
     needs: metadata
     runs-on: macos-15
     timeout-minutes: 60
@@ -651,7 +573,7 @@ jobs:
 
   artifact-inventory:
     name: Verify complete unsigned artifact set
-    needs: [metadata, localization, validate, windows-build]
+    needs: [metadata, packages]
     runs-on: ubuntu-24.04
     env:
       RELEASE_VERSION: ${{ needs.metadata.outputs.version }}

--- a/.github/workflows/qt-checks.yml
+++ b/.github/workflows/qt-checks.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   contracts:
     name: Workflow, packaging contracts, and localization
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -34,76 +34,3 @@ jobs:
         run: |
           npm run locales:check
           node --test scripts/check-translations.test.mjs
-
-  unit-tests:
-    name: Linux Rust and Qt unit tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
-    env:
-      CARGO_TERM_COLOR: always
-      CARGO_BUILD_JOBS: "4"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - name: Check Rust formatting
-        run: |
-          cargo fmt --manifest-path native/opennow-core/Cargo.toml -- --check
-          cargo fmt --manifest-path native/opennow-streamer/Cargo.toml --all -- --check
-      - name: Install test dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            clang libclang-dev libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev libgl1-mesa-dev \
-            libpulse-dev libsecret-1-dev libva-dev libvulkan-dev libwayland-dev \
-            libx11-dev libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcursor-dev libxext-dev libxfixes-dev \
-            libxi-dev libxkbcommon-dev libxkbcommon-x11-0 libxrandr-dev libxrender-dev libxss-dev \
-            mesa-vulkan-drivers nasm ninja-build pkg-config wayland-protocols xvfb
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
-        with:
-          key: qt-checks-linux-x64
-          cache-bin: false
-          workspaces: |
-            native/opennow-core -> target
-            native/opennow-streamer -> target
-      - name: Lint Rust
-        run: |
-          cargo clippy --locked --manifest-path native/opennow-core/Cargo.toml --all-targets -- -D warnings
-          cargo clippy --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace --all-targets -- -D warnings
-      - name: Test Rust
-        run: |
-          cargo test --locked --manifest-path native/opennow-core/Cargo.toml
-          cargo test --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: "6.8.3"
-          host: linux
-          target: desktop
-          arch: linux_gcc_64
-          modules: qtmultimedia qtshadertools
-          cache: true
-          cache-key-prefix: qt-target-linux-x64
-      - uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
-        with:
-          key: qt-checks-linux-x64
-          max-size: 1G
-      - name: Build and cache SDL3 test dependency
-        uses: ./.github/actions/sdl3
-        with:
-          version: release-3.2.20
-          target-arch: x64
-          parallel: "4"
-      - name: Check QML syntax
-        shell: bash
-        run: find opennow-qt/qml -name '*.qml' -print0 | xargs -0 -n1 "$QT_ROOT_DIR/bin/qmlformat" > /dev/null
-      - name: Compile Qt unit tests only
-        run: |
-          cmake -S opennow-qt -B build/opennow-qt-checks -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install"
-          cmake --build build/opennow-qt-checks --target opennow-ci-unit-tests --parallel 4
-      - name: Run Qt unit tests
-        run: ctest --test-dir build/opennow-qt-checks --output-on-failure --no-tests=error -L ci-unit --parallel 4

--- a/.github/workflows/qt-checks.yml
+++ b/.github/workflows/qt-checks.yml
@@ -1,0 +1,109 @@
+name: Qt checks
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    name: Workflow, packaging contracts, and localization
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Lint GitHub workflows
+        shell: bash
+        run: |
+          curl --fail --location --retry 3 \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz \
+            --output "$RUNNER_TEMP/actionlint.tar.gz"
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  $RUNNER_TEMP/actionlint.tar.gz" \
+            | sha256sum --check --strict
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
+          "$RUNNER_TEMP/actionlint" -color=false \
+            .github/workflows/qt-ci.yml .github/workflows/qt-checks.yml \
+            .github/workflows/qt-build.yml .github/workflows/qt-release-candidate.yml
+      - name: Test build and packaging contracts
+        run: python3 -m unittest discover -s opennow-qt/tests -p 'test_*.py'
+      - name: Validate localization
+        run: |
+          npm run locales:check
+          node --test scripts/check-translations.test.mjs
+
+  unit-tests:
+    name: Linux Rust and Qt unit tests
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_BUILD_JOBS: "4"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Check Rust formatting
+        run: |
+          cargo fmt --manifest-path native/opennow-core/Cargo.toml -- --check
+          cargo fmt --manifest-path native/opennow-streamer/Cargo.toml --all -- --check
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang libclang-dev libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev libgl1-mesa-dev \
+            libpulse-dev libsecret-1-dev libva-dev libvulkan-dev libwayland-dev \
+            libx11-dev libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcursor-dev libxext-dev libxfixes-dev \
+            libxi-dev libxkbcommon-dev libxkbcommon-x11-0 libxrandr-dev libxrender-dev libxss-dev \
+            mesa-vulkan-drivers nasm ninja-build pkg-config wayland-protocols xvfb
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          key: qt-checks-linux-x64
+          cache-bin: false
+          workspaces: |
+            native/opennow-core -> target
+            native/opennow-streamer -> target
+      - name: Lint Rust
+        run: |
+          cargo clippy --locked --manifest-path native/opennow-core/Cargo.toml --all-targets -- -D warnings
+          cargo clippy --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace --all-targets -- -D warnings
+      - name: Test Rust
+        run: |
+          cargo test --locked --manifest-path native/opennow-core/Cargo.toml
+          cargo test --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.3"
+          host: linux
+          target: desktop
+          arch: linux_gcc_64
+          modules: qtmultimedia qtshadertools
+          cache: true
+          cache-key-prefix: qt-target-linux-x64
+      - uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639
+        with:
+          key: qt-checks-linux-x64
+          max-size: 1G
+      - name: Build and cache SDL3 test dependency
+        uses: ./.github/actions/sdl3
+        with:
+          version: release-3.2.20
+          target-arch: x64
+          parallel: "4"
+      - name: Check QML syntax
+        shell: bash
+        run: find opennow-qt/qml -name '*.qml' -print0 | xargs -0 -n1 "$QT_ROOT_DIR/bin/qmlformat" > /dev/null
+      - name: Compile Qt unit tests only
+        run: |
+          cmake -S opennow-qt -B build/opennow-qt-checks -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install"
+          cmake --build build/opennow-qt-checks --target opennow-ci-unit-tests --parallel 4
+      - name: Run Qt unit tests
+        run: ctest --test-dir build/opennow-qt-checks --output-on-failure --no-tests=error -L ci-unit --parallel 4

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - ".github/workflows/qt-ci.yml"
       - ".github/workflows/qt-build.yml"
+      - ".github/workflows/qt-checks.yml"
       - ".github/workflows/qt-release-candidate.yml"
       - ".github/actionlint.yaml"
       - ".github/actions/**"
@@ -31,6 +32,7 @@ on:
     paths:
       - ".github/workflows/qt-ci.yml"
       - ".github/workflows/qt-build.yml"
+      - ".github/workflows/qt-checks.yml"
       - ".github/workflows/qt-release-candidate.yml"
       - ".github/actionlint.yaml"
       - ".github/actions/**"
@@ -50,7 +52,14 @@ permissions:
   contents: read
 
 jobs:
+  checks:
+    name: Checks and tests
+    uses: ./.github/workflows/qt-checks.yml
+
   build:
+    name: Manual packages
+    if: github.event_name == 'workflow_dispatch'
+    needs: checks
     uses: ./.github/workflows/qt-build.yml
     with:
       upload_complete: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -52,14 +52,62 @@ permissions:
   contents: read
 
 jobs:
-  checks:
-    name: Checks and tests
+  contracts:
+    name: Shared checks
     uses: ./.github/workflows/qt-checks.yml
+
+  checks:
+    name: ${{ matrix.label }}
+    needs: contracts
+    if: always()
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux-x64
+            os: blacksmith-4vcpu-ubuntu-2404
+            qt-host: linux
+            qt-arch: linux_gcc_64
+            target-arch: x64
+            parallel: "4"
+          - label: windows-x64
+            os: blacksmith-4vcpu-windows-2025
+            qt-host: windows
+            qt-arch: win64_msvc2022_64
+            target-arch: x64
+            parallel: "4"
+          - label: macos-arm64
+            os: blacksmith-6vcpu-macos-15
+            qt-host: mac
+            qt-arch: clang_64
+            target-arch: arm64
+            parallel: "3"
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_BUILD_JOBS: ${{ matrix.parallel }}
+      OPENNOW_CHECKOUT: ${{ matrix.label == 'windows-x64' && 'O:/' || github.workspace }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.label == 'macos-arm64' && '13.0' || '' }}
+    steps:
+      - name: Require shared checks to pass
+        shell: bash
+        env:
+          CONTRACTS_RESULT: ${{ needs.contracts.result }}
+        run: test "$CONTRACTS_RESULT" = success
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/qt-unit-tests
+        with:
+          label: ${{ matrix.label }}
+          qt-host: ${{ matrix.qt-host }}
+          qt-arch: ${{ matrix.qt-arch }}
+          target-arch: ${{ matrix.target-arch }}
+          parallel: ${{ matrix.parallel }}
 
   build:
     name: Manual packages
     if: github.event_name == 'workflow_dispatch'
-    needs: checks
+    needs: [contracts, checks]
     uses: ./.github/workflows/qt-build.yml
     with:
       upload_complete: ${{ github.event_name == 'workflow_dispatch' }}
@@ -68,7 +116,7 @@ jobs:
     name: Publish unsigned nightly prerelease
     if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
     env:

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   preflight:
     name: release-preflight
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       source_sha: ${{ steps.source.outputs.source_sha }}
     steps:

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -5,7 +5,30 @@ or newer and uses SDL3 for controller input. A bundled Rust process owns setting
 and is the start of the shell-neutral application core. See
 `docs/qt-migration.md` for the migration history and remaining release checklist.
 
-## Manual artifact-only builds
+## CI checks and manual builds
+
+Pull requests and pushes to `dev` or `main` run workflow lint, packaging-contract
+tests, localization validation, Rust format/lint/tests, QML syntax checks, and the
+`ci-unit` Qt tests on Linux x64. The Qt check compiles only the
+`opennow-ci-unit-tests` target, not the application or the release streamer with
+bundled FFmpeg. Rust test binaries and the SDL3 test dependency still need compiling;
+Rust, Qt, and SDL caches reduce repeated work.
+
+Full application builds, embedded-runtime/QML acceptance tests, Windows/macOS/ARM64
+platform validation, and package creation run only on manual dispatch. Automatic
+checks do not prove those platform-specific or full-application paths work; run a
+manual build before shipping changes that touch them. Windows and Linux packages
+share one four-platform matrix; macOS has a separate package job because its app
+bundle, relocation, and native test commands differ.
+
+To run the test-only Qt suite locally after configuring a Debug build:
+
+```sh
+cmake --build build/opennow-qt --target opennow-ci-unit-tests --parallel 4
+ctest --test-dir build/opennow-qt --output-on-failure --no-tests=error -L ci-unit --parallel 4
+```
+
+### Manual artifact-only builds
 
 In GitHub **Actions → qt-ci → Run workflow**, select `dev` (or the branch or tag
 to build) and leave **Publish an unsigned nightly prerelease after all checks pass**
@@ -171,7 +194,7 @@ so it can load outside the build tree.
 The app explicitly links Qt Svg so macdeployqt includes the SVG image plugin used
 by the QML icons; the relocated-bundle check requires that plugin to be present.
 
-The separate `macos-validate` CI job builds and tests the native Apple Silicon
+The manual `macos-package` job builds and tests the native Apple Silicon
 stack, then checks a relocated ZIP with the development dependencies hidden.
 These are unsigned validation artifacts, not notarized releases, and are not
 part of the Linux/Windows nightly inventory. Offscreen tests cover shell and FFI

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -10,12 +10,17 @@ and is the start of the shell-neutral application core. See
 Pull requests and pushes to `dev` or `main` run workflow lint, packaging-contract
 tests and localization validation, followed by a native test matrix for Linux x64,
 Windows x64, and macOS ARM64. Each platform must pass Rust format/lint/tests, QML
-syntax checks, and the `ci-unit` Qt tests. The Qt check compiles only the
+syntax checks, and the headless-compatible `ci-unit` Qt tests. The Qt check compiles only the
 `opennow-ci-unit-tests` target, not the application or the release streamer with
 bundled FFmpeg. Rust test binaries and the SDL3 test dependency still need compiling;
 Rust, Qt, and SDL caches reduce repeated work.
 General-purpose check and package jobs use Blacksmith runners. The isolated
 release-signing job remains on `opennow-release-signer`.
+
+The upstream Rust cache action automatically uses Blacksmith's colocated cache.
+Platform-specific shared keys survive job renames, and dependency caches are saved
+even if a later test fails. Check and release-build caches remain separate; each
+still invalidates when the Rust toolchain or dependency configuration changes.
 
 Full application builds, embedded-runtime/QML acceptance tests, Linux/Windows ARM64
 builds, and package creation run only on manual dispatch. Automatic checks do not
@@ -32,6 +37,23 @@ To run the test-only Qt suite locally after configuring a Debug build:
 ```sh
 cmake --build build/opennow-qt --target opennow-ci-unit-tests --parallel 4
 ctest --test-dir build/opennow-qt --output-on-failure --no-tests=error -L ci-unit --parallel 4
+```
+
+Windows CI runs 16 Qt targets; Linux and macOS run 17. The Windows HDR/native-window
+test and macOS native cursor-capture test require an interactive desktop, so they
+remain registered under `interactive-desktop` instead of `ci-unit`. Blacksmith
+package jobs also exclude this label. No test assertions are disabled or relaxed.
+
+Run the separate suite from an interactive Windows or macOS session after configuring
+the Debug build. On Windows, first verify the desktop with the existing preflight:
+
+```powershell
+.github/scripts/ensure-windows-test-desktop.ps1
+```
+
+```sh
+cmake --build build/opennow-qt --target opennow-interactive-tests --config Debug --parallel 4
+ctest --test-dir build/opennow-qt -C Debug --output-on-failure --no-tests=error -L interactive-desktop
 ```
 
 ### Manual artifact-only builds

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -8,18 +8,24 @@ and is the start of the shell-neutral application core. See
 ## CI checks and manual builds
 
 Pull requests and pushes to `dev` or `main` run workflow lint, packaging-contract
-tests, localization validation, Rust format/lint/tests, QML syntax checks, and the
-`ci-unit` Qt tests on Linux x64. The Qt check compiles only the
+tests and localization validation, followed by a native test matrix for Linux x64,
+Windows x64, and macOS ARM64. Each platform must pass Rust format/lint/tests, QML
+syntax checks, and the `ci-unit` Qt tests. The Qt check compiles only the
 `opennow-ci-unit-tests` target, not the application or the release streamer with
 bundled FFmpeg. Rust test binaries and the SDL3 test dependency still need compiling;
 Rust, Qt, and SDL caches reduce repeated work.
+General-purpose check and package jobs use Blacksmith runners. The isolated
+release-signing job remains on `opennow-release-signer`.
 
-Full application builds, embedded-runtime/QML acceptance tests, Windows/macOS/ARM64
-platform validation, and package creation run only on manual dispatch. Automatic
-checks do not prove those platform-specific or full-application paths work; run a
-manual build before shipping changes that touch them. Windows and Linux packages
-share one four-platform matrix; macOS has a separate package job because its app
-bundle, relocation, and native test commands differ.
+Full application builds, embedded-runtime/QML acceptance tests, Linux/Windows ARM64
+builds, and package creation run only on manual dispatch. Automatic checks do not
+prove those full-application or ARM64 cross-platform paths work; run a manual build
+before shipping changes that touch them. All five package platforms share one
+matrix, including macOS; platform-specific steps handle its app bundle and relocation.
+
+Required status names are `linux-x64`, `windows-x64`, and `macos-arm64`. Keep all
+three required in the repository's branch rules. Each also fails if shared checks
+fail or are cancelled, and manual packaging waits for every platform to pass.
 
 To run the test-only Qt suite locally after configuring a Debug build:
 
@@ -194,7 +200,7 @@ so it can load outside the build tree.
 The app explicitly links Qt Svg so macdeployqt includes the SVG image plugin used
 by the QML icons; the relocated-bundle check requires that plugin to be present.
 
-The manual `macos-package` job builds and tests the native Apple Silicon
+The manual `macos-arm64` package matrix entry builds and tests the native Apple Silicon
 stack, then checks a relocated ZIP with the development dependencies hidden.
 These are unsigned validation artifacts, not notarized releases, and are not
 part of the Linux/Windows nightly inventory. Offscreen tests cover shell and FFI

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -355,7 +355,7 @@ if(BUILD_TESTING)
         add_test(NAME opennow-macpointer-native-tests
             COMMAND opennow-macpointer-tests nativeCocoaCaptureRestoresCursor -o -,txt)
         set_tests_properties(opennow-macpointer-native-tests PROPERTIES
-            ENVIRONMENT "QT_QPA_PLATFORM=cocoa" RUN_SERIAL TRUE TIMEOUT 30)
+            ENVIRONMENT "QT_QPA_PLATFORM=cocoa" RUN_SERIAL TRUE TIMEOUT 30 LABELS "ci-unit")
     endif()
 
     qt_add_executable(opennow-nativestreamruntime-tests

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -355,7 +355,7 @@ if(BUILD_TESTING)
         add_test(NAME opennow-macpointer-native-tests
             COMMAND opennow-macpointer-tests nativeCocoaCaptureRestoresCursor -o -,txt)
         set_tests_properties(opennow-macpointer-native-tests PROPERTIES
-            ENVIRONMENT "QT_QPA_PLATFORM=cocoa" RUN_SERIAL TRUE TIMEOUT 30 LABELS "ci-unit")
+            ENVIRONMENT "QT_QPA_PLATFORM=cocoa" RUN_SERIAL TRUE TIMEOUT 30 LABELS "interactive-desktop")
     endif()
 
     qt_add_executable(opennow-nativestreamruntime-tests
@@ -499,6 +499,13 @@ if(BUILD_TESTING)
         opennow-controllersources-tests
         opennow-controllermetadata-tests
     )
+    if(WIN32)
+        list(REMOVE_ITEM OPENNOW_CI_UNIT_TEST_TARGETS opennow-hdrcolor-tests)
+        set_tests_properties(opennow-hdrcolor-tests PROPERTIES LABELS "interactive-desktop")
+        add_custom_target(opennow-interactive-tests DEPENDS opennow-hdrcolor-tests)
+    elseif(APPLE)
+        add_custom_target(opennow-interactive-tests DEPENDS opennow-macpointer-tests)
+    endif()
     add_custom_target(opennow-ci-unit-tests DEPENDS ${OPENNOW_CI_UNIT_TEST_TARGETS})
     set_tests_properties(${OPENNOW_CI_UNIT_TEST_TARGETS} PROPERTIES LABELS "ci-unit")
 
@@ -552,6 +559,7 @@ if(BUILD_TESTING)
             add_dependencies(opennow-qt-test-runtime opennow-msvc-runtime)
         endif()
         foreach(test_target IN ITEMS
+                opennow-hdrcolor-tests
                 opennow-localization-tests
                 opennow-qt-tests
                 opennow-coreclient-tests

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -480,6 +480,28 @@ if(BUILD_TESTING)
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
         TIMEOUT 30
     )
+    set(OPENNOW_CI_UNIT_TEST_TARGETS
+        opennow-hdrcolor-tests
+        opennow-theme-tests
+        opennow-framepacer-tests
+        opennow-frameinterpolator-tests
+        opennow-streamcolor-tests
+        opennow-localization-tests
+        opennow-qt-tests
+        opennow-coreclient-tests
+        opennow-waylandpointer-tests
+        opennow-macpointer-tests
+        opennow-embedded-orchestration-tests
+        opennow-singleinstance-tests
+        opennow-thumbnail-tests
+        opennow-controllerinput-tests
+        opennow-controllertuning-tests
+        opennow-controllersources-tests
+        opennow-controllermetadata-tests
+    )
+    add_custom_target(opennow-ci-unit-tests DEPENDS ${OPENNOW_CI_UNIT_TEST_TARGETS})
+    set_tests_properties(${OPENNOW_CI_UNIT_TEST_TARGETS} PROPERTIES LABELS "ci-unit")
+
     if(WIN32)
         add_dependencies(opennow-nativeframegeneration-tests opennow-streamer-ffi-test-runtime)
         # Qt's executable helper defaults to the GUI subsystem on Windows. Keep

--- a/opennow-qt/tests/test_ci_workflow.py
+++ b/opennow-qt/tests/test_ci_workflow.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+import os
 import re
+import subprocess
 import unittest
 
 
@@ -16,11 +18,11 @@ class CIWorkflowTest(unittest.TestCase):
     def test_automatic_events_run_checks_without_packages(self):
         ci = (WORKFLOWS / "qt-ci.yml").read_text()
         entries = jobs(ci)
-        self.assertEqual(set(entries), {"checks", "build", "publish-nightly"})
-        self.assertIn("uses: ./.github/workflows/qt-checks.yml", entries["checks"])
-        self.assertNotIn("    if:", entries["checks"])
+        self.assertEqual(set(entries), {"contracts", "checks", "build", "publish-nightly"})
+        self.assertIn("uses: ./.github/workflows/qt-checks.yml", entries["contracts"])
+        self.assertNotIn("    if:", entries["contracts"])
         self.assertIn("    if: github.event_name == 'workflow_dispatch'\n", entries["build"])
-        self.assertIn("    needs: checks\n", entries["build"])
+        self.assertIn("    needs: [contracts, checks]\n", entries["build"])
         self.assertIn("uses: ./.github/workflows/qt-build.yml", entries["build"])
         self.assertIn("  pull_request:\n", ci)
         self.assertIn("  push:\n", ci)
@@ -28,37 +30,59 @@ class CIWorkflowTest(unittest.TestCase):
 
     def test_manual_packages_cannot_bypass_dispatch_gate(self):
         entries = jobs((WORKFLOWS / "qt-build.yml").read_text())
-        self.assertEqual(set(entries), {"metadata", "packages", "macos-package", "artifact-inventory"})
+        self.assertEqual(set(entries), {"metadata", "packages", "artifact-inventory"})
         self.assertIn("    if: github.event_name == 'workflow_dispatch'\n", entries["metadata"])
-        for name in ("packages", "macos-package"):
-            self.assertIn("    needs: metadata\n", entries[name])
-            self.assertNotIn("always()", entries[name])
+        self.assertIn("    needs: metadata\n", entries["packages"])
+        self.assertNotIn("always()", entries["packages"])
         self.assertIn("    needs: [metadata, packages]\n", entries["artifact-inventory"])
         self.assertIn("        if: inputs.upload_complete\n", entries["artifact-inventory"])
 
-    def test_windows_and_linux_share_one_packaging_matrix(self):
+    def test_all_platforms_share_one_packaging_matrix(self):
         entries = jobs((WORKFLOWS / "qt-build.yml").read_text())
         labels = re.findall(r"^          - label: (.+)$", entries["packages"], re.MULTILINE)
-        self.assertCountEqual(labels, ["linux-x64", "linux-arm64", "windows-x64", "windows-arm64"])
+        self.assertCountEqual(labels, ["linux-x64", "linux-arm64", "windows-x64", "windows-arm64", "macos-arm64"])
         self.assertIn("name: Package ${{ matrix.label }}", entries["packages"])
         self.assertIn("Create Linux AppImage", entries["packages"])
-        self.assertIn("Test relocated bundle without development libraries", entries["macos-package"])
+        self.assertIn("Test relocated bundle without development libraries", entries["packages"])
+
+    def test_all_native_platform_checks_keep_required_status_names(self):
+        checks = jobs((WORKFLOWS / "qt-ci.yml").read_text())["checks"]
+        labels = re.findall(r"^          - label: (.+)$", checks, re.MULTILINE)
+        self.assertCountEqual(labels, ["linux-x64", "windows-x64", "macos-arm64"])
+        self.assertIn("    name: ${{ matrix.label }}\n", checks)
+        self.assertIn("    runs-on: ${{ matrix.os }}\n", checks)
+        self.assertIn("      fail-fast: false\n", checks)
+        self.assertIn("uses: ./.github/actions/qt-unit-tests", checks)
+        self.assertIn("os: blacksmith-4vcpu-windows-2025", checks)
+        self.assertIn("os: blacksmith-6vcpu-macos-15", checks)
+        self.assertNotIn("continue-on-error", checks)
+
+    def test_required_platform_checks_fail_when_shared_checks_do_not_succeed(self):
+        checks = jobs((WORKFLOWS / "qt-ci.yml").read_text())["checks"]
+        self.assertIn("    needs: contracts\n    if: always()\n", checks)
+        self.assertIn("CONTRACTS_RESULT: ${{ needs.contracts.result }}", checks)
+        script = re.search(r"        run: (test .+)\n", checks)[1]
+        for result in ("success", "failure", "cancelled", "skipped", ""):
+            with self.subTest(result=result):
+                process = subprocess.run(["bash", "-c", script], env={**os.environ, "CONTRACTS_RESULT": result})
+                self.assertEqual(process.returncode == 0, result == "success")
 
     def test_checks_compile_tests_without_packaging_or_runtime_targets(self):
-        checks = (WORKFLOWS / "qt-checks.yml").read_text()
-        entries = jobs(checks)
-        self.assertEqual(set(entries), {"contracts", "unit-tests"})
-        self.assertIn("runs-on: ubuntu-24.04", entries["contracts"])
-        self.assertIn("runs-on: blacksmith-4vcpu-ubuntu-2404", entries["unit-tests"])
+        contracts = (WORKFLOWS / "qt-checks.yml").read_text()
+        checks = (ROOT / ".github/actions/qt-unit-tests/action.yml").read_text()
+        entries = jobs(contracts)
+        self.assertEqual(set(entries), {"contracts"})
+        self.assertIn("runs-on: blacksmith-2vcpu-ubuntu-2404", entries["contracts"])
         for forbidden in ("matrix:", "cpack ", "linuxdeploy", "upload-artifact", "--release",
                           "uses: ./.github/workflows/qt-build.yml"):
             self.assertNotIn(forbidden, checks)
-        self.assertIn("--target opennow-ci-unit-tests --parallel 4", checks)
+        self.assertIn('--target opennow-ci-unit-tests --parallel "$BUILD_PARALLEL"', checks)
         self.assertIn("--no-tests=error -L ci-unit", checks)
         self.assertIn("cargo clippy --locked", checks)
         self.assertIn("cargo test --locked", checks)
         self.assertIn("--workspace --all-targets -- -D warnings", checks)
         self.assertIn('"$QT_ROOT_DIR/bin/qmlformat"', checks)
+        self.assertIn("ensure-windows-test-desktop.ps1", checks)
         cmake = (ROOT / "opennow-qt/cmake/Tests.cmake").read_text()
         targets = re.search(r"set\(OPENNOW_CI_UNIT_TEST_TARGETS\s+(.*?)\)", cmake, re.DOTALL)[1].split()
         self.assertEqual(len(targets), 17)
@@ -68,6 +92,17 @@ class CIWorkflowTest(unittest.TestCase):
             self.assertNotIn(forbidden, targets)
         self.assertIn("add_custom_target(opennow-ci-unit-tests DEPENDS ${OPENNOW_CI_UNIT_TEST_TARGETS})", cmake)
         self.assertIn('set_tests_properties(${OPENNOW_CI_UNIT_TEST_TARGETS} PROPERTIES LABELS "ci-unit")', cmake)
+        self.assertIn('ENVIRONMENT "QT_QPA_PLATFORM=cocoa" RUN_SERIAL TRUE TIMEOUT 30 LABELS "ci-unit"', cmake)
+
+    def test_general_purpose_runners_are_blacksmith(self):
+        for workflow in WORKFLOWS.glob("*.yml"):
+            runners = re.findall(r"^\s+(?:runs-on|os|runner): (.+)$", workflow.read_text(), re.MULTILINE)
+            for runner in runners:
+                with self.subTest(workflow=workflow.name, runner=runner):
+                    self.assertTrue(
+                        runner.startswith(("blacksmith-", "${{"))
+                        or runner == "[self-hosted, opennow-release-signer]",
+                    )
 
     def test_publishing_remains_explicitly_opt_in_after_build(self):
         ci = (WORKFLOWS / "qt-ci.yml").read_text()

--- a/opennow-qt/tests/test_ci_workflow.py
+++ b/opennow-qt/tests/test_ci_workflow.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github/workflows"
+
+
+def jobs(workflow):
+    sections = re.split(r"^  ([a-z][a-z-]*):\n", workflow.split("jobs:\n", 1)[1], flags=re.MULTILINE)
+    return dict(zip(sections[1::2], sections[2::2]))
+
+
+class CIWorkflowTest(unittest.TestCase):
+    def test_automatic_events_run_checks_without_packages(self):
+        ci = (WORKFLOWS / "qt-ci.yml").read_text()
+        entries = jobs(ci)
+        self.assertEqual(set(entries), {"checks", "build", "publish-nightly"})
+        self.assertIn("uses: ./.github/workflows/qt-checks.yml", entries["checks"])
+        self.assertNotIn("    if:", entries["checks"])
+        self.assertIn("    if: github.event_name == 'workflow_dispatch'\n", entries["build"])
+        self.assertIn("    needs: checks\n", entries["build"])
+        self.assertIn("uses: ./.github/workflows/qt-build.yml", entries["build"])
+        self.assertIn("  pull_request:\n", ci)
+        self.assertIn("  push:\n", ci)
+        self.assertEqual(ci.count('      - ".github/workflows/qt-checks.yml"'), 2)
+
+    def test_manual_packages_cannot_bypass_dispatch_gate(self):
+        entries = jobs((WORKFLOWS / "qt-build.yml").read_text())
+        self.assertEqual(set(entries), {"metadata", "packages", "macos-package", "artifact-inventory"})
+        self.assertIn("    if: github.event_name == 'workflow_dispatch'\n", entries["metadata"])
+        for name in ("packages", "macos-package"):
+            self.assertIn("    needs: metadata\n", entries[name])
+            self.assertNotIn("always()", entries[name])
+        self.assertIn("    needs: [metadata, packages]\n", entries["artifact-inventory"])
+        self.assertIn("        if: inputs.upload_complete\n", entries["artifact-inventory"])
+
+    def test_windows_and_linux_share_one_packaging_matrix(self):
+        entries = jobs((WORKFLOWS / "qt-build.yml").read_text())
+        labels = re.findall(r"^          - label: (.+)$", entries["packages"], re.MULTILINE)
+        self.assertCountEqual(labels, ["linux-x64", "linux-arm64", "windows-x64", "windows-arm64"])
+        self.assertIn("name: Package ${{ matrix.label }}", entries["packages"])
+        self.assertIn("Create Linux AppImage", entries["packages"])
+        self.assertIn("Test relocated bundle without development libraries", entries["macos-package"])
+
+    def test_checks_compile_tests_without_packaging_or_runtime_targets(self):
+        checks = (WORKFLOWS / "qt-checks.yml").read_text()
+        entries = jobs(checks)
+        self.assertEqual(set(entries), {"contracts", "unit-tests"})
+        self.assertIn("runs-on: ubuntu-24.04", entries["contracts"])
+        self.assertIn("runs-on: blacksmith-4vcpu-ubuntu-2404", entries["unit-tests"])
+        for forbidden in ("matrix:", "cpack ", "linuxdeploy", "upload-artifact", "--release",
+                          "uses: ./.github/workflows/qt-build.yml"):
+            self.assertNotIn(forbidden, checks)
+        self.assertIn("--target opennow-ci-unit-tests --parallel 4", checks)
+        self.assertIn("--no-tests=error -L ci-unit", checks)
+        self.assertIn("cargo clippy --locked", checks)
+        self.assertIn("cargo test --locked", checks)
+        self.assertIn("--workspace --all-targets -- -D warnings", checks)
+        self.assertIn('"$QT_ROOT_DIR/bin/qmlformat"', checks)
+        cmake = (ROOT / "opennow-qt/cmake/Tests.cmake").read_text()
+        targets = re.search(r"set\(OPENNOW_CI_UNIT_TEST_TARGETS\s+(.*?)\)", cmake, re.DOTALL)[1].split()
+        self.assertEqual(len(targets), 17)
+        self.assertEqual(len(set(targets)), 17)
+        for forbidden in ("opennow-qt", "opennow-streamvideo-tests", "opennow-nativestreamruntime-tests",
+                          "opennow-nativeframegeneration-tests", "opennow-linuxvulkangraphics-tests"):
+            self.assertNotIn(forbidden, targets)
+        self.assertIn("add_custom_target(opennow-ci-unit-tests DEPENDS ${OPENNOW_CI_UNIT_TEST_TARGETS})", cmake)
+        self.assertIn('set_tests_properties(${OPENNOW_CI_UNIT_TEST_TARGETS} PROPERTIES LABELS "ci-unit")', cmake)
+
+    def test_publishing_remains_explicitly_opt_in_after_build(self):
+        ci = (WORKFLOWS / "qt-ci.yml").read_text()
+        self.assertIn("        type: boolean\n        default: false", ci)
+        publish = jobs(ci)["publish-nightly"]
+        self.assertIn("if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly", publish)
+        self.assertIn("    needs: build\n", publish)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opennow-qt/tests/test_ci_workflow.py
+++ b/opennow-qt/tests/test_ci_workflow.py
@@ -82,7 +82,8 @@ class CIWorkflowTest(unittest.TestCase):
         self.assertIn("cargo test --locked", checks)
         self.assertIn("--workspace --all-targets -- -D warnings", checks)
         self.assertIn('"$QT_ROOT_DIR/bin/qmlformat"', checks)
-        self.assertIn("ensure-windows-test-desktop.ps1", checks)
+        self.assertNotIn("ensure-windows-test-desktop.ps1", checks)
+        self.assertIn("ensure-windows-media-foundation.ps1", checks)
         cmake = (ROOT / "opennow-qt/cmake/Tests.cmake").read_text()
         targets = re.search(r"set\(OPENNOW_CI_UNIT_TEST_TARGETS\s+(.*?)\)", cmake, re.DOTALL)[1].split()
         self.assertEqual(len(targets), 17)
@@ -92,7 +93,20 @@ class CIWorkflowTest(unittest.TestCase):
             self.assertNotIn(forbidden, targets)
         self.assertIn("add_custom_target(opennow-ci-unit-tests DEPENDS ${OPENNOW_CI_UNIT_TEST_TARGETS})", cmake)
         self.assertIn('set_tests_properties(${OPENNOW_CI_UNIT_TEST_TARGETS} PROPERTIES LABELS "ci-unit")', cmake)
-        self.assertIn('ENVIRONMENT "QT_QPA_PLATFORM=cocoa" RUN_SERIAL TRUE TIMEOUT 30 LABELS "ci-unit"', cmake)
+        self.assertIn('ENVIRONMENT "QT_QPA_PLATFORM=cocoa" RUN_SERIAL TRUE TIMEOUT 30 LABELS "interactive-desktop"', cmake)
+
+    def test_interactive_tests_remain_registered_outside_headless_ci(self):
+        cmake = (ROOT / "opennow-qt/cmake/Tests.cmake").read_text()
+        self.assertIn("list(REMOVE_ITEM OPENNOW_CI_UNIT_TEST_TARGETS opennow-hdrcolor-tests)", cmake)
+        self.assertIn('set_tests_properties(opennow-hdrcolor-tests PROPERTIES LABELS "interactive-desktop")', cmake)
+        self.assertIn("add_custom_target(opennow-interactive-tests DEPENDS opennow-hdrcolor-tests)", cmake)
+        self.assertIn("add_custom_target(opennow-interactive-tests DEPENDS opennow-macpointer-tests)", cmake)
+        self.assertIn("add_test(NAME opennow-hdrcolor-tests", cmake)
+        self.assertIn("add_test(NAME opennow-macpointer-native-tests", cmake)
+        runtime_consumers = cmake.split("foreach(test_target IN ITEMS", 1)[1]
+        self.assertIn("opennow-hdrcolor-tests", runtime_consumers)
+        packages = (WORKFLOWS / "qt-build.yml").read_text()
+        self.assertEqual(packages.count("--no-tests=error -LE interactive-desktop"), 2)
 
     def test_general_purpose_runners_are_blacksmith(self):
         for workflow in WORKFLOWS.glob("*.yml"):
@@ -103,6 +117,15 @@ class CIWorkflowTest(unittest.TestCase):
                         runner.startswith(("blacksmith-", "${{"))
                         or runner == "[self-hosted, opennow-release-signer]",
                     )
+
+    def test_rust_caches_survive_job_renames_and_later_test_failures(self):
+        for path in (ROOT / ".github/actions/qt-unit-tests/action.yml", WORKFLOWS / "qt-build.yml"):
+            with self.subTest(path=path):
+                cache = path.read_text().split("uses: Swatinem/rust-cache@", 1)[1].split("\n      -", 1)[0]
+                self.assertIn("shared-key:", cache)
+                self.assertIn("cache-on-failure: true", cache)
+                self.assertIn("native/opennow-core -> target", cache)
+                self.assertIn("native/opennow-streamer -> target", cache)
 
     def test_publishing_remains_explicitly_opt_in_after_build(self):
         ci = (WORKFLOWS / "qt-ci.yml").read_text()


### PR DESCRIPTION
PRs and pushes now run native checks in one Linux x64 / Windows x64 / macOS ARM64 matrix, without building the full desktop app or packages. Exact status names `linux-x64`, `windows-x64`, and `macos-arm64` match the intended required checks. Shared workflow, packaging-contract, and localization checks run first; each required platform status fails if those shared checks fail, cancel, or skip. All platform jobs must pass before manual packaging.

The platform checks share a composite action for Rust formatting, Clippy, workspace tests, QML syntax, and the `ci-unit` Qt suite. Windows runs a headless-compatible 16-target Qt suite; Linux and macOS run 17 targets. The Windows HDR/native-window test and macOS native cursor-capture test remain unchanged under a separate `interactive-desktop` label with an `opennow-interactive-tests` build target. Blacksmith CI and package jobs exclude this desktop-only label; the README documents separate interactive validation. The test-only CMake target avoids application and release-streamer/bundled-FFmpeg builds. Full embedded-runtime and end-to-end coverage remains in manual builds.

Full package creation is gated on manual dispatch. All five package platforms—including macOS—now share a single matrix with platform-specific steps. Existing package formats, artifact names, retention, and opt-in nightly publishing remain unchanged. All general-purpose workflow runners use Blacksmith; the isolated credential-owning release signer stays unchanged.

Rust caches now use stable per-platform shared keys and save compiled dependencies even when later tests fail. The existing upstream action uses Blacksmith's colocated cache; no paid sticky disks were enabled.

Validation: actionlint passed for all four related workflows; all 60 Python contract tests and 17 Linux Qt CTest entries passed. The previous revision also passed both Rust format/Clippy checks, 694 Rust tests (9 existing ignored), localization validation and 6 tooling tests, and QML syntax. The previous macOS run passed Rust checks and all 17 regular Qt targets, failing only on interactive cursor capture; the previous Windows run stopped at the incompatible desktop preflight. Updated headless native-platform CI is pending. No full package build was manually dispatched.

Repository setting: verified that the dev ruleset now requires `linux-x64`, `windows-x64`, and `macos-arm64`. Existing required checks were not removed or weakened.