### PR TITLE
fix(core): send the local timezone offset to CloudMatch

### DIFF
--- a/native/opennow-core/Cargo.lock
+++ b/native/opennow-core/Cargo.lock
@@ -23,6 +23,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +267,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -811,6 +831,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1198,7 @@ name = "opennow-core"
 version = "1.0.0"
 dependencies = [
  "base64",
+ "chrono",
  "ed25519-dalek",
  "httpdate",
  "keyring",
@@ -2273,10 +2318,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/native/opennow-core/Cargo.toml
+++ b/native/opennow-core/Cargo.toml
@@ -7,6 +7,7 @@ rust-version = "1.85"
 
 [dependencies]
 base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ed25519-dalek = "2.2"
 httpdate = "1"
 md5 = "0.7"

--- a/native/opennow-core/src/cloudmatch.rs
+++ b/native/opennow-core/src/cloudmatch.rs
@@ -796,7 +796,7 @@ fn build_create_body(app_id: &str, params: &Value, settings: &Value, device_id: 
         "clientDisplayHdrCapabilities":null,
         "surroundAudioInfo":0,
         "remoteControllersBitmap":0,
-        "clientTimezoneOffset":0,
+        "clientTimezoneOffset":chrono::Local::now().offset().utc_minus_local() * 1000,
         "enhancedStreamMode":0,
         "appLaunchMode":app_launch_mode(params),
         "secureRTSPSupported":true,
@@ -1779,6 +1779,20 @@ mod tests {
                 "device-id",
             );
             assert_eq!(body["sessionRequestData"]["appLaunchMode"], expected);
+        }
+    }
+
+    #[test]
+    fn native_session_requests_use_the_current_local_timezone_in_milliseconds() {
+        let offset_before = chrono::Local::now().offset().utc_minus_local() * 1000;
+        let created = build_create_body("12345", &json!({}), &json!({}), "device-id");
+        let resumed = build_resume_body("12345", &json!({}), &json!({}), "device-id");
+        let offset_after = chrono::Local::now().offset().utc_minus_local() * 1000;
+        for body in [created, resumed] {
+            let offset = body["sessionRequestData"]["clientTimezoneOffset"]
+                .as_i64()
+                .unwrap();
+            assert!(offset == i64::from(offset_before) || offset == i64::from(offset_after));
         }
     }
 

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
@@ -98,6 +98,35 @@ fn stream_ping_bounds_pending_requests_and_expires_late_replies() {
 }
 
 #[test]
+fn stream_ping_keeps_fresh_source_priority_when_other_samples_arrive_later() {
+    let feedback = NvstFeedbackState::default();
+    let start = Instant::now();
+    *feedback.ice_ping.lock().unwrap() = Some((start, Duration::from_millis(10)));
+    feedback.publish_ping(
+        true,
+        start + Duration::from_secs(1),
+        Duration::from_millis(30),
+    );
+    feedback.publish_ping(
+        false,
+        start + Duration::from_secs(2),
+        Duration::from_millis(50),
+    );
+    assert_eq!(feedback.ping_ms(start + Duration::from_secs(2)), Some(10.0));
+    assert_eq!(feedback.ping_ms(start + STREAM_PING_TIMEOUT), Some(30.0));
+    feedback.publish_ping(
+        false,
+        start + STREAM_PING_TIMEOUT,
+        Duration::from_millis(60),
+    );
+    assert_eq!(feedback.ping_ms(start + STREAM_PING_TIMEOUT), Some(30.0));
+    assert_eq!(
+        feedback.ping_ms(start + STREAM_PING_TIMEOUT + Duration::from_secs(1)),
+        Some(60.0)
+    );
+}
+
+#[test]
 fn stream_ping_prefers_video_with_fresh_bundle_fallback_and_resets_per_session() {
     let feedback = NvstFeedbackState::default();
     let start = Instant::now();


### PR DESCRIPTION
## Changes
- Replace the hardcoded UTC offset with the OS's current local offset, including daylight saving, for both session creation and resume. Send UTC-minus-local milliseconds, matching [OpenNOW-Mac's native session request](https://github.com/OpenCloudGaming/OpenNOW-Mac/blob/666bd4a3391e13b074b37eecfd61d568e9231d34/OPN/GameServices/OPNSessionManager.swift#L114).
- Add timezone request coverage and a transport regression test proving that newer video/bundle samples do not override a fresh higher-priority ping source. Ping selection behavior is unchanged: ICE → video → bundle, with five-second expiry. This does not claim to fix reported ping jumps.

## Verification
- Full Rust core test suite passed; focused CloudMatch tests passed with `TZ=Asia/Kathmandu`.
- Timezone regression passed separately under UTC, America/New_York, Europe/Berlin, Asia/Kolkata, and Pacific/Chatham.
- All 8 focused ping tests and all 156 transport tests passed.
- Core and transport Clippy (`--all-targets -- -D warnings`), touched-file formatting, and `git diff --check` passed.
- Live VM clock and gameplay ping behavior require an authenticated GFN session and were not verified here.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M254GCBJCWHZ5FFSFC917GDT"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->