### PR TITLE
feat(qt): enter fullscreen when sessions are ready by default

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,8 @@
 {
+  "sessionFullscreen": {
+    "title": "Fullscreen when session is ready",
+    "description": "Automatically enter fullscreen when your session is ready. F11 toggles fullscreen during play."
+  },
   "controllerTuning": {
     "leftDeadzone": "Left stick dead zone",
     "rightDeadzone": "Right stick dead zone",

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -804,7 +804,7 @@ fn defaults() -> Map<String, Value> {
         "desktopRailCollapsed":true, "desktopSidebarHover":true, "desktopBackground":"art",
         "desktopBackgroundImage":"", "desktopBackgroundOpacity":30,
         "switchToConsoleOnPad":false, "leaveConsoleOnPointer":true,
-        "autoFullScreen":false, "favoriteGameIds":[], "hiddenGameIds":[], "gameCollections":[], "homeTileSizes":{}, "sessionCounterEnabled":false,
+        "autoFullScreen":true, "favoriteGameIds":[], "hiddenGameIds":[], "gameCollections":[], "homeTileSizes":{}, "sessionCounterEnabled":false,
         "showSessionReport":true, "showSessionTimeRemainingInStatsOverlay":false,
         "sessionClockShowEveryMinutes":60, "sessionClockShowDurationSeconds":30,
         "windowWidth":1400, "windowHeight":900, "keyboardLayout":"en-US",
@@ -1394,6 +1394,28 @@ mod tests {
         assert_eq!(store.all()["desktopBackground"], json!("art"));
         assert_eq!(store.all()["desktopBackgroundImage"], json!(""));
         assert_eq!(store.all()["desktopBackgroundOpacity"], json!(30));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn automatic_fullscreen_defaults_on_and_preserves_opt_out() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = env::temp_dir().join(format!("opennow-fullscreen-settings-{unique}"));
+        let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["autoFullScreen"], json!(true));
+        store.set("autoFullScreen", json!(false)).unwrap();
+        let mut loaded = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(loaded.all()["autoFullScreen"], json!(false));
+        loaded.reset().unwrap();
+        assert_eq!(loaded.all()["autoFullScreen"], json!(true));
+        fs::write(directory.join("settings.json"), r#"{"fps":60}"#).unwrap();
+        assert_eq!(
+            SettingsStore::load(Some(directory.clone())).unwrap().all()["autoFullScreen"],
+            json!(true)
+        );
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -282,7 +282,9 @@ to verify that session exit restores the pre-session windowed, maximized, or ful
 mode in both desktop and console shells, and F11 still toggles correctly afterward.
 The fixture also checks exit cancellation, launch/reconnect route transitions, and a
 subsequent aborted launch with a different initial window mode, and automatic fullscreen
-on direct launch.
+once a session is ready (including direct launches). Settings → Stream → Fullscreen when
+session is ready is enabled by default; saved opt-outs are preserved. F11 remains available
+during play, and reconnects or overlays do not reapply fullscreen after a manual override.
 
 ### Local frame generation (experimental)
 

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -54,6 +54,7 @@ ApplicationWindow {
     property bool lockedStreamDesktopSurface: true
     property int visibilityBeforeFullscreen: ApplicationWindow.Windowed
     property bool sessionWindowModeSaved: false
+    property bool sessionFullscreenApplied: false
     property int visibilityBeforeSession: ApplicationWindow.Windowed
     property int fullscreenRestoreVisibilityBeforeSession: ApplicationWindow.Windowed
     readonly property string configuredStatsShortcut: String(
@@ -241,11 +242,20 @@ ApplicationWindow {
     function updateSessionWindowMode() {
         if (["inserting", "joining", "stream"].indexOf(AppController.route) >= 0) {
             window.saveSessionWindowMode()
+            if (AppController.route === "stream" && !window.sessionFullscreenApplied) {
+                window.sessionFullscreenApplied = true
+                if (ShellStore.settings.autoFullScreen === true
+                        && window.visibility !== ApplicationWindow.FullScreen) {
+                    window.visibilityBeforeFullscreen = window.visibility
+                    window.showFullScreen()
+                }
+            }
             return
         }
         if (!window.sessionWindowModeSaved)
             return
         window.sessionWindowModeSaved = false
+        window.sessionFullscreenApplied = false
         window.visibilityBeforeFullscreen = window.fullscreenRestoreVisibilityBeforeSession
         if (window.visibility === window.visibilityBeforeSession)
             return
@@ -570,12 +580,6 @@ ApplicationWindow {
                     Qt.callLater(() => routeLoader.item.forceActiveFocus())
             }
             function onDirectLaunchRequested(appId, title) {
-                if (ShellStore.settings.autoFullScreen) {
-                    window.saveSessionWindowMode()
-                    if (window.visibility !== ApplicationWindow.FullScreen)
-                        window.visibilityBeforeFullscreen = window.visibility
-                    window.showFullScreen()
-                }
                 ShellStore.acceptDirectLaunch(appId, title)
             }
         }

--- a/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
+++ b/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
@@ -24,7 +24,7 @@ FocusScope {
     signal requestConsoleMode(bool enabled)
 
     readonly property var sections: [
-        {label: qsTr("Stream"), detail: qsTr("Picture, codec, bitrate"), icon: "monitor", page: 3, keywords: "resolution fps hdr color audio stats overlay bitrate codec reflex backend gpu directx vulkan steam big picture launch gamepad"},
+        {label: qsTr("Stream"), detail: qsTr("Picture, codec, bitrate"), icon: "monitor", page: 3, keywords: "resolution fps hdr color audio stats overlay bitrate codec reflex backend gpu directx vulkan steam big picture launch gamepad fullscreen session ready"},
         {label: qsTr("Audio"), detail: qsTr("Output and stream audio"), icon: "wave", page: 4, keywords: "sound audio volume output microphone"},
         {label: qsTr("Recording"), detail: qsTr("Capture, replay, shortcuts"), icon: "image", page: 12, keywords: "recording capture clip replay buffer memory duration folder resolution fps quality shortcuts F12"},
         {label: qsTr("Controls"), detail: qsTr("Pads, mouse, shortcuts"), icon: "controller", page: 5, keywords: "controller gyroscope steam sensitivity keyboard language shortcuts"},

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsConsolePage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsConsolePage.qml
@@ -31,11 +31,6 @@ DesktopSettingsPanel {
         DesktopSettingsToggle { checked: page.settingsScreen.boolSetting("leaveConsoleOnPointer",true); onValueChangedByUser: value => page.settingsScreen.setSetting("leaveConsoleOnPointer",value) }
     }
     DesktopSettingsRow {
-        width: parent.width; paperStyle: true; glyph: "monitor"; title: qsTr("Go fullscreen in console mode")
-        description: qsTr("Recommended on a TV · hides the window chrome entirely")
-        DesktopSettingsToggle { checked: page.settingsScreen.boolSetting("autoFullScreen",false); onValueChangedByUser: value => page.settingsScreen.setSetting("autoFullScreen",value) }
-    }
-    DesktopSettingsRow {
         width: parent.width; paperStyle: true; glyph: "person"; title: qsTr("Controller profile picker")
         description: qsTr("Choose a saved profile when console mode starts"); showDivider: false
         DesktopSettingsToggle { checked: page.settingsScreen.boolSetting("consoleProfilePickerOnLaunch",true); onValueChangedByUser: value => page.settingsScreen.setSetting("consoleProfilePickerOnLaunch",value) }

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
@@ -12,6 +12,16 @@ Column {
     DesktopSettingsPanel {
         width: parent.width; paperStyle: true
         DesktopSettingsRow {
+            width: parent.width; paperStyle: true; glyph: "monitor"; title: qsTr("Fullscreen when session is ready")
+            description: qsTr("Automatically enter fullscreen when your session is ready. F11 toggles fullscreen during play.")
+            DesktopSettingsToggle {
+                objectName: "autoFullScreenToggle"
+                checked: page.settingsScreen.boolSetting("autoFullScreen", true)
+                Accessible.name: qsTr("Fullscreen when session is ready")
+                onValueChangedByUser: value => page.settingsScreen.setSetting("autoFullScreen", value)
+            }
+        }
+        DesktopSettingsRow {
             width: parent.width; paperStyle: true; glyph: "controller"; title: qsTr("Steam Big Picture mode")
             description: qsTr("Request gamepad-friendly launchers such as Steam Big Picture. Applies to new GeForce NOW sessions only.")
             showDivider: false

--- a/opennow-qt/qml/screens/SettingsScreen.qml
+++ b/opennow-qt/qml/screens/SettingsScreen.qml
@@ -313,7 +313,7 @@ FocusScope {
                 {t:"Display", d:"The Qt stream surface uses the current display", v:"Monitor 1 · current display", info:true},
                 choice("Resolution", "Exact stream size · up / down to browse, A to pick", "resolution", resolutions, resolutionLabels(resolutions)),
                 choice("Frame rate", root.fpsNote(), "fps", frameRates, frameRates.map(value => String(value)), "segments", root.fpsLockedValues()),
-                toggle("Fullscreen on launch", "F11 toggles in-game", "autoFullScreen"),
+                toggle(qsTr("Fullscreen when session is ready"), qsTr("Automatically enter fullscreen when your session is ready. F11 toggles fullscreen during play."), "autoFullScreen"),
                 {t:"Video shader", d:"Post-process on this device after decode", v:["Off","Sharpen","FidelityFX","CRT"][shaderIndex], key:"videoShader", values:shaderValues, labels:["Off","Sharpen","FidelityFX","CRT"], control:"segments", selectedIndex:shaderIndex},
                 choice("Cursor", "Lock the pointer to the game window · F8", "nativeCursorOverlay", [true,false], ["Lock to window","Free"], "segments"),
             ]

--- a/opennow-qt/src/acceptance/SessionFullscreenAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SessionFullscreenAcceptance.cpp
@@ -21,6 +21,7 @@ int AcceptanceSession::startSessionFullscreenWorkload()
     auto *store = m_engine.singletonInstance<QObject *>(u"OpenNOW"_s, u"ShellStore"_s);
     if (!window || !store) return EXIT_FAILURE;
     m_controller.navigate(u"home"_s);
+    store->setProperty("settings", QVariantMap{{u"autoFullScreen"_s, false}});
     store->setProperty("streamer", QVariantMap{{u"status"_s, u"streaming"_s}});
     store->setProperty("streamState", u"streaming"_s);
     const auto restoredVisibility = m_arguments.contains(u"--smoke-fullscreen-restore-maximized"_s)
@@ -141,19 +142,56 @@ int AcceptanceSession::startSessionFullscreenWorkload()
             m_controller.directLaunchRequested(u"12345"_s, u"Fullscreen acceptance fixture"_s);
             break;
         case 15:
-            if (!require(window->visibility() == QWindow::FullScreen,
-                         "direct launch did not apply automatic fullscreen")) return;
+            if (!require(window->visibility() == nextSessionVisibility,
+                         "direct launch entered fullscreen before the session was ready")) return;
             m_controller.navigate(u"inserting"_s);
             break;
         case 16:
+            if (!require(window->visibility() == nextSessionVisibility,
+                         "session preparation entered fullscreen before readiness")) return;
             m_controller.navigate(u"stream"_s);
             break;
         case 17:
-            m_controller.navigate(u"home"_s);
+            if (!require(window->visibility() == QWindow::FullScreen,
+                         "ready session did not apply automatic fullscreen")) return;
+            if (!require(QMetaObject::invokeMethod(window, "toggleFullscreen"),
+                         "manual fullscreen override unavailable")) return;
             break;
         case 18:
             if (!require(window->visibility() == nextSessionVisibility,
+                         "manual fullscreen exit did not restore the launch mode")) return;
+            m_controller.showOverlay(u"desktop-stream-menu"_s);
+            break;
+        case 19:
+            if (!require(window->visibility() == nextSessionVisibility,
+                         "overlay reapplied automatic fullscreen")) return;
+            m_controller.showOverlay(QString{});
+            m_controller.navigate(u"joining"_s);
+            break;
+        case 20:
+            m_controller.navigate(u"stream"_s);
+            break;
+        case 21:
+            if (!require(window->visibility() == nextSessionVisibility,
+                         "reconnect overrode the manual window mode")) return;
+            m_controller.navigate(u"home"_s);
+            break;
+        case 22:
+            if (!require(window->visibility() == nextSessionVisibility,
                          "direct launch captured its automatic fullscreen as the initial mode")) return;
+            m_controller.navigate(u"joining"_s);
+            break;
+        case 23:
+            m_controller.navigate(u"stream"_s);
+            break;
+        case 24:
+            if (!require(window->visibility() == QWindow::FullScreen,
+                         "new session did not rearm automatic fullscreen")) return;
+            m_controller.navigate(u"home"_s);
+            break;
+        case 25:
+            if (!require(window->visibility() == nextSessionVisibility,
+                         "automatic fullscreen did not restore the pre-session mode")) return;
             timer->stop();
             m_application.exit(EXIT_SUCCESS);
             break;


### PR DESCRIPTION
## Changes
- Reuse `autoFullScreen`, defaulting it on for new or unset preferences while preserving saved opt-outs.
- Move the desktop toggle to Settings → Stream and clarify its label in both shells.
- Apply fullscreen once when entering the ready session, including direct launches, rather than while preparing or queueing. Preserve manual window changes through overlays and reconnects, then restore the pre-session mode on exit.

## Verification
- Qt Debug build passed.
- Full Qt suite: 208/208 passed, including six session-fullscreen cases covering both shells and windowed/maximized/fullscreen restoration.
- Rust settings tests: 23 passed; formatting and localization checks passed.
- Visually inspected the account-free settings screenshot. Live GFN gameplay was not tested.

![Default-on fullscreen setting in Stream settings](https://api-nightly.capy.ai/pr-assets/jPouhdrXiHz4swwxl4OnZ0CQdmvB0nVgjC2W3POZkfM)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23CVSXJJH0VGWYECBW9BNPR"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->