### PR TITLE
feat(qt): add MetalFX clarity and noise reduction sliders

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -9,7 +9,11 @@
   },
   "upscalingSettings": {
     "title": "Upscaling",
-    "description": "Spatial upscaling for enlarged video. Uses extra GPU time; falls back to normal scaling when MetalFX is unavailable."
+    "description": "Spatial upscaling for enlarged video. Uses extra GPU time; falls back to normal scaling when MetalFX is unavailable.",
+    "clarity": "Clarity",
+    "clarityDescription": "Sharpen details before MetalFX upscaling. Set to 0 to disable.",
+    "noiseReduction": "Noise Reduction",
+    "noiseReductionDescription": "Smooth noise before MetalFX upscaling. Set to 0 to disable."
   },
   "recordingSettings": {
     "recordingElapsed": "Recording · %1",

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -261,6 +261,8 @@ impl SettingsStore {
         );
         normalize_choice(&mut self.values, "frameGeneration", &["off", "2x"], "off");
         normalize_choice(&mut self.values, "upscaling", &["off", "metalfx"], "off");
+        clamp_integer(&mut self.values, "upscalingSharpness", 0, 15, 10);
+        clamp_integer(&mut self.values, "upscalingDenoise", 0, 20, 0);
         for key in ["decoderPreference", "encoderPreference"] {
             normalize_choice(
                 &mut self.values,
@@ -768,7 +770,8 @@ fn legacy_data_dirs(primary: &Path) -> Vec<PathBuf> {
 fn defaults() -> Map<String, Value> {
     json!({
         "resolution":"1920x1080", "aspectRatio":"16:9", "posterSizeScale":1.05,
-        "fps":60, "frameGeneration":"off", "upscaling":"off", "maxBitrateMbps":75, "recordingBitrateMbps":null,
+        "fps":60, "frameGeneration":"off", "upscaling":"off", "upscalingSharpness":10, "upscalingDenoise":0,
+        "maxBitrateMbps":75, "recordingBitrateMbps":null,
         "recordingResolution":"720p", "recordingFps":30, "streamClientMode":"native",
         "replayBufferEnabled":false, "replayBufferSeconds":30, "replayBufferMemoryMiB":256,
         "nativeVideoBackend":"auto", "nativeStreamerExecutablePath":"", "audioOutputDevice":"",
@@ -1598,6 +1601,40 @@ mod tests {
         .unwrap();
         let store = SettingsStore::load(Some(directory.clone())).unwrap();
         assert_eq!(store.all()["upscaling"], json!("off"));
+        let _ = fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn upscaling_enhancement_defaults_bounds_and_persistence() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = env::temp_dir().join(format!("opennow-upscaling-enhancement-{unique}"));
+        let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
+        for (key, maximum, fallback) in
+            [("upscalingSharpness", 15, 10), ("upscalingDenoise", 20, 0)]
+        {
+            assert_eq!(store.all()[key], json!(fallback));
+            assert_eq!(store.set(key, json!(-1)).unwrap(), json!(0));
+            assert_eq!(store.set(key, json!(maximum + 1)).unwrap(), json!(maximum));
+            for invalid in [json!("7"), json!(true), json!(null), json!(1.5)] {
+                assert_eq!(store.set(key, invalid).unwrap(), json!(fallback));
+            }
+            assert_eq!(store.set(key, json!(7)).unwrap(), json!(7));
+        }
+        let store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["upscalingSharpness"], json!(7));
+        assert_eq!(store.all()["upscalingDenoise"], json!(7));
+        fs::write(
+            directory.join("settings.json"),
+            serde_json::to_vec(&json!({"upscalingSharpness": 100, "upscalingDenoise": -2}))
+                .unwrap(),
+        )
+        .unwrap();
+        let store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["upscalingSharpness"], json!(15));
+        assert_eq!(store.all()["upscalingDenoise"], json!(0));
         let _ = fs::remove_dir_all(directory);
     }
 

--- a/native/opennow-streamer/crates/opennow-streamer-ffi/README.md
+++ b/native/opennow-streamer/crates/opennow-streamer-ffi/README.md
@@ -42,18 +42,33 @@ overflow, without discarding status or response callbacks. The shell owns
 physical-device routing and shutdown. Individual rumble events are
 not logged on the high-frequency callback path.
 
-### Optional MetalFX spatial upscaling (ABI 7, render command 2)
+### Optional MetalFX spatial upscaling (ABI 8, render command 3)
 
-ABI 7 requires rebuilding the Qt shell and native runtime together. Version 2 of
-`OpenNowStreamerRecordCommand` appends `upscale_width` and `upscale_height`.
-Set both to zero for normal scaling. On Metal, nonzero values request spatial
+ABI 8 requires rebuilding the Qt shell and native runtime together. Version 3 of
+`OpenNowStreamerRecordCommand` appends `upscale_sharpness` and `upscale_denoise`
+after the version-2 `upscale_width` and `upscale_height` fields. Earlier command
+versions and truncated layouts are rejected. Initialize sharpness to 10 and denoise
+to 0; valid inclusive ranges are 0–15 and 0–20 respectively. Invalid controls are
+rejected even when scaling is disabled. Other graphics backends ignore valid controls.
+Set both target dimensions to zero for normal scaling. On Metal, nonzero dimensions request spatial
 MetalFX at the video viewport's physical pixel size, excluding letterboxing.
 Dimensions must both be zero or each be in `1..=16384`. Other graphics backends
 ignore the target. Unsupported MetalFX configurations fall back to the original
 converted texture without stopping the session.
 
 The Mac producer encodes scaling after YUV-to-RGB conversion in the same borrowed
-command buffer. The returned texture dimensions describe the actual output;
+command buffer. Clarity and denoise filter source-resolution RGB in that conversion
+pass, before MetalFX; they are not MetalFX descriptor settings. The four cardinal
+neighbors form `blur`, with `sharpness = value / 10` and
+`denoise = min(value / 10 * 0.65, 1)`. The shader computes
+`denoised = mix(center, blur, denoise)`, then clamps
+`denoised + (denoised - blur) * sharpness` to 0–1, matching OpenNOW-Mac's native
+spatial shader. Zero controls skip the neighborhood samples. Changes update
+uniforms without rebuilding the scaler or restarting the session.
+New control values apply when the next decoded frame is recorded; a retained output
+keeps its existing processing until that frame arrives. Token ownership and the
+single-record contract remain unchanged.
+The returned texture dimensions describe the actual output;
 `OpenNowStreamerFrameInfo` still describes the decoded source. Source sequence,
 timestamps, color precision, frame-slot ownership, and scene-graph retirement
 remain unchanged. Qt must refresh the target after resize, fullscreen, or display

--- a/native/opennow-streamer/crates/opennow-streamer-ffi/include/opennow_streamer_ffi.h
+++ b/native/opennow-streamer/crates/opennow-streamer-ffi/include/opennow_streamer_ffi.h
@@ -9,10 +9,10 @@
 extern "C" {
 #endif
 
-#define OPENNOW_STREAMER_FFI_ABI_VERSION 7u
+#define OPENNOW_STREAMER_FFI_ABI_VERSION 8u
 #define OPENNOW_STREAMER_VULKAN_DEVICE_INFO_VERSION 1u
 #define OPENNOW_STREAMER_GRAPHICS_CONTEXT_VERSION 3u
-#define OPENNOW_STREAMER_RENDER_COMMAND_VERSION 2u
+#define OPENNOW_STREAMER_RENDER_COMMAND_VERSION 3u
 
 #define OPENNOW_STREAMER_GRAPHICS_API_D3D11 1u
 #define OPENNOW_STREAMER_GRAPHICS_API_VULKAN 2u
@@ -98,6 +98,7 @@ typedef struct OpenNowStreamerGraphicsContext {
  * One shell-owned in-flight slot and the current QRhi native command buffer.
  * record_frame writes conversion/synchronization commands into this command stream; it never
  * creates, commits, submits, or waits for another command buffer.
+ * Sharpness is 0..15 (default 10), denoise is 0..20 (default 0); both apply before MetalFX.
  */
 typedef struct OpenNowStreamerRecordCommand {
     uint32_t version;
@@ -106,6 +107,8 @@ typedef struct OpenNowStreamerRecordCommand {
     uint32_t frame_slot;
     uint32_t upscale_width;
     uint32_t upscale_height;
+    uint32_t upscale_sharpness;
+    uint32_t upscale_denoise;
 } OpenNowStreamerRecordCommand;
 
 typedef struct OpenNowStreamerFrameInfo {

--- a/native/opennow-streamer/crates/opennow-streamer-ffi/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-ffi/src/lib.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 
 static FIRST_FRAME_LOGGED: AtomicBool = AtomicBool::new(false);
 
-pub const OPENNOW_STREAMER_FFI_ABI_VERSION: u32 = 7;
+pub const OPENNOW_STREAMER_FFI_ABI_VERSION: u32 = 8;
 pub const OPENNOW_STREAMER_VULKAN_DEVICE_INFO_VERSION: u32 = 1;
 const DEFAULT_MAX_COMMAND_BYTES: usize = 1024 * 1024;
 const MAX_QUEUE_CAPACITY: usize = 4096;
@@ -204,7 +204,7 @@ pub enum OpenNowStreamerStatus {
 pub const OPENNOW_STREAMER_GRAPHICS_CONTEXT_VERSION: u32 = 3;
 pub const OPENNOW_STREAMER_GRAPHICS_CAP_VULKAN_DMABUF_IMPORT: u32 = 1;
 pub const OPENNOW_STREAMER_GRAPHICS_CAP_VULKAN_DMABUF_BUFFER_IMPORT: u32 = 2;
-pub const OPENNOW_STREAMER_RENDER_COMMAND_VERSION: u32 = 2;
+pub const OPENNOW_STREAMER_RENDER_COMMAND_VERSION: u32 = 3;
 pub const OPENNOW_STREAMER_GRAPHICS_API_D3D11: u32 = 1;
 pub const OPENNOW_STREAMER_GRAPHICS_API_VULKAN: u32 = 2;
 pub const OPENNOW_STREAMER_GRAPHICS_API_METAL: u32 = 3;
@@ -241,6 +241,8 @@ pub struct OpenNowStreamerRecordCommand {
     pub frame_slot: u32,
     pub upscale_width: u32,
     pub upscale_height: u32,
+    pub upscale_sharpness: u32,
+    pub upscale_denoise: u32,
 }
 
 #[repr(C)]
@@ -626,6 +628,8 @@ fn render_command(
 ) -> Result<GraphicsRecordCommand, OpenNowStreamerStatus> {
     if command.version != OPENNOW_STREAMER_RENDER_COMMAND_VERSION
         || command.struct_size < size_of::<OpenNowStreamerRecordCommand>()
+        || command.upscale_sharpness > 15
+        || command.upscale_denoise > 20
     {
         return Err(OpenNowStreamerStatus::InvalidConfig);
     }
@@ -634,6 +638,8 @@ fn render_command(
         frame_slot: command.frame_slot,
         upscale_width: command.upscale_width,
         upscale_height: command.upscale_height,
+        upscale_sharpness: command.upscale_sharpness,
+        upscale_denoise: command.upscale_denoise,
     })
 }
 
@@ -1492,7 +1498,7 @@ mod tests {
 
     #[test]
     fn abi_five_appends_the_shared_vulkan_owner() {
-        assert_eq!(OPENNOW_STREAMER_FFI_ABI_VERSION, 7);
+        assert_eq!(OPENNOW_STREAMER_FFI_ABI_VERSION, 8);
         assert_eq!(OPENNOW_STREAMER_VULKAN_DEVICE_INFO_VERSION, 1);
         assert_eq!(
             std::mem::offset_of!(OpenNowStreamerConfig, vulkan_device),
@@ -1792,13 +1798,55 @@ mod tests {
             frame_slot: 2,
             upscale_width: 0,
             upscale_height: 0,
+            upscale_sharpness: 10,
+            upscale_denoise: 0,
         }
+    }
+
+    #[test]
+    fn render_command_three_preserves_controls_and_rejects_previous_layout_and_ranges() {
+        let mut command = ffi_render_command();
+        let native = render_command(command).unwrap();
+        assert_eq!(native.upscale_sharpness, 10);
+        assert_eq!(native.upscale_denoise, 0);
+        command.upscale_sharpness = 15;
+        command.upscale_denoise = 20;
+        let native = render_command(command).unwrap();
+        assert_eq!(native.upscale_sharpness, 15);
+        assert_eq!(native.upscale_denoise, 20);
+        command.version = 2;
+        assert_eq!(
+            render_command(command),
+            Err(OpenNowStreamerStatus::InvalidConfig)
+        );
+        command.version = OPENNOW_STREAMER_RENDER_COMMAND_VERSION;
+        command.struct_size = std::mem::offset_of!(OpenNowStreamerRecordCommand, upscale_sharpness);
+        assert_eq!(
+            render_command(command),
+            Err(OpenNowStreamerStatus::InvalidConfig)
+        );
+        for (sharpness, denoise) in [(16, 0), (0, 21), (u32::MAX, u32::MAX)] {
+            command = ffi_render_command();
+            command.upscale_sharpness = sharpness;
+            command.upscale_denoise = denoise;
+            assert_eq!(
+                render_command(command),
+                Err(OpenNowStreamerStatus::InvalidConfig)
+            );
+        }
+        let messages = CallbackMessages::default();
+        let mut config = test_config(&messages);
+        config.abi_version = 7;
+        assert_eq!(
+            validate_config(&config),
+            Err(OpenNowStreamerStatus::InvalidConfig)
+        );
     }
 
     #[test]
     fn render_command_two_preserves_upscaling_and_rejects_old_layouts() {
         let mut command = ffi_render_command();
-        assert_eq!(OPENNOW_STREAMER_RENDER_COMMAND_VERSION, 2);
+        assert_eq!(OPENNOW_STREAMER_RENDER_COMMAND_VERSION, 3);
         assert_eq!(render_command(command).unwrap().upscale_width, 0);
         assert_eq!(render_command(command).unwrap().upscale_height, 0);
         command.upscale_width = 2560;

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/README.md
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/README.md
@@ -51,6 +51,15 @@ viewport pixels; pass both as zero to disable scaling. Scaling is attempted only
 axis shrinks and at least one grows. As an allocation safety policy, targets above 8192 on
 either axis or above 7680 × 4320 total pixels use normal conversion instead.
 
+`upscale_sharpness` (0–15, default 10) and `upscale_denoise` (0–20, default 0)
+match OpenNOW-Mac's native spatial shader before MetalFX. The existing source-size
+conversion pass averages four cardinal RGB neighbors, mixes the center toward that
+average by `min(denoise / 10 * 0.65, 1)`, then adds the difference from that average
+multiplied by `sharpness / 10` and clamps to 0–1. The normal non-MetalFX path ignores
+both controls, and zero controls avoid the extra samples. The uniforms are updated
+per recording and are not part of the scaler's dimension/format cache key, so live
+adjustments allocate no textures and rebuild no pipeline or scaler.
+
 MetalFX is dynamically loaded at runtime and checked against the adopted device. It is not a
 required framework at application load time. Unsupported systems, devices, formats, dimensions,
 allocation failures, and Objective-C scaler exceptions fall back to the source-size conversion.
@@ -73,7 +82,11 @@ and [metal-cpp declarations](https://github.com/apple/metal-cpp/blob/main/MetalF
 The focused Linux tests cover sizing, bounds, and format keys. On a MetalFX-capable Mac, run
 `cargo test -p opennow-streamer-platform-macos spatial_ -- --include-ignored` from the native
 streamer workspace to additionally check cache/retirement behavior and GPU constant-color
-preservation for eight- and ten-bit SDR. Only that hardware test reads GPU pixels back to the CPU.
+preservation for eight- and ten-bit SDR.
+The `spatial_source_shader_matches_reference_controls_without_rebuilding_pipeline` hardware
+test also checks zero-control passthrough, independent and combined effects on textured pixels,
+clipping and flat-color preservation at both output depths, and reuse of the same spatial
+textures and pipeline across control changes. GPU readback is confined to these tests.
 
 ## Standalone integration API
 

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
@@ -30,7 +30,7 @@ use objc2_metal::{
 use crate::color::ConversionParameters;
 use crate::failure::FailureReporter;
 use crate::format::{MetalFrameFormat, VideoBitDepth, VideoColorSpace};
-use crate::spatial::SpatialConfig;
+use crate::spatial::{SpatialConfig, SpatialControls};
 
 use super::mailbox::LatestMailbox;
 use super::metalfx::{self, SpatialResources};
@@ -79,21 +79,41 @@ vertex VertexOut embedded_video_vertex(uint vertex_id [[vertex_id]]) {
     return out;
 }
 
-fragment float4 embedded_video_fragment(
-    VertexOut in [[stage_in]],
-    texture2d<float> luma [[texture(0)]],
-    texture2d<float> chroma [[texture(1)]],
-    constant ConversionParameters &parameters [[buffer(0)]]) {
+float3 embedded_video_rgb(
+    texture2d<float> luma,
+    texture2d<float> chroma,
+    float2 uv,
+    constant ConversionParameters &parameters) {
     constexpr sampler linear_sampler(coord::normalized, address::clamp_to_edge, filter::linear);
-    float y = luma.sample(linear_sampler, in.texcoord).r * parameters.sample_scale;
-    float2 cbcr = chroma.sample(linear_sampler, in.texcoord).rg * parameters.sample_scale;
+    float y = luma.sample(linear_sampler, uv).r * parameters.sample_scale;
+    float2 cbcr = chroma.sample(linear_sampler, uv).rg * parameters.sample_scale;
     y = (y - parameters.luma_offset) * parameters.luma_scale;
     cbcr = (cbcr - parameters.chroma_offset) * parameters.chroma_scale;
     float3 rgb = float3(
         y + parameters.red_cr * cbcr.y,
         y + parameters.green_cb * cbcr.x + parameters.green_cr * cbcr.y,
         y + parameters.blue_cb * cbcr.x);
-    return float4(saturate(rgb), 1.0);
+    return saturate(rgb);
+}
+
+fragment float4 embedded_video_fragment(
+    VertexOut in [[stage_in]],
+    texture2d<float> luma [[texture(0)]],
+    texture2d<float> chroma [[texture(1)]],
+    constant ConversionParameters &parameters [[buffer(0)]],
+    constant float2 &controls [[buffer(1)]]) {
+    float3 center = embedded_video_rgb(luma, chroma, in.texcoord, parameters);
+    if (controls.x == 0.0 && controls.y == 0.0) {
+        return float4(center, 1.0);
+    }
+    float2 texel = max(1.0 / float2(luma.get_width(), luma.get_height()), float2(1.0 / 8192.0));
+    float3 blur = (
+        embedded_video_rgb(luma, chroma, in.texcoord + float2(texel.x, 0.0), parameters) +
+        embedded_video_rgb(luma, chroma, in.texcoord - float2(texel.x, 0.0), parameters) +
+        embedded_video_rgb(luma, chroma, in.texcoord + float2(0.0, texel.y), parameters) +
+        embedded_video_rgb(luma, chroma, in.texcoord - float2(0.0, texel.y), parameters)) * 0.25;
+    float3 denoised = mix(center, blur, clamp(controls.y, 0.0, 1.0));
+    return float4(clamp(denoised + (denoised - blur) * controls.x, float3(0.0), float3(1.0)), 1.0);
 }
 "#;
 
@@ -192,6 +212,8 @@ pub struct AdoptedMetalContext {
     pub command_buffer: *mut c_void,
     pub upscale_width: u32,
     pub upscale_height: u32,
+    pub upscale_sharpness: u32,
+    pub upscale_denoise: u32,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -278,6 +300,7 @@ impl MetalFrame {
             command_buffer,
             frame_slot,
             (adopted.upscale_width, adopted.upscale_height),
+            SpatialControls::new(adopted.upscale_sharpness, adopted.upscale_denoise),
             Arc::clone(&self.counters),
             Arc::clone(&self.failures),
         )?;
@@ -419,6 +442,7 @@ impl MetalState {
         command_buffer: &ProtocolObject<dyn MTLCommandBuffer>,
         frame_slot: u32,
         upscale_size: (u32, u32),
+        controls: SpatialControls,
         counters: Arc<Counters>,
         failures: Arc<FailureReporter>,
     ) -> Result<MetalRecordedFrame, BackendError> {
@@ -485,6 +509,12 @@ impl MetalState {
                 })?
         };
 
+        let controls = if spatial.is_some() {
+            controls
+        } else {
+            SpatialControls::new(0, 0)
+        };
+
         let render_pass = MTLRenderPassDescriptor::renderPassDescriptor();
         let attachments = render_pass.colorAttachments();
         let attachment = unsafe { attachments.objectAtIndexedSubscript(0) };
@@ -508,6 +538,11 @@ impl MetalState {
                 NonNull::from(&parameters).cast::<c_void>(),
                 std::mem::size_of_val(&parameters),
                 0,
+            );
+            encoder.setFragmentBytes_length_atIndex(
+                NonNull::from(&controls).cast::<c_void>(),
+                std::mem::size_of_val(&controls),
+                1,
             );
         }
         encoder.setViewport(MTLViewport {
@@ -719,6 +754,186 @@ mod tests {
         kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
     };
     use objc2_metal::MTLPixelFormat;
+
+    #[test]
+    #[ignore = "requires a Mac with MetalFX spatial scaling and GPU readback"]
+    fn spatial_source_shader_matches_reference_controls_without_rebuilding_pipeline() {
+        use super::*;
+        use objc2_metal::{
+            MTLBlitCommandEncoder, MTLBuffer, MTLCommandQueue, MTLCreateSystemDefaultDevice,
+            MTLOrigin, MTLRegion, MTLResourceOptions, MTLSize,
+        };
+
+        let device = MTLCreateSystemDefaultDevice().expect("Metal device");
+        assert!(metalfx::supports_device(&device));
+        let queue = device.newCommandQueue().unwrap();
+        let mut state = MetalState::new(&device, 1).unwrap();
+        let region = MTLRegion {
+            origin: MTLOrigin { x: 0, y: 0, z: 0 },
+            size: MTLSize {
+                width: 64,
+                height: 64,
+                depth: 1,
+            },
+        };
+        for format in [BiPlanarFormat::Nv12Full, BiPlanarFormat::P010Full] {
+            let output_format = format.output_format();
+            state.ensure_pipeline(output_format).unwrap();
+            let pipeline = state.pipelines[output_format.pipeline_index()]
+                .as_ref()
+                .unwrap()
+                .clone();
+            let config = SpatialConfig::new(64, 64, 128, 128, output_format).unwrap();
+            let spatial = state.spatial_resources(0, Some(config)).unwrap();
+            let parameters = format.parameters(VideoColorSpace::Bt709);
+            let texture = |pixel_format, usage| {
+                let descriptor = unsafe {
+                    MTLTextureDescriptor::texture2DDescriptorWithPixelFormat_width_height_mipmapped(
+                        pixel_format,
+                        64,
+                        64,
+                        false,
+                    )
+                };
+                descriptor.setStorageMode(MTLStorageMode::Shared);
+                descriptor.setUsage(usage);
+                device.newTextureWithDescriptor(&descriptor).unwrap()
+            };
+            let luma = texture(MTLPixelFormat::R32Float, MTLTextureUsage::ShaderRead);
+            let chroma = texture(MTLPixelFormat::RG32Float, MTLTextureUsage::ShaderRead);
+            let output = spatial.input.clone();
+            let mut luma_data = vec![0.3 / parameters.sample_scale; 64 * 64];
+            luma_data[32 * 64 + 32] = 0.4 / parameters.sample_scale;
+            luma_data[32 * 64 + 48] = 1.0 / parameters.sample_scale;
+            luma_data[32 * 64 + 16] = 0.0;
+            let chroma_data = vec![parameters.chroma_offset / parameters.sample_scale; 64 * 64 * 2];
+            unsafe {
+                luma.replaceRegion_mipmapLevel_withBytes_bytesPerRow(
+                    region,
+                    0,
+                    NonNull::new(luma_data.as_mut_ptr()).unwrap().cast(),
+                    64 * 4,
+                );
+                chroma.replaceRegion_mipmapLevel_withBytes_bytesPerRow(
+                    region,
+                    0,
+                    NonNull::new(chroma_data.as_ptr().cast_mut())
+                        .unwrap()
+                        .cast(),
+                    64 * 8,
+                );
+            }
+            for (sharpness, denoise, expected) in [
+                (0, 0, 0.4),
+                (10, 0, 0.5),
+                (15, 0, 0.55),
+                (0, 10, 0.335),
+                (10, 10, 0.37),
+                (15, 20, 0.3),
+                (0, 0, 0.4),
+            ] {
+                let controls = SpatialControls::new(sharpness, denoise);
+                let reused = state.spatial_resources(0, Some(config)).unwrap();
+                assert_eq!(
+                    Retained::as_ptr(&spatial.input),
+                    Retained::as_ptr(&reused.input)
+                );
+                assert_eq!(
+                    Retained::as_ptr(&spatial.output),
+                    Retained::as_ptr(&reused.output)
+                );
+                state.ensure_pipeline(output_format).unwrap();
+                assert_eq!(
+                    Retained::as_ptr(&pipeline),
+                    Retained::as_ptr(
+                        state.pipelines[output_format.pipeline_index()]
+                            .as_ref()
+                            .unwrap()
+                    )
+                );
+                let command = queue.commandBuffer().unwrap();
+                let pass = MTLRenderPassDescriptor::renderPassDescriptor();
+                let attachment = unsafe { pass.colorAttachments().objectAtIndexedSubscript(0) };
+                attachment.setTexture(Some(&output));
+                attachment.setLoadAction(MTLLoadAction::DontCare);
+                attachment.setStoreAction(MTLStoreAction::Store);
+                let encoder = command.renderCommandEncoderWithDescriptor(&pass).unwrap();
+                encoder.setRenderPipelineState(&pipeline);
+                unsafe {
+                    encoder.setFragmentTexture_atIndex(Some(&luma), 0);
+                    encoder.setFragmentTexture_atIndex(Some(&chroma), 1);
+                    encoder.setFragmentBytes_length_atIndex(
+                        NonNull::from(&parameters).cast(),
+                        std::mem::size_of_val(&parameters),
+                        0,
+                    );
+                    encoder.setFragmentBytes_length_atIndex(
+                        NonNull::from(&controls).cast(),
+                        std::mem::size_of_val(&controls),
+                        1,
+                    );
+                    encoder.drawPrimitives_vertexStart_vertexCount(
+                        MTLPrimitiveType::Triangle,
+                        0,
+                        3,
+                    );
+                }
+                encoder.endEncoding();
+                assert!(reused.encode(&command));
+                let readback = device
+                    .newBufferWithLength_options(64 * 64 * 4, MTLResourceOptions::StorageModeShared)
+                    .unwrap();
+                let blit = command.blitCommandEncoder().unwrap();
+                unsafe {
+                    blit.copyFromTexture_sourceSlice_sourceLevel_sourceOrigin_sourceSize_toBuffer_destinationOffset_destinationBytesPerRow_destinationBytesPerImage(
+                        &output, 0, 0, region.origin, region.size, &readback, 0, 64 * 4, 64 * 64 * 4,
+                    );
+                }
+                blit.endEncoding();
+                command.commit();
+                command.waitUntilCompleted();
+                assert_eq!(command.status(), MTLCommandBufferStatus::Completed);
+                let maximum = if output_format == MetalFrameFormat::Rgba8Unorm {
+                    255
+                } else {
+                    1023
+                };
+                let shift = if maximum == 255 { 8 } else { 10 };
+                for (x, y, expected) in [
+                    (32, 32, expected),
+                    (0, 0, 0.3),
+                    (
+                        48,
+                        32,
+                        ((1.0 - 0.7 * controls.denoise) * (1.0 + controls.sharpness)
+                            - 0.3 * controls.sharpness)
+                            .clamp(0.0, 1.0),
+                    ),
+                    (
+                        16,
+                        32,
+                        (0.3 * controls.denoise * (1.0 + controls.sharpness)
+                            - 0.3 * controls.sharpness)
+                            .clamp(0.0, 1.0),
+                    ),
+                ] {
+                    let pixel =
+                        unsafe { *readback.contents().cast::<u32>().as_ptr().add(y * 64 + x) };
+                    for channel in [
+                        pixel & maximum,
+                        (pixel >> shift) & maximum,
+                        (pixel >> (2 * shift)) & maximum,
+                    ] {
+                        assert!(
+                            (channel as f32 / maximum as f32 - expected).abs()
+                                <= 1.5 / maximum as f32,
+                            "{format:?} {controls:?} ({x},{y}): {channel}/{maximum} != {expected}"
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     #[ignore = "requires a Mac with MetalFX spatial scaling"]

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/embedded.rs
@@ -299,8 +299,7 @@ impl MetalFrame {
             self.frame.clone(),
             command_buffer,
             frame_slot,
-            (adopted.upscale_width, adopted.upscale_height),
-            SpatialControls::new(adopted.upscale_sharpness, adopted.upscale_denoise),
+            adopted,
             Arc::clone(&self.counters),
             Arc::clone(&self.failures),
         )?;
@@ -441,8 +440,7 @@ impl MetalState {
         frame: DecodedFrame,
         command_buffer: &ProtocolObject<dyn MTLCommandBuffer>,
         frame_slot: u32,
-        upscale_size: (u32, u32),
-        controls: SpatialControls,
+        adopted: AdoptedMetalContext,
         counters: Arc<Counters>,
         failures: Arc<FailureReporter>,
     ) -> Result<MetalRecordedFrame, BackendError> {
@@ -479,7 +477,13 @@ impl MetalState {
 
         let spatial = self.spatial_resources(
             frame_slot,
-            SpatialConfig::new(width, height, upscale_size.0, upscale_size.1, output_format),
+            SpatialConfig::new(
+                width,
+                height,
+                adopted.upscale_width,
+                adopted.upscale_height,
+                output_format,
+            ),
         );
         let output = if let Some(spatial) = &spatial {
             spatial.input.clone()
@@ -510,7 +514,7 @@ impl MetalState {
         };
 
         let controls = if spatial.is_some() {
-            controls
+            SpatialControls::new(adopted.upscale_sharpness, adopted.upscale_denoise)
         } else {
             SpatialControls::new(0, 0)
         };

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/video.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/macos/video.rs
@@ -678,6 +678,8 @@ mod tests {
                         command_buffer: Retained::as_ptr(&command).cast_mut().cast(),
                         upscale_width: 0,
                         upscale_height: 0,
+                        upscale_sharpness: 10,
+                        upscale_denoise: 0,
                     },
                     0,
                 )

--- a/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/spatial.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-macos/src/spatial.rs
@@ -3,6 +3,22 @@ use crate::format::MetalFrameFormat;
 const MAX_SPATIAL_DIMENSION: usize = 8192;
 const MAX_SPATIAL_PIXELS: usize = 7680 * 4320;
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct SpatialControls {
+    pub sharpness: f32,
+    pub denoise: f32,
+}
+
+impl SpatialControls {
+    pub fn new(sharpness: u32, denoise: u32) -> Self {
+        Self {
+            sharpness: sharpness.min(15) as f32 / 10.0,
+            denoise: (denoise.min(20) as f32 / 10.0 * 0.65).min(1.0),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct SpatialConfig {
     pub input_width: usize,
@@ -46,6 +62,25 @@ impl SpatialConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn spatial_controls_match_mac_source_stage_uniforms() {
+        assert_eq!(std::mem::size_of::<SpatialControls>(), 8);
+        assert_eq!(std::mem::offset_of!(SpatialControls, denoise), 4);
+        for (sharpness, denoise, expected_sharpness, expected_denoise) in [
+            (0, 0, 0.0, 0.0),
+            (10, 0, 1.0, 0.0),
+            (15, 10, 1.5, 0.65),
+            (5, 15, 0.5, 0.975),
+            (15, 16, 1.5, 1.0),
+            (15, 20, 1.5, 1.0),
+            (u32::MAX, u32::MAX, 1.5, 1.0),
+        ] {
+            let controls = SpatialControls::new(sharpness, denoise);
+            assert!((controls.sharpness - expected_sharpness).abs() < 0.000001);
+            assert!((controls.denoise - expected_denoise).abs() < 0.000001);
+        }
+    }
 
     #[test]
     fn spatial_scaling_requires_enlargement_on_at_least_one_axis() {

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/graphics.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/graphics.rs
@@ -59,6 +59,8 @@ pub struct GraphicsRecordCommand {
     pub frame_slot: u32,
     pub upscale_width: u32,
     pub upscale_height: u32,
+    pub upscale_sharpness: u32,
+    pub upscale_denoise: u32,
 }
 
 impl GraphicsRecordCommand {
@@ -74,6 +76,11 @@ impl GraphicsRecordCommand {
         {
             return Err(GraphicsRuntimeError::InvalidRenderCommand(
                 "upscale dimensions must both be zero or between 1 and 16384",
+            ));
+        }
+        if self.upscale_sharpness > 15 || self.upscale_denoise > 20 {
+            return Err(GraphicsRuntimeError::InvalidRenderCommand(
+                "upscale sharpness must be between 0 and 15 and denoise between 0 and 20",
             ));
         }
         Ok(self)
@@ -250,6 +257,8 @@ impl GraphicsFrame for opennow_streamer_platform_macos::MetalFrame {
                     command_buffer: command.command_buffer as *mut std::ffi::c_void,
                     upscale_width: command.upscale_width,
                     upscale_height: command.upscale_height,
+                    upscale_sharpness: command.upscale_sharpness,
+                    upscale_denoise: command.upscale_denoise,
                 },
                 command.frame_slot,
             )
@@ -758,6 +767,8 @@ mod tests {
             frame_slot: 7,
             upscale_width: 0,
             upscale_height: 0,
+            upscale_sharpness: 10,
+            upscale_denoise: 0,
         }
     }
 
@@ -778,6 +789,29 @@ mod tests {
                 ..command()
             };
             assert_eq!(request.validate().is_ok(), valid, "{width}x{height}");
+        }
+    }
+
+    #[test]
+    fn upscale_controls_are_bounded_even_when_scaling_is_disabled() {
+        for (sharpness, denoise, valid) in [
+            (0, 0, true),
+            (10, 0, true),
+            (15, 20, true),
+            (16, 0, false),
+            (0, 21, false),
+            (u32::MAX, u32::MAX, false),
+        ] {
+            for (width, height) in [(0, 0), (2560, 1440)] {
+                let request = GraphicsRecordCommand {
+                    upscale_width: width,
+                    upscale_height: height,
+                    upscale_sharpness: sharpness,
+                    upscale_denoise: denoise,
+                    ..command()
+                };
+                assert_eq!(request.validate().is_ok(), valid);
+            }
         }
     }
 

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -154,6 +154,10 @@ black/white levels on the intended GPU and display in windowed and fullscreen mo
 ## macOS upscaling
 
 Settings → Stream → Upscaling offers **Off** (default) and **MetalFX** on macOS.
+The **Clarity** slider runs from 0–15 (default 10), and **Noise Reduction** from
+0–20 (default 0), matching OpenNOW-Mac. Both are enabled only with MetalFX selected;
+zero disables that enhancement. Values persist when upscaling is turned off and
+update both desktop and console stream surfaces without restarting the session.
 The console-oriented Stream settings expose the same saved preference. Linux and
 Windows show no upscaling control and never enable MetalFX, even if a settings file
 was copied from a Mac.

--- a/opennow-qt/qml/desktop/settings/controls/DesktopSettingsSlider.qml
+++ b/opennow-qt/qml/desktop/settings/controls/DesktopSettingsSlider.qml
@@ -11,6 +11,7 @@ Row {
     property real trackWidth: DesktopTokens.px(200)
     property string suffix: "%"
     property int decimals: 0
+    property string accessibleName: ""
     signal moved(real value)
     signal committed(real value)
     spacing: 14
@@ -24,6 +25,7 @@ Row {
 
     Slider {
         id: slider
+        Accessible.name: root.accessibleName
         width: root.trackWidth
         height: DesktopTokens.px(28)
         live: true

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
@@ -64,6 +64,40 @@ Column {
             }
         }
         DesktopSettingsRow {
+            id: clarityRow
+            objectName: "upscalingSharpnessRow"
+            visible: Qt.platform.os === "osx"
+            enabled: page.settingsScreen.valueSetting("upscaling", "off") === "metalfx"
+            opacity: enabled ? 1 : 0.45
+            width: parent.width; paperStyle: true; glyph: "sun"; title: qsTr("Clarity")
+            description: qsTr("Sharpen details before MetalFX upscaling. Set to 0 to disable.")
+            DesktopSettingsSlider {
+                objectName: "upscalingSharpnessSlider"
+                accessibleName: qsTr("Clarity")
+                trackWidth: Math.max(DesktopTokens.px(160), clarityRow.width - DesktopTokens.px(460))
+                from: 0; to: 15; stepSize: 1; suffix: ""
+                value: Number(page.settingsScreen.valueSetting("upscalingSharpness", 10))
+                onCommitted: value => page.settingsScreen.setSetting("upscalingSharpness", Math.round(value))
+            }
+        }
+        DesktopSettingsRow {
+            id: denoiseRow
+            objectName: "upscalingDenoiseRow"
+            visible: Qt.platform.os === "osx"
+            enabled: page.settingsScreen.valueSetting("upscaling", "off") === "metalfx"
+            opacity: enabled ? 1 : 0.45
+            width: parent.width; paperStyle: true; glyph: "drop"; title: qsTr("Noise Reduction")
+            description: qsTr("Smooth noise before MetalFX upscaling. Set to 0 to disable.")
+            DesktopSettingsSlider {
+                objectName: "upscalingDenoiseSlider"
+                accessibleName: qsTr("Noise Reduction")
+                trackWidth: Math.max(DesktopTokens.px(160), denoiseRow.width - DesktopTokens.px(460))
+                from: 0; to: 20; stepSize: 1; suffix: ""
+                value: Number(page.settingsScreen.valueSetting("upscalingDenoise", 0))
+                onCommitted: value => page.settingsScreen.setSetting("upscalingDenoise", Math.round(value))
+            }
+        }
+        DesktopSettingsRow {
             width: parent.width; paperStyle: true; glyph: "sun"; title: qsTr("HDR")
             description: HdrOutput.supported && !ShellStore.hdrDecoderAvailable()
                 ? qsTr("HDR requires a supported 10-bit H.265 or AV1 hardware decoder.") : HdrOutput.status

--- a/opennow-qt/qml/desktop/stream/DesktopStreamScreen.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopStreamScreen.qml
@@ -98,6 +98,8 @@ FocusScope {
         videoSize: Qt.size(Number(root.profile.width || 0), Number(root.profile.height || 0))
         frameGeneration: String(ShellStore.settings.frameGeneration || 'off') === '2x'
         metalFxUpscaling: Qt.platform.os === "osx" && ShellStore.settings.upscaling === "metalfx"
+        upscalingSharpness: Number(ShellStore.settings.upscalingSharpness ?? 10)
+        upscalingDenoise: Number(ShellStore.settings.upscalingDenoise ?? 0)
         z: 0
         onLocalShortcutRequested: action => ShellStore.applyStreamShortcutAction(action)
     }

--- a/opennow-qt/qml/screens/SettingsScreen.qml
+++ b/opennow-qt/qml/screens/SettingsScreen.qml
@@ -292,6 +292,16 @@ FocusScope {
                 {t:"Max bitrate", d:"Maximum requested stream bitrate", v:Number(settings.maxBitrateMbps || 75) + " Mbps", key:"maxBitrateMbps", values:[25,50,75,100,150,200], labels:["25 Mbps","50 Mbps","75 Mbps","100 Mbps","150 Mbps","200 Mbps"], control:"slider", sliderPercent:Number(settings.maxBitrateMbps || 75) / 106},
                 {t:qsTr("Frame generation (Experimental)"), d:qsTr("Targets 120 displayed FPS from a 60 FPS stream. Requires a fast GPU and 120 Hz display; adds latency and artifacts."), v:frameGeneration ? qsTr("2×") : qsTr("Off"), key:"frameGeneration", values:["off","2x"], labels:[qsTr("Off"),qsTr("2×")], control:"segments", selectedIndex:frameGeneration ? 1 : 0},
                 ...(Qt.platform.os === "osx" ? [choice(qsTr("Upscaling"), qsTr("Spatial upscaling for enlarged video. Uses extra GPU time; falls back to normal scaling when MetalFX is unavailable."), "upscaling", ["off", "metalfx"], [qsTr("Off"), "MetalFX"], "segments")] : []),
+                ...(Qt.platform.os === "osx" ? [
+                    {key:"upscalingSharpness", title:qsTr("Clarity"), description:qsTr("Sharpen details before MetalFX upscaling. Set to 0 to disable."), maximum:15, fallback:10},
+                    {key:"upscalingDenoise", title:qsTr("Noise Reduction"), description:qsTr("Smooth noise before MetalFX upscaling. Set to 0 to disable."), maximum:20, fallback:0}
+                ].map(setting => {
+                    const value = Number(settings[setting.key] ?? setting.fallback)
+                    const values = Array.from({length:setting.maximum + 1}, (_, index) => index)
+                    return {t:setting.title, d:setting.description, v:String(value), key:setting.key,
+                        values:values, labels:values.map(String), control:"slider", sliderPercent:value / setting.maximum,
+                        info:settings.upscaling !== "metalfx"}
+                }) : []),
                 toggle("Cloud G-Sync", "Variable refresh on G-Sync and FreeSync displays", "enableCloudGsync"),
                 toggle("Stats overlay on launch", "Ctrl+N toggles it in-game", "showStatsOnLaunch"),
                 choice("Stats overlay position", "FPS, RTT, loss and bitrate readout", "statsOverlayPosition", ["top-right","top-left","bottom-right","bottom-left"], ["Top-right","Top-left","Bottom-right","Bottom-left"])

--- a/opennow-qt/qml/screens/StreamScreen.qml
+++ b/opennow-qt/qml/screens/StreamScreen.qml
@@ -93,6 +93,8 @@ FocusScope {
         videoSize: Qt.size(Number(root.profile.width || 0), Number(root.profile.height || 0))
         frameGeneration: String(ShellStore.settings.frameGeneration || 'off') === '2x'
         metalFxUpscaling: Qt.platform.os === "osx" && ShellStore.settings.upscaling === "metalfx"
+        upscalingSharpness: Number(ShellStore.settings.upscalingSharpness ?? 10)
+        upscalingDenoise: Number(ShellStore.settings.upscalingDenoise ?? 0)
         z: 0
         onLocalShortcutRequested: action => ShellStore.applyStreamShortcutAction(action)
     }

--- a/opennow-qt/src/streaming/StreamVideoItem.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItem.cpp
@@ -211,6 +211,34 @@ QVariantMap StreamVideoItem::frameGenerationStats() const
     return m_renderCallback ? m_renderCallback->frameGenerationStats() : QVariantMap{};
 }
 
+int StreamVideoItem::upscalingSharpness() const
+{
+    return m_upscalingSharpness;
+}
+
+void StreamVideoItem::setUpscalingSharpness(int value)
+{
+    value = qBound(0, value, 15);
+    if (m_upscalingSharpness == value) return;
+    m_upscalingSharpness = value;
+    emit upscalingSharpnessChanged();
+    update();
+}
+
+int StreamVideoItem::upscalingDenoise() const
+{
+    return m_upscalingDenoise;
+}
+
+void StreamVideoItem::setUpscalingDenoise(int value)
+{
+    value = qBound(0, value, 20);
+    if (m_upscalingDenoise == value) return;
+    m_upscalingDenoise = value;
+    emit upscalingDenoiseChanged();
+    update();
+}
+
 bool StreamVideoItem::metalFxUpscaling() const
 {
     return m_metalFxUpscaling;

--- a/opennow-qt/src/streaming/StreamVideoItem.h
+++ b/opennow-qt/src/streaming/StreamVideoItem.h
@@ -38,6 +38,10 @@ class StreamVideoItem : public QQuickItem
                    NOTIFY frameGenerationChanged)
     Q_PROPERTY(bool metalFxUpscaling READ metalFxUpscaling WRITE setMetalFxUpscaling
                    NOTIFY metalFxUpscalingChanged)
+    Q_PROPERTY(int upscalingSharpness READ upscalingSharpness WRITE setUpscalingSharpness
+                   NOTIFY upscalingSharpnessChanged)
+    Q_PROPERTY(int upscalingDenoise READ upscalingDenoise WRITE setUpscalingDenoise
+                   NOTIFY upscalingDenoiseChanged)
     Q_PROPERTY(QVariantMap frameGenerationStats READ frameGenerationStats
                    NOTIFY frameGenerationStatsChanged)
 
@@ -71,6 +75,10 @@ public:
     void setFrameGeneration(bool enabled);
     bool metalFxUpscaling() const;
     void setMetalFxUpscaling(bool enabled);
+    int upscalingSharpness() const;
+    void setUpscalingSharpness(int value);
+    int upscalingDenoise() const;
+    void setUpscalingDenoise(int value);
     QVariantMap frameGenerationStats() const;
 
     static void setNativeStreamRuntime(NativeStreamRuntime *runtime);
@@ -108,6 +116,8 @@ signals:
     void shortcutBindingsChanged();
     void frameGenerationChanged();
     void metalFxUpscalingChanged();
+    void upscalingSharpnessChanged();
+    void upscalingDenoiseChanged();
     void frameGenerationStatsChanged();
     void localShortcutRequested(const QString &action);
 
@@ -164,6 +174,8 @@ private:
     bool m_inputEnabled = true;
     bool m_frameGeneration = false;
     bool m_metalFxUpscaling = false;
+    int m_upscalingSharpness = 10;
+    int m_upscalingDenoise = 0;
     QTimer m_frameStatsTimer;
     QMetaObject::Connection m_frameSwapConnection;
     QMetaObject::Connection m_frameUpdateConnection;

--- a/opennow-qt/src/streaming/rendering/NativeStreamRenderCallback.cpp
+++ b/opennow-qt/src/streaming/rendering/NativeStreamRenderCallback.cpp
@@ -157,6 +157,8 @@ public:
         if (m_rhi->backend() == QRhi::Metal && !m_upscalingTarget.isEmpty()) {
             command.upscale_width = static_cast<std::uint32_t>(m_upscalingTarget.width());
             command.upscale_height = static_cast<std::uint32_t>(m_upscalingTarget.height());
+            command.upscale_sharpness = static_cast<std::uint32_t>(m_upscalingSharpness);
+            command.upscale_denoise = static_cast<std::uint32_t>(m_upscalingDenoise);
         }
         finishFrame();
         OpenNowStreamerFrameInfo info{};
@@ -323,6 +325,16 @@ public:
         m_upscalingTarget = target;
     }
 
+    void setUpscalingEnhancement(int sharpness, int denoise) override
+    {
+        sharpness = qBound(0, sharpness, 15);
+        denoise = qBound(0, denoise, 20);
+        if (m_upscalingSharpness == sharpness && m_upscalingDenoise == denoise) return;
+        m_upscalingSharpness = sharpness;
+        m_upscalingDenoise = denoise;
+        if (!m_upscalingTarget.isEmpty()) m_resetFrameGeneration = true;
+    }
+
     void setFrameGeneration(bool enabled, double refreshRate) override
     {
         if (m_frameGeneration != enabled || m_refreshRate != refreshRate)
@@ -446,6 +458,8 @@ private:
     double m_refreshRate = 0;
     bool m_frameGeneration = false;
     QSize m_upscalingTarget;
+    int m_upscalingSharpness = 10;
+    int m_upscalingDenoise = 0;
     bool m_frameGenerationFailed = false;
     bool m_resetFrameGeneration = false;
     bool m_outputDirty = false;

--- a/opennow-qt/src/streaming/rendering/StreamVideoItemRendering.cpp
+++ b/opennow-qt/src/streaming/rendering/StreamVideoItemRendering.cpp
@@ -28,6 +28,8 @@ public:
                 m_window->screen() ? m_window->screen()->refreshRate() : 0.0);
         m_viewport = StreamVideoItem::aspectFitRect(item->videoSize(), m_bounds.size().toSize());
         m_metalFxUpscaling = item->metalFxUpscaling() && item->isVisible();
+        if (m_callback)
+            m_callback->setUpscalingEnhancement(item->upscalingSharpness(), item->upscalingDenoise());
         markDirty(QSGNode::DirtyGeometry | QSGNode::DirtyMaterial);
     }
 

--- a/opennow-qt/src/streaming/rendering/StreamVideoRenderCallback.h
+++ b/opennow-qt/src/streaming/rendering/StreamVideoRenderCallback.h
@@ -21,6 +21,7 @@ public:
     virtual void setClip(bool, int) {}
     virtual void setFrameGeneration(bool, double) {}
     virtual void setUpscalingTarget(const QSize &) {}
+    virtual void setUpscalingEnhancement(int, int) {}
     virtual bool needsFrame() const { return false; }
     virtual void frameSwapped() {}
     virtual QVariantMap frameGenerationStats() const { return {}; }

--- a/opennow-qt/tests/UpscalingAcceptance.qml
+++ b/opennow-qt/tests/UpscalingAcceptance.qml
@@ -22,6 +22,14 @@ QtObject {
         const selector = find(parent, "upscalingSelector")
         check(row && row.visible === mac, "desktop setting is visible only on macOS")
         check(selector && selector.options.length === 2 && selector.selectedIndex === 0, "exactly Off and MetalFX; default Off")
+        const clarityRow = find(parent, "upscalingSharpnessRow")
+        const denoiseRow = find(parent, "upscalingDenoiseRow")
+        const clarity = find(parent, "upscalingSharpnessSlider")
+        const denoise = find(parent, "upscalingDenoiseSlider")
+        check(clarityRow && denoiseRow && clarityRow.visible === mac && denoiseRow.visible === mac, "enhancement controls are macOS-only")
+        check(!clarityRow.enabled && !denoiseRow.enabled, "enhancement controls are disabled when upscaling is off")
+        check(clarity.from === 0 && clarity.to === 15 && clarity.stepSize === 1 && clarity.value === 10, "Clarity matches Mac range and default")
+        check(denoise.from === 0 && denoise.to === 20 && denoise.stepSize === 1 && denoise.value === 0, "Noise Reduction matches Mac range and default")
         const settings = consoleSettings.createObject(parent)
         const consoleRow = settings.settingsModel().find(item => item.key === "upscaling")
         check(Boolean(consoleRow) === mac, "console setting exists only on macOS")
@@ -33,14 +41,33 @@ QtObject {
         selector.selected(1, selector.options[1])
         check(ShellStore.settings.upscaling === "metalfx" && selector.selectedIndex === 1, "selection persists exact MetalFX value")
         check(surfaces.every(surface => surface.metalFxUpscaling === mac), "only macOS enables native upscaling")
+        check(clarityRow.enabled && denoiseRow.enabled, "MetalFX enables enhancement controls")
+        clarity.committed(15)
+        denoise.committed(20)
+        check(ShellStore.settings.upscalingSharpness === 15 && ShellStore.settings.upscalingDenoise === 20, "slider changes persist")
+        check(surfaces.every(surface => surface.upscalingSharpness === 15 && surface.upscalingDenoise === 20), "both existing surfaces receive live values")
+        if (mac) {
+            const controls = settings.settingsModel().filter(item => item.key === "upscalingSharpness" || item.key === "upscalingDenoise")
+            check(controls.length === 2 && controls[0].values.length === 16 && controls[1].values.length === 21, "console exposes the same integer ranges")
+            check(controls.every(item => !item.info), "console controls are enabled with MetalFX")
+        }
         check(ShellStore.settings.fps === 60, "upscaling does not change source FPS")
         selector.selected(0, selector.options[0])
         check(ShellStore.settings.upscaling === "off", "Off selection persists")
         check(surfaces.every(surface => !surface.metalFxUpscaling), "both surfaces return to normal scaling")
+        check(ShellStore.settings.upscalingSharpness === 15 && ShellStore.settings.upscalingDenoise === 20, "Off retains enhancement preferences")
+        clarity.committed(0)
+        denoise.committed(0)
+        check(surfaces.every(surface => surface.upscalingSharpness === 0 && surface.upscalingDenoise === 0), "zero disables each enhancement without using the default")
         check(find(desktop, "streamSurfaceHost") === surfaces[0]
             && find(console, "streamSurfaceHost") === surfaces[1], "toggling never replaces the presenter")
-        if (Qt.application.arguments.indexOf("--screenshot") >= 0)
+        if (Qt.application.arguments.indexOf("--screenshot") >= 0) {
             row.visible = true
+            clarityRow.visible = true
+            denoiseRow.visible = true
+            selector.selected(1, selector.options[1])
+            clarity.committed(10)
+        }
         ShellStore.lastError = ""
         settings.destroy()
         desktop.destroy()

--- a/opennow-qt/tests/tst_streamvideoitem.cpp
+++ b/opennow-qt/tests/tst_streamvideoitem.cpp
@@ -68,6 +68,12 @@ public:
         ++finishCount;
     }
 
+    void setUpscalingEnhancement(int sharpness, int denoise) override
+    {
+        upscaleSharpness.store(sharpness);
+        upscaleDenoise.store(denoise);
+    }
+
     void releaseResources() override
     {
         ++releaseCount;
@@ -83,6 +89,8 @@ public:
     std::atomic_int viewportHeight = 0;
     std::atomic_int upscaleWidth = 0;
     std::atomic_int upscaleHeight = 0;
+    std::atomic_int upscaleSharpness = 0;
+    std::atomic_int upscaleDenoise = 0;
 };
 
 // Exercise the production import/material with a GPU texture, without a remote
@@ -944,6 +952,33 @@ private slots:
         QVERIFY(!item.frameGeneration());
     }
 
+    void upscalingEnhancementIsBoundedAndPreservesPresenter()
+    {
+        StreamVideoItem item;
+        const auto callback = std::make_shared<TestRenderCallback>();
+        item.setRenderCallback(callback);
+        QSignalSpy sharpnessChanges(&item, &StreamVideoItem::upscalingSharpnessChanged);
+        QSignalSpy denoiseChanges(&item, &StreamVideoItem::upscalingDenoiseChanged);
+        QCOMPARE(item.upscalingSharpness(), 10);
+        QCOMPARE(item.upscalingDenoise(), 0);
+        item.setUpscalingSharpness(10);
+        item.setUpscalingDenoise(0);
+        QCOMPARE(sharpnessChanges.size(), 0);
+        QCOMPARE(denoiseChanges.size(), 0);
+        item.setUpscalingSharpness(100);
+        item.setUpscalingDenoise(100);
+        QCOMPARE(item.upscalingSharpness(), 15);
+        QCOMPARE(item.upscalingDenoise(), 20);
+        item.setUpscalingSharpness(-1);
+        item.setUpscalingDenoise(-1);
+        QCOMPARE(item.upscalingSharpness(), 0);
+        QCOMPARE(item.upscalingDenoise(), 0);
+        QCOMPARE(sharpnessChanges.size(), 2);
+        QCOMPARE(denoiseChanges.size(), 2);
+        QVERIFY(!item.metalFxUpscaling());
+        QCOMPARE(item.renderCallback(), callback);
+    }
+
     void frameGenerationIsOptInAndDoesNotReplaceThePresenter()
     {
         StreamVideoItem item;
@@ -1041,6 +1076,11 @@ private slots:
                 const auto target = (QSizeF(viewport.size()) * window.effectiveDevicePixelRatio()).toSize();
                 QCOMPARE(callback->upscaleWidth.load(), target.width());
                 QCOMPARE(callback->upscaleHeight.load(), target.height());
+                item->setUpscalingSharpness(visible ? 15 : 0);
+                item->setUpscalingDenoise(visible ? 20 : 0);
+                item->requestFrame();
+                QTRY_COMPARE(callback->upscaleSharpness.load(), visible ? 15 : 0);
+                QTRY_COMPARE(callback->upscaleDenoise.load(), visible ? 20 : 0);
                 QCOMPARE(item->renderCallback(), callback);
                 QCOMPARE(item->videoSize(), QSize(320, 180));
             }


### PR DESCRIPTION
## Changes
- Add macOS-only Clarity (0–15, default 10) and Noise Reduction (0–20, default 0) controls beneath Upscaling in desktop and console Stream settings. Disable the controls when MetalFX is off and retain their saved values.
- Bind both existing stream surfaces to the preferences. Apply changes on the next decoded frame without restarting the session or replacing the presenter, and reset active interpolation history when the controls change.
- Match OpenNOW-Mac’s source-resolution sharpening/denoise math in the existing Metal YUV-to-RGB pass before MetalFX. Reuse the scaler and textures; zero controls skip neighborhood sampling. Normal scaling and unsupported configurations keep the unfiltered conversion path.
- Advance the FFI to ABI 8 / render command 3, validate both numeric ranges, and update native producers, consumers, fixtures, and documentation. Qt and the native runtime must be rebuilt together.

## Verification
- Full Linux Qt Debug build and all 208 CTest entries passed, including the expanded upscaling acceptance checks.
- Windowed/fullscreen and overlay render-callback test passed under Xvfb/OpenGL with changing control values.
- All 23 Rust settings tests passed; native streamer workspace: 612 passed, 9 existing ignored.
- Rust formatting, core and affected native-crate Clippy, affected native all-target checks, QML syntax, localization, C ABI layout, and whitespace checks passed.
- Visually inspected the actual Qt acceptance previews at 1600 and 960 pixels wide. The preview reveals macOS controls on Linux without enabling MetalFX there.
- **Mac GPU execution and live GFN gameplay were not tested.** Apple cross-checking was blocked by the missing Apple linker/SDK in `audiopus_sys`. Added an ignored Metal GPU readback test for zero controls, separate/combined effects, 8/10-bit precision, clipping, and resource reuse; run `cargo test -p opennow-streamer-platform-macos spatial_ -- --include-ignored` on a supported Mac.

![MetalFX sliders — desktop acceptance preview](https://api-nightly.capy.ai/pr-assets/cL6ZMpoIMX3NKCKyW_qnrXXneXAmgfqQ1mh96QIIlC8)

![MetalFX sliders — compact acceptance preview](https://api-nightly.capy.ai/pr-assets/UFLAcexEjPW4tb-GLHvkYmzB_rlTWBTyVU3S_HPAJ2I)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23EG6NXEBWVMHRFE5Q2M5BP"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->