### PR TITLE
ci(qt): persist Linux native build caches on Blacksmith

### DIFF
--- a/.github/actions/linux-build-cache/action.yml
+++ b/.github/actions/linux-build-cache/action.yml
@@ -1,0 +1,77 @@
+name: Persistent Linux native build cache
+description: Mount protected Blacksmith build disks with archive fallback until main seeds them
+inputs:
+  key:
+    description: Stable platform and build-profile identity, independent of CPU count and source revision
+    required: true
+  core-target:
+    description: Core Cargo target directory relative to the checkout
+    required: true
+  streamer-target:
+    description: Streamer Cargo target directory relative to the checkout
+    required: true
+outputs:
+  rust-warm:
+    description: Both Cargo target disks contain compiled dependencies
+    value: ${{ steps.inspect.outputs.rust-warm }}
+  ccache-warm:
+    description: The C++ disk contains compiler-cache results
+    value: ${{ steps.inspect.outputs.ccache-warm }}
+runs:
+  using: composite
+  steps:
+    - name: Mount Cargo registry
+      uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc
+      with:
+        key: opennow-native-v1-${{ inputs.key }}-registry
+        path: ${{ env.CARGO_HOME }}/registry
+        commit: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    - name: Mount Cargo git dependencies
+      uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc
+      with:
+        key: opennow-native-v1-${{ inputs.key }}-git
+        path: ${{ env.CARGO_HOME }}/git
+        commit: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    - name: Mount compiled core dependencies
+      uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc
+      with:
+        key: opennow-native-v1-${{ inputs.key }}-core
+        path: ${{ github.workspace }}/${{ inputs.core-target }}
+        commit: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    - name: Mount compiled streamer dependencies
+      uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc
+      with:
+        key: opennow-native-v1-${{ inputs.key }}-streamer
+        path: ${{ github.workspace }}/${{ inputs.streamer-target }}
+        commit: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    - name: Mount C++ compiler cache
+      uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc
+      with:
+        key: opennow-native-v1-${{ inputs.key }}-ccache
+        path: ${{ github.workspace }}/.ccache
+        commit: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    - name: Inspect persistent build artifacts
+      id: inspect
+      shell: bash
+      env:
+        CORE_TARGET: ${{ github.workspace }}/${{ inputs.core-target }}
+        STREAMER_TARGET: ${{ github.workspace }}/${{ inputs.streamer-target }}
+        CXX_CACHE: ${{ github.workspace }}/.ccache
+      run: |
+        rust_warm=false
+        ccache_warm=false
+        if [[ -n "$(find "$CORE_TARGET" -type f -name '*.rlib' -print -quit)" &&
+              -n "$(find "$STREAMER_TARGET" -type f -name '*.rlib' -print -quit)" ]]; then
+          rust_warm=true
+        fi
+        if [[ -n "$(find "$CXX_CACHE" -type f -name '*R' -print -quit)" ]]; then
+          ccache_warm=true
+        fi
+        echo "rust-warm=$rust_warm" >> "$GITHUB_OUTPUT"
+        echo "ccache-warm=$ccache_warm" >> "$GITHUB_OUTPUT"
+        {
+          echo '### Persistent Linux build cache'
+          echo "Compiled Cargo dependencies present: $rust_warm"
+          echo "C++ compiler-cache results present: $ccache_warm"
+          echo 'Empty disks fall back to branch-scoped archive caches. Only default-branch push/manual jobs save disk snapshots.'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/qt-unit-tests/action.yml
+++ b/.github/actions/qt-unit-tests/action.yml
@@ -66,7 +66,16 @@ runs:
           libx11-dev libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcursor-dev libxext-dev libxfixes-dev \
           libxi-dev libxkbcommon-dev libxkbcommon-x11-0 libxrandr-dev libxrender-dev libxss-dev \
           mesa-vulkan-drivers nasm ninja-build pkg-config wayland-protocols xvfb
+    - name: Mount persistent Linux build cache
+      id: sticky-cache
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/linux-build-cache
+      with:
+        key: ubuntu-2404-checks-${{ inputs.label }}
+        core-target: native/opennow-core/target
+        streamer-target: native/opennow-streamer/target
     - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+      if: runner.os != 'Linux' || steps.sticky-cache.outputs.rust-warm != 'true'
       with:
         shared-key: qt-checks-${{ inputs.label }}
         cache-bin: false
@@ -104,6 +113,8 @@ runs:
       with:
         key: qt-checks-${{ inputs.label }}
         max-size: 1G
+        restore: ${{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}
+        save: ${{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}
     - name: Build and cache SDL3 test dependency
       uses: ./.github/actions/sdl3
       with:

--- a/.github/actions/qt-unit-tests/action.yml
+++ b/.github/actions/qt-unit-tests/action.yml
@@ -113,6 +113,7 @@ runs:
       with:
         key: qt-checks-${{ inputs.label }}
         max-size: 1G
+        restore-keys: qt-checks-${{ inputs.label }}
         restore: ${{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}
         save: ${{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}
     - name: Build and cache SDL3 test dependency

--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -292,6 +292,7 @@ jobs:
         with:
           key: ${{ runner.os == 'macOS' && 'qt-ci-macos-arm64' || format('qt-ci-{0}-{1}', matrix.os, matrix.label) }}
           max-size: 1G
+          restore-keys: ${{ runner.os == 'macOS' && 'qt-ci-macos-arm64' || format('qt-ci-{0}-{1}', matrix.os, matrix.label) }}
           restore: ${{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}
           save: ${{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}
 

--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -265,7 +265,17 @@ jobs:
         if: matrix.label == 'linux-arm64'
         run: sudo apt-get install -y libudev-dev
 
+      - name: Mount persistent Linux build cache
+        id: sticky-cache
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/linux-build-cache
+        with:
+          key: ubuntu-2404-release-${{ matrix.label }}
+          core-target: build/opennow-qt-release/rust-target
+          streamer-target: build/opennow-qt-release/streamer-rust-target
+
       - name: Cache Rust dependencies and build artifacts
+        if: runner.os != 'Linux' || steps.sticky-cache.outputs.rust-warm != 'true'
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
           shared-key: ${{ runner.os == 'macOS' && 'qt-ci-macos-arm64' || format('qt-ci-{0}-{1}', matrix.os, matrix.label) }}
@@ -282,6 +292,8 @@ jobs:
         with:
           key: ${{ runner.os == 'macOS' && 'qt-ci-macos-arm64' || format('qt-ci-{0}-{1}', matrix.os, matrix.label) }}
           max-size: 1G
+          restore: ${{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}
+          save: ${{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}
 
       - name: Build and cache SDL3
         uses: ./.github/actions/sdl3

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -136,6 +136,7 @@ jobs:
         with:
           key: qt-release-${{ matrix.runner }}-${{ matrix.arch }}
           max-size: 500M
+          restore-keys: qt-release-${{ matrix.runner }}-${{ matrix.arch }}
 
       - name: Build and cache SDL3
         uses: ./.github/actions/sdl3
@@ -358,6 +359,7 @@ jobs:
         with:
           key: qt-release-windows-2025-${{ matrix.arch }}
           max-size: 1G
+          restore-keys: qt-release-windows-2025-${{ matrix.arch }}
 
       - name: Build and cache SDL3
         uses: ./.github/actions/sdl3

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -17,10 +17,24 @@ Rust, Qt, and SDL caches reduce repeated work.
 General-purpose check and package jobs use Blacksmith runners. The isolated
 release-signing job remains on `opennow-release-signer`.
 
-The upstream Rust cache action automatically uses Blacksmith's colocated cache.
-Platform-specific shared keys survive job renames, and dependency caches are saved
-even if a later test fails. Check and release-build caches remain separate; each
-still invalidates when the Rust toolchain or dependency configuration changes.
+Linux checks and unsigned packages mount Blacksmith sticky disks for the Cargo registry,
+Git dependencies, both compiled Rust target directories, and the C++ compiler cache.
+Disk keys separate architectures and check/release profiles without changing on each
+commit or runner CPU-count change. Cargo and ccache still validate their inputs; a
+toolchain, dependency, or source change rebuilds the affected outputs.
+
+Keep **Sticky Disks: branch protection** enabled in Blacksmith. Only default-branch
+(`main`) push/manual jobs save these snapshots; PRs and `dev` consume isolated clones.
+After these workflows reach `main`, run **qt-ci** manually on `main`, without publishing,
+to populate both check and package disks. Until then, empty disks fall back to the
+existing branch-scoped archive caches rather than forcing every PR to rebuild cleanly.
+The job summary reports whether compiled Cargo dependencies and C++ results were found.
+
+Windows/macOS and cold Linux disks use the upstream Rust and C++ cache actions, which
+automatically use Blacksmith's colocated archive cache. Platform-specific shared keys
+survive job renames, and Rust dependency caches are saved even if a later test fails.
+Build concurrency is scoped to Rust compile/test steps so it does not invalidate the
+checks archive cache. Warm Linux disks bypass archive cleanup and keep workspace outputs.
 
 Full application builds, embedded-runtime/QML acceptance tests, Linux/Windows ARM64
 builds, and package creation run only on manual dispatch. Automatic checks do not
@@ -30,7 +44,8 @@ matrix, including macOS; platform-specific steps handle its app bundle and reloc
 
 Required status names are `linux-x64`, `windows-x64`, and `macos-arm64`. Keep all
 three required in the repository's branch rules. Each also fails if shared checks
-fail or are cancelled, and manual packaging waits for every platform to pass.
+fail or are cancelled. Manual packaging runs alongside platform checks after shared
+checks pass; nightly publication still waits for every platform and package to pass.
 
 To run the test-only Qt suite locally after configuring a Debug build:
 

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -34,7 +34,9 @@ Windows/macOS and cold Linux disks use the upstream Rust and C++ cache actions, 
 automatically use Blacksmith's colocated archive cache. Platform-specific shared keys
 survive job renames, and Rust dependency caches are saved even if a later test fails.
 Build concurrency is scoped to Rust compile/test steps so it does not invalidate the
-checks archive cache. Warm Linux disks bypass archive cleanup and keep workspace outputs.
+checks archive cache. C++ archive caches explicitly restore their platform/profile
+prefix so timestamped entries can be found on later runs. Warm Linux disks bypass
+archive cleanup and keep workspace outputs.
 
 Full application builds, embedded-runtime/QML acceptance tests, Linux/Windows ARM64
 builds, and package creation run only on manual dispatch. Automatic checks do not

--- a/opennow-qt/tests/test_linux_build_cache.py
+++ b/opennow-qt/tests/test_linux_build_cache.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+import os
+import re
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTION = ROOT / ".github/actions/linux-build-cache/action.yml"
+
+
+class LinuxBuildCacheTest(unittest.TestCase):
+    def test_disks_are_stable_and_only_default_branch_jobs_commit(self):
+        action = ACTION.read_text()
+        self.assertEqual(action.count("uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc"), 5)
+        self.assertEqual(action.count(
+            "commit: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) "
+            "&& (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}"
+        ), 5)
+        for suffix in ("registry", "git", "core", "streamer", "ccache"):
+            self.assertIn(f"key: opennow-native-v1-${{{{ inputs.key }}}}-{suffix}\n", action)
+        for invalidator in ("github.sha", "github.run_id", "hashFiles", "matrix.os", "CARGO_BUILD_JOBS"):
+            self.assertNotIn(invalidator, action)
+        paths = [line.strip().removeprefix("path: ") for line in action.splitlines()
+                 if line.strip().startswith("path: ")]
+        self.assertEqual(paths, [
+            "${{ env.CARGO_HOME }}/registry",
+            "${{ env.CARGO_HOME }}/git",
+            "${{ github.workspace }}/${{ inputs.core-target }}",
+            "${{ github.workspace }}/${{ inputs.streamer-target }}",
+            "${{ github.workspace }}/.ccache",
+        ])
+
+    def test_only_linux_mounts_disks_with_separate_check_and_release_targets(self):
+        for path, key, core_target, streamer_target in (
+            (ROOT / ".github/actions/qt-unit-tests/action.yml", "ubuntu-2404-checks-${{ inputs.label }}",
+             "native/opennow-core/target", "native/opennow-streamer/target"),
+            (ROOT / ".github/workflows/qt-build.yml", "ubuntu-2404-release-${{ matrix.label }}",
+             "build/opennow-qt-release/rust-target", "build/opennow-qt-release/streamer-rust-target"),
+        ):
+            with self.subTest(path=path):
+                workflow = path.read_text()
+                step = re.split(r"\n\s+- ", workflow.split("- name: Mount persistent Linux build cache\n", 1)[1], 1)[0] + "\n"
+                self.assertIn("if: runner.os == 'Linux'", step)
+                self.assertIn("uses: ./.github/actions/linux-build-cache", step)
+                self.assertIn(f"key: {key}\n", step)
+                self.assertIn(f"core-target: {core_target}\n", step)
+                self.assertIn(f"streamer-target: {streamer_target}\n", step)
+                self.assertLess(workflow.index("dtolnay/rust-toolchain@"), workflow.index("id: sticky-cache"))
+
+    def test_archive_fallback_remains_available_until_disks_are_populated(self):
+        for path in (ROOT / ".github/actions/qt-unit-tests/action.yml", ROOT / ".github/workflows/qt-build.yml"):
+            with self.subTest(path=path):
+                workflow = path.read_text()
+                self.assertIn("if: runner.os != 'Linux' || steps.sticky-cache.outputs.rust-warm != 'true'", workflow)
+                self.assertIn("cache-on-failure: true", workflow)
+                for operation in ("restore", "save"):
+                    self.assertIn(
+                        f"{operation}: ${{{{ runner.os != 'Linux' || steps.sticky-cache.outputs.ccache-warm != 'true' }}}}",
+                        workflow,
+                    )
+
+    def test_artifact_detection_distinguishes_empty_partial_and_populated_disks(self):
+        script = textwrap.dedent(ACTION.read_text().split("      run: |\n", 1)[1])
+        for core, streamer, ccache in ((False, False, False), (True, False, False),
+                                        (False, True, True), (True, True, False), (True, True, True)):
+            with self.subTest(core=core, streamer=streamer, ccache=ccache), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                for name in ("core", "streamer", "ccache"):
+                    (root / name).mkdir()
+                (root / "ccache/ccache.conf").write_text("max_size = 1G\n")
+                for present, artifact in ((core, "core/libdependency.rlib"),
+                                          (streamer, "streamer/libdependency.rlib"),
+                                          (ccache, "ccache/compiledR")):
+                    if present:
+                        (root / artifact).write_bytes(b"fixture")
+                result = subprocess.run(["bash", "-euo", "pipefail", "-c", script], env={
+                    **os.environ,
+                    "CORE_TARGET": str(root / "core"),
+                    "STREAMER_TARGET": str(root / "streamer"),
+                    "CXX_CACHE": str(root / "ccache"),
+                    "GITHUB_OUTPUT": str(root / "output"),
+                    "GITHUB_STEP_SUMMARY": str(root / "summary"),
+                }, capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual((root / "output").read_text(),
+                                 f"rust-warm={str(core and streamer).lower()}\nccache-warm={str(ccache).lower()}\n")
+                self.assertIn("Only default-branch", (root / "summary").read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opennow-qt/tests/test_linux_build_cache.py
+++ b/opennow-qt/tests/test_linux_build_cache.py
@@ -12,6 +12,20 @@ ACTION = ROOT / ".github/actions/linux-build-cache/action.yml"
 
 
 class LinuxBuildCacheTest(unittest.TestCase):
+    def test_timestamped_cpp_archives_have_explicit_restore_prefixes(self):
+        caches = 0
+        for path in (ROOT / ".github/actions/qt-unit-tests/action.yml",
+                     ROOT / ".github/workflows/qt-build.yml",
+                     ROOT / ".github/workflows/qt-release-candidate.yml"):
+            for entry in path.read_text().split("uses: hendrikmuhs/ccache-action@")[1:]:
+                with self.subTest(path=path, cache=caches):
+                    step = re.split(r"\n\s+- ", entry, 1)[0]
+                    key = re.search(r"^\s+key: (.+)$", step, re.MULTILINE)[1]
+                    restore = re.search(r"^\s+restore-keys: (.+)$", step, re.MULTILINE)[1]
+                    self.assertEqual(restore, key)
+                    caches += 1
+        self.assertEqual(caches, 4)
+
     def test_disks_are_stable_and_only_default_branch_jobs_commit(self):
         action = ACTION.read_text()
         self.assertEqual(action.count("uses: useblacksmith/stickydisk@25e27b93b68733b532d9af6b201df28ffaf7dbfc"), 5)


### PR DESCRIPTION
Mount pinned Blacksmith sticky disks for Linux check and unsigned-package jobs: Cargo registry, Git dependencies, core/streamer target directories, and the C++ compiler cache. Keys separate architectures and check/release profiles without depending on source revisions or runner CPU count. Cargo and ccache continue validating build inputs.

Only default-branch push/manual jobs commit snapshots; other jobs consume isolated clones. Keep Blacksmith's Sticky Disk Branch Protection enabled (confirmed enabled during this work). Warm disks bypass Rust archive cleanup and redundant C++ archive transfer. Empty/partially populated disks retain the existing branch-scoped archive fallback, and Windows/macOS retain archive caching. A job summary distinguishes populated disks from cold ones.

**Rollout:** once this workflow reaches `main`, run `qt-ci` manually on `main` with publishing disabled to seed both check and package disks. Branch protection deliberately prevents this PR or `dev` from seeding trusted snapshots; pre-merge runs validate mounting and archive fallback, not cross-run sticky persistence.

Explicit C++ restore prefixes also fix lookup of timestamped archives across the checks, unsigned builds, and release-candidate workflows. Same-branch repeat runs confirmed Rust/SDL hits but still missed every C++ archive before this correction.

Validation: all 70 Python workflow/packaging contract tests pass, including executed empty/partial/populated cache probes; actionlint 1.7.12 passes for all four Qt workflows; composite Bash syntax and `git diff --check` pass. Initial normal CI and the full artifact-only run passed. Live logs confirm Linux disks mount/unmount successfully and Blacksmith refuses branch writes as intended; a same-branch repeat restored Rust/SDL archives on Linux and Windows. A new run is verifying explicit C++ prefix restoration. Trusted sticky snapshot reuse still requires seeding on main.

This follows #870, whose artifact-only run passed in 17m02s versus the investigated 29m19s run.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M23X5SX5B19JFYJ7DRDT5XAX"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->