### PR TITLE
fix(qt): align onboarding controls and add setup replay

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,16 @@
 {
+  "onboardingReplay": {
+    "title": "Replay onboarding",
+    "confirmation": "Replay onboarding?",
+    "description": "Restart OpenNOW and walk through setup again. Your preferences are kept.",
+    "sessionActive": "End your streaming session before replaying setup.",
+    "restart": "Restart and replay",
+    "restarting": "Restarting…",
+    "confirmationDescription": "OpenNOW will restart to show the introduction and setup steps. Your saved preferences and account will not be reset.",
+    "disconnected": "The connection was interrupted. Reconnect and try again.",
+    "failed": "Setup could not be reset. Try again.",
+    "failedDetail": "Setup could not be reset. %1"
+  },
   "clipboardSettings": {
     "title": "Clipboard paste",
     "description": "Paste local text into the stream with Ctrl+V (Command+V on macOS). Up to 64 KiB per paste. No automatic clipboard sync.",

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -262,6 +262,18 @@ setup keeps the draft and presents the error for retry. Selecting console mode d
 not replace the wizard while its settings are being saved. No payment or diagnostic
 upload happens during onboarding.
 
+To repeat setup, open **Settings → About → Replay onboarding** at the bottom of
+the page, then confirm **Restart and replay**. OpenNOW saves only
+`onboardingCompleted=false` before restarting; other preferences and saved accounts
+are kept. End an active or starting stream first. A failed save leaves the app open
+and allows retrying. The replacement process starts after the old window, core,
+native runtime and single-instance listener have been released.
+
+The Picture step uses the same aspect-ratio groups, monitor filter and resolution
+stepper as Settings. Selection still edits the onboarding draft rather than saving
+immediately. Short pages center within the available content area; longer pages
+remain scrollable, including keyboard focus inside the expanded resolution picker.
+
 On macOS, setup requires the `awdl0` interface to be down. Boost offers an explicit,
 confirmed disable action using the macOS administrator prompt. Finish and Skip
 both check the current interface state, with a fresh check before sending the
@@ -288,6 +300,11 @@ QT_QPA_PLATFORM=offscreen build/opennow-qt/opennow-qt \
 `--onboarding-step` accepts 0 through 5. Add `--smoke-light-theme` or
 `--onboarding-ui-scale 1.25` to inspect alternate appearances. For the existing
 provider sign-in screen, replace `--onboarding-step 0` with `--onboarding-login`.
+Add `--onboarding-ui-check` to verify centering and draft resolution selection, and
+`--onboarding-resolution-expanded --onboarding-step 2` to exercise the expanded
+picker. Use `--onboarding-replay-check` to verify the Settings confirmation,
+cancellation and failed-save retry; add `--onboarding-replay-dialog` for a dialog
+screenshot. These replay UI fixtures do not restart the test process.
 Add `--onboarding-awdl-check --onboarding-step 3` to exercise the macOS card with an
 injected controller on any platform. This checks confirmation, cancellation,
 restore, busy, error and unsupported states without changing a network interface.

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -41,7 +41,30 @@ if(BUILD_TESTING)
     set_tests_properties(opennow-onboarding-tests PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 30)
     qt_add_resources(opennow-qt "onboarding-acceptance"
-        PREFIX "/acceptance" BASE tests FILES tests/OnboardingAcceptance.qml tests/OnboardingScrollAcceptance.qml tests/OnboardingAwdlAcceptance.qml)
+        PREFIX "/acceptance" BASE tests FILES tests/OnboardingAcceptance.qml tests/OnboardingScrollAcceptance.qml tests/OnboardingAwdlAcceptance.qml tests/OnboardingReplayAcceptance.qml tests/OnboardingUiAcceptance.qml)
+    foreach(width 960 1440)
+        add_test(NAME "qml-onboarding-replay-${width}" COMMAND opennow-qt
+            --smoke-test --allow-multiple-instances --desktop --route settings
+            --smoke-onboarding --onboarding-replay-check --smoke-width ${width} --reduced-motion)
+        set_tests_properties("qml-onboarding-replay-${width}" PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 30)
+    endforeach()
+    foreach(width 960 1440)
+        foreach(step 0 2 5)
+            add_test(NAME "qml-onboarding-layout-${width}-${step}" COMMAND opennow-qt
+                --smoke-test --allow-multiple-instances --desktop --route home
+                --smoke-onboarding --onboarding-ui-check --onboarding-step ${step}
+                --smoke-width ${width} --smoke-height 900 --onboarding-ui-scale 1.25 --reduced-motion)
+            set_tests_properties("qml-onboarding-layout-${width}-${step}" PROPERTIES
+                ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 30)
+        endforeach()
+        add_test(NAME "qml-onboarding-resolution-${width}" COMMAND opennow-qt
+            --smoke-test --allow-multiple-instances --desktop --route home
+            --smoke-onboarding --onboarding-ui-check --onboarding-step 2 --onboarding-resolution-expanded
+            --smoke-width ${width} --smoke-height 540 --onboarding-ui-scale 1.25 --reduced-motion)
+        set_tests_properties("qml-onboarding-resolution-${width}" PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 30)
+    endforeach()
     foreach(width 960 1440)
         if(width EQUAL 960)
             set(awdl_height 540)

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -41,6 +41,7 @@ ApplicationWindow {
     readonly property bool settingsLoaded: Object.keys(ShellStore.settings || {}).length > 0
     readonly property bool onboardingVisible: ShellStore.signedIn
         && !ShellStore.authRestorePending
+        && !ShellStore.onboardingReplaying
         && (ShellStore.onboardingRequired || ShellStore.onboardingSaving
             || ShellStore.onboardingError !== "")
         && !ShellStore.activeSession

--- a/opennow-qt/qml/desktop/onboarding/DesktopOnboardingPicture.qml
+++ b/opennow-qt/qml/desktop/onboarding/DesktopOnboardingPicture.qml
@@ -177,33 +177,12 @@ Column {
             Column {
                 id: rows
                 width: parent.width
-                SettingRow {
-                    width: parent.width; title: qsTr("Resolution"); glyph: "monitor"
-                    description: qsTr("Choose the size of your stream.")
-                    ComboBox {
-                        id: resolutionPicker
-                        objectName: "onboardingResolution"
-                        readonly property var choices: root.store.resolutionItems().filter(item => item.kind !== "heading")
-                        width: DesktopTokens.px(216); height: DesktopTokens.px(40)
-                        model: choices; textRole: "label"; valueRole: "value"
-                        currentIndex: choices.findIndex(item => item.value === root.resolution)
-                        Accessible.name: qsTr("Resolution")
-                        onActivated: index => { if (!choices[index].disabled) root.store.setOnboardingSetting("resolution", choices[index].value) }
-                        background: Rectangle { radius: height / 2; color: DesktopTokens.raised; border.color: resolutionPicker.activeFocus ? Theme.focus : Theme.seam }
-                        contentItem: Text {
-                            leftPadding: DesktopTokens.px(14); rightPadding: DesktopTokens.px(32)
-                            text: resolutionPicker.displayText + "   " + root.resolution.replace("x", "×"); color: Theme.label
-                            font.family: Theme.bodyFont; font.pixelSize: DesktopTokens.px(13); font.weight: Font.ExtraBold
-                            verticalAlignment: Text.AlignVCenter; elide: Text.ElideRight
-                        }
-                        indicator: DesktopSettingsIcon { x: parent.width - width - DesktopTokens.px(12); anchors.verticalCenter: parent.verticalCenter; width: DesktopTokens.px(12); height: width; glyph: "chevron"; rotation: 90; ink: Theme.label }
-                        delegate: ItemDelegate {
-                            required property var modelData
-                            width: resolutionPicker.width; text: modelData.label
-                            enabled: !modelData.disabled
-                            font.family: Theme.bodyFont; font.pixelSize: DesktopTokens.px(13)
-                        }
-                    }
+                DesktopSettingsResolution {
+                    objectName: "onboardingResolution"
+                    width: parent.width
+                    items: root.store.resolutionItems()
+                    value: root.resolution
+                    onSelected: value => root.store.setOnboardingSetting("resolution", value)
                 }
                 SettingRow {
                     width: parent.width; title: qsTr("Frame rate"); glyph: "speed"

--- a/opennow-qt/qml/desktop/onboarding/DesktopOnboardingScreen.qml
+++ b/opennow-qt/qml/desktop/onboarding/DesktopOnboardingScreen.qml
@@ -88,13 +88,21 @@ FocusScope {
             ancestor = ancestor.parent
         if (!ancestor)
             return
-        const point = focused.mapToItem(pageBody, 0, 0)
         const margin = DesktopTokens.px(16)
-        if (point.y < pageScroll.contentY + margin)
-            pageScroll.contentY = Math.max(0, point.y - margin)
-        else if (point.y + focused.height > pageScroll.contentY + pageScroll.height - margin)
-            pageScroll.contentY = Math.min(Math.max(0, pageScroll.contentHeight - pageScroll.height),
-                point.y + focused.height - pageScroll.height + margin)
+        ancestor = focused.parent
+        while (ancestor) {
+            if (ancestor instanceof Flickable) {
+                const point = focused.mapToItem(ancestor.contentItem, 0, 0)
+                if (point.y < ancestor.contentY + margin)
+                    ancestor.contentY = Math.max(0, point.y - margin)
+                else if (point.y + focused.height > ancestor.contentY + ancestor.height - margin)
+                    ancestor.contentY = Math.min(Math.max(0, ancestor.contentHeight - ancestor.height),
+                        point.y + focused.height - ancestor.height + margin)
+            }
+            if (ancestor === pageScroll)
+                break
+            ancestor = ancestor.parent
+        }
     }
 
     onStepIndexChanged: {
@@ -400,8 +408,8 @@ FocusScope {
             ColumnLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                Layout.leftMargin: DesktopTokens.px(root.compact ? 20 : 24)
-                Layout.rightMargin: DesktopTokens.px(root.compact ? 20 : 64)
+                Layout.leftMargin: DesktopTokens.px(root.compact ? 20 : 40)
+                Layout.rightMargin: DesktopTokens.px(root.compact ? 20 : 40)
                 spacing: DesktopTokens.px(12)
 
                 RowLayout {
@@ -442,15 +450,17 @@ FocusScope {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     contentWidth: width
-                    contentHeight: pageBody.implicitHeight + DesktopTokens.px(24)
+                    readonly property real pageMargin: DesktopTokens.px(root.compact ? 16 : 28)
+                    contentHeight: Math.max(height, pageBody.y + pageBody.implicitHeight + pageMargin)
                     clip: true
                     boundsBehavior: Flickable.StopAtBounds
                     ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
                     Column {
                         id: pageBody
+                        objectName: "onboardingPageBody"
                         width: pageScroll.width
+                        y: Math.max(pageScroll.pageMargin, (pageScroll.height - implicitHeight) / 2)
                         spacing: DesktopTokens.px(28)
-                        topPadding: DesktopTokens.px(root.compact ? 16 : 28)
                         Column {
                             visible: root.stepIndex !== 0
                             width: parent.width
@@ -494,8 +504,8 @@ FocusScope {
         Rectangle {
             visible: root.error !== ""
             Layout.fillWidth: true
-            Layout.leftMargin: DesktopTokens.px(root.compact ? 20 : 260)
-            Layout.rightMargin: DesktopTokens.px(root.compact ? 20 : 64)
+            Layout.leftMargin: DesktopTokens.px(root.compact ? 20 : 276)
+            Layout.rightMargin: DesktopTokens.px(root.compact ? 20 : 40)
             implicitHeight: errorLabel.implicitHeight + DesktopTokens.px(24)
             radius: DesktopTokens.px(10)
             color: Qt.rgba(root.coral.r,root.coral.g,root.coral.b,0.12)

--- a/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
+++ b/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
@@ -32,7 +32,7 @@ FocusScope {
         {label: qsTr("Console mode"), detail: qsTr("Gamepad-first interface"), icon: "controller", page: 9, keywords: "console fullscreen gamepad startup"},
         {label: qsTr("Network"), detail: qsTr("Region, ping, proxy"), icon: "globe", page: 6, keywords: "server region ping proxy l4s"},
         {label: qsTr("Account"), detail: qsTr("NVIDIA, stores, privacy"), icon: "person", page: 0, keywords: "profile subscription stores steam epic xbox ubisoft battle gaijin privacy"},
-        {label: qsTr("About"), detail: qsTr("Updates, diagnostics"), icon: "info", page: 11, keywords: "version release update diagnostics"}
+        {label: qsTr("About"), detail: qsTr("Updates, diagnostics"), icon: "info", page: 11, keywords: "version release update diagnostics onboarding introduction replay setup restart"}
     ]
     readonly property var pageTitles: [qsTr("Account"), qsTr("Account"), qsTr("Account"), qsTr("Stream"), qsTr("Audio"), qsTr("Controls"), qsTr("Network"), qsTr("Look"), qsTr("Look"), qsTr("Console mode"), qsTr("Controls"), qsTr("About"), qsTr("Recording")]
     readonly property var pageComponents: [accountGroup, subscriptionPage, accountGroup, streamPage, audioPage, controlsGroup, networkPage, lookGroup, lookGroup, consolePage, controlsGroup, aboutPage, recordingPage]

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsAboutPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsAboutPage.qml
@@ -69,4 +69,77 @@ Column {
             showDivider: false
         }
     }
+    DesktopSettingsPanel {
+        width: parent.width; paperStyle: true
+        DesktopSettingsRow {
+            width: parent.width; paperStyle: true; glyph: "arrows"
+            title: qsTr("Replay onboarding")
+            description: ShellStore.onboardingReplayError || (ShellStore.activeSession || ShellStore.streamBusy
+                || ["idle", "error"].indexOf(ShellStore.streamState) < 0
+                ? qsTr("End your streaming session before replaying setup.")
+                : qsTr("Restart OpenNOW and walk through setup again. Your preferences are kept."))
+            showDivider: false
+            DesktopSettingsButton {
+                objectName: "replayOnboardingButton"
+                text: ShellStore.onboardingReplaying ? qsTr("Restarting…") : qsTr("Replay onboarding")
+                enabled: ShellStore.onboardingReplayAvailable
+                onClicked: replayConfirmation.open()
+            }
+        }
+    }
+
+    Dialog {
+        id: replayConfirmation
+        objectName: "replayOnboardingConfirmation"
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        width: Math.min(DesktopTokens.px(520), parent.width - DesktopTokens.px(32))
+        contentWidth: width - leftPadding - rightPadding
+        implicitHeight: header.implicitHeight + replayCopy.implicitHeight + footer.implicitHeight
+            + topPadding + bottomPadding
+        padding: DesktopTokens.px(22)
+        modal: true
+        focus: true
+        closePolicy: Popup.CloseOnEscape
+        title: qsTr("Replay onboarding?")
+        header: Text {
+            width: replayConfirmation.width
+            text: replayConfirmation.title
+            padding: DesktopTokens.px(22)
+            bottomPadding: 0
+            color: Theme.label
+            font.family: Theme.bodyFont
+            font.pixelSize: DesktopTokens.px(20)
+            font.weight: Font.ExtraBold
+            wrapMode: Text.WordWrap
+        }
+        background: Rectangle { radius: DesktopTokens.px(16); color: Theme.shell; border.color: Theme.seam }
+        contentItem: Text {
+            id: replayCopy
+            width: replayConfirmation.contentWidth
+            text: qsTr("OpenNOW will restart to show the introduction and setup steps. Your saved preferences and account will not be reset.")
+            color: Theme.textMuted
+            font.family: Theme.bodyFont
+            font.pixelSize: DesktopTokens.bodySize
+            wrapMode: Text.WordWrap
+        }
+        footer: DialogButtonBox {
+            padding: DesktopTokens.px(16)
+            implicitHeight: DesktopTokens.controlHeight + topPadding + bottomPadding
+            background: Item {}
+            DesktopSettingsButton {
+                objectName: "replayOnboardingCancel"
+                text: qsTr("Cancel")
+                DialogButtonBox.buttonRole: DialogButtonBox.RejectRole
+            }
+            DesktopSettingsButton {
+                objectName: "replayOnboardingConfirm"
+                text: qsTr("Restart and replay")
+                primary: true
+                enabled: ShellStore.onboardingReplayAvailable
+                DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
+            }
+        }
+        onAccepted: ShellStore.replayOnboarding()
+    }
 }

--- a/opennow-qt/qml/state/ShellStore.qml
+++ b/opennow-qt/qml/state/ShellStore.qml
@@ -67,6 +67,11 @@ QtObject {
         ready: root.ready
         signedIn: root.signedIn
         checkRequirements: root.checkOnboardingRequirements
+        replayAllowed: root.ready && !root.activeSession && !root.streamBusy
+            && root.activeSessionRequestId === "" && root.sessionClaimRequestId === ""
+            && ["idle", "error"].indexOf(root.streamState) >= 0
+            && ["starting", "streaming", "stopping"].indexOf(root.streamerStatus) < 0
+        onRestartRequested: AppController.restartApplication()
         onRequirementsMissing: root.onboardingRequirementsMissing()
         onSettingSaved: (key, value, changes) => {
             settingsOwner.applyCoupledSettings(changes)
@@ -82,6 +87,10 @@ QtObject {
     readonly property var onboardingSettings: onboardingOwner.settings
     readonly property bool onboardingSaving: onboardingOwner.saving
     readonly property string onboardingError: onboardingOwner.error
+    readonly property bool onboardingReplayAvailable: onboardingOwner.replayAllowed
+        && !onboardingOwner.saving && !onboardingOwner.replaying
+    readonly property bool onboardingReplaying: onboardingOwner.replaying
+    readonly property string onboardingReplayError: onboardingOwner.replayError
     signal onboardingCompleted()
     signal onboardingRequirementsMissing()
 
@@ -109,6 +118,10 @@ QtObject {
 
     function finishOnboarding() {
         onboardingOwner.finish()
+    }
+
+    function replayOnboarding() {
+        onboardingOwner.replay()
     }
 
     property alias previewThemePack: settingsOwner.previewThemePack
@@ -1058,7 +1071,7 @@ QtObject {
         if (!pendingDirectLaunch)
             return
         if (Object.keys(settings).length === 0 || onboardingRequired
-                || onboardingSaving || onboardingError !== "")
+                || onboardingSaving || onboardingReplaying || onboardingError !== "")
             return
         if (catalogState !== "ready") {
             if (ready && catalogRequestId === "")
@@ -1126,7 +1139,7 @@ QtObject {
             lastError = streamMessage
             return
         }
-        if (!ready || streamBusy)
+        if (!ready || streamBusy || onboardingReplaying)
             return
         const membershipError = selectedGameMembershipError()
         if (membershipError !== "") {
@@ -1173,7 +1186,7 @@ QtObject {
     }
 
     function createPendingSession() {
-        if (!pendingLaunchParams || !ready || streamCreateRequestId !== "")
+        if (!pendingLaunchParams || !ready || streamCreateRequestId !== "" || onboardingReplaying)
             return
         streamState = "requesting"
         streamMessage = qsTr("Requesting a cloud gaming seat…")

--- a/opennow-qt/qml/state/settings/OnboardingState.qml
+++ b/opennow-qt/qml/state/settings/OnboardingState.qml
@@ -15,13 +15,20 @@ QtObject {
     property string requestId: ""
     property string requestKey: ""
     property var remainingKeys: []
+    property bool replayAllowed: false
+    property bool replaying: false
+    property string replayRequestId: ""
+    property string replayError: ""
     signal completed()
+    signal restartRequested()
     signal requirementsMissing()
     signal settingSaved(string key, var value, var changes)
 
     onReadyChanged: {
         if (!ready && saving)
             fail(qsTr("The connection was interrupted. Reconnect and try saving again."))
+        if (!ready && replayRequestId !== "")
+            failReplay(qsTr("The connection was interrupted. Reconnect and try again."))
     }
     onSignedInChanged: {
         if (!signedIn) {
@@ -45,7 +52,7 @@ QtObject {
     }
 
     function finish() {
-        if (saving)
+        if (saving || replaying)
             return
         if (!ready || !signedIn) {
             error = qsTr("Connect and sign in before finishing setup.")
@@ -94,6 +101,15 @@ QtObject {
     }
 
     function acceptResponse(id, result) {
+        if (replayRequestId !== "" && id === replayRequestId) {
+            if (result.value !== false) {
+                failReplay(qsTr("Setup could not be reset. Try again."))
+                return true
+            }
+            replayRequestId = ""
+            restartRequested()
+            return true
+        }
         if (!saving || id !== requestId || requestId === "")
             return false
         const key = requestKey
@@ -106,6 +122,10 @@ QtObject {
     }
 
     function acceptFailure(id, message) {
+        if (replayRequestId !== "" && id === replayRequestId) {
+            failReplay(qsTr("Setup could not be reset. %1").arg(message))
+            return true
+        }
         if (!saving || id !== requestId || requestId === "")
             return false
         fail(qsTr("Setup could not be saved. Your choices are still here. %1").arg(message))
@@ -118,5 +138,21 @@ QtObject {
         remainingKeys = []
         saving = false
         error = message
+    }
+
+    function replay() {
+        if (!ready || !replayAllowed || saving || replaying)
+            return
+        replayError = ""
+        replaying = true
+        replayRequestId = coreClient.request("settings.set", {key: "onboardingCompleted", value: false})
+        if (replayRequestId === "")
+            failReplay(qsTr("Setup could not be reset. Try again."))
+    }
+
+    function failReplay(message) {
+        replayRequestId = ""
+        replaying = false
+        replayError = message
     }
 }

--- a/opennow-qt/src/acceptance/SmokeAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SmokeAcceptance.cpp
@@ -45,7 +45,11 @@ int AcceptanceSession::startSmokeWorkload()
         const bool customBackground = m_arguments.contains(u"--smoke-custom-background"_s);
         const bool streamStats = m_arguments.contains(u"--smoke-stream-stats"_s);
         QQmlComponent component(&m_engine, QUrl(m_arguments.contains(u"--smoke-onboarding"_s)
-            ? m_arguments.contains(u"--onboarding-awdl-check"_s)
+            ? m_arguments.contains(u"--onboarding-replay-check"_s)
+                ? u"qrc:/acceptance/OnboardingReplayAcceptance.qml"_s
+                : m_arguments.contains(u"--onboarding-ui-check"_s)
+                ? u"qrc:/acceptance/OnboardingUiAcceptance.qml"_s
+                : m_arguments.contains(u"--onboarding-awdl-check"_s)
                 ? u"qrc:/acceptance/OnboardingAwdlAcceptance.qml"_s
                 : m_arguments.contains(u"--onboarding-scroll-check"_s)
                 ? u"qrc:/acceptance/OnboardingScrollAcceptance.qml"_s

--- a/opennow-qt/src/app/AppController.cpp
+++ b/opennow-qt/src/app/AppController.cpp
@@ -413,6 +413,11 @@ void AppController::quitApplication()
     QCoreApplication::quit();
 }
 
+void AppController::restartApplication()
+{
+    emit restartRequested();
+}
+
 bool AppController::handleArguments(const QStringList &arguments)
 {
     static const QStringList appIdFlags{u"--launch-app-id"_s, u"--app-id"_s};

--- a/opennow-qt/src/app/AppController.h
+++ b/opennow-qt/src/app/AppController.h
@@ -51,6 +51,7 @@ public:
     Q_INVOKABLE bool ensureDirectLaunchAssociation() const;
     Q_INVOKABLE void activateWindow();
     Q_INVOKABLE void quitApplication();
+    Q_INVOKABLE void restartApplication();
     Q_INVOKABLE bool handleArguments(const QStringList &arguments);
 
     void setOverlayTransitionGuard(std::function<bool(bool)> guard);
@@ -67,6 +68,7 @@ signals:
     void controllerCountChanged();
     void inputModeChanged();
     void activationRequested();
+    void restartRequested();
     void directLaunchRequested(const QString &appId, const QString &title);
 
 private:

--- a/opennow-qt/src/app/ApplicationStartup.cpp
+++ b/opennow-qt/src/app/ApplicationStartup.cpp
@@ -28,6 +28,7 @@
 #include <QQuickWindow>
 #include <QSGRendererInterface>
 #include <QFileOpenEvent>
+#include <QProcess>
 
 #include <cstdlib>
 
@@ -61,7 +62,7 @@ private:
 };
 }
 
-int runApplication(int argc, char *argv[])
+static int runApplicationSession(int argc, char *argv[], QString &restartExecutable)
 {
     qputenv("QT_TLS_BACKEND", "schannel");
     QElapsedTimer startupTimer;
@@ -108,6 +109,15 @@ int runApplication(int argc, char *argv[])
         return EXIT_SUCCESS;
     }
     AppController controller;
+    QObject::connect(&controller, &AppController::restartRequested, &application, [&] {
+        restartExecutable = QCoreApplication::applicationFilePath();
+#ifdef Q_OS_LINUX
+        const auto appImage = qEnvironmentVariable("APPIMAGE");
+        if (!appImage.isEmpty())
+            restartExecutable = appImage;
+#endif
+        application.quit();
+    });
     if (!controller.ensureDirectLaunchAssociation())
         qWarning("Could not register the opennow:// direct-launch association");
     FileOpenFilter fileOpenFilter(&controller);
@@ -275,5 +285,18 @@ int runApplication(int argc, char *argv[])
                  qUtf8Printable(nativeStreamRuntime.lastError()));
     }
 #endif
+    return exitCode;
+}
+
+int runApplication(int argc, char *argv[])
+{
+    QString restartExecutable;
+    const auto exitCode = runApplicationSession(argc, argv, restartExecutable);
+    if (restartExecutable.isEmpty())
+        return exitCode;
+    if (!QProcess::startDetached(restartExecutable, {}, QFileInfo(restartExecutable).absolutePath())) {
+        qCritical("Could not restart OpenNOW. Reopen the application to continue setup.");
+        return EXIT_FAILURE;
+    }
     return exitCode;
 }

--- a/opennow-qt/tests/OnboardingReplayAcceptance.qml
+++ b/opennow-qt/tests/OnboardingReplayAcceptance.qml
@@ -1,0 +1,62 @@
+import QtQuick
+import OpenNOW
+
+QtObject {
+    id: root
+    property OnboardingAcceptance acceptance: OnboardingAcceptance {}
+    property var contentRoot: null
+    property var page: null
+
+    function run(parent) {
+        contentRoot = parent
+        ShellStore.authRestorePending = false
+        ShellStore.authSession = {user: {displayName: "Setup fixture", userId: "onboarding-replay-fixture"}}
+        ShellStore.activeSession = null
+        ShellStore.settings = Object.assign({}, ShellStore.settings, {
+            onboardingCompleted: true, desktopUiScale: 1.25, reducedMotion: true
+        })
+        const owner = ShellStore.onboardingOwnerState
+        owner.coreClient = acceptance.client
+        owner.ready = true
+        owner.replayAllowed = true
+        AppController.navigate("settings")
+        const screen = acceptance.find(parent, "desktopSettingsScreen")
+        acceptance.check(screen, "settings did not open")
+        screen.selectedSection = 11
+        page = acceptance.find(screen, "settingsPageLoader").item
+        const button = acceptance.find(page, "replayOnboardingButton")
+        acceptance.check(button && button.enabled, "replay action is missing or disabled")
+        let flick = button.parent
+        while (flick && !(flick instanceof Flickable))
+            flick = flick.parent
+        acceptance.check(flick, "About is not scrollable")
+        flick.contentY = Math.max(0, flick.contentHeight - flick.height)
+        button.clicked()
+        return true
+    }
+
+    function verify() {
+        const confirmation = page.data.find(item => item.objectName === "replayOnboardingConfirmation")
+        acceptance.check(confirmation && confirmation.opened, "replay confirmation did not open")
+        const owner = ShellStore.onboardingOwnerState
+        confirmation.reject()
+        acceptance.check(acceptance.client.requests.length === 0, "cancel reset onboarding")
+        confirmation.open()
+        confirmation.accept()
+        acceptance.check(owner.replaying && acceptance.client.requests.length === 1,
+            "confirmation did not request a single reset")
+        acceptance.check(!owner.needed, "reset changed the visible shell before persistence")
+        const request = acceptance.client.requests[0]
+        acceptance.check(request.params.key === "onboardingCompleted" && request.params.value === false,
+            "replay wrote the wrong setting")
+        owner.acceptFailure(request.id, "Fixture denied settings persistence")
+        acceptance.check(!owner.replaying && ShellStore.onboardingReplayError.length > 0,
+            "failed reset did not remain available for retry")
+        acceptance.check(acceptance.find(page, "replayOnboardingButton").enabled,
+            "failed reset disabled retry")
+        owner.replayError = ""
+        if (Qt.application.arguments.indexOf("--onboarding-replay-dialog") >= 0)
+            confirmation.open()
+        return true
+    }
+}

--- a/opennow-qt/tests/OnboardingUiAcceptance.qml
+++ b/opennow-qt/tests/OnboardingUiAcceptance.qml
@@ -1,0 +1,100 @@
+import QtQuick
+import OpenNOW
+
+QtObject {
+    property OnboardingAcceptance acceptance: OnboardingAcceptance {}
+    property var contentRoot: null
+
+    function run(parent) {
+        contentRoot = parent
+        acceptance.run(parent)
+        const screen = acceptance.find(parent, "desktopOnboardingScreen")
+        acceptance.check(screen, "UI fixture needs an onboarding step")
+        const step = screen.stepIndex
+        screen.goToStep(2)
+        const picker = acceptance.find(screen, "onboardingResolution")
+        acceptance.check(picker && picker.groups.length > 0 && picker.available.length > 1,
+            "resolution picker lost the grouped settings choices")
+        const persisted = ShellStore.settings.resolution
+        const requests = acceptance.client.requests.length
+        const original = picker.value
+        const choice = picker.available.find(item => item.value !== original)
+        picker.selected(choice.value)
+        acceptance.check(ShellStore.onboardingSettings.resolution === choice.value,
+            "resolution selection did not update the draft")
+        acceptance.check(picker.value === choice.value, "resolution picker did not follow the draft")
+        picker.step(1)
+        acceptance.check(picker.available.some(item => item.value === picker.value),
+            "resolution stepper selected an unavailable choice")
+        acceptance.check(ShellStore.settings.resolution === persisted
+            && acceptance.client.requests.length === requests,
+            "resolution selection persisted before finishing setup")
+        picker.selected(original)
+        screen.goToStep(step)
+        if (Qt.application.arguments.indexOf("--onboarding-resolution-expanded") >= 0) {
+            acceptance.check(step === 2, "expanded resolution capture needs Picture")
+            acceptance.find(screen, "onboardingResolution").expanded = true
+        }
+        return true
+    }
+
+    function verify() {
+        acceptance.verify()
+        const screen = acceptance.find(contentRoot, "desktopOnboardingScreen")
+        const scroll = acceptance.find(screen, "onboardingScroll")
+        const body = acceptance.find(screen, "onboardingPageBody")
+        const point = scroll.mapToItem(screen, 0, 0)
+        const railWidth = screen.compact ? 0 : DesktopTokens.px(236)
+        acceptance.check(Math.abs((point.x - railWidth) - (screen.width - point.x - scroll.width)) <= 1,
+            "onboarding page has unequal horizontal gutters")
+        if (body.height + 2 * scroll.pageMargin <= scroll.height) {
+            acceptance.check(Math.abs(body.y - (scroll.height - body.height) / 2) <= 1,
+                "short onboarding page is not vertically centered")
+            acceptance.check(Math.abs(scroll.contentHeight - scroll.height) <= 1,
+                "short onboarding page scrolls unnecessarily")
+        } else {
+            acceptance.check(Math.abs(body.y - scroll.pageMargin) <= 1,
+                "overflowing onboarding page lost its top margin")
+            acceptance.check(scroll.contentHeight >= body.y + body.height,
+                "overflowing onboarding page is not fully scrollable")
+        }
+        const picker = acceptance.find(screen, "onboardingResolution")
+        if (picker && picker.expanded) {
+            const controls = []
+            function collect(item) {
+                if (!item.visible || !item.enabled)
+                    return
+                if (item.activeFocusOnTab && item.height > 0 && item.height < scroll.height)
+                    controls.push(item)
+                for (const child of item.children || [])
+                    collect(child)
+            }
+            collect(picker)
+            acceptance.check(controls.length > picker.available.length,
+                "expanded resolution choices are not keyboard reachable")
+            for (const control of controls) {
+                control.forceActiveFocus(Qt.TabFocusReason)
+                screen.revealFocusedControl()
+                let ancestor = control.parent
+                while (ancestor) {
+                    if (ancestor instanceof Flickable) {
+                        const position = control.mapToItem(ancestor, 0, 0)
+                        acceptance.check(position.y >= -1
+                            && position.y + control.height <= ancestor.height + 1,
+                            "focused resolution control is vertically clipped")
+                        acceptance.check(position.x >= -1
+                            && position.x + control.width <= ancestor.width + 1,
+                            "focused resolution control is horizontally clipped")
+                    }
+                    if (ancestor === scroll)
+                        break
+                    ancestor = ancestor.parent
+                }
+            }
+            controls[0].forceActiveFocus(Qt.TabFocusReason)
+            picker.children.find(item => item instanceof Flickable).contentY = 0
+            scroll.contentY = 0
+        }
+        return true
+    }
+}

--- a/opennow-qt/tests/onboarding/tst_replay.qml
+++ b/opennow-qt/tests/onboarding/tst_replay.qml
@@ -1,0 +1,119 @@
+import QtQuick
+import QtTest
+import OpenNOW.OnboardingTests
+
+TestCase {
+    id: testCase
+    name: "OnboardingReplay"
+
+    QtObject {
+        id: core
+        property var calls: []
+        property bool refuse: false
+        function request(method, params) {
+            const id = "replay-" + (calls.length + 1)
+            calls = calls.concat([{id: id, method: method, params: params}])
+            return refuse ? "" : id
+        }
+    }
+
+    OnboardingState {
+        id: state
+        coreClient: core
+        persistedSettings: ({onboardingCompleted: true, resolution: "2560x1440"})
+        ready: true
+        signedIn: true
+        checkRequirements: () => ""
+        replayAllowed: true
+    }
+
+    SignalSpy { id: restart; target: state; signalName: "restartRequested" }
+    SignalSpy { id: saved; target: state; signalName: "settingSaved" }
+
+    function init() {
+        state.failReplay("")
+        state.ready = true
+        state.replayAllowed = true
+        core.calls = []
+        core.refuse = false
+        restart.clear()
+        saved.clear()
+    }
+
+    function test_restartWaitsForPersistedFalse() {
+        state.replay()
+        verify(state.replaying)
+        compare(core.calls.length, 1)
+        compare(core.calls[0].method, "settings.set")
+        compare(core.calls[0].params, {key: "onboardingCompleted", value: false})
+        compare(restart.count, 0)
+        state.replay()
+        state.finish()
+        compare(core.calls.length, 1)
+        verify(!state.acceptResponse("unrelated", {value: false}))
+        verify(state.acceptResponse(core.calls[0].id, {value: false}))
+        compare(restart.count, 1)
+        compare(saved.count, 0)
+        verify(!state.needed)
+        compare(state.persistedSettings.resolution, "2560x1440")
+        state.replay()
+        verify(!state.acceptResponse(core.calls[0].id, {value: false}))
+        compare(core.calls.length, 1)
+        compare(restart.count, 1)
+    }
+
+    function test_failedSaveStaysOpenAndCanRetry() {
+        state.replay()
+        verify(state.acceptFailure(core.calls[0].id, "Disk full"))
+        verify(!state.replaying)
+        verify(state.replayError.indexOf("Disk full") >= 0)
+        compare(restart.count, 0)
+        verify(!state.needed)
+        state.replay()
+        compare(state.replayError, "")
+        verify(state.acceptResponse(core.calls[1].id, {value: false}))
+        compare(restart.count, 1)
+    }
+
+    function test_disconnectRejectsLateAcknowledgement() {
+        state.replay()
+        const id = core.calls[0].id
+        state.ready = false
+        verify(!state.replaying)
+        verify(state.replayError.length > 0)
+        state.ready = true
+        verify(!state.acceptResponse(id, {value: false}))
+        compare(restart.count, 0)
+    }
+
+    function test_refusedRequestDoesNotRestart() {
+        core.refuse = true
+        state.replay()
+        verify(!state.replaying)
+        verify(state.replayError.length > 0)
+        compare(restart.count, 0)
+    }
+
+    function test_invalidAcknowledgementDoesNotRestart_data() {
+        return [{tag: "true", value: true}, {tag: "string", value: "false"}, {tag: "missing"}]
+    }
+
+    function test_invalidAcknowledgementDoesNotRestart(data) {
+        state.replay()
+        verify(state.acceptResponse(core.calls[0].id, {value: data.value}))
+        verify(!state.replaying)
+        verify(state.replayError.length > 0)
+        compare(restart.count, 0)
+    }
+
+    function test_unavailableReplayDoesNotWrite() {
+        state.replayAllowed = false
+        state.replay()
+        compare(core.calls.length, 0)
+        state.replayAllowed = true
+        state.ready = false
+        state.replay()
+        compare(core.calls.length, 0)
+        compare(restart.count, 0)
+    }
+}

--- a/opennow-qt/tests/tst_appcontroller.cpp
+++ b/opennow-qt/tests/tst_appcontroller.cpp
@@ -12,6 +12,15 @@ class AppControllerTest final : public QObject
     Q_OBJECT
 
 private slots:
+    void restartIsDelegatedToApplicationLifetimeOwner()
+    {
+        AppController controller;
+        QSignalSpy restart(&controller, &AppController::restartRequested);
+        controller.restartApplication();
+        QCOMPARE(restart.count(), 1);
+        QCOMPARE(controller.route(), QStringLiteral("home"));
+    }
+
     void shortcutCaptureUsesPortableSingleChords()
     {
         AppController controller;

--- a/opennow-qt/tests/tst_embeddedorchestration.cpp
+++ b/opennow-qt/tests/tst_embeddedorchestration.cpp
@@ -56,7 +56,7 @@ private slots:
         }
         engine.globalObject().setProperty(QStringLiteral("requiredTier"), requiredTier);
         QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
-            var signedIn = true, ready = true, streamBusy = false;
+            var signedIn = true, ready = true, streamBusy = false, onboardingReplaying = false;
             var selectedGame = {launchAppId: "123", title: "Test", membershipTierLabel: requiredTier};
             var authSession = {user: {membershipTier: "FREE"}};
             var subscriptionRequestId = "", streamState = "idle", streamMessage = "", lastError = "";


### PR DESCRIPTION
## Onboarding
- Reuse Settings' grouped resolution picker, including the stepper and monitor filter, while keeping selections in the onboarding draft.
- Use equal content gutters and vertically center pages that fit. Preserve scrolling for taller pages and reveal keyboard focus through both the resolution picker and the outer page.

## Replay setup
- Add **Settings → About → Replay onboarding** at the bottom of the page, with a Qt confirmation dialog and searchable settings keywords.
- Save only `onboardingCompleted=false` and wait for acknowledgement before restarting. Failed writes and disconnects leave the app open for retry; active or starting sessions block replay.
- Relaunch after the old QML engine, core, native runtime and single-instance listener have been released. Preserve the AppImage entry point on Linux and avoid replaying previous launch arguments.

## Validation
- Full Debug Qt/native application build passed with Qt 6.8.3 on Linux.
- All **246 Qt tests passed**, including the new replay persistence, confirmation, layout and nested-focus acceptance cases.
- QML syntax validation, `npm run locales:check`, and `git diff --check` passed.
- Visually checked desktop and compact onboarding, scaled UI, and windowed/fullscreen picker interaction using software Vulkan.
- Exercised the live Settings action with an isolated fixture account/core: a new process opened onboarding, the old core had stopped before relaunch, and the only settings change was `onboardingCompleted: true → false`.
- macOS/Windows runtime validation and real-account streaming were not performed locally.

## Screenshots
![Shared resolution picker in onboarding](https://api-nightly.capy.ai/pr-assets/TTvvEtojTo-JyvBxqpdIUVdA6wlh5NzbIv2A7RAeBQU)
![Replay onboarding confirmation](https://api-nightly.capy.ai/pr-assets/KmVmTe8Kyygk5v8UlcLYotER9XZIXZ394FgIXFc-F-U)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M263Q51JB2M5D9EWJJ7R605Q"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->