### PR TITLE
fix(streamer): allow time for Windows firewall approval at startup

### DIFF
--- a/docs/native-streamer-no-video.md
+++ b/docs/native-streamer-no-video.md
@@ -63,6 +63,33 @@ not live WARP interoperability. The affected PC still needs fresh-session retest
 with WARP enabled and disabled; success requires authenticated video, assembled
 frames, and visible playback in both cases.
 
+## Windows firewall prompt during startup
+
+The 2026-09-10 Windows AV1 capture negotiated 2560x1440 at 120 FPS and completed
+PLAY, ICE, DTLS and SCTP. Audio arrived, but the video socket received no datagrams
+before the two eight-second timeouts stopped the session. The user reported that
+playback worked after resolving the firewall prompt. This was not an AV1 decoder
+failure.
+
+Windows sessions now allow 60 seconds for the first authenticated video packet
+before attempting transport recovery. The regular eight-second idle timeout
+applies as soon as authenticated video arrives, and after recovery or resume.
+The startup allowance is not renewed by invalid packets or recovery, and audio
+on the separate bundle socket does not end it. Permission is still controlled
+by Windows; OpenNOW does not add firewall rules or bypass a denied permission.
+
+The internal `nvstVideo` handoff carries optional `startupTimeoutMs`, defaulting
+to `timeoutMs`. It must be at least the idle timeout and no more than 90 seconds.
+The native session negotiator supplies 60 seconds on Windows and eight seconds
+elsewhere. This changes neither the external core protocol nor the C ABI.
+
+To verify on Windows, use a new executable path with no existing firewall rule,
+start a session, and leave the Windows permission prompt open for more than
+16 seconds but less than 60 seconds before allowing access. Video should start
+in the same session. Denying access must still produce a bounded timeout.
+After playback starts, a video delivery failure should still enter recovery
+after eight seconds rather than receiving another startup allowance.
+
 ## Verification
 
 Run the native streamer workspace tests and `opennow-embedded-orchestration-tests`.

--- a/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-core/src/nvst_rtsp.rs
@@ -28,6 +28,11 @@ const MAX_STREAM_BITRATE_MBPS: u64 = 200;
 // while audio/control remained alive; use the official receiver timeout so the existing bounded
 // transport recovery runs promptly.
 const VIDEO_TIMEOUT_MS: u64 = 8_000;
+const VIDEO_STARTUP_TIMEOUT_MS: u64 = if cfg!(windows) {
+    60_000
+} else {
+    VIDEO_TIMEOUT_MS
+};
 
 #[derive(Debug)]
 pub struct NvstRtspError {
@@ -714,7 +719,8 @@ pub fn prepare_owned_nvst(
         "microphoneOnBundle":microphone_available,
         "codec":codec,
         "audioTrack":{"payloadType":111,"codec":"opus","clockRateHz":48000,"channels":2,"mid":"0"},
-        "timeoutMs":VIDEO_TIMEOUT_MS
+        "timeoutMs":VIDEO_TIMEOUT_MS,
+        "startupTimeoutMs":VIDEO_STARTUP_TIMEOUT_MS
     });
     if let Some(media) = context.session.media_connection_info.as_ref() {
         handoff["bundlePeerIp"] = json!(media.ip);
@@ -726,7 +732,7 @@ pub fn prepare_owned_nvst(
         "INFO",
         "nvst-handoff",
         &format!(
-            "video_local_port={mjolnir_port} bundle_local_port={client_port} video_peer_port={video_peer_port} video_peer_port_end={video_peer_port_end} bundle_peer_port={} same_peer_host={} ping_version={ping_version} ping_bytes={} legacy_ping_payload={} srtp_profile={srtp_profile} rtcp_on_sctp={rtcp_on_sctp} sockets_retained=true reachability=unverified",
+            "video_local_port={mjolnir_port} bundle_local_port={client_port} video_peer_port={video_peer_port} video_peer_port_end={video_peer_port_end} bundle_peer_port={} same_peer_host={} ping_version={ping_version} ping_bytes={} legacy_ping_payload={} srtp_profile={srtp_profile} rtcp_on_sctp={rtcp_on_sctp} sockets_retained=true reachability=unverified video_startup_timeout_ms={VIDEO_STARTUP_TIMEOUT_MS} video_idle_timeout_ms={VIDEO_TIMEOUT_MS}",
             context
                 .session
                 .media_connection_info

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -804,6 +804,7 @@ pub struct NvstVideoConfig {
     reorder_window_packets: usize,
     max_access_unit_bytes: usize,
     timeout: Duration,
+    startup_timeout: Duration,
     frame_time_us: u32,
     /// Negotiated `x-nv-video[0].packetSize`; FEC shards are this plus 16 RTP bytes.
     video_packet_size: usize,
@@ -836,6 +837,7 @@ impl fmt::Debug for NvstVideoConfig {
             .field("reorder_window_packets", &self.reorder_window_packets)
             .field("max_access_unit_bytes", &self.max_access_unit_bytes)
             .field("timeout", &self.timeout)
+            .field("startup_timeout", &self.startup_timeout)
             .field("frame_time_us", &self.frame_time_us)
             .field("video_packet_size", &self.video_packet_size)
             .finish()
@@ -1128,6 +1130,14 @@ impl NvstVideoConfig {
         if !(MIN_TIMEOUT..=MAX_TIMEOUT).contains(&timeout) {
             return Err(NvstConfigError::OutOfRange { field: "timeoutMs" });
         }
+        let startup_timeout = optional_u64(object, "startupTimeoutMs")?
+            .map(Duration::from_millis)
+            .unwrap_or(timeout);
+        if !(timeout..=MAX_TIMEOUT).contains(&startup_timeout) {
+            return Err(NvstConfigError::OutOfRange {
+                field: "startupTimeoutMs",
+            });
+        }
         let video_packet_size =
             optional_usize(object, "packetSize")?.unwrap_or(DEFAULT_NVST_VIDEO_PACKET_SIZE);
         if !(MIN_NVST_VIDEO_PACKET_SIZE..=MAX_NVST_VIDEO_PACKET_SIZE).contains(&video_packet_size) {
@@ -1160,6 +1170,7 @@ impl NvstVideoConfig {
             reorder_window_packets,
             max_access_unit_bytes,
             timeout,
+            startup_timeout,
             frame_time_us: DEFAULT_FRAME_TIME_US,
             video_packet_size,
             feedback: Arc::new(NvstFeedbackState::default()),
@@ -3447,6 +3458,7 @@ pub struct NvstVideoReceiver {
     packet_gap_recoveries: u64,
     timeout_origin: Instant,
     last_authenticated_packet: Option<Instant>,
+    initial_timeout_pending: bool,
 }
 
 impl NvstVideoReceiver {
@@ -3480,6 +3492,7 @@ impl NvstVideoReceiver {
             packet_gap_recoveries: 0,
             timeout_origin: Instant::now(),
             last_authenticated_packet: None,
+            initial_timeout_pending: true,
         }
     }
 
@@ -3503,6 +3516,7 @@ impl NvstVideoReceiver {
         self.reset_media_state();
         self.last_authenticated_packet = None;
         self.timeout_origin = Instant::now();
+        self.initial_timeout_pending = false;
         self.state = NvstReceiverState::Running;
         Some(NvstReceiveEvent::Lifecycle(self.state))
     }
@@ -3514,6 +3528,7 @@ impl NvstVideoReceiver {
         self.reset_media_state();
         self.last_authenticated_packet = None;
         self.timeout_origin = Instant::now();
+        self.initial_timeout_pending = false;
         self.state = NvstReceiverState::Running;
         Some(NvstReceiveEvent::Lifecycle(self.state))
     }
@@ -3537,7 +3552,12 @@ impl NvstVideoReceiver {
             .last_authenticated_packet
             .unwrap_or(self.timeout_origin);
         let idle_for = now.saturating_duration_since(last_packet);
-        if idle_for < self.config.timeout {
+        let timeout = if self.initial_timeout_pending {
+            self.config.startup_timeout
+        } else {
+            self.config.timeout
+        };
+        if idle_for < timeout {
             return None;
         }
         self.reset_media_state();
@@ -3603,6 +3623,7 @@ impl NvstVideoReceiver {
         }
         self.bound_ssrc.get_or_insert(packet.header.ssrc);
         self.last_authenticated_packet = Some(now);
+        self.initial_timeout_pending = false;
         self.authenticated_packets += 1;
         let sequence = u32::try_from(packet.index & 0xffff_ffff).unwrap_or(u32::MAX);
         self.highest_sequence_received = self.highest_sequence_received.max(sequence);
@@ -3787,6 +3808,7 @@ impl NvstVideoReceiver {
         }
         self.bound_ssrc.get_or_insert(ssrc);
         self.last_authenticated_packet = Some(now);
+        self.initial_timeout_pending = false;
         // The bundle path cannot assemble video: the Mjolnir frame metadata lives
         // in the `0x4753` RTP extension, which str0m does not surface. The official
         // cloud path delivers video exclusively on the raw Mjolnir socket, so bundle
@@ -8958,6 +8980,139 @@ mod tests {
                 ))
             ));
         }
+    }
+
+    #[test]
+    fn startup_timeout_is_optional_and_bounded_by_idle_timeout_and_maximum() {
+        assert_eq!(config().startup_timeout, config().timeout);
+        for milliseconds in [500, 60_000, 90_000] {
+            let mut handoff = legacy_handoff();
+            handoff["startupTimeoutMs"] = json!(milliseconds);
+            let config = NvstVideoConfig::from_legacy_handoff(&handoff, None).unwrap();
+            assert_eq!(config.startup_timeout, Duration::from_millis(milliseconds));
+        }
+        for invalid in [
+            json!(0),
+            json!(499),
+            json!(90_001),
+            json!(-1),
+            json!("60000"),
+        ] {
+            let mut handoff = legacy_handoff();
+            handoff["startupTimeoutMs"] = invalid;
+            assert!(NvstVideoConfig::from_legacy_handoff(&handoff, None).is_err());
+        }
+    }
+
+    #[test]
+    fn startup_grace_waits_for_firewall_without_spending_recovery_budget() {
+        let mut config = config();
+        config.startup_timeout = Duration::from_secs(60);
+        let mut receiver = NvstVideoReceiver::new(config);
+        let origin = receiver.timeout_origin;
+
+        for seconds in [8, 16, 30, 59] {
+            assert_eq!(
+                receiver.poll_timeout(origin + Duration::from_secs(seconds)),
+                None
+            );
+            assert_eq!(receiver.state(), NvstReceiverState::Running);
+        }
+        assert!(matches!(
+            receiver.poll_timeout(origin + Duration::from_secs(60)),
+            Some(NvstReceiveEvent::RecoveryNeeded(
+                NvstRecovery::Timeout { .. }
+            ))
+        ));
+        assert_eq!(
+            receiver.poll_timeout(origin + Duration::from_secs(61)),
+            None
+        );
+        receiver
+            .recover()
+            .expect("bounded recovery after startup grace");
+        assert!(matches!(
+            receiver.poll_timeout(receiver.timeout_origin + receiver.config.timeout),
+            Some(NvstReceiveEvent::RecoveryNeeded(
+                NvstRecovery::Timeout { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn authenticated_video_ends_startup_grace_and_keeps_idle_recovery_short() {
+        let mut config = config();
+        config.startup_timeout = Duration::from_secs(60);
+        let packet = protect_for_test(
+            &test_srtp(&config),
+            build_plaintext_rtp(
+                1,
+                FLAG_SOF | FLAG_EOF | FLAG_CONTAINS_PIC_DATA,
+                1,
+                &[0, 0, 1, 0x65],
+            ),
+            0,
+        );
+        let mut receiver = NvstVideoReceiver::new(config);
+        let received_at = receiver.timeout_origin + Duration::from_secs(30);
+        assert_eq!(receiver.poll_timeout(received_at), None);
+        let events = receiver.process_datagram(peer(), &packet, received_at);
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, NvstReceiveEvent::Frame(_)))
+        );
+        assert_eq!(receiver.poll_timeout(received_at), None);
+        assert!(matches!(
+            receiver.poll_timeout(received_at + receiver.config.timeout),
+            Some(NvstReceiveEvent::RecoveryNeeded(
+                NvstRecovery::Timeout { .. }
+            ))
+        ));
+        receiver.recover().expect("recover established stream");
+        assert!(matches!(
+            receiver.poll_timeout(receiver.timeout_origin + receiver.config.timeout),
+            Some(NvstReceiveEvent::RecoveryNeeded(
+                NvstRecovery::Timeout { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn invalid_datagrams_do_not_extend_or_end_startup_grace() {
+        let mut config = config();
+        config.startup_timeout = Duration::from_secs(60);
+        let mut receiver = NvstVideoReceiver::new(config);
+        let origin = receiver.timeout_origin;
+        for seconds in [8, 16, 30, 59] {
+            let now = origin + Duration::from_secs(seconds);
+            assert!(matches!(
+                receiver.process_datagram(peer(), &[], now).as_slice(),
+                [NvstReceiveEvent::Dropped(_)]
+            ));
+            assert_eq!(receiver.poll_timeout(now), None);
+        }
+        assert!(matches!(
+            receiver.poll_timeout(origin + Duration::from_secs(60)),
+            Some(NvstReceiveEvent::RecoveryNeeded(
+                NvstRecovery::Timeout { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn resume_does_not_regrant_startup_grace() {
+        let mut config = config();
+        config.startup_timeout = Duration::from_secs(60);
+        let mut receiver = NvstVideoReceiver::new(config);
+        receiver.pause().expect("pause during startup");
+        receiver.resume().expect("resume during startup");
+        assert!(matches!(
+            receiver.poll_timeout(receiver.timeout_origin + receiver.config.timeout),
+            Some(NvstReceiveEvent::RecoveryNeeded(
+                NvstRecovery::Timeout { .. }
+            ))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Windows sessions now allow 60 seconds for the first authenticated video packet before spending the transport recovery attempt. Once video arrives, the existing eight-second idle timeout applies. Recovery and resume also use the normal timeout, so a blocked connection cannot keep renewing the startup allowance. Other platforms retain the eight-second startup behavior.

The failed Windows AV1 capture completed PLAY and ICE/DTLS/SCTP and received audio, but the video socket received zero datagrams before two eight-second timeouts ended the session. This change gives the user time to resolve the Windows firewall prompt without changing codec handling, firewall rules, or recovery limits.

- Add a bounded, optional `startupTimeoutMs` to the internal NVST handoff, defaulting to the existing idle timeout, and include both timeout values in handoff diagnostics.
- Add five regression tests for delayed first video, the bounded startup/recovery sequence, invalid datagrams, resume, and configuration validation.
- Document a Windows permission-dialog retest and the handoff contract.

Verification on Linux:
- All native streamer workspace tests passed: 586 passed, 9 ignored.
- Transport and core Clippy checks passed with `--all-targets -- -D warnings`.
- Changed Rust files passed rustfmt checks; `git diff --check` passed.

The Windows firewall dialog and live GFN playback have not been exercised locally. Retest by allowing the firewall prompt after more than 16 seconds but before 60 seconds, then confirm video starts in the same session.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M26D44CZJY3E876QC1PGBNMH"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->