### PR TITLE
fix(streamer): retire D3D11 decoder with the scene graph

### DIFF
--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
@@ -4124,7 +4124,9 @@ mod tests {
             let mut submission = submission.lock().unwrap();
             assert!(submission.pending.is_empty());
             assert!(submission.submitter.is_none());
-            let outcome = submission.push(embedded_h264_frame(cycle + 1, false)).unwrap();
+            let outcome = submission
+                .push(embedded_h264_frame(cycle + 1, false))
+                .unwrap();
             assert!(outcome.queued && outcome.needs_graphics);
         }
     }

--- a/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-platform/src/media.rs
@@ -2207,9 +2207,23 @@ struct PendingD3d11Frame {
 }
 
 #[cfg(target_os = "windows")]
+impl crate::GraphicsRenderResources for Mutex<EmbeddedD3d11State> {
+    fn retire(&self) -> Result<(), String> {
+        let mut state = self.lock().unwrap_or_else(|error| error.into_inner());
+        state.reset();
+        state.keyframe_required = true;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
 impl crate::GraphicsFrame for PendingD3d11Frame {
     fn info(&self) -> crate::GraphicsFrameInfo {
         self.info
+    }
+
+    fn render_resources(&self) -> Option<Arc<dyn crate::GraphicsRenderResources>> {
+        Some(self.state.clone())
     }
 
     fn record(
@@ -4062,6 +4076,56 @@ mod tests {
             duration_100ns: 166_667,
             key_frame,
             reset_decoder: key_frame,
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn embedded_d3d11_retirement_rearms_graphics_and_reference_recovery() {
+        use crate::GraphicsFrame;
+
+        let submission = Arc::new(Mutex::new(EmbeddedD3d11Submission::new()));
+        let state = Arc::new(Mutex::new(EmbeddedD3d11State::new(
+            MediaStreamConfig::default(),
+            Arc::clone(&submission),
+        )));
+        state.lock().unwrap().first_frame_recorded = true;
+        let (shared, _feedback) = software_test_pipeline();
+        let frame = PendingD3d11Frame {
+            state: Arc::clone(&state),
+            shared,
+            mid: "video".to_owned(),
+            info: crate::GraphicsFrameInfo {
+                width: 1920,
+                height: 1080,
+                sequence: 1,
+                presentation_time_ns: 0,
+            },
+        };
+        let resources = frame.render_resources().expect("D3D11 render resources");
+        assert!(Arc::ptr_eq(&resources, &frame.render_resources().unwrap()));
+
+        for cycle in 0..3 {
+            submission
+                .lock()
+                .unwrap()
+                .push(embedded_h264_frame(cycle, true))
+                .unwrap();
+            resources.retire().unwrap();
+            resources.retire().unwrap();
+
+            let mut state = state.lock().unwrap();
+            assert!(state.producer.is_none());
+            assert!(state.take_keyframe_required());
+            assert!(!state.take_keyframe_required());
+            assert!(!state.take_first_recorded_frame(true));
+            drop(state);
+
+            let mut submission = submission.lock().unwrap();
+            assert!(submission.pending.is_empty());
+            assert!(submission.submitter.is_none());
+            let outcome = submission.push(embedded_h264_frame(cycle + 1, false)).unwrap();
+            assert!(outcome.queued && outcome.needs_graphics);
         }
     }
 


### PR DESCRIPTION
Register the embedded D3D11 state with the existing render-resource retirement contract. Scene-graph shutdown now detaches the compressed-frame submitter and retires the old producer on the render thread. Incoming frames return to the bounded staging queue and bootstrap the replacement context, with a fresh keyframe requested on the next record. Playback-start notification remains session-scoped.

This addresses a persistent black-screen recovery failure seen after decoder queue overflows and Qt graphics-context recreation. Previously, the decoder could remain attached to the retired device, lose its recovery notification while graphics was absent, and consume incoming delta frames without producing another image. This does not establish or fix the cause of the preceding Radeon R7 decoder slowdown or the separate attempt that received no video UDP datagrams.

Validation:
- Added a Windows regression covering stable resource identity, repeated retirement, staging-queue reset, graphics reinitialization, and one-shot keyframe recovery without a duplicate playback-start event.
- Confirmed the regression fails with the retirement hook removed and passes when restored.
- Windows: 120 platform tests and 81 Windows-backend tests passed; six existing environment-specific tests ignored. Platform Clippy passed with `-D warnings`.
- Linux: full native streamer workspace tests and platform Clippy passed.

Live GFN reproduction on the reported Radeon R7 remains unverified. Windows checks ran on an RTX 3080.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M26DM4DFS4P7N2JMKH0TBV8H"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->