### PR TITLE
fix(packaging): require Qt SVG plugins for Debian icons

### DIFF
--- a/opennow-qt/cmake/Packaging.cmake
+++ b/opennow-qt/cmake/Packaging.cmake
@@ -121,7 +121,7 @@ else()
             "${OPENNOW_SDL3_RUNTIME_DIRECTORY}")
     endif()
     set(CPACK_DEBIAN_PACKAGE_DEPENDS
-        "libqt6core6 (>= 6.8) | libqt6core6t64 (>= 6.8), libqt6gui6 (>= 6.8), libqt6network6 (>= 6.8), libqt6qml6 (>= 6.8), libqt6quick6 (>= 6.8), libqt6quickcontrols2-6 (>= 6.8), libqt6multimedia6 (>= 6.8), qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-effects, qml6-module-qtmultimedia, libsdl3-0 | libsdl3-0.0, libva2, libva-drm2")
+        "libqt6core6 (>= 6.8) | libqt6core6t64 (>= 6.8), libqt6gui6 (>= 6.8), libqt6network6 (>= 6.8), libqt6qml6 (>= 6.8), libqt6quick6 (>= 6.8), libqt6quickcontrols2-6 (>= 6.8), libqt6multimedia6 (>= 6.8), qt6-svg-plugins (>= 6.8), qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-effects, qml6-module-qtmultimedia, libsdl3-0 | libsdl3-0.0, libva2, libva-drm2")
     set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${OPENNOW_DEBIAN_ARCH}")
 endif()
 include(CPack)

--- a/opennow-qt/packaging/verify_linux_package.py
+++ b/opennow-qt/packaging/verify_linux_package.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     verify_package(args.bin_dir.resolve())
     if args.deb:
         dependencies = subprocess.check_output(["dpkg-deb", "-f", args.deb, "Depends"], text=True)
-        for dependency in ("libva2", "libva-drm2"):
+        for dependency in ("libva2", "libva-drm2", "qt6-svg-plugins"):
             if not any(item.strip().split()[0] == dependency for item in dependencies.split(",")):
                 raise ValueError(f"The DEB does not require {dependency}")
         with tempfile.TemporaryDirectory(prefix="opennow-deb-check-") as directory:

--- a/opennow-qt/tests/test_linux_package.py
+++ b/opennow-qt/tests/test_linux_package.py
@@ -1,10 +1,59 @@
 import copy
 from pathlib import Path
+import subprocess
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packaging"))
 from verify_linux_package import verify_capabilities
+
+
+class LinuxPackageDependenciesTest(unittest.TestCase):
+    def test_debian_packages_require_svg_image_plugin(self):
+        qt_source = Path(__file__).resolve().parents[1]
+        for processor, architecture in (("x86_64", "amd64"), ("aarch64", "arm64")):
+            with self.subTest(architecture=architecture), tempfile.TemporaryDirectory() as directory:
+                source = Path(directory)
+                build = source / "build"
+                (source / "main.cpp").write_text("int main() { return 0; }\n")
+                (source / "CMakeLists.txt").write_text(
+                    f'''cmake_minimum_required(VERSION 3.24)
+project(LinuxPackageContract VERSION 1.0.0 LANGUAGES CXX)
+include(GNUInstallDirs)
+add_executable(opennow-qt main.cpp)
+set(APPLE FALSE)
+set(WIN32 FALSE)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR "{processor}")
+set(CMAKE_CURRENT_SOURCE_DIR "{qt_source.as_posix()}")
+include("{qt_source.as_posix()}/cmake/BuildMetadata.cmake")
+set(OPENNOW_SDL3_RUNTIME_TARGET SDL3-runtime)
+add_library(SDL3-runtime SHARED IMPORTED)
+set_target_properties(SDL3-runtime PROPERTIES
+    IMPORTED_LOCATION "${{CMAKE_BINARY_DIR}}/libSDL3.so")
+set(OPENNOW_STREAMER_FFI_RUNTIME "${{CMAKE_BINARY_DIR}}/libopennow_streamer_ffi.so")
+set(OPENNOW_STREAMER_BIN_ARTIFACT "${{CMAKE_BINARY_DIR}}/opennow-streamer")
+set(OPENNOW_GENERATED_NOTICES "${{CMAKE_BINARY_DIR}}/THIRD_PARTY_NOTICES")
+include("{qt_source.as_posix()}/cmake/Packaging.cmake")
+'''
+                )
+                result = subprocess.run(
+                    ["cmake", "-S", str(source), "-B", str(build), "-G", "Unix Makefiles"],
+                    capture_output=True, text=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                contract = source / "check.cmake"
+                contract.write_text(
+                    f'''include("{build.as_posix()}/CPackConfig.cmake")
+file(WRITE "{source.as_posix()}/dependencies.txt" "${{CPACK_DEBIAN_PACKAGE_DEPENDS}}")
+file(WRITE "{source.as_posix()}/architecture.txt" "${{CPACK_DEBIAN_PACKAGE_ARCHITECTURE}}")
+'''
+                )
+                subprocess.run(["cmake", "-P", str(contract)], check=True, capture_output=True)
+                dependencies = (source / "dependencies.txt").read_text().split(",")
+                self.assertIn("qt6-svg-plugins (>= 6.8)", [item.strip() for item in dependencies])
+                self.assertEqual((source / "architecture.txt").read_text(), architecture)
 
 
 class LinuxPackageCapabilitiesTest(unittest.TestCase):


### PR DESCRIPTION
Require `qt6-svg-plugins (>= 6.8)` in Debian packages so QML can load the SVG navigation and settings icons on clean installations, including Raspberry Pi ARM64. Debian 13 ships `imageformats/libqsvg.so` in this separate package; the SVG library alone does not supply it, and shared-library dependency scanning cannot discover this dynamically loaded plugin.

Extend the existing release-package verifier to reject `.deb` artifacts without the SVG plugin dependency. Add a CMake packaging contract test that evaluates the generated CPack dependencies for both ARM64 and amd64.

### Verification
- Confirmed Debian's ARM64 `qt6-svg-plugins_6.8.2-3` contains `imageformats/libqsvg.so` and depends on the matching Qt/SVG runtime.
- New regression failed on the missing dependency for both architectures before the fix, then passed afterward.
- All 61 Python build/packaging contract tests passed; `git diff --check` passed.
- Full Qt configure could not proceed because this workspace has no Qt 6.8 SDK. Raspberry Pi rendering and a full application package build have not been validated here.

Existing affected Debian installations can install `qt6-svg-plugins` and restart OpenNOW.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23SAJY05VNDJSNA0ANFKZAG"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->