### PR TITLE
fix(streamer): allow TLS 1.2 for Alliance RTSPS servers

### DIFF
--- a/native/opennow-streamer/Cargo.lock
+++ b/native/opennow-streamer/Cargo.lock
@@ -1664,6 +1664,7 @@ dependencies = [
  "opennow-streamer-platform",
  "opennow-streamer-protocol",
  "opennow-streamer-transport",
+ "rcgen",
  "rustls",
  "serde_json",
  "tungstenite",
@@ -2042,6 +2043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
 dependencies = [
  "aws-lc-rs",
+ "ring",
  "rustls-pki-types",
  "time",
  "x509-parser",
@@ -3096,6 +3098,7 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/native/opennow-streamer/Cargo.toml
+++ b/native/opennow-streamer/Cargo.toml
@@ -54,7 +54,7 @@ socket2 = { version = "0.5", features = ["all"] }
 str0m = { version = "0.23", default-features = false }
 subtle = "2"
 thiserror = "2"
-rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "ring", "tls12"] }
 tungstenite = { version = "0.28", default-features = false, features = ["handshake", "rustls-tls-native-roots"] }
 
 [profile.release]

--- a/native/opennow-streamer/crates/opennow-streamer-core/Cargo.toml
+++ b/native/opennow-streamer/crates/opennow-streamer-core/Cargo.toml
@@ -17,3 +17,4 @@ tungstenite.workspace = true
 
 [dev-dependencies]
 opennow-streamer-platform = { path = "../opennow-streamer-platform", features = ["test-runtime"] }
+rcgen = { version = "0.14", default-features = false, features = ["crypto", "ring"] }

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
@@ -1381,6 +1381,10 @@ fn set_io_timeout(socket: &mut WebSocket<MaybeTlsStream<TcpStream>>, timeout: Du
 mod control_ping_tests;
 
 #[cfg(test)]
+#[path = "nvst_rtsp_tls_tests.rs"]
+mod tls_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -1453,6 +1457,21 @@ mod tests {
             "shortcuts": {}
         }))
         .expect("context")
+    }
+
+    #[test]
+    fn rtsps_supports_tls12_and_tls13_without_legacy_versions() {
+        let versions: Vec<_> = rustls::DEFAULT_VERSIONS
+            .iter()
+            .map(|version| version.version)
+            .collect();
+        assert_eq!(
+            versions,
+            vec![
+                rustls::ProtocolVersion::TLSv1_3,
+                rustls::ProtocolVersion::TLSv1_2
+            ]
+        );
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp_tls_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp_tls_tests.rs
@@ -1,0 +1,95 @@
+use super::*;
+use std::net::TcpListener;
+
+fn exchange_over_tls(
+    server_versions: &[&'static rustls::SupportedProtocolVersion],
+    expected_version: rustls::ProtocolVersion,
+) {
+    ensure_tls_crypto_provider().unwrap();
+    let rcgen::CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
+    let server_config = rustls::ServerConfig::builder_with_protocol_versions(server_versions)
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![cert.der().clone()],
+            rustls::pki_types::PrivatePkcs8KeyDer::from(signing_key.serialize_der()).into(),
+        )
+        .unwrap();
+    let mut roots = rustls::RootCertStore::empty();
+    roots.add(cert.der().clone()).unwrap();
+    let client_config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let stream = TcpStream::connect(address).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let (server_stream, _) = listener.accept().unwrap();
+    server_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    server_stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let server = thread::spawn(move || {
+        let connection = rustls::ServerConnection::new(Arc::new(server_config)).unwrap();
+        let mut socket =
+            tungstenite::accept(rustls::StreamOwned::new(connection, server_stream)).unwrap();
+        assert_eq!(
+            socket.get_ref().conn.protocol_version(),
+            Some(expected_version)
+        );
+        let Message::Text(request) = socket.read().unwrap() else {
+            panic!("expected an RTSP request");
+        };
+        assert!(request.starts_with("OPTIONS rtsps://localhost:322 RTSP/1.0\r\n"));
+        assert!(request.contains("\r\nCSeq: 1\r\n"));
+        socket
+            .send(Message::Text(
+                "RTSP/1.0 200 OK\r\nCSeq: 1\r\nContent-Length: 0\r\n\r\n".into(),
+            ))
+            .unwrap();
+    });
+    let (socket, _) = tungstenite::client_tls_with_config(
+        format!("wss://localhost:{}/rtsp", address.port()),
+        stream,
+        None,
+        Some(tungstenite::Connector::Rustls(Arc::new(client_config))),
+    )
+    .unwrap();
+    let MaybeTlsStream::Rustls(tls) = socket.get_ref() else {
+        panic!("RTSPS must remain encrypted");
+    };
+    assert_eq!(tls.conn.protocol_version(), Some(expected_version));
+    let mut client = RtspClient {
+        socket,
+        cseq: 0,
+        buffer: String::new(),
+    };
+    let response = client
+        .request("OPTIONS", "rtsps://localhost:322", &[], "")
+        .unwrap();
+    assert_eq!(response.status, 200);
+    server.join().unwrap();
+}
+
+#[test]
+fn rtsps_exchanges_requests_with_tls12_only_servers() {
+    exchange_over_tls(&[&rustls::version::TLS12], rustls::ProtocolVersion::TLSv1_2);
+}
+
+#[test]
+fn rtsps_exchanges_requests_with_tls13_only_servers() {
+    exchange_over_tls(&[&rustls::version::TLS13], rustls::ProtocolVersion::TLSv1_3);
+}
+
+#[test]
+fn rtsps_prefers_tls13_when_both_versions_are_available() {
+    exchange_over_tls(rustls::DEFAULT_VERSIONS, rustls::ProtocolVersion::TLSv1_3);
+}


### PR DESCRIPTION
The native streamer disabled rustls defaults without enabling `tls12`, so its RTSPS WebSocket client offered only TLS 1.3. TLS 1.2-only servers reject that handshake with the reported fatal `ProtocolVersion` alert. OpenNOW-Mac's RTSPS connection explicitly permits TLS 1.2 and newer.

Enable rustls TLS 1.2 support while retaining TLS 1.3 preference, native certificate validation, and the existing endpoint allowlist. No Qt UI or provider-specific fallback changes are needed.

Add regression coverage for the supported protocol list and local encrypted WebSocket/RTSP exchanges against TLS 1.2-only, TLS 1.3-only, and dual-version servers. Test certificates and keys are generated in memory.

Validation:
- The protocol-list test failed before the fix: actual `[TLSv1_3]`, expected `[TLSv1_3, TLSv1_2]`.
- All four focused TLS tests pass.
- `cargo test --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace`: 581 passed, 9 ignored.
- `cargo clippy --locked --manifest-path native/opennow-streamer/Cargo.toml -p opennow-streamer-core --all-targets -- -D warnings`: passed.
- Workspace formatting and `git diff --check`: passed.

Live Alliance-provider login and gameplay were not tested; no account/session was available.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M25X4FK6FFEY5Y5Z8MQD6DTH"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->