### PR TITLE
ci(qt): use eight-core checks and overlap manual packaging

### DIFF
--- a/.github/actions/qt-unit-tests/action.yml
+++ b/.github/actions/qt-unit-tests/action.yml
@@ -77,12 +77,16 @@ runs:
     - name: Lint Rust
       shell: bash
       working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      env:
+        CARGO_BUILD_JOBS: ${{ inputs.parallel }}
       run: |
         cargo clippy --locked --manifest-path native/opennow-core/Cargo.toml --all-targets -- -D warnings
         cargo clippy --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace --all-targets -- -D warnings
     - name: Test Rust
       shell: bash
       working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      env:
+        CARGO_BUILD_JOBS: ${{ inputs.parallel }}
       run: |
         cargo test --locked --manifest-path native/opennow-core/Cargo.toml
         cargo test --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace

--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -50,7 +50,7 @@ jobs:
         include:
           - label: linux-x64
             os: blacksmith-8vcpu-ubuntu-2404
-            build-parallel: 6
+            build-parallel: 8
             qt-host: linux
             qt-arch: linux_gcc_64
             package-generator: DEB
@@ -62,7 +62,7 @@ jobs:
             appimage-runtime-sha256: 2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d
           - label: linux-arm64
             os: blacksmith-8vcpu-ubuntu-2404-arm
-            build-parallel: 6
+            build-parallel: 8
             qt-host: linux_arm64
             qt-arch: linux_gcc_arm64
             package-generator: DEB

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -86,7 +86,6 @@ jobs:
             parallel: "3"
     env:
       CARGO_TERM_COLOR: always
-      CARGO_BUILD_JOBS: ${{ matrix.parallel }}
       OPENNOW_CHECKOUT: ${{ matrix.label == 'windows-x64' && 'O:/' || github.workspace }}
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.label == 'macos-arm64' && '13.0' || '' }}
     steps:

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -67,17 +67,17 @@ jobs:
       matrix:
         include:
           - label: linux-x64
-            os: blacksmith-4vcpu-ubuntu-2404
+            os: blacksmith-8vcpu-ubuntu-2404
             qt-host: linux
             qt-arch: linux_gcc_64
             target-arch: x64
-            parallel: "4"
+            parallel: "8"
           - label: windows-x64
-            os: blacksmith-4vcpu-windows-2025
+            os: blacksmith-8vcpu-windows-2025
             qt-host: windows
             qt-arch: win64_msvc2022_64
             target-arch: x64
-            parallel: "4"
+            parallel: "8"
           - label: macos-arm64
             os: blacksmith-6vcpu-macos-15
             qt-host: mac
@@ -107,7 +107,7 @@ jobs:
   build:
     name: Manual packages
     if: github.event_name == 'workflow_dispatch'
-    needs: [contracts, checks]
+    needs: contracts
     uses: ./.github/workflows/qt-build.yml
     with:
       upload_complete: ${{ github.event_name == 'workflow_dispatch' }}
@@ -115,7 +115,7 @@ jobs:
   publish-nightly:
     name: Publish unsigned nightly prerelease
     if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly
-    needs: build
+    needs: [contracts, checks, build]
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write

--- a/native/opennow-core/src/gfn.rs
+++ b/native/opennow-core/src/gfn.rs
@@ -2708,6 +2708,7 @@ mod tests {
                         Err(error) => panic!("{error}"),
                     }
                 };
+                stream.set_nonblocking(false).unwrap();
                 stream
                     .set_read_timeout(Some(Duration::from_secs(5)))
                     .unwrap();

--- a/opennow-qt/tests/test_ci_workflow.py
+++ b/opennow-qt/tests/test_ci_workflow.py
@@ -36,7 +36,7 @@ class CIWorkflowTest(unittest.TestCase):
         self.assertIn("uses: ./.github/workflows/qt-checks.yml", entries["contracts"])
         self.assertNotIn("    if:", entries["contracts"])
         self.assertIn("    if: github.event_name == 'workflow_dispatch'\n", entries["build"])
-        self.assertIn("    needs: [contracts, checks]\n", entries["build"])
+        self.assertIn("    needs: contracts\n", entries["build"])
         self.assertIn("uses: ./.github/workflows/qt-build.yml", entries["build"])
         self.assertIn("  pull_request:\n", ci)
         self.assertIn("  push:\n", ci)
@@ -67,9 +67,38 @@ class CIWorkflowTest(unittest.TestCase):
         self.assertIn("    runs-on: ${{ matrix.os }}\n", checks)
         self.assertIn("      fail-fast: false\n", checks)
         self.assertIn("uses: ./.github/actions/qt-unit-tests", checks)
-        self.assertIn("os: blacksmith-4vcpu-windows-2025", checks)
+        self.assertIn("os: blacksmith-8vcpu-windows-2025", checks)
         self.assertIn("os: blacksmith-6vcpu-macos-15", checks)
         self.assertNotIn("continue-on-error", checks)
+
+    def test_linux_and_windows_checks_use_eight_core_build_parallelism(self):
+        checks = jobs((WORKFLOWS / "qt-ci.yml").read_text())["checks"]
+        for label, runner in (("linux-x64", "blacksmith-8vcpu-ubuntu-2404"),
+                              ("windows-x64", "blacksmith-8vcpu-windows-2025")):
+            with self.subTest(label=label):
+                entry = checks.split(f"          - label: {label}\n", 1)[1].split("          - label:", 1)[0]
+                self.assertIn(f"            os: {runner}\n", entry)
+                self.assertIn('            parallel: "8"\n', entry)
+        self.assertIn("CARGO_BUILD_JOBS: ${{ matrix.parallel }}", checks)
+        self.assertIn("parallel: ${{ matrix.parallel }}", checks)
+
+    def test_linux_and_windows_packages_use_eight_core_build_parallelism(self):
+        packages = jobs((WORKFLOWS / "qt-build.yml").read_text())["packages"]
+        for label in ("linux-x64", "linux-arm64", "windows-x64", "windows-arm64"):
+            with self.subTest(label=label):
+                entry = packages.split(f"          - label: {label}\n", 1)[1].split("          - label:", 1)[0]
+                self.assertIn("            os: blacksmith-8vcpu-", entry)
+                self.assertIn("            build-parallel: 8\n", entry)
+
+    def test_manual_packages_overlap_checks_without_bypassing_publication_gates(self):
+        entries = jobs((WORKFLOWS / "qt-ci.yml").read_text())
+        self.assertIn("    needs: contracts\n", entries["build"])
+        self.assertIn("    if: github.event_name == 'workflow_dispatch'\n", entries["build"])
+        self.assertIn("    needs: [contracts, checks, build]\n", entries["publish-nightly"])
+        self.assertNotIn("always()", entries["build"])
+        self.assertNotIn("always()", entries["publish-nightly"])
+        self.assertNotIn("continue-on-error", entries["checks"])
+        self.assertNotIn("continue-on-error", entries["build"])
 
     def test_required_platform_checks_fail_when_shared_checks_do_not_succeed(self):
         checks = jobs((WORKFLOWS / "qt-ci.yml").read_text())["checks"]
@@ -147,7 +176,7 @@ class CIWorkflowTest(unittest.TestCase):
         self.assertIn("        type: boolean\n        default: false", ci)
         publish = jobs(ci)["publish-nightly"]
         self.assertIn("if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly", publish)
-        self.assertIn("    needs: build\n", publish)
+        self.assertIn("    needs: [contracts, checks, build]\n", publish)
 
 
 if __name__ == "__main__":

--- a/opennow-qt/tests/test_ci_workflow.py
+++ b/opennow-qt/tests/test_ci_workflow.py
@@ -79,7 +79,12 @@ class CIWorkflowTest(unittest.TestCase):
                 entry = checks.split(f"          - label: {label}\n", 1)[1].split("          - label:", 1)[0]
                 self.assertIn(f"            os: {runner}\n", entry)
                 self.assertIn('            parallel: "8"\n', entry)
-        self.assertIn("CARGO_BUILD_JOBS: ${{ matrix.parallel }}", checks)
+        self.assertNotIn("CARGO_BUILD_JOBS:", checks)
+        action = (ROOT / ".github/actions/qt-unit-tests/action.yml").read_text()
+        self.assertNotIn("CARGO_BUILD_JOBS:", action.split("    - name: Lint Rust", 1)[0])
+        for step in ("Lint Rust", "Test Rust"):
+            entry = action.split(f"    - name: {step}\n", 1)[1].split("    - name:", 1)[0]
+            self.assertIn("CARGO_BUILD_JOBS: ${{ inputs.parallel }}", entry)
         self.assertIn("parallel: ${{ matrix.parallel }}", checks)
 
     def test_linux_and_windows_packages_use_eight_core_build_parallelism(self):

--- a/opennow-qt/tests/test_supporter_build.py
+++ b/opennow-qt/tests/test_supporter_build.py
@@ -107,7 +107,7 @@ class SupporterBuildTest(unittest.TestCase):
         self.assertIn("--channel \"$BUILD_CHANNEL\"", build)
         self.assertIn("uses: ./.github/workflows/qt-build.yml", ci)
         self.assertIn("if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly", ci)
-        self.assertIn("needs: build", ci)
+        self.assertIn("needs: [contracts, checks, build]", ci)
         self.assertIn("gh release create", ci)
 
 


### PR DESCRIPTION
Move Linux x64 and Windows x64 native checks from 4-vCPU runners / four build jobs to 8-vCPU runners / eight build jobs. Raise Linux x64 and ARM64 package build parallelism from six to eight on their existing 8-vCPU runners. Keep macOS's existing 6-vCPU runner and Windows release Rust concurrency bound unchanged.

Manual packages now start after shared contracts pass, alongside platform checks instead of after them. Nightly publication explicitly depends on contracts, all platform checks, and the complete package build, so failed checks still prevent releases. Automatic push/PR events remain checks-only. This trades some build work on failing manual runs for a shorter successful critical path.

The investigated [run](https://github.com/OpenCloudGaming/OpenNOW/actions/runs/34396816071) took 29m19s. Packages started about 12 minutes into the run; Linux ARM64 then took 15m43s, including a 9m39s release build. Its Rust, C++, and SDL caches missed (C++: 488/498 misses). Keep existing cache prefixes and saving. Scope `CARGO_BUILD_JOBS` to the Rust compile/test steps instead of the job environment, so future concurrency changes no longer enter the checks cache fingerprint. The first run with the corrected fingerprint is cold.

Validation: all 65 Python build/packaging contract tests pass, including runner capacity, concurrent scheduling, and release gating assertions; actionlint 1.7.12 passes for all four Qt workflows; `git diff --check` passes. Also fix the mock GFN HTTP server to make accepted sockets explicitly blocking: Windows inherits the listener’s nonblocking mode and failed with WSAEWOULDBLOCK. All 23 focused GFN tests, Rust formatting, and core Clippy with warnings denied pass locally. Windows CI rerun and end-to-end artifact timing validation remain pending.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23X5SX5B19JFYJ7DRDT5XAX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->