### PR TITLE
fix(streaming): stabilize cursor ownership and capture handoff

### DIFF
--- a/docs/streamer-comparison/features.md
+++ b/docs/streamer-comparison/features.md
@@ -44,7 +44,48 @@ off  08 03 01 00 00
 on   08 03 01 00 01
 ```
 
-Activation sends **on**. After the first local cursor, OpenNOW sends **off** so the host stops compositing its cursor into the video. Notifications keep arriving.
+Activation sends **on**. OpenNOW requests **off** after the first cursor notification,
+including native bitmap notifications whose pixel layout is not decoded. If the host
+publishes no cursor notification, a three-second watchdog requests **off** instead.
+Tracking stays enabled so notifications keep arriving. Startup capture/tracking retries
+are limited to eight attempts including activation, paced at 250 ms; disabling uses a
+separate budget of eight attempts at 250 ms. Failed disable attempts retain the
+server-composited state, and exhaustion is logged without retrying indefinitely.
+
+The streamer emits `{"type":"cursor-capture","startId":"…","composited":true}` through its existing
+JSON event output on each activation attempt, conservatively covering partially queued
+activation chains. It emits `composited:false` only after capture **off** is successfully
+queued. This records local command acceptance, not a host acknowledgement. Closing the
+reliable control channel cancels the handoff; reactivation resets its deadline and retry
+budgets and emits `true` again.
+
+Composition output retains one pending latest state per session and retries a full
+bounded event queue without blocking media or input. `startId` identifies the accepted
+start command so Qt can reject callbacks from a previous session. Native bitmap
+notifications must contain at least their eight-byte header; dedicated cursor-channel
+messages must have a supported normalized type and complete MIME/image/optional-position
+framing before they can trigger handoff or be forwarded as a shape.
+
+Composition is independent of cursor shape, visibility, and relative-input mode. Native
+bitmap notifications change composition only: they do not synthesize a system cursor,
+unhide a previously hidden cursor, or change its mode. Existing cursor callbacks retain
+their wire format and the predefined system cursor ID 0 hidden/relative rule. When local
+composition starts without a known shape, Qt may use its Arrow fallback without replacing
+known hidden/relative state. No cursor ABI change is required.
+
+The composition/visibility split and three-second silent-host fallback follow
+OpenNOW-Mac revision `666bd4a3391e13b074b37eecfd61d568e9231d34`
+(`NativeWebRTCStreamViewCursorVisibility.swift`, `NvstBifrostFreeCursorWatchdog.swift`,
+and `NvstRemoteCursor.swift`). OpenNOW retains its existing system-ID mode mapping;
+the reference does not provide a verified native bitmap pixel layout.
+
+Qt hides its local stream cursor only while input capture is active and either the
+server is compositing or relative input is active; manual unlock retains its local
+cursor override. Releasing capture restores the
+local cursor on every platform. Accepted session starts reset cached cursor state;
+composition callbacks are session-checked and coalesced outside the general bounded
+callback queue so telemetry pressure cannot lose the handoff. Window activation
+signals are attached for an existing parent window as well as later window changes.
 
 ### `0x030d` track remote cursor image
 

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
@@ -1597,7 +1597,12 @@ fn forward_nvst_session_events<R: NvstSessionResources>(
     } = event_resources;
     let mut feedback_state = NvstMediaFeedbackState::new(false);
     let mut pending_rumble = [None; 4];
+    let mut pending_cursor_capture = NvstCursorCaptureOutput {
+        start_id: start_id.clone(),
+        pending: None,
+    };
     'session: loop {
+        flush_cursor_capture(output, lifecycle, generation, &mut pending_cursor_capture);
         if let Some(feedback) = media_feedback.as_ref() {
             while let Ok(feedback) = feedback.try_recv() {
                 forward_nvst_media_feedback(
@@ -1709,6 +1714,7 @@ fn forward_nvst_session_events<R: NvstSessionResources>(
                     generation,
                     &resources,
                     &mut feedback_state.recovery_attempts,
+                    &mut pending_cursor_capture,
                     nvst_event,
                 );
                 if terminal {
@@ -1763,12 +1769,42 @@ fn forward_controller_rumble(
         .is_ok()
 }
 
+#[derive(Default)]
+struct NvstCursorCaptureOutput {
+    start_id: String,
+    pending: Option<bool>,
+}
+
+fn flush_cursor_capture(
+    output: &EventSender,
+    lifecycle: &Mutex<Lifecycle>,
+    generation: u64,
+    state: &mut NvstCursorCaptureOutput,
+) {
+    let Some(composited) = state.pending else {
+        return;
+    };
+    let current = lock_lifecycle(lifecycle);
+    if current.generation != generation
+        || current.context.is_none()
+        || output
+            .send(event(
+                "cursor-capture",
+                json!({ "startId": state.start_id, "composited": composited }),
+            ))
+            .is_ok()
+    {
+        state.pending = None;
+    }
+}
+
 fn forward_nvst_event<R: NvstSessionResources>(
     output: &EventSender,
     lifecycle: &Mutex<Lifecycle>,
     generation: u64,
     resources: &R,
     recovery_attempts: &mut usize,
+    pending_cursor_capture: &mut NvstCursorCaptureOutput,
     nvst_event: NvstReceiveEvent,
 ) -> bool {
     if lock_lifecycle(lifecycle).generation != generation {
@@ -1879,6 +1915,11 @@ fn forward_nvst_event<R: NvstSessionResources>(
         }
         NvstReceiveEvent::Cursor(bytes) => {
             resources.apply_cursor(bytes);
+            false
+        }
+        NvstReceiveEvent::CursorCapture(composited) => {
+            pending_cursor_capture.pending = Some(composited);
+            flush_cursor_capture(output, lifecycle, generation, pending_cursor_capture);
             false
         }
         NvstReceiveEvent::Dropped(
@@ -3345,6 +3386,7 @@ mod tests {
             7,
             &resources,
             &mut recovery_attempts,
+            &mut NvstCursorCaptureOutput::default(),
             NvstReceiveEvent::RecoveryNeeded(opennow_streamer_transport::NvstRecovery::Timeout {
                 idle_for: Duration::from_secs(2),
             }),
@@ -3364,6 +3406,102 @@ mod tests {
     }
 
     #[test]
+    fn cursor_capture_output_survives_setup_before_running() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let sender = EventSender::bounded(sender);
+        let lifecycle = connected_lifecycle();
+        lock_lifecycle(&lifecycle).state = State::Idle;
+        let mut state = NvstCursorCaptureOutput {
+            start_id: "cursor-setup".to_owned(),
+            pending: Some(false),
+        };
+        sender.send(json!({ "type": "log" })).unwrap();
+        flush_cursor_capture(&sender, &lifecycle, 7, &mut state);
+        assert_eq!(state.pending, Some(false));
+        receiver.try_recv().unwrap();
+        flush_cursor_capture(&sender, &lifecycle, 7, &mut state);
+        assert_eq!(state.pending, None);
+        assert_eq!(receiver.try_recv().unwrap()["composited"], false);
+        lock_lifecycle(&lifecycle).state = State::Connected;
+        flush_cursor_capture(&sender, &lifecycle, 7, &mut state);
+        assert!(receiver.try_recv().is_err());
+        state.pending = Some(true);
+        lock_lifecycle(&lifecycle).context = None;
+        flush_cursor_capture(&sender, &lifecycle, 7, &mut state);
+        assert_eq!(state.pending, None);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn cursor_capture_output_retries_latest_state_after_backpressure() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let sender = EventSender::bounded(sender);
+        let lifecycle = connected_lifecycle();
+        let resources = TestNvstResources::default();
+        let mut recovery_attempts = 0;
+        let mut state = NvstCursorCaptureOutput {
+            start_id: "cursor-session".to_owned(),
+            pending: None,
+        };
+        sender.send(json!({ "type": "log" })).unwrap();
+        for composited in [true, false] {
+            assert!(!forward_nvst_event(
+                &sender,
+                &lifecycle,
+                7,
+                &resources,
+                &mut recovery_attempts,
+                &mut state,
+                NvstReceiveEvent::CursorCapture(composited),
+            ));
+            assert_eq!(state.pending, Some(composited));
+        }
+        assert_eq!(receiver.try_recv().unwrap()["type"], "log");
+        flush_cursor_capture(&sender, &lifecycle, 7, &mut state);
+        assert_eq!(state.pending, None);
+        let message = receiver.try_recv().unwrap();
+        assert_eq!(message["type"], "cursor-capture");
+        assert_eq!(message["startId"], "cursor-session");
+        assert_eq!(message["composited"], false);
+        flush_cursor_capture(&sender, &lifecycle, 7, &mut state);
+        assert!(receiver.try_recv().is_err());
+        state.pending = Some(true);
+        lock_lifecycle(&lifecycle).generation += 1;
+        flush_cursor_capture(&sender, &lifecycle, 7, &mut state);
+        assert_eq!(state.pending, None);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn cursor_capture_events_preserve_composition_across_reactivation() {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let sender = EventSender::unbounded(sender);
+        let lifecycle = connected_lifecycle();
+        let resources = TestNvstResources::default();
+        let mut recovery_attempts = 0;
+
+        for composited in [true, false, true, false] {
+            assert!(!forward_nvst_event(
+                &sender,
+                &lifecycle,
+                7,
+                &resources,
+                &mut recovery_attempts,
+                &mut NvstCursorCaptureOutput::default(),
+                NvstReceiveEvent::CursorCapture(composited),
+            ));
+            let message = receiver.try_recv().expect("cursor composition event");
+            assert_eq!(message["type"], "cursor-capture");
+            assert_eq!(message["composited"], composited);
+        }
+        assert_eq!(resources.stops.load(Ordering::Relaxed), 0);
+        assert_eq!(resources.keyframe_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(resources.recoveries.load(Ordering::Relaxed), 0);
+        assert_eq!(lock_lifecycle(&lifecycle).state, State::Connected);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
     fn repeated_packet_gaps_request_keyframes_without_stopping_the_session() {
         let (sender, receiver) = std::sync::mpsc::channel();
         let sender = EventSender::unbounded(sender);
@@ -3378,6 +3516,7 @@ mod tests {
                 7,
                 &resources,
                 &mut recovery_attempts,
+                &mut NvstCursorCaptureOutput::default(),
                 NvstReceiveEvent::RecoveryNeeded(NvstRecovery::PacketGap {
                     first_missing_index,
                     last_missing_index: first_missing_index + 31,
@@ -3411,6 +3550,7 @@ mod tests {
             7,
             &resources,
             &mut recovery_attempts,
+            &mut NvstCursorCaptureOutput::default(),
             NvstReceiveEvent::Dropped(NvstDropReason::MediaConsumerBackpressured),
         ));
 
@@ -3444,6 +3584,7 @@ mod tests {
             7,
             &resources,
             &mut recovery_attempts,
+            &mut NvstCursorCaptureOutput::default(),
             recovery(),
         ));
         assert!(forward_nvst_event(
@@ -3452,6 +3593,7 @@ mod tests {
             7,
             &resources,
             &mut recovery_attempts,
+            &mut NvstCursorCaptureOutput::default(),
             recovery(),
         ));
 
@@ -3487,6 +3629,7 @@ mod tests {
             7,
             &resources,
             &mut recovery_attempts,
+            &mut NvstCursorCaptureOutput::default(),
             NvstReceiveEvent::Frame(opennow_streamer_transport::EncodedVideoAccessUnit {
                 codec: opennow_streamer_transport::NvstVideoCodec::H264,
                 timestamp: 1,

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/lib.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 
 pub mod nvst;
 mod nvst_control;
+mod nvst_cursor;
 mod nvst_haptics;
 mod nvst_input;
 mod nvst_microphone;

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -42,6 +42,7 @@ use super::nvst_control::{
     DEFAULT_FRAME_TIME_US, QOS_REPORT_INTERVAL, QOS_WARM_UP, QosReport, frame_ack,
     frame_pacing_report, idr_request,
 };
+use super::nvst_cursor::{CursorCommand, NvstCursorCapture, valid_cursor_channel_message};
 use super::nvst_input::{
     NvstInputChannelState, NvstInputChannels, NvstInputCodec, native_input_type_is_motion,
     native_input_type_name, native_input_types, next_control_keepalive, server_cursor_messages,
@@ -166,8 +167,6 @@ const MAX_TIMEOUT: Duration = Duration::from_secs(90);
 const MAX_PING_BYTES: usize = 512;
 const PING_INTERVAL_BEFORE_CONNECTION: Duration = Duration::from_millis(20);
 const PING_INTERVAL_AFTER_CONNECTION: Duration = Duration::from_millis(100);
-const CURSOR_CAPTURE_RETRY_INTERVAL: Duration = Duration::from_millis(250);
-const MAX_CURSOR_CAPTURE_ATTEMPTS: u8 = 8;
 const UDP_RECEIVE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 // The WebRTC bundle owns the SCTP input channels. A 10 ms socket wait batches
 // raw mouse reports and makes high-refresh streams feel closer to 100 Hz.
@@ -1539,6 +1538,7 @@ pub enum NvstReceiveEvent {
     InputUnavailable(String),
     MicrophoneError(String),
     Cursor(Vec<u8>),
+    CursorCapture(bool),
     Dropped(NvstDropReason),
     RecoveryNeeded(NvstRecovery),
     Lifecycle(NvstReceiverState),
@@ -5177,9 +5177,7 @@ fn run_nvst_webrtc_bundle(
     let mut input_codec = NvstInputCodec::default();
     let mut last_input_types = Vec::new();
     let mut mouse_motion_packets = 0_u64;
-    let mut server_cursor_hidden = false;
-    let mut cursor_capture_retry_at: Option<Instant> = None;
-    let mut cursor_capture_attempts = 0_u8;
+    let mut cursor_capture = NvstCursorCapture::default();
     let mut control_keepalive_at = next_control_keepalive(Instant::now());
     let mut input_timeout_reported = false;
     let mut audio_receiver = NvstAudioReceiver::default();
@@ -5307,29 +5305,15 @@ fn run_nvst_webrtc_bundle(
             }
             control_keepalive_at = next_control_keepalive(now);
         }
-        if !server_cursor_hidden
-            && cursor_capture_attempts < MAX_CURSOR_CAPTURE_ATTEMPTS
-            && cursor_capture_retry_at.is_some_and(|retry_at| now >= retry_at)
-            && let Some(channels) = input_channels
+        if let Some(channels) = input_channels
+            && cursor_capture.update(now, |command| match command {
+                CursorCommand::Capture(enabled) => {
+                    channels.send_mouse_cursor_capture(&mut rtc, enabled)
+                }
+                CursorCommand::Tracking => channels.send_remote_cursor_tracking(&mut rtc, true),
+            })
         {
-            cursor_capture_attempts += 1;
-            let capture_sent = channels.send_mouse_cursor_capture(&mut rtc, true);
-            let tracking_sent = channels.send_remote_cursor_tracking(&mut rtc, true);
-            if capture_sent && tracking_sent {
-                eprintln!(
-                    "NVST cursor capture tx: channel={} command=0x0308 enabled=true reason=post-play-retry attempt={cursor_capture_attempts}",
-                    channels.label(channels.control_reliable),
-                );
-                eprintln!(
-                    "NVST remote cursor tracking tx: channel={} command=0x030d enabled=true reason=post-play-retry attempt={cursor_capture_attempts}",
-                    channels.label(channels.control_reliable),
-                );
-            } else {
-                eprintln!(
-                    "NVST cursor feature retry could not be queued: attempt={cursor_capture_attempts} captureSent={capture_sent} trackingSent={tracking_sent}"
-                );
-            }
-            cursor_capture_retry_at = Some(now + CURSOR_CAPTURE_RETRY_INTERVAL);
+            let _ = event_sender.send(NvstReceiveEvent::CursorCapture(false));
         }
         if !input_timeout_reported && input_state.handshake_timed_out(sctp_started_at, now) {
             input_timeout_reported = true;
@@ -5663,6 +5647,11 @@ fn run_nvst_webrtc_bundle(
                                 control_partial_open = true;
                             }
                             if let Some(version) = input_state.channel_opened(channels, id) {
+                                if !input_state.activation_sent() {
+                                    cursor_capture.activate(Instant::now());
+                                    let _ =
+                                        event_sender.send(NvstReceiveEvent::CursorCapture(true));
+                                }
                                 if !finish_nvst_input_handshake(
                                     &mut input_state,
                                     channels,
@@ -5674,9 +5663,6 @@ fn run_nvst_webrtc_bundle(
                                 ) {
                                     continue;
                                 }
-                                cursor_capture_attempts = 1;
-                                cursor_capture_retry_at =
-                                    Some(Instant::now() + CURSOR_CAPTURE_RETRY_INTERVAL);
                             }
                         }
                         if Some(id) == rtcp_channel {
@@ -5693,8 +5679,13 @@ fn run_nvst_webrtc_bundle(
                             {
                                 feedback.haptics.receive(&data.data);
                             }
-                            let cursor_messages = server_cursor_messages(&data.data);
+                            let cursor_messages = if data.id == channels.cursor {
+                                Vec::new()
+                            } else {
+                                server_cursor_messages(&data.data)
+                            };
                             for message in cursor_messages {
+                                cursor_capture.notify(Instant::now());
                                 eprintln!(
                                     "NVST cursor wire rx: channel={label} id={:?} command=0x{:04x} offset={} cursorId={:?} position={:?} visible={:?} bytes={} raw={}",
                                     data.id,
@@ -5707,16 +5698,6 @@ fn run_nvst_webrtc_bundle(
                                     diagnostic_hex(&message.raw, 512),
                                 );
                                 if let Some(cursor) = message.normalized {
-                                    cursor_capture_retry_at = None;
-                                    if !server_cursor_hidden
-                                        && channels.send_mouse_cursor_capture(&mut rtc, false)
-                                    {
-                                        server_cursor_hidden = true;
-                                        eprintln!(
-                                            "NVST cursor capture tx: channel={} command=0x0308 enabled=false reason=first-local-cursor",
-                                            channels.label(channels.control_reliable),
-                                        );
-                                    }
                                     eprintln!(
                                         "NVST cursor dispatch: source={label} type={} id={} bytes={} raw={}",
                                         cursor[0],
@@ -5729,16 +5710,14 @@ fn run_nvst_webrtc_bundle(
                             }
 
                             if data.id == channels.cursor {
-                                cursor_capture_retry_at = None;
-                                if !server_cursor_hidden
-                                    && channels.send_mouse_cursor_capture(&mut rtc, false)
-                                {
-                                    server_cursor_hidden = true;
+                                if !valid_cursor_channel_message(&data.data) {
                                     eprintln!(
-                                        "NVST cursor capture tx: channel={} command=0x0308 enabled=false reason=cursor-channel",
-                                        channels.label(channels.control_reliable),
+                                        "NVST malformed cursor-channel notification ignored: bytes={}",
+                                        data.data.len(),
                                     );
+                                    continue;
                                 }
+                                cursor_capture.notify(Instant::now());
                                 eprintln!(
                                     "NVST cursor-channel raw rx: id={:?} bytes={} type={:?} cursorId={:?} raw={}",
                                     data.id,
@@ -5765,6 +5744,10 @@ fn run_nvst_webrtc_bundle(
                             && let Some(version) =
                                 input_state.channel_data(channels, data.id, &data.data)
                         {
+                            if !input_state.activation_sent() {
+                                cursor_capture.activate(Instant::now());
+                                let _ = event_sender.send(NvstReceiveEvent::CursorCapture(true));
+                            }
                             if !finish_nvst_input_handshake(
                                 &mut input_state,
                                 channels,
@@ -5776,9 +5759,6 @@ fn run_nvst_webrtc_bundle(
                             ) {
                                 continue;
                             }
-                            cursor_capture_attempts = 1;
-                            cursor_capture_retry_at =
-                                Some(Instant::now() + CURSOR_CAPTURE_RETRY_INTERVAL);
                         } else if Some(data.id) == rtcp_channel {
                             eprintln!(
                                 "NVST rtcp1 inbound: id={:?} binary={} bytes={}",
@@ -5791,9 +5771,7 @@ fn run_nvst_webrtc_bundle(
                     Event::ChannelClose(id) => {
                         if let Some(channels) = input_channels {
                             if id == channels.control_reliable {
-                                server_cursor_hidden = false;
-                                cursor_capture_retry_at = None;
-                                cursor_capture_attempts = 0;
+                                cursor_capture.reset();
                             }
                             let input_channel_closed = id == channels.input_partial;
                             if input_state.channel_closed(channels, id) || input_channel_closed {

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_cursor.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_cursor.rs
@@ -1,0 +1,297 @@
+use std::time::{Duration, Instant};
+
+const RETRY_INTERVAL: Duration = Duration::from_millis(250);
+const MAX_ATTEMPTS: u8 = 8;
+const SILENT_HOST_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub(crate) fn valid_cursor_channel_message(bytes: &[u8]) -> bool {
+    if bytes.len() < 7 || !matches!(bytes[0], 0 | 1) {
+        return false;
+    }
+    let image_length_offset = 5 + usize::from(bytes[4]);
+    let Some(length) = bytes.get(image_length_offset..image_length_offset + 2) else {
+        return false;
+    };
+    let image_length = usize::from(u16::from_le_bytes([length[0], length[1]]));
+    let image_end = image_length_offset + 2 + image_length;
+    bytes.len() >= image_end
+        && matches!(bytes.len() - image_end, 0 | 4 | 6)
+        && (bytes[0] != 0 || (bytes[4] == 0 && image_length == 0))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CursorCommand {
+    Capture(bool),
+    Tracking,
+}
+
+#[derive(Debug, Default)]
+enum CaptureState {
+    #[default]
+    Inactive,
+    Waiting {
+        deadline: Instant,
+        retry_at: Instant,
+        attempts: u8,
+    },
+    Disabling {
+        retry_at: Instant,
+        attempts: u8,
+        reason: &'static str,
+    },
+    Local,
+    Exhausted,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct NvstCursorCapture {
+    state: CaptureState,
+}
+
+impl NvstCursorCapture {
+    pub(crate) fn activate(&mut self, now: Instant) {
+        self.state = CaptureState::Waiting {
+            deadline: now + SILENT_HOST_TIMEOUT,
+            retry_at: now + RETRY_INTERVAL,
+            attempts: 1,
+        };
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.state = CaptureState::Inactive;
+    }
+
+    pub(crate) fn notify(&mut self, now: Instant) {
+        if matches!(self.state, CaptureState::Waiting { .. }) {
+            self.state = CaptureState::Disabling {
+                retry_at: now,
+                attempts: 0,
+                reason: "cursor-notification",
+            };
+        }
+    }
+
+    pub(crate) fn update(
+        &mut self,
+        now: Instant,
+        mut send: impl FnMut(CursorCommand) -> bool,
+    ) -> bool {
+        if let CaptureState::Waiting { deadline, .. } = self.state
+            && now >= deadline
+        {
+            self.state = CaptureState::Disabling {
+                retry_at: now,
+                attempts: 0,
+                reason: "silent-host-timeout",
+            };
+        }
+        match &mut self.state {
+            CaptureState::Waiting {
+                retry_at, attempts, ..
+            } if *attempts < MAX_ATTEMPTS && now >= *retry_at => {
+                *attempts += 1;
+                let capture_sent = send(CursorCommand::Capture(true));
+                let tracking_sent = send(CursorCommand::Tracking);
+                eprintln!(
+                    "NVST cursor feature retry: attempt={attempts} captureSent={capture_sent} trackingSent={tracking_sent}"
+                );
+                *retry_at = now + RETRY_INTERVAL;
+            }
+            CaptureState::Disabling {
+                retry_at,
+                attempts,
+                reason,
+            } if now >= *retry_at => {
+                *attempts += 1;
+                let sent = send(CursorCommand::Capture(false));
+                eprintln!(
+                    "NVST cursor capture tx: command=0x0308 enabled=false reason={reason} attempt={attempts} queued={sent}"
+                );
+                if sent {
+                    self.state = CaptureState::Local;
+                    return true;
+                }
+                if *attempts == MAX_ATTEMPTS {
+                    eprintln!(
+                        "NVST cursor capture disable retries exhausted; retaining server-composited cursor until reactivation"
+                    );
+                    self.state = CaptureState::Exhausted;
+                } else {
+                    *retry_at = now + RETRY_INTERVAL;
+                }
+            }
+            _ => {}
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_channel_requires_complete_supported_framing() {
+        assert!(valid_cursor_channel_message(&[0, 0, 0, 0, 0, 0, 0]));
+        assert!(valid_cursor_channel_message(&[
+            0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ]));
+        let custom = [
+            1, 0, 1, 2, 3, b'p', b'n', b'g', 4, 0, b'a', b'b', b'c', b'd',
+        ];
+        assert!(valid_cursor_channel_message(&custom));
+        for len in 0..custom.len() {
+            assert!(!valid_cursor_channel_message(&custom[..len]));
+        }
+        assert!(!valid_cursor_channel_message(&[2, 1, 0, 0, 0, 0, 0]));
+        assert!(!valid_cursor_channel_message(&[0, 1, 0, 0, 0, 1, 0, 42]));
+        assert!(!valid_cursor_channel_message(&[0, 1, 0, 0, 0, 0, 0, 0]));
+    }
+
+    #[test]
+    fn truncated_native_bitmaps_do_not_trigger_handoff() {
+        let now = Instant::now();
+        let mut capture = NvstCursorCapture::default();
+        capture.activate(now);
+        for length in 0..8_u8 {
+            let mut bytes = vec![0x10, 0x01, length, 0];
+            bytes.resize(4 + usize::from(length), 0);
+            assert!(crate::nvst_input::server_cursor_messages(&bytes).is_empty());
+        }
+        assert!(!capture.update(now, |_| panic!("no valid notification")));
+    }
+
+    #[test]
+    fn notification_hands_off_once_and_stops_enable_retries() {
+        let now = Instant::now();
+        let mut capture = NvstCursorCapture::default();
+        capture.activate(now);
+        capture.notify(now);
+        let mut commands = Vec::new();
+        assert!(capture.update(now, |command| {
+            commands.push(command);
+            true
+        }));
+        capture.notify(now + RETRY_INTERVAL);
+        assert!(!capture.update(now + SILENT_HOST_TIMEOUT, |command| {
+            commands.push(command);
+            true
+        }));
+        assert_eq!(commands, [CursorCommand::Capture(false)]);
+    }
+
+    #[test]
+    fn bitmap_notification_hands_off_without_synthesizing_shape_or_mode() {
+        let now = Instant::now();
+        let mut capture = NvstCursorCapture::default();
+        capture.activate(now);
+        let messages = crate::nvst_input::server_cursor_messages(&[
+            0x10, 0x01, 0x08, 0x00, 0xde, 0xad, 0xbe, 0xef, 0, 0, 0, 0,
+        ]);
+        assert_eq!(messages.len(), 1);
+        for message in messages {
+            assert_eq!(message.normalized, None);
+            assert_eq!(message.visible, None);
+            capture.notify(now);
+        }
+        assert!(capture.update(now, |command| {
+            assert_eq!(command, CursorCommand::Capture(false));
+            true
+        }));
+    }
+
+    #[test]
+    fn silent_host_falls_back_after_bounded_enable_retries() {
+        let now = Instant::now();
+        let mut capture = NvstCursorCapture::default();
+        capture.activate(now);
+        let mut commands = Vec::new();
+        for tick in 0..12 {
+            assert!(!capture.update(now + RETRY_INTERVAL * tick, |command| {
+                commands.push(command);
+                true
+            }));
+        }
+        assert_eq!(commands.len(), usize::from(MAX_ATTEMPTS - 1) * 2);
+        assert!(
+            commands
+                .chunks_exact(2)
+                .all(|pair| { pair == [CursorCommand::Capture(true), CursorCommand::Tracking] })
+        );
+        assert!(capture.update(now + SILENT_HOST_TIMEOUT, |command| {
+            assert_eq!(command, CursorCommand::Capture(false));
+            true
+        }));
+    }
+
+    #[test]
+    fn failed_disable_is_paced_and_reports_handoff_only_on_success() {
+        let now = Instant::now();
+        let mut capture = NvstCursorCapture::default();
+        capture.activate(now);
+        capture.notify(now);
+        assert!(!capture.update(now, |command| {
+            assert_eq!(command, CursorCommand::Capture(false));
+            false
+        }));
+        capture.notify(now);
+        assert!(!capture.update(now, |_| panic!("retry must be paced")));
+        assert!(capture.update(now + RETRY_INTERVAL, |command| {
+            assert_eq!(command, CursorCommand::Capture(false));
+            true
+        }));
+    }
+
+    #[test]
+    fn exhausted_disable_retries_do_not_report_local_composition() {
+        let now = Instant::now();
+        let mut capture = NvstCursorCapture::default();
+        capture.activate(now);
+        capture.notify(now);
+        let mut attempts = 0;
+        for tick in 0..20 {
+            capture.notify(now + RETRY_INTERVAL * tick);
+            assert!(!capture.update(now + RETRY_INTERVAL * tick, |command| {
+                assert_eq!(command, CursorCommand::Capture(false));
+                attempts += 1;
+                false
+            }));
+        }
+        assert_eq!(attempts, MAX_ATTEMPTS);
+        capture.activate(now);
+        capture.notify(now);
+        assert!(capture.update(now, |_| true));
+    }
+
+    #[test]
+    fn reset_cancels_retries_and_reactivation_rearms_local_handoff() {
+        let now = Instant::now();
+        let mut capture = NvstCursorCapture::default();
+        capture.notify(now);
+        assert!(!capture.update(now, |_| panic!("inactive capture")));
+        capture.activate(now);
+        capture.notify(now);
+        capture.reset();
+        assert!(!capture.update(now + SILENT_HOST_TIMEOUT, |_| panic!("closed channel")));
+        capture.activate(now);
+        capture.notify(now);
+        assert!(capture.update(now, |_| true));
+        capture.activate(now);
+        assert!(capture.update(now + SILENT_HOST_TIMEOUT, |command| {
+            assert_eq!(command, CursorCommand::Capture(false));
+            true
+        }));
+    }
+
+    #[test]
+    fn failed_enable_retries_do_not_cancel_silent_host_deadline() {
+        let now = Instant::now();
+        let mut capture = NvstCursorCapture::default();
+        capture.activate(now);
+        assert!(!capture.update(now + RETRY_INTERVAL, |_| false));
+        assert!(capture.update(now + SILENT_HOST_TIMEOUT, |command| {
+            assert_eq!(command, CursorCommand::Capture(false));
+            true
+        }));
+    }
+}

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_input.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_input.rs
@@ -444,7 +444,7 @@ pub(crate) fn server_cursor_messages(bytes: &[u8]) -> Vec<NvstServerCursorMessag
                     normalized,
                 });
             }
-            COMMAND_BITMAP_CURSOR => {
+            COMMAND_BITMAP_CURSOR if payload.len() >= 8 => {
                 // Bitmap cursor payloads have a distinct native pixel layout.
                 // Keep detecting them explicitly so they cannot be mistaken for
                 // input/control commands while raw bitmap support is added.

--- a/opennow-qt/src/streaming/NativeStreamRuntime.cpp
+++ b/opennow-qt/src/streaming/NativeStreamRuntime.cpp
@@ -113,6 +113,7 @@ struct NativeStreamRuntime::CallbackState final
 
     std::mutex mutex;
     QQueue<Message> pending;
+    QByteArray cursorCapture;
     QPointer<NativeStreamRuntime> target;
     int dropped = 0;
     bool accepting = true;
@@ -143,6 +144,8 @@ struct NativeStreamRuntime::Private {
     std::atomic_bool presentationAllowed{false};
     std::atomic_bool inputAllowed{false};
     bool inputAuthorizationPending = false;
+    bool serverCursorComposited = true;
+    QString cursorStartId;
     QString presentationStartId;
     QString rumbleStartId;
     quint64 rumbleStartEpoch = 0;
@@ -198,6 +201,7 @@ NativeStreamRuntime::~NativeStreamRuntime()
         callbacks->accepting = false;
         callbacks->target.clear();
         callbacks->pending.clear();
+        callbacks->cursorCapture.clear();
         callbacks->framePending = false;
     }
     new std::shared_ptr<CallbackState>(std::move(callbacks));
@@ -235,6 +239,7 @@ void NativeStreamRuntime::invalidatePresentation()
     d->presentationGeneration.fetch_add(1, std::memory_order_acq_rel);
     d->presentationStartId.clear();
     d->rumbleStartId.clear();
+    d->cursorStartId.clear();
     emit controllerRumbleStopped();
     emit frameAvailable(); // Repaint even when the dead transport sends no more frames.
 }
@@ -320,6 +325,11 @@ bool NativeStreamRuntime::start()
     return true;
 }
 
+bool NativeStreamRuntime::serverCursorComposited() const
+{
+    return d->serverCursorComposited;
+}
+
 bool NativeStreamRuntime::send(const QJsonObject &command)
 {
     return sendBytes(QJsonDocument(command).toJson(QJsonDocument::Compact));
@@ -362,14 +372,17 @@ bool NativeStreamRuntime::sendBytes(const QByteArray &command)
     if (type == u"start"_s || type == u"stop"_s) {
         invalidatePresentation();
         if (type == u"start"_s) {
+            d->serverCursorComposited = true;
             d->firstNotification = false;
             d->presentationStartId = object.value(u"id"_s).toString();
+            d->cursorStartId = d->presentationStartId;
             d->rumbleStartId = d->presentationStartId;
             if (d->callbackState) {
                 const std::lock_guard lock(d->callbackState->mutex);
                 d->rumbleStartEpoch = d->callbackState->rumbleEpoch;
             }
             d->inputAuthorizationPending = true;
+            emit cursorStateReset();
         }
     }
     setLastError({});
@@ -641,19 +654,28 @@ void NativeStreamRuntime::enqueueCallback(CallbackState *state, const std::uint8
         return;
     }
 
+    const QByteArray payload(reinterpret_cast<const char *>(bytes), static_cast<qsizetype>(length));
+    bool cursorCapture = false;
+    if (event && payload.size() <= 1024 && payload.contains("\"cursor-capture\"")) {
+        const auto object = QJsonDocument::fromJson(payload).object();
+        cursorCapture = object.value(u"type"_s) == u"cursor-capture"_s
+            && object.value(u"composited"_s).isBool()
+            && object.value(u"startId"_s).isString();
+    }
     const auto sharedState = state->shared_from_this();
     bool shouldSchedule = false;
     {
         const std::lock_guard lock(state->mutex);
         if (!state->accepting) return;
-        if (state->pending.size() >= MaximumPendingCallbacks) {
+        if (cursorCapture) {
+            state->cursorCapture = payload;
+        } else if (state->pending.size() >= MaximumPendingCallbacks) {
             ++state->dropped;
             ++state->rumbleEpoch;
             return;
+        } else {
+            state->pending.enqueue({payload, event, false, state->rumbleEpoch});
         }
-        state->pending.enqueue(
-            {QByteArray(reinterpret_cast<const char *>(bytes), static_cast<qsizetype>(length)),
-             event, false, state->rumbleEpoch});
         if (!state->drainScheduled) {
             state->drainScheduled = true;
             shouldSchedule = true;
@@ -693,6 +715,7 @@ void NativeStreamRuntime::scheduleDrain(const std::shared_ptr<CallbackState> &st
     const std::lock_guard lock(state->mutex);
     state->drainScheduled = false;
     state->pending.clear();
+    state->cursorCapture.clear();
 }
 
 void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &state)
@@ -710,6 +733,9 @@ void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &s
     {
         const std::lock_guard lock(state->mutex);
         constexpr qsizetype BatchSize = 64;
+        if (!state->cursorCapture.isEmpty()) {
+            messages.enqueue({std::exchange(state->cursorCapture, {}), true});
+        }
         while (!state->pending.isEmpty() && messages.size() < BatchSize)
             messages.enqueue(state->pending.dequeue());
         dropped = std::exchange(state->dropped, 0);
@@ -752,6 +778,16 @@ void NativeStreamRuntime::drainCallbacks(const std::shared_ptr<CallbackState> &s
         }
         const auto kind = document.object().value(u"type"_s).toString();
         const auto status = document.object().value(u"status"_s).toString();
+        if (message.event && kind == u"cursor-capture"_s) {
+            if (d->cursorStartId.isEmpty()
+                || document.object().value(u"startId"_s).toString() != d->cursorStartId) continue;
+            const auto composited = document.object().value(u"composited"_s);
+            if (composited.isBool() && d->serverCursorComposited != composited.toBool()) {
+                d->serverCursorComposited = composited.toBool();
+                emit cursorCaptureChanged(d->serverCursorComposited);
+                if (!current()) return;
+            }
+        }
         if (message.event && kind == u"controller-rumble"_s) {
             const auto object = document.object();
             if (message.rumbleEpoch != rumbleEpoch || !inputAllowed() || d->rumbleStartId.isEmpty()

--- a/opennow-qt/src/streaming/NativeStreamRuntime.h
+++ b/opennow-qt/src/streaming/NativeStreamRuntime.h
@@ -90,6 +90,7 @@ public:
     [[nodiscard]] quint64 presentationGeneration() const;
     [[nodiscard]] bool presentationAllowed() const;
     [[nodiscard]] bool inputAllowed() const;
+    [[nodiscard]] bool serverCursorComposited() const;
     [[nodiscard]] const OpenNowStreamerVulkanDevice *vulkanDevice() const;
     // Called at most once per presentation failure from the scene-graph thread.
     void reportPresentationError(const QString &message);
@@ -136,6 +137,8 @@ signals:
     void eventReceived(const QJsonObject &event);
     void frameAvailable();
     void cursorUpdated(const QByteArray &bytes);
+    void cursorCaptureChanged(bool composited);
+    void cursorStateReset();
     void controllerRumbleRequested(quint8 controllerId, quint16 lowFrequency,
                                    quint16 highFrequency, quint32 durationMs);
     void controllerRumbleStopped();

--- a/opennow-qt/src/streaming/StreamVideoItem.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItem.cpp
@@ -54,6 +54,14 @@ StreamVideoItem::StreamVideoItem(std::unique_ptr<MacPointerCapture> pointerCaptu
     connect(&m_frameStatsTimer, &QTimer::timeout,
             this, &StreamVideoItem::frameGenerationStatsChanged);
     if (s_nativeRuntime) {
+        m_serverCursorComposited = s_nativeRuntime->serverCursorComposited();
+        connect(s_nativeRuntime, &NativeStreamRuntime::cursorCaptureChanged, this,
+                [this](bool composited) {
+            m_serverCursorComposited = composited;
+            updateLocalCursor();
+        });
+        connect(s_nativeRuntime, &NativeStreamRuntime::cursorStateReset,
+                this, &StreamVideoItem::resetRemoteCursor);
         connect(s_nativeRuntime, &NativeStreamRuntime::inputAllowedChanged,
                 this, &StreamVideoItem::syncCaptureState);
         connect(s_nativeRuntime, &NativeStreamRuntime::inputCaptureReset, this, [this] {
@@ -66,20 +74,16 @@ StreamVideoItem::StreamVideoItem(std::unique_ptr<MacPointerCapture> pointerCaptu
         connect(s_nativeRuntime, &NativeStreamRuntime::frameAvailable,
                 this, &StreamVideoItem::requestFrame);
         connect(s_nativeRuntime, &NativeStreamRuntime::cursorUpdated,
-                this, &StreamVideoItem::applyRemoteCursor, Qt::QueuedConnection);
+                this, &StreamVideoItem::applyRemoteCursor);
         connect(s_nativeRuntime, &NativeStreamRuntime::runningChanged, this, [this] {
             if (!s_nativeRuntime || !s_nativeRuntime->running()) {
                 m_manualRelativeMouse.reset();
-                m_remoteCursorKnown = false;
-                m_remoteCursorVisible = false;
-                m_remoteCursor = QCursor();
-                if (m_relativeMouse) setRelativeMouse(false);
-                else unsetCursor();
+                resetRemoteCursor();
             }
             syncCaptureState();
         });
     }
-    connect(this, &QQuickItem::windowChanged, this, [this](QQuickWindow *currentWindow) {
+    const auto attachWindow = [this](QQuickWindow *currentWindow) {
         connectFrameSwaps();
         if (currentWindow) {
             connect(currentWindow, &QWindow::activeChanged,
@@ -96,7 +100,9 @@ StreamVideoItem::StreamVideoItem(std::unique_ptr<MacPointerCapture> pointerCaptu
                     this, &StreamVideoItem::resynchronizeInput, Qt::UniqueConnection);
         }
         syncCaptureState();
-    });
+    };
+    connect(this, &QQuickItem::windowChanged, this, attachWindow);
+    attachWindow(window());
 }
 
 StreamVideoItem::~StreamVideoItem()

--- a/opennow-qt/src/streaming/StreamVideoItem.h
+++ b/opennow-qt/src/streaming/StreamVideoItem.h
@@ -136,6 +136,7 @@ private:
     };
 
     void applyRemoteCursor(const QByteArray &bytes);
+    void resetRemoteCursor();
     void setRemoteCursorShape(const QCursor &cursor);
     void updateLocalCursor();
     void syncCaptureState();
@@ -172,6 +173,7 @@ private:
     bool m_rawInputActive = false;
     bool m_cursorConfined = false;
     bool m_remoteCursorKnown = false;
+    bool m_serverCursorComposited = true;
     bool m_remoteCursorVisible = false;
     QCursor m_remoteCursor;
     std::optional<bool> m_pendingRelativeMouse;

--- a/opennow-qt/src/streaming/StreamVideoItemInput.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItemInput.cpp
@@ -353,11 +353,7 @@ void StreamVideoItem::itemChange(ItemChange change, const ItemChangeData &data)
     QQuickItem::itemChange(change, data);
     if (change == ItemVisibleHasChanged && !isVisible()) {
         m_manualRelativeMouse.reset();
-        m_remoteCursorKnown = false;
-        m_remoteCursorVisible = false;
-        m_remoteCursor = QCursor();
-        if (m_relativeMouse) setRelativeMouse(false);
-        else unsetCursor();
+        resetRemoteCursor();
     }
     if (change == ItemVisibleHasChanged || change == ItemSceneChange)
         syncCaptureState();
@@ -556,11 +552,9 @@ void StreamVideoItem::releaseInput()
     // syncCaptureState() or acquiring a new grab while releasing the old one.
     if (pendingRelativeMouse && m_relativeMouse != *pendingRelativeMouse) {
         m_relativeMouse = *pendingRelativeMouse;
-        if (m_relativeMouse) setCursor(Qt::BlankCursor);
-        else setCursor(m_remoteCursor);
         emit relativeMouseChanged();
     }
-    if (m_usesMacPointerCapture) unsetCursor();
+    unsetCursor();
 }
 
 void StreamVideoItem::releaseQtMouseButtons()
@@ -654,7 +648,6 @@ void StreamVideoItem::setRelativeMouse(bool relative)
     if (relative && !m_rawInputActive) releaseQtMouseButtons();
     m_relativeMouse = relative;
     if (relative) {
-        setCursor(Qt::BlankCursor);
         if (m_captureActive && !WaylandPointerCapture::isWayland()
                 && !m_usesMacPointerCapture) {
             grabMouse();
@@ -665,7 +658,6 @@ void StreamVideoItem::setRelativeMouse(bool relative)
     } else {
         ungrabMouse();
         releaseCursorConfinement();
-        setCursor(m_remoteCursor);
     }
     syncCaptureState();
     emit relativeMouseChanged();
@@ -679,16 +671,25 @@ void StreamVideoItem::setRemoteCursorShape(const QCursor &cursor)
 
 void StreamVideoItem::updateLocalCursor()
 {
-    if (m_usesMacPointerCapture && !m_captureActive) {
+    if (!m_captureActive) {
         unsetCursor();
         return;
     }
-    if (m_relativeMouse || (m_usesMacPointerCapture && !m_remoteCursorKnown
-                           && m_manualRelativeMouse != false)) {
+    if (m_relativeMouse || (m_serverCursorComposited && m_manualRelativeMouse != false)) {
         setCursor(Qt::BlankCursor);
         return;
     }
     setCursor(m_remoteCursor);
+}
+
+void StreamVideoItem::resetRemoteCursor()
+{
+    m_remoteCursorKnown = false;
+    m_remoteCursorVisible = false;
+    m_serverCursorComposited = s_nativeRuntime ? s_nativeRuntime->serverCursorComposited() : true;
+    m_remoteCursor = QCursor();
+    setRelativeMouse(m_manualRelativeMouse.value_or(false));
+    updateLocalCursor();
 }
 
 void StreamVideoItem::togglePointerLock()

--- a/opennow-qt/tests/tst_nativestreamruntime.cpp
+++ b/opennow-qt/tests/tst_nativestreamruntime.cpp
@@ -551,6 +551,68 @@ private slots:
         QVERIFY(runtime.shutdown());
     }
 
+    void cursorCompositionIsValidatedCachedAndResetForAcceptedStarts()
+    {
+        static OpenNowStreamerConfig callbacks;
+        auto api = fakeApi();
+        api.create = [](const OpenNowStreamerConfig *config, OpenNowStreamer **output) {
+            callbacks = *config;
+            return fakeCreate(config, output);
+        };
+        NativeStreamRuntime runtime(api);
+        QSignalSpy composition(&runtime, &NativeStreamRuntime::cursorCaptureChanged);
+        QSignalSpy resets(&runtime, &NativeStreamRuntime::cursorStateReset);
+        QVERIFY(runtime.start());
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("initial")}}));
+        resets.clear();
+        QVERIFY(runtime.serverCursorComposited());
+        const auto deliver = [](const QByteArray &bytes) {
+            callbacks.event_callback(reinterpret_cast<const std::uint8_t *>(bytes.constData()),
+                                     bytes.size(), callbacks.user_data);
+        };
+        deliver(R"({"type":"cursor-capture","startId":"initial","composited":false})");
+        QTRY_VERIFY(!runtime.serverCursorComposited());
+        QCOMPARE(composition.size(), 1);
+        for (const auto &bytes : {R"({"type":"cursor-capture","startId":"initial"})",
+                                 R"({"type":"cursor-capture","startId":"initial","composited":"true"})",
+                                 R"({"type":"cursor-capture","startId":"initial","composited":1})",
+                                 R"({"type":"cursor-capture","startId":"initial","composited":false})"}) {
+            deliver(bytes);
+        }
+        QCoreApplication::processEvents();
+        QVERIFY(!runtime.serverCursorComposited());
+        QCOMPARE(composition.size(), 1);
+        sendStatus = OPENNOW_STREAMER_QUEUE_FULL;
+        const auto restore = qScopeGuard([] { sendStatus = OPENNOW_STREAMER_OK; });
+        QVERIFY(!runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                               {QStringLiteral("id"), QStringLiteral("rejected")}}));
+        QVERIFY(!runtime.serverCursorComposited());
+        QCOMPARE(resets.size(), 0);
+        sendStatus = OPENNOW_STREAMER_OK;
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("accepted")}}));
+        QVERIFY(runtime.serverCursorComposited());
+        QCOMPARE(resets.size(), 1);
+        deliver(R"({"type":"cursor-capture","startId":"initial","composited":false})");
+        QCoreApplication::processEvents();
+        QVERIFY(runtime.serverCursorComposited());
+        deliver(R"({"type":"cursor-capture","startId":"accepted","composited":false})");
+        QTRY_VERIFY(!runtime.serverCursorComposited());
+        deliver(R"({"type":"cursor-capture","startId":"accepted","composited":true})");
+        QTRY_VERIFY(runtime.serverCursorComposited());
+        QCOMPARE(composition.size(), 3);
+        QSignalSpy dropped(&runtime, &NativeStreamRuntime::callbacksDropped);
+        for (qsizetype i = 0; i < NativeStreamRuntime::MaximumPendingCallbacks + 1; ++i)
+            deliver(R"({"type":"telemetry"})");
+        deliver(R"({"type":"cursor-capture","startId":"accepted","composited":true})");
+        deliver(R"({"type":"cursor-capture","startId":"accepted","composited":false})");
+        QTRY_VERIFY(!runtime.serverCursorComposited());
+        QCOMPARE(composition.size(), 4);
+        QTRY_VERIFY(!dropped.isEmpty());
+        QVERIFY(runtime.shutdown());
+    }
+
     void lateRenderFailureKeepsItsOriginalSessionGeneration()
     {
         NativeStreamRuntime runtime(fakeApi());

--- a/opennow-qt/tests/tst_streamvideoitem.cpp
+++ b/opennow-qt/tests/tst_streamvideoitem.cpp
@@ -183,6 +183,63 @@ class StreamVideoItemTest final : public QObject
 {
     Q_OBJECT
 
+    struct CursorSession {
+        inline static OpenNowStreamerConfig callbacks;
+
+        static NativeStreamRuntime::Api api()
+        {
+            NativeStreamRuntime::Api api{};
+            api.create = [](const OpenNowStreamerConfig *config, OpenNowStreamer **output) {
+                callbacks = *config;
+                *output = reinterpret_cast<OpenNowStreamer *>(new int(1));
+                return OPENNOW_STREAMER_OK;
+            };
+            api.destroy = [](OpenNowStreamer *handle) {
+                delete reinterpret_cast<int *>(handle);
+                return OPENNOW_STREAMER_OK;
+            };
+            api.send = [](const OpenNowStreamer *, const std::uint8_t *, std::size_t) {
+                return OPENNOW_STREAMER_OK;
+            };
+            api.setCaptureActive = [](const OpenNowStreamer *, bool, bool, std::uintptr_t, bool *raw) {
+                *raw = false;
+                return OPENNOW_STREAMER_OK;
+            };
+            return api;
+        }
+
+        bool start()
+        {
+            if (!runtime.start()) return false;
+            StreamVideoItem::setNativeStreamRuntime(&runtime);
+            if (!runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                               {QStringLiteral("id"), QStringLiteral("cursor-test")}})) return false;
+            const QByteArray ready = R"({"id":"cursor-test","type":"ok"})";
+            callbacks.response_callback(reinterpret_cast<const std::uint8_t *>(ready.constData()),
+                                        ready.size(), callbacks.user_data);
+            window.resize(640, 480);
+            window.show();
+            window.requestActivate();
+            return true;
+        }
+
+        void composition(bool composited)
+        {
+            const auto bytes = QJsonDocument(QJsonObject{
+                {QStringLiteral("type"), QStringLiteral("cursor-capture")},
+                {QStringLiteral("startId"), startId},
+                {QStringLiteral("composited"), composited}}).toJson(QJsonDocument::Compact);
+            callbacks.event_callback(reinterpret_cast<const std::uint8_t *>(bytes.constData()),
+                                     bytes.size(), callbacks.user_data);
+        }
+
+        ~CursorSession() { StreamVideoItem::setNativeStreamRuntime(nullptr); }
+
+        NativeStreamRuntime runtime{api()};
+        QQuickWindow window;
+        QString startId = QStringLiteral("cursor-test");
+    };
+
 private slots:
     void macPointerCaptureOwnsMotionAndReleasesAcrossTransitions()
     {
@@ -381,6 +438,7 @@ private slots:
         item.updateLocalCursor();
         QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
         item.m_manualRelativeMouse.reset();
+        item.m_serverCursorComposited = false;
         item.m_remoteCursorKnown = true;
         item.setRemoteCursorShape(QCursor(Qt::CrossCursor));
         QCOMPARE(item.cursor().shape(), Qt::CrossCursor);
@@ -391,6 +449,110 @@ private slots:
         QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
         item.m_captureActive = false;
         item.updateLocalCursor();
+        QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+    }
+
+    void cursorOwnershipSurvivesOverlaysFullscreenAndRestart()
+    {
+        CursorSession session;
+        QVERIFY(session.start());
+        StreamVideoItem item(session.window.contentItem());
+        item.m_usesMacPointerCapture = false;
+        item.setRenderCallback({});
+        item.setSize(session.window.size());
+        item.forceActiveFocus();
+        QTRY_VERIFY(session.runtime.inputAllowed());
+        QTRY_VERIFY(session.window.isActive());
+        QTRY_VERIFY(item.hasActiveFocus());
+        QVERIFY(item.isVisible());
+        QTRY_VERIFY(item.captureActive());
+        QVERIFY(!item.m_remoteCursorKnown);
+        QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+        session.composition(false);
+        QTRY_COMPARE(item.cursor().shape(), Qt::ArrowCursor);
+        QVERIFY(!item.m_remoteCursorKnown);
+
+        QQuickItem overlay(session.window.contentItem());
+        overlay.setVisible(false);
+        for (const bool fullscreen : {false, true}) {
+            if (fullscreen) session.window.showFullScreen();
+            else session.window.showNormal();
+            session.window.requestActivate();
+            QTRY_VERIFY(session.window.isActive());
+            item.setSize(session.window.size());
+            item.forceActiveFocus();
+            QTRY_VERIFY(item.captureActive());
+            item.applyRemoteCursor(QByteArray::fromHex("0002"));
+            QCOMPARE(item.cursor().shape(), Qt::IBeamCursor);
+            session.composition(true);
+            QTRY_COMPARE(item.cursor().shape(), Qt::BlankCursor);
+            session.composition(false);
+            QTRY_COMPARE(item.cursor().shape(), Qt::IBeamCursor);
+            item.applyRemoteCursor(QByteArray::fromHex("0000"));
+            QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+            overlay.setVisible(true);
+            overlay.forceActiveFocus();
+            QTRY_VERIFY(!item.captureActive());
+            QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+            item.applyRemoteCursor(QByteArray::fromHex("000c"));
+            QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+            item.applyRemoteCursor(QByteArray::fromHex("0000"));
+            QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+            overlay.setVisible(false);
+            item.forceActiveFocus();
+            QTRY_VERIFY(item.captureActive());
+            QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+            item.setInputEnabled(false);
+            QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+            item.setInputEnabled(true);
+            QTRY_VERIFY(item.captureActive());
+            QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+            item.applyRemoteCursor(QByteArray::fromHex("000c"));
+            QCOMPARE(item.cursor().shape(), Qt::PointingHandCursor);
+        }
+
+        QVERIFY(session.runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                                      {QStringLiteral("id"), QStringLiteral("replacement")}}));
+        session.startId = QStringLiteral("replacement");
+        QVERIFY(!item.captureActive());
+        QVERIFY(!item.m_remoteCursorKnown);
+        QVERIFY(item.m_serverCursorComposited);
+        QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+        const QByteArray ready = R"({"id":"replacement","type":"ok"})";
+        CursorSession::callbacks.response_callback(
+            reinterpret_cast<const std::uint8_t *>(ready.constData()), ready.size(),
+            CursorSession::callbacks.user_data);
+        QTRY_VERIFY(item.captureActive());
+        QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+        session.composition(false);
+        QTRY_COMPARE(item.cursor().shape(), Qt::ArrowCursor);
+        item.applyRemoteCursor(QByteArray::fromHex("0000"));
+        QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
+        QVERIFY(session.runtime.send({{QStringLiteral("type"), QStringLiteral("stop")}}));
+        QVERIFY(!item.captureActive());
+        QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+    }
+
+    void cursorVisibilityPolicyIsTheSameAcrossPlatforms()
+    {
+        StreamVideoItem item;
+        for (const bool mac : {false, true}) {
+            item.m_usesMacPointerCapture = mac;
+            for (const bool capture : {false, true}) {
+                item.m_captureActive = capture;
+                for (const bool composited : {false, true}) {
+                    item.m_serverCursorComposited = composited;
+                    for (const bool relative : {false, true}) {
+                        item.m_relativeMouse = relative;
+                        item.m_remoteCursor = QCursor(Qt::CrossCursor);
+                        item.updateLocalCursor();
+                        QCOMPARE(item.cursor().shape(), !capture ? Qt::ArrowCursor
+                            : relative || composited ? Qt::BlankCursor : Qt::CrossCursor);
+                    }
+                }
+            }
+        }
+        item.releaseInput();
         QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
     }
 
@@ -1368,7 +1530,16 @@ private slots:
 
     void visibleCursorUpdatesStayHiddenUntilRelativeButtonRelease()
     {
-        StreamVideoItem item;
+        CursorSession session;
+        QVERIFY(session.start());
+        StreamVideoItem item(session.window.contentItem());
+        item.m_usesMacPointerCapture = false;
+        item.setRenderCallback({});
+        item.setSize(session.window.size());
+        item.forceActiveFocus();
+        QTRY_VERIFY(item.captureActive());
+        session.composition(false);
+        QTRY_VERIFY(!item.m_serverCursorComposited);
         item.applyRemoteCursor(QByteArray::fromHex("0000"));
         QVERIFY(item.relativeMouse());
         QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
@@ -1398,7 +1569,16 @@ private slots:
 
     void deferredCursorUpdatesSurviveInputRelease()
     {
-        StreamVideoItem item;
+        CursorSession session;
+        QVERIFY(session.start());
+        StreamVideoItem item(session.window.contentItem());
+        item.m_usesMacPointerCapture = false;
+        item.setRenderCallback({});
+        item.setSize(session.window.size());
+        item.forceActiveFocus();
+        QTRY_VERIFY(item.captureActive());
+        session.composition(false);
+        QTRY_VERIFY(!item.m_serverCursorComposited);
         item.applyRemoteCursor(QByteArray::fromHex("0002"));
         QCOMPARE(item.cursor().shape(), Qt::IBeamCursor);
         item.m_pressedMouseButtons.insert(1);
@@ -1407,6 +1587,8 @@ private slots:
         QCOMPARE(item.cursor().shape(), Qt::IBeamCursor);
         item.releaseInput();
         QVERIFY(item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+        item.syncCaptureState();
         QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
         item.m_pressedMouseButtons.insert(1);
         item.applyRemoteCursor(QByteArray::fromHex("000c"));
@@ -1414,6 +1596,8 @@ private slots:
         QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
         item.releaseInput();
         QVERIFY(!item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+        item.syncCaptureState();
         QCOMPARE(item.cursor().shape(), Qt::IBeamCursor);
         QVERIFY(item.m_pressedMouseButtons.isEmpty());
         QVERIFY(!item.m_pendingRelativeMouse.has_value());
@@ -1433,7 +1617,16 @@ private slots:
         message.append(static_cast<char>((encoded.size() >> 8) & 0xff));
         message.append(encoded);
 
-        StreamVideoItem item;
+        CursorSession session;
+        QVERIFY(session.start());
+        StreamVideoItem item(session.window.contentItem());
+        item.m_usesMacPointerCapture = false;
+        item.setRenderCallback({});
+        item.setSize(session.window.size());
+        item.forceActiveFocus();
+        QTRY_VERIFY(item.captureActive());
+        session.composition(false);
+        QTRY_VERIFY(!item.m_serverCursorComposited);
         item.applyRemoteCursor(QByteArray::fromHex("0000"));
         item.m_pressedMouseButtons.insert(1);
         item.applyRemoteCursor(message);
@@ -1441,6 +1634,8 @@ private slots:
         QCOMPARE(item.cursor().shape(), Qt::BlankCursor);
         item.releaseInput();
         QVERIFY(!item.relativeMouse());
+        QCOMPARE(item.cursor().shape(), Qt::ArrowCursor);
+        item.syncCaptureState();
         QCOMPARE(item.cursor().shape(), Qt::BitmapCursor);
         QCOMPARE(item.cursor().hotSpot(), QPoint(2, 3));
         QCOMPARE(item.cursor().pixmap().toImage(), image.toImage());


### PR DESCRIPTION
Separate server-composited cursor ownership from Qt cursor shape and relative-input mode. The local cursor stays hidden while the server draws it into the video, and capture release restores the local pointer on every platform. Connect activation and geometry signals for an existing parent window as well as later window changes; otherwise a newly created stream item can remain uncaptured despite having focus.

Use the first valid cursor notification, including native bitmap notifications, to begin the handoff to local cursor rendering. A three-second silent-host fallback and paced, bounded capture-off retries prevent startup ownership from remaining unresolved. Composition changes carry the session start ID and retain/coalesce their latest state through Rust and Qt event-queue backpressure. Accepted starts reset cursor state, and callbacks from previous sessions are rejected. Existing deferred drag transitions and manual pointer-lock behavior remain intact.

The ownership split and silent-host fallback follow OpenNOW-Mac revision `666bd4a3391e13b074b37eecfd61d568e9231d34`. Native bitmap pixel decoding remains unsupported: bitmap notifications do not invent visibility or unlock a hidden gameplay pointer, and an unknown local shape uses the arrow fallback. Existing system cursor ID0 semantics and the cursor ABI are unchanged. Capture-off success means the command was queued locally, not acknowledged by the host.

Validation: 522 streamer workspace tests passed (9 existing ignored); workspace/all-targets Clippy with `-D warnings`, Rust formatting, and `git diff --check` passed. Built and passed the complete stream-video, native-runtime, mac-pointer and embedded-orchestration Qt suites on Linux with Qt 6.8.3. The real X11 stream-video run passed 62 cases (2 platform-specific skips), including fullscreen, overlays and native video composition. New regressions cover startup fallback, capture release, initial window activation, session restart/stale events, malformed cursor framing and queue overflow. Live GFN gameplay on macOS/Windows and full application packaging were not tested.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23FXR21YMY2194SR4ZJV9AW"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->