### PR TITLE
fix(input): restore controller reconnects and enable host vibration

### DIFF
--- a/docs/streamer-comparison/features.md
+++ b/docs/streamer-comparison/features.md
@@ -155,7 +155,8 @@ First update in the test. sequence `1`, buttons `0x1000`, timestamp `0x015b171a`
 
 The inner player index is hardcoded `03`. Slot and bitmap from the 38-byte type-12 packet are not copied.
 
-`INPUT_HAPTICS_ENABLED` encodes to `22 03 01 00 01` when the flag is on.
+`INPUT_HAPTICS_ENABLED` uses remote-input type 13 under command `0x0206`, with a
+little-endian u16 enable flag and timestamp envelope; see Type 6 haptics enable above.
 
 ## Media control, not NVB features
 

--- a/docs/streamer-comparison/features.md
+++ b/docs/streamer-comparison/features.md
@@ -25,7 +25,7 @@ From `geronimo.log` and `geronimo.log.bak` on this machine. `nvbFeatureControl` 
 | NVB type | Log verb | When | Meaning from surrounding lines | OpenNOW command | Payload in this tree |
 |---|---|---|---|---|---|
 | 0 | Enabled / Disabled | Every cursor-info change. Official then hides the remote cursor. | Server-composited cursor in the video | `0x0308` `COMMAND_MOUSE_CURSOR_CAPTURE` | Known. See below. |
-| 6 | Enabled | After `Sending haptics state 1 to server` | Gamepad rumble | `0x0322` `COMMAND_HAPTICS_STATE` | Known. One byte. See test `transport_control_inputs_do_not_disable_native_input`. |
+| 6 | Enabled | After `Sending haptics state 1 to server` | Gamepad rumble | `0x0206` remote input, inner type 13 | Little-endian u16 enable flag in the timestamp envelope. See test `transport_control_inputs_do_not_disable_native_input`. |
 | 8 | Enabled | Once when the session is ready, with type 0 | Track remote cursor image | `0x030d` `COMMAND_TRACK_REMOTE_CURSOR_IMAGE` | Known. See below. |
 | 10 | Update | Next to `Sending SDL mouse settings` or `Sending alt mouse settings (accel=0, speed=10)` | Host mouse accel and speed | none captured | **Not dumped. Do not send a guess.** |
 
@@ -56,6 +56,18 @@ on   0d 03 01 00 01
 ```
 
 Activation sends **on** and leaves it on.
+
+### Type 6 haptics enable
+
+Activation sends remote-input type 13 with body `01 00`, padded and timestamped inside
+the type `0x0e` envelope carried by control command `0x0206`. Disabling uses body
+`00 00`. The earlier mapping to `0x0322` was incorrect: that command controls cursor
+mimic strategy, not haptics.
+
+This mapping follows OpenNOW-Mac revision `666bd4a3391e13b074b37eecfd61d568e9231d34`,
+`GFN/NVST/BifrostFree/NvstRemoteInput.swift` (`hapticsState` and `framed`) and
+`NvstControlCommand.swift` (`mimicCursorStrategy`). Activation and enable/disable
+vectors are checked in `nvst_input.rs`.
 
 ### Type 10 mouse settings — no captured frame
 

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_input.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_input.rs
@@ -35,7 +35,6 @@ const COMMAND_MOUSE_CURSOR_CAPTURE: u16 = 0x0308;
 const COMMAND_TRACK_REMOTE_CURSOR_IMAGE: u16 = 0x030d;
 const COMMAND_WINDOW_STATE: u16 = 0x0320;
 const COMMAND_SYSTEM_STATE: u16 = 0x0321;
-const COMMAND_HAPTICS_STATE: u16 = 0x0322;
 
 const INPUT_KEY_DOWN: u32 = 3;
 const INPUT_KEY_UP: u32 = 4;
@@ -697,10 +696,10 @@ impl NvstInputCodec {
                 }
                 INPUT_HAPTICS_ENABLED => {
                     require_len(event.bytes, 6, "short haptics packet")?;
-                    encoded.push(NvstEncodedInput {
-                        route: NvstInputRoute::ControlReliable,
-                        bytes: haptics_state(read_u16_be(event.bytes, 4).unwrap_or_default() != 0),
-                    });
+                    encoded.push(haptics_state(
+                        read_u16_be(event.bytes, 4).unwrap_or_default() != 0,
+                        event.timestamp_us,
+                    ));
                 }
                 INPUT_LOCK_KEYS_SYNC => {
                     require_len(event.bytes, 5, "short lock-key sync packet")?;
@@ -940,10 +939,10 @@ fn activation_chain(timestamp_us: u64) -> [Vec<u8>; 8] {
         device_descriptor(timestamp_us, 0),
         mouse_cursor_capture(true),
         remote_cursor_tracking(true),
-        haptics_state(true),
         state_change(COMMAND_WINDOW_STATE, 19, 0),
         state_change(COMMAND_SYSTEM_STATE, 0, 0),
         enable_input(1, true),
+        haptics_state(true, timestamp_us).bytes,
     ]
 }
 
@@ -955,8 +954,11 @@ fn remote_cursor_tracking(enabled: bool) -> Vec<u8> {
     control_command(COMMAND_TRACK_REMOTE_CURSOR_IMAGE, &[u8::from(enabled)])
 }
 
-fn haptics_state(enabled: bool) -> Vec<u8> {
-    control_command(COMMAND_HAPTICS_STATE, &[u8::from(enabled)])
+fn haptics_state(enabled: bool, timestamp_us: u64) -> NvstEncodedInput {
+    remote_input_message(
+        remote_input_packet(INPUT_HAPTICS_ENABLED, &u16::from(enabled).to_le_bytes()),
+        timestamp_us,
+    )
 }
 
 fn control_keepalive(stream_value: u32) -> Vec<u8> {
@@ -1229,10 +1231,15 @@ mod tests {
         );
         assert_eq!(chain[2], hex("0803010001"));
         assert_eq!(chain[3], hex("0d03010001"));
-        assert_eq!(chain[4], hex("2203010001"));
-        assert_eq!(chain[5], hex("20030c00000000001300000000000000"));
-        assert_eq!(chain[6], hex("21030c00000000000000000000000000"));
-        assert_eq!(chain[7], hex("0b020c00000000000100000001000000"));
+        assert_eq!(chain[4], hex("20030c00000000001300000000000000"));
+        assert_eq!(chain[5], hex("21030c00000000000000000000000000"));
+        assert_eq!(chain[6], hex("0b020c00000000000100000001000000"));
+        assert_eq!(
+            chain[7],
+            hex(
+                "06022800000000240e000000000000060d0000000100000000000000000000000000000031bc320100000000"
+            )
+        );
     }
 
     #[test]
@@ -1482,7 +1489,12 @@ mod tests {
         let haptics = codec.encode(&haptics, 0).unwrap();
         assert_eq!(haptics.len(), 1);
         assert_eq!(haptics[0].route, NvstInputRoute::ControlReliable);
-        assert_eq!(haptics[0].bytes, hex("2203010001"));
+        assert_eq!(
+            haptics[0].bytes,
+            hex(
+                "06022800000000240e000000000000060d000000010000000000000000000000000000000b00000000000000"
+            )
+        );
 
         let mut lock_keys = vec![0x23];
         lock_keys.extend_from_slice(&12_u64.to_be_bytes());
@@ -1500,6 +1512,25 @@ mod tests {
                 .any(|bytes| bytes == lock_keys_type)
         );
         assert!(encoded[0].bytes.contains(&0b011));
+    }
+
+    #[test]
+    fn haptics_disable_uses_remote_input_envelope_and_preserves_timestamp() {
+        let mut codec = NvstInputCodec::default();
+        let disabled = hex("0d0000000000");
+        let expected = hex(
+            "06022800000000240e000000000000060d000000000000000000000000000000000000000c00000000000000",
+        );
+        let encoded = codec.encode(&disabled, 12).unwrap();
+        assert_eq!(encoded.len(), 1);
+        assert_eq!(encoded[0].route, NvstInputRoute::ControlReliable);
+        assert_eq!(encoded[0].bytes, expected);
+
+        let mut wrapped = hex("23000000000000000c22");
+        wrapped.extend_from_slice(&disabled);
+        assert_eq!(codec.encode(&wrapped, 999).unwrap(), encoded);
+        assert!(codec.encode(&disabled[..5], 12).is_err());
+        assert!(codec.encode(&wrapped[..wrapped.len() - 1], 999).is_err());
     }
 
     #[test]

--- a/opennow-qt/src/input/ControllerInput.cpp
+++ b/opennow-qt/src/input/ControllerInput.cpp
@@ -358,6 +358,10 @@ void ControllerInput::closeController(SDL_JoystickID id)
     if (accepted)
         emit gamepadSnapshot(m_inputControllerId ? 0 : static_cast<quint8>(slotIndex),
                              gamepadBitmap(), 0, 0, 0, 0, 0, 0, 0);
+    if (m_inputControllerId == id) {
+        setInputControllerId(0);
+        return;
+    }
     emit controllerCountChanged(controllerCount());
     updatePollInterval();
     refreshControllerMetadata();

--- a/opennow-qt/tests/tst_controllersources.cpp
+++ b/opennow-qt/tests/tst_controllersources.cpp
@@ -179,7 +179,7 @@ private slots:
         QVERIFY(snapshots.at(2).at(5).toInt() > 0);
     }
 
-    void disconnectedSelectionDoesNotFallBackToDuplicate()
+    void disconnectedSelectionReturnsToAutomaticInput()
     {
         ControllerInput input;
         QSignalSpy snapshots(&input, &ControllerInput::gamepadSnapshot);
@@ -189,18 +189,24 @@ private slots:
         QTRY_COMPARE(input.controllerCount(), 2);
         input.setInputControllerId(mapped.id);
         input.setShellCaptureEnabled(false);
-        const auto selected = mapped.id;
+        QSignalSpy selectionChanges(&input, &ControllerInput::inputControllerIdChanged);
+        snapshots.clear();
         QVERIFY(SDL_DetachVirtualJoystick(mapped.id));
         mapped.id = 0;
-        QTRY_COMPARE(input.controllerCount(), 0);
+        QTRY_COMPARE(input.availableControllers().size(), 1);
         auto *pollTimer = input.findChild<QTimer *>(QStringLiteral("controllerPollTimer"));
         QVERIFY(pollTimer);
-        QCOMPARE(pollTimer->interval(), 100);
-        QCOMPARE(input.inputControllerId(), selected);
-        QVERIFY(input.controllers().isEmpty());
-        QCOMPARE(input.availableControllers().size(), 1);
-        QCOMPARE(snapshots.last().at(0).toUInt(), 0u);
-        QCOMPARE(snapshots.last().at(1).toUInt(), 0u);
+        QCOMPARE(pollTimer->interval(), 4);
+        QCOMPARE(input.inputControllerId(), 0u);
+        QCOMPARE(selectionChanges.size(), 1);
+        QCOMPARE(input.controllerCount(), 1);
+        QCOMPARE(input.controllers().size(), 1);
+        QVERIFY(!snapshots.isEmpty());
+        QCOMPARE(snapshots.first().at(0).toUInt(), 0u);
+        QCOMPARE(snapshots.first().at(1).toUInt(), 0u);
+        for (int index = 2; index < 9; ++index)
+            QCOMPARE(snapshots.first().at(index).toInt(), 0);
+        QCOMPARE(snapshots.last().at(1).toUInt(), 0x0101u);
         snapshots.clear();
         VirtualPad reconnected;
         QVERIFY(reconnected.id);
@@ -208,12 +214,66 @@ private slots:
         QVERIFY(physical.button(true));
         QVERIFY(reconnected.button(true));
         QTest::qWait(150);
-        QVERIFY(snapshots.isEmpty());
+        QCOMPARE(input.controllerCount(), 2);
+        QVERIFY(!snapshots.isEmpty());
+        for (const auto &snapshot : snapshots)
+            QCOMPARE(snapshot.at(1).toUInt(), 0x0303u);
         input.setInputControllerId(reconnected.id);
         QCOMPARE(input.controllerCount(), 1);
         QCOMPARE(pollTimer->interval(), 4);
         QCOMPARE(snapshots.last().at(0).toUInt(), 0u);
         QCOMPARE(snapshots.last().at(2).toUInt(), 0x1000u);
+    }
+
+    void repeatedReplacementUsesPlayerOne_data()
+    {
+        QTest::addColumn<bool>("selected");
+        QTest::addColumn<bool>("shell");
+        QTest::newRow("automatic-gameplay") << false << false;
+        QTest::newRow("selected-gameplay") << true << false;
+        QTest::newRow("automatic-shell") << false << true;
+        QTest::newRow("selected-shell") << true << true;
+    }
+
+    void repeatedReplacementUsesPlayerOne()
+    {
+        QFETCH(bool, selected);
+        QFETCH(bool, shell);
+        ControllerInput input;
+        SourceKeySink sink;
+        QSignalSpy snapshots(&input, &ControllerInput::gamepadSnapshot);
+        input.setShellCaptureEnabled(shell);
+        SDL_JoystickID previous = 0;
+        for (int cycle = 0; cycle < 3; ++cycle) {
+            VirtualPad pad;
+            QVERIFY(pad.id && pad.id != previous);
+            previous = pad.id;
+            QTRY_COMPARE(input.controllerCount(), 1);
+            QCOMPARE(input.inputControllerId(), 0u);
+            QCOMPARE(input.controllers().first().toMap().value(QStringLiteral("slot")).toInt(), 1);
+            if (selected) input.setInputControllerId(pad.id);
+            QVERIFY(pad.button(true));
+            if (shell) {
+                QTRY_COMPARE(sink.presses.value(Qt::Key_Return), cycle + 1);
+            } else {
+                QTRY_VERIFY(!snapshots.isEmpty() && snapshots.last().at(2).toUInt() == 0x1000u);
+                QCOMPARE(snapshots.last().at(0).toUInt(), 0u);
+                QCOMPARE(snapshots.last().at(1).toUInt(), 0x0101u);
+            }
+            snapshots.clear();
+            QVERIFY(SDL_DetachVirtualJoystick(pad.id));
+            pad.id = 0;
+            QTRY_COMPARE(input.controllerCount(), 0);
+            QCOMPARE(input.inputControllerId(), 0u);
+            QVERIFY(input.controllers().isEmpty());
+            QVERIFY(input.availableControllers().isEmpty());
+            if (shell) QTRY_COMPARE(sink.releases.value(Qt::Key_Return), cycle + 1);
+            QVERIFY(!snapshots.isEmpty());
+            QCOMPARE(snapshots.last().at(0).toUInt(), 0u);
+            QCOMPARE(snapshots.last().at(1).toUInt(), 0u);
+            for (int index = 2; index < 9; ++index)
+                QCOMPARE(snapshots.last().at(index).toInt(), 0);
+        }
     }
 
     void shellButtonsReleaseOnlyAfterLastSourceReleases()

--- a/opennow-qt/tests/tst_controllertuning.cpp
+++ b/opennow-qt/tests/tst_controllertuning.cpp
@@ -189,7 +189,7 @@ private slots:
         QCOMPARE(pad.lowFrequency, 0);
     }
 
-    void disconnectedSelectedControllerDoesNotRumbleReplacement()
+    void disconnectedSelectedControllerReleasesPlayerOneForReplacement()
     {
         ControllerInput input;
         auto pad = std::make_unique<TuningPad>();
@@ -201,11 +201,15 @@ private slots:
         QCOMPARE(pad->lowFrequency, 5000);
         pad.reset();
         QTRY_COMPARE(input.controllerCount(), 0);
+        QCOMPARE(input.inputControllerId(), 0u);
         TuningPad replacement;
         QVERIFY(replacement.id);
-        QTRY_COMPARE(input.availableControllers().size(), 1);
-        input.playRumble(0, 5000, 9000, 1000);
+        QTRY_COMPARE(input.controllerCount(), 1);
+        QCOMPARE(input.controllers().first().toMap().value(QStringLiteral("slot")).toInt(), 1);
         QCOMPARE(replacement.lowFrequency, 0);
+        input.playRumble(0, 5000, 9000, 1000);
+        QCOMPARE(replacement.lowFrequency, 5000);
+        QCOMPARE(replacement.highFrequency, 9000);
     }
 };
 


### PR DESCRIPTION
Clear a selected controller's stale SDL instance ID on disconnect and return to automatic input through the existing ownership-transfer path. Disconnect still publishes a neutral snapshot and removes the device from the remote bitmap; a replacement can reuse player 1 without manual reselection. Controllers that remain connected keep their slots. This intentionally replaces the old policy of keeping a disconnected selection pinned indefinitely.

Correct native NVST haptics negotiation on all desktop platforms: send remote-input type 13 with a little-endian u16 enable flag in the timestamp envelope under command `0x0206`, after input activation. The previous `0x0322` command controls cursor mimic strategy, not haptics. The packet and activation ordering follow OpenNOW-Mac revision `666bd4a3391e13b074b37eecfd61d568e9231d34`; the protocol comparison document now records that reference.

Regression coverage includes repeated replacement in shell/gameplay with automatic and selected input, disconnect neutralization, replacement rumble routing, exact activation/enable/disable packets, timestamps, and truncated haptics input.

Validation: the selected reconnect regressions fail against the original ControllerInput implementation and pass with this change. All 17 Qt `ci-unit` CTest entries pass on Linux with Qt 6.8.3 / SDL 3.2.20. All 510 native streamer workspace tests pass (9 existing ignored); transport Clippy with `-D warnings`, workspace Rust formatting, and `git diff --check` pass. Full application packaging, a live GFN session, and physical macOS/Windows controller vibration were not tested. The separate Switch-client fix is being handled independently.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23DV6M1AFV6JXZCM7GVCPHQ"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->