### PR TITLE
fix(streamer): report only network RTT as ping

### DIFF
--- a/native/opennow-streamer/README.md
+++ b/native/opennow-streamer/README.md
@@ -175,25 +175,27 @@ reception loss since stream start). Values are null before a stream is known.
 Reading these measurements does not advance RTCP report intervals. Qt forwards
 measured values without converting nulls into zeros.
 
-The optional `pingMs` field measures round-trip time on the active session. It prefers
+The optional `pingMs` field measures network round-trip time on the active session. It prefers
 the nominated ICE candidate pair's measured RTT, then authenticated STUN/NATT replies
-on the dedicated video socket or control/audio bundle, then a timed RTSPS keepalive.
+on the dedicated video socket or control/audio bundle. RTSPS keepalive response times
+are not used: they include application-level request handling and can overstate network latency.
 STUN replies must match an outstanding transaction, the peer address, fingerprint, and
 message integrity. Each receiver tracks at most 64 probes. ICE statistics only refresh
 the sample when the pair's response count changes; rereading old statistics cannot keep
 an old measurement alive.
 
-The control fallback follows [OpenNOW-Mac's live-tested keepalive method](https://github.com/OpenCloudGaming/OpenNOW-Mac/blob/90627114383501dd18ef165baa005d9ea603fdf3/GFN/NVST/Rtsp/NvstRtspConnection.swift#L161-L234):
+Session liveness follows [OpenNOW-Mac's live-tested keepalive method](https://github.com/OpenCloudGaming/OpenNOW-Mac/blob/90627114383501dd18ef165baa005d9ea603fdf3/GFN/NVST/Rtsp/NvstRtspConnection.swift#L161-L234):
 send `GET_PARAMETER` with the RTSP Session header every two seconds over the existing
-RTSPS WebSocket, and time the matching response. A `551 Option Not Supported` response
-still measures a real round trip. Some seats do not answer STUN/ICE probes and close the
+RTSPS WebSocket, and match the response. A `551 Option Not Supported` response
+still completes the keepalive. Some seats do not answer STUN/ICE probes and close the
 connection on client WebSocket pings, so those pings are replaced by session-scoped
 RTSP keepalives. Server-initiated WebSocket pings are still answered with pongs.
 
 Measurements expire after five seconds, and new sessions start without a sample.
-Missing or expired ping is emitted as null. No discovery-server ping, remote-clock
+Missing or expired ping is emitted as null, including on seats that only answer RTSPS
+keepalives. No discovery-server ping, remote-clock
 assumptions, stale handshake timing, or synthesized ICE replies supply this metric.
-Ping is network/control-path RTT, not one-way video or input-to-display latency. Decode duration
+Ping is network RTT, not control-request, decode, one-way video, or input-to-display latency. Decode duration
 and end-to-end latency remain unavailable without a measurement source; Qt hides those
 two metrics when unavailable in the panel, compact bar, and copied statistics.
 

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/lib.rs
@@ -32,7 +32,7 @@ mod queue_drops;
 
 use microphone::MicrophoneController;
 
-use nvst_rtsp::{ActiveNvstRtspSession, NvstControlPing, prepare_owned_nvst};
+use nvst_rtsp::{ActiveNvstRtspSession, prepare_owned_nvst};
 use queue_drops::QueueDropReports;
 
 pub use opennow_streamer_transport::{EncodedMediaFrame, MediaConsumer};
@@ -109,7 +109,6 @@ struct ActiveNvstResources {
     bundle: NvstUdpReceiverControl,
     mjolnir: Option<NvstUdpReceiverControl>,
     feedback: SharedNvstFeedback,
-    control_ping: Option<NvstControlPing>,
     media: Option<MediaControl>,
 }
 
@@ -118,12 +117,7 @@ impl NvstSessionResources for ActiveNvstResources {
         self.feedback.haptics.take()
     }
     fn ping_ms(&self) -> Option<f64> {
-        let now = Instant::now();
-        self.feedback.ping_ms(now).or_else(|| {
-            self.control_ping
-                .as_ref()
-                .and_then(|ping| ping.ping_ms(now))
-        })
+        self.feedback.ping_ms(Instant::now())
     }
     fn network_metrics(&self) -> Option<(f64, f64)> {
         self.feedback.network_metrics()
@@ -891,9 +885,6 @@ impl Engine {
                 bundle: bundle_control,
                 mjolnir: mjolnir_control,
                 feedback,
-                control_ping: prepared_nvst
-                    .as_ref()
-                    .map(|prepared| prepared.control_ping.clone()),
                 media: self.media_session.as_ref().map(MediaSession::control),
             });
             nvst_events = Some(event_receiver);
@@ -3045,6 +3036,62 @@ mod tests {
             assert!(telemetry.get("pingMs").is_some());
             assert_eq!(telemetry["pingMs"], json!(ping_ms));
         }
+    }
+
+    #[test]
+    fn active_video_telemetry_requires_a_network_ping_sample() {
+        let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let peer = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let config = parse_nvst_video_handoff(&json!({
+            "nvstVideo": {
+                "clientUdpPort": socket.local_addr().unwrap().port(),
+                "videoPeerIp": "127.0.0.1",
+                "videoPeerPort": peer.local_addr().unwrap().port(),
+                "srtpAesKeyHex": "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
+                "srtpSaltHex": "00000000000000009ECA935E",
+                "codec": "H264"
+            }
+        }))
+        .unwrap()
+        .unwrap();
+        let feedback = config.feedback();
+        let (media_sender, _media_receiver) = std::sync::mpsc::sync_channel(1);
+        let (event_sender, _event_receiver) = std::sync::mpsc::channel();
+        let transport = spawn_nvst_udp_receiver_with_socket(
+            config,
+            media_sender,
+            event_sender,
+            Some(socket),
+            None,
+        )
+        .unwrap();
+        let resources = ActiveNvstResources {
+            bundle: transport.control(),
+            mjolnir: None,
+            feedback,
+            media: None,
+        };
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let mut state = NvstMediaFeedbackState::new(true);
+        state.telemetry_window_started = Instant::now() - Duration::from_secs(1);
+        forward_nvst_media_feedback(
+            &EventSender::unbounded(sender),
+            &connected_lifecycle(),
+            7,
+            &resources,
+            MediaFeedback::VideoFrameAccepted {
+                frame_index: Some(72),
+                timestamp: 90_000,
+                bytes: 125_000,
+                keyframe: false,
+            },
+            &mut state,
+        );
+        let telemetry = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        transport.stop();
+        assert_eq!(telemetry["type"], "telemetry");
+        assert!(telemetry["framesPerSecond"].as_f64().unwrap() > 0.0);
+        assert_eq!(telemetry.get("pingMs"), Some(&Value::Null));
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
@@ -17,6 +17,7 @@ use tungstenite::{Message, WebSocket, connect};
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(2);
+#[cfg(test)]
 const CONTROL_PING_EXPIRY: Duration = Duration::from_secs(5);
 const CONTROL_IO_TIMEOUT: Duration = Duration::from_millis(100);
 const MAX_REQUEST_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
@@ -57,12 +58,13 @@ struct RtspClient {
 }
 
 #[derive(Clone, Default)]
-pub struct NvstControlPing {
+struct NvstControlPing {
     sample: Arc<Mutex<Option<(Instant, Duration)>>>,
 }
 
 impl NvstControlPing {
-    pub fn ping_ms(&self, now: Instant) -> Option<f64> {
+    #[cfg(test)]
+    fn ping_ms(&self, now: Instant) -> Option<f64> {
         let mut sample = self.sample.lock().ok()?;
         let (received_at, elapsed) = (*sample)?;
         if now.checked_duration_since(received_at)? >= CONTROL_PING_EXPIRY {
@@ -287,7 +289,7 @@ fn rtsp_connect_error(error: &tungstenite::Error) -> NvstRtspError {
 }
 
 pub struct PreparedNvstRtspSession {
-    pub control_ping: NvstControlPing,
+    control_ping: NvstControlPing,
     client: Option<RtspClient>,
     target: String,
     common_headers: Vec<(&'static str, String)>,


### PR DESCRIPTION
The stream ping fell back to timed RTSPS `GET_PARAMETER` responses when ICE/STUN measurements were unavailable. Those timings include application-level request handling and can overstate network latency.

Use only fresh ICE candidate-pair RTT or authenticated STUN/NATT probe RTT for `pingMs`. Remove the control-timing connection from active telemetry resources and keep its accessor private to keepalive tests. RTSPS keepalives and shutdown behavior remain unchanged. Sessions without a fresh network measurement now emit null, which the existing Qt stats display renders as N/A.

Add coverage exercising active UDP resources through video telemetry without a network ping sample, and document the network-only metric and availability tradeoff.

Validation on Linux:
- Focused core ping tests: 18 passed.
- Native streamer workspace: 570 passed, 9 existing tests ignored.
- Core Clippy, all targets with warnings denied: passed.
- Workspace Rust formatting and `git diff --check`: passed.

Live GFN gameplay was not verified; this environment has no authenticated session.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M24017ZPGJPGQGT9684G15Q1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->