### PR TITLE
feat(input): add opt-in clipboard paste to Controls

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,9 @@
 {
+  "clipboardSettings": {
+    "title": "Clipboard paste",
+    "description": "Paste local text into the stream with Ctrl+V (Command+V on macOS). Up to 64 KiB per paste. No automatic clipboard sync.",
+    "failed": "Clipboard paste failed. Use plain text up to 64 KiB and try again."
+  },
   "sessionFullscreen": {
     "title": "Fullscreen when session is ready",
     "description": "Automatically enter fullscreen when your session is ready. F11 toggles fullscreen during play."

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
@@ -95,6 +95,11 @@ trait NvstSessionResources {
     fn request_keyframe(&self);
     fn acknowledge_video_frame(&self, frame_index: u32, bytes: u32);
     fn send_captured_input(&self, bytes: Vec<u8>) -> Result<(), String>;
+    fn send_captured_text(
+        &self,
+        text: opennow_streamer_protocol::text_input::UnicodeText,
+        timestamp_us: u64,
+    ) -> Result<(), String>;
     fn apply_cursor(&self, bytes: Vec<u8>);
     fn recover(&self) -> Result<(), String>;
     fn stop(&self);
@@ -135,6 +140,16 @@ impl NvstSessionResources for ActiveNvstResources {
     fn send_captured_input(&self, bytes: Vec<u8>) -> Result<(), String> {
         self.bundle
             .queue_input(bytes, false)
+            .map_err(|error| error.to_string())
+    }
+
+    fn send_captured_text(
+        &self,
+        text: opennow_streamer_protocol::text_input::UnicodeText,
+        timestamp_us: u64,
+    ) -> Result<(), String> {
+        self.bundle
+            .queue_text(text, timestamp_us)
             .map_err(|error| error.to_string())
     }
 
@@ -1596,6 +1611,9 @@ fn forward_nvst_session_events<R: NvstSessionResources>(
         transport: resources,
     } = event_resources;
     let mut feedback_state = NvstMediaFeedbackState::new(false);
+    if let Some(queue) = captured_input.as_ref() {
+        queue.set_text_ready(generation, false);
+    }
     let mut pending_rumble = [None; 4];
     let mut pending_cursor_capture = NvstCursorCaptureOutput {
         start_id: start_id.clone(),
@@ -1702,9 +1720,17 @@ fn forward_nvst_session_events<R: NvstSessionResources>(
         match nvst_events.recv_timeout(NATIVE_INPUT_POLL_INTERVAL) {
             Ok(nvst_event) => {
                 match &nvst_event {
-                    NvstReceiveEvent::InputReady(_) => feedback_state.input_available = true,
+                    NvstReceiveEvent::InputReady(_) => {
+                        feedback_state.input_available = true;
+                        if let Some(queue) = captured_input.as_ref() {
+                            queue.set_text_ready(generation, true);
+                        }
+                    }
                     NvstReceiveEvent::InputUnavailable(_) => {
                         feedback_state.input_available = false;
+                        if let Some(queue) = captured_input.as_ref() {
+                            queue.set_text_ready(generation, false);
+                        }
                     }
                     _ => {}
                 }
@@ -1734,6 +1760,9 @@ fn forward_nvst_session_events<R: NvstSessionResources>(
                 break;
             }
         }
+    }
+    if let Some(queue) = captured_input.as_ref() {
+        queue.set_text_ready(generation, false);
     }
     feedback_state
         .drop_reports
@@ -2182,6 +2211,9 @@ fn forward_nvst_captured_input<R: NvstSessionResources>(
         return Ok(());
     }
     let timestamp_us = u64::try_from(state.input_origin.elapsed().as_micros()).unwrap_or(u64::MAX);
+    if let CapturedInput::Text(text) = input {
+        return resources.send_captured_text(text, timestamp_us);
+    }
     resources.send_captured_input(captured_input_packet(input, timestamp_us))
 }
 
@@ -2207,11 +2239,15 @@ fn forward_nvst_captured_sample<R: NvstSessionResources>(
         .checked_duration_since(state.input_origin)
         .unwrap_or_default();
     let timestamp_us = u64::try_from(captured.as_micros()).unwrap_or(u64::MAX);
+    if let CapturedInput::Text(text) = sample.input {
+        return resources.send_captured_text(text, timestamp_us);
+    }
     resources.send_captured_input(captured_input_packet(sample.input, timestamp_us))
 }
 
 fn captured_input_packet(input: CapturedInput, timestamp_us: u64) -> Vec<u8> {
     match input {
+        CapturedInput::Text(_) => unreachable!("text uses typed transport submission"),
         CapturedInput::Key {
             virtual_key,
             modifiers,
@@ -2824,6 +2860,18 @@ mod tests {
 
         fn apply_cursor(&self, _bytes: Vec<u8>) {}
 
+        fn send_captured_text(
+            &self,
+            text: opennow_streamer_protocol::text_input::UnicodeText,
+            _timestamp_us: u64,
+        ) -> Result<(), String> {
+            self.captured_inputs
+                .lock()
+                .unwrap()
+                .push(text.as_str().as_bytes().to_vec());
+            Ok(())
+        }
+
         fn recover(&self) -> Result<(), String> {
             self.recoveries.fetch_add(1, Ordering::Relaxed);
             Ok(())
@@ -3079,6 +3127,29 @@ mod tests {
         assert_eq!(
             u64::from_be_bytes(inputs[0][14..22].try_into().unwrap()),
             4_242
+        );
+    }
+
+    #[test]
+    fn captured_unicode_text_uses_typed_transport_without_key_expansion() {
+        use opennow_streamer_protocol::text_input::TextInputSlot;
+        let resources = TestNvstResources::default();
+        let state = NvstMediaFeedbackState::new(true);
+        let text = TextInputSlot::default()
+            .submit("é世界🦫".as_bytes())
+            .unwrap();
+        forward_nvst_captured_sample(
+            &resources,
+            CapturedInputSample {
+                input: CapturedInput::Text(text),
+                captured_at: state.input_origin,
+            },
+            &state,
+        )
+        .unwrap();
+        assert_eq!(
+            *resources.captured_inputs.lock().unwrap(),
+            vec!["é世界🦫".as_bytes().to_vec()]
         );
     }
 

--- a/native/opennow-streamer/crates/opennow-streamer-ffi/README.md
+++ b/native/opennow-streamer/crates/opennow-streamer-ffi/README.md
@@ -13,6 +13,50 @@ This crate exposes `opennow-streamer-core::Engine` as a C-compatible in-process 
 - `opennow_streamer_destroy` consumes the handle exactly once, waits for the engine and both callback queues to drain, and then returns. No call may race with destroy. A null handle is rejected; reusing a destroyed pointer is caller-side undefined behavior.
 - Every exported function catches Rust panics before they can unwind through the C ABI. A worker-thread panic closes the command queue.
 
+### Clipboard text (ABI 9)
+
+Rebuild Qt and the native library together with ABI version 9. Existing structure
+layouts and the graphics render-command version are unchanged. The new export is
+`opennow_streamer_submit_text(const OpenNowStreamer *, const uint8_t *, size_t)`;
+`OPENNOW_STREAMER_MAX_TEXT_BYTES` is 65,536.
+
+The caller supplies nonempty, strictly valid UTF-8 without embedded NUL or a trailing
+terminator. The library copies the complete text before returning; it never truncates,
+normalizes newlines, interprets text as key combinations, or logs its contents.
+Null pointers return `NULL_POINTER`, empty/invalid/NUL-containing text returns
+`INVALID_CONFIG`, and lengths over the bound return `MESSAGE_TOO_LARGE` before the
+buffer is read. An oversized length takes precedence over a null text pointer.
+
+Admission requires active embedded capture and negotiated session input. Otherwise
+it returns `CLOSED`. One paste occupies a capture-queue entry and retains a single-flight
+reservation through the ordered transport command queue. A second paste or a full
+256-entry capture queue returns `QUEUE_FULL` without admitting any text, evicting
+gameplay input, or triggering the control-overflow shutdown. `OK` acknowledges whole
+local admission, not delivery to or insertion by the remote application.
+
+Capture loss, input unavailability, and session teardown cancel text still pending
+in capture or transport. Readiness changes are generation-scoped, so stale session
+events cannot enable or cancel text belonging to a replacement session. A paste
+already submitted to SCTP cannot be recalled.
+Transport checks capacity for the complete encoded batch across all eight negotiated
+SCTP channels before writing any chunk. This matches str0m 0.23's 128-KiB aggregate
+send-buffer limit; the receive worker owns all writes and does not poll the network
+between chunks. Insufficient capacity rejects the whole batch and emits a payload-free
+diagnostic rather than retrying a paste that might duplicate text. Connection failure
+can interrupt remote delivery; the protocol provides no paste-level acknowledgement
+or rollback.
+
+Each packet uses ordered reliable control command `0x0206` and remote-input type 23,
+with raw UTF-8 bodies of at most `0x3f8` (1,016) bytes. Overflow cuts back to the nearest
+code-point boundary (at most three bytes). The RI header is a big-endian 32-bit length
+of `4 + body bytes`, then little-endian type 23. Following the verified
+`NvstRemoteInput.utf8TextPackets` / `sendFramedRemoteInput` reference contract, inner
+packets up to 1,007 bytes receive a type-14 envelope with zero padding to
+`((inner_length + 8) / 8) * 8 + 8` bytes and one little-endian 64-bit capture timestamp.
+Larger inner packets (text bodies of 1,000–1,016 bytes) are sent bare. The older
+serialized ASCII text command retains its key-stroke conversion for compatibility;
+the typed clipboard path never enters that codec or its raw-input diagnostics.
+
 ### Controller rumble events
 
 The additive `controller-rumble` JSON event uses the existing `event_callback` (no C ABI

--- a/native/opennow-streamer/crates/opennow-streamer-ffi/include/opennow_streamer_ffi.h
+++ b/native/opennow-streamer/crates/opennow-streamer-ffi/include/opennow_streamer_ffi.h
@@ -9,7 +9,8 @@
 extern "C" {
 #endif
 
-#define OPENNOW_STREAMER_FFI_ABI_VERSION 8u
+#define OPENNOW_STREAMER_FFI_ABI_VERSION 9u
+#define OPENNOW_STREAMER_MAX_TEXT_BYTES 65536u
 #define OPENNOW_STREAMER_VULKAN_DEVICE_INFO_VERSION 1u
 #define OPENNOW_STREAMER_GRAPHICS_CONTEXT_VERSION 3u
 #define OPENNOW_STREAMER_RENDER_COMMAND_VERSION 3u
@@ -186,6 +187,17 @@ OpenNowStreamerStatus opennow_streamer_submit_key(
     uint16_t virtual_key,
     uint16_t modifiers,
     bool pressed);
+
+/* Copies nonempty strict UTF-8 without NUL or a terminator (at most MAX_TEXT_BYTES).
+ * OK admits the entire paste locally, not a remote delivery acknowledgement.
+ * Requires active capture and negotiated session input. One paste may be in flight.
+ * Invalid/empty: INVALID_CONFIG; oversize: MESSAGE_TOO_LARGE; null: NULL_POINTER;
+ * inactive/unavailable: CLOSED; occupied/full capture queue: QUEUE_FULL.
+ * Pending text is discarded when capture or session input becomes unavailable. */
+OpenNowStreamerStatus opennow_streamer_submit_text(
+    const OpenNowStreamer *handle,
+    const uint8_t *text,
+    size_t text_len);
 
 OpenNowStreamerStatus opennow_streamer_submit_mouse_relative(
     const OpenNowStreamer *handle,

--- a/native/opennow-streamer/crates/opennow-streamer-ffi/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-ffi/src/lib.rs
@@ -19,7 +19,9 @@ use serde_json::Value;
 
 static FIRST_FRAME_LOGGED: AtomicBool = AtomicBool::new(false);
 
-pub const OPENNOW_STREAMER_FFI_ABI_VERSION: u32 = 8;
+pub const OPENNOW_STREAMER_FFI_ABI_VERSION: u32 = 9;
+pub const OPENNOW_STREAMER_MAX_TEXT_BYTES: usize =
+    opennow_streamer_protocol::text_input::MAX_TEXT_BYTES;
 pub const OPENNOW_STREAMER_VULKAN_DEVICE_INFO_VERSION: u32 = 1;
 const DEFAULT_MAX_COMMAND_BYTES: usize = 1024 * 1024;
 const MAX_QUEUE_CAPACITY: usize = 4096;
@@ -847,6 +849,47 @@ pub unsafe extern "C" fn opennow_streamer_create(
 }
 
 #[unsafe(no_mangle)]
+/// Atomically admits one nonempty UTF-8 paste to the bounded captured input queue.
+/// Success acknowledges local admission, not remote delivery.
+///
+/// # Safety
+///
+/// `handle` must be null or point to a live handle not being destroyed.
+/// `text` must be null or readable for `text_len` bytes for the duration of the call.
+pub unsafe extern "C" fn opennow_streamer_submit_text(
+    handle: *const OpenNowStreamer,
+    text: *const u8,
+    text_len: usize,
+) -> OpenNowStreamerStatus {
+    ffi_status(|| {
+        use opennow_streamer_protocol::text_input::TextInputError;
+        let Some(handle) = (unsafe { handle.as_ref() }) else {
+            return OpenNowStreamerStatus::NullPointer;
+        };
+        if text_len > OPENNOW_STREAMER_MAX_TEXT_BYTES {
+            return OpenNowStreamerStatus::MessageTooLarge;
+        }
+        if text.is_null() {
+            return OpenNowStreamerStatus::NullPointer;
+        }
+        if text_len == 0 {
+            return OpenNowStreamerStatus::InvalidConfig;
+        }
+        let bytes = unsafe { std::slice::from_raw_parts(text, text_len) };
+        if bytes.contains(&0) || std::str::from_utf8(bytes).is_err() {
+            return OpenNowStreamerStatus::InvalidConfig;
+        }
+        match handle.input.submit_text(bytes) {
+            Ok(()) => OpenNowStreamerStatus::Ok,
+            Err(TextInputError::Invalid) => OpenNowStreamerStatus::InvalidConfig,
+            Err(TextInputError::TooLarge) => OpenNowStreamerStatus::MessageTooLarge,
+            Err(TextInputError::Busy) => OpenNowStreamerStatus::QueueFull,
+            Err(TextInputError::Unavailable) => OpenNowStreamerStatus::Closed,
+        }
+    })
+}
+
+#[unsafe(no_mangle)]
 /// Submits one keyboard transition to the embedded input queue.
 ///
 /// # Safety
@@ -1498,7 +1541,7 @@ mod tests {
 
     #[test]
     fn abi_five_appends_the_shared_vulkan_owner() {
-        assert_eq!(OPENNOW_STREAMER_FFI_ABI_VERSION, 8);
+        assert_eq!(OPENNOW_STREAMER_FFI_ABI_VERSION, 9);
         assert_eq!(OPENNOW_STREAMER_VULKAN_DEVICE_INFO_VERSION, 1);
         assert_eq!(
             std::mem::offset_of!(OpenNowStreamerConfig, vulkan_device),
@@ -1981,6 +2024,71 @@ mod tests {
         assert_eq!(queue.take(), None);
 
         handle.shutdown();
+    }
+
+    #[test]
+    fn typed_text_submission_validates_copies_and_bounds_the_whole_paste() {
+        let messages = Box::new(CallbackMessages::default());
+        let mut handle = graphics_test_handle(&messages);
+        let submit = |bytes: &[u8]| unsafe {
+            opennow_streamer_submit_text(&handle, bytes.as_ptr(), bytes.len())
+        };
+        assert_eq!(
+            unsafe { opennow_streamer_submit_text(ptr::null(), b"a".as_ptr(), 1) },
+            OpenNowStreamerStatus::NullPointer
+        );
+        assert_eq!(
+            unsafe { opennow_streamer_submit_text(&handle, ptr::null(), 1) },
+            OpenNowStreamerStatus::NullPointer
+        );
+        assert_eq!(
+            unsafe { opennow_streamer_submit_text(&handle, ptr::null(), usize::MAX) },
+            OpenNowStreamerStatus::MessageTooLarge
+        );
+        for invalid in [
+            &b""[..],
+            &b"a\0b"[..],
+            &[0xff],
+            &[0xc0, 0x80],
+            &[0xed, 0xa0, 0x80],
+        ] {
+            assert_eq!(submit(invalid), OpenNowStreamerStatus::InvalidConfig);
+        }
+        assert_eq!(
+            submit(&vec![b'a'; OPENNOW_STREAMER_MAX_TEXT_BYTES + 1]),
+            OpenNowStreamerStatus::MessageTooLarge
+        );
+        assert_eq!(submit(b"paste"), OpenNowStreamerStatus::Closed);
+        handle.input.set_active(true, false, 0);
+        assert_eq!(submit(b"paste"), OpenNowStreamerStatus::Closed);
+        let queue = handle.input.queue();
+        queue.set_text_ready(1, true);
+        let mut bytes = "café 世界 🦫\r\n".as_bytes().to_vec();
+        assert_eq!(submit(&bytes), OpenNowStreamerStatus::Ok);
+        bytes.fill(b'x');
+        assert_eq!(submit(b"again"), OpenNowStreamerStatus::QueueFull);
+        let Some(CapturedInput::Text(text)) = queue.take() else {
+            panic!("missing paste")
+        };
+        assert_eq!(text.as_str(), "café 世界 🦫\r\n");
+        assert_eq!(submit(b"again"), OpenNowStreamerStatus::QueueFull);
+        drop(text);
+        assert_eq!(
+            submit(&vec![b'a'; OPENNOW_STREAMER_MAX_TEXT_BYTES]),
+            OpenNowStreamerStatus::Ok
+        );
+        handle.input.set_active(false, false, 0);
+        assert!(queue.take().is_none());
+        handle.shutdown();
+    }
+
+    #[test]
+    fn abi_9_header_and_text_bound_match_rust() {
+        let header = include_str!("../include/opennow_streamer_ffi.h");
+        assert!(header.contains("#define OPENNOW_STREAMER_FFI_ABI_VERSION 9u"));
+        assert!(header.contains("#define OPENNOW_STREAMER_MAX_TEXT_BYTES 65536u"));
+        assert_eq!(OPENNOW_STREAMER_MAX_TEXT_BYTES, 65_536);
+        assert!(header.contains("opennow_streamer_submit_text("));
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/embedded_input.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/embedded_input.rs
@@ -86,12 +86,27 @@ impl EmbeddedInputCapture {
         });
     }
 
+    pub fn submit_text(
+        &self,
+        bytes: &[u8],
+    ) -> Result<(), opennow_streamer_protocol::text_input::TextInputError> {
+        let _guard = self
+            .gamepads
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !self.active.load(Ordering::Acquire) {
+            return Err(opennow_streamer_protocol::text_input::TextInputError::Unavailable);
+        }
+        self.queue.submit_text(bytes)
+    }
+
     pub fn set_active(&self, active: bool, relative_mouse: bool, window_handle: usize) -> bool {
         let mut gamepads = self
             .gamepads
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if !active {
+            self.queue.discard_text();
             if self.active.load(Ordering::Acquire) {
                 for (controller_id, bitmap) in gamepads.iter_mut().enumerate() {
                     if let Some(bitmap) = bitmap.take() {
@@ -180,6 +195,87 @@ const fn raw_capture_enabled(active: bool, relative_mouse: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn old_session_teardown_cannot_cancel_or_enable_new_session_text() {
+        use opennow_streamer_protocol::text_input::TextInputError;
+        let queue = std::sync::Arc::new(crate::CapturedInputQueue::default());
+        let capture = super::EmbeddedInputCapture::new(queue.clone());
+        capture.set_active(true, false, 0);
+        queue.set_text_ready(1, true);
+        capture.submit_text(b"old").unwrap();
+        let Some(crate::CapturedInput::Text(old)) = queue.take() else {
+            panic!("missing old paste")
+        };
+        queue.set_text_ready(2, false);
+        assert!(old.is_cancelled());
+        drop(old);
+        queue.set_text_ready(1, true);
+        assert_eq!(
+            capture.submit_text(b"new"),
+            Err(TextInputError::Unavailable)
+        );
+        queue.set_text_ready(2, true);
+        capture.submit_text(b"new").unwrap();
+        queue.set_text_ready(1, false);
+        let Some(crate::CapturedInput::Text(new)) = queue.take() else {
+            panic!("missing new paste")
+        };
+        assert!(!new.is_cancelled());
+    }
+
+    #[test]
+    fn text_requires_capture_and_session_and_cancels_in_flight_on_focus_loss() {
+        use opennow_streamer_protocol::text_input::TextInputError;
+        let queue = std::sync::Arc::new(crate::CapturedInputQueue::default());
+        let capture = super::EmbeddedInputCapture::new(queue.clone());
+        assert_eq!(
+            capture.submit_text(b"paste"),
+            Err(TextInputError::Unavailable)
+        );
+        capture.set_active(true, false, 0);
+        assert_eq!(
+            capture.submit_text(b"paste"),
+            Err(TextInputError::Unavailable)
+        );
+        queue.set_text_ready(1, true);
+        assert_eq!(capture.submit_text(b"paste"), Ok(()));
+        assert_eq!(capture.submit_text(b"again"), Err(TextInputError::Busy));
+        let Some(crate::CapturedInput::Text(text)) = queue.take() else {
+            panic!("missing text")
+        };
+        assert_eq!(capture.submit_text(b"again"), Err(TextInputError::Busy));
+        capture.set_active(false, false, 0);
+        assert!(text.is_cancelled());
+        drop(text);
+        capture.set_active(true, false, 0);
+        assert_eq!(capture.submit_text(b"again"), Ok(()));
+        queue.set_text_ready(1, false);
+        assert!(queue.take().is_none());
+        assert_eq!(
+            capture.submit_text(b"again"),
+            Err(TextInputError::Unavailable)
+        );
+    }
+
+    #[test]
+    fn full_capture_queue_rejects_paste_atomically_without_control_overflow() {
+        use opennow_streamer_protocol::text_input::TextInputError;
+        let queue = std::sync::Arc::new(crate::CapturedInputQueue::default());
+        let capture = super::EmbeddedInputCapture::new(queue.clone());
+        capture.set_active(true, false, 0);
+        queue.set_text_ready(1, true);
+        for _ in 0..256 {
+            capture.submit(crate::CapturedInput::Guide);
+        }
+        assert_eq!(capture.submit_text(b"paste"), Err(TextInputError::Busy));
+        assert!(!queue.take_overflowed());
+        for _ in 0..256 {
+            assert_eq!(queue.take(), Some(crate::CapturedInput::Guide));
+        }
+        assert!(queue.take().is_none());
+        assert_eq!(capture.submit_text(b"paste"), Ok(()));
+    }
+
     use super::*;
 
     fn gamepad(controller_id: u8, bitmap: u16, buttons: u16) -> CapturedInput {

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
@@ -1,7 +1,5 @@
 use std::collections::VecDeque;
-#[cfg(target_os = "windows")]
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvError, Sender, SyncSender, TrySendError, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -403,6 +401,7 @@ pub struct EncodedFrame {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CapturedInput {
+    Text(opennow_streamer_protocol::text_input::UnicodeText),
     Key {
         virtual_key: u16,
         modifiers: u16,
@@ -455,9 +454,60 @@ pub struct CapturedInputSample {
 pub struct CapturedInputQueue {
     pending: Mutex<VecDeque<CapturedInputSample>>,
     overflowed: AtomicBool,
+    text_ready: AtomicBool,
+    text_generation: AtomicU64,
+    text_slot: opennow_streamer_protocol::text_input::TextInputSlot,
 }
 
 impl CapturedInputQueue {
+    pub fn set_text_ready(&self, generation: u64, ready: bool) {
+        let mut pending = self
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = self.text_generation.load(Ordering::Relaxed);
+        if generation.wrapping_sub(previous) > u64::MAX / 2 {
+            return;
+        }
+        self.text_generation.store(generation, Ordering::Relaxed);
+        self.text_ready.store(ready, Ordering::Release);
+        if !ready || generation != previous {
+            self.text_slot.cancel();
+            pending.retain(|sample| !matches!(sample.input, CapturedInput::Text(_)));
+        }
+    }
+
+    pub(crate) fn submit_text(
+        &self,
+        bytes: &[u8],
+    ) -> Result<(), opennow_streamer_protocol::text_input::TextInputError> {
+        use opennow_streamer_protocol::text_input::TextInputError;
+        let mut pending = self
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !self.text_ready.load(Ordering::Acquire) {
+            return Err(TextInputError::Unavailable);
+        }
+        if pending.len() >= CAPTURED_INPUT_CAPACITY {
+            return Err(TextInputError::Busy);
+        }
+        let text = self.text_slot.submit(bytes)?;
+        pending.push_back(CapturedInputSample {
+            input: CapturedInput::Text(text),
+            captured_at: Instant::now(),
+        });
+        Ok(())
+    }
+
+    pub(crate) fn discard_text(&self) {
+        self.text_slot.cancel();
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .retain(|sample| !matches!(sample.input, CapturedInput::Text(_)));
+    }
+
     pub fn push(&self, input: CapturedInput) {
         self.push_sample(CapturedInputSample {
             input,

--- a/native/opennow-streamer/crates/opennow-streamer-protocol/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-protocol/src/lib.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 pub mod log;
+pub mod text_input;
 
 pub const PROTOCOL_VERSION: u64 = 6;
 

--- a/native/opennow-streamer/crates/opennow-streamer-protocol/src/text_input.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-protocol/src/text_input.rs
@@ -1,0 +1,134 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+
+pub const MAX_TEXT_BYTES: usize = 65_536;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextInputError {
+    Invalid,
+    TooLarge,
+    Busy,
+    Unavailable,
+}
+
+#[derive(Debug, Default)]
+pub struct TextInputSlot(Mutex<Weak<TextPayload>>);
+
+impl TextInputSlot {
+    pub fn submit(&self, bytes: &[u8]) -> Result<UnicodeText, TextInputError> {
+        if bytes.len() > MAX_TEXT_BYTES {
+            return Err(TextInputError::TooLarge);
+        }
+        if bytes.is_empty() || bytes.contains(&0) {
+            return Err(TextInputError::Invalid);
+        }
+        let text = std::str::from_utf8(bytes).map_err(|_| TextInputError::Invalid)?;
+        let mut slot = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if slot.upgrade().is_some() {
+            return Err(TextInputError::Busy);
+        }
+        let payload = Arc::new(TextPayload {
+            text: text.to_owned(),
+            cancelled: AtomicBool::new(false),
+        });
+        *slot = Arc::downgrade(&payload);
+        Ok(UnicodeText(payload))
+    }
+
+    pub fn cancel(&self) {
+        if let Some(payload) = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .upgrade()
+        {
+            payload.cancelled.store(true, Ordering::Release);
+        }
+    }
+}
+
+struct TextPayload {
+    text: String,
+    cancelled: AtomicBool,
+}
+
+#[derive(Clone)]
+pub struct UnicodeText(Arc<TextPayload>);
+
+impl UnicodeText {
+    pub fn as_str(&self) -> &str {
+        &self.0.text
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.cancelled.load(Ordering::Acquire)
+    }
+}
+
+impl std::fmt::Debug for UnicodeText {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnicodeText")
+            .field("bytes", &self.0.text.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for UnicodeText {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for UnicodeText {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_text_without_truncation_or_payload_diagnostics() {
+        let slot = TextInputSlot::default();
+        for invalid in [
+            &b""[..],
+            &b"a\0b"[..],
+            &[0xff],
+            &[0xc0, 0x80],
+            &[0xed, 0xa0, 0x80],
+        ] {
+            assert_eq!(slot.submit(invalid), Err(TextInputError::Invalid));
+        }
+        assert_eq!(
+            slot.submit(&vec![b'a'; MAX_TEXT_BYTES + 1]),
+            Err(TextInputError::TooLarge)
+        );
+        let text = slot.submit("secret café 世界 🦫\r\n".as_bytes()).unwrap();
+        assert_eq!(text.as_str(), "secret café 世界 🦫\r\n");
+        assert!(!format!("{text:?}").contains("secret"));
+        drop(text);
+        assert_eq!(
+            slot.submit(&vec![b'a'; MAX_TEXT_BYTES])
+                .unwrap()
+                .as_str()
+                .len(),
+            MAX_TEXT_BYTES
+        );
+    }
+
+    #[test]
+    fn one_paste_remains_reserved_through_clones_and_cancellation() {
+        let slot = TextInputSlot::default();
+        let text = slot.submit(b"first").unwrap();
+        let transport = text.clone();
+        drop(text);
+        assert_eq!(slot.submit(b"second"), Err(TextInputError::Busy));
+        slot.cancel();
+        assert!(transport.is_cancelled());
+        assert_eq!(slot.submit(b"second"), Err(TextInputError::Busy));
+        drop(transport);
+        let next = slot.submit(b"second").unwrap();
+        assert!(!next.is_cancelled());
+    }
+}

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -4024,6 +4024,10 @@ fn handle_stun_datagram(
 }
 
 enum UdpReceiverCommand {
+    SendText {
+        text: opennow_streamer_protocol::text_input::UnicodeText,
+        timestamp_us: u64,
+    },
     Pause,
     Resume,
     Recover,
@@ -4111,6 +4115,19 @@ impl NvstUdpReceiverSession {
 }
 
 impl NvstUdpReceiverControl {
+    pub fn queue_text(
+        &self,
+        text: opennow_streamer_protocol::text_input::UnicodeText,
+        timestamp_us: u64,
+    ) -> Result<(), TransportError> {
+        if !self.input_ready.load(Ordering::Acquire) {
+            return Err(TransportError::InputNotReady);
+        }
+        self.commands
+            .send(UdpReceiverCommand::SendText { text, timestamp_us })
+            .map_err(|_| TransportError::Closed)
+    }
+
     pub fn set_microphone_enabled(&self, enabled: bool) -> Result<(), NvstUdpReceiverError> {
         self.microphone
             .lock()
@@ -5210,6 +5227,15 @@ fn run_nvst_webrtc_bundle(
                 Ok(UdpReceiverCommand::Recover) => {
                     forward_optional(&event_sender, receiver.recover())
                 }
+                Ok(UdpReceiverCommand::SendText { text, timestamp_us }) => {
+                    if !text.is_cancelled()
+                        && input_state.is_ready()
+                        && let Some(channels) = input_channels
+                        && !channels.send_text(&mut rtc, &text, timestamp_us)
+                    {
+                        eprintln!("NVST text submission rejected by reliable channel");
+                    }
+                }
                 Ok(UdpReceiverCommand::SendInput { bytes, reply }) => {
                     let mut sent = true;
                     if input_state.is_ready()
@@ -6052,6 +6078,7 @@ fn run_nvst_udp_receiver(
                 Ok(UdpReceiverCommand::Recover) => {
                     forward_optional(&event_sender, receiver.recover())
                 }
+                Ok(UdpReceiverCommand::SendText { .. }) => {}
                 Ok(UdpReceiverCommand::SendInput { reply, .. }) => {
                     if let Some(reply) = reply {
                         let _ = reply.send(Err(TransportError::InputNotReady));
@@ -6295,6 +6322,56 @@ fn forward_receive_event(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn typed_text_queue_preserves_order_reservation_and_readiness() {
+        use opennow_streamer_protocol::text_input::{TextInputError, TextInputSlot};
+        let (commands, receiver) = std::sync::mpsc::channel();
+        let control = super::NvstUdpReceiverControl {
+            commands,
+            input_ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            microphone: std::sync::Arc::new(std::sync::Mutex::new(super::MicrophoneQueue::new(
+                false,
+            ))),
+        };
+        let slot = TextInputSlot::default();
+        assert!(matches!(
+            control.queue_text(slot.submit(b"paste").unwrap(), 42),
+            Err(super::TransportError::InputNotReady)
+        ));
+        assert!(receiver.try_recv().is_err());
+        control
+            .input_ready
+            .store(true, std::sync::atomic::Ordering::Release);
+        control.queue_input(vec![1, 2], false).unwrap();
+        control
+            .queue_text(slot.submit("世界".as_bytes()).unwrap(), 42)
+            .unwrap();
+        control.queue_input(vec![3, 4], false).unwrap();
+        assert_eq!(slot.submit(b"again"), Err(TextInputError::Busy));
+        assert!(
+            matches!(receiver.try_recv().unwrap(), super::UdpReceiverCommand::SendInput { bytes, .. } if bytes == [1, 2])
+        );
+        let super::UdpReceiverCommand::SendText { text, timestamp_us } =
+            receiver.try_recv().unwrap()
+        else {
+            panic!("missing text command")
+        };
+        assert_eq!(text.as_str(), "世界");
+        assert_eq!(timestamp_us, 42);
+        slot.cancel();
+        assert!(text.is_cancelled());
+        drop(text);
+        assert!(
+            matches!(receiver.try_recv().unwrap(), super::UdpReceiverCommand::SendInput { bytes, .. } if bytes == [3, 4])
+        );
+        drop(receiver);
+        assert!(matches!(
+            control.queue_text(slot.submit(b"paste").unwrap(), 42),
+            Err(super::TransportError::Closed)
+        ));
+        assert!(slot.submit(b"released").is_ok());
+    }
+
     mod audio_tests {
         include!("nvst_audio_tests.rs");
     }

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_input.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_input.rs
@@ -131,6 +131,34 @@ pub(crate) struct NvstInputChannels {
 }
 
 impl NvstInputChannels {
+    pub(crate) fn send_text(
+        self,
+        rtc: &mut Rtc,
+        text: &opennow_streamer_protocol::text_input::UnicodeText,
+        timestamp_us: u64,
+    ) -> bool {
+        let messages = unicode_text_messages(text, timestamp_us);
+        let buffered: usize = self
+            .all()
+            .into_iter()
+            .chain([self.rtcp])
+            .filter_map(|id| rtc.channel(id).map(|mut channel| channel.buffered_amount()))
+            .sum();
+        let Some(mut channel) = rtc.channel(self.control_reliable) else {
+            return false;
+        };
+        let total_bytes: usize = messages.iter().map(|message| message.bytes.len()).sum();
+        if !text_batch_fits(buffered, total_bytes) {
+            return false;
+        }
+        if text.is_cancelled() {
+            return true;
+        }
+        messages
+            .iter()
+            .all(|message| channel.write(true, &message.bytes).unwrap_or(false))
+    }
+
     pub(crate) fn create(rtc: &mut Rtc) -> Self {
         let mut ids = Vec::with_capacity(NVST_CHANNEL_PROFILE.len());
         for definition in NVST_CHANNEL_PROFILE {
@@ -223,6 +251,10 @@ impl NvstInputChannels {
             self.cursor,
         ]
     }
+}
+
+fn text_batch_fits(buffered: usize, batch_bytes: usize) -> bool {
+    buffered.saturating_add(batch_bytes) <= 128 * 1024
 }
 
 fn channel_config(definition: NvstChannelDefinition) -> ChannelConfig {
@@ -854,6 +886,32 @@ fn remote_input_packet(input_type: u32, body: &[u8]) -> Vec<u8> {
     packet
 }
 
+fn unicode_text_messages(
+    text: &opennow_streamer_protocol::text_input::UnicodeText,
+    timestamp_us: u64,
+) -> Vec<NvstEncodedInput> {
+    let mut remaining = text.as_str();
+    let mut messages = Vec::new();
+    while !remaining.is_empty() {
+        let mut end = remaining.len().min(0x3f8);
+        while !remaining.is_char_boundary(end) {
+            end -= 1;
+        }
+        let mut packet = remote_input_packet(INPUT_TEXT, &remaining.as_bytes()[..end]);
+        if packet.len() < 0x7e * 8 {
+            packet.resize(((packet.len() + 8) / 8) * 8 + 8, 0);
+            packet.extend_from_slice(&timestamp_us.to_le_bytes());
+            packet = remote_input_packet(0x0e, &packet);
+        }
+        messages.push(NvstEncodedInput {
+            route: NvstInputRoute::ControlReliable,
+            bytes: control_command(COMMAND_REMOTE_INPUT, &packet),
+        });
+        remaining = &remaining[end..];
+    }
+    messages
+}
+
 fn gamepad_command(packet: &[u8], timestamp_us: u64, sequence: u16) -> Vec<u8> {
     let mut payload = Vec::with_capacity(54);
     payload.push(0x23);
@@ -1064,6 +1122,87 @@ fn read_u64_le(bytes: &[u8], offset: usize) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unicode_text_uses_verified_type_23_bytes_and_timestamp_envelope() {
+        let text = opennow_streamer_protocol::text_input::TextInputSlot::default()
+            .submit("é世🦫".as_bytes())
+            .unwrap();
+        let messages = unicode_text_messages(&text, 0x0102030405060708);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].route, NvstInputRoute::ControlReliable);
+        assert_eq!(
+            messages[0].bytes,
+            hex(concat!(
+                "06023000",
+                "0000002c0e000000",
+                "0000000d17000000",
+                "c3a9e4b896f09fa6ab",
+                "000000000000000000000000000000",
+                "0807060504030201"
+            ))
+        );
+    }
+
+    #[test]
+    fn unicode_text_chunk_boundaries_preserve_every_utf8_byte() {
+        use opennow_streamer_protocol::text_input::{MAX_TEXT_BYTES, TextInputSlot};
+        for length in [1, 991, 992, 999, 1000, 1015, 1016, 1017, MAX_TEXT_BYTES] {
+            let source = "a".repeat(length);
+            let text = TextInputSlot::default().submit(source.as_bytes()).unwrap();
+            let messages = unicode_text_messages(&text, 7);
+            let mut reconstructed = Vec::new();
+            for message in &messages {
+                assert_eq!(message.route, NvstInputRoute::ControlReliable);
+                assert_eq!(&message.bytes[..2], &[6, 2]);
+                assert_eq!(
+                    usize::from(u16::from_le_bytes(message.bytes[2..4].try_into().unwrap())),
+                    message.bytes.len() - 4
+                );
+                let mut packet = &message.bytes[4..];
+                if read_u32_le(packet, 4) == Some(14) {
+                    assert_eq!(&packet[packet.len() - 8..], &7_u64.to_le_bytes());
+                    packet = &packet[8..];
+                }
+                assert_eq!(read_u32_le(packet, 4), Some(23));
+                let body_len = u32::from_be_bytes(packet[..4].try_into().unwrap()) as usize - 4;
+                assert!(body_len <= 1016);
+                assert_eq!(
+                    read_u32_le(&message.bytes[4..], 4) == Some(14),
+                    body_len < 1000
+                );
+                let body = &packet[8..8 + body_len];
+                assert!(std::str::from_utf8(body).is_ok());
+                reconstructed.extend_from_slice(body);
+            }
+            assert_eq!(reconstructed, source.as_bytes());
+        }
+        for prefix in 1013..=1016 {
+            for suffix in ["é", "世", "🦫"] {
+                let source = format!("{}{suffix}tail", "x".repeat(prefix));
+                let text = TextInputSlot::default().submit(source.as_bytes()).unwrap();
+                let messages = unicode_text_messages(&text, 0);
+                assert_eq!(messages.len(), 2);
+                let first = &messages[0].bytes[4..];
+                let first_len = u32::from_be_bytes(first[..4].try_into().unwrap()) as usize - 4;
+                assert!(source.is_char_boundary(first_len));
+                assert!(first_len <= 1016);
+                let mut reconstructed = first[8..8 + first_len].to_vec();
+                let tail = &messages[1].bytes[12..];
+                let tail_len = u32::from_be_bytes(tail[..4].try_into().unwrap()) as usize - 4;
+                reconstructed.extend_from_slice(&tail[8..8 + tail_len]);
+                assert_eq!(reconstructed, source.as_bytes());
+            }
+        }
+    }
+
+    #[test]
+    fn unicode_text_batch_admission_rejects_whole_batch_before_capacity_overflow() {
+        assert!(text_batch_fits(0, 70_000));
+        assert!(text_batch_fits(128 * 1024 - 70_000, 70_000));
+        assert!(!text_batch_fits(128 * 1024 - 70_000 + 1, 70_000));
+        assert!(!text_batch_fits(usize::MAX, 70_000));
+    }
 
     fn hex(value: &str) -> Vec<u8> {
         assert_eq!(value.len() % 2, 0, "hex input must contain whole bytes");

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -443,6 +443,22 @@ and `--smoke-test --desktop --route stream --overlay desktop-stream-menu
 `--smoke-microphone` acceptance workload checks state, commands and reconnect mute
 preservation against a mock runtime.
 
+Settings → Controls → **Clipboard paste** enables local-to-stream plain-text paste
+with Ctrl+V (Command+V on macOS). The console Controls page exposes the same persisted
+`clipboardPaste` preference. It is disabled by default and only reads the clipboard
+on an explicit paste shortcut while the stream has input capture. Blocking overlays
+and focus loss prevent paste; custom stream shortcuts take priority.
+
+Paste uses native NVST Unicode text packets, preserving UTF-8 characters and line
+breaks without depending on the remote keyboard layout. Each paste is limited to
+64 KiB of UTF-8; empty, invalid, NUL-containing, oversized, or locally rejected input
+shows a brief nonblocking notice instead of forwarding the paste shortcut or silently
+truncating text. There is no automatic synchronization, image/file transfer, or
+remote-to-local clipboard copying. Network acceptance is not a remote application
+delivery acknowledgement; live GFN paste still needs account-backed validation.
+Run `opennow-streamvideo-tests clipboardPasteRouting` for windowed/fullscreen
+shortcut, Unicode, size-limit, overlay, and focus regression coverage.
+
 If one controller appears as both a physical device and a remapper's virtual device,
 open Settings → Controls → Controller input source (Controllers in the console
 settings) and select one device before starting the stream. The selected device is

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsControlsPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsControlsPage.qml
@@ -103,6 +103,15 @@ Column {
     DesktopSettingsPanel {
         width: parent.width; paperStyle: true
         DesktopSettingsSection { text: qsTr("MOUSE & KEYBOARD") }
+        DesktopSettingsRow {
+            width: parent.width; paperStyle: true; glyph: "keyboard"; title: qsTr("Clipboard paste")
+            description: qsTr("Paste local text into the stream with Ctrl+V (Command+V on macOS). Up to 64 KiB per paste. No automatic clipboard sync.")
+            DesktopSettingsToggle {
+                objectName: "clipboardPasteToggle"
+                checked: controlsRoot.settingsScreen.boolSetting("clipboardPaste", false)
+                onValueChangedByUser: value => controlsRoot.settingsScreen.setSetting("clipboardPaste", value)
+            }
+        }
         DesktopSettingsRow { width: parent.width; paperStyle: true; glyph: "mouse"; title: qsTr("Mouse capture"); description: qsTr("Follows the remote cursor · F8 toggles capture")
             DesktopSettingsSegmented { options: [qsTr("Automatic")]; optionWidth: 112; selectedIndex: 0 }
         }

--- a/opennow-qt/qml/desktop/stream/DesktopStreamScreen.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopStreamScreen.qml
@@ -95,6 +95,7 @@ FocusScope {
         inputEnabled: visible
             && !ShellStore.streamOverlayBlocksGameplayInput(AppController.overlay)
         shortcutBindings: ShellStore.streamShortcutBindings()
+        clipboardPaste: ShellStore.settings.clipboardPaste === true
         videoSize: Qt.size(Number(root.profile.width || 0), Number(root.profile.height || 0))
         frameGeneration: String(ShellStore.settings.frameGeneration || 'off') === '2x'
         metalFxUpscaling: Qt.platform.os === "osx" && ShellStore.settings.upscaling === "metalfx"
@@ -102,12 +103,17 @@ FocusScope {
         upscalingDenoise: Number(ShellStore.settings.upscalingDenoise ?? 0)
         z: 0
         onLocalShortcutRequested: action => ShellStore.applyStreamShortcutAction(action)
+        onClipboardPasteFailed: clipboardPasteNotice.restart()
     }
+
+    Timer { id: clipboardPasteNotice; interval: 5000 }
 
     StreamInputNotice {
         layer.enabled: HdrOutput.chromeRequired
         layer.effect: HdrChromeEffect {}
-        message: root.streaming && streamVideo.relativeMouse ? streamVideo.inputCaptureError : ""
+        message: !root.streaming ? "" : clipboardPasteNotice.running
+            ? qsTr("Clipboard paste failed. Use plain text up to 64 KiB and try again.")
+            : streamVideo.relativeMouse ? streamVideo.inputCaptureError : ""
         z: 3
     }
 

--- a/opennow-qt/qml/screens/SettingsScreen.qml
+++ b/opennow-qt/qml/screens/SettingsScreen.qml
@@ -344,6 +344,7 @@ FocusScope {
                 "controllerInputSource", [0].concat(ControllerInput.availableControllers.map(controller => Number(controller.instanceId))),
                 [qsTr("All controllers (multiplayer)")].concat(ControllerInput.availableControllers.map(controller => qsTr("Device %1 · %2").arg(controller.slot).arg(controller.name)))))
             rows.push(toggle("Gyroscope", "Forward motion data to the rig", "enableGyroscopeControls"))
+            rows.push(toggle(qsTr("Clipboard paste"), qsTr("Paste local text into the stream with Ctrl+V (Command+V on macOS). Up to 64 KiB per paste. No automatic clipboard sync."), "clipboardPaste"))
             for (const setting of [
                 {key:"controllerLeftStickDeadzone", title:qsTr("Left stick dead zone"), description:qsTr("Ignore stick drift during gameplay. Default: 24%. The remaining travel is rescaled to full range."), maximum:50, fallback:24},
                 {key:"controllerRightStickDeadzone", title:qsTr("Right stick dead zone"), description:qsTr("Ignore stick drift during gameplay. Default: 27%. Set to 0% to leave dead zones to the game."), maximum:50, fallback:27},

--- a/opennow-qt/qml/screens/StreamScreen.qml
+++ b/opennow-qt/qml/screens/StreamScreen.qml
@@ -90,6 +90,7 @@ FocusScope {
         inputEnabled: visible
             && !ShellStore.streamOverlayBlocksGameplayInput(AppController.overlay)
         shortcutBindings: ShellStore.streamShortcutBindings()
+        clipboardPaste: ShellStore.settings.clipboardPaste === true
         videoSize: Qt.size(Number(root.profile.width || 0), Number(root.profile.height || 0))
         frameGeneration: String(ShellStore.settings.frameGeneration || 'off') === '2x'
         metalFxUpscaling: Qt.platform.os === "osx" && ShellStore.settings.upscaling === "metalfx"
@@ -97,12 +98,17 @@ FocusScope {
         upscalingDenoise: Number(ShellStore.settings.upscalingDenoise ?? 0)
         z: 0
         onLocalShortcutRequested: action => ShellStore.applyStreamShortcutAction(action)
+        onClipboardPasteFailed: clipboardPasteNotice.restart()
     }
+
+    Timer { id: clipboardPasteNotice; interval: 5000 }
 
     StreamInputNotice {
         layer.enabled: HdrOutput.chromeRequired
         layer.effect: HdrChromeEffect {}
-        message: root.streaming && streamVideo.relativeMouse ? streamVideo.inputCaptureError : ""
+        message: !root.streaming ? "" : clipboardPasteNotice.running
+            ? qsTr("Clipboard paste failed. Use plain text up to 64 KiB and try again.")
+            : streamVideo.relativeMouse ? streamVideo.inputCaptureError : ""
         z: 3
     }
 

--- a/opennow-qt/src/streaming/NativeStreamRuntime.cpp
+++ b/opennow-qt/src/streaming/NativeStreamRuntime.cpp
@@ -169,7 +169,8 @@ NativeStreamRuntime::NativeStreamRuntime(QObject *parent,
                               &opennow_streamer_submit_gamepad,
                               &opennow_streamer_submit_local_action,
                               &opennow_streamer_set_capture_active,
-                              &opennow_streamer_set_log_file}, parent, vulkanDevice)
+                              &opennow_streamer_set_log_file,
+                              &opennow_streamer_submit_text}, parent, vulkanDevice)
 {
 }
 
@@ -536,6 +537,19 @@ OpenNowStreamerStatus NativeStreamRuntime::submitMouseRelative(std::int16_t delt
     const std::shared_lock lock(d->handleMutex);
     return d->handle && d->api.submitMouseRelative
         ? d->api.submitMouseRelative(d->handle, deltaX, deltaY)
+        : OPENNOW_STREAMER_CLOSED;
+}
+
+OpenNowStreamerStatus NativeStreamRuntime::submitText(const QByteArray &text)
+{
+    if (text.size() > OPENNOW_STREAMER_MAX_TEXT_BYTES) return OPENNOW_STREAMER_MESSAGE_TOO_LARGE;
+    if (text.isEmpty() || text.contains('\0') || !text.isValidUtf8())
+        return OPENNOW_STREAMER_INVALID_CONFIG;
+    const std::shared_lock lock(d->handleMutex);
+    return inputAllowed() && d->handle && d->api.submitText
+        ? d->api.submitText(d->handle,
+                           reinterpret_cast<const std::uint8_t *>(text.constData()),
+                           static_cast<std::size_t>(text.size()))
         : OPENNOW_STREAMER_CLOSED;
 }
 

--- a/opennow-qt/src/streaming/NativeStreamRuntime.h
+++ b/opennow-qt/src/streaming/NativeStreamRuntime.h
@@ -71,6 +71,7 @@ public:
         SubmitLocalAction submitLocalAction = nullptr;
         SetCaptureActive setCaptureActive = nullptr;
         SetLogFile setLogFile = nullptr;
+        Send submitText = nullptr;
     };
 
     static constexpr int DefaultShutdownTimeoutMs = 1'500;
@@ -112,6 +113,7 @@ public:
     OpenNowStreamerStatus sceneGraphShutdown();
     OpenNowStreamerStatus submitKey(std::uint16_t virtualKey, std::uint16_t modifiers,
                                     bool pressed);
+    OpenNowStreamerStatus submitText(const QByteArray &text);
     OpenNowStreamerStatus submitMouseRelative(std::int16_t deltaX, std::int16_t deltaY);
     OpenNowStreamerStatus submitMouseAbsolute(std::uint16_t x, std::uint16_t y,
                                               std::uint16_t width, std::uint16_t height);

--- a/opennow-qt/src/streaming/StreamVideoItem.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItem.cpp
@@ -159,6 +159,18 @@ bool StreamVideoItem::captureActive() const
     return m_captureActive;
 }
 
+bool StreamVideoItem::clipboardPaste() const
+{
+    return m_clipboardPaste;
+}
+
+void StreamVideoItem::setClipboardPaste(bool enabled)
+{
+    if (m_clipboardPaste == enabled) return;
+    m_clipboardPaste = enabled;
+    emit clipboardPasteChanged();
+}
+
 QString StreamVideoItem::inputCaptureError() const
 {
     return m_usesMacPointerCapture ? m_macPointer->error() : m_waylandPointer->error();

--- a/opennow-qt/src/streaming/StreamVideoItem.h
+++ b/opennow-qt/src/streaming/StreamVideoItem.h
@@ -29,6 +29,8 @@ class StreamVideoItem : public QQuickItem
     Q_PROPERTY(bool inputEnabled READ inputEnabled WRITE setInputEnabled
                    NOTIFY inputEnabledChanged)
     Q_PROPERTY(bool captureActive READ captureActive NOTIFY captureActiveChanged)
+    Q_PROPERTY(bool clipboardPaste READ clipboardPaste WRITE setClipboardPaste
+                   NOTIFY clipboardPasteChanged)
     Q_PROPERTY(QString inputCaptureError READ inputCaptureError NOTIFY inputCaptureErrorChanged)
     Q_PROPERTY(bool relativeMouse READ relativeMouse WRITE setRelativeMouse
                    NOTIFY relativeMouseChanged)
@@ -64,6 +66,8 @@ public:
     [[nodiscard]] bool inputEnabled() const;
     void setInputEnabled(bool enabled);
     [[nodiscard]] bool captureActive() const;
+    [[nodiscard]] bool clipboardPaste() const;
+    void setClipboardPaste(bool enabled);
     [[nodiscard]] QString inputCaptureError() const;
     [[nodiscard]] bool relativeMouse() const;
     void setRelativeMouse(bool relative);
@@ -111,6 +115,8 @@ signals:
     void renderCallbackAvailableChanged();
     void inputEnabledChanged();
     void captureActiveChanged();
+    void clipboardPasteChanged();
+    void clipboardPasteFailed();
     void inputCaptureErrorChanged();
     void relativeMouseChanged();
     void shortcutBindingsChanged();
@@ -173,6 +179,7 @@ private:
     std::unique_ptr<class MacPointerCapture> m_macPointer;
     bool m_usesMacPointerCapture = false;
     bool m_inputEnabled = true;
+    bool m_clipboardPaste = false;
     bool m_frameGeneration = false;
     bool m_metalFxUpscaling = false;
     int m_upscalingSharpness = 10;

--- a/opennow-qt/src/streaming/StreamVideoItemInput.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItemInput.cpp
@@ -5,6 +5,7 @@
 #include "streaming/NativeStreamRuntime.h"
 
 #include <QCursor>
+#include <QClipboard>
 #include <QFocusEvent>
 #include <QGuiApplication>
 #include <QHoverEvent>
@@ -187,6 +188,34 @@ void StreamVideoItem::keyPressEvent(QKeyEvent *event)
     }
     if (!m_captureActive) {
         event->ignore();
+        return;
+    }
+    if (m_clipboardPaste && event->matches(QKeySequence::Paste)) {
+        m_pressedShortcuts.insert(identity);
+        event->accept();
+        const auto *clipboard = QGuiApplication::clipboard();
+        const auto text = clipboard ? clipboard->text(QClipboard::Clipboard) : QString{};
+        if (text.isEmpty() || text.size() > OPENNOW_STREAMER_MAX_TEXT_BYTES || !text.isValidUtf16()
+            || text.contains(QChar::Null)) {
+            emit clipboardPasteFailed();
+            return;
+        }
+        const auto utf8 = text.toUtf8();
+        if (utf8.size() > OPENNOW_STREAMER_MAX_TEXT_BYTES) {
+            emit clipboardPasteFailed();
+            return;
+        }
+        for (auto key = m_pressedKeys.begin(); key != m_pressedKeys.end();) {
+            const auto vk = key->virtualKey;
+            if (vk == 0xa0 || vk == 0xa2 || vk == 0xa4 || vk == 0x5b) {
+                s_nativeRuntime->submitKey(vk, 0, false);
+                key = m_pressedKeys.erase(key);
+            } else {
+                ++key;
+            }
+        }
+        if (s_nativeRuntime->submitText(utf8) != OPENNOW_STREAMER_OK)
+            emit clipboardPasteFailed();
         return;
     }
     const auto virtualKey = windowsVirtualKey(event->key(), event->modifiers());

--- a/opennow-qt/tests/tst_embeddedorchestration.cpp
+++ b/opennow-qt/tests/tst_embeddedorchestration.cpp
@@ -17,6 +17,25 @@ class EmbeddedOrchestrationTest final : public QObject
     Q_OBJECT
 
 private slots:
+    void clipboardPasteUsesTheSharedOptInOnBothSurfaces()
+    {
+        const auto controls = source(QStringLiteral(
+            "qml/desktop/settings/pages/DesktopSettingsControlsPage.qml"));
+        QVERIFY(controls.contains(QStringLiteral("boolSetting(\"clipboardPaste\", false)")));
+        QVERIFY(controls.contains(QStringLiteral("setSetting(\"clipboardPaste\", value)")));
+        const auto console = source(QStringLiteral("qml/screens/SettingsScreen.qml"));
+        QVERIFY(console.contains(QStringLiteral("qsTr(\"Clipboard paste\")")));
+        QVERIFY(console.contains(QStringLiteral("\"clipboardPaste\"")));
+        for (const auto &path : {QStringLiteral("qml/screens/StreamScreen.qml"),
+                                QStringLiteral("qml/desktop/stream/DesktopStreamScreen.qml")}) {
+            const auto stream = source(path);
+            QVERIFY(stream.contains(QStringLiteral(
+                "clipboardPaste: ShellStore.settings.clipboardPaste === true")));
+            QVERIFY(stream.contains(QStringLiteral(
+                "onClipboardPasteFailed: clipboardPasteNotice.restart()")));
+        }
+    }
+
     void replayClippingRequiresAnEnabledSessionAndResetsPendingWork()
     {
         const auto shell = source(QStringLiteral("qml/state/ShellStore.qml"));

--- a/opennow-qt/tests/tst_streamvideoitem.cpp
+++ b/opennow-qt/tests/tst_streamvideoitem.cpp
@@ -6,6 +6,8 @@
 #include "input/platform/MacPointerCapture.h"
 
 #include <QGuiApplication>
+#include <QClipboard>
+#include <QKeySequence>
 #include <QBuffer>
 #include <QJsonDocument>
 #include <QKeyEvent>
@@ -19,6 +21,7 @@
 #include <QTest>
 
 #include <atomic>
+#include <algorithm>
 #include <memory>
 
 #if QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
@@ -249,6 +252,129 @@ class StreamVideoItemTest final : public QObject
     };
 
 private slots:
+    void clipboardPasteRouting_data()
+    {
+        QTest::addColumn<bool>("fullscreen");
+        QTest::newRow("windowed") << false;
+        QTest::newRow("fullscreen") << true;
+    }
+
+    void clipboardPasteRouting()
+    {
+        QFETCH(bool, fullscreen);
+        static QList<QList<quint16>> keys;
+        static QList<QByteArray> texts;
+        static OpenNowStreamerStatus textStatus;
+        keys.clear();
+        texts.clear();
+        textStatus = OPENNOW_STREAMER_OK;
+        auto api = CursorSession::api();
+        api.submitKey = [](const OpenNowStreamer *, std::uint16_t vk,
+                           std::uint16_t modifiers, bool pressed) {
+            keys.append({vk, modifiers, quint16(pressed)});
+            return OPENNOW_STREAMER_OK;
+        };
+        api.submitText = [](const OpenNowStreamer *, const std::uint8_t *text, std::size_t size) {
+            if (textStatus == OPENNOW_STREAMER_OK)
+                texts.append(QByteArray(reinterpret_cast<const char *>(text), qsizetype(size)));
+            return textStatus;
+        };
+        NativeStreamRuntime runtime(api);
+        QVERIFY(runtime.start());
+        StreamVideoItem::setNativeStreamRuntime(&runtime);
+        const auto reset = qScopeGuard([] { StreamVideoItem::setNativeStreamRuntime(nullptr); });
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("paste-test")}}));
+        const QByteArray ready = R"({"id":"paste-test","type":"ok"})";
+        CursorSession::callbacks.response_callback(
+            reinterpret_cast<const std::uint8_t *>(ready.constData()), ready.size(),
+            CursorSession::callbacks.user_data);
+        QTRY_VERIFY(runtime.inputAllowed());
+        QQuickWindow window;
+        window.resize(640, 480);
+        auto *item = new StreamVideoItem(window.contentItem());
+        item->setRenderCallback({});
+        item->setSize(window.size());
+        if (fullscreen) window.showFullScreen();
+        else window.showNormal();
+        window.requestActivate();
+        QTRY_VERIFY(window.isActive());
+        item->forceActiveFocus();
+        QTRY_VERIFY(item->captureActive());
+        const auto paste = QKeySequence::keyBindings(QKeySequence::Paste).first()[0];
+        const auto sendPaste = [&] {
+            QTest::keyClick(&window, paste.key(), paste.keyboardModifiers());
+        };
+        auto *clipboard = QGuiApplication::clipboard();
+        const auto previousText = clipboard->text();
+        const auto restoreClipboard = qScopeGuard([&] { clipboard->setText(previousText); });
+        const auto text = QString::fromUtf8("Hello café 世界 🎮\nsecond\tline");
+        clipboard->setText(text);
+        QVERIFY(!item->clipboardPaste());
+        sendPaste();
+        QVERIFY(texts.isEmpty());
+        QVERIFY(std::any_of(keys.cbegin(), keys.cend(), [](const auto &key) {
+            return key[0] == 0x56 && key[2] == 1;
+        }));
+        keys.clear();
+        QSignalSpy changes(item, &StreamVideoItem::clipboardPasteChanged);
+        QSignalSpy failures(item, &StreamVideoItem::clipboardPasteFailed);
+        item->setClipboardPaste(true);
+        item->setClipboardPaste(true);
+        QCOMPARE(changes.size(), 1);
+        sendPaste();
+        QCOMPARE(texts, QList<QByteArray>{text.toUtf8()});
+        QVERIFY(std::none_of(keys.cbegin(), keys.cend(), [](const auto &key) {
+            return key[0] == 0x56;
+        }));
+        QVERIFY(item->m_pressedKeys.isEmpty());
+        QVERIFY(item->m_pressedShortcuts.isEmpty());
+        QKeyEvent repeat(QEvent::KeyPress, paste.key(), paste.keyboardModifiers(), {}, true);
+        item->keyPressEvent(&repeat);
+        QCOMPARE(texts.size(), 1);
+        QCOMPARE(failures.size(), 0);
+        for (const auto &invalid : {QString{}, QString(65'537, u'x'),
+                                   QString(32'769, QChar(0x00e9)),
+                                   QString(QChar::Null)}) {
+            clipboard->setText(invalid);
+            sendPaste();
+        }
+        QCOMPARE(failures.size(), 4);
+        QCOMPARE(texts.size(), 1);
+        clipboard->setText(QString(65'536, u'x'));
+        sendPaste();
+        QCOMPARE(texts.last().size(), 65'536);
+        textStatus = OPENNOW_STREAMER_QUEUE_FULL;
+        sendPaste();
+        QCOMPARE(failures.size(), 5);
+        QCOMPARE(texts.size(), 2);
+        textStatus = OPENNOW_STREAMER_OK;
+        QSignalSpy shortcuts(item, &StreamVideoItem::localShortcutRequested);
+        item->setShortcutBindings({{QStringLiteral("test"),
+            QKeySequence(paste).toString(QKeySequence::PortableText)}});
+        sendPaste();
+        QCOMPARE(shortcuts.size(), 1);
+        QCOMPARE(texts.size(), 2);
+        item->setShortcutBindings({});
+        item->setInputEnabled(false);
+        auto *overlay = new QQuickItem(window.contentItem());
+        overlay->forceActiveFocus();
+        sendPaste();
+        QCOMPARE(texts.size(), 2);
+        item->setInputEnabled(true);
+        item->forceActiveFocus();
+        QTRY_VERIFY(item->captureActive());
+        sendPaste();
+        QCOMPARE(texts.size(), 3);
+        item->setFocus(false);
+        sendPaste();
+        QCOMPARE(texts.size(), 3);
+        QCOMPARE(runtime.submitText(QByteArray(65'537, 'x')), OPENNOW_STREAMER_MESSAGE_TOO_LARGE);
+        QCOMPARE(runtime.submitText(QByteArray(1, char(0xff))), OPENNOW_STREAMER_INVALID_CONFIG);
+        QCOMPARE(runtime.submitText(QByteArray(1, '\0')), OPENNOW_STREAMER_INVALID_CONFIG);
+        QCOMPARE(runtime.submitText({}), OPENNOW_STREAMER_INVALID_CONFIG);
+    }
+
     void macPointerCaptureOwnsMotionAndReleasesAcrossTransitions()
     {
         struct PointerState {


### PR DESCRIPTION
Adds **Clipboard paste** under Controls → Mouse & Keyboard, disabled by default and persisted through the existing `clipboardPaste` preference. Desktop and console streams use Ctrl+V (Command+V on macOS) to paste local plain text only while gameplay input is captured. Custom local shortcuts take priority; paste presses/releases/repeats don't leak to gameplay. Blocking overlays and focus loss prevent paste. Local validation/admission failures show a nonblocking notice.

The Qt wrapper and ABI 9 add bounded UTF-8 text submission using the OpenNOW-Mac RI type-23 reference encoding, including Unicode-safe chunk boundaries and the timestamp-envelope cutoff. Pastes are limited to 64 KiB, never truncated or logged, and occupy a single-flight reservation through the native capture and transport queues. Capture loss, input unavailability, and generation-scoped teardown cancel pending text. SCTP capacity is checked for the complete batch before writing. Existing ASCII command behavior remains unchanged.

This is local-to-stream text paste, not automatic synchronization or remote-to-local clipboard copying. Local admission is not a remote insertion acknowledgement; connection failures cannot roll back already delivered text.

### Verification
- Built the Qt application and affected native Qt test targets with Qt 6.8.3.
- All 12 selected Qt/QML checks passed: complete StreamVideoItem, NativeStreamRuntime, orchestration, Controls desktop/compact/console, stream routes, and notice smoke tests.
- Clipboard routing passed in windowed and fullscreen modes on both offscreen and X11/Xvfb, covering Unicode, limits, disabled mode, local shortcut priority, repeats, queue rejection, overlays, and focus loss.
- Native workspace: 541 tests passed, 9 existing ignores; final transport rerun: 155 passed.
- Scoped Rust Clippy with `-D warnings`, formatting, C11 ABI header checks, localization validation, and diff whitespace checks passed.
- Rendered and inspected the Controls settings screenshot below. Live GFN insertion and Windows/macOS/Wayland runtime validation still require account/platform-backed testing.

![Clipboard paste under Controls](https://api-nightly.capy.ai/pr-assets/FORju5vGTlfACCG0mp6Gj9_57b4NKXVAfpZOr3ljcZk)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23P1F7F7X286525MR5XW477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->