### PR TITLE
fix(ci): isolate Windows frame interpolation tests

### DIFF
--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -100,6 +100,10 @@ if(BUILD_TESTING)
     endif()
     set_tests_properties(opennow-hdrcolor-tests PROPERTIES TIMEOUT 60)
     set_tests_properties(opennow-frameinterpolator-tests PROPERTIES TIMEOUT 60)
+    if(WIN32)
+        set_tests_properties(opennow-frameinterpolator-tests PROPERTIES
+            RUN_SERIAL TRUE TIMEOUT 180)
+    endif()
     qt_add_executable(opennow-streamcolor-tests tests/tst_streamcolor.cpp)
     target_include_directories(opennow-streamcolor-tests PRIVATE src)
     target_link_libraries(opennow-streamcolor-tests PRIVATE
@@ -540,6 +544,7 @@ if(BUILD_TESTING)
         set_target_properties(
             opennow-controllericons-tests
             opennow-waylandhdroutput-tests
+            opennow-frameinterpolator-tests
             opennow-localization-tests
             opennow-qt-tests
             opennow-coreclient-tests


### PR DESCRIPTION
The manual build in [run 34407159033](https://github.com/OpenCloudGaming/OpenNOW/actions/runs/34407159033) produced all unsigned packages but failed when the Windows frame-interpolator test exceeded 60 seconds. The same source passed that test in 35.65 seconds in the preceding push run.

Run this GPU-heavy test serially on Windows and allow a bounded 180 seconds, without changing its cases or assertions. Build its Windows runner as a console executable so CTest captures QtTest diagnostics instead of timing out with no output. Linux and macOS retain their existing scheduling and timeout.

Validation: all 65 Python build/packaging contract tests pass; `git diff --check` passes. Local native configuration is blocked by missing Qt 6.8. Windows validation and a full manual build with `publish_nightly=false` will run on this branch.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2414ZNM1YXXDM7CMMCCFFFY"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->