### PR TITLE
fix(linux): repair Pi HEVC discovery and decoder diagnostics

### DIFF
--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -224,7 +224,7 @@ jobs:
           host: ${{ matrix.qt-host }}
           target: desktop
           arch: ${{ matrix.qt-arch }}
-          modules: qtmultimedia qtshadertools
+          modules: qtmultimedia qtshadertools ${{ runner.os == 'Linux' && 'qtwaylandcompositor' || '' }}
           cache: true
           cache-key-prefix: qt-target-${{ matrix.label }}
 
@@ -351,7 +351,8 @@ jobs:
         shell: bash
         env:
           APPIMAGE_EXTRACT_AND_RUN: "1"
-          EXTRA_PLATFORM_PLUGINS: libqoffscreen.so
+          EXTRA_PLATFORM_PLUGINS: libqoffscreen.so;libqwayland-egl.so;libqwayland-generic.so
+          EXTRA_QT_MODULES: waylandcompositor
           LINUXDEPLOY_ARCH: ${{ matrix.linuxdeploy-arch }}
           LINUXDEPLOY_SHA256: ${{ matrix.linuxdeploy-sha256 }}
           QT_PLUGIN_SHA256: ${{ matrix.qt-plugin-sha256 }}
@@ -391,6 +392,9 @@ jobs:
           test -f build/AppDir/usr/lib/libva.so.2
           test -f build/AppDir/usr/lib/libva-drm.so.2
           test -f build/AppDir/usr/plugins/platforms/libqoffscreen.so
+          test -f build/AppDir/usr/plugins/platforms/libqwayland-egl.so
+          test -f build/AppDir/usr/plugins/platforms/libqwayland-generic.so
+          test -f build/AppDir/usr/plugins/wayland-shell-integration/libxdg-shell.so
           LD_LIBRARY_PATH="$PWD/build/AppDir/usr/lib:$LD_LIBRARY_PATH" \
             python3 opennow-qt/packaging/verify_linux_package.py build/AppDir/usr/bin
           mv OpenNOW-Qt-*.AppImage build/qt-packages/

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -105,7 +105,7 @@ jobs:
           host: ${{ matrix.qt_host }}
           target: desktop
           arch: ${{ matrix.qt_arch }}
-          modules: qtmultimedia qtshadertools
+          modules: qtmultimedia qtshadertools qtwaylandcompositor
           cache: true
           cache-key-prefix: qt-release-linux-${{ matrix.arch }}
 
@@ -162,7 +162,8 @@ jobs:
         shell: bash
         env:
           APPIMAGE_EXTRACT_AND_RUN: "1"
-          EXTRA_PLATFORM_PLUGINS: libqoffscreen.so
+          EXTRA_PLATFORM_PLUGINS: libqoffscreen.so;libqwayland-egl.so;libqwayland-generic.so
+          EXTRA_QT_MODULES: waylandcompositor
           LINUXDEPLOY_ARCH: ${{ matrix.linuxdeploy_arch }}
           LINUXDEPLOY_SHA256: ${{ matrix.linuxdeploy_sha256 }}
           QT_PLUGIN_SHA256: ${{ matrix.qt_plugin_sha256 }}
@@ -198,6 +199,9 @@ jobs:
           test -f build/AppDir/usr/lib/libva.so.2
           test -f build/AppDir/usr/lib/libva-drm.so.2
           test -f build/AppDir/usr/plugins/platforms/libqoffscreen.so
+          test -f build/AppDir/usr/plugins/platforms/libqwayland-egl.so
+          test -f build/AppDir/usr/plugins/platforms/libqwayland-generic.so
+          test -f build/AppDir/usr/plugins/wayland-shell-integration/libxdg-shell.so
           LD_LIBRARY_PATH="$PWD/build/AppDir/usr/lib:$LD_LIBRARY_PATH" \
             python3 opennow-qt/packaging/verify_linux_package.py build/AppDir/usr/bin
           mv OpenNOW-Qt-*.AppImage build/release-artifacts/

--- a/docs/core-protocol.md
+++ b/docs/core-protocol.md
@@ -208,6 +208,12 @@ The core copies only bounded, non-negative numeric counters into the export's
 counters survive embedded-runtime stop and remain separate from the core's
 process-streamer snapshot and its legacy mixed-unit `queueDropCount`.
 
+`diagnostics.export` also optionally accepts `runtimeCapabilities` from the
+in-process Qt streamer. The export's separate `nativeRuntime` section preserves
+allowlisted backend and codec availability, HDR support, and bounded, redacted
+failure reasons, even before a stream starts. It does not copy arbitrary runtime
+fields or treat an empty process-streamer snapshot as the embedded capabilities.
+
 ### Session resume and reconnect
 
 `session.claim` discovers the session's actual control server, sends the minimal

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -110,6 +110,48 @@ before sharing; never publish account credentials or session authentication
 material. Include the operating-system and device checks above when reporting a
 missing decoder or failed DMA-BUF import.
 
+### Interpreting failed discovery
+
+The export's `nativeRuntime.videoBackends` contains the embedded decoder results,
+including each codec's failure reason before a session starts. On Pi 5, inspect
+the `v4l2` backend's `h265` entry; an unavailable stateful H.264 decoder is expected
+and is not the HEVC failure reason. The standalone probe's Vulkan or software
+availability does not establish embedded hardware decoding or successful playback.
+
+HEVC discovery enumerates numeric `/dev/video*` and `/dev/media*` nodes and uses
+`MEDIA_IOC_G_TOPOLOGY` to match the video device's major/minor number to a media
+interface. It does not assume that `/dev/video19` has minor number 19, that the
+media node has a fixed number, or that a `/sys/class/media` directory exists.
+Linux registers media devices on the media bus, not that sysfs class. Discovery
+then allocates and immediately closes a media request to verify request support.
+The scan, topology allocations, retry count, and retained errors are bounded.
+
+Failures identify the operation: opening a device, querying or setting V4L2
+formats, querying media topology, or allocating a media request. `EACCES` indicates
+an access failure; `ENOTTY` from `MEDIA_IOC_REQUEST_ALLOC` means the driver does not
+support requests. Fixing discovery does not prove FFmpeg decode, DMA-BUF import,
+or sustained presentation; use the real-device acceptance matrix above.
+
+The AppImage packages Wayland platform and shell-integration plugins explicitly.
+A missing Qt Wayland plugin is a packaging failure, separate from HEVC discovery.
+CUDA probe failures are expected on non-NVIDIA Pi hardware, and VA-API is not the
+Pi HEVC path. Do not install CUDA or replace the Pi GPU driver to fix those probes.
+
+References:
+
+- [Linux media-device registration](https://github.com/raspberrypi/linux/blob/rpi-6.18.y/drivers/media/mc/mc-devnode.c)
+  registers the media bus rather than a media class.
+- [Media topology API](https://docs.kernel.org/userspace-api/media/mediactl/media-ioc-g-topology.html)
+  defines device-number matching and retries when a topology changes.
+- [Media request allocation](https://docs.kernel.org/userspace-api/media/mediactl/media-ioc-request-alloc.html)
+  defines descriptor ownership and unsupported-request errors.
+- [Pi kernel 6.18 HEVC compatibility discussion](https://github.com/raspberrypi/linux/issues/7306)
+  describes older FFmpeg control-layout incompatibilities during actual decoding.
+  That is distinct from a discovery rejection before FFmpeg is initialized; do not
+  infer that a kernel downgrade is required from the generic discovery error.
+- [linuxdeploy Qt plugin configuration](https://github.com/linuxdeploy/linuxdeploy-plugin-qt#environment-variables)
+  documents the additional Wayland deployment settings.
+
 Unit tests, ARM64 compilation, and software-Vulkan rendering tests can validate
 contracts and conversion logic. They cannot validate `rpivid`, Pi DMA-BUF
 interoperability, sustained performance, or live GFN gameplay without a Pi.

--- a/native/opennow-core/src/diagnostics.rs
+++ b/native/opennow-core/src/diagnostics.rs
@@ -9,6 +9,104 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const ENTRY_LIMIT: usize = 1_200;
 const LOG_LIMIT_BYTES: u64 = 1_500_000;
 
+pub fn native_runtime_evidence(capabilities: &Value) -> Value {
+    let mut evidence = serde_json::Map::new();
+    for field in [
+        "supportsVideoDecode",
+        "supportsVideoPresent",
+        "nativeHdrSupported",
+    ] {
+        if let Some(value) = capabilities[field].as_bool() {
+            evidence.insert(field.to_owned(), json!(value));
+        }
+    }
+    if let Some(version) = capabilities["protocolVersion"]
+        .as_u64()
+        .filter(|v| *v <= u32::MAX as u64)
+    {
+        evidence.insert("protocolVersion".to_owned(), json!(version));
+    }
+    let mut backends = Vec::new();
+    for backend in capabilities["videoBackends"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .take(16)
+    {
+        let Some(name) = backend["backend"].as_str().filter(|name| {
+            matches!(
+                *name,
+                "vulkan"
+                    | "cuda"
+                    | "vaapi"
+                    | "v4l2"
+                    | "d3d11"
+                    | "d3d12"
+                    | "videotoolbox"
+                    | "software"
+                    | "ffmpeg"
+            )
+        }) else {
+            continue;
+        };
+        let mut entry = serde_json::Map::from_iter([("backend".to_owned(), json!(name))]);
+        if let Some(platform) = backend["platform"]
+            .as_str()
+            .filter(|name| matches!(*name, "linux" | "windows" | "macos" | "cross-platform"))
+        {
+            entry.insert("platform".to_owned(), json!(platform));
+        }
+        if let Some(value) = backend["available"].as_bool() {
+            entry.insert("available".to_owned(), json!(value));
+        }
+        if let Some(reason) = backend["reason"].as_str() {
+            entry.insert("reason".to_owned(), json!(runtime_failure_reason(reason)));
+        }
+        let mut codecs = Vec::new();
+        for codec in backend["codecs"].as_array().into_iter().flatten().take(8) {
+            let Some(name) = codec["codec"]
+                .as_str()
+                .filter(|name| matches!(*name, "h264" | "h265" | "av1"))
+            else {
+                continue;
+            };
+            let mut item = serde_json::Map::from_iter([("codec".to_owned(), json!(name))]);
+            for field in ["available", "hdrSupported"] {
+                if let Some(value) = codec[field].as_bool() {
+                    item.insert(field.to_owned(), json!(value));
+                }
+            }
+            if let Some(reason) = codec["reason"].as_str() {
+                item.insert("reason".to_owned(), json!(runtime_failure_reason(reason)));
+            }
+            codecs.push(Value::Object(item));
+        }
+        entry.insert("codecs".to_owned(), json!(codecs));
+        backends.push(Value::Object(entry));
+    }
+    evidence.insert("videoBackends".to_owned(), json!(backends));
+    Value::Object(evidence)
+}
+
+pub fn runtime_failure_reason(value: &str) -> String {
+    static SENSITIVE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let pattern = SENSITIVE.get_or_init(|| {
+        regex::Regex::new(r#"(?i)(?:https?://|wss://|/home/|/users/|[a-z]:\\+users\\+)\S+|\bbearer\s+[^\s,;]+|\b[a-z_]*(?:token|authorization|password|secret)[a-z_]*\s*[\"']?\s*[:=]?\s*[\"']?\s*(?:bearer\s+)?[^\s,;]+"#).unwrap()
+    });
+    let bounded: String = value
+        .chars()
+        .take(4096)
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect();
+    redact(&pattern.replace_all(&bounded, "[redacted]"), 480)
+}
+
 pub fn embedded_drop_evidence(params: &Value) -> Value {
     let mut evidence = serde_json::Map::new();
     for section in ["embeddedStream", "lastSessionReport"] {
@@ -429,6 +527,111 @@ mod tests {
         assert!(!text.contains("/home/alice"));
         assert!(!text.contains("Alice"));
         assert!(!text.contains("/Users/alice"));
+        let _ = fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn native_runtime_evidence_allowlists_bounds_and_redacts_probe_results() {
+        let capabilities = json!({
+            "protocolVersion": 6, "supportsVideoDecode": false, "supportsVideoPresent": "yes",
+            "sessionId": "private-session", "accessToken": "private-access",
+            "videoBackends": [{
+                "backend": "v4l2", "platform": "linux", "available": false,
+                "devicePath": "/home/alice/device", "unknown": "private-extra",
+                "reason": "HEVC topology probe failed path=/home/alice/private Authorization: Bearer abc123 token=xyz password: hunter2 https://example.com user@example.com",
+                "codecs": [{"codec": "h265", "available": false,
+                    "reason": "MEDIA_IOC_G_TOPOLOGY failed", "secret": "private-codec"},
+                    {"codec": "private-unknown-codec", "available": true}]
+            }, {"backend": "private-unknown-backend", "available": true}]
+        });
+        let evidence = native_runtime_evidence(&capabilities);
+        assert_eq!(evidence["supportsVideoDecode"], false);
+        assert!(evidence.get("supportsVideoPresent").is_none());
+        assert_eq!(evidence["videoBackends"].as_array().unwrap().len(), 1);
+        let backend = &evidence["videoBackends"][0];
+        assert_eq!(backend["available"], false);
+        assert_eq!(
+            backend["codecs"],
+            json!([{"codec":"h265", "available":false, "reason":"MEDIA_IOC_G_TOPOLOGY failed"}])
+        );
+        let rendered = evidence.to_string();
+        assert!(rendered.contains("HEVC topology probe failed"));
+        for sensitive in [
+            "private",
+            "alice",
+            "abc123",
+            "xyz",
+            "hunter2",
+            "example.com",
+        ] {
+            assert!(
+                !rendered.contains(sensitive),
+                "{sensitive} leaked: {rendered}"
+            );
+        }
+        let oversized = json!({"protocolVersion": u64::MAX, "videoBackends": vec![json!({
+            "backend":"v4l2", "reason":"x".repeat(10000), "codecs":vec![json!({
+                "codec":"h265", "available":"true", "reason":"y".repeat(10000)
+            }); 100]
+        }); 100]});
+        let evidence = native_runtime_evidence(&oversized);
+        assert!(evidence.get("protocolVersion").is_none());
+        let backends = evidence["videoBackends"].as_array().unwrap();
+        assert_eq!(backends.len(), 16);
+        assert!(backends[0]["reason"].as_str().unwrap().len() <= 483);
+        assert_eq!(backends[0]["codecs"].as_array().unwrap().len(), 8);
+        assert!(backends[0]["codecs"][0].get("available").is_none());
+        assert_eq!(
+            native_runtime_evidence(&Value::Null),
+            json!({"videoBackends":[]})
+        );
+    }
+
+    #[test]
+    fn runtime_failure_reasons_redact_bearer_values_and_quoted_credentials() {
+        for reason in [
+            "probe failed Bearer private-value",
+            r#"probe failed {"Authorization": "Bearer private-value"}"#,
+            r#"probe failed access_token: "private-value""#,
+            r"probe failed device=C:\Users\Alice\video path=/Users/Alice/video",
+        ] {
+            let redacted = runtime_failure_reason(reason);
+            assert!(redacted.starts_with("probe failed"));
+            assert!(!redacted.contains("private-value"));
+            assert!(!redacted.contains("Alice"));
+        }
+        let evidence = native_runtime_evidence(&json!({"videoBackends":[{
+            "backend":"software", "platform":"cross-platform", "available":true,
+            "codecs":[{"codec":"h265","available":true},{"codec":"hevc","available":true}]
+        }]}));
+        assert_eq!(evidence["videoBackends"][0]["platform"], "cross-platform");
+        assert_eq!(
+            evidence["videoBackends"][0]["codecs"],
+            json!([{"codec":"h265","available":true}])
+        );
+    }
+
+    #[test]
+    fn diagnostics_export_includes_native_probe_failures_before_stream_start() {
+        let directory = env::temp_dir().join(format!("opennow-probe-diagnostics-{}", now_ms()));
+        let service = DiagnosticsService::new(&directory).unwrap();
+        let streamer = crate::streamer::StreamerService::new();
+        let runtime = json!({
+            "streamer": streamer.acceptance_snapshot(),
+            "nativeRuntime": native_runtime_evidence(&json!({
+                "protocolVersion": 6, "supportsVideoDecode": false,
+                "videoBackends": [{"backend":"v4l2", "available":false,
+                    "reason":"HEVC probe failed", "codecs":[{"codec":"h265", "available":false,
+                        "reason":"MEDIA_IOC_G_TOPOLOGY failed"}]}]
+            }))
+        });
+        assert_eq!(runtime["streamer"]["status"], "stopped");
+        let exported = service.export_with_runtime(Some(&runtime)).unwrap();
+        let text = fs::read_to_string(exported["path"].as_str().unwrap()).unwrap();
+        assert!(text.contains("\"nativeRuntime\""));
+        assert!(text.contains("\"backend\": \"v4l2\""));
+        assert!(text.contains("\"available\": false"));
+        assert!(text.contains("MEDIA_IOC_G_TOPOLOGY failed"));
         let _ = fs::remove_dir_all(directory);
     }
 

--- a/native/opennow-core/src/main.rs
+++ b/native/opennow-core/src/main.rs
@@ -619,6 +619,7 @@ fn dispatch(method: &str, params: &Value, core: &AppCore) -> DispatchResult {
                 "os": std::env::consts::OS,
                 "cpuArchitecture": std::env::consts::ARCH,
                 "streamer": core.streamer.acceptance_snapshot(),
+                "nativeRuntime": diagnostics::native_runtime_evidence(&params["runtimeCapabilities"]),
                 "shell": diagnostics::embedded_drop_evidence(params)
             });
             core.diagnostics

--- a/native/opennow-core/src/streamer.rs
+++ b/native/opennow-core/src/streamer.rs
@@ -344,11 +344,32 @@ impl StreamerService {
             .iter()
             .any(|backend| backend["available"].as_bool() == Some(true))
         {
+            let message = if requested_backend == "auto" {
+                "No hardware video backend is available for embedded streaming on this device. Check the hardware drivers and export diagnostics for backend probe failures.".to_owned()
+            } else {
+                let mut message = format!(
+                    "The {} backend is unavailable for embedded streaming on this device. Select Auto in Stream settings.",
+                    crate::diagnostics::runtime_failure_reason(requested_backend)
+                );
+                let evidence = crate::diagnostics::native_runtime_evidence(capabilities);
+                if let Some(reason) = evidence["videoBackends"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .find(|backend| {
+                        backend["backend"] == requested_backend
+                            || (requested_backend == "nvdec" && backend["backend"] == "cuda")
+                    })
+                    .and_then(|backend| backend["reason"].as_str())
+                    .filter(|reason| !reason.is_empty())
+                {
+                    message.push_str(&format!(" {reason}"));
+                }
+                message
+            };
             return Err(StreamerError {
                 code: "streamer_backend_unavailable",
-                message: format!(
-                    "The {requested_backend} backend is unavailable for embedded streaming on this device. Select Auto in Stream settings."
-                ),
+                message,
             });
         }
         let videotoolbox = backends.iter().any(|backend| {
@@ -2034,6 +2055,51 @@ mod tests {
             StreamerService::embedded_session_settings(&json!({"codec":"auto"}), &caps).unwrap()["codec"],
             "h265"
         );
+    }
+
+    #[test]
+    fn unavailable_embedded_backends_distinguish_auto_from_explicit_selection() {
+        let capabilities = json!({"protocolVersion":STREAMER_PROTOCOL_VERSION,"videoBackends":[
+            {"backend":"v4l2", "available":false, "reason":"HEVC topology probe failed: errno 13 (Permission denied) token=private-value"},
+            {"backend":"cuda", "available":false, "reason":"CUDA unavailable"},
+            {"backend":"software", "available":true, "reason":"unused software reason"}
+        ]});
+        for selection in ["auto", "v4l2", "nvdec"] {
+            let error = StreamerService::embedded_session_settings(
+                &json!({"nativeVideoBackend":selection}),
+                &capabilities,
+            )
+            .unwrap_err();
+            assert_eq!(error.code, "streamer_backend_unavailable");
+            assert_eq!(error.message.contains("Select Auto"), selection != "auto");
+            assert_eq!(
+                error
+                    .message
+                    .contains("HEVC topology probe failed: errno 13 (Permission denied)"),
+                selection == "v4l2"
+            );
+            assert_eq!(
+                error.message.contains("CUDA unavailable"),
+                selection == "nvdec"
+            );
+            assert!(!error.message.contains("private-value"));
+            assert!(!error.message.contains("unused software reason"));
+        }
+        let error =
+            StreamerService::embedded_session_settings(&json!({}), &capabilities).unwrap_err();
+        assert!(error.message.starts_with("No hardware video backend"));
+        let mut oversized = capabilities.clone();
+        oversized["videoBackends"][0]["reason"] = json!("failure ".repeat(10000));
+        let concise =
+            StreamerService::embedded_session_settings(&json!({}), &oversized).unwrap_err();
+        assert_eq!(concise.message, error.message);
+        assert!(concise.message.len() < 200);
+        let error = StreamerService::embedded_session_settings(
+            &json!({}),
+            &json!({"protocolVersion":STREAMER_PROTOCOL_VERSION,"videoBackends":[]}),
+        )
+        .unwrap_err();
+        assert!(!error.message.contains("Select Auto"));
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/video/mod.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/video/mod.rs
@@ -5,7 +5,8 @@ use crate::{DecodedVideoFrame, EncodedVideoFrame, Result, StreamFormat, VideoCod
 #[cfg(feature = "ffmpeg")]
 mod ffmpeg;
 mod v4l2;
-#[cfg(feature = "ffmpeg")]
+#[cfg(any(feature = "ffmpeg", test))]
+#[cfg_attr(not(feature = "ffmpeg"), allow(dead_code))]
 mod v4l2_request;
 #[cfg(feature = "vaapi")]
 mod vaapi;

--- a/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/video/v4l2_request.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform-linux/src/video/v4l2_request.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use super::v4l2::ffi::*;
@@ -10,29 +11,124 @@ const HEVC_SLICE: u32 = u32::from_le_bytes(*b"S265");
 const SAND_NV12: [u32; 2] = [u32::from_le_bytes(*b"NC12"), u32::from_le_bytes(*b"Nc12")];
 const MEDIA_IOC_REQUEST_ALLOC: vidioc::_IOC_TYPE =
     ((2_u64 << 30) | (4 << 16) | ((b'|' as u64) << 8) | 5) as vidioc::_IOC_TYPE;
+const MEDIA_IOC_G_TOPOLOGY: vidioc::_IOC_TYPE =
+    ((3_u64 << 30) | (72 << 16) | ((b'|' as u64) << 8) | 4) as vidioc::_IOC_TYPE;
+const MEDIA_INTF_T_V4L_VIDEO: u32 = 0x200;
+const MAX_DEVICE_NODES: usize = 256;
+const MAX_INTERFACES: usize = 1024;
+const MAX_FAILURES: usize = 4;
 
-pub(super) fn probe() -> std::result::Result<String, String> {
-    for index in 0..64 {
-        let path = PathBuf::from(format!("/dev/video{index}"));
-        if let Ok(media) = inspect(&path) {
-            return Ok(format!(
-                "HEVC request decode with SAND128 NV12 via {} and {}",
-                path.display(),
-                media.display()
-            ));
-        }
-    }
-    Err(
-        "no accessible HEVC_SLICE/SAND128 NV12 decoder with a linked media request device"
-            .to_owned(),
-    )
+#[repr(C, packed)]
+#[derive(Default)]
+struct MediaTopology {
+    topology_version: u64,
+    num_entities: u32,
+    reserved1: u32,
+    ptr_entities: u64,
+    num_interfaces: u32,
+    reserved2: u32,
+    ptr_interfaces: u64,
+    num_pads: u32,
+    reserved3: u32,
+    ptr_pads: u64,
+    num_links: u32,
+    reserved4: u32,
+    ptr_links: u64,
 }
 
-fn inspect(path: &Path) -> io::Result<PathBuf> {
-    let video = open_device(path)?;
+#[repr(C, packed)]
+#[derive(Clone, Copy, Default)]
+struct MediaInterface {
+    id: u32,
+    intf_type: u32,
+    flags: u32,
+    reserved: [u32; 9],
+    devnode: [u32; 16],
+}
+
+struct HevcDevice {
+    file: fs::File,
+    output_type: u32,
+    capture_type: u32,
+}
+
+pub(super) fn probe() -> std::result::Result<String, String> {
+    let videos = device_paths(Path::new("/dev"), "video")
+        .map_err(|error| format!("enumerating /dev/video* failed: {error}"))?;
+    let media = device_paths(Path::new("/dev"), "media")
+        .map_err(|error| format!("enumerating /dev/media* failed: {error}"))?;
+    let mut failures = Vec::new();
+    let mut discovery_failures = Vec::new();
+    for path in videos {
+        let video = match open_hevc(&path) {
+            Ok(Some(video)) => video,
+            Ok(None) => continue,
+            Err(error) => {
+                if discovery_failures.len() < MAX_FAILURES {
+                    discovery_failures.push(format!("{}: {error}", path.display()));
+                }
+                continue;
+            }
+        };
+        match inspect(&video, &media) {
+            Ok(media) => {
+                return Ok(format!(
+                    "HEVC request decode with SAND128 NV12 via {} and {}",
+                    path.display(),
+                    media.display()
+                ));
+            }
+            Err(error) => {
+                if failures.len() < MAX_FAILURES {
+                    failures.push(format!("{}: {error}", path.display()));
+                }
+            }
+        }
+    }
+    if failures.is_empty() {
+        failures = discovery_failures;
+    }
+    if failures.is_empty() {
+        Err("no accessible streaming HEVC_SLICE (S265) decoder under /dev/video*".to_owned())
+    } else {
+        Err(format!(
+            "HEVC request discovery failed: {}",
+            failures.join("; ")
+        ))
+    }
+}
+
+fn device_paths(directory: &Path, prefix: &str) -> io::Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(index) = name.to_str().and_then(|name| name.strip_prefix(prefix)) else {
+            continue;
+        };
+        if index.is_empty() || !index.bytes().all(|byte| byte.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(index) = index.parse::<u32>() else {
+            continue;
+        };
+        if paths.len() == MAX_DEVICE_NODES {
+            return Err(io::Error::other(format!(
+                "more than {MAX_DEVICE_NODES} {prefix} nodes"
+            )));
+        }
+        paths.push((index, entry.path()));
+    }
+    paths.sort_by_key(|(index, _)| *index);
+    Ok(paths.into_iter().map(|(_, path)| path).collect())
+}
+
+fn open_hevc(path: &Path) -> std::result::Result<Option<HevcDevice>, String> {
+    let video = open_device(path).map_err(|error| format!("open failed: {error}"))?;
     let fd = video.as_raw_fd();
     let mut capability: v4l2_capability = zeroed();
-    ioctl(fd, vidioc::VIDIOC_QUERYCAP, &mut capability)?;
+    ioctl(fd, vidioc::VIDIOC_QUERYCAP, &mut capability)
+        .map_err(|error| format!("VIDIOC_QUERYCAP failed: {error}"))?;
     let caps = if capability.capabilities & V4L2_CAP_DEVICE_CAPS != 0 {
         capability.device_caps
     } else {
@@ -41,10 +137,10 @@ fn inspect(path: &Path) -> io::Result<PathBuf> {
     if caps & V4L2_CAP_STREAMING == 0
         || caps & (V4L2_CAP_VIDEO_M2M | V4L2_CAP_VIDEO_M2M_MPLANE) == 0
     {
-        return Err(io::ErrorKind::Unsupported.into());
+        return Ok(None);
     }
     let multiplanar = caps & V4L2_CAP_VIDEO_M2M_MPLANE != 0;
-    let (output, capture) = if multiplanar {
+    let (output_type, capture_type) = if multiplanar {
         (
             v4l2_buf_type_V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE,
             v4l2_buf_type_V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE,
@@ -55,45 +151,115 @@ fn inspect(path: &Path) -> io::Result<PathBuf> {
             v4l2_buf_type_V4L2_BUF_TYPE_VIDEO_CAPTURE,
         )
     };
-    if !enum_formats(fd, output)?.contains(&HEVC_SLICE) {
-        return Err(io::ErrorKind::Unsupported.into());
+    let formats = enum_formats(fd, output_type)
+        .map_err(|error| format!("VIDIOC_ENUM_FMT output failed: {error}"))?;
+    Ok(formats.contains(&HEVC_SLICE).then_some(HevcDevice {
+        file: video,
+        output_type,
+        capture_type,
+    }))
+}
+
+fn inspect(video: &HevcDevice, media_paths: &[PathBuf]) -> std::result::Result<PathBuf, String> {
+    let fd = video.file.as_raw_fd();
+    set_format(
+        fd,
+        video.output_type,
+        HEVC_SLICE,
+        1920,
+        1080,
+        Some(1024 * 1024),
+    )
+    .map_err(|error| format!("VIDIOC_S_FMT HEVC_SLICE failed: {error}"))?;
+    let formats = enum_formats(fd, video.capture_type)
+        .map_err(|error| format!("VIDIOC_ENUM_FMT capture failed: {error}"))?;
+    if !supports_capture(&formats) {
+        return Err("capture formats lack 8-bit SAND128 NC12/Nc12".to_owned());
     }
-    set_format(fd, output, HEVC_SLICE, 1920, 1080, Some(1024 * 1024))
-        .map_err(|error| io::Error::other(error.to_string()))?;
-    if !supports_capture(&enum_formats(fd, capture)?) {
-        return Err(io::ErrorKind::Unsupported.into());
-    }
-    let video_name = path.file_name().ok_or(io::ErrorKind::InvalidInput)?;
-    let parent = fs::canonicalize(
-        Path::new("/sys/class/video4linux")
-            .join(video_name)
-            .join("device"),
-    )?;
-    for index in 0..64 {
-        let media_name = format!("media{index}");
-        let Ok(media_parent) = fs::canonicalize(
-            Path::new("/sys/class/media")
-                .join(&media_name)
-                .join("device"),
-        ) else {
-            continue;
-        };
-        if media_parent != parent {
-            continue;
-        }
-        let media_path = Path::new("/dev").join(media_name);
-        let Ok(media) = open_device(&media_path) else {
-            continue;
-        };
-        let mut request_fd: libc::c_int = -1;
-        if ioctl(media.as_raw_fd(), MEDIA_IOC_REQUEST_ALLOC, &mut request_fd).is_ok()
-            && request_fd >= 0
-        {
+    let metadata = video
+        .file
+        .metadata()
+        .map_err(|error| format!("fstat failed: {error}"))?;
+    let device = (libc::major(metadata.rdev()), libc::minor(metadata.rdev()));
+    let mut failures = Vec::new();
+    for path in media_paths {
+        let result = (|| {
+            let media = open_device(path).map_err(|error| format!("open failed: {error}"))?;
+            if !media_contains_video(
+                |topology| ioctl(media.as_raw_fd(), MEDIA_IOC_G_TOPOLOGY, topology),
+                device,
+            )
+            .map_err(|error| format!("MEDIA_IOC_G_TOPOLOGY failed: {error}"))?
+            {
+                return Ok(None);
+            }
+            let mut request_fd: libc::c_int = -1;
+            ioctl(media.as_raw_fd(), MEDIA_IOC_REQUEST_ALLOC, &mut request_fd)
+                .map_err(|error| format!("MEDIA_IOC_REQUEST_ALLOC failed: {error}"))?;
+            if request_fd < 0 {
+                return Err("MEDIA_IOC_REQUEST_ALLOC returned an invalid descriptor".to_owned());
+            }
             drop(unsafe { OwnedFd::from_raw_fd(request_fd) });
-            return Ok(media_path);
+            Ok(Some(path.clone()))
+        })();
+        match result {
+            Ok(Some(path)) => return Ok(path),
+            Ok(None) => {}
+            Err(error) => {
+                if failures.len() < MAX_FAILURES {
+                    failures.push(format!("{}: {error}", path.display()));
+                }
+            }
         }
     }
-    Err(io::ErrorKind::NotFound.into())
+    Err(if failures.is_empty() {
+        format!(
+            "no /dev/media* topology contains video device {}:{}",
+            device.0, device.1
+        )
+    } else {
+        failures.join("; ")
+    })
+}
+
+fn media_contains_video(
+    mut query: impl FnMut(&mut MediaTopology) -> io::Result<()>,
+    device: (u32, u32),
+) -> io::Result<bool> {
+    for _ in 0..3 {
+        let mut topology = MediaTopology::default();
+        query(&mut topology)?;
+        let count = topology.num_interfaces as usize;
+        if count > MAX_INTERFACES {
+            return Err(io::Error::other(format!(
+                "more than {MAX_INTERFACES} media interfaces"
+            )));
+        }
+        if count == 0 {
+            return Ok(false);
+        }
+        let version = topology.topology_version;
+        let mut interfaces = vec![MediaInterface::default(); count];
+        topology.ptr_interfaces = interfaces.as_mut_ptr() as usize as u64;
+        match query(&mut topology) {
+            Err(error) if error.raw_os_error() == Some(libc::ENOSPC) => continue,
+            Err(error) => return Err(error),
+            Ok(()) => {}
+        }
+        if topology.topology_version != version || topology.num_interfaces as usize > count {
+            continue;
+        }
+        return Ok(interfaces[..topology.num_interfaces as usize]
+            .iter()
+            .any(|interface| {
+                interface.intf_type == MEDIA_INTF_T_V4L_VIDEO
+                    && interface.devnode[0] == device.0
+                    && interface.devnode[1] == device.1
+            }));
+    }
+    Err(io::Error::other(
+        "media topology changed during three attempts",
+    ))
 }
 
 fn supports_capture(formats: &[u32]) -> bool {
@@ -103,6 +269,178 @@ fn supports_capture(formats: &[u32]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn interface(device: (u32, u32), intf_type: u32) -> MediaInterface {
+        let mut interface = MediaInterface {
+            intf_type,
+            ..Default::default()
+        };
+        interface.devnode[0] = device.0;
+        interface.devnode[1] = device.1;
+        interface
+    }
+
+    fn fill_topology(topology: &mut MediaTopology, interfaces: &[MediaInterface], version: u64) {
+        if topology.ptr_interfaces != 0 {
+            assert!(topology.num_interfaces as usize >= interfaces.len());
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    interfaces.as_ptr(),
+                    topology.ptr_interfaces as usize as *mut MediaInterface,
+                    interfaces.len(),
+                );
+            }
+        }
+        topology.num_interfaces = interfaces.len() as u32;
+        topology.topology_version = version;
+    }
+
+    #[test]
+    fn topology_abi_matches_linux_uapi() {
+        assert_eq!(std::mem::size_of::<MediaTopology>(), 72);
+        assert_eq!(std::mem::size_of::<MediaInterface>(), 112);
+        assert_eq!(std::mem::offset_of!(MediaTopology, ptr_interfaces), 32);
+        assert_eq!(std::mem::offset_of!(MediaInterface, devnode), 48);
+        assert_eq!(MEDIA_IOC_G_TOPOLOGY, 0xc0487c04);
+        assert_eq!(MEDIA_IOC_REQUEST_ALLOC, 0x80047c05);
+    }
+
+    #[test]
+    fn topology_matches_the_video_device_number_not_its_filename_or_parent() {
+        let interfaces = [interface((81, 16), MEDIA_INTF_T_V4L_VIDEO)];
+        for (device, expected) in [((81, 16), true), ((81, 19), false), ((82, 16), false)] {
+            let mut calls = 0;
+            let found = media_contains_video(
+                |topology| {
+                    calls += 1;
+                    fill_topology(topology, &interfaces, 7);
+                    Ok(())
+                },
+                device,
+            )
+            .unwrap();
+            assert_eq!(found, expected);
+            assert_eq!(calls, 2);
+        }
+    }
+
+    #[test]
+    fn topology_ignores_other_interface_types_and_empty_graphs() {
+        for interfaces in [vec![], vec![interface((81, 16), 0x201)]] {
+            assert!(
+                !media_contains_video(
+                    |topology| {
+                        fill_topology(topology, &interfaces, 7);
+                        Ok(())
+                    },
+                    (81, 16)
+                )
+                .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn topology_retries_version_changes_and_growth() {
+        for errno in [None, Some(libc::ENOSPC)] {
+            let interfaces = [interface((81, 16), MEDIA_INTF_T_V4L_VIDEO)];
+            let mut calls = 0;
+            assert!(
+                media_contains_video(
+                    |topology| {
+                        calls += 1;
+                        if calls == 2 {
+                            if let Some(errno) = errno {
+                                return Err(io::Error::from_raw_os_error(errno));
+                            }
+                        }
+                        fill_topology(topology, &interfaces, if calls == 1 { 7 } else { 8 });
+                        Ok(())
+                    },
+                    (81, 16)
+                )
+                .unwrap()
+            );
+            assert_eq!(calls, 4);
+        }
+    }
+
+    #[test]
+    fn topology_churn_is_bounded_and_errors_are_preserved() {
+        let mut calls = 0;
+        let error = media_contains_video(
+            |topology| {
+                calls += 1;
+                fill_topology(
+                    topology,
+                    &[interface((81, 16), MEDIA_INTF_T_V4L_VIDEO)],
+                    calls,
+                );
+                Ok(())
+            },
+            (81, 16),
+        )
+        .unwrap_err();
+        assert_eq!(calls, 6);
+        assert!(error.to_string().contains("three attempts"));
+        for errno in [libc::EACCES, libc::ENOTTY, libc::ENODEV] {
+            let error =
+                media_contains_video(|_| Err(io::Error::from_raw_os_error(errno)), (81, 16))
+                    .unwrap_err();
+            assert_eq!(error.raw_os_error(), Some(errno));
+        }
+    }
+
+    #[test]
+    fn topology_rejects_unbounded_allocations() {
+        let mut calls = 0;
+        let error = media_contains_video(
+            |topology| {
+                calls += 1;
+                topology.num_interfaces = MAX_INTERFACES as u32 + 1;
+                Ok(())
+            },
+            (81, 16),
+        )
+        .unwrap_err();
+        assert_eq!(calls, 1);
+        assert!(error.to_string().contains("media interfaces"));
+    }
+
+    #[test]
+    fn device_enumeration_accepts_high_indices_and_is_bounded() {
+        let directory =
+            std::env::temp_dir().join(format!("opennow-v4l2-request-{}", std::process::id()));
+        fs::create_dir(&directory).unwrap();
+        for name in [
+            "video128",
+            "video19",
+            "video2",
+            "video-old",
+            "video",
+            "media71",
+        ] {
+            fs::write(directory.join(name), []).unwrap();
+        }
+        assert_eq!(
+            device_paths(&directory, "video").unwrap(),
+            ["video2", "video19", "video128"].map(|name| directory.join(name))
+        );
+        assert_eq!(
+            device_paths(&directory, "media").unwrap(),
+            vec![directory.join("media71")]
+        );
+        for index in 0..=MAX_DEVICE_NODES {
+            fs::write(directory.join(format!("media{index}")), []).unwrap();
+        }
+        assert!(
+            device_paths(&directory, "media")
+                .unwrap_err()
+                .to_string()
+                .contains("media nodes")
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn request_capture_requires_eight_bit_sand() {

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/linux_backend.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/linux_backend.rs
@@ -364,6 +364,20 @@ fn v4l2_capability(
     backend.available = backend.codecs.iter().any(|codec| codec.available);
     if backend.available {
         backend.reason = None;
+    } else {
+        backend.reason = Some(static_reason(
+            backend
+                .codecs
+                .iter()
+                .filter(|codec| matches!(codec.codec, "h264" | "h265"))
+                .filter_map(|codec| {
+                    codec
+                        .reason
+                        .map(|reason| format!("{}: {reason}", codec.codec))
+                })
+                .collect::<Vec<_>>()
+                .join("; "),
+        ));
     }
     backend
 }
@@ -477,6 +491,22 @@ fn static_reason(reason: String) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unavailable_v4l2_summary_preserves_the_hevc_failure() {
+        let mut capabilities = snapshot(false, false, false, true, vec!["wayland"]);
+        capabilities.decoders.push(BackendCapability {
+            name: "v4l2-h265",
+            available: false,
+            detail: "MEDIA_IOC_REQUEST_ALLOC failed: Permission denied (os error 13)".to_owned(),
+        });
+        let backend = v4l2_capability(&capabilities, "wayland");
+        assert!(!backend.available);
+        let reason = backend.reason.unwrap();
+        assert!(reason.contains("h264:"));
+        assert!(reason.contains("h265: MEDIA_IOC_REQUEST_ALLOC failed"));
+        assert!(reason.contains("os error 13"));
+    }
 
     #[test]
     fn hevc_request_is_available_without_stateful_h264_and_never_ten_bit() {

--- a/opennow-qt/qml/state/ShellStore.qml
+++ b/opennow-qt/qml/state/ShellStore.qml
@@ -794,6 +794,7 @@ QtObject {
             return
         diagnosticsMessage = qsTr("Creating redacted diagnostic export…")
         diagnosticsExportRequestId = CoreClient.request("diagnostics.export", {
+            runtimeCapabilities: nativeRuntimeCapabilities,
             embeddedStream: {drops: streamDropCounts},
             lastSessionReport: lastSessionReport ? {drops: lastSessionReport.drops} : null
         }, 15000)

--- a/opennow-qt/tests/QueueDropsAcceptance.qml
+++ b/opennow-qt/tests/QueueDropsAcceptance.qml
@@ -44,6 +44,19 @@ QtObject {
     }
 
     function run(parent) {
+        ShellStore.activeSession = null
+        ShellStore.streamer = {status: "stopped"}
+        ShellStore.acceptNativeCapabilities({protocolVersion: 6, supportsVideoDecode: false,
+            videoBackends: [{backend: "v4l2", available: false, reason: "HEVC probe failed",
+                codecs: [{codec: "h265", available: false, reason: "MEDIA_IOC_G_TOPOLOGY failed"}]}]})
+        client.state = "ready"
+        ShellStore.exportDiagnostics()
+        const beforeStart = client.calls[client.calls.length - 1]
+        check(beforeStart.method === "diagnostics.export", "export works before streaming")
+        check(beforeStart.params.runtimeCapabilities.videoBackends[0].codecs[0].reason === "MEDIA_IOC_G_TOPOLOGY failed",
+            "export includes actual native runtime probe failures before start")
+        ShellStore.diagnosticsExportRequestId = ""
+        client.state = "stopped"
         ShellStore.streamerStartRequestId = "fixture-blocked"
         ShellStore.activeSession = {sessionId: "drop-fixture", zone: "Fixture region"}
         ShellStore.streamer = {status: "streaming", framesPerSecond: 60, queueDropCount: 0}

--- a/opennow-qt/tests/test_ci_workflow.py
+++ b/opennow-qt/tests/test_ci_workflow.py
@@ -15,6 +15,20 @@ def jobs(workflow):
 
 
 class CIWorkflowTest(unittest.TestCase):
+    def test_linux_appimages_deploy_wayland_platform_and_shell_plugins(self):
+        for name in ("qt-build.yml", "qt-release-candidate.yml"):
+            with self.subTest(workflow=name):
+                workflow = (WORKFLOWS / name).read_text()
+                self.assertIn("qtwaylandcompositor", workflow)
+                self.assertIn("EXTRA_QT_MODULES: waylandcompositor", workflow)
+                self.assertIn(
+                    "EXTRA_PLATFORM_PLUGINS: libqoffscreen.so;libqwayland-egl.so;libqwayland-generic.so",
+                    workflow,
+                )
+                for plugin in ("platforms/libqwayland-egl.so", "platforms/libqwayland-generic.so",
+                               "wayland-shell-integration/libxdg-shell.so"):
+                    self.assertIn(f"test -f build/AppDir/usr/plugins/{plugin}", workflow)
+
     def test_automatic_events_run_checks_without_packages(self):
         ci = (WORKFLOWS / "qt-ci.yml").read_text()
         entries = jobs(ci)


### PR DESCRIPTION
## Pi HEVC discovery

The Pi 5 report showed an accessible `rpi-hevc-dec` device with S265 input and NC12/Nc12 capture formats, but OpenNOW rejected it before FFmpeg initialization. Discovery assumed `/sys/class/media` existed. Linux registers media devices on the **media bus**, not that class ([kernel registration](https://github.com/raspberrypi/linux/blob/rpi-6.18.y/drivers/media/mc/mc-devnode.c)).

Replace the sysfs-parent assumption with `MEDIA_IOC_G_TOPOLOGY`, matching the opened video node's actual major/minor number. Enumerate numeric device nodes instead of assuming indices below 64, bound scans/allocations/retries, and retain operation-specific errors. Continue verifying and closing an allocated media request before advertising discovery success.

## Actionable diagnostics and Linux packaging

- Preserve both H.264 and HEVC rejection reasons in the unavailable V4L2 summary.
- Export the Qt runtime's allowlisted backend/codec results before a session starts, with bounded, redacted reasons rather than an empty process-streamer capability snapshot.
- Stop telling Auto users to select Auto; explicit selections retain their specific safe failure reason.
- Install the Qt Wayland deployment module and explicitly bundle/check Wayland platform and xdg-shell plugins in both Linux AppImage workflows, following the pinned [linuxdeploy Qt configuration](https://github.com/linuxdeploy/linuxdeploy-plugin-qt/tree/1-alpha-20250213-1#environment-variables).
- Document the probe stages, expected non-Pi backend failures, and distinction from [kernel/FFmpeg compatibility failures during decoding](https://github.com/raspberrypi/linux/issues/7306).

## Verification

- 8 focused V4L2 request tests: UAPI layout, device-number matching, interface filtering, graph changes, allocation/retry limits, high-numbered devices, and supported capture formats.
- Native topology struct sizes, offsets, ioctl values, and interface type independently checked against Linux C UAPI headers.
- 10 Linux backend-selection tests.
- `cargo test --manifest-path native/opennow-streamer/Cargo.toml --workspace -- --test-threads=1`: 565 passed, 9 ignored. The initial parallel run hit an existing preferred-port assertion in an untouched transport test; the serialized full suite passes. No transport code or tests changed.
- 185 core tests; strict Clippy on the changed core/native crates; relevant Rust formatting checks.
- All 4 `QueueDropsAcceptance.qml` variants passed using Qt 6.9.3 and the fixture's mock runtime via a temporary QML harness (960/1440 × statistics/report), with no QML warnings.
- All 61 Python build/packaging contracts and actionlint 1.7.12 passed.

Actual Pi HEVC decoding, Qt DMA-BUF import, sustained streaming, and the newly packaged ARM64 Wayland AppImage still require real-device acceptance. Neither the mock QML harness nor a successful discovery probe proves playback; the full native Qt application/AppImage was not rebuilt locally.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23Q35396F7SYHF8VCTV8VX9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->