### PR TITLE
fix(qt): block free-tier launches of premium games

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -3066,6 +3066,8 @@
     "s_qt_store_page_05": "Loaded %1 of %2 games",
     "s_qt_store_page_06": "Load more",
     "s_qt_store_direct_launch": "Direct launch",
+    "s_qt_membership_launch_unavailable": "Membership details unavailable. Please try again.",
+    "s_qt_membership_launch_required": "This game requires a paid GeForce NOW membership.",
     "s_qt_store_categories": "Categories",
     "s_qt_store_searching": "Searching…",
     "s_qt_audio_navigation": "Output and stream audio",

--- a/opennow-qt/qml/state/ShellStore.qml
+++ b/opennow-qt/qml/state/ShellStore.qml
@@ -1037,6 +1037,21 @@ QtObject {
         return /^\d+$/.test(launchId) ? launchId : ""
     }
 
+    function selectedGameMembershipError() {
+        const requiredTier = String(selectedGame.membershipTierLabel || "").trim()
+        if (requiredTier === "" || /^free(?: tier|-tier)?$/i.test(requiredTier))
+            return ""
+        const accountTier = String((subscription && subscription.membershipTier) || "").trim()
+        if (accountTier === "") {
+            if (subscriptionRequestId === "")
+                subscriptionRequestId = CoreClient.request("account.subscription.get", {}, 30000)
+            return qsTr("Membership details unavailable. Please try again.")
+        }
+        if (/^free(?: tier|-tier)?$/i.test(accountTier))
+            return qsTr("This game requires a paid GeForce NOW membership.")
+        return ""
+    }
+
     function launchSelectedGame(directConsoleMode) {
         if (!signedIn) {
             AppController.navigate("sign-in")
@@ -1051,6 +1066,14 @@ QtObject {
         }
         if (!ready || streamBusy)
             return
+        const membershipError = selectedGameMembershipError()
+        if (membershipError !== "") {
+            streamState = "error"
+            streamMessage = membershipError
+            lastError = membershipError
+            AppController.navigate("inserting")
+            return
+        }
         streamerRestartAttempts = 0
         streamerRecoveryExhausted = false
         sessionReconnectAttempts = 0

--- a/opennow-qt/tests/tst_embeddedorchestration.cpp
+++ b/opennow-qt/tests/tst_embeddedorchestration.cpp
@@ -17,6 +17,81 @@ class EmbeddedOrchestrationTest final : public QObject
     Q_OBJECT
 
 private slots:
+    void premiumGamesRequirePaidMembershipBeforeLaunch_data()
+    {
+        QTest::addColumn<QString>("requiredTier");
+        QTest::addColumn<QString>("subscriptionJson");
+        QTest::addColumn<bool>("allowed");
+        QTest::addColumn<bool>("refreshMembership");
+        QTest::newRow("free-premium") << QStringLiteral("Premium") << QStringLiteral(R"({"membershipTier":"FREE"})") << false << false;
+        QTest::newRow("free-tier-premium") << QStringLiteral("Performance") << QStringLiteral(R"({"membershipTier":" Free Tier "})") << false << false;
+        QTest::newRow("free-hyphen-premium") << QStringLiteral("Ultimate") << QStringLiteral(R"({"membershipTier":"free-tier"})") << false << false;
+        QTest::newRow("paid-premium") << QStringLiteral("Premium") << QStringLiteral(R"({"membershipTier":"PERFORMANCE"})") << true << false;
+        QTest::newRow("alliance-paid-premium") << QStringLiteral("Premium") << QStringLiteral(R"({"membershipTier":"Priority"})") << true << false;
+        QTest::newRow("unrestricted") << QStringLiteral("") << QStringLiteral(R"({"membershipTier":"FREE"})") << true << false;
+        QTest::newRow("blank-requirement") << QStringLiteral("  ") << QStringLiteral("null") << true << false;
+        QTest::newRow("free-requirement") << QStringLiteral(" FREE ") << QStringLiteral(R"({"membershipTier":"FREE"})") << true << false;
+        QTest::newRow("free-tier-requirement") << QStringLiteral("Free Tier") << QStringLiteral("null") << true << false;
+        QTest::newRow("free-hyphen-requirement") << QStringLiteral("free-tier") << QStringLiteral("null") << true << false;
+        QTest::newRow("subscription-loading") << QStringLiteral("Premium") << QStringLiteral("null") << false << true;
+        QTest::newRow("subscription-missing-tier") << QStringLiteral("Premium") << QStringLiteral("{}") << false << true;
+        QTest::newRow("subscription-blank-tier") << QStringLiteral("Premium") << QStringLiteral(R"({"membershipTier":" "})") << false << true;
+    }
+
+    void premiumGamesRequirePaidMembershipBeforeLaunch()
+    {
+        QFETCH(QString, requiredTier);
+        QFETCH(QString, subscriptionJson);
+        QFETCH(bool, allowed);
+        QFETCH(bool, refreshMembership);
+        const auto shell = source(QStringLiteral("qml/state/ShellStore.qml"));
+        QJSEngine engine;
+        engine.installExtensions(QJSEngine::TranslationExtension);
+        for (const auto &name : {"selectedLaunchAppId", "selectedGameMembershipError", "launchSelectedGame"}) {
+            const auto match = QRegularExpression(QStringLiteral(
+                "    function %1\\([^\\n]*\\) \\{.*?\\n    \\}").arg(QString::fromLatin1(name)),
+                QRegularExpression::DotMatchesEverythingOption).match(shell);
+            QVERIFY(match.hasMatch());
+            QVERIFY(!engine.evaluate(match.captured()).isError());
+        }
+        engine.globalObject().setProperty(QStringLiteral("requiredTier"), requiredTier);
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            var signedIn = true, ready = true, streamBusy = false;
+            var selectedGame = {launchAppId: "123", title: "Test", membershipTierLabel: requiredTier};
+            var authSession = {user: {membershipTier: "FREE"}};
+            var subscriptionRequestId = "", streamState = "idle", streamMessage = "", lastError = "";
+            var settings = {}, regions = [], pendingLaunchParams = null;
+            var requests = [], routes = [];
+            var CoreClient = {request: function(method, params) {
+                requests.push({method: method, params: params}); return "request-" + requests.length;
+            }};
+            var AppController = {navigate: function(route) { routes.push(route); }};
+        )JS")).isError());
+        QVERIFY(!engine.evaluate(QStringLiteral("var subscription = ") + subscriptionJson).isError());
+        QVERIFY(!engine.evaluate(QStringLiteral("launchSelectedGame(false)")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("streamState")).toString(),
+                 allowed ? QStringLiteral("checking") : QStringLiteral("error"));
+        QCOMPARE(engine.evaluate(QStringLiteral("pendingLaunchParams !== null")).toBool(), allowed);
+        QCOMPARE(engine.evaluate(QStringLiteral("requests.length")).toInt(), allowed || refreshMembership ? 1 : 0);
+        if (allowed || refreshMembership) {
+            QCOMPARE(engine.evaluate(QStringLiteral("requests[0].method")).toString(),
+                     allowed ? QStringLiteral("session.remote.list") : QStringLiteral("account.subscription.get"));
+        }
+        QCOMPARE(engine.evaluate(QStringLiteral("routes[0]")).toString(), QStringLiteral("inserting"));
+        if (!allowed) {
+            QVERIFY(!engine.evaluate(QStringLiteral("streamMessage")).toString().isEmpty());
+            QCOMPARE(engine.evaluate(QStringLiteral("lastError")).toString(),
+                     engine.evaluate(QStringLiteral("streamMessage")).toString());
+            QVERIFY(!engine.evaluate(QStringLiteral("launchSelectedGame(true)")).isError());
+            QCOMPARE(engine.evaluate(QStringLiteral("requests.length")).toInt(), refreshMembership ? 1 : 0);
+            QVERIFY(!engine.evaluate(QStringLiteral(
+                "subscription = {membershipTier: 'ULTIMATE'}; launchSelectedGame(true)")).isError());
+            QCOMPARE(engine.evaluate(QStringLiteral("streamState")).toString(), QStringLiteral("checking"));
+            QCOMPARE(engine.evaluate(QStringLiteral("requests[requests.length - 1].method")).toString(),
+                     QStringLiteral("session.remote.list"));
+        }
+    }
+
     void clipboardPasteUsesTheSharedOptInOnBothSurfaces()
     {
         const auto controls = source(QStringLiteral(


### PR DESCRIPTION
Block premium-game launches in the shared Qt launch function before session discovery or creation. Desktop, console, and direct launches use the same check.

- Compare the catalog's minimum membership label with the loaded subscription, matching the Mac client's Free / Free Tier / Free-Tier normalization.
- Show a paid-membership explanation for free accounts. If subscription details are missing, request them once and require a retry instead of guessing from the login token.
- Preserve launches for paid memberships and games without a paid-membership requirement.

Validation: all 45 embedded orchestration test cases pass, including 13 membership cases. `opennow-qt_qmllint` completed successfully with warnings, `npm run locales:check` passed, and `git diff --check` passed. A before/after check confirms that the free-tier premium launch previously requested `session.remote.list` and now issues no session requests. Live NVIDIA account testing was not performed.

The screenshot uses the production session-starting QML screen and launch functions with fixture account/game data:

![Premium membership launch restriction](https://api-nightly.capy.ai/pr-assets/tD-rBVQyRQAVP_rP_N6-2pcOY2eTsNBdKrKTIHeEK5o)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M25FQB7A246MAPX49VWNNA4G"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->