### PR TITLE
feat(updater): replace verified installations and restart after confirmation

### DIFF
--- a/.github/actions/qt-unit-tests/action.yml
+++ b/.github/actions/qt-unit-tests/action.yml
@@ -94,6 +94,17 @@ runs:
       run: |
         cargo test --locked --manifest-path native/opennow-core/Cargo.toml
         cargo test --locked --manifest-path native/opennow-streamer/Cargo.toml --workspace
+    - name: Test signed update helper integration
+      shell: bash
+      working-directory: ${{ env.OPENNOW_CHECKOUT }}
+      env:
+        CARGO_BUILD_JOBS: ${{ inputs.parallel }}
+      run: |
+        if [[ "$RUNNER_OS" == Windows ]]; then
+          python opennow-qt/tests/run_update_helper_integration.py
+        else
+          python3 opennow-qt/tests/run_update_helper_integration.py
+        fi
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:

--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -159,7 +159,9 @@ jobs:
       - name: Test Windows MSI upgrades and stable isolation
         if: matrix.label == 'windows-x64'
         shell: pwsh
-        run: opennow-qt/tests/test_windows_installer.ps1
+        run: |
+          opennow-qt/tests/test_windows_installer.ps1
+          opennow-qt/tests/test_windows_helper_dependencies.ps1
 
       - name: Add package Rust target
         if: matrix.rust-target != ''
@@ -303,6 +305,7 @@ jobs:
             native/opennow-core -> target
             native/opennow-streamer -> target
             native/opennow-core -> ../../build/opennow-qt-release/rust-target
+            native/opennow-core -> ../../build/opennow-qt-release/update-helper-rust-target
             native/opennow-streamer -> ../../build/opennow-qt-release/streamer-rust-target
 
       - name: Cache Qt C++ compilation
@@ -373,7 +376,23 @@ jobs:
           cpack --config build/opennow-qt-release/CPackConfig.cmake \
             -C Release \
             -G "$PACKAGE_GENERATOR" \
-            -B build/qt-packages
+            -B build/qt-packages || {
+              status=$?
+              if [[ "$RUNNER_OS" == Windows ]]; then
+                log_count=0
+                while IFS= read -r -d '' log; do
+                  printf '\n--- WiX packaging log: %s (last 200 lines, at most 64 KiB) ---\n' "$log"
+                  tail -n 200 "$log" | tail -c 65536 || true
+                  log_count=$((log_count + 1))
+                  if [[ "$log_count" -ge 4 ]]; then
+                    echo "WiX diagnostics limited to four logs."
+                    break
+                  fi
+                done < <(find build/qt-packages -maxdepth 6 -type f -iname wix.log -print0)
+                if [[ "$log_count" -eq 0 ]]; then echo "No generated WiX logs found."; fi
+              fi
+              exit "$status"
+            }
 
       - name: Verify Windows MSI and portable ZIP payloads
         if: runner.os == 'Windows'
@@ -491,6 +510,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET" \
+            -DOPENNOW_MACOS_ADHOC_SIGN=ON \
             -DOPENNOW_BUILD_VERSION="$OPENNOW_BUILD_VERSION" \
             -DOPENNOW_UPDATE_ED25519_PUBLIC_KEY="$OPENNOW_UPDATE_PUBLIC_KEY" \
             -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/SDL-install"
@@ -529,8 +549,14 @@ jobs:
           hdiutil detach "$mount"
           trap - EXIT
           for app in "$zip_app" "$RUNNER_TEMP/dmg-relocated/OpenNOW.app"; do
+            /usr/bin/codesign --verify --deep --strict "$app"
+            [[ $(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist") == io.github.opencloudgaming.OpenNOW ]]
+            identity=$(/usr/bin/codesign --display --verbose=4 "$app" 2>&1)
+            printf '%s\n' "$identity" | grep -Fx 'Identifier=io.github.opencloudgaming.OpenNOW'
+            printf '%s\n' "$identity" | grep -Fx 'Signature=adhoc'
+            printf '%s\n' "$identity" | grep -Fx 'TeamIdentifier=not set'
             bin="$app/Contents/MacOS"
-            for executable in OpenNOW opennow-core opennow-acceptance-verify opennow-streamer; do
+            for executable in OpenNOW opennow-core opennow-acceptance-verify opennow-update-helper opennow-streamer; do
               test -x "$bin/$executable"
               lipo "$bin/$executable" -verify_arch arm64
             done
@@ -563,7 +589,7 @@ jobs:
 
           bin_dir = Path(sys.argv[1])
           for name in ("OpenNOW", "opennow-core", "opennow-acceptance-verify",
-                       "opennow-streamer", "libopennow_streamer_ffi.dylib"):
+                       "opennow-update-helper", "opennow-streamer", "libopennow_streamer_ffi.dylib"):
               dependencies = subprocess.check_output(["otool", "-L", bin_dir / name], text=True)
               for line in dependencies.splitlines()[1:]:
                   dependency = line.strip().split(" (", 1)[0]

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       publish_nightly:
-        description: Publish an unsigned nightly prerelease after all checks pass
+        description: Publish a nightly with signed update manifests after all checks pass
         type: boolean
         default: false
+      public_key:
+        description: Canonical base64 Ed25519 public key (32 bytes; required to publish)
+        type: string
+        default: ""
   pull_request:
     branches:
       - dev
@@ -52,6 +56,21 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    name: Validate nightly update key
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Require a pinned public key for publication
+        env:
+          OPENNOW_UPDATE_PUBLIC_KEY: ${{ inputs.public_key }}
+          PUBLISH_NIGHTLY: ${{ inputs.publish_nightly }}
+        run: python3 opennow-qt/packaging/sign_nightly_release.py preflight
+
   contracts:
     name: Shared checks
     uses: ./.github/workflows/qt-checks.yml
@@ -106,34 +125,81 @@ jobs:
   build:
     name: Manual packages
     if: github.event_name == 'workflow_dispatch'
-    needs: contracts
+    needs: [contracts, preflight]
     uses: ./.github/workflows/qt-build.yml
     with:
       upload_complete: ${{ github.event_name == 'workflow_dispatch' }}
+      update_public_key: ${{ inputs.public_key }}
+
+  sign-nightly:
+    name: Isolated nightly update signing
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly
+    needs: [preflight, contracts, checks, build]
+    runs-on: [self-hosted, opennow-release-signer]
+    environment: qt-update-signing
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: opennow-qt/packaging
+      - uses: actions/download-artifact@v4
+        with:
+          name: opennow-qt-${{ needs.build.outputs.version }}-complete-unsigned
+          path: unsigned-release
+      - name: Sign and verify the immutable nine-package inventory
+        env:
+          OPENNOW_UPDATE_PUBLIC_KEY: ${{ inputs.public_key }}
+          OPENNOW_UPDATE_ED25519_PRIVATE_KEY: ${{ secrets.OPENNOW_UPDATE_ED25519_PRIVATE_KEY }}
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          python3 opennow-qt/packaging/sign_nightly_release.py sign \
+            --source unsigned-release --destination signed-release \
+            --version "$RELEASE_VERSION" --commit "$SOURCE_SHA"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opennow-qt-${{ needs.build.outputs.version }}-complete-update-signed
+          path: signed-release/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+      - name: Remove signing workspace artifacts
+        if: always()
+        run: rm -rf unsigned-release signed-release
 
   publish-nightly:
-    name: Publish unsigned nightly prerelease
+    name: Publish update-signed nightly prerelease
     if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly
-    needs: [contracts, checks, build]
+    needs: [contracts, checks, build, sign-nightly]
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
     env:
       RELEASE_VERSION: ${{ needs.build.outputs.version }}
       SOURCE_SHA: ${{ github.sha }}
+      OPENNOW_UPDATE_PUBLIC_KEY: ${{ inputs.public_key }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: opennow-qt/packaging
       - uses: actions/download-artifact@v4
         with:
-          name: opennow-qt-${{ needs.build.outputs.version }}-complete-unsigned
+          name: opennow-qt-${{ needs.build.outputs.version }}-complete-update-signed
           path: nightly-release
-      - name: Verify checksums and prepare unsigned release notes
+      - name: Verify signed inventory and prepare release notes
         shell: bash
         run: |
+          python3 opennow-qt/packaging/sign_nightly_release.py verify \
+            --source nightly-release --version "$RELEASE_VERSION" --commit "$SOURCE_SHA"
           (cd nightly-release && sha256sum --check --strict SHA256SUMS)
           cat > nightly-notes.md <<EOF
           Experimental OpenNOW Qt/native nightly from commit \`$SOURCE_SHA\`.
 
-          **All packages are unsigned.** Windows may display a SmartScreen or unknown-publisher warning.
+          **Platform packages remain unsigned; update manifests are Ed25519-signed.** Windows may display a SmartScreen or unknown-publisher warning.
           Windows x64 and ARM64 downloads include MSI installers and portable ZIPs.
           The MSI installs OpenNOW Nightly separately from stable OpenNOW. For the portable ZIP, extract the entire archive and run \`bin/OpenNOW.exe\`.
           The macOS DMG supports Apple Silicon on macOS 13+: open it and drag OpenNOW into Applications.
@@ -141,9 +207,11 @@ jobs:
           Linux AppImages are the recommended portable download; mark the file executable before launching it.
           DEBs require a distribution providing Qt 6.8+ and SDL3; stock Ubuntu 24.04 does not satisfy those requirements.
 
-          These builds have no pinned update-signing key and require manual downloads for updates.
+          These builds pin the update-signing public key and include a verified manifest for every package.
+          If your installed nightly has no pinned key, manually install this release once; that older build cannot securely bootstrap trust from the update feed.
           SHA256SUMS detects corrupted downloads; it is not a cryptographic publisher signature.
           Intel macOS is not included. Windows ARM64 is cross-built, not runtime-tested by CI.
+          **Known issue: Alliance Partners are not working correctly in this build.**
           EOF
       - name: Publish only after the complete upload succeeds
         shell: bash

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -351,6 +351,7 @@ jobs:
           cache-bin: false
           workspaces: |
             native/opennow-core -> ../../build/opennow-qt-release/rust-target
+            native/opennow-core -> ../../build/opennow-qt-release/update-helper-rust-target
             native/opennow-streamer -> ../../build/opennow-qt-release/streamer-rust-target
 
       - name: Cache Qt C++ compilation

--- a/docs/core-protocol.md
+++ b/docs/core-protocol.md
@@ -196,7 +196,7 @@ and artwork only near the viewport, using the section's local category ID
 - `cache.delete`
 - `queue.status.get`, `queue.serverMapping.get`
 - `thanks.data.get`, `communityProxy.provision`
-- `updater.state.get`, `updater.check`, `updater.download`, `updater.install`
+- `updater.state.get`, `updater.check`, `updater.download`, `updater.install`, `updater.startup.ack`
 - `updater.highlights.get`, `updater.highlights.ack`
 - `social.capabilities.get`
 - `discord.activity.sync`, `discord.activity.clear`
@@ -437,6 +437,71 @@ release, independently of `updater.state.get.availableVersion`. Historical notes
 do not emit `updater.highlights.show` or enable downloading a downgrade. Missing
 release bodies and empty channels return an explanatory note instead of the
 pre-check placeholder.
+
+Updater preferences are independent. `autoCheckForUpdates` defaults to `true`;
+`autoDownloadUpdates` defaults to `false` and requires an explicit opt-in. Neither
+preference authorizes installation or application shutdown. New profiles use the
+nightly update channel when the embedded application version has a `nightly`
+prerelease identifier; existing persisted channel choices are preserved.
+
+`updater.install` requires the boolean parameter `confirmed: true`. The core
+serializes update preparation against session creation, claiming, polling, and
+streamer startup. It rejects installation while a CloudMatch session exists or
+the streamer is starting, negotiating, streaming, or recovering. The shell must
+also check its local native-runtime state before requesting installation.
+
+`updater.state.get` is authoritative after an error or request timeout. The core
+emits `updater.changed` after update operations even if the original request was
+cancelled, because cancellation does not undo an installation already prepared
+by the native helper. Clients must not synthesize `canDownload`, `canInstall`, or
+`canCheck` from an error message. A failed check or a later release check does not
+discard an already verified download.
+
+The additive updater state fields `exitRequired` and `installVersion` describe
+the prepared installation, separately from `availableVersion` and
+`downloadedVersion`. The shell may quit for an update only after a confirmed
+install request in that same shell process, with authoritative
+`status: "awaiting-exit"` and `exitRequired: true`, and while the local session
+remains inactive. `preparing`, `applying`, and `restarting` are not permission to
+quit. Terminal outcomes are `succeeded`, `rolled-back`, and `failed`;
+`managed-pending` and `reboot-required` require native package-manager or operating
+system completion. Spawning an installer or the replacement application never
+counts as success.
+
+On a later launch, the core reconciles these managed outcomes against the native
+package registration and its running version. A known live installer keeps
+`managed-pending` active. A completed installer resolves to `succeeded` or
+`failed`, and the core clears the persisted active transaction. An MSI reboot
+warning remains until Windows' per-boot sequence number changes. Sessions
+remain available, but another update must wait for the required reboot so it
+cannot overlap pending Windows file replacements. Reopening the app before
+reboot does not count as successful installation.
+
+If an installer process cannot be identified, the core keeps the transaction
+pending until a recorded boot change proves that the previous installer has
+stopped. Legacy transactions without a boot marker establish a baseline and may
+require one additional restart rather than guessing that installation finished.
+
+Windows portable replacement requires a volume with persistent ACL support;
+FAT/exFAT installations are refused before shutdown because private staging
+cannot be enforced there. Preserved portable profile data retains its ownership
+and effective access permissions. Preparation also fails before shutdown if the
+replacement overlaps user data or exceeds the bounded copy limits. MSI packages
+use Windows Installer registration and preserve the registered installation root;
+they are not treated as portable directories.
+
+`updater.startup.ack` accepts no parameters and returns `{ "acknowledged": true }`
+only for a valid helper-launched update attempt. A normal launch returns
+`acknowledged: false`. The shell calls it after its UI and core connection are
+ready. The core validates the prepared version, per-attempt nonce, and running
+Qt application identity before acknowledging startup to the waiting helper.
+These changes are additive within protocol version 1; they do not change the
+native streamer ABI.
+
+`updater.highlights.show` announces unread release notes, not a navigation
+command. The shell keeps the current stream and its video item alive, defers the
+announcement during sessions, and acknowledges the notes only when the user
+opens them.
 
 Setting `themePack` applies its default appearance (`light` for Bone/Cobalt, `dark`
 for the other built-in packs) and clears `themeAccentOverride` in the same save.

--- a/docs/qt-nightly-release.md
+++ b/docs/qt-nightly-release.md
@@ -2,7 +2,11 @@
 
 Use `qt-ci` on `dev` for the current Qt/native application. Nightly applications have no Windows
 Authenticode certificate or Apple Developer ID signature and are not notarized. This workflow
-requires no signing environment or key and produces manual-update builds.
+supports no-key artifact-only builds, but public nightlies require a pinned Ed25519 public key
+and manifests signed by the protected isolated signer. Configure the environment, runner, and
+key described in [`update-signing-setup.md`](update-signing-setup.md) before publishing.
+
+**Known issue: Alliance Partners are not working correctly in this build.**
 
 ## Build and publish
 
@@ -12,21 +16,32 @@ After the release changes are merged into `dev`, run:
 gh workflow run qt-ci --repo OpenCloudGaming/OpenNOW --ref dev -f publish_nightly=false
 ```
 
+Leave `public_key` empty for this no-key artifact-only path. It requires no signing environment,
+does not create updater manifests, and cannot download updates in the application.
 This builds all five targets without publishing anything. Download the five unsigned
 artifact groups from that workflow run and perform the relevant checks in
 [`qt-acceptance.md`](qt-acceptance.md), especially Windows ARM64, which is cross-compiled and
 cannot run its application tests on the x64 CI worker.
 
-To publish a nightly from the selected branch after all CI jobs pass, run:
+To publish, set `OPENNOW_UPDATE_PUBLIC_KEY` to the matching canonical base64-encoded 32-byte
+public key from the signing setup. This is the public key, never the private seed. Then run:
 
 ```sh
-gh workflow run qt-ci --repo OpenCloudGaming/OpenNOW --ref dev -f publish_nightly=true
+gh workflow run qt-ci --repo OpenCloudGaming/OpenNOW --ref dev \
+  -f publish_nightly=true -f public_key="$OPENNOW_UPDATE_PUBLIC_KEY"
 ```
+
+An empty or malformed key fails preflight. After checks and package builds pass, approve the
+exact source/workflow revision in the protected `qt-update-signing` environment. Its isolated
+signer verifies the complete nine-package inventory, signs each package's sibling manifest,
+and uploads `opennow-qt-<version>-complete-update-signed`. The publisher independently verifies
+that finalized set before uploading it. Missing signing configuration blocks publication; it
+does not fall back to an unsigned public update.
 
 Use the registered `qt-ci` workflow name and an explicit `--ref dev`. The Actions web UI may not
 show the dispatch control until this workflow is also present on the default branch. Do not use
-the legacy `release` workflow instead. Publishing is opt-in: pushes, pull requests, and a manual
-run with the default input only upload validation artifacts.
+the legacy `release` workflow instead. Publishing is opt-in: pushes and pull requests run checks,
+and a manual run with the default inputs uploads validation artifacts without publishing.
 Manual runs have their own concurrency group, so a later branch push cannot cancel a publication.
 
 The version comes from `project(OpenNOWQt VERSION ...)` and the workflow run identity:
@@ -61,7 +76,9 @@ Each release contains nine packages with distinct version/platform/architecture 
   macOS offers it. Do not disable Gatekeeper globally. CI also retains a separate macOS ZIP for
   validation; that ZIP is not a public release asset.
 
-`SHA256SUMS` covers the nine packages and `RELEASE-INFO.json`.
+The public signed set contains 20 files: nine packages, nine `<package>.manifest.json` siblings,
+`RELEASE-INFO.json`, and `SHA256SUMS`. Its checksums cover all 19 other files. The no-key
+artifact-only inventory has no manifests; its checksums cover the packages and release metadata.
 Checksums detect corruption; they do not replace a publisher signature. The inventory rejects
 missing platforms, duplicate basenames, wrong versions, empty files, and unexpected assets
 before any release upload.
@@ -69,9 +86,11 @@ AppImage smoke tests use the packaged offscreen plugin with host Qt plugin, QML,
 search paths removed, so the installed CI toolkit cannot hide missing bundled dependencies.
 macOS checks mount the actual DMG, copy the app out, detach the image, and smoke both that app
 and the validation ZIP with development Qt, SDL3, and build directories hidden. Windows checks
-extract MSI and ZIP payloads and compare all five first-party binaries against the deployment
-copies. Native Windows x64 installer fixtures exercise run upgrades, retry upgrades, downgrade
-rejection, and stable/nightly isolation. Windows ARM64 still requires runtime testing on hardware.
+extract MSI and ZIP payloads and compare every binary in the
+[Windows release list](../opennow-qt/packaging/windows-release-binaries.txt) against the deployment
+copies, including the update helper. Native Windows x64 installer fixtures exercise run upgrades,
+retry upgrades, downgrade rejection, and stable/nightly isolation. Windows ARM64 still requires
+runtime testing on hardware.
 
 The MSI version is independent of the full application SemVer. For nightly run `R` and attempt
 `A`, Windows Installer receives `floor(R / 256).(R % 256).A`. Both values must be in `1..65535`;
@@ -82,13 +101,22 @@ upgrade family and numeric version; supporter packages use a third family and di
 
 ## Updates and signed candidates
 
-These nightlies deliberately have no pinned Ed25519 update-signing key and require manual
-downloads. The reusable package workflow accepts an optional public key for a separately
-configured signed-update release path, but `qt-ci` does not pass one or produce updater manifests.
-The client never bypasses signature verification. The updater compares complete semantic
-versions, so nightly runs order numerically and stable `1.0.0` sorts after its nightlies when
-signed updates are configured. A stable MSI installs separately from the nightly MSI family
-rather than replacing it.
+Public nightlies embed the supplied Ed25519 public key in both the core and apply helper.
+Their manifests authenticate each exact package before download completion and again before
+installation. Installation requires confirmation and no active or recovering streaming session;
+the helper applies the replacement and waits for the restarted Qt application and core to
+acknowledge startup. Automatic downloading is a separate opt-in and never authorizes shutdown.
+
+An earlier nightly without a pinned key requires **one manual upgrade** to an update-enabled
+build. It cannot securely learn a trust key from release metadata. Artifact-only builds still
+default to that no-key, manual-update behavior. The client never bypasses signature verification.
+See the [signing setup and bootstrap instructions](update-signing-setup.md) before the first
+public update-enabled release.
+
+The updater compares complete semantic versions, so nightly runs order numerically and stable
+`1.0.0` sorts after its nightlies. A stable MSI installs separately from the nightly MSI family
+rather than replacing it. Portable Windows replacement requires persistent ACL support;
+FAT/exFAT installations are refused before shutdown and require manual updating.
 
 Authenticode and Apple Developer ID signatures authenticate platform applications. Ed25519
 manifests authenticate the exact updater payload bytes; they do not remove SmartScreen or
@@ -97,4 +125,4 @@ or notarization. Keep the Ed25519 private key on the isolated signer, never on p
 
 The separate [`qt-release-candidate`](qt-release-candidate.md) workflow remains a signed,
 numeric-version production-candidate path. It still requires its documented certificates,
-environments, and isolated signer. It is not the unsigned nightly publishing workflow.
+environments, and isolated signer. It remains separate from nightly update-manifest signing.

--- a/docs/update-signing-setup.md
+++ b/docs/update-signing-setup.md
@@ -1,0 +1,82 @@
+# Activate nightly update signing
+
+Publication is blocked until a repository administrator configures signing. At the
+time of this implementation, the `qt-update-signing` GitHub environment does not exist,
+and the available API credentials return HTTP 403 for its configuration. The workflow
+change does not create an environment, provision a runner, or install a production key.
+
+## Configure the protected signer
+
+1. In the repository's Settings → Environments, create `qt-update-signing`.
+2. Enable required reviewers and prevent self-review. Disable administrator bypass
+   where the repository plan permits it.
+3. Restrict deployment branches and tags to the protected release refs your reviewers
+   approve. For nightly dispatches from `dev`, explicitly allow protected `dev`.
+   Do not allow unreviewed feature branches or pull-request refs.
+4. Provision a dedicated Linux runner with both `self-hosted` and
+   `opennow-release-signer` labels. Restrict its runner group to approved release
+   workflows in this repository. Do not assign these labels to platform build workers.
+5. Install Python 3.11 or newer and OpenSSL 3 on that runner. Reset the runner after
+   every signing job, including failures and cancellations, before accepting another job.
+   Do not run pull-request jobs or candidate programs on it.
+6. Generate and retain a production Ed25519 key outside CI. Add only its canonical
+   base64-encoded 32-byte private seed as the environment secret
+   `OPENNOW_UPDATE_ED25519_PRIVATE_KEY`. Do not put the seed in repository secrets,
+   workflow inputs, CMake arguments, build artifacts, logs, or a developer message.
+7. Record the matching canonical base64-encoded 32-byte public key for dispatches.
+   The public key is not secret. The signing job derives it independently from the
+   seed and rejects a mismatch.
+
+Environment protections are part of the trust boundary. GitHub can create an environment
+name referenced by a workflow without adding protections. Verify the reviewer and ref
+rules before the first dispatch; the YAML cannot enforce those server-side settings.
+Reviewers must approve the exact dispatched source/workflow revision and inspect its
+workflow and packaging/signing scripts before allowing access to the seed. The signer
+checks out only that immutable revision, with persisted Git credentials disabled, and
+treats downloaded packages as data. Never execute downloaded artifacts or candidate
+programs on the signer. Only the approved release tooling may run there.
+
+## Publish the first update-enabled nightly
+
+1. Select the reviewed protected revision in GitHub Actions → qt-ci → Run workflow.
+2. Set `public_key` to the recorded public key and set `publish_nightly` to `true`.
+3. Wait for shared checks, all platform checks, and the complete package build to pass.
+4. Inspect the source commit and the nine-package inventory before approving the
+   `qt-update-signing` deployment.
+5. Confirm that the publisher verifies the signed set and uploads all 20 files before
+   making the draft prerelease public. These are nine packages, nine sibling manifests,
+   `RELEASE-INFO.json`, and `SHA256SUMS`.
+
+For artifact-only testing, leave `publish_nightly` false. An empty `public_key` is
+allowed only for that non-public path. The resulting build cannot download updates
+because its signature policy remains `unconfigured-fail-closed`.
+
+Users running an earlier nightly without a pinned key must manually download and
+install the first update-enabled nightly once. That older application cannot securely
+learn a trust key from release metadata. Do not bypass signature checks to bootstrap it.
+Later updates require manifests signed by the already pinned key.
+
+Update-manifest signing does not remove Windows publisher warnings or macOS Gatekeeper
+warnings. The platform packages remain unsigned. Keep the Alliance Partners release
+warning: **Known issue: Alliance Partners are not working correctly in this build.**
+Update signing does not fix partner authentication or streaming compatibility.
+
+## Verify the repository contract without production credentials
+
+Run the packaging and workflow tests:
+
+```sh
+python3 -m unittest discover -s opennow-qt/tests -p 'test_*.py'
+actionlint -color=false .github/workflows/qt-ci.yml .github/workflows/qt-checks.yml \
+  .github/workflows/qt-build.yml .github/workflows/qt-release-candidate.yml
+```
+
+The signing tests generate ephemeral test-only keys, sign and verify all nine fixture
+packages with OpenSSL, and reject mismatched keys, incomplete inventories, changed
+packages, changed manifests, and invalid public inputs. No production seed is needed.
+
+The platform-check action also runs `opennow-qt/tests/run_update_helper_integration.py`
+with `python` on Windows x64 and `python3` on Linux x64 and macOS ARM64. That driver
+builds the helper and candidate fixtures in a temporary Cargo target directory and
+runs all four signed-helper integration tests with an ephemeral key. It runs only
+on platform test workers, never on the protected release signer.

--- a/docs/update-signing.md
+++ b/docs/update-signing.md
@@ -4,6 +4,10 @@ Qt updates fail closed unless the application core was compiled with a pinned
 Ed25519 public key. GitHub ownership, HTTPS and an asset checksum alone are not
 treated as an update signature.
 
+Public nightly publication requires the protected signing environment. See
+[Activate nightly update signing](update-signing-setup.md) for the current activation
+blocker and the first manual upgrade from a nightly without a pinned key.
+
 ## Release key boundary
 
 - Keep the 32-byte Ed25519 private seed only in the protected `qt-update-signing` environment secret
@@ -43,25 +47,95 @@ size=<decimal byte count>
 sha256=<lowercase digest>
 ```
 
-Generate a manifest on the isolated release runner after packaging and platform
-code signing:
+`qt-ci.yml` generates nightly manifests only after the shared checks, platform checks,
+and complete build succeed. The signing job uses `qt-update-signing` on the isolated
+`[self-hosted, opennow-release-signer]` runner. Its reviewed Python signing script and
+the runner's OpenSSL tools read packages as data. The signer never compiles source,
+extracts packages, or executes candidate binaries, including `opennow-update-manifest`.
+The checkout is pinned to the workflow's immutable `github.sha`, with Git credentials
+disabled. Environment approval covers that revision, including its signing scripts.
 
-```sh
-OPENNOW_UPDATE_ED25519_PRIVATE_KEY="$RELEASE_SECRET" \
-OPENNOW_UPDATE_ED25519_PUBLIC_KEY="$PINNED_PUBLIC_KEY" \
-  cargo run --manifest-path native/opennow-core/Cargo.toml \
-  --bin opennow-update-manifest -- \
-  build/OpenNOW-Qt-linux-x64.AppImage 0.6.0
-```
+The public `qt-ci` input `public_key` must be canonical base64 encoding of exactly
+32 bytes when `publish_nightly` is enabled. `qt-build` passes that same value through
+its optional `update_public_key` input to both CMake configurations. Artifact-only
+builds may omit the key and retain the core's unconfigured, fail-closed update policy.
 
-The generator refuses to write a manifest unless the supplied public key matches the private seed
-and the freshly generated signature verifies with that public key. Use the same public-key value
-for the CMake `OPENNOW_UPDATE_ED25519_PUBLIC_KEY` option and manifest generation; this prevents a
-signed release whose client cannot verify its own update feed.
+`opennow-qt/packaging/sign_nightly_release.py` checks the unsigned inventory's source
+commit, version, complete package names, sizes, and checksums before signing. It derives
+the public key from the private seed and requires an exact match with the build's key.
+Every generated signature is verified against its package before the final directory
+becomes available. A separate publisher job verifies the complete signed inventory
+again, without receiving the seed, before creating a draft prerelease. Only a complete
+upload is made public.
 
-Publish the package and its manifest together. The updater pins the repository,
-release-download URL, platform/architecture, asset name, manifest signature,
-declared size and SHA-256 digest before atomically staging anything executable.
-It re-hashes the staged file immediately before install. AppImage replacement
-keeps a `.previous` rollback copy and restores it if the updated image cannot
-restart; native installers remain responsible for their platform rollback.
+For version `<version>`, the public nightly inventory contains exactly these packages:
+
+- `OpenNOW-Qt-<version>-Windows-x64.msi`
+- `OpenNOW-Qt-<version>-Windows-x64.zip`
+- `OpenNOW-Qt-<version>-Windows-arm64.msi`
+- `OpenNOW-Qt-<version>-Windows-arm64.zip`
+- `OpenNOW-Qt-<version>-Linux-x64.AppImage`
+- `OpenNOW-Qt-<version>-Linux-x64.deb`
+- `OpenNOW-Qt-<version>-Linux-arm64.AppImage`
+- `OpenNOW-Qt-<version>-Linux-arm64.deb`
+- `OpenNOW-Qt-<version>-Darwin-arm64.dmg`
+
+Each package has its exact sibling manifest. `RELEASE-INFO.json` retains the immutable
+package inventory and changes `updates` from `manual-download` to `signed-manifest`.
+`platformSigning` remains `unsigned`: update signatures do not provide Authenticode
+or macOS notarization. Final `SHA256SUMS` covers all nine packages, all nine manifests,
+and the rewritten release metadata. The validation-only macOS ZIP is never published.
+
+The production `qt-release-candidate.yml` contract remains separate: eight Linux and
+Windows packages, platform signing, isolated update signing, and a candidate artifact.
+This nightly follow-up does not add a macOS production candidate or alter that contract.
+Nightly release notes retain the Alliance Partners warning and do not claim a compatibility fix.
+
+Nightly macOS packaging enables `OPENNOW_MACOS_ADHOC_SIGN`. Qt deployment signs nested
+code with `macdeployqt -codesign=-`, then the final install script seals the complete
+bundle with the target's stable `io.github.opencloudgaming.OpenNOW` identifier. This
+explicit final seal avoids inheriting a linker's temporary Mach-O identifier. Packaging
+fails if `codesign --verify --deep --strict` fails after deployment. Both relocated
+DMG and validation-ZIP bundles must also pass strict verification and report the same
+bundle identifier, `Signature=adhoc`, and `TeamIdentifier=not set` before any smoke test.
+Ad-hoc sealing provides no publisher identity or notarization; release warnings remain
+in place. This option is off by default and does not change production candidate signing.
+
+The updater pins the repository, release-download URL, platform/architecture, asset
+name, manifest signature, declared size, and SHA-256 digest before atomically staging
+anything executable. It re-hashes the staged file immediately before install.
+AppImage replacement keeps a `.previous` rollback copy and restores it if the updated
+image cannot restart; native installers remain responsible for their platform rollback.
+
+## Windows installation identity
+
+`opennow-qt/cmake/WindowsInstaller.cmake` preserves the existing MSI UpgradeCodes:
+
+- Stable: `6E81F7AE-B19D-4E87-A94A-2B2F01EBF762`
+- Nightly: `9661F4F8-656C-4B64-9035-01B04F4822B1`
+- Supporter: `B3AF8A40-5F44-445A-AD99-CECE00593601`
+
+Each channel's code is shared by x64 and ARM64 for compatibility with installed
+packages. It identifies an upgrade family, not an architecture. The helper must also
+validate the incoming MSI's SummaryInformation architecture and match an installed
+related product's registered root to the running installation. Portable ZIPs do not
+create an MSI product registration. A product registered elsewhere does not make a
+portable copy an MSI installation.
+
+CPack's WiX generator sets `ARPINSTALLLOCATION` to the resolved `[INSTALL_ROOT]`
+after `CostFinalize`. The installer policy leaves `CPACK_WIX_PROPERTY_ARPINSTALLLOCATION`
+unset so CPack also restores the previous product's registered root through its secure
+`INSTALL_ROOT` property. Do not add a second `SetARPINSTALLLOCATION` action in a product
+patch. Windows Installer stores the resolved value as `InstallLocation`, including
+custom installation paths.
+CPack still generates a new ProductCode for each MSI package and uses its existing
+`MajorUpgrade` behavior. The Windows installer integration test checks the registered
+root and requires exactly one related product after each successful channel upgrade.
+
+The Windows update helper builds separately in `update-helper-rust-target` with
+`RUSTFLAGS=-C target-feature=+crt-static` and an explicit Rust target. That invocation
+clears inherited encoded Rust flags without changing core or streamer builds. The
+helper is deployed as the usual sibling `opennow-update-helper.exe`. Final Windows
+MSI and ZIP validation rejects helper imports outside an explicit Windows system-DLL
+list, so Qt libraries and a separately installed Visual C++ runtime cannot mask a
+dependency that would break the helper when it runs outside the installation.

--- a/locales/en.json
+++ b/locales/en.json
@@ -7,6 +7,18 @@
     "dedicatedMemory": "%1 GB dedicated memory",
     "sharedMemory": "Shared graphics memory"
   },
+  "safeUpdates": {
+    "installVersion": "Install %1 and restart",
+    "availableVersion": "Available version: %1",
+    "confirmation": "OpenNOW will prepare the verified update, close, replace this installation, and restart. Continue?",
+    "sessionDeferred": "End your streaming session before installing an update. Background updates will wait.",
+    "progress": "Update in progress",
+    "highlights": "Release notes are available in Updates.",
+    "autoCheck": "Automatically check for updates",
+    "autoCheckDescription": "Check every six hours while no streaming session is active.",
+    "autoDownload": "Automatically download updates",
+    "autoDownloadDescription": "Download verified updates while idle. Installation always requires your confirmation."
+  },
   "streamStatsV2": {
     "allocatedBitrate": "Allocated bitrate usage",
     "unstable": "Connection unstable",

--- a/native/opennow-core/Cargo.lock
+++ b/native/opennow-core/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +35,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -350,6 +365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +453,17 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -559,12 +594,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1092,6 +1147,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,8 +1265,10 @@ dependencies = [
  "base64",
  "chrono",
  "ed25519-dalek",
+ "fs2",
  "httpdate",
  "keyring",
+ "libc",
  "md5",
  "qrcode",
  "rand 0.9.5",
@@ -1213,7 +1280,10 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
+ "tempfile",
  "url",
+ "windows-sys 0.59.0",
+ "zip",
 ]
 
 [[package]]
@@ -1865,6 +1935,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2394,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,10 +2844,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/native/opennow-core/Cargo.toml
+++ b/native/opennow-core/Cargo.toml
@@ -23,6 +23,15 @@ scrypt = "0.11"
 semver = "1"
 subtle = "2"
 url = "2"
+zip = { version = "2.4", default-features = false, features = ["deflate"] }
+fs2 = "0.4"
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Threading", "Win32_System_JobObjects", "Win32_System_ProcessStatus", "Win32_System_ApplicationInstallationAndServicing", "Win32_System_SystemServices", "Win32_Storage_FileSystem", "Wdk_System_Threading"] }
+
+[dev-dependencies]
+tempfile = "3"
 
 [profile.release]
 lto = "thin"

--- a/native/opennow-core/src/bin/opennow-update-helper.rs
+++ b/native/opennow-core/src/bin/opennow-update-helper.rs
@@ -1,0 +1,15 @@
+use opennow_core::update_apply;
+
+fn main() {
+    let mut arguments = std::env::args_os().skip(1);
+    let result = match (arguments.next(), arguments.next(), arguments.next()) {
+        (Some(flag), Some(path), None) if flag == "--apply" => {
+            update_apply::run_helper(std::path::Path::new(&path))
+        }
+        _ => Err("Usage: opennow-update-helper --apply <prepared-plan.json>".to_owned()),
+    };
+    if let Err(error) = result {
+        eprintln!("opennow-update-helper: {error}");
+        std::process::exit(1);
+    }
+}

--- a/native/opennow-core/src/lib.rs
+++ b/native/opennow-core/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod update_apply;

--- a/native/opennow-core/src/main.rs
+++ b/native/opennow-core/src/main.rs
@@ -27,6 +27,7 @@ mod updater;
 mod version;
 
 use gfn::GfnService;
+use opennow_core::update_apply;
 use rand::RngCore;
 use serde_json::{Value, json};
 use settings::{SettingsStore, resolve_data_dir};
@@ -42,6 +43,7 @@ const PROTOCOL_VERSION: i64 = 1;
 const MAXIMUM_LINE_BYTES: usize = 1024 * 1024;
 
 struct AppCore {
+    session_update_gate: Mutex<()>,
     artwork: artwork_cache::ArtworkCache,
     settings: Mutex<SettingsStore>,
     gfn: GfnService,
@@ -88,6 +90,7 @@ fn run() -> Result<(), String> {
         })
         .map_err(|error| error.to_string())?;
     let core = Arc::new(AppCore {
+        session_update_gate: Mutex::new(()),
         artwork: artwork_cache::ArtworkCache::new(&data_dir, output_tx.clone()),
         settings: Mutex::new(
             SettingsStore::load(Some(data_dir.clone())).map_err(|error| error.to_string())?,
@@ -161,6 +164,12 @@ fn run() -> Result<(), String> {
                 format!("outcome={outcome} durationMs={}", started.elapsed().as_millis()),
             );
             let was_cancelled = permit.token.cancelled();
+            if matches!(method.as_str(), "updater.check" | "updater.download" | "updater.install") {
+                if let Err((_, message)) = &result {
+                    worker_core.updater.request_failed(message);
+                }
+                let _ = worker_output.send(json!({"type":"event", "name":"updater.changed", "payload":worker_core.updater.state()}));
+            }
             if !was_cancelled {
                 match result {
                     Ok((value, event)) => {
@@ -181,6 +190,14 @@ fn run() -> Result<(), String> {
 }
 
 type DispatchResult = Result<(Value, Option<(&'static str, Value)>), (String, String)>;
+
+fn update_session_idle(session: &Value, streamer: &Value) -> bool {
+    session.get("session") == Some(&Value::Null)
+        && matches!(
+            streamer["streamer"]["status"].as_str(),
+            Some("stopped" | "error")
+        )
+}
 
 fn unix_time_millis() -> u128 {
     SystemTime::now()
@@ -264,6 +281,26 @@ fn acceptance_shell_evidence(params: &Value) -> Result<Value, (String, String)> 
 }
 
 fn dispatch(method: &str, params: &Value, core: &AppCore) -> DispatchResult {
+    let session_transition = matches!(
+        method,
+        "session.create" | "session.claim" | "session.poll" | "streamer.start" | "streamer.prepare"
+    );
+    let _session_update_guard = if session_transition || method == "updater.install" {
+        Some(core.session_update_gate.try_lock().map_err(|_| {
+            (
+                "session_update_busy".to_owned(),
+                "A session transition or update preparation is in progress".to_owned(),
+            )
+        })?)
+    } else {
+        None
+    };
+    if session_transition && core.updater.installation_pending() {
+        return Err((
+            "update_pending".to_owned(),
+            "An update is waiting for OpenNOW to exit".to_owned(),
+        ));
+    }
     match method {
         "core.hello" => {
             if params["protocolVersion"].as_i64() != Some(PROTOCOL_VERSION) {
@@ -742,12 +779,17 @@ fn dispatch(method: &str, params: &Value, core: &AppCore) -> DispatchResult {
             .map(|value| (value, None))
             .map_err(|message| ("community_proxy_failed".to_owned(), message)),
         "updater.state.get" => Ok((core.updater.state(), None)),
+        "updater.startup.ack" => {
+            update_apply::acknowledge_startup_from_env(version::APPLICATION_VERSION)
+                .map(|acknowledged| (json!({"acknowledged":acknowledged}), None))
+                .map_err(|message| ("update_startup_ack_failed".to_owned(), message))
+        }
         "updater.check" => {
             let value = core
                 .updater
                 .check(params)
                 .map_err(|message| ("update_check_failed".to_owned(), message))?;
-            Ok((value.clone(), Some(("updater.changed", value))))
+            Ok((value, None))
         }
         "updater.highlights.get" => {
             let highlights = core.updater.highlights();
@@ -797,13 +839,21 @@ fn dispatch(method: &str, params: &Value, core: &AppCore) -> DispatchResult {
         "updater.download" => core
             .updater
             .download()
-            .map(|value| (value.clone(), Some(("updater.changed", value))))
+            .map(|value| (value, None))
             .map_err(|message| ("update_download_failed".to_owned(), message)),
-        "updater.install" => core
-            .updater
-            .install(params)
-            .map(|value| (value.clone(), Some(("updater.changed", value))))
-            .map_err(|message| ("update_install_failed".to_owned(), message)),
+        "updater.install" => {
+            let session = core.gfn.active_session().map_err(gfn_error)?;
+            if !update_session_idle(&session, &core.streamer.status()) {
+                return Err((
+                    "update_session_active".to_owned(),
+                    "End the active session before installing an update".to_owned(),
+                ));
+            }
+            core.updater
+                .install(params)
+                .map(|value| (value, None))
+                .map_err(|message| ("update_install_failed".to_owned(), message))
+        }
         "discord.activity.sync" => core
             .discord
             .sync(params)
@@ -907,6 +957,38 @@ fn argument_value(name: &str) -> Option<String> {
 #[cfg(test)]
 mod acceptance_tests {
     use super::*;
+
+    #[test]
+    fn updates_require_no_session_and_a_terminal_streamer() {
+        for status in ["stopped", "error"] {
+            assert!(update_session_idle(
+                &json!({"session":null}),
+                &json!({"streamer":{"status":status}})
+            ));
+        }
+        for status in [
+            "starting",
+            "streaming",
+            "recovering",
+            "negotiating",
+            "unknown",
+        ] {
+            assert!(!update_session_idle(
+                &json!({"session":null}),
+                &json!({"streamer":{"status":status}})
+            ));
+        }
+        for session in [
+            json!({}),
+            json!({"session":{"phase":"queued"}}),
+            json!({"session":{"phase":"ready"}}),
+        ] {
+            assert!(!update_session_idle(
+                &session,
+                &json!({"streamer":{"status":"stopped"}})
+            ));
+        }
+    }
 
     #[test]
     fn shell_acceptance_evidence_is_bounded_normalized_and_complete() {

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -366,7 +366,7 @@ impl SettingsStore {
             &mut self.values,
             "updateChannel",
             &["stable", "nightly"],
-            "stable",
+            crate::version::update_channel(crate::version::APPLICATION_VERSION),
         );
         clamp_integer(&mut self.values, "mouseAcceleration", 1, 150, 1);
         clamp_integer(&mut self.values, "controllerLeftStickDeadzone", 0, 50, 24);
@@ -898,7 +898,8 @@ fn defaults() -> Map<String, Value> {
         "gameLanguage":"en_US", "enablePersistingInGameSettings":false, "enableL4S":false,
         "identifyAsSteamDeck":false, "steamBigPictureMode":false,
         "enableCloudGsync":false, "discordRichPresence":false,
-        "autoCheckForUpdates":true, "updateChannel":"stable",
+        "autoCheckForUpdates":true, "autoDownloadUpdates":false,
+        "updateChannel":crate::version::update_channel(crate::version::APPLICATION_VERSION),
         "allowEscapeToExitFullscreen":false, "lastSeenReleaseHighlightsVersion":"",
         "videoShader":{"enabled":false,"sharpen":40,"saturation":100,"contrast":100,"brightness":100,"vibrance":0,"filmGrain":0},
         "frameInterpolation":{"enabled":false,"factor":2,"quality":480},
@@ -913,6 +914,28 @@ fn defaults() -> Map<String, Value> {
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn updater_preferences_are_independent_and_preserved() {
+        let directory =
+            env::temp_dir().join(format!("opennow-update-settings-{}", rand::random::<u64>()));
+        let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
+        assert_eq!(store.all()["autoDownloadUpdates"], json!(false));
+        assert_eq!(
+            store.all()["updateChannel"],
+            json!(crate::version::update_channel(
+                crate::version::APPLICATION_VERSION
+            ))
+        );
+        store.set("autoCheckForUpdates", json!(false)).unwrap();
+        store.set("autoDownloadUpdates", json!(true)).unwrap();
+        store.set("updateChannel", json!("stable")).unwrap();
+        let settings = SettingsStore::load(Some(directory.clone())).unwrap().all();
+        assert_eq!(settings["autoCheckForUpdates"], json!(false));
+        assert_eq!(settings["autoDownloadUpdates"], json!(true));
+        assert_eq!(settings["updateChannel"], json!("stable"));
+        fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn onboarding_new_profile_stays_incomplete_across_unrelated_writes() {

--- a/native/opennow-core/src/update_apply/archive.rs
+++ b/native/opennow-core/src/update_apply/archive.rs
@@ -1,0 +1,170 @@
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+
+const MAX_ENTRIES: usize = 100_000;
+const MAX_EXPANDED_BYTES: u64 = 12 * 1024 * 1024 * 1024;
+
+pub(super) fn extract_zip(
+    package: &Path,
+    destination: &Path,
+    allow_links: bool,
+) -> Result<(), String> {
+    fs::create_dir(destination).map_err(|error| error.to_string())?;
+    let result = extract(package, destination, allow_links);
+    if result.is_err() {
+        let _ = fs::remove_dir_all(destination);
+    }
+    result
+}
+
+fn extract(package: &Path, destination: &Path, allow_links: bool) -> Result<(), String> {
+    let mut archive = zip::ZipArchive::new(File::open(package).map_err(|error| error.to_string())?)
+        .map_err(|error| format!("Invalid update ZIP: {error}"))?;
+    if archive.len() > MAX_ENTRIES {
+        return Err("Update archive has too many entries".to_owned());
+    }
+    let mut paths = HashSet::new();
+    let mut expanded = 0u64;
+    let mut links = Vec::new();
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|error| error.to_string())?;
+        let relative = archive_path(entry.name())?;
+        if !paths.insert(relative.to_string_lossy().to_lowercase()) {
+            return Err("Update archive contains duplicate paths".to_owned());
+        }
+        expanded = expanded
+            .checked_add(entry.size())
+            .ok_or("Update archive size overflow")?;
+        if expanded > MAX_EXPANDED_BYTES || entry.size() > super::verification::MAXIMUM_UPDATE_BYTES
+        {
+            return Err("Expanded update exceeds its size limit".to_owned());
+        }
+        let mode = entry.unix_mode().unwrap_or(0o100644);
+        let file_type = mode & 0o170000;
+        let output = destination.join(&relative);
+        if file_type == 0o120000 {
+            if !allow_links || entry.size() > 4096 {
+                return Err("Unsupported update archive symlink".to_owned());
+            }
+            let mut target = String::new();
+            entry
+                .by_ref()
+                .take(4097)
+                .read_to_string(&mut target)
+                .map_err(|error| error.to_string())?;
+            validate_link(&relative, &target)?;
+            links.push((output, PathBuf::from(target)));
+            continue;
+        }
+        if !matches!(file_type, 0 | 0o040000 | 0o100000) {
+            return Err("Update archive contains a special file".to_owned());
+        }
+        if entry.is_dir() {
+            fs::create_dir_all(&output).map_err(|error| error.to_string())?;
+            continue;
+        }
+        fs::create_dir_all(output.parent().ok_or("Invalid archive path")?)
+            .map_err(|error| error.to_string())?;
+        let expected = entry.size();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&output)
+            .map_err(|error| error.to_string())?;
+        let copied = std::io::copy(&mut entry.by_ref().take(expected + 1), &mut file)
+            .map_err(|error| error.to_string())?;
+        if copied != expected {
+            return Err("Update ZIP entry has an invalid expanded size".to_owned());
+        }
+        file.flush()
+            .and_then(|_| file.sync_all())
+            .map_err(|error| error.to_string())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(
+                &output,
+                fs::Permissions::from_mode(if mode & 0o111 != 0 { 0o755 } else { 0o644 }),
+            )
+            .map_err(|error| error.to_string())?;
+        }
+    }
+    #[cfg(not(unix))]
+    if !links.is_empty() {
+        return Err("Update symlinks are unsupported on this platform".to_owned());
+    }
+    #[cfg(unix)]
+    for (path, target) in &links {
+        fs::create_dir_all(path.parent().ok_or("Invalid symlink path")?)
+            .map_err(|error| error.to_string())?;
+        std::os::unix::fs::symlink(target, path).map_err(|error| error.to_string())?;
+    }
+    let root = fs::canonicalize(destination).map_err(|error| error.to_string())?;
+    for (path, _) in links {
+        if !fs::canonicalize(path)
+            .map_err(|error| format!("Invalid update symlink: {error}"))?
+            .starts_with(&root)
+        {
+            return Err("Update symlink escapes the package".to_owned());
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn archive_path(value: &str) -> Result<PathBuf, String> {
+    if value.is_empty() || value.contains(['\\', ':', '\0']) || value.starts_with('/') {
+        return Err("Unsafe update archive path".to_owned());
+    }
+    let value = value.trim_end_matches('/');
+    for part in value.split('/') {
+        let stem = part
+            .split('.')
+            .next()
+            .unwrap_or_default()
+            .to_ascii_uppercase();
+        if part.is_empty()
+            || part == "."
+            || part == ".."
+            || part.ends_with(['.', ' '])
+            || matches!(stem.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+            || (stem.len() == 4
+                && (stem.starts_with("COM") || stem.starts_with("LPT"))
+                && stem.as_bytes()[3].is_ascii_digit())
+        {
+            return Err("Unsafe update archive component".to_owned());
+        }
+    }
+    let path = PathBuf::from(value);
+    if !path
+        .components()
+        .all(|part| matches!(part, Component::Normal(_)))
+    {
+        return Err("Unsafe update archive path".to_owned());
+    }
+    Ok(path)
+}
+
+fn validate_link(path: &Path, target: &str) -> Result<(), String> {
+    if target.is_empty() || target.contains(['\\', ':', '\0']) || Path::new(target).is_absolute() {
+        return Err("Unsafe update symlink target".to_owned());
+    }
+    let mut depth = path
+        .parent()
+        .map(|parent| parent.components().count())
+        .unwrap_or(0);
+    for part in Path::new(target).components() {
+        match part {
+            Component::ParentDir => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or("Update symlink escapes the package")?;
+            }
+            Component::Normal(_) => depth += 1,
+            Component::CurDir => (),
+            _ => return Err("Unsafe update symlink target".to_owned()),
+        }
+    }
+    Ok(())
+}

--- a/native/opennow-core/src/update_apply/bundle.rs
+++ b/native/opennow-core/src/update_apply/bundle.rs
@@ -1,0 +1,267 @@
+use std::path::Path;
+
+pub(super) const MAX_COPY_ENTRIES: u64 = 100_000;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum CopyPolicy {
+    Bundle,
+    UserData,
+}
+
+pub(super) struct CopyBudget {
+    remaining_entries: u64,
+    remaining_bytes: u64,
+}
+
+impl CopyBudget {
+    pub fn new() -> Self {
+        Self {
+            remaining_entries: MAX_COPY_ENTRIES,
+            remaining_bytes: 12 * 1024 * 1024 * 1024,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_limits(entries: u64, bytes: u64) -> Self {
+        Self {
+            remaining_entries: entries,
+            remaining_bytes: bytes,
+        }
+    }
+
+    pub fn consume_entry(&mut self) -> Result<(), String> {
+        self.remaining_entries = self
+            .remaining_entries
+            .checked_sub(1)
+            .ok_or("Preserved data exceeds its aggregate entry limit")?;
+        Ok(())
+    }
+
+    pub fn copy_file(
+        &mut self,
+        source: &Path,
+        destination: &Path,
+        policy: CopyPolicy,
+    ) -> Result<(), String> {
+        let copied = super::copy_synced_bounded(
+            source,
+            destination,
+            self.remaining_bytes
+                .min(super::verification::MAXIMUM_UPDATE_BYTES),
+            policy,
+        )?;
+        self.remaining_bytes -= copied;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run(command: &mut std::process::Command) -> Result<(), String> {
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().map_err(|error| error.to_string())? {
+            return if status.success() {
+                Ok(())
+            } else {
+                Err("macOS package operation failed".to_owned())
+            };
+        }
+        if start.elapsed() >= Duration::from_secs(120) {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("macOS package operation exceeded its deadline".to_owned());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+pub(super) fn extract_dmg(package: &Path, destination: &Path) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+        let mount = destination.with_extension("mount");
+        std::fs::create_dir(&mount).map_err(|error| error.to_string())?;
+        let attached = run(Command::new("/usr/bin/hdiutil")
+            .args([
+                "attach",
+                "-readonly",
+                "-nobrowse",
+                "-noautoopen",
+                "-mountpoint",
+            ])
+            .arg(&mount)
+            .arg(package));
+        let result = attached.and_then(|_| {
+            let apps: Vec<_> = std::fs::read_dir(&mount)
+                .map_err(|error| error.to_string())?
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| {
+                    path.extension().is_some_and(|value| value == "app") && path.is_dir()
+                })
+                .collect();
+            if apps.len() != 1 || apps[0].file_name().is_none_or(|name| name != "OpenNOW.app") {
+                return Err("DMG must contain exactly one OpenNOW.app bundle".to_owned());
+            }
+            std::fs::create_dir(destination).map_err(|error| error.to_string())?;
+            copy_tree(
+                &apps[0],
+                &destination.join("OpenNOW.app"),
+                &mut CopyBudget::new(),
+                CopyPolicy::Bundle,
+            )
+        });
+        let detached =
+            run(Command::new("/usr/bin/hdiutil").arg("detach").arg(&mount)).or_else(|_| {
+                run(Command::new("/usr/bin/hdiutil")
+                    .args(["detach", "-force"])
+                    .arg(&mount))
+            });
+        if detached.is_ok() {
+            let _ = std::fs::remove_dir(&mount);
+        }
+        result.and(detached)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (package, destination);
+        Err("DMG updates require macOS".to_owned())
+    }
+}
+
+pub(super) fn copy_tree(
+    source: &Path,
+    destination: &Path,
+    budget: &mut CopyBudget,
+    policy: CopyPolicy,
+) -> Result<(), String> {
+    use std::fs;
+    budget.consume_entry()?;
+    let source = fs::canonicalize(source).map_err(|error| error.to_string())?;
+    if policy == CopyPolicy::UserData {
+        super::security::create_private_directory(destination)?;
+    } else {
+        fs::create_dir(destination).map_err(|error| error.to_string())?;
+    }
+    let result = (|| {
+        let mut pending = vec![(source.clone(), destination.to_path_buf())];
+        let mut links = Vec::new();
+        let mut directory_permissions = Vec::new();
+        while let Some((from, to)) = pending.pop() {
+            if policy == CopyPolicy::UserData {
+                directory_permissions.push((from.clone(), to.clone()));
+            }
+            for entry in fs::read_dir(&from).map_err(|error| error.to_string())? {
+                let entry = entry.map_err(|error| error.to_string())?;
+                budget.consume_entry()?;
+                let metadata =
+                    fs::symlink_metadata(entry.path()).map_err(|error| error.to_string())?;
+                let path = to.join(entry.file_name());
+                if metadata.is_symlink() {
+                    let resolved =
+                        fs::canonicalize(entry.path()).map_err(|error| error.to_string())?;
+                    if !resolved.starts_with(&source) {
+                        return Err("Application bundle symlink escapes its root".to_owned());
+                    }
+                    let target = fs::read_link(entry.path()).map_err(|error| error.to_string())?;
+                    if target.is_absolute() {
+                        return Err("Application bundle contains an absolute symlink".to_owned());
+                    }
+                    links.push((path, target));
+                } else if metadata.is_dir() {
+                    if policy == CopyPolicy::UserData {
+                        super::security::create_private_directory(&path)?;
+                    } else {
+                        fs::create_dir(&path).map_err(|error| error.to_string())?;
+                    }
+                    pending.push((entry.path(), path));
+                } else if metadata.is_file() {
+                    budget.copy_file(&entry.path(), &path, policy)?;
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        if policy == CopyPolicy::Bundle {
+                            fs::set_permissions(
+                                &path,
+                                fs::Permissions::from_mode(
+                                    if metadata.permissions().mode() & 0o111 != 0 {
+                                        0o755
+                                    } else {
+                                        0o644
+                                    },
+                                ),
+                            )
+                            .map_err(|error| error.to_string())?;
+                        }
+                    }
+                } else {
+                    return Err("Application bundle contains a special file".to_owned());
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        if !links.is_empty() {
+            return Err("Bundle symlinks require macOS or Unix".to_owned());
+        }
+        #[cfg(unix)]
+        for (path, target) in links {
+            std::os::unix::fs::symlink(&target, &path).map_err(|error| error.to_string())?;
+        }
+        for (source, destination) in directory_permissions.into_iter().rev() {
+            super::security::preserve_permissions(&source, &destination)?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir_all(destination);
+    }
+    result
+}
+
+pub(super) fn verify_bundle(bundle: &Path, installed_bundle: &Path) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+        run(Command::new("/usr/bin/codesign")
+            .args(["--verify", "--deep", "--strict"])
+            .arg(bundle))?;
+        let identity = |path: &Path| -> Result<String, String> {
+            let output = super::command_output(
+                Command::new("/usr/bin/codesign")
+                    .args(["-dv", "--verbose=4"])
+                    .arg(path),
+                std::time::Duration::from_secs(120),
+            )?;
+            if !output.status.success() || output.stderr.len() > 64 * 1024 {
+                return Err("Cannot read application signing identity".to_owned());
+            }
+            let value = String::from_utf8_lossy(&output.stderr);
+            Ok(value
+                .lines()
+                .filter(|line| {
+                    line.starts_with("TeamIdentifier=") || line.starts_with("Identifier=")
+                })
+                .collect::<Vec<_>>()
+                .join("\n"))
+        };
+        let old = identity(installed_bundle)?;
+        if old.is_empty() || old != identity(bundle)? {
+            return Err(
+                "Updated app bundle signing identity does not match the installation".to_owned(),
+            );
+        }
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (bundle, installed_bundle);
+        Err("macOS bundle verification requires macOS".to_owned())
+    }
+}

--- a/native/opennow-core/src/update_apply/integration_tests.rs
+++ b/native/opennow-core/src/update_apply/integration_tests.rs
@@ -1,0 +1,478 @@
+use super::*;
+use base64::Engine as _;
+use ed25519_dalek::{Signer, SigningKey};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+struct OwnedChild(Child);
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+struct Fixture {
+    _temporary: TempDir,
+    plan: Plan,
+    directory: PathBuf,
+    original: Vec<u8>,
+    candidate: Vec<u8>,
+    application: OwnedChild,
+    core: OwnedChild,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::write(self.directory.join("exit-fixture"), b"exit");
+        if let Ok(ack) = read_json::<Acknowledgement>(&self.directory.join("ack.json"), 64 * 1024) {
+            let start = Instant::now();
+            while ack.application.is_running().unwrap_or(false)
+                && start.elapsed() < Duration::from_secs(10)
+            {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+        let _ = self.application.0.kill();
+        let _ = self.application.0.wait();
+        let _ = self.core.0.kill();
+        let _ = self.core.0.wait();
+    }
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    fs::canonicalize(std::env::var_os(name).unwrap_or_else(|| {
+        panic!("Run opennow-qt/tests/run_update_helper_integration.py; missing {name}")
+    }))
+    .unwrap()
+}
+
+#[cfg(target_os = "macos")]
+fn command_ok(command: &mut Command) {
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn sign(package: &Path) {
+    let seed: [u8; 32] = fs::read(fixture_path("OPENNOW_TEST_UPDATE_SEED_FILE"))
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let key = SigningKey::from_bytes(&seed);
+    assert_eq!(
+        verification::embedded_update_key().unwrap(),
+        key.verifying_key(),
+        "Test key must be compiled into the helper; runtime key overrides are forbidden"
+    );
+    let bytes = fs::read(package).unwrap();
+    let mut manifest = verification::UpdateManifest {
+        schema_version: 1,
+        version: "1.2.3".to_owned(),
+        asset: package.file_name().unwrap().to_str().unwrap().to_owned(),
+        size: bytes.len() as u64,
+        sha256: format!("{:x}", Sha256::digest(&bytes)),
+        signature: String::new(),
+    };
+    manifest.signature = base64::engine::general_purpose::STANDARD.encode(
+        key.sign(verification::signature_payload(&manifest).as_bytes())
+            .to_bytes(),
+    );
+    atomic_json(&manifest_path(package).unwrap(), &manifest).unwrap();
+}
+
+fn stage_executable(source: &Path, target: &Path) {
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    fs::copy(source, target).unwrap();
+    make_executable(target).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+fn sign_bundle(root: &Path, identifier: &str, version: &str) {
+    fs::write(root.join("Contents/Info.plist"), format!(r#"<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>CFBundleIdentifier</key><string>{identifier}</string><key>CFBundleExecutable</key><string>OpenNOW</string><key>CFBundlePackageType</key><string>APPL</string><key>CFBundleShortVersionString</key><string>{version}</string><key>CFBundleVersion</key><string>{version}</string></dict></plist>"#)).unwrap();
+    command_ok(
+        Command::new("/usr/bin/codesign")
+            .args([
+                "--force",
+                "--deep",
+                "--sign",
+                "-",
+                "--identifier",
+                identifier,
+            ])
+            .arg(root),
+    );
+    command_ok(
+        Command::new("/usr/bin/codesign")
+            .args(["--verify", "--deep", "--strict"])
+            .arg(root),
+    );
+}
+
+#[cfg(windows)]
+fn zip_tree(root: &Path, package: &Path) {
+    let mut zip = zip::ZipWriter::new(File::create(package).unwrap());
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(directory).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            let name = path
+                .strip_prefix(root)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .replace('\\', "/");
+            zip.start_file(
+                name,
+                zip::write::SimpleFileOptions::default()
+                    .compression_method(zip::CompressionMethod::Stored),
+            )
+            .unwrap();
+            zip.write_all(&fs::read(path).unwrap()).unwrap();
+        }
+    }
+    zip.finish().unwrap();
+}
+
+fn fixture(wrong_identity: bool) -> Fixture {
+    let temporary = TempDir::new().unwrap();
+    let root = fs::canonicalize(temporary.path()).unwrap();
+    let directory = root.join(".opennow-update-integration");
+    fs::create_dir(&directory).unwrap();
+    let previous = fixture_path("OPENNOW_TEST_UPDATE_PREVIOUS");
+    let candidate = fixture_path("OPENNOW_TEST_UPDATE_CANDIDATE");
+    #[cfg(any(windows, target_os = "macos"))]
+    let helper = fixture_path("OPENNOW_TEST_UPDATE_HELPER");
+    #[cfg(target_os = "linux")]
+    let (kind, target, application, package, candidate_bytes) = {
+        let target = root.join("OpenNOW.AppImage");
+        stage_executable(&previous, &target);
+        let package = directory.join("OpenNOW-1.2.3.AppImage");
+        let mut bytes = fs::read(&candidate).unwrap();
+        assert_eq!(&bytes[..4], b"\x7fELF");
+        bytes[8..11].copy_from_slice(b"AI\x02");
+        fs::write(&package, &bytes).unwrap();
+        (
+            InstallKind::AppImage,
+            target.clone(),
+            target,
+            package,
+            bytes,
+        )
+    };
+    #[cfg(any(windows, target_os = "macos"))]
+    let (kind, target, application, package, candidate_bytes) = {
+        #[cfg(windows)]
+        let (kind, target, relative, package) = (
+            InstallKind::WindowsPortable,
+            root.join("installed"),
+            PathBuf::from("bin/OpenNOW.exe"),
+            directory.join("OpenNOW-1.2.3.zip"),
+        );
+        #[cfg(target_os = "macos")]
+        let (kind, target, relative, package) = (
+            InstallKind::MacBundle,
+            root.join("OpenNOW.app"),
+            PathBuf::from("Contents/MacOS/OpenNOW"),
+            directory.join("OpenNOW-1.2.3.dmg"),
+        );
+        let application = target.join(&relative);
+        stage_executable(&previous, &application);
+        let image_root = root.join("image-root");
+        #[cfg(target_os = "macos")]
+        let payload = image_root.join("OpenNOW.app");
+        #[cfg(windows)]
+        let payload = image_root.clone();
+        let payload_application = payload.join(&relative);
+        stage_executable(&candidate, &payload_application);
+        let suffix = if cfg!(windows) { ".exe" } else { "" };
+        for (name, source) in [
+            (format!("opennow-core{suffix}"), &previous),
+            (format!("opennow-update-helper{suffix}"), &helper),
+        ] {
+            stage_executable(source, &application.parent().unwrap().join(&name));
+            stage_executable(source, &payload_application.parent().unwrap().join(&name));
+        }
+        #[cfg(windows)]
+        {
+            if wrong_identity {
+                fs::rename(
+                    &payload_application,
+                    payload_application.with_file_name("OtherNOW.exe"),
+                )
+                .unwrap();
+            }
+            zip_tree(&payload, &package);
+        }
+        #[cfg(target_os = "macos")]
+        {
+            sign_bundle(&target, "org.opennow.integration", "1.0.0");
+            sign_bundle(
+                &payload,
+                if wrong_identity {
+                    "org.opennow.unrelated"
+                } else {
+                    "org.opennow.integration"
+                },
+                "1.2.3",
+            );
+            command_ok(
+                Command::new("/usr/bin/hdiutil")
+                    .args([
+                        "create",
+                        "-quiet",
+                        "-format",
+                        "UDZO",
+                        "-volname",
+                        "OpenNOW integration",
+                        "-srcfolder",
+                    ])
+                    .arg(&image_root)
+                    .arg(&package),
+            );
+        }
+        let bytes = if payload_application.exists() {
+            fs::read(&payload_application).unwrap()
+        } else {
+            Vec::new()
+        };
+        (kind, target, application, package, bytes)
+    };
+    sign(&package);
+    let target = fs::canonicalize(target).unwrap();
+    let application_path = fs::canonicalize(application).unwrap();
+    let original = fs::read(&application_path).unwrap();
+    let data_dir = if cfg!(windows) {
+        target.join("user-data")
+    } else {
+        root.join("settings")
+    };
+    fs::create_dir(&data_dir).unwrap();
+    fs::write(data_dir.join("preferences.json"), b"{\"preserved\":true}").unwrap();
+    let application = OwnedChild(
+        Command::new(&application_path)
+            .arg("--hold")
+            .spawn()
+            .unwrap(),
+    );
+    let core = OwnedChild(Command::new(&previous).arg("--hold").spawn().unwrap());
+    let plan = Plan {
+        schema_version: 1,
+        version: if cfg!(target_os = "linux") && wrong_identity {
+            "1.2.4"
+        } else {
+            "1.2.3"
+        }
+        .to_owned(),
+        kind,
+        package,
+        target,
+        application_executable: application_path,
+        data_dir: fs::canonicalize(data_dir).unwrap(),
+        processes: vec![
+            ProcessIdentity::capture(application.0.id()).unwrap(),
+            ProcessIdentity::capture(core.0.id()).unwrap(),
+        ],
+        nonce: "a".repeat(64),
+        managed_identity: None,
+    };
+    atomic_json(&directory.join("plan.json"), &plan).unwrap();
+    write_outcome(
+        &directory,
+        &plan,
+        OutcomeStatus::Prepared,
+        "Integration transaction prepared",
+        None,
+        None,
+    )
+    .unwrap();
+    Fixture {
+        _temporary: temporary,
+        plan,
+        directory,
+        original,
+        candidate: candidate_bytes,
+        application,
+        core,
+    }
+}
+
+fn wait_for_status(fixture: &Fixture, helper: &mut OwnedChild, status: OutcomeStatus) {
+    let start = Instant::now();
+    loop {
+        if read_outcome(&fixture.directory.join("outcome.json"))
+            .unwrap()
+            .is_some_and(|outcome| outcome.status == status)
+        {
+            return;
+        }
+        assert!(
+            helper.0.try_wait().unwrap().is_none(),
+            "Helper exited before {status:?}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(150),
+            "Helper never reached {status:?}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn apply_after_exit(fixture: &mut Fixture) -> std::process::ExitStatus {
+    let mut helper = OwnedChild(
+        Command::new(fixture_path("OPENNOW_TEST_UPDATE_HELPER"))
+            .arg("--apply")
+            .arg(fixture.directory.join("plan.json"))
+            .spawn()
+            .unwrap(),
+    );
+    wait_for_status(fixture, &mut helper, OutcomeStatus::WaitingForExit);
+    assert_eq!(
+        fs::read(&fixture.plan.application_executable).unwrap(),
+        fixture.original
+    );
+    assert!(!fixture.directory.join("ack.json").exists());
+    fixture.application.0.kill().unwrap();
+    fixture.application.0.wait().unwrap();
+    fixture.core.0.kill().unwrap();
+    fixture.core.0.wait().unwrap();
+    let start = Instant::now();
+    loop {
+        if let Some(status) = helper.0.try_wait().unwrap() {
+            return status;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(120),
+            "Helper did not finish replacement"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+#[ignore = "Run opennow-qt/tests/run_update_helper_integration.py with an ephemeral pinned test key"]
+fn signed_native_package_replaces_and_candidate_acknowledges_its_own_restart() {
+    let mut fixture = fixture(false);
+    assert!(apply_after_exit(&mut fixture).success());
+    let outcome = read_outcome(&fixture.directory.join("outcome.json"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(outcome.status, OutcomeStatus::Completed);
+    assert_eq!(outcome.installed_version.as_deref(), Some("1.2.3"));
+    assert_eq!(
+        fs::read(&fixture.plan.application_executable).unwrap(),
+        fixture.candidate
+    );
+    assert_ne!(fixture.candidate, fixture.original);
+    let ack: Acknowledgement = read_json(&fixture.directory.join("ack.json"), 64 * 1024).unwrap();
+    assert_eq!(ack.version, "1.2.3");
+    assert_eq!(ack.nonce, fixture.plan.nonce);
+    assert_ne!(ack.application.pid, std::process::id());
+    assert_ne!(ack.application.pid, fixture.plan.processes[0].pid);
+    assert_eq!(
+        ack.application.executable,
+        fixture.plan.application_executable
+    );
+    assert!(ack.application.is_running().unwrap());
+    assert_eq!(
+        fs::read_to_string(fixture.directory.join("candidate-started")).unwrap(),
+        ack.application.pid.to_string()
+    );
+    assert_eq!(
+        fs::read(fixture.plan.data_dir.join("preferences.json")).unwrap(),
+        b"{\"preserved\":true}"
+    );
+    assert!(!fixture.directory.join("previous").exists());
+    assert!(!fixture.plan.package.exists());
+    #[cfg(target_os = "macos")]
+    assert!(!fixture.directory.join("payload.mount").exists());
+}
+
+#[test]
+#[ignore = "Run opennow-qt/tests/run_update_helper_integration.py with an ephemeral pinned test key"]
+fn signed_native_package_with_failed_startup_rolls_back_and_restarts_previous() {
+    let mut fixture = fixture(false);
+    fs::write(fixture.directory.join("reject-startup"), b"reject").unwrap();
+    assert!(!apply_after_exit(&mut fixture).success());
+    assert_eq!(
+        read_outcome(&fixture.directory.join("outcome.json"))
+            .unwrap()
+            .unwrap()
+            .status,
+        OutcomeStatus::RolledBack
+    );
+    assert_eq!(
+        fs::read(&fixture.plan.application_executable).unwrap(),
+        fixture.original
+    );
+    assert!(!fixture.directory.join("ack.json").exists());
+    assert!(fixture.directory.join("candidate-started").exists());
+    let start = Instant::now();
+    while !fixture.plan.data_dir.join("previous-restarted").exists() {
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "Previous application did not restart after rollback"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(
+        fs::read(fixture.plan.data_dir.join("previous-restarted")).unwrap(),
+        b"1.0.0"
+    );
+}
+
+#[test]
+#[ignore = "Run opennow-qt/tests/run_update_helper_integration.py with an ephemeral pinned test key"]
+fn tampered_native_package_never_replaces_or_restarts() {
+    let fixture = fixture(false);
+    let mut bytes = fs::read(&fixture.plan.package).unwrap();
+    let last = bytes.len() - 1;
+    bytes[last] ^= 1;
+    fs::write(&fixture.plan.package, bytes).unwrap();
+    assert!(
+        run_helper(&fixture.directory.join("plan.json"))
+            .unwrap_err()
+            .contains("SHA256")
+    );
+    assert_eq!(
+        fs::read(&fixture.plan.application_executable).unwrap(),
+        fixture.original
+    );
+    assert!(fixture.plan.processes[0].is_running().unwrap());
+    assert!(!fixture.directory.join("candidate-started").exists());
+    assert_eq!(
+        read_outcome(&fixture.directory.join("outcome.json"))
+            .unwrap()
+            .unwrap()
+            .status,
+        OutcomeStatus::Failed
+    );
+}
+
+#[test]
+#[ignore = "Run opennow-qt/tests/run_update_helper_integration.py with an ephemeral pinned test key"]
+fn signed_wrong_package_or_bundle_identity_never_replaces() {
+    let fixture = fixture(true);
+    assert!(run_helper(&fixture.directory.join("plan.json")).is_err());
+    assert_eq!(
+        fs::read(&fixture.plan.application_executable).unwrap(),
+        fixture.original
+    );
+    assert!(fixture.plan.processes[0].is_running().unwrap());
+    assert!(!fixture.directory.join("candidate-started").exists());
+    assert_eq!(
+        read_outcome(&fixture.directory.join("outcome.json"))
+            .unwrap()
+            .unwrap()
+            .status,
+        OutcomeStatus::Failed
+    );
+}

--- a/native/opennow-core/src/update_apply/managed.rs
+++ b/native/opennow-core/src/update_apply/managed.rs
@@ -1,0 +1,539 @@
+use super::{InstallKind, OutcomeStatus, Plan, write_outcome};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Identity {
+    package: String,
+    version: String,
+    architecture: String,
+    installed_product: String,
+}
+
+pub(super) fn prepare(
+    kind: InstallKind,
+    package: &Path,
+    target: &Path,
+    version: &str,
+) -> Result<Option<Identity>, String> {
+    match kind {
+        InstallKind::DebianPackage => deb_identity(package, target, version).map(Some),
+        InstallKind::WindowsMsi => msi_identity(package, target, version).map(Some),
+        _ => Ok(None),
+    }
+}
+
+pub(super) fn verify_identity(
+    kind: InstallKind,
+    package: &Path,
+    target: &Path,
+    version: &str,
+    expected: Option<&Identity>,
+) -> Result<(), String> {
+    if prepare(kind, package, target, version)?.as_ref() != expected {
+        return Err("Native package identity changed after preparation".to_owned());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn output(command: &mut Command) -> Result<String, String> {
+    let result = super::command_output(command, Duration::from_secs(120))?;
+    if !result.status.success() {
+        return Err("Native package identity query failed".to_owned());
+    }
+    if result.stdout.len() > 64 * 1024 {
+        return Err("Native package query exceeded its limit".to_owned());
+    }
+    String::from_utf8(result.stdout)
+        .map(|value| value.trim().to_owned())
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn deb_identity(package: &Path, target: &Path, version: &str) -> Result<Identity, String> {
+    if !Path::new("/usr/bin/pkexec").is_file() {
+        return Err(
+            "DEB updates require PolicyKit's pkexec and an interactive authorization agent"
+                .to_owned(),
+        );
+    }
+    let field = |name| {
+        output(
+            Command::new("/usr/bin/dpkg-deb")
+                .arg("--field")
+                .arg(package)
+                .arg(name),
+        )
+    };
+    let name = field("Package")?;
+    let architecture = field("Architecture")?;
+    let expected_arch = if cfg!(target_arch = "x86_64") {
+        "amd64"
+    } else if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        return Err("Unsupported DEB architecture".to_owned());
+    };
+    let version = version
+        .trim_start_matches('v')
+        .replace("-nightly.", "~nightly.")
+        .replace("-supporter.", "~supporter.");
+    if name != "opennow" || architecture != expected_arch || field("Version")? != version {
+        return Err(
+            "DEB package identity does not match OpenNOW, architecture, or signed version"
+                .to_owned(),
+        );
+    }
+    let owner = output(
+        Command::new("/usr/bin/dpkg-query")
+            .arg("--search")
+            .arg(target),
+    )?;
+    if !owner.lines().any(|line| {
+        line.strip_prefix("opennow: ")
+            .is_some_and(|path| Path::new(path) == target)
+    }) {
+        return Err(
+            "Running application is not owned by the installed OpenNOW DEB package".to_owned(),
+        );
+    }
+    let installed = output(Command::new("/usr/bin/dpkg-query").args([
+        "--show",
+        "--showformat=${db:Status-Status}\t${Architecture}",
+        "opennow",
+    ]))?;
+    if installed != format!("installed\t{expected_arch}") {
+        return Err("Installed OpenNOW DEB is not configured for this architecture".to_owned());
+    }
+    Ok(Identity {
+        package: name,
+        version,
+        architecture,
+        installed_product: "opennow".to_owned(),
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn deb_identity(_: &Path, _: &Path, _: &str) -> Result<Identity, String> {
+    Err("DEB updates require Linux".to_owned())
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::*;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::System::ApplicationInstallationAndServicing::*;
+    pub(super) fn wide(value: impl AsRef<std::ffi::OsStr>) -> Vec<u16> {
+        value.as_ref().encode_wide().chain(Some(0)).collect()
+    }
+
+    pub(super) fn argument_path(path: &Path) -> Result<String, String> {
+        let value = path
+            .to_str()
+            .ok_or("Windows Installer requires a Unicode installation path")?;
+        if let Some(unc) = value.strip_prefix("\\\\?\\UNC\\") {
+            return Ok(format!("\\\\{unc}"));
+        }
+        Ok(value.strip_prefix("\\\\?\\").unwrap_or(value).to_owned())
+    }
+
+    struct Handle(u32);
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            unsafe {
+                MsiCloseHandle(self.0);
+            }
+        }
+    }
+
+    pub(super) fn property(package: &Path, name: &str) -> Result<String, String> {
+        let mut database = 0;
+        if unsafe { MsiOpenDatabaseW(wide(package).as_ptr(), std::ptr::null(), &mut database) } != 0
+        {
+            return Err("Cannot read signed MSI database".to_owned());
+        }
+        let database = Handle(database);
+        let mut view = 0;
+        let query = format!("SELECT `Value` FROM `Property` WHERE `Property`='{name}'");
+        if unsafe { MsiDatabaseOpenViewW(database.0, wide(query).as_ptr(), &mut view) } != 0 {
+            return Err("Cannot query MSI identity".to_owned());
+        }
+        let view = Handle(view);
+        if unsafe { MsiViewExecute(view.0, 0) } != 0 {
+            return Err("Cannot execute MSI identity query".to_owned());
+        }
+        let mut record = 0;
+        if unsafe { MsiViewFetch(view.0, &mut record) } != 0 {
+            return Err(format!("MSI identity property {name} is missing"));
+        }
+        let record = Handle(record);
+        let mut buffer = vec![0u16; 32768];
+        let mut size = buffer.len() as u32;
+        if unsafe { MsiRecordGetStringW(record.0, 1, buffer.as_mut_ptr(), &mut size) } != 0 {
+            return Err("Cannot read MSI identity property".to_owned());
+        }
+        String::from_utf16(&buffer[..size as usize]).map_err(|error| error.to_string())
+    }
+
+    pub(super) fn registered(product: &str, property: &str) -> Result<String, String> {
+        let mut buffer = vec![0u16; 32768];
+        let mut size = buffer.len() as u32;
+        if unsafe {
+            MsiGetProductInfoW(
+                wide(product).as_ptr(),
+                wide(property).as_ptr(),
+                buffer.as_mut_ptr(),
+                &mut size,
+            )
+        } != 0
+        {
+            return Err("Cannot read registered MSI installation identity".to_owned());
+        }
+        String::from_utf16(&buffer[..size as usize]).map_err(|error| error.to_string())
+    }
+
+    fn architecture(package: &Path) -> Result<String, String> {
+        let mut summary = 0;
+        if unsafe { MsiGetSummaryInformationW(0, wide(package).as_ptr(), 0, &mut summary) } != 0 {
+            return Err("Cannot read MSI architecture".to_owned());
+        }
+        let summary = Handle(summary);
+        let mut buffer = [0u16; 1024];
+        let mut size = buffer.len() as u32;
+        let mut kind = 0;
+        let mut integer = 0;
+        let mut time = windows_sys::Win32::Foundation::FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        if unsafe {
+            MsiSummaryInfoGetPropertyW(
+                summary.0,
+                7,
+                &mut kind,
+                &mut integer,
+                &mut time,
+                buffer.as_mut_ptr(),
+                &mut size,
+            )
+        } != 0
+        {
+            return Err("Cannot read MSI architecture template".to_owned());
+        }
+        Ok(String::from_utf16(&buffer[..size as usize])
+            .map_err(|error| error.to_string())?
+            .split(';')
+            .next()
+            .unwrap_or_default()
+            .to_owned())
+    }
+
+    pub(super) fn family(version: &str) -> Result<&'static str, String> {
+        let version = semver::Version::parse(version.trim_start_matches('v'))
+            .map_err(|error| error.to_string())?;
+        if version.pre.is_empty() {
+            Ok("{6E81F7AE-B19D-4E87-A94A-2B2F01EBF762}")
+        } else if version.pre.as_str().starts_with("nightly.") {
+            Ok("{9661F4F8-656C-4B64-9035-01B04F4822B1}")
+        } else if version.pre.as_str().starts_with("supporter.") {
+            Ok("{B3AF8A40-5F44-445A-AD99-CECE00593601}")
+        } else {
+            Err("Unsupported MSI release channel".to_owned())
+        }
+    }
+
+    pub(super) fn installed_at(target: &Path, upgrade: &str) -> Result<Option<String>, String> {
+        for index in 0..256 {
+            let mut product = [0u16; 39];
+            let status = unsafe {
+                MsiEnumRelatedProductsW(wide(upgrade).as_ptr(), 0, index, product.as_mut_ptr())
+            };
+            if status == 259 {
+                return Ok(None);
+            }
+            if status != 0 {
+                return Err("Cannot enumerate registered MSI products".to_owned());
+            }
+            let product = String::from_utf16(&product[..38]).map_err(|error| error.to_string())?;
+            let location = registered(&product, "InstallLocation")?;
+            if location.is_empty() {
+                return Err("An OpenNOW MSI registration has no installation location; repair it before updating".to_owned());
+            }
+            let location = std::fs::canonicalize(location).map_err(|_| "An OpenNOW MSI registration points to an unavailable installation; repair it before updating")?;
+            if location == target {
+                return Ok(Some(product));
+            }
+        }
+        Err("Too many registered MSI products".to_owned())
+    }
+
+    pub(super) fn identity(
+        package: &Path,
+        target: &Path,
+        version: &str,
+    ) -> Result<Identity, String> {
+        let upgrade = family(version)?;
+        let parsed = semver::Version::parse(version.trim_start_matches('v'))
+            .map_err(|error| error.to_string())?;
+        let (name, expected_version) = if parsed.pre.is_empty() {
+            (
+                "OpenNOW",
+                format!("{}.{}.{}", parsed.major, parsed.minor, parsed.patch),
+            )
+        } else {
+            let parts: Vec<_> = parsed.pre.as_str().split('.').collect();
+            if parts.len() != 3 {
+                return Err("Invalid MSI channel version".to_owned());
+            }
+            let run: u32 = parts[1].parse().map_err(|_| "Invalid MSI release run")?;
+            let attempt: u32 = parts[2]
+                .parse()
+                .map_err(|_| "Invalid MSI release attempt")?;
+            if !(1..=65535).contains(&run) || !(1..=65535).contains(&attempt) {
+                return Err("MSI release sequence is outside its supported range".to_owned());
+            }
+            (
+                if parts[0] == "nightly" {
+                    "OpenNOW Nightly"
+                } else {
+                    "OpenNOW Supporter"
+                },
+                format!("{}.{}.{}", run / 256, run % 256, attempt),
+            )
+        };
+        if !property(package, "UpgradeCode")?.eq_ignore_ascii_case(upgrade)
+            || property(package, "ProductName")? != name
+            || property(package, "Manufacturer")? != "OpenCloudGaming"
+        {
+            return Err("MSI product family or channel does not match OpenNOW".to_owned());
+        }
+        let arch = architecture(package)?;
+        let expected_arch = if cfg!(target_arch = "aarch64") {
+            "Arm64"
+        } else {
+            "x64"
+        };
+        if !arch.eq_ignore_ascii_case(expected_arch) {
+            return Err("MSI architecture does not match this installation".to_owned());
+        }
+        let installed_product = installed_at(target, upgrade)?
+            .ok_or("No matching Windows Installer registration owns this application")?;
+        let cached = registered(&installed_product, "LocalPackage")?;
+        if architecture(Path::new(&cached))? != arch {
+            return Err("MSI update architecture differs from the installed product".to_owned());
+        }
+        let numeric = property(package, "ProductVersion")?;
+        if numeric != expected_version {
+            return Err("MSI product version does not match the signed release version".to_owned());
+        }
+        Ok(Identity {
+            package: property(package, "ProductCode")?,
+            version: numeric,
+            architecture: arch,
+            installed_product,
+        })
+    }
+}
+
+#[cfg(windows)]
+fn msi_identity(package: &Path, target: &Path, version: &str) -> Result<Identity, String> {
+    windows::identity(package, target, version)
+}
+#[cfg(not(windows))]
+fn msi_identity(_: &Path, _: &Path, _: &str) -> Result<Identity, String> {
+    Err("MSI updates require Windows".to_owned())
+}
+
+pub(super) fn windows_managed(target: &Path) -> Result<bool, String> {
+    #[cfg(windows)]
+    {
+        for version in ["1.0.0", "1.0.0-nightly.1.1", "1.0.0-supporter.1.1"] {
+            if windows::installed_at(target, windows::family(version)?)?.is_some() {
+                return Ok(true);
+            }
+        }
+    }
+    let _ = target;
+    Ok(false)
+}
+
+pub(super) fn install(plan: &Plan, directory: &Path) -> Result<(), String> {
+    let identity = plan
+        .managed_identity
+        .as_ref()
+        .ok_or("Missing prepared managed-package identity")?;
+    if matches!(
+        plan.kind,
+        InstallKind::WindowsMsi | InstallKind::DebianPackage
+    ) {
+        super::recovery::record_install_boot(directory)?;
+    }
+    let mut command = match plan.kind {
+        InstallKind::DebianPackage => {
+            let mut command = Command::new("/usr/bin/pkexec");
+            command
+                .args(["/usr/bin/dpkg", "--install"])
+                .arg(&plan.package);
+            command
+        }
+        InstallKind::WindowsMsi => {
+            let system =
+                std::env::var_os("SystemRoot").ok_or("Windows system directory is unavailable")?;
+            let mut command = Command::new(Path::new(&system).join("System32/msiexec.exe"));
+            command.arg("/i");
+            #[cfg(windows)]
+            command.arg(windows::argument_path(&plan.package)?);
+            #[cfg(not(windows))]
+            command.arg(&plan.package);
+            command.args(["/passive", "/norestart", "REBOOT=ReallySuppress"]);
+            #[cfg(windows)]
+            command.arg(format!(
+                "INSTALL_ROOT={}",
+                windows::argument_path(&plan.target)?
+            ));
+            #[cfg(not(windows))]
+            command.arg(format!("INSTALL_ROOT={}", plan.target.display()));
+            command
+        }
+        _ => return Err("Not a managed package update".to_owned()),
+    };
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("Cannot start native package manager: {error}"))?;
+    let started = Instant::now();
+    let code = loop {
+        if let Some(status) = child.try_wait().map_err(|error| error.to_string())? {
+            break status.code().unwrap_or(-1);
+        }
+        if started.elapsed() > Duration::from_secs(15 * 60) {
+            write_outcome(
+                directory,
+                plan,
+                OutcomeStatus::ManagedPending,
+                "Native package manager is still running; installation completion is not confirmed. Do not start another update.",
+                None,
+                super::ProcessIdentity::capture(child.id()).ok(),
+            )?;
+            return Err("Native installer exceeded the monitoring deadline; it was not killed or reported as successful".to_owned());
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    };
+    if plan.kind == InstallKind::WindowsMsi && matches!(code, 3010 | 1641) {
+        write_outcome(
+            directory,
+            plan,
+            OutcomeStatus::RebootRequired,
+            "Windows Installer requires a system restart; application startup is not yet confirmed",
+            Some(identity.version.clone()),
+            None,
+        )?;
+        return Ok(());
+    }
+    if code != 0 {
+        let mut message = format!(
+            "Native package manager exited with code {code}; update completion is not confirmed"
+        );
+        if prepare(plan.kind, &plan.package, &plan.target, &plan.version).is_ok()
+            && super::canonical_file(&plan.application_executable).is_ok()
+        {
+            match super::restart_previous(plan) {
+                Ok(_) => message.push_str("; the surviving registered application was restarted"),
+                Err(error) => message.push_str(&format!(
+                    "; the surviving application could not restart: {error}"
+                )),
+            }
+        } else {
+            message
+                .push_str("; a usable registered installation could not be confirmed for restart");
+        }
+        write_outcome(directory, plan, OutcomeStatus::Failed, &message, None, None)?;
+        return Err(message);
+    }
+    verify_installed(plan.kind, identity, &plan.target)?;
+    if let Err(error) = super::restart_and_acknowledge(plan, directory, Duration::from_secs(90)) {
+        let message = format!(
+            "Native package manager installed {}; application restart failed: {error}. No filesystem rollback was attempted for a managed installation.",
+            identity.version
+        );
+        write_outcome(
+            directory,
+            plan,
+            OutcomeStatus::Failed,
+            &message,
+            Some(identity.version.clone()),
+            None,
+        )?;
+        return Err(message);
+    }
+    write_outcome(
+        directory,
+        plan,
+        OutcomeStatus::Completed,
+        "Native package manager confirmed installation and the updated application acknowledged healthy startup",
+        Some(plan.version.clone()),
+        None,
+    )?;
+    super::cleanup_completed(plan, directory)
+}
+
+pub(super) fn verify_installed(
+    kind: InstallKind,
+    identity: &Identity,
+    target: &Path,
+) -> Result<(), String> {
+    let _ = target;
+    match kind {
+        InstallKind::DebianPackage => {
+            let value = super::command_output(
+                Command::new("/usr/bin/dpkg-query").args([
+                    "--show",
+                    "--showformat=${db:Status-Status}\t${Version}\t${Architecture}",
+                    &identity.package,
+                ]),
+                Duration::from_secs(5),
+            )?;
+            if !value.status.success()
+                || value.stdout
+                    != format!("installed\t{}\t{}", identity.version, identity.architecture)
+                        .as_bytes()
+            {
+                return Err(
+                    "The OpenNOW DEB is not configured at the expected version and architecture."
+                        .to_owned(),
+                );
+            }
+            Ok(())
+        }
+        InstallKind::WindowsMsi => {
+            #[cfg(windows)]
+            {
+                if windows::registered(&identity.package, "VersionString")? != identity.version {
+                    return Err(
+                        "Windows Installer registration does not confirm the installed version"
+                            .to_owned(),
+                    );
+                }
+                if std::fs::canonicalize(windows::registered(&identity.package, "InstallLocation")?)
+                    .map_err(|error| error.to_string())?
+                    != target
+                {
+                    return Err(
+                        "Windows Installer registered an unexpected installation location"
+                            .to_owned(),
+                    );
+                }
+                Ok(())
+            }
+            #[cfg(not(windows))]
+            Err("MSI updates require Windows".to_owned())
+        }
+        _ => Err("Not a managed package".to_owned()),
+    }
+}

--- a/native/opennow-core/src/update_apply/mod.rs
+++ b/native/opennow-core/src/update_apply/mod.rs
@@ -1,0 +1,1451 @@
+mod archive;
+mod bundle;
+mod managed;
+mod process;
+mod recovery;
+mod security;
+pub mod verification;
+
+use fs2::FileExt;
+pub use process::ProcessIdentity;
+pub use recovery::{ManagedRecovery, recover_managed_update};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum InstallKind {
+    AppImage,
+    WindowsPortable,
+    MacBundle,
+    WindowsMsi,
+    DebianPackage,
+}
+
+#[derive(Debug)]
+pub(super) enum RestartFailure {
+    RollbackSafe(String),
+    ProcessesMayBeRunning(String),
+}
+
+impl std::fmt::Display for RestartFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RollbackSafe(message) | Self::ProcessesMayBeRunning(message) => {
+                formatter.write_str(message)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PrepareRequest {
+    pub package: PathBuf,
+    pub expected_version: String,
+    pub application_executable: PathBuf,
+    pub application_pid: u32,
+    pub core_pid: u32,
+    pub kind: InstallKind,
+    pub data_dir: PathBuf,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PreparedUpdate {
+    pub plan_path: PathBuf,
+    pub outcome_path: PathBuf,
+    pub version: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Plan {
+    schema_version: u32,
+    version: String,
+    kind: InstallKind,
+    package: PathBuf,
+    target: PathBuf,
+    application_executable: PathBuf,
+    data_dir: PathBuf,
+    processes: Vec<ProcessIdentity>,
+    nonce: String,
+    managed_identity: Option<managed::Identity>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum OutcomeStatus {
+    Prepared,
+    WaitingForExit,
+    BackingUp,
+    Installing,
+    AwaitingStartup,
+    Completed,
+    RolledBack,
+    Failed,
+    ManagedPending,
+    RebootRequired,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateOutcome {
+    pub schema_version: u32,
+    pub version: String,
+    pub status: OutcomeStatus,
+    pub message: String,
+    pub installed_version: Option<String>,
+    pub restarted_process: Option<ProcessIdentity>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Acknowledgement {
+    nonce: String,
+    version: String,
+    application: ProcessIdentity,
+}
+
+pub fn detect_install_kind(application: &Path, package: &Path) -> Result<InstallKind, String> {
+    let extension = package
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "appimage" if cfg!(target_os = "linux") => Ok(InstallKind::AppImage),
+        "deb" if cfg!(target_os = "linux") => Ok(InstallKind::DebianPackage),
+        "msi" if cfg!(windows) => Ok(InstallKind::WindowsMsi),
+        "zip" if cfg!(windows) => Ok(InstallKind::WindowsPortable),
+        "zip" | "dmg"
+            if cfg!(target_os = "macos")
+                && application
+                    .ancestors()
+                    .any(|path| path.extension().is_some_and(|extension| extension == "app")) =>
+        {
+            Ok(InstallKind::MacBundle)
+        }
+        _ => Err(
+            "No safe native update mechanism exists for this package and installation".to_owned(),
+        ),
+    }
+}
+
+pub fn compatible_package_extension() -> Result<&'static str, String> {
+    #[cfg(target_os = "linux")]
+    {
+        Ok(if std::env::var_os("APPIMAGE").is_some() {
+            "appimage"
+        } else {
+            "deb"
+        })
+    }
+    #[cfg(target_os = "macos")]
+    {
+        Ok("dmg")
+    }
+    #[cfg(windows)]
+    {
+        let executable = std::env::var_os("OPENNOW_APP_EXECUTABLE")
+            .ok_or("Missing trusted application executable")?;
+        let executable = canonical_file(Path::new(&executable))?;
+        let root = installation_target(InstallKind::WindowsMsi, &executable)?;
+        Ok(if managed::windows_managed(&root)? {
+            "msi"
+        } else {
+            "zip"
+        })
+    }
+}
+
+pub fn prepare_update(request: PrepareRequest) -> Result<PreparedUpdate, String> {
+    let package = canonical_file(&request.package)?;
+    let manifest = read_manifest(&package)?;
+    if manifest.version.trim_start_matches('v') != request.expected_version.trim_start_matches('v')
+    {
+        return Err("Signed update version does not match the selected release".to_owned());
+    }
+    verification::verify_package(&package, &manifest)?;
+    let application = canonical_file(&request.application_executable)?;
+    if detect_install_kind(&application, &package)? != request.kind {
+        return Err("Update package does not match the installation type".to_owned());
+    }
+    let app_process = ProcessIdentity::capture(request.application_pid)?;
+    app_process.matches_executable(&application)?;
+    let core_process = ProcessIdentity::capture(request.core_pid)?;
+    core_process
+        .matches_executable(&std::env::current_exe().map_err(|error| error.to_string())?)?;
+    let target = installation_target(request.kind, &application)?;
+    if request.kind == InstallKind::WindowsPortable && managed::windows_managed(&target)? {
+        return Err(
+            "Windows Installer owns this installation; a portable ZIP cannot replace it".to_owned(),
+        );
+    }
+    let data_dir = fs::canonicalize(&request.data_dir).map_err(|error| error.to_string())?;
+    if (data_dir.starts_with(&target) && request.kind != InstallKind::WindowsPortable)
+        || target.starts_with(&data_dir)
+    {
+        return Err(
+            "Application settings must be outside the installation being replaced".to_owned(),
+        );
+    }
+    let parent = if matches!(
+        request.kind,
+        InstallKind::WindowsMsi | InstallKind::DebianPackage
+    ) {
+        data_dir.join("updates")
+    } else {
+        target
+            .parent()
+            .ok_or("Installation has no parent")?
+            .to_path_buf()
+    };
+    fs::create_dir_all(&parent).map_err(|error| error.to_string())?;
+    let directory = parent.join(format!(".opennow-update-{:032x}", rand::random::<u128>()));
+    security::create_private_directory(&directory)
+        .map_err(|error| format!("Cannot write beside the installed application: {error}"))?;
+    let result = (|| {
+        let private_package = directory.join(&manifest.asset);
+        copy_synced(&package, &private_package)?;
+        copy_synced(&manifest_path(&package)?, &manifest_path(&private_package)?)?;
+        verification::verify_package(&private_package, &manifest)?;
+        let managed_identity =
+            managed::prepare(request.kind, &private_package, &target, &manifest.version)?;
+        let plan = Plan {
+            schema_version: 1,
+            version: manifest.version.trim_start_matches('v').to_owned(),
+            kind: request.kind,
+            package: private_package,
+            target,
+            application_executable: application,
+            data_dir,
+            processes: vec![app_process, core_process],
+            nonce: format!("{:064x}", rand::random::<u128>()),
+            managed_identity,
+        };
+        let preflight = prepare_payload(&plan, &directory.join("preflight"))?;
+        preserve_portable_data(&plan, &preflight)?;
+        remove_path(&directory.join("preflight"))?;
+        let helper = std::env::current_exe()
+            .map_err(|error| error.to_string())?
+            .parent()
+            .ok_or("Core has no executable directory")?
+            .join(if cfg!(windows) {
+                "opennow-update-helper.exe"
+            } else {
+                "opennow-update-helper"
+            });
+        copy_synced(
+            &canonical_file(&helper)?,
+            &directory.join(helper.file_name().ok_or("Invalid helper name")?),
+        )?;
+        make_executable(&directory.join(helper.file_name().ok_or("Invalid helper name")?))?;
+        #[cfg(windows)]
+        for name in ["vcruntime140.dll", "vcruntime140_1.dll", "msvcp140.dll"] {
+            let runtime = helper
+                .parent()
+                .ok_or("Missing helper directory")?
+                .join(name);
+            if runtime.is_file() {
+                copy_synced(&canonical_file(&runtime)?, &directory.join(name))?;
+            }
+        }
+        let plan_path = directory.join("plan.json");
+        atomic_json(&plan_path, &plan)?;
+        write_outcome(
+            &directory,
+            &plan,
+            OutcomeStatus::Prepared,
+            "Update verified and prepared; application is still running",
+            None,
+            None,
+        )?;
+        Ok(PreparedUpdate {
+            plan_path,
+            outcome_path: directory.join("outcome.json"),
+            version: plan.version,
+        })
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&directory);
+    }
+    result
+}
+
+pub fn launch_prepared_update(prepared: &PreparedUpdate) -> Result<u32, String> {
+    let directory = prepared
+        .plan_path
+        .parent()
+        .ok_or("Update plan has no directory")?;
+    let helper = directory.join(if cfg!(windows) {
+        "opennow-update-helper.exe"
+    } else {
+        "opennow-update-helper"
+    });
+    let mut command = Command::new(helper);
+    command
+        .current_dir(directory)
+        .arg("--apply")
+        .arg(&prepared.plan_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x00000008 | 0x00000200);
+    }
+    let plan: Plan = read_json(&prepared.plan_path, 64 * 1024)?;
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            let message = format!("Cannot start update helper: {error}");
+            write_outcome(
+                directory,
+                &plan,
+                OutcomeStatus::Failed,
+                &message,
+                None,
+                None,
+            )?;
+            return Err(message);
+        }
+    };
+    let result = (|| {
+        let start = Instant::now();
+        loop {
+            if child
+                .try_wait()
+                .map_err(|error| error.to_string())?
+                .is_some()
+            {
+                return Err(read_outcome(&prepared.outcome_path)?
+                    .map(|outcome| outcome.message)
+                    .unwrap_or_else(|| "Update helper stopped before it was ready".to_owned()));
+            }
+            if read_outcome(&prepared.outcome_path)?
+                .is_some_and(|outcome| outcome.status == OutcomeStatus::WaitingForExit)
+                && helper_is_running(prepared)?
+            {
+                return Ok(child.id());
+            }
+            if start.elapsed() > Duration::from_secs(300) {
+                return Err(
+                    "Update helper preparation timed out; the application remains running"
+                        .to_owned(),
+                );
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    })();
+    if let Err(error) = &result {
+        let _ = child.kill();
+        let _ = child.wait();
+        write_outcome(directory, &plan, OutcomeStatus::Failed, error, None, None)?;
+    }
+    result
+}
+
+pub fn helper_is_running(prepared: &PreparedUpdate) -> Result<bool, String> {
+    let path = prepared
+        .plan_path
+        .parent()
+        .ok_or("Invalid update plan directory")?
+        .join("apply.lock");
+    if !path.exists() {
+        return Ok(false);
+    }
+    let lock = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|error| error.to_string())?;
+    match lock.try_lock_exclusive() {
+        Ok(()) => Ok(false),
+        Err(error) if error.raw_os_error() == fs2::lock_contended_error().raw_os_error() => {
+            Ok(true)
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub fn read_outcome(path: &Path) -> Result<Option<UpdateOutcome>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let outcome: UpdateOutcome = read_json(path, 64 * 1024)?;
+    if outcome.schema_version != 1 {
+        return Err("Unsupported update outcome schema".to_owned());
+    }
+    Ok(Some(outcome))
+}
+
+pub fn acknowledge_startup_from_env(application_version: &str) -> Result<bool, String> {
+    let Some(plan_path) = std::env::var_os("OPENNOW_UPDATE_PLAN") else {
+        return Ok(false);
+    };
+    let plan_path = PathBuf::from(plan_path);
+    let plan: Plan = read_json(&plan_path, 64 * 1024)?;
+    let nonce =
+        std::env::var("OPENNOW_UPDATE_NONCE").map_err(|_| "Missing update startup nonce")?;
+    if plan.schema_version != 1
+        || plan.version != application_version.trim_start_matches('v')
+        || nonce != plan.nonce
+    {
+        return Err(
+            "Updated application startup identity does not match the update plan".to_owned(),
+        );
+    }
+    let pid = std::env::var("OPENNOW_APP_PID")
+        .map_err(|_| "Missing trusted application PID")?
+        .parse()
+        .map_err(|_| "Invalid trusted application PID")?;
+    let application = ProcessIdentity::capture(pid)?;
+    if plan.kind == InstallKind::AppImage {
+        let image = std::env::var_os("APPIMAGE")
+            .ok_or("Updated process is not running from an AppImage")?;
+        if canonical_file(Path::new(&image))? != plan.target {
+            return Err("Updated AppImage does not match the installation target".to_owned());
+        }
+    } else {
+        application.matches_executable(&plan.application_executable)?;
+    }
+    atomic_json(
+        &plan_path
+            .parent()
+            .ok_or("Invalid update plan path")?
+            .join("ack.json"),
+        &Acknowledgement {
+            nonce,
+            version: plan.version,
+            application,
+        },
+    )?;
+    Ok(true)
+}
+
+pub fn run_helper(plan_path: &Path) -> Result<(), String> {
+    let plan_path = canonical_file(plan_path)?;
+    let directory = plan_path.parent().ok_or("Invalid update plan path")?;
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(directory.join("apply.lock"))
+        .map_err(|error| error.to_string())?;
+    lock.try_lock_exclusive()
+        .map_err(|_| "Another helper owns this update transaction")?;
+    let plan: Plan = read_json(&plan_path, 64 * 1024)?;
+    if read_outcome(&directory.join("outcome.json"))?.is_some_and(|outcome| {
+        matches!(
+            outcome.status,
+            OutcomeStatus::Completed | OutcomeStatus::RolledBack | OutcomeStatus::RebootRequired
+        )
+    }) {
+        return Ok(());
+    }
+    let result = validate_plan(&plan, directory).and_then(|_| apply(&plan, directory));
+    if let Err(error) = &result {
+        let outcome = read_outcome(&directory.join("outcome.json"))?;
+        if outcome.as_ref().is_none_or(|outcome| {
+            !matches!(
+                outcome.status,
+                OutcomeStatus::RolledBack
+                    | OutcomeStatus::Failed
+                    | OutcomeStatus::ManagedPending
+                    | OutcomeStatus::RebootRequired
+            )
+        }) {
+            write_outcome(
+                directory,
+                &plan,
+                OutcomeStatus::Failed,
+                error,
+                outcome
+                    .as_ref()
+                    .and_then(|outcome| outcome.installed_version.clone()),
+                outcome.and_then(|outcome| outcome.restarted_process),
+            )?;
+        }
+    }
+    result
+}
+
+fn validate_plan(plan: &Plan, directory: &Path) -> Result<(), String> {
+    if plan.schema_version != 1
+        || plan.nonce.len() != 64
+        || !plan.nonce.bytes().all(|value| value.is_ascii_hexdigit())
+        || plan.processes.len() != 2
+    {
+        return Err("Invalid update plan schema or process identities".to_owned());
+    }
+    if !plan.target.is_absolute()
+        || !plan.application_executable.is_absolute()
+        || !plan.data_dir.is_absolute()
+        || plan.package.parent() != Some(directory)
+        || (plan.kind != InstallKind::AppImage
+            && installation_target(plan.kind, &plan.application_executable)? != plan.target)
+        || (plan.data_dir.starts_with(&plan.target) && plan.kind != InstallKind::WindowsPortable)
+        || plan.target.starts_with(&plan.data_dir)
+    {
+        return Err("Invalid update installation paths".to_owned());
+    }
+    if !matches!(
+        plan.kind,
+        InstallKind::WindowsMsi | InstallKind::DebianPackage
+    ) && plan.target.parent() != directory.parent()
+    {
+        return Err("Update payload is not beside its installation".to_owned());
+    }
+    if plan.processes[0].executable != plan.application_executable {
+        return Err("Update process identity does not match the application".to_owned());
+    }
+    let manifest = read_manifest(&plan.package)?;
+    if manifest.version.trim_start_matches('v') != plan.version
+        || detect_install_kind(&plan.application_executable, &plan.package)? != plan.kind
+    {
+        return Err("Update plan does not match the signed manifest".to_owned());
+    }
+    verification::verify_package(&plan.package, &manifest)
+}
+
+fn apply(plan: &Plan, directory: &Path) -> Result<(), String> {
+    let previous =
+        read_outcome(&directory.join("outcome.json"))?.ok_or("Missing prepared update outcome")?;
+    if previous.status != OutcomeStatus::Prepared {
+        if matches!(
+            previous.status,
+            OutcomeStatus::BackingUp
+                | OutcomeStatus::Installing
+                | OutcomeStatus::AwaitingStartup
+                | OutcomeStatus::Failed
+        ) && !matches!(
+            plan.kind,
+            InstallKind::WindowsMsi | InstallKind::DebianPackage
+        ) {
+            if previous.restarted_process.is_none()
+                && (previous.status == OutcomeStatus::AwaitingStartup
+                    || (previous.status == OutcomeStatus::Failed
+                        && directory.join("previous").exists()))
+            {
+                return Err("Interrupted startup has no confirmed process identity; automatic rollback is unsafe".to_owned());
+            }
+            if previous
+                .restarted_process
+                .as_ref()
+                .map(process::owned_tree_is_running)
+                .transpose()?
+                .unwrap_or(false)
+            {
+                return Err(
+                    "Interrupted update still has a running application; close it before recovery"
+                        .to_owned(),
+                );
+            }
+            rollback(plan, directory)?;
+            let message = match restart_previous(plan) {
+                Ok(_) => "Recovered an interrupted replacement; previous installation restored and restart requested".to_owned(),
+                Err(error) => format!("Recovered an interrupted replacement; previous installation restored but restart failed: {error}"),
+            };
+            write_outcome(
+                directory,
+                plan,
+                OutcomeStatus::RolledBack,
+                &message,
+                None,
+                None,
+            )?;
+            return Ok(());
+        }
+        return Err("Update transaction has already started or completed".to_owned());
+    }
+    let payload = prepare_payload(plan, &directory.join("payload"))?;
+    let preserved = preserve_portable_data(plan, &payload)?;
+    managed::verify_identity(
+        plan.kind,
+        &plan.package,
+        &plan.target,
+        &plan.version,
+        plan.managed_identity.as_ref(),
+    )?;
+    write_outcome(
+        directory,
+        plan,
+        OutcomeStatus::WaitingForExit,
+        "Helper independently verified the signed update and is waiting for application shutdown",
+        None,
+        None,
+    )?;
+    process::wait_for_exit(&plan.processes, Duration::from_secs(90))?;
+    let refresh = (|| {
+        for (_, destination) in preserved {
+            remove_path(&destination)?;
+        }
+        preserve_portable_data(plan, &payload).map(|_| ())
+    })();
+    if let Err(error) = refresh {
+        let _ = restart_previous(plan);
+        return Err(error);
+    }
+    if matches!(
+        plan.kind,
+        InstallKind::WindowsMsi | InstallKind::DebianPackage
+    ) {
+        write_outcome(
+            directory,
+            plan,
+            OutcomeStatus::Installing,
+            "Native package manager is installing the verified update",
+            None,
+            None,
+        )?;
+        return managed::install(plan, directory);
+    }
+    replace_and_restart(plan, directory, &payload, Duration::from_secs(90))
+}
+
+fn replace_and_restart(
+    plan: &Plan,
+    directory: &Path,
+    payload: &Path,
+    startup_timeout: Duration,
+) -> Result<(), String> {
+    write_outcome(
+        directory,
+        plan,
+        OutcomeStatus::BackingUp,
+        "Preserving the previous installation",
+        None,
+        None,
+    )?;
+    let installed = rename_synced(&plan.target, &directory.join("previous")).and_then(|_| {
+        write_outcome(
+            directory,
+            plan,
+            OutcomeStatus::Installing,
+            "Replacing the complete installation",
+            None,
+            None,
+        )?;
+        rename_synced(payload, &plan.target)?;
+        if plan.kind == InstallKind::MacBundle {
+            bundle::verify_bundle(&plan.target, &directory.join("previous"))?;
+        }
+        Ok(())
+    });
+    let result = installed
+        .map_err(RestartFailure::RollbackSafe)
+        .and_then(|_| restart_and_acknowledge(plan, directory, startup_timeout));
+    if let Err(error) = result {
+        return recover_replacement(plan, directory, error);
+    }
+    write_outcome(
+        directory,
+        plan,
+        OutcomeStatus::Completed,
+        "Updated application acknowledged healthy startup",
+        Some(plan.version.clone()),
+        None,
+    )?;
+    cleanup_completed(plan, directory)?;
+    Ok(())
+}
+
+fn recover_replacement(
+    plan: &Plan,
+    directory: &Path,
+    failure: RestartFailure,
+) -> Result<(), String> {
+    let error = match failure {
+        RestartFailure::ProcessesMayBeRunning(error) => return Err(error),
+        RestartFailure::RollbackSafe(error) => error,
+    };
+    if let Err(rollback_error) = rollback(plan, directory) {
+        let message = format!(
+            "{error}; rollback failed: {rollback_error}. Previous installation remains in {}",
+            directory.join("previous").display()
+        );
+        write_outcome(directory, plan, OutcomeStatus::Failed, &message, None, None)?;
+        return Err(message);
+    }
+    let restart = restart_previous(plan);
+    let message = format!(
+        "{error}; previous installation restored{}",
+        restart
+            .err()
+            .map(|error| format!(" but restart failed: {error}"))
+            .unwrap_or_default()
+    );
+    write_outcome(
+        directory,
+        plan,
+        OutcomeStatus::RolledBack,
+        &message,
+        None,
+        None,
+    )?;
+    Err(message)
+}
+
+fn cleanup_completed(plan: &Plan, directory: &Path) -> Result<(), String> {
+    for path in [
+        directory.join("previous"),
+        directory.join("payload"),
+        plan.package.clone(),
+        manifest_path(&plan.package)?,
+    ] {
+        if let Err(error) = remove_path(&path) {
+            write_outcome(
+                directory,
+                plan,
+                OutcomeStatus::Completed,
+                &format!(
+                    "Updated application acknowledged healthy startup; cleanup of {} was deferred: {error}",
+                    path.display()
+                ),
+                Some(plan.version.clone()),
+                None,
+            )?;
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+fn rollback(plan: &Plan, directory: &Path) -> Result<(), String> {
+    let backup = directory.join("previous");
+    if !backup.exists() {
+        if plan.target.exists() {
+            return Ok(());
+        }
+        return Err("Previous installation is missing".to_owned());
+    }
+    if plan.target.exists() {
+        rename_synced(&plan.target, &directory.join("failed"))?;
+    }
+    rename_synced(&backup, &plan.target)
+}
+
+fn restart_previous(plan: &Plan) -> Result<Child, String> {
+    Command::new(restart_executable(plan))
+        .current_dir(
+            restart_executable(plan)
+                .parent()
+                .ok_or("Application executable has no directory")?,
+        )
+        .env("OPENNOW_DATA_DIR", &plan.data_dir)
+        .env_remove("APPIMAGE")
+        .env_remove("APPDIR")
+        .env_remove("ARGV0")
+        .env_remove("OPENNOW_UPDATE_PLAN")
+        .env_remove("OPENNOW_UPDATE_NONCE")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| error.to_string())
+}
+
+fn restart_executable(plan: &Plan) -> &Path {
+    if plan.kind == InstallKind::AppImage {
+        &plan.target
+    } else {
+        &plan.application_executable
+    }
+}
+
+fn restart_and_acknowledge(
+    plan: &Plan,
+    directory: &Path,
+    timeout: Duration,
+) -> Result<(), RestartFailure> {
+    let mut command = Command::new(restart_executable(plan));
+    command
+        .env("OPENNOW_DATA_DIR", &plan.data_dir)
+        .current_dir(restart_executable(plan).parent().ok_or_else(|| {
+            RestartFailure::RollbackSafe("Application executable has no directory".to_owned())
+        })?)
+        .env_remove("APPIMAGE")
+        .env_remove("APPDIR")
+        .env_remove("ARGV0")
+        .env("OPENNOW_UPDATE_PLAN", directory.join("plan.json"))
+        .env("OPENNOW_UPDATE_NONCE", &plan.nonce)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    write_outcome(
+        directory,
+        plan,
+        OutcomeStatus::AwaitingStartup,
+        "Preparing to start the updated application",
+        Some(plan.version.clone()),
+        None,
+    )
+    .map_err(RestartFailure::RollbackSafe)?;
+    let mut application = process::OwnedApplication::start(&mut command)?;
+    let result = (|| {
+        write_outcome(
+            directory,
+            plan,
+            OutcomeStatus::AwaitingStartup,
+            "Updated application started; waiting for healthy UI and core acknowledgement",
+            Some(plan.version.clone()),
+            Some(application.identity.clone()),
+        )?;
+        let started = Instant::now();
+        loop {
+            if application
+                .child
+                .try_wait()
+                .map_err(|error| error.to_string())?
+                .is_some()
+            {
+                break Err("Updated application exited before healthy startup".to_owned());
+            }
+            if directory.join("ack.json").exists() {
+                match read_json::<Acknowledgement>(&directory.join("ack.json"), 64 * 1024) {
+                    Ok(ack)
+                        if ack.nonce == plan.nonce
+                            && ack.version == plan.version
+                            && application.owns(&ack.application)?
+                            && (plan.kind == InstallKind::AppImage
+                                || ack.application.executable == plan.application_executable)
+                            && ack.application.is_running()? =>
+                    {
+                        break Ok(());
+                    }
+                    _ => {
+                        break Err(
+                            "Updated application returned an invalid startup acknowledgement"
+                                .to_owned(),
+                        );
+                    }
+                }
+            }
+            if started.elapsed() >= timeout {
+                break Err(
+                    "Updated application did not acknowledge healthy startup before the deadline"
+                        .to_owned(),
+                );
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    })();
+    let Err(error) = result else {
+        return Ok(());
+    };
+    let stopped = application.stop();
+    Err(failed_restart(error, stopped, |message| {
+        write_outcome(
+            directory,
+            plan,
+            OutcomeStatus::Failed,
+            message,
+            Some(plan.version.clone()),
+            Some(application.identity.clone()),
+        )
+    }))
+}
+
+fn failed_restart(
+    error: String,
+    stopped: Result<(), String>,
+    record: impl FnOnce(&str) -> Result<(), String>,
+) -> RestartFailure {
+    match stopped {
+        Ok(()) => RestartFailure::RollbackSafe(error),
+        Err(shutdown_error) => {
+            let message = format!(
+                "{error}; {shutdown_error}; rollback was not attempted while updated processes may still be running"
+            );
+            let _ = record(&message);
+            RestartFailure::ProcessesMayBeRunning(message)
+        }
+    }
+}
+
+fn prepare_payload(plan: &Plan, destination: &Path) -> Result<PathBuf, String> {
+    match plan.kind {
+        InstallKind::AppImage => {
+            let mut file = File::open(&plan.package).map_err(|error| error.to_string())?;
+            let mut magic = [0u8; 11];
+            file.read_exact(&mut magic)
+                .map_err(|error| error.to_string())?;
+            if &magic[..4] != b"\x7fELF" || &magic[8..11] != b"AI\x02" {
+                return Err("Signed package is not a type-2 AppImage".to_owned());
+            }
+            validate_executable_architecture(&plan.package, plan.kind)?;
+            copy_synced(&plan.package, destination)?;
+            make_executable(destination)?;
+            Ok(destination.to_path_buf())
+        }
+        InstallKind::WindowsPortable | InstallKind::MacBundle => {
+            if plan.kind == InstallKind::MacBundle
+                && plan
+                    .package
+                    .extension()
+                    .is_some_and(|value| value.eq_ignore_ascii_case("dmg"))
+            {
+                bundle::extract_dmg(&plan.package, destination)?;
+            } else {
+                archive::extract_zip(
+                    &plan.package,
+                    destination,
+                    plan.kind == InstallKind::MacBundle,
+                )?;
+            }
+            let relative = plan
+                .application_executable
+                .strip_prefix(&plan.target)
+                .map_err(|error| error.to_string())?;
+            let candidates = std::iter::once(destination.to_path_buf()).chain(
+                fs::read_dir(destination)
+                    .map_err(|error| error.to_string())?
+                    .filter_map(|entry| entry.ok().map(|entry| entry.path())),
+            );
+            let roots: Vec<_> = candidates
+                .filter(|root| root.join(relative).is_file())
+                .collect();
+            if roots.len() != 1 {
+                return Err(
+                    "Update archive does not contain exactly one expected application root"
+                        .to_owned(),
+                );
+            }
+            let root = roots.into_iter().next().ok_or("Missing update root")?;
+            let executable = root.join(relative);
+            canonical_file(&executable)?;
+            let core = executable
+                .parent()
+                .ok_or("Missing update executable directory")?
+                .join(if cfg!(windows) {
+                    "opennow-core.exe"
+                } else {
+                    "opennow-core"
+                });
+            canonical_file(&core)?;
+            let helper = executable
+                .parent()
+                .ok_or("Missing update executable directory")?
+                .join(if cfg!(windows) {
+                    "opennow-update-helper.exe"
+                } else {
+                    "opennow-update-helper"
+                });
+            canonical_file(&helper)?;
+            for path in [&executable, &core, &helper] {
+                validate_executable_architecture(path, plan.kind)?;
+            }
+            if plan.kind == InstallKind::MacBundle {
+                bundle::verify_bundle(&root, &plan.target)?;
+            }
+            Ok(root)
+        }
+        InstallKind::WindowsMsi | InstallKind::DebianPackage => Ok(plan.package.clone()),
+    }
+}
+
+fn validate_executable_architecture(path: &Path, kind: InstallKind) -> Result<(), String> {
+    use std::io::{Seek, SeekFrom};
+    if kind == InstallKind::MacBundle {
+        #[cfg(target_os = "macos")]
+        {
+            let architecture = if cfg!(target_arch = "aarch64") {
+                "arm64"
+            } else {
+                "x86_64"
+            };
+            if !command_output(
+                Command::new("/usr/bin/lipo")
+                    .arg(path)
+                    .args(["-verify_arch", architecture]),
+                Duration::from_secs(120),
+            )?
+            .status
+            .success()
+            {
+                return Err(
+                    "Application bundle does not contain this processor architecture".to_owned(),
+                );
+            }
+        }
+        return Ok(());
+    }
+    let mut file = File::open(path).map_err(|error| error.to_string())?;
+    let mut header = [0u8; 64];
+    file.read_exact(&mut header)
+        .map_err(|error| error.to_string())?;
+    if kind == InstallKind::AppImage {
+        let expected: u16 = if cfg!(target_arch = "aarch64") {
+            183
+        } else {
+            62
+        };
+        if header[4] != 2
+            || header[5] != 1
+            || u16::from_le_bytes([header[18], header[19]]) != expected
+        {
+            return Err("AppImage architecture does not match this installation".to_owned());
+        }
+        return Ok(());
+    }
+    if &header[..2] != b"MZ" {
+        return Err("Windows package contains a non-PE executable".to_owned());
+    }
+    let offset = u32::from_le_bytes(header[60..64].try_into().map_err(|_| "Invalid PE header")?);
+    if offset > 1024 * 1024 {
+        return Err("Windows PE header exceeds its bound".to_owned());
+    }
+    file.seek(SeekFrom::Start(offset as u64))
+        .map_err(|error| error.to_string())?;
+    let mut pe = [0u8; 6];
+    file.read_exact(&mut pe)
+        .map_err(|error| error.to_string())?;
+    let expected: u16 = if cfg!(target_arch = "aarch64") {
+        0xaa64
+    } else {
+        0x8664
+    };
+    if &pe[..4] != b"PE\0\0" || u16::from_le_bytes([pe[4], pe[5]]) != expected {
+        return Err("Windows executable architecture does not match this installation".to_owned());
+    }
+    Ok(())
+}
+
+fn preserve_portable_data(plan: &Plan, payload: &Path) -> Result<Vec<(PathBuf, PathBuf)>, String> {
+    if plan.kind != InstallKind::WindowsPortable {
+        return Ok(Vec::new());
+    }
+    let mut sources = Vec::new();
+    for (index, entry) in fs::read_dir(&plan.target)
+        .map_err(|error| error.to_string())?
+        .enumerate()
+    {
+        if index as u64 >= bundle::MAX_COPY_ENTRIES {
+            return Err(
+                "Portable installation has too many root entries to preserve safely".to_owned(),
+            );
+        }
+        let entry = entry.map_err(|error| error.to_string())?;
+        if !matches!(
+            entry.file_name().to_str(),
+            Some("bin" | "share" | "LICENSE" | "THIRD_PARTY_NOTICES.json")
+        ) {
+            sources.push(entry.path());
+        }
+    }
+    if plan.data_dir.starts_with(&plan.target)
+        && !sources.iter().any(|path| plan.data_dir.starts_with(path))
+    {
+        sources.push(plan.data_dir.clone());
+    }
+    let mut copied = Vec::new();
+    let mut budget = bundle::CopyBudget::new();
+    for source in sources {
+        let destination = payload.join(
+            source
+                .strip_prefix(&plan.target)
+                .map_err(|error| error.to_string())?,
+        );
+        if destination.exists() {
+            return Err(format!(
+                "Update package overlaps preserved user data at {}; move that data outside the installation before updating",
+                source.display()
+            ));
+        }
+        copy_user_data(&source, &destination, &mut budget)?;
+        copied.push((source, destination));
+    }
+    Ok(copied)
+}
+
+fn copy_user_data(
+    source: &Path,
+    destination: &Path,
+    budget: &mut bundle::CopyBudget,
+) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    fs::create_dir_all(destination.parent().ok_or("User data has no parent")?)
+        .map_err(|error| error.to_string())?;
+    if metadata.is_dir() {
+        return bundle::copy_tree(source, destination, budget, bundle::CopyPolicy::UserData);
+    }
+    if !metadata.is_file() || metadata.len() > verification::MAXIMUM_UPDATE_BYTES {
+        return Err(
+            "Portable user data must contain bounded regular files or internal relative symlinks"
+                .to_owned(),
+        );
+    }
+    budget.consume_entry()?;
+    budget.copy_file(source, destination, bundle::CopyPolicy::UserData)
+}
+
+fn installation_target(kind: InstallKind, executable: &Path) -> Result<PathBuf, String> {
+    let parent = executable.parent().ok_or("Application has no directory")?;
+    match kind {
+        InstallKind::AppImage => {
+            let image = std::env::var_os("APPIMAGE")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| executable.to_path_buf());
+            canonical_file(&image)
+        }
+        InstallKind::MacBundle => {
+            if parent.file_name().is_none_or(|name| name != "MacOS")
+                || parent
+                    .parent()
+                    .and_then(Path::file_name)
+                    .is_none_or(|name| name != "Contents")
+            {
+                return Err("Application is not inside a standard macOS bundle".to_owned());
+            }
+            let root = parent
+                .parent()
+                .and_then(Path::parent)
+                .ok_or("Invalid app bundle")?;
+            if root.extension().is_none_or(|extension| extension != "app") {
+                return Err("Application bundle has no .app suffix".to_owned());
+            }
+            Ok(root.to_path_buf())
+        }
+        InstallKind::WindowsPortable | InstallKind::WindowsMsi => {
+            if parent.file_name().is_none_or(|name| name != "bin")
+                || executable
+                    .file_name()
+                    .is_none_or(|name| name != "OpenNOW.exe")
+            {
+                return Err(
+                    "Application does not use the supported Windows bin/OpenNOW.exe layout"
+                        .to_owned(),
+                );
+            }
+            Ok(parent
+                .parent()
+                .ok_or("Invalid Windows installation")?
+                .to_path_buf())
+        }
+        InstallKind::DebianPackage => Ok(executable.to_path_buf()),
+    }
+}
+
+fn read_manifest(package: &Path) -> Result<verification::UpdateManifest, String> {
+    let mut bytes = Vec::new();
+    File::open(canonical_file(&manifest_path(package)?)?)
+        .map_err(|error| error.to_string())?
+        .take(verification::MAXIMUM_MANIFEST_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| error.to_string())?;
+    verification::verify_signed_manifest(&bytes)
+}
+
+fn manifest_path(package: &Path) -> Result<PathBuf, String> {
+    Ok(package.with_file_name(format!(
+        "{}.manifest.json",
+        package
+            .file_name()
+            .and_then(|value| value.to_str())
+            .ok_or("Invalid update package name")?
+    )))
+}
+
+fn canonical_file(path: &Path) -> Result<PathBuf, String> {
+    if !fs::symlink_metadata(path)
+        .map_err(|error| error.to_string())?
+        .is_file()
+    {
+        return Err("Expected a regular file, not a link or directory".to_owned());
+    }
+    fs::canonicalize(path).map_err(|error| error.to_string())
+}
+
+fn copy_synced(source: &Path, destination: &Path) -> Result<(), String> {
+    copy_synced_bounded(
+        source,
+        destination,
+        verification::MAXIMUM_UPDATE_BYTES,
+        bundle::CopyPolicy::Bundle,
+    )
+    .map(|_| ())
+}
+
+fn copy_synced_bounded(
+    source: &Path,
+    destination: &Path,
+    maximum: u64,
+    policy: bundle::CopyPolicy,
+) -> Result<u64, String> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        options.custom_flags(windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let mut input = options.open(source).map_err(|error| error.to_string())?;
+    let metadata = input.metadata().map_err(|error| error.to_string())?;
+    if !metadata.is_file() || metadata.len() > maximum {
+        return Err(
+            "Update copy exceeds its remaining byte budget or is not a regular file".to_owned(),
+        );
+    }
+    let mut output_options = OpenOptions::new();
+    output_options.write(true).create_new(true);
+    #[cfg(unix)]
+    if policy == bundle::CopyPolicy::UserData {
+        use std::os::unix::fs::OpenOptionsExt;
+        output_options.mode(0o600);
+    }
+    let mut output = output_options
+        .open(destination)
+        .map_err(|error| error.to_string())?;
+    let result = (|| {
+        #[cfg(windows)]
+        if policy == bundle::CopyPolicy::UserData {
+            security::preserve_permissions(source, destination)?;
+        }
+        let copied = copy_bounded(&mut input, &mut output, maximum)?;
+        #[cfg(unix)]
+        if policy == bundle::CopyPolicy::UserData {
+            security::preserve_permissions(source, destination)?;
+        }
+        output.sync_all().map_err(|error| error.to_string())?;
+        Ok(copied)
+    })();
+    drop(output);
+    if result.is_err() {
+        let _ = fs::remove_file(destination);
+    }
+    result
+}
+
+fn copy_bounded(
+    input: &mut impl Read,
+    output: &mut impl Write,
+    maximum: u64,
+) -> Result<u64, String> {
+    let copied = std::io::copy(&mut (&mut *input).take(maximum), output)
+        .map_err(|error| error.to_string())?;
+    let mut overflow = [0u8; 1];
+    if input
+        .read(&mut overflow)
+        .map_err(|error| error.to_string())?
+        != 0
+    {
+        return Err("Update copy exceeds its remaining streaming byte budget".to_owned());
+    }
+    Ok(copied)
+}
+
+fn make_executable(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+            .map_err(|error| error.to_string())?;
+    }
+    let _ = path;
+    Ok(())
+}
+
+fn command_output(
+    command: &mut Command,
+    timeout: Duration,
+) -> Result<std::process::Output, String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let stdout = child.stdout.take().ok_or("Missing command stdout")?;
+    let stderr = child.stderr.take().ok_or("Missing command stderr")?;
+    let (sender, receiver) = std::sync::mpsc::sync_channel(2);
+    let read = |index: usize, stream: Box<dyn Read + Send>| {
+        let sender = sender.clone();
+        std::thread::spawn(move || {
+            let result = (|| {
+                let mut bytes = Vec::new();
+                stream
+                    .take(64 * 1024 + 1)
+                    .read_to_end(&mut bytes)
+                    .map_err(|error| error.to_string())?;
+                if bytes.len() > 64 * 1024 {
+                    return Err("Native package command output exceeds its limit".to_owned());
+                }
+                Ok(bytes)
+            })();
+            let _ = sender.send((index, result));
+        });
+    };
+    read(0, Box::new(stdout));
+    read(1, Box::new(stderr));
+    drop(sender);
+    let start = Instant::now();
+    let result = (|| {
+        let mut streams = [None, None];
+        let mut status = None;
+        loop {
+            if status.is_none() {
+                status = child.try_wait().map_err(|error| error.to_string())?;
+            }
+            while let Ok((index, result)) = receiver.try_recv() {
+                streams[index] = Some(result?);
+            }
+            if let (Some(status), true) = (status, streams.iter().all(Option::is_some)) {
+                return Ok(std::process::Output {
+                    status,
+                    stdout: streams[0].take().ok_or("Missing command stdout")?,
+                    stderr: streams[1].take().ok_or("Missing command stderr")?,
+                });
+            }
+            if start.elapsed() > timeout {
+                return Err("Native package command exceeded its deadline".to_owned());
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    })();
+    if result.is_err() {
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(-(child.id() as i32), libc::SIGKILL);
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    result
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(path: &Path, maximum: u64) -> Result<T, String> {
+    let mut bytes = Vec::new();
+    File::open(path)
+        .map_err(|error| error.to_string())?
+        .take(maximum + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| error.to_string())?;
+    if bytes.len() as u64 > maximum {
+        return Err("Update transaction metadata exceeds its size limit".to_owned());
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|error| format!("Invalid update transaction metadata: {error}"))
+}
+
+fn atomic_json(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    let temporary = path.with_extension(format!("{:016x}.tmp", rand::random::<u64>()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .map_err(|error| error.to_string())?;
+    let result = (|| {
+        file.write_all(&serde_json::to_vec(value).map_err(|error| error.to_string())?)
+            .and_then(|_| file.sync_all())
+            .map_err(|error| error.to_string())?;
+        drop(file);
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStrExt;
+            use windows_sys::Win32::Storage::FileSystem::{
+                MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+            };
+            let old: Vec<_> = temporary.as_os_str().encode_wide().chain(Some(0)).collect();
+            let new: Vec<_> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+            if unsafe {
+                MoveFileExW(
+                    old.as_ptr(),
+                    new.as_ptr(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+                )
+            } == 0
+            {
+                return Err(std::io::Error::last_os_error().to_string());
+            }
+        }
+        #[cfg(not(windows))]
+        fs::rename(&temporary, path).map_err(|error| error.to_string())?;
+        sync_directory(path.parent().ok_or("Metadata has no parent")?)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temporary);
+    }
+    result
+}
+
+fn rename_synced(source: &Path, destination: &Path) -> Result<(), String> {
+    if destination.exists() {
+        return Err("Update rename destination already exists".to_owned());
+    }
+    fs::rename(source, destination)
+        .map_err(|error| format!("Could not replace {}: {error}", source.display()))?;
+    sync_directory(source.parent().ok_or("Missing source parent")?)?;
+    sync_directory(destination.parent().ok_or("Missing destination parent")?)
+}
+
+fn sync_directory(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    File::open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| error.to_string())?;
+    let _ = path;
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> Result<(), String> {
+    if path.is_dir() {
+        fs::remove_dir_all(path)
+    } else if path.exists() {
+        fs::remove_file(path)
+    } else {
+        Ok(())
+    }
+    .map_err(|error| error.to_string())
+}
+
+fn write_outcome(
+    directory: &Path,
+    plan: &Plan,
+    status: OutcomeStatus,
+    message: &str,
+    installed_version: Option<String>,
+    restarted_process: Option<ProcessIdentity>,
+) -> Result<(), String> {
+    atomic_json(
+        &directory.join("outcome.json"),
+        &UpdateOutcome {
+            schema_version: 1,
+            version: plan.version.clone(),
+            status,
+            message: message.to_owned(),
+            installed_version,
+            restarted_process,
+        },
+    )
+}
+
+#[cfg(test)]
+mod integration_tests;
+#[cfg(test)]
+mod tests;

--- a/native/opennow-core/src/update_apply/process.rs
+++ b/native/opennow-core/src/update_apply/process.rs
@@ -1,0 +1,544 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+pub(super) struct OwnedApplication {
+    pub child: std::process::Child,
+    pub identity: ProcessIdentity,
+    #[cfg(windows)]
+    job: Job,
+}
+
+impl OwnedApplication {
+    pub fn start(command: &mut std::process::Command) -> Result<Self, super::RestartFailure> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            command.creation_flags(0x00000004);
+        }
+        let mut child = command.spawn().map_err(|error| {
+            super::RestartFailure::RollbackSafe(format!(
+                "Updated application could not start: {error}"
+            ))
+        })?;
+        #[cfg(windows)]
+        let job = match Job::assign(&child) {
+            Ok(job) => job,
+            Err(error) => {
+                return Err(failed_start(&mut child, error));
+            }
+        };
+        let identity = match ProcessIdentity::capture(child.id()) {
+            Ok(identity) => identity,
+            Err(error) => {
+                return Err(failed_start(&mut child, error));
+            }
+        };
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            #[link(name = "ntdll")]
+            unsafe extern "system" {
+                fn NtResumeProcess(process: windows_sys::Win32::Foundation::HANDLE) -> i32;
+            }
+            if unsafe { NtResumeProcess(child.as_raw_handle()) } != 0 {
+                return Err(failed_start(
+                    &mut child,
+                    "Cannot resume the owned updated application".to_owned(),
+                ));
+            }
+        }
+        Ok(Self {
+            child,
+            identity,
+            #[cfg(windows)]
+            job,
+        })
+    }
+
+    pub fn owns(&self, process: &ProcessIdentity) -> Result<bool, String> {
+        if !process.is_running()? || process.started < self.identity.started {
+            return Ok(false);
+        }
+        #[cfg(unix)]
+        {
+            Ok(process.group == self.identity.group)
+        }
+        #[cfg(windows)]
+        {
+            self.job.contains(process.pid)
+        }
+    }
+
+    pub fn stop(&mut self) -> Result<(), String> {
+        #[cfg(unix)]
+        {
+            if capture(self.identity.pid)?.is_some_and(|current| {
+                current.started != self.identity.started || current.boot_id != self.identity.boot_id
+            }) {
+                return Err(
+                    "Updated application process identity was reused; refusing group shutdown"
+                        .to_owned(),
+                );
+            }
+            if unsafe { libc::kill(-(self.identity.group as i32), libc::SIGKILL) } < 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    return Err(error.to_string());
+                }
+            }
+        }
+        #[cfg(windows)]
+        self.job.stop()?;
+        let start = Instant::now();
+        loop {
+            let exited = self
+                .child
+                .try_wait()
+                .map_err(|error| error.to_string())?
+                .is_some();
+            #[cfg(unix)]
+            let descendants = group_is_running(self.identity.group)?;
+            #[cfg(windows)]
+            let descendants = self.job.active()?;
+            if exited && !descendants {
+                return Ok(());
+            }
+            if start.elapsed() > Duration::from_secs(10) {
+                return Err(
+                    "Could not stop all updated application processes before rollback".to_owned(),
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+pub(super) fn failed_start(
+    child: &mut std::process::Child,
+    error: String,
+) -> super::RestartFailure {
+    let cleanup = (|| {
+        #[cfg(unix)]
+        if unsafe { libc::kill(-(child.id() as i32), libc::SIGKILL) } < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error.to_string());
+            }
+        }
+        if let (Err(error), None) = (
+            child.kill(),
+            child.try_wait().map_err(|error| error.to_string())?,
+        ) {
+            return Err(error.to_string());
+        }
+        let start = Instant::now();
+        loop {
+            let exited = child
+                .try_wait()
+                .map_err(|error| error.to_string())?
+                .is_some();
+            #[cfg(unix)]
+            let descendants = group_is_running(child.id())?;
+            #[cfg(windows)]
+            let descendants = false;
+            if exited && !descendants {
+                return Ok(());
+            }
+            if start.elapsed() >= Duration::from_secs(10) {
+                return Err(
+                    "Failed startup process tree did not stop before the deadline".to_owned(),
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    })();
+    match cleanup {
+        Ok(()) => super::RestartFailure::RollbackSafe(error),
+        Err(cleanup_error) => super::RestartFailure::ProcessesMayBeRunning(format!(
+            "{error}; startup cleanup failed: {cleanup_error}"
+        )),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn group_is_running(group: u32) -> Result<bool, String> {
+    for entry in std::fs::read_dir("/proc").map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        if !entry
+            .file_name()
+            .to_string_lossy()
+            .bytes()
+            .all(|byte| byte.is_ascii_digit())
+        {
+            continue;
+        }
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        let Some((_, fields)) = stat.rsplit_once(')') else {
+            continue;
+        };
+        let fields: Vec<_> = fields.split_whitespace().collect();
+        if fields.first() != Some(&"Z")
+            && fields.get(2).and_then(|value| value.parse::<u32>().ok()) == Some(group)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(target_os = "macos")]
+fn group_is_running(group: u32) -> Result<bool, String> {
+    unsafe extern "C" {
+        fn proc_listpids(kind: u32, info: u32, buffer: *mut std::ffi::c_void, size: i32) -> i32;
+    }
+    let mut pids = vec![0u32; 100_000];
+    let length =
+        unsafe { proc_listpids(2, group, pids.as_mut_ptr().cast(), (pids.len() * 4) as i32) };
+    if length < 0 || length as usize >= pids.len() * 4 {
+        return Err("Cannot bound the updated application's process group".to_owned());
+    }
+    for pid in pids
+        .into_iter()
+        .take(length as usize / 4)
+        .filter(|pid| *pid != 0)
+    {
+        if capture(pid)?.is_some() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(windows)]
+struct Job(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for Job {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Job {
+    fn assign(child: &std::process::Child) -> Result<Self, String> {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::System::JobObjects::*;
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if handle.is_null() {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        let job = Self(handle);
+        if unsafe { AssignProcessToJobObject(handle, child.as_raw_handle()) } == 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        Ok(job)
+    }
+    fn contains(&self, pid: u32) -> Result<bool, String> {
+        use windows_sys::Win32::System::{JobObjects::*, Threading::*};
+        let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if process.is_null() {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        let mut member = 0;
+        let result = unsafe { IsProcessInJob(process, self.0, &mut member) };
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(process);
+        }
+        if result == 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        Ok(member != 0)
+    }
+    fn stop(&self) -> Result<(), String> {
+        if unsafe { windows_sys::Win32::System::JobObjects::TerminateJobObject(self.0, 1) } == 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        Ok(())
+    }
+    fn active(&self) -> Result<bool, String> {
+        use windows_sys::Win32::System::JobObjects::*;
+        let mut info: JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = unsafe { std::mem::zeroed() };
+        if unsafe {
+            QueryInformationJobObject(
+                self.0,
+                JobObjectBasicAccountingInformation,
+                (&mut info as *mut JOBOBJECT_BASIC_ACCOUNTING_INFORMATION).cast(),
+                std::mem::size_of_val(&info) as u32,
+                std::ptr::null_mut(),
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        Ok(info.ActiveProcesses != 0)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ProcessIdentity {
+    pub pid: u32,
+    pub started: u64,
+    pub executable: PathBuf,
+    pub group: u32,
+    pub boot_id: String,
+}
+
+impl ProcessIdentity {
+    pub fn capture(pid: u32) -> Result<Self, String> {
+        capture(pid)?.ok_or_else(|| format!("Process {pid} is not running"))
+    }
+
+    pub fn matches_executable(&self, executable: &Path) -> Result<(), String> {
+        if std::fs::canonicalize(executable).map_err(|error| error.to_string())? != self.executable
+        {
+            return Err("Application process does not match its trusted executable".to_owned());
+        }
+        Ok(())
+    }
+
+    pub fn is_running(&self) -> Result<bool, String> {
+        Ok(capture(self.pid)?.is_some_and(|current| {
+            current.started == self.started && current.boot_id == self.boot_id
+        }))
+    }
+}
+
+pub(super) fn wait_for_exit(
+    processes: &[ProcessIdentity],
+    timeout: Duration,
+) -> Result<(), String> {
+    let start = Instant::now();
+    loop {
+        let mut running = false;
+        for process in processes {
+            running |= process.is_running()?;
+        }
+        if !running {
+            return Ok(());
+        }
+        if start.elapsed() >= timeout {
+            return Err(
+                "Timed out waiting for the original application and core to exit".to_owned(),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+pub(super) fn owned_tree_is_running(identity: &ProcessIdentity) -> Result<bool, String> {
+    #[cfg(target_os = "linux")]
+    if std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .map_err(|error| error.to_string())?
+        .trim()
+        != identity.boot_id
+    {
+        return Ok(false);
+    }
+    #[cfg(unix)]
+    {
+        group_is_running(identity.group)
+    }
+    #[cfg(windows)]
+    {
+        identity.is_running()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn capture(pid: u32) -> Result<Option<ProcessIdentity>, String> {
+    let path = PathBuf::from(format!("/proc/{pid}"));
+    let stat = match std::fs::read_to_string(path.join("stat")) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    let fields: Vec<_> = stat
+        .rsplit_once(')')
+        .ok_or("Invalid process identity")?
+        .1
+        .split_whitespace()
+        .collect();
+    if fields.first() == Some(&"Z") {
+        return Ok(None);
+    }
+    let started = fields
+        .get(19)
+        .ok_or("Missing process start identity")?
+        .parse()
+        .map_err(|_| "Invalid process start identity")?;
+    let executable = match std::fs::read_link(path.join("exe")) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    Ok(Some(ProcessIdentity {
+        pid,
+        started,
+        executable,
+        group: fields
+            .get(2)
+            .ok_or("Missing process group")?
+            .parse()
+            .map_err(|_| "Invalid process group")?,
+        boot_id: std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+            .map_err(|error| error.to_string())?
+            .trim()
+            .to_owned(),
+    }))
+}
+
+#[cfg(target_os = "macos")]
+fn capture(pid: u32) -> Result<Option<ProcessIdentity>, String> {
+    #[repr(C)]
+    #[derive(Default)]
+    struct BsdInfo {
+        flags: u32,
+        status: u32,
+        xstatus: u32,
+        pid: u32,
+        ppid: u32,
+        uid: u32,
+        gid: u32,
+        ruid: u32,
+        rgid: u32,
+        svuid: u32,
+        svgid: u32,
+        rfu_1: u32,
+        comm: [u8; 16],
+        name: [u8; 32],
+        nfiles: u32,
+        pgid: u32,
+        pjobc: u32,
+        e_tdev: u32,
+        e_tpgid: u32,
+        nice: i32,
+        start_tvsec: u64,
+        start_tvusec: u64,
+    }
+    unsafe extern "C" {
+        fn proc_pidinfo(
+            pid: i32,
+            flavor: i32,
+            arg: u64,
+            buffer: *mut std::ffi::c_void,
+            size: i32,
+        ) -> i32;
+        fn proc_pidpath(pid: i32, buffer: *mut std::ffi::c_void, size: u32) -> i32;
+    }
+    let mut info = BsdInfo::default();
+    let length = unsafe {
+        proc_pidinfo(
+            pid as i32,
+            3,
+            0,
+            (&mut info as *mut BsdInfo).cast(),
+            std::mem::size_of::<BsdInfo>() as i32,
+        )
+    };
+    if length == 0 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            return Ok(None);
+        }
+        return Err(error.to_string());
+    }
+    if length as usize != std::mem::size_of::<BsdInfo>() {
+        return Err("Incomplete macOS process identity".to_owned());
+    }
+    if info.status == 5 {
+        return Ok(None);
+    }
+    let mut path = [0u8; 4096];
+    let length = unsafe { proc_pidpath(pid as i32, path.as_mut_ptr().cast(), path.len() as u32) };
+    if length <= 0 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            return Ok(None);
+        }
+        return Err(error.to_string());
+    }
+    use std::os::unix::ffi::OsStrExt;
+    let end = path
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(length as usize);
+    let executable = std::fs::canonicalize(Path::new(std::ffi::OsStr::from_bytes(&path[..end])))
+        .map_err(|error| error.to_string())?;
+    Ok(Some(ProcessIdentity {
+        pid,
+        started: info.start_tvsec * 1_000_000 + info.start_tvusec,
+        executable,
+        group: info.pgid,
+        boot_id: String::new(),
+    }))
+}
+
+#[cfg(windows)]
+fn capture(pid: u32) -> Result<Option<ProcessIdentity>, String> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER, FILETIME};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        QueryFullProcessImageNameW,
+    };
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(ERROR_INVALID_PARAMETER as i32) {
+            return Ok(None);
+        }
+        return Err(error.to_string());
+    }
+    let result = (|| {
+        let mut exit = 0;
+        if unsafe { GetExitCodeProcess(handle, &mut exit) } == 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        if exit != 259 {
+            return Ok(None);
+        }
+        let mut creation = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let mut end = creation;
+        let mut kernel = creation;
+        let mut user = creation;
+        if unsafe { GetProcessTimes(handle, &mut creation, &mut end, &mut kernel, &mut user) } == 0
+        {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        let mut buffer = vec![0u16; 32768];
+        let mut length = buffer.len() as u32;
+        if unsafe { QueryFullProcessImageNameW(handle, 0, buffer.as_mut_ptr(), &mut length) } == 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        let executable = std::fs::canonicalize(PathBuf::from(std::ffi::OsString::from_wide(
+            &buffer[..length as usize],
+        )))
+        .map_err(|error| error.to_string())?;
+        Ok(Some(ProcessIdentity {
+            pid,
+            started: (creation.dwHighDateTime as u64) << 32 | creation.dwLowDateTime as u64,
+            executable,
+            group: 0,
+            boot_id: String::new(),
+        }))
+    })();
+    unsafe {
+        CloseHandle(handle);
+    }
+    result
+}

--- a/native/opennow-core/src/update_apply/recovery.rs
+++ b/native/opennow-core/src/update_apply/recovery.rs
@@ -1,0 +1,313 @@
+use super::{InstallKind, OutcomeStatus, Plan, PreparedUpdate, UpdateOutcome, managed};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug)]
+pub enum ManagedRecovery {
+    Pending(String),
+    RebootRequired(String),
+    Finished(UpdateOutcome),
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct InstallBoot {
+    schema_version: u32,
+    boot_id: String,
+}
+
+pub(super) fn record_install_boot(directory: &Path) -> Result<(), String> {
+    super::atomic_json(
+        &directory.join("install-boot.json"),
+        &InstallBoot {
+            schema_version: 1,
+            boot_id: current_boot_id()?,
+        },
+    )
+}
+
+pub fn recover_managed_update(
+    prepared: &PreparedUpdate,
+    outcome: &UpdateOutcome,
+    running_version: &str,
+) -> Result<ManagedRecovery, String> {
+    match super::helper_is_running(prepared) {
+        Ok(true) => {
+            return Ok(ManagedRecovery::Pending(
+                "The update helper is still finishing the native installation.".to_owned(),
+            ));
+        }
+        Err(error) => {
+            return Ok(ManagedRecovery::Pending(format!(
+                "Could not confirm that the update helper has finished: {error}"
+            )));
+        }
+        Ok(false) => (),
+    }
+    let directory = prepared
+        .plan_path
+        .parent()
+        .ok_or("Missing update transaction directory.")?;
+    let unknown_installer = match &outcome.restarted_process {
+        Some(installer) => match installer.is_running() {
+            Ok(true) => return Ok(ManagedRecovery::Pending(
+                "The native package manager is still running; update completion is not confirmed."
+                    .to_owned(),
+            )),
+            Err(error) => Some(error),
+            Ok(false) => None,
+        },
+        None if outcome.status == OutcomeStatus::ManagedPending => {
+            Some("The native installer process identity was not recorded.".to_owned())
+        }
+        None => None,
+    };
+    if let Some(reason) = unknown_installer {
+        match reboot_completed(directory) {
+            Ok(true) => (),
+            Ok(false) => {
+                return Ok(ManagedRecovery::Pending(format!(
+                    "Native installer completion cannot be confirmed: {reason} Restart your system before starting another update or session."
+                )));
+            }
+            Err(error) => {
+                return Ok(ManagedRecovery::Pending(format!(
+                    "Native installer completion cannot be confirmed: {reason} The restart boundary also could not be verified: {error}"
+                )));
+            }
+        }
+    }
+    let plan: Plan = super::read_json(&prepared.plan_path, 64 * 1024)?;
+    if plan.schema_version != 1
+        || plan.version != prepared.version
+        || outcome.version != prepared.version
+        || !matches!(
+            plan.kind,
+            InstallKind::WindowsMsi | InstallKind::DebianPackage
+        )
+        || !matches!(
+            outcome.status,
+            OutcomeStatus::ManagedPending | OutcomeStatus::RebootRequired
+        )
+        || (outcome.status == OutcomeStatus::RebootRequired && plan.kind != InstallKind::WindowsMsi)
+    {
+        return Err("Persisted managed update identity does not match its outcome.".to_owned());
+    }
+    let identity = plan
+        .managed_identity
+        .as_ref()
+        .ok_or("Missing persisted native package identity.")?;
+    let reboot_completed = if outcome.status == OutcomeStatus::RebootRequired {
+        match reboot_completed(directory) {
+            Ok(value) => value,
+            Err(error) => {
+                return Ok(ManagedRecovery::RebootRequired(format!(
+                    "Windows Installer requires a restart; reboot completion could not be verified: {error}"
+                )));
+            }
+        }
+    } else {
+        true
+    };
+    let recovery = classify_recovery(outcome, running_version, reboot_completed, || {
+        managed::verify_installed(plan.kind, identity, &plan.target)
+    });
+    if let ManagedRecovery::Finished(result) = &recovery {
+        super::atomic_json(&prepared.outcome_path, result)?;
+    }
+    Ok(recovery)
+}
+
+fn classify_recovery(
+    outcome: &UpdateOutcome,
+    running_version: &str,
+    reboot_completed: bool,
+    verify_installed: impl FnOnce() -> Result<(), String>,
+) -> ManagedRecovery {
+    if outcome.status == OutcomeStatus::RebootRequired && !reboot_completed {
+        return ManagedRecovery::RebootRequired("Windows Installer requires a system restart before all updated files can be confirmed. Sessions remain available, but restart before checking for another update.".to_owned());
+    }
+    let mut result = outcome.clone();
+    result.restarted_process = None;
+    result.installed_version = None;
+    if let Err(error) = verify_installed() {
+        result.status = OutcomeStatus::Failed;
+        result.message = format!(
+            "The native installer has finished, but the expected installed package could not be verified: {error}"
+        );
+    } else if running_version.trim_start_matches('v') != outcome.version.trim_start_matches('v') {
+        result.status = OutcomeStatus::Failed;
+        result.message = format!(
+            "The native package is installed, but OpenNOW is running {running_version} instead of {}. Restart OpenNOW before retrying the update.",
+            outcome.version
+        );
+    } else {
+        result.status = OutcomeStatus::Completed;
+        result.installed_version = Some(outcome.version.clone());
+        result.message = format!(
+            "Native package identity and running OpenNOW {} were verified after installation.",
+            outcome.version
+        );
+    }
+    ManagedRecovery::Finished(result)
+}
+
+fn reboot_completed(directory: &Path) -> Result<bool, String> {
+    let path = directory.join("install-boot.json");
+    if !path.try_exists().map_err(|error| error.to_string())? {
+        record_install_boot(directory)?;
+        return Ok(false);
+    }
+    recorded_boot_changed(directory)
+}
+
+fn recorded_boot_changed(directory: &Path) -> Result<bool, String> {
+    let previous: InstallBoot = super::read_json(&directory.join("install-boot.json"), 1024)?;
+    if previous.schema_version != 1 || previous.boot_id.is_empty() {
+        return Err("The recorded installation boot identity is invalid.".to_owned());
+    }
+    Ok(previous.boot_id != current_boot_id()?)
+}
+
+#[cfg(windows)]
+fn current_boot_id() -> Result<String, String> {
+    use windows_sys::Wdk::System::Threading::{
+        NtQueryInformationProcess, ProcessTelemetryIdInformation,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+    let mut returned = 0u32;
+    unsafe {
+        NtQueryInformationProcess(
+            GetCurrentProcess(),
+            ProcessTelemetryIdInformation,
+            std::ptr::null_mut(),
+            0,
+            &mut returned,
+        );
+    }
+    if !(64..=1024 * 1024).contains(&returned) {
+        return Err("Windows did not provide bounded process telemetry.".to_owned());
+    }
+    let mut information = vec![0u64; (returned as usize).div_ceil(8)];
+    let status = unsafe {
+        NtQueryInformationProcess(
+            GetCurrentProcess(),
+            ProcessTelemetryIdInformation,
+            information.as_mut_ptr().cast(),
+            (information.len() * 8) as u32,
+            &mut returned,
+        )
+    };
+    let header_size = information[0] as u32;
+    let process_id = (information[0] >> 32) as u32;
+    let boot_id = (information[7] >> 32) as u32;
+    if status < 0
+        || returned < 64
+        || header_size < 64
+        || header_size > returned
+        || process_id != std::process::id()
+    {
+        return Err("Windows did not provide a valid boot sequence number.".to_owned());
+    }
+    Ok(format!("windows-boot-sequence:{boot_id}"))
+}
+
+#[cfg(target_os = "linux")]
+fn current_boot_id() -> Result<String, String> {
+    let value = std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .map_err(|error| error.to_string())?;
+    let value = value.trim();
+    if value.len() != 36
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+    {
+        return Err("The operating system boot identifier is invalid.".to_owned());
+    }
+    Ok(value.to_owned())
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+fn current_boot_id() -> Result<String, String> {
+    Err("Managed reboot recovery is not supported on this platform.".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome(status: OutcomeStatus) -> UpdateOutcome {
+        UpdateOutcome {
+            schema_version: 1,
+            version: "1.2.3".to_owned(),
+            status,
+            message: "Native installation is pending".to_owned(),
+            installed_version: None,
+            restarted_process: None,
+        }
+    }
+
+    #[test]
+    fn recovery_requires_native_identity_and_the_running_version() {
+        for status in [OutcomeStatus::ManagedPending, OutcomeStatus::RebootRequired] {
+            for (version, installed, expected) in [
+                ("1.2.3", Ok(()), OutcomeStatus::Completed),
+                ("1.2.2", Ok(()), OutcomeStatus::Failed),
+                (
+                    "1.2.3",
+                    Err("Native registration does not match".to_owned()),
+                    OutcomeStatus::Failed,
+                ),
+            ] {
+                let ManagedRecovery::Finished(result) =
+                    classify_recovery(&outcome(status), version, true, || installed)
+                else {
+                    panic!("Finished installer must resolve to an outcome")
+                };
+                assert_eq!(result.status, expected);
+                assert_eq!(
+                    result.installed_version.is_some(),
+                    expected == OutcomeStatus::Completed
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reboot_required_never_claims_success_before_a_proven_reboot() {
+        assert!(matches!(
+            classify_recovery(
+                &outcome(OutcomeStatus::RebootRequired),
+                "1.2.3",
+                false,
+                || panic!("Native package verification must not run before reboot")
+            ),
+            ManagedRecovery::RebootRequired(_)
+        ));
+    }
+
+    #[cfg(any(windows, target_os = "linux"))]
+    #[test]
+    fn legacy_reboot_marker_requires_a_subsequent_boot() {
+        let directory = tempfile::tempdir().unwrap();
+        assert!(!reboot_completed(directory.path()).unwrap());
+        assert!(!reboot_completed(directory.path()).unwrap());
+        super::super::atomic_json(
+            &directory.path().join("install-boot.json"),
+            &InstallBoot {
+                schema_version: 1,
+                boot_id: "a-previous-boot".to_owned(),
+            },
+        )
+        .unwrap();
+        assert!(reboot_completed(directory.path()).unwrap());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_boot_sequence_is_available_and_stable() {
+        let first = current_boot_id().unwrap();
+        assert!(first.starts_with("windows-boot-sequence:"));
+        assert_eq!(first, current_boot_id().unwrap());
+    }
+}

--- a/native/opennow-core/src/update_apply/security.rs
+++ b/native/opennow-core/src/update_apply/security.rs
@@ -1,0 +1,355 @@
+use std::path::Path;
+
+pub(super) fn create_private_directory(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(0o700);
+        builder.create(path).map_err(|error| error.to_string())
+    }
+    #[cfg(windows)]
+    {
+        windows::create_private(path)
+    }
+}
+
+pub(super) fn preserve_permissions(source: &Path, destination: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = std::fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+        if metadata.is_symlink() {
+            return Err("Cannot preserve permissions through a user-data symlink".to_owned());
+        }
+        std::os::unix::fs::chown(destination, Some(metadata.uid()), Some(metadata.gid()))
+            .map_err(|error| format!("Cannot preserve user-data ownership: {error}"))?;
+        std::fs::set_permissions(destination, metadata.permissions())
+            .map_err(|error| format!("Cannot preserve user-data permissions: {error}"))?;
+        preserve_unix_acl(source, destination)
+    }
+    #[cfg(windows)]
+    {
+        windows::preserve(source, destination)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn preserve_unix_acl(source: &Path, destination: &Path) -> Result<(), String> {
+    use std::os::unix::ffi::OsStrExt;
+    let source =
+        std::ffi::CString::new(source.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let destination = std::ffi::CString::new(destination.as_os_str().as_bytes())
+        .map_err(|error| error.to_string())?;
+    for name in [c"system.posix_acl_access", c"system.posix_acl_default"] {
+        let size =
+            unsafe { libc::getxattr(source.as_ptr(), name.as_ptr(), std::ptr::null_mut(), 0) };
+        if size < 0 {
+            let error = std::io::Error::last_os_error();
+            if !matches!(error.raw_os_error(), Some(libc::ENODATA | libc::ENOTSUP)) {
+                return Err(format!("Cannot inspect user-data ACL: {error}"));
+            }
+            if unsafe { libc::removexattr(destination.as_ptr(), name.as_ptr()) } < 0 {
+                let error = std::io::Error::last_os_error();
+                if !matches!(error.raw_os_error(), Some(libc::ENODATA | libc::ENOTSUP)) {
+                    return Err(format!("Cannot remove inherited user-data ACL: {error}"));
+                }
+            }
+            continue;
+        }
+        if size > 64 * 1024 {
+            return Err("User-data ACL exceeds its size limit".to_owned());
+        }
+        let mut acl = vec![0u8; size as usize];
+        let read = unsafe {
+            libc::getxattr(
+                source.as_ptr(),
+                name.as_ptr(),
+                acl.as_mut_ptr().cast(),
+                acl.len(),
+            )
+        };
+        if read != size {
+            return Err("User-data ACL changed while it was being copied".to_owned());
+        }
+        if unsafe {
+            libc::setxattr(
+                destination.as_ptr(),
+                name.as_ptr(),
+                acl.as_ptr().cast(),
+                acl.len(),
+                0,
+            )
+        } < 0
+        {
+            return Err(format!(
+                "Cannot preserve user-data ACL: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn preserve_unix_acl(source: &Path, destination: &Path) -> Result<(), String> {
+    use std::os::unix::ffi::OsStrExt;
+    unsafe extern "C" {
+        fn copyfile(
+            source: *const libc::c_char,
+            destination: *const libc::c_char,
+            state: *mut libc::c_void,
+            flags: u32,
+        ) -> i32;
+    }
+    let source =
+        std::ffi::CString::new(source.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let destination = std::ffi::CString::new(destination.as_os_str().as_bytes())
+        .map_err(|error| error.to_string())?;
+    if unsafe {
+        copyfile(
+            source.as_ptr(),
+            destination.as_ptr(),
+            std::ptr::null_mut(),
+            1,
+        )
+    } != 0
+    {
+        return Err(format!(
+            "Cannot preserve user-data ACL: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::*;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Authorization::*;
+    use windows_sys::Win32::Security::*;
+
+    struct Descriptor(PSECURITY_DESCRIPTOR);
+    impl Drop for Descriptor {
+        fn drop(&mut self) {
+            unsafe {
+                LocalFree(self.0);
+            }
+        }
+    }
+
+    fn wide(path: &Path) -> Vec<u16> {
+        path.as_os_str().encode_wide().chain(Some(0)).collect()
+    }
+
+    pub(super) fn create_private(path: &Path) -> Result<(), String> {
+        use std::os::windows::fs::OpenOptionsExt;
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_FLAG_BACKUP_SEMANTICS, GetVolumeInformationByHandleW,
+        };
+        let parent = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+            .open(
+                path.parent()
+                    .ok_or("Private update directory has no parent")?,
+            )
+            .map_err(|error| error.to_string())?;
+        let mut flags = 0;
+        if unsafe {
+            GetVolumeInformationByHandleW(
+                parent.as_raw_handle(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut flags,
+                std::ptr::null_mut(),
+                0,
+            )
+        } == 0
+        {
+            return Err(format!(
+                "Cannot verify update volume ACL support: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        require_persistent_acls(flags)?;
+        let text: Vec<_> = "D:P(A;OICI;FA;;;OW)"
+            .encode_utf16()
+            .chain(Some(0))
+            .collect();
+        let mut descriptor = std::ptr::null_mut();
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                text.as_ptr(),
+                1,
+                &mut descriptor,
+                std::ptr::null_mut(),
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        let descriptor = Descriptor(descriptor);
+        let attributes = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: descriptor.0,
+            bInheritHandle: 0,
+        };
+        if unsafe {
+            windows_sys::Win32::Storage::FileSystem::CreateDirectoryW(
+                wide(path).as_ptr(),
+                &attributes,
+            )
+        } == 0
+        {
+            return Err(format!(
+                "Cannot create private update directory: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        Ok(())
+    }
+
+    fn require_persistent_acls(flags: u32) -> Result<(), String> {
+        if flags & windows_sys::Win32::System::SystemServices::FILE_PERSISTENT_ACLS == 0 {
+            return Err("Update staging requires a filesystem with persistent ACLs; FAT and exFAT cannot protect the transaction".to_owned());
+        }
+        Ok(())
+    }
+
+    pub(super) fn preserve(source: &Path, destination: &Path) -> Result<(), String> {
+        let mut owner = std::ptr::null_mut();
+        let mut group = std::ptr::null_mut();
+        let mut acl = std::ptr::null_mut();
+        let mut descriptor = std::ptr::null_mut();
+        let info =
+            OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
+        let code = unsafe {
+            GetNamedSecurityInfoW(
+                wide(source).as_ptr(),
+                SE_FILE_OBJECT,
+                info,
+                &mut owner,
+                &mut group,
+                &mut acl,
+                std::ptr::null_mut(),
+                &mut descriptor,
+            )
+        };
+        if code != 0 {
+            return Err(format!(
+                "Cannot inspect user-data security descriptor: Windows error {code}"
+            ));
+        }
+        let _descriptor = Descriptor(descriptor);
+        let code = unsafe {
+            SetNamedSecurityInfoW(
+                wide(destination).as_ptr(),
+                SE_FILE_OBJECT,
+                info | PROTECTED_DACL_SECURITY_INFORMATION,
+                owner,
+                group,
+                acl,
+                std::ptr::null_mut(),
+            )
+        };
+        if code != 0 {
+            return Err(format!(
+                "Cannot preserve the original effective user-data DACL and ownership: Windows error {code}"
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn private_staging_requires_persistent_acl_support() {
+            assert!(require_persistent_acls(0).is_err());
+            assert!(
+                require_persistent_acls(
+                    !windows_sys::Win32::System::SystemServices::FILE_PERSISTENT_ACLS
+                )
+                .is_err()
+            );
+            assert!(
+                require_persistent_acls(
+                    windows_sys::Win32::System::SystemServices::FILE_PERSISTENT_ACLS
+                )
+                .is_ok()
+            );
+        }
+
+        fn dacl(path: &Path) -> (Vec<Vec<u8>>, bool) {
+            let mut acl = std::ptr::null_mut();
+            let mut descriptor = std::ptr::null_mut();
+            assert_eq!(
+                unsafe {
+                    GetNamedSecurityInfoW(
+                        wide(path).as_ptr(),
+                        SE_FILE_OBJECT,
+                        DACL_SECURITY_INFORMATION,
+                        std::ptr::null_mut(),
+                        std::ptr::null_mut(),
+                        &mut acl,
+                        std::ptr::null_mut(),
+                        &mut descriptor,
+                    )
+                },
+                0
+            );
+            let descriptor = Descriptor(descriptor);
+            let mut control = 0;
+            let mut revision = 0;
+            assert_ne!(
+                unsafe { GetSecurityDescriptorControl(descriptor.0, &mut control, &mut revision) },
+                0
+            );
+            assert!(!acl.is_null());
+            let mut entries = Vec::new();
+            for index in 0..unsafe { (*acl).AceCount } {
+                let mut ace = std::ptr::null_mut();
+                assert_ne!(unsafe { GetAce(acl, index as u32, &mut ace) }, 0);
+                let header = ace.cast::<ACE_HEADER>();
+                let mut bytes = unsafe {
+                    std::slice::from_raw_parts(ace.cast::<u8>(), (*header).AceSize as usize)
+                }
+                .to_vec();
+                bytes[1] &= !(INHERITED_ACE as u8);
+                entries.push(bytes);
+            }
+            (entries, control & SE_DACL_PROTECTED != 0)
+        }
+
+        #[test]
+        fn private_transactions_and_preserved_profiles_keep_effective_dacls() {
+            let directory = tempfile::TempDir::new().unwrap();
+            let profile = directory.path().join("profile");
+            create_private(&profile).unwrap();
+            std::fs::write(profile.join("account.json"), b"private fixture data").unwrap();
+            let root_before = dacl(&profile);
+            let file_before = dacl(&profile.join("account.json"));
+            assert!(root_before.1);
+            let destination = directory.path().join("preserved");
+            crate::update_apply::copy_user_data(
+                &profile,
+                &destination,
+                &mut crate::update_apply::bundle::CopyBudget::new(),
+            )
+            .unwrap();
+            let root_after = dacl(&destination);
+            let file_after = dacl(&destination.join("account.json"));
+            assert_eq!(root_before.0, root_after.0);
+            assert_eq!(file_before.0, file_after.0);
+            assert!(root_after.1);
+            assert!(file_after.1);
+        }
+    }
+}

--- a/native/opennow-core/src/update_apply/tests.rs
+++ b/native/opennow-core/src/update_apply/tests.rs
@@ -174,7 +174,10 @@ fn fixture_executable() -> &'static Path {
             r#"fn main() {
                 if let Ok(path) = std::env::var("OPENNOW_FIXTURE_CHILD_PID") {
                     let child = std::process::Command::new(std::env::current_exe().unwrap()).env_remove("OPENNOW_FIXTURE_CHILD_PID").spawn().unwrap();
-                    std::fs::write(path, child.id().to_string()).unwrap();
+                    let path = std::path::PathBuf::from(path);
+                    let temporary = path.with_extension("tmp");
+                    std::fs::write(&temporary, child.id().to_string()).unwrap();
+                    std::fs::rename(temporary, path).unwrap();
                 }
                 let lifetime = std::env::var("OPENNOW_FIXTURE_LIFETIME_MS").ok().and_then(|value| value.parse().ok()).unwrap_or(900);
                 std::thread::sleep(std::time::Duration::from_millis(lifetime));

--- a/native/opennow-core/src/update_apply/tests.rs
+++ b/native/opennow-core/src/update_apply/tests.rs
@@ -1,0 +1,887 @@
+use super::*;
+use base64::Engine as _;
+use ed25519_dalek::{Signer, SigningKey};
+use sha2::{Digest, Sha256};
+use std::sync::OnceLock;
+use tempfile::TempDir;
+
+fn signed_manifest(asset: &str, bytes: &[u8]) -> (verification::UpdateManifest, SigningKey) {
+    let key = SigningKey::from_bytes(&[91; 32]);
+    let mut manifest = verification::UpdateManifest {
+        schema_version: 1,
+        version: "1.2.3".to_owned(),
+        asset: asset.to_owned(),
+        size: bytes.len() as u64,
+        sha256: format!("{:x}", Sha256::digest(bytes)),
+        signature: String::new(),
+    };
+    manifest.signature = base64::engine::general_purpose::STANDARD.encode(
+        key.sign(verification::signature_payload(&manifest).as_bytes())
+            .to_bytes(),
+    );
+    (manifest, key)
+}
+
+#[test]
+fn signature_rejects_tampering_wrong_key_and_invalid_schema() {
+    let (manifest, key) = signed_manifest("OpenNOW.zip", b"valid package");
+    verification::verify_manifest(&manifest, &key.verifying_key()).unwrap();
+    assert!(
+        verification::verify_manifest(
+            &manifest,
+            &SigningKey::from_bytes(&[90; 32]).verifying_key()
+        )
+        .is_err()
+    );
+    let mut tampered = manifest.clone();
+    tampered.version = "1.2.4".to_owned();
+    assert!(verification::verify_manifest(&tampered, &key.verifying_key()).is_err());
+    let mut invalid = manifest;
+    invalid.schema_version = 2;
+    assert!(verification::verify_manifest(&invalid, &key.verifying_key()).is_err());
+}
+
+#[test]
+fn package_verification_rejects_tampering_and_wrong_filename() {
+    let dir = TempDir::new().unwrap();
+    let bytes = b"valid package";
+    let (manifest, _) = signed_manifest("OpenNOW.zip", bytes);
+    let package = dir.path().join("OpenNOW.zip");
+    fs::write(&package, bytes).unwrap();
+    verification::verify_package(&package, &manifest).unwrap();
+    fs::write(&package, b"evil! package").unwrap();
+    assert!(
+        verification::verify_package(&package, &manifest)
+            .unwrap_err()
+            .contains("SHA256")
+    );
+    let other = dir.path().join("Other.zip");
+    fs::write(&other, bytes).unwrap();
+    assert!(verification::verify_package(&other, &manifest).is_err());
+}
+
+fn zip_file(path: &Path, entries: &[(&str, &[u8])]) {
+    let mut zip = zip::ZipWriter::new(File::create(path).unwrap());
+    for (name, bytes) in entries {
+        zip.start_file(
+            *name,
+            zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored),
+        )
+        .unwrap();
+        zip.write_all(bytes).unwrap();
+    }
+    zip.finish().unwrap();
+}
+
+#[test]
+fn archive_rejects_traversal_case_aliases_and_partial_extraction() {
+    for entries in [
+        vec![
+            ("safe.txt", b"first".as_slice()),
+            ("../escaped", b"evil".as_slice()),
+        ],
+        vec![
+            ("Bin/app", b"first".as_slice()),
+            ("bin/App", b"evil".as_slice()),
+        ],
+        vec![
+            ("safe.txt", b"first".as_slice()),
+            ("C:/evil", b"evil".as_slice()),
+        ],
+        vec![
+            ("safe.txt", b"first".as_slice()),
+            ("dir/CON.txt", b"evil".as_slice()),
+        ],
+    ] {
+        let dir = TempDir::new().unwrap();
+        let package = dir.path().join("update.zip");
+        zip_file(&package, &entries);
+        let destination = dir.path().join("extracted");
+        assert!(archive::extract_zip(&package, &destination, false).is_err());
+        assert!(!destination.exists());
+        assert!(!dir.path().join("escaped").exists());
+    }
+}
+
+#[test]
+fn archive_rejects_corruption_without_leaving_a_partial_tree() {
+    let dir = TempDir::new().unwrap();
+    let package = dir.path().join("update.zip");
+    zip_file(&package, &[("bin/app", b"candidate executable")]);
+    let mut bytes = fs::read(&package).unwrap();
+    let offset = bytes
+        .windows(20)
+        .position(|window| window == b"candidate executable")
+        .unwrap();
+    bytes[offset] ^= 1;
+    fs::write(&package, bytes).unwrap();
+    let destination = dir.path().join("extracted");
+    assert!(archive::extract_zip(&package, &destination, false).is_err());
+    assert!(!destination.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn framework_symlinks_are_preserved_and_escaping_links_are_rejected() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("OpenNOW.app");
+    let framework = source.join("Contents/Frameworks/Qt.framework");
+    fs::create_dir_all(framework.join("Versions/A")).unwrap();
+    fs::write(framework.join("Versions/A/Qt"), b"framework").unwrap();
+    std::os::unix::fs::symlink("A", framework.join("Versions/Current")).unwrap();
+    std::os::unix::fs::symlink("Versions/Current/Qt", framework.join("Qt")).unwrap();
+    let copy = dir.path().join("copied.app");
+    bundle::copy_tree(
+        &source,
+        &copy,
+        &mut bundle::CopyBudget::new(),
+        bundle::CopyPolicy::Bundle,
+    )
+    .unwrap();
+    assert!(
+        fs::symlink_metadata(copy.join("Contents/Frameworks/Qt.framework/Qt"))
+            .unwrap()
+            .is_symlink()
+    );
+    assert_eq!(
+        fs::read(copy.join("Contents/Frameworks/Qt.framework/Qt")).unwrap(),
+        b"framework"
+    );
+    fs::write(dir.path().join("secret"), b"outside").unwrap();
+    std::os::unix::fs::symlink("../secret", source.join("escape")).unwrap();
+    let bad = dir.path().join("bad.app");
+    assert!(
+        bundle::copy_tree(
+            &source,
+            &bad,
+            &mut bundle::CopyBudget::new(),
+            bundle::CopyPolicy::Bundle
+        )
+        .is_err()
+    );
+    assert!(!bad.exists());
+}
+
+fn fixture_executable() -> &'static Path {
+    static FIXTURE: OnceLock<TempDir> = OnceLock::new();
+    FIXTURE
+        .get_or_init(|| {
+            let directory = TempDir::new().unwrap();
+            let source = directory.path().join("fixture.rs");
+        fs::write(
+            &source,
+            r#"fn main() {
+                if let Ok(path) = std::env::var("OPENNOW_FIXTURE_CHILD_PID") {
+                    let child = std::process::Command::new(std::env::current_exe().unwrap()).env_remove("OPENNOW_FIXTURE_CHILD_PID").spawn().unwrap();
+                    std::fs::write(path, child.id().to_string()).unwrap();
+                }
+                let lifetime = std::env::var("OPENNOW_FIXTURE_LIFETIME_MS").ok().and_then(|value| value.parse().ok()).unwrap_or(900);
+                std::thread::sleep(std::time::Duration::from_millis(lifetime));
+            }"#,
+            )
+            .unwrap();
+            let mut compiler = Command::new("rustc");
+            #[cfg(all(windows, target_env = "msvc"))]
+            {
+                let version = Command::new("rustc").arg("-vV").output().unwrap();
+                assert!(version.status.success());
+                let version = String::from_utf8(version.stdout).unwrap();
+                let host = version.lines().find_map(|line| line.strip_prefix("host: ")).expect("rustc host triple");
+                if host.ends_with("-windows-msvc") {
+                    let variable = format!("CARGO_TARGET_{}_LINKER", host.replace('-', "_").to_ascii_uppercase());
+                    if let Some(linker) = std::env::var_os(variable) {
+                        let mut option = std::ffi::OsString::from("linker=");
+                        option.push(linker);
+                        compiler.arg("-C").arg(option);
+                    }
+                }
+            }
+            let output = compiler.arg(&source)
+                .arg("-o")
+                .arg(directory.path().join("fixture.exe"))
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            directory
+        })
+        .path()
+}
+
+#[test]
+fn owned_application_accepts_descendants_and_stops_the_entire_tree() {
+    let directory = TempDir::new().unwrap();
+    let pid_file = directory.path().join("child.pid");
+    let mut command = Command::new(fixture_executable().join("fixture.exe"));
+    command
+        .env("OPENNOW_FIXTURE_CHILD_PID", &pid_file)
+        .env("OPENNOW_FIXTURE_LIFETIME_MS", "60000");
+    let mut application = process::OwnedApplication::start(&mut command).unwrap();
+    let start = Instant::now();
+    while !pid_file.exists() {
+        assert!(start.elapsed() < Duration::from_secs(5));
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let pid = fs::read_to_string(&pid_file).unwrap().parse().unwrap();
+    let descendant = ProcessIdentity::capture(pid).unwrap();
+    assert!(application.owns(&descendant).unwrap());
+    assert!(
+        !application
+            .owns(&ProcessIdentity::capture(std::process::id()).unwrap())
+            .unwrap()
+    );
+    application.stop().unwrap();
+    assert!(!descendant.is_running().unwrap());
+    assert!(!application.identity.is_running().unwrap());
+}
+
+#[cfg(unix)]
+#[test]
+fn zip_framework_links_are_preserved_but_external_links_are_rejected() {
+    let directory = TempDir::new().unwrap();
+    let package = directory.path().join("app.zip");
+    let mut zip = zip::ZipWriter::new(File::create(&package).unwrap());
+    zip.start_file(
+        "Contents/Frameworks/Qt/Versions/A/Qt",
+        zip::write::SimpleFileOptions::default(),
+    )
+    .unwrap();
+    zip.write_all(b"framework").unwrap();
+    zip.add_symlink(
+        "Contents/Frameworks/Qt/Versions/Current",
+        "A",
+        zip::write::SimpleFileOptions::default(),
+    )
+    .unwrap();
+    zip.add_symlink(
+        "Contents/Frameworks/Qt/Qt",
+        "Versions/Current/Qt",
+        zip::write::SimpleFileOptions::default(),
+    )
+    .unwrap();
+    zip.finish().unwrap();
+    let payload = directory.path().join("payload");
+    archive::extract_zip(&package, &payload, true).unwrap();
+    assert_eq!(
+        fs::read(payload.join("Contents/Frameworks/Qt/Qt")).unwrap(),
+        b"framework"
+    );
+    let mut zip = zip::ZipWriter::new(File::create(&package).unwrap());
+    zip.add_symlink(
+        "escape",
+        "../outside",
+        zip::write::SimpleFileOptions::default(),
+    )
+    .unwrap();
+    zip.finish().unwrap();
+    assert!(archive::extract_zip(&package, &directory.path().join("bad"), true).is_err());
+    assert!(!directory.path().join("bad").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn fixture_plan_uses_canonical_installation_paths() {
+    let directory = TempDir::new().unwrap();
+    let target = directory.path().join("actual");
+    fs::create_dir(&target).unwrap();
+    let alias = directory.path().join("alias");
+    std::os::unix::fs::symlink(&target, &alias).unwrap();
+    let plan = plan(&alias, InstallKind::WindowsPortable);
+    assert_eq!(
+        plan.target,
+        fs::canonicalize(&target).unwrap().join("installed")
+    );
+    assert_eq!(
+        plan.application_executable,
+        plan.target.join("bin/OpenNOW.exe")
+    );
+}
+
+fn plan(directory: &Path, kind: InstallKind) -> Plan {
+    let directory = fs::canonicalize(directory).unwrap();
+    let target = directory.join(if kind == InstallKind::AppImage {
+        "OpenNOW.AppImage"
+    } else {
+        "installed"
+    });
+    let application = if kind == InstallKind::AppImage {
+        target.clone()
+    } else {
+        target.join("bin/OpenNOW.exe")
+    };
+    Plan {
+        schema_version: 1,
+        version: "1.2.3".to_owned(),
+        kind,
+        package: directory.join("package.zip"),
+        target,
+        application_executable: application,
+        data_dir: directory.join("settings"),
+        processes: vec![],
+        nonce: "a".repeat(64),
+        managed_identity: None,
+    }
+}
+
+fn stage_native_executable(path: &Path) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::copy(fixture_executable().join("fixture.exe"), path).unwrap();
+    make_executable(path).unwrap();
+}
+
+#[test]
+fn failed_appimage_restart_restores_previous_binary() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::AppImage);
+    fs::write(&plan.target, b"original appimage").unwrap();
+    let candidate = directory.path().join("candidate");
+    fs::write(&candidate, b"not an executable").unwrap();
+    make_executable(&candidate).unwrap();
+    assert!(
+        replace_and_restart(
+            &plan,
+            directory.path(),
+            &candidate,
+            Duration::from_millis(100)
+        )
+        .is_err()
+    );
+    assert_eq!(fs::read(&plan.target).unwrap(), b"original appimage");
+    assert_eq!(
+        fs::read(directory.path().join("failed")).unwrap(),
+        b"not an executable"
+    );
+    assert_eq!(
+        read_outcome(&directory.path().join("outcome.json"))
+            .unwrap()
+            .unwrap()
+            .status,
+        OutcomeStatus::RolledBack
+    );
+}
+
+#[test]
+fn failed_directory_replacement_restores_all_original_files_and_settings() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::WindowsPortable);
+    fs::create_dir_all(plan.application_executable.parent().unwrap()).unwrap();
+    fs::write(&plan.application_executable, b"original executable").unwrap();
+    fs::write(plan.target.join("original.dll"), b"original dependency").unwrap();
+    fs::create_dir(&plan.data_dir).unwrap();
+    fs::write(plan.data_dir.join("settings.json"), b"keep settings").unwrap();
+    let missing = directory.path().join("missing");
+    assert!(
+        replace_and_restart(
+            &plan,
+            directory.path(),
+            &missing,
+            Duration::from_millis(100)
+        )
+        .is_err()
+    );
+    assert_eq!(
+        fs::read(&plan.application_executable).unwrap(),
+        b"original executable"
+    );
+    assert_eq!(
+        fs::read(plan.target.join("original.dll")).unwrap(),
+        b"original dependency"
+    );
+    assert_eq!(
+        fs::read(plan.data_dir.join("settings.json")).unwrap(),
+        b"keep settings"
+    );
+}
+
+#[test]
+fn failed_shutdown_and_failed_outcome_write_never_authorize_rollback() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::AppImage);
+    fs::write(&plan.target, b"running candidate").unwrap();
+    fs::write(directory.path().join("previous"), b"previous application").unwrap();
+    write_outcome(
+        directory.path(),
+        &plan,
+        OutcomeStatus::AwaitingStartup,
+        "candidate running",
+        None,
+        None,
+    )
+    .unwrap();
+    let before = fs::read(directory.path().join("outcome.json")).unwrap();
+    let mut attempted_record = false;
+    let failure = failed_restart(
+        "startup failed".to_owned(),
+        Err("process shutdown failed".to_owned()),
+        |_| {
+            attempted_record = true;
+            Err("disk full".to_owned())
+        },
+    );
+    assert!(attempted_record);
+    assert!(matches!(failure, RestartFailure::ProcessesMayBeRunning(_)));
+    assert!(recover_replacement(&plan, directory.path(), failure).is_err());
+    assert_eq!(fs::read(&plan.target).unwrap(), b"running candidate");
+    assert_eq!(
+        fs::read(directory.path().join("previous")).unwrap(),
+        b"previous application"
+    );
+    assert_eq!(
+        fs::read(directory.path().join("outcome.json")).unwrap(),
+        before
+    );
+    assert!(!directory.path().join("failed").exists());
+}
+
+#[test]
+fn interrupted_startup_without_identity_does_not_roll_back_under_unknown_processes() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::AppImage);
+    fs::write(&plan.target, b"candidate").unwrap();
+    fs::write(directory.path().join("previous"), b"previous").unwrap();
+    write_outcome(
+        directory.path(),
+        &plan,
+        OutcomeStatus::AwaitingStartup,
+        "startup interrupted",
+        None,
+        None,
+    )
+    .unwrap();
+    assert!(
+        apply(&plan, directory.path())
+            .unwrap_err()
+            .contains("unsafe")
+    );
+    assert_eq!(fs::read(&plan.target).unwrap(), b"candidate");
+    assert_eq!(
+        fs::read(directory.path().join("previous")).unwrap(),
+        b"previous"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn failed_start_cleans_the_forked_group_before_reaping_the_parent() {
+    use std::os::unix::process::CommandExt;
+    let directory = TempDir::new().unwrap();
+    let pid_file = directory.path().join("child.pid");
+    let mut child = Command::new(fixture_executable().join("fixture.exe"))
+        .process_group(0)
+        .env("OPENNOW_FIXTURE_CHILD_PID", &pid_file)
+        .env("OPENNOW_FIXTURE_LIFETIME_MS", "60000")
+        .spawn()
+        .unwrap();
+    let start = Instant::now();
+    while !pid_file.exists() {
+        assert!(start.elapsed() < Duration::from_secs(5));
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let descendant =
+        ProcessIdentity::capture(fs::read_to_string(pid_file).unwrap().parse().unwrap()).unwrap();
+    let failure =
+        process::failed_start(&mut child, "identity capture failed after fork".to_owned());
+    assert!(
+        matches!(failure, RestartFailure::RollbackSafe(_)),
+        "{failure}"
+    );
+    assert!(!descendant.is_running().unwrap());
+    assert!(child.try_wait().unwrap().is_some());
+}
+
+#[test]
+fn spawn_without_startup_acknowledgement_rolls_back_the_complete_directory() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::WindowsPortable);
+    fs::create_dir_all(plan.application_executable.parent().unwrap()).unwrap();
+    fs::write(&plan.application_executable, b"old executable").unwrap();
+    let payload = directory.path().join("payload");
+    stage_native_executable(&payload.join("bin/OpenNOW.exe"));
+    assert!(
+        replace_and_restart(&plan, directory.path(), &payload, Duration::from_millis(30))
+            .unwrap_err()
+            .contains("acknowledge")
+    );
+    assert_eq!(
+        fs::read(&plan.application_executable).unwrap(),
+        b"old executable"
+    );
+    assert!(directory.path().join("failed/bin/OpenNOW.exe").is_file());
+}
+
+#[test]
+fn portable_directory_replacement_requires_ack_and_preserves_settings() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::WindowsPortable);
+    fs::create_dir_all(plan.application_executable.parent().unwrap()).unwrap();
+    fs::write(&plan.application_executable, b"old executable").unwrap();
+    fs::write(plan.target.join("old-only.dll"), b"old dependency").unwrap();
+    fs::create_dir(&plan.data_dir).unwrap();
+    fs::write(plan.data_dir.join("settings.json"), b"unchanged").unwrap();
+    let payload = directory.path().join("payload");
+    stage_native_executable(&payload.join("bin/OpenNOW.exe"));
+    fs::write(payload.join("new-only.dll"), b"new dependency").unwrap();
+    let acknowledgement_directory = directory.path().to_path_buf();
+    let nonce = plan.nonce.clone();
+    let version = plan.version.clone();
+    let worker = std::thread::spawn(move || {
+        let start = Instant::now();
+        loop {
+            if let Some(outcome) =
+                read_outcome(&acknowledgement_directory.join("outcome.json")).unwrap()
+            {
+                if let (OutcomeStatus::AwaitingStartup, Some(application)) =
+                    (outcome.status, outcome.restarted_process)
+                {
+                    atomic_json(
+                        &acknowledgement_directory.join("ack.json"),
+                        &Acknowledgement {
+                            nonce,
+                            version,
+                            application,
+                        },
+                    )
+                    .unwrap();
+                    break;
+                }
+            }
+            assert!(start.elapsed() < Duration::from_secs(10));
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    });
+    replace_and_restart(&plan, directory.path(), &payload, Duration::from_secs(10)).unwrap();
+    worker.join().unwrap();
+    assert!(!plan.target.join("old-only.dll").exists());
+    assert_eq!(
+        fs::read(plan.target.join("new-only.dll")).unwrap(),
+        b"new dependency"
+    );
+    assert_eq!(
+        fs::read(plan.data_dir.join("settings.json")).unwrap(),
+        b"unchanged"
+    );
+    assert!(!directory.path().join("previous").exists());
+    assert_eq!(
+        read_outcome(&directory.path().join("outcome.json"))
+            .unwrap()
+            .unwrap()
+            .status,
+        OutcomeStatus::Completed
+    );
+    std::thread::sleep(Duration::from_millis(950));
+}
+
+#[test]
+fn acknowledged_application_remains_running_after_owner_drop() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::WindowsPortable);
+    stage_native_executable(&plan.application_executable);
+    let acknowledgement_directory = directory.path().to_path_buf();
+    let nonce = plan.nonce.clone();
+    let version = plan.version.clone();
+    let worker = std::thread::spawn(move || {
+        let start = Instant::now();
+        loop {
+            if let Some(outcome) =
+                read_outcome(&acknowledgement_directory.join("outcome.json")).unwrap()
+            {
+                if let (OutcomeStatus::AwaitingStartup, Some(application)) =
+                    (outcome.status, outcome.restarted_process)
+                {
+                    atomic_json(
+                        &acknowledgement_directory.join("ack.json"),
+                        &Acknowledgement {
+                            nonce,
+                            version,
+                            application: application.clone(),
+                        },
+                    )
+                    .unwrap();
+                    return application;
+                }
+            }
+            assert!(start.elapsed() < Duration::from_secs(10));
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    });
+    restart_and_acknowledge(&plan, directory.path(), Duration::from_secs(10)).unwrap();
+    let application = worker.join().unwrap();
+    assert!(application.is_running().unwrap());
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(application.is_running().unwrap());
+    let deadline = Instant::now();
+    while application.is_running().unwrap() {
+        assert!(deadline.elapsed() < Duration::from_secs(5));
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn interrupted_replacement_recovers_without_the_target_existing() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::AppImage);
+    fs::write(directory.path().join("previous"), b"original bytes").unwrap();
+    write_outcome(
+        directory.path(),
+        &plan,
+        OutcomeStatus::Installing,
+        "interrupted",
+        None,
+        None,
+    )
+    .unwrap();
+    apply(&plan, directory.path()).unwrap();
+    assert_eq!(fs::read(&plan.target).unwrap(), b"original bytes");
+    assert_eq!(
+        read_outcome(&directory.path().join("outcome.json"))
+            .unwrap()
+            .unwrap()
+            .status,
+        OutcomeStatus::RolledBack
+    );
+}
+
+#[test]
+fn repeated_helper_invocation_preserves_cleaned_up_terminal_outcomes() {
+    for status in [OutcomeStatus::Completed, OutcomeStatus::RolledBack] {
+        let directory = TempDir::new().unwrap();
+        let plan = plan(directory.path(), InstallKind::AppImage);
+        atomic_json(&directory.path().join("plan.json"), &plan).unwrap();
+        write_outcome(
+            directory.path(),
+            &plan,
+            status,
+            "terminal result",
+            Some(plan.version.clone()),
+            None,
+        )
+        .unwrap();
+        assert!(!plan.package.exists());
+        let outcome = fs::read(directory.path().join("outcome.json")).unwrap();
+        run_helper(&directory.path().join("plan.json")).unwrap();
+        run_helper(&directory.path().join("plan.json")).unwrap();
+        assert_eq!(
+            fs::read(directory.path().join("outcome.json")).unwrap(),
+            outcome
+        );
+    }
+}
+
+#[test]
+fn advisory_lock_distinguishes_live_helper_from_stale_outcomes() {
+    let directory = TempDir::new().unwrap();
+    let prepared = PreparedUpdate {
+        plan_path: directory.path().join("plan.json"),
+        outcome_path: directory.path().join("outcome.json"),
+        version: "1.2.3".to_owned(),
+    };
+    assert!(!helper_is_running(&prepared).unwrap());
+    let lock = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(directory.path().join("apply.lock"))
+        .unwrap();
+    lock.lock_exclusive().unwrap();
+    assert!(helper_is_running(&prepared).unwrap());
+    FileExt::unlock(&lock).unwrap();
+    assert!(!helper_is_running(&prepared).unwrap());
+}
+
+#[test]
+fn portable_nested_profile_and_extra_root_files_are_preserved() {
+    let directory = TempDir::new().unwrap();
+    let mut plan = plan(directory.path(), InstallKind::WindowsPortable);
+    plan.data_dir = plan.target.join("bin/profile");
+    fs::create_dir_all(&plan.data_dir).unwrap();
+    fs::write(plan.data_dir.join("settings.json"), b"custom profile").unwrap();
+    fs::write(plan.target.join("personal-notes.txt"), b"user-owned notes").unwrap();
+    let payload = directory.path().join("payload");
+    fs::create_dir_all(payload.join("bin")).unwrap();
+    let paths = preserve_portable_data(&plan, &payload).unwrap();
+    assert_eq!(paths.len(), 2);
+    assert_eq!(
+        fs::read(payload.join("bin/profile/settings.json")).unwrap(),
+        b"custom profile"
+    );
+    assert_eq!(
+        fs::read(payload.join("personal-notes.txt")).unwrap(),
+        b"user-owned notes"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn portable_profile_preserves_restrictive_unix_permissions_and_ownership() {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    let directory = TempDir::new().unwrap();
+    let source = directory.path().join("profile");
+    fs::create_dir_all(source.join("credentials")).unwrap();
+    fs::write(
+        source.join("credentials/account.json"),
+        b"private fixture data",
+    )
+    .unwrap();
+    for path in [&source, &source.join("credentials")] {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    fs::set_permissions(
+        source.join("credentials/account.json"),
+        fs::Permissions::from_mode(0o600),
+    )
+    .unwrap();
+    let destination = directory.path().join("preserved-profile");
+    copy_user_data(&source, &destination, &mut bundle::CopyBudget::new()).unwrap();
+    for relative in ["", "credentials", "credentials/account.json"] {
+        let before = fs::metadata(source.join(relative)).unwrap();
+        let after = fs::metadata(destination.join(relative)).unwrap();
+        assert_eq!(before.mode() & 0o7777, after.mode() & 0o7777);
+        assert_eq!(before.uid(), after.uid());
+        assert_eq!(before.gid(), after.gid());
+    }
+    assert_eq!(
+        fs::metadata(destination.join("credentials/account.json"))
+            .unwrap()
+            .mode()
+            & 0o777,
+        0o600
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn transaction_directory_is_private_at_creation() {
+    use std::os::unix::fs::PermissionsExt;
+    let directory = TempDir::new().unwrap();
+    let transaction = directory.path().join("transaction");
+    security::create_private_directory(&transaction).unwrap();
+    assert_eq!(
+        fs::metadata(transaction).unwrap().permissions().mode() & 0o777,
+        0o700
+    );
+}
+
+#[test]
+fn preserved_roots_share_one_entry_and_byte_budget() {
+    let directory = TempDir::new().unwrap();
+    for name in ["first", "second"] {
+        fs::create_dir(directory.path().join(name)).unwrap();
+        fs::write(directory.path().join(name).join("data"), b"123456").unwrap();
+    }
+    let mut bytes = bundle::CopyBudget::with_limits(10, 10);
+    copy_user_data(
+        &directory.path().join("first"),
+        &directory.path().join("copy-first"),
+        &mut bytes,
+    )
+    .unwrap();
+    assert!(
+        copy_user_data(
+            &directory.path().join("second"),
+            &directory.path().join("copy-second"),
+            &mut bytes
+        )
+        .unwrap_err()
+        .contains("byte budget")
+    );
+    assert!(!directory.path().join("copy-second").exists());
+    let mut entries = bundle::CopyBudget::with_limits(3, 100);
+    copy_user_data(
+        &directory.path().join("first"),
+        &directory.path().join("entries-first"),
+        &mut entries,
+    )
+    .unwrap();
+    assert!(
+        copy_user_data(
+            &directory.path().join("second"),
+            &directory.path().join("entries-second"),
+            &mut entries
+        )
+        .unwrap_err()
+        .contains("entry limit")
+    );
+    assert!(!directory.path().join("entries-second").exists());
+}
+
+#[test]
+fn streaming_copy_rejects_file_growth_without_writing_past_the_budget() {
+    let directory = TempDir::new().unwrap();
+    let source = directory.path().join("live-data");
+    fs::write(&source, b"before").unwrap();
+    let mut input = File::open(&source).unwrap();
+    let observed_size = input.metadata().unwrap().len();
+    OpenOptions::new()
+        .append(true)
+        .open(&source)
+        .unwrap()
+        .write_all(b"appended after metadata")
+        .unwrap();
+    let mut output = Vec::new();
+    assert!(
+        copy_bounded(&mut input, &mut output, observed_size)
+            .unwrap_err()
+            .contains("streaming byte budget")
+    );
+    assert_eq!(output.len() as u64, observed_size);
+    assert_eq!(output, b"before");
+}
+
+#[test]
+fn preserved_roots_are_rediscovered_and_rebudgeted_after_shutdown() {
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::WindowsPortable);
+    fs::create_dir_all(plan.target.join("bin")).unwrap();
+    fs::write(plan.target.join("first-profile"), b"old").unwrap();
+    let payload = directory.path().join("payload");
+    fs::create_dir(&payload).unwrap();
+    let prepared = preserve_portable_data(&plan, &payload).unwrap();
+    fs::write(plan.target.join("first-profile"), b"latest").unwrap();
+    fs::write(plan.target.join("created-during-shutdown"), b"new").unwrap();
+    for (_, destination) in prepared {
+        remove_path(&destination).unwrap();
+    }
+    let refreshed = preserve_portable_data(&plan, &payload).unwrap();
+    assert_eq!(refreshed.len(), 2);
+    assert_eq!(fs::read(payload.join("first-profile")).unwrap(), b"latest");
+    assert_eq!(
+        fs::read(payload.join("created-during-shutdown")).unwrap(),
+        b"new"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_busy_file_rejects_replacement_without_losing_original() {
+    use std::os::windows::fs::OpenOptionsExt;
+    let directory = TempDir::new().unwrap();
+    let plan = plan(directory.path(), InstallKind::WindowsPortable);
+    fs::create_dir_all(plan.application_executable.parent().unwrap()).unwrap();
+    fs::write(&plan.application_executable, b"original executable").unwrap();
+    let _busy = OpenOptions::new()
+        .read(true)
+        .share_mode(0)
+        .open(&plan.application_executable)
+        .unwrap();
+    let payload = directory.path().join("payload");
+    stage_native_executable(&payload.join("bin/OpenNOW.exe"));
+    assert!(
+        replace_and_restart(&plan, directory.path(), &payload, Duration::from_millis(30)).is_err()
+    );
+    assert!(plan.application_executable.exists());
+    assert!(!directory.path().join("previous").exists());
+}
+
+#[test]
+fn running_process_identity_has_a_bounded_wait() {
+    let identity = ProcessIdentity::capture(std::process::id()).unwrap();
+    assert!(identity.is_running().unwrap());
+    assert!(
+        process::wait_for_exit(&[identity], Duration::from_millis(20))
+            .unwrap_err()
+            .contains("Timed out")
+    );
+}

--- a/native/opennow-core/src/update_apply/verification.rs
+++ b/native/opennow-core/src/update_apply/verification.rs
@@ -1,0 +1,134 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use ed25519_dalek::{Signature, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+pub const MAXIMUM_MANIFEST_BYTES: u64 = 64 * 1024;
+pub const MAXIMUM_UPDATE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateManifest {
+    pub schema_version: u32,
+    pub version: String,
+    pub asset: String,
+    pub size: u64,
+    pub sha256: String,
+    pub signature: String,
+}
+
+pub fn embedded_update_key() -> Result<VerifyingKey, String> {
+    let encoded = option_env!("OPENNOW_UPDATE_ED25519_PUBLIC_KEY")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or("This build has no pinned update signing key")?;
+    decode_verifying_key(encoded)
+}
+
+pub fn decode_verifying_key(encoded: &str) -> Result<VerifyingKey, String> {
+    let bytes: [u8; 32] = BASE64
+        .decode(encoded)
+        .map_err(|_| "Pinned update signing key is not valid base64")?
+        .try_into()
+        .map_err(|_| "Pinned update signing key has the wrong length")?;
+    VerifyingKey::from_bytes(&bytes).map_err(|_| "Pinned update signing key is invalid".to_owned())
+}
+
+pub fn signature_payload(manifest: &UpdateManifest) -> String {
+    format!(
+        "OpenNOW update manifest v1\nversion={}\nasset={}\nsize={}\nsha256={}\n",
+        manifest.version.trim_start_matches('v'),
+        manifest.asset,
+        manifest.size,
+        manifest.sha256.to_ascii_lowercase()
+    )
+}
+
+pub fn verify_manifest(manifest: &UpdateManifest, key: &VerifyingKey) -> Result<(), String> {
+    if manifest.schema_version != 1
+        || semver::Version::parse(
+            manifest
+                .version
+                .strip_prefix('v')
+                .unwrap_or(&manifest.version),
+        )
+        .is_err()
+        || !safe_asset_name(&manifest.asset)
+        || manifest.size == 0
+        || manifest.size > MAXIMUM_UPDATE_BYTES
+        || manifest.sha256.len() != 64
+        || !manifest.sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("Signed update metadata fields are invalid".to_owned());
+    }
+    let bytes = BASE64
+        .decode(&manifest.signature)
+        .map_err(|_| "Update signature is not valid base64")?;
+    let signature =
+        Signature::from_slice(&bytes).map_err(|_| "Update signature has the wrong length")?;
+    key.verify_strict(signature_payload(manifest).as_bytes(), &signature)
+        .map_err(|_| "Update manifest signature is invalid".to_owned())
+}
+
+pub fn safe_asset_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 240
+        && !value.contains("..")
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+}
+
+pub fn verify_signed_manifest(bytes: &[u8]) -> Result<UpdateManifest, String> {
+    if bytes.len() as u64 > MAXIMUM_MANIFEST_BYTES {
+        return Err("Update manifest exceeds its size limit".to_owned());
+    }
+    let manifest = serde_json::from_slice(bytes)
+        .map_err(|error| format!("Invalid update manifest: {error}"))?;
+    verify_manifest(&manifest, &embedded_update_key()?)?;
+    Ok(manifest)
+}
+
+pub fn verify_package(path: &Path, manifest: &UpdateManifest) -> Result<(), String> {
+    if path.file_name().and_then(|name| name.to_str()) != Some(manifest.asset.as_str()) {
+        return Err("Update package name does not match its signed manifest".to_owned());
+    }
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    if !metadata.is_file() || metadata.len() != manifest.size {
+        return Err(
+            "Update package size or file type does not match its signed manifest".to_owned(),
+        );
+    }
+    let mut file = File::open(path).map_err(|error| error.to_string())?;
+    let (size, hash) = hash_reader(&mut file, MAXIMUM_UPDATE_BYTES)?;
+    if size != manifest.size || !hash.eq_ignore_ascii_case(&manifest.sha256) {
+        return Err("Update package SHA256 does not match its signed manifest".to_owned());
+    }
+    Ok(())
+}
+
+pub(super) fn hash_reader(reader: &mut impl Read, maximum: u64) -> Result<(u64, String), String> {
+    let mut hasher = Sha256::new();
+    let mut total = 0u64;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let length = reader
+            .read(&mut buffer)
+            .map_err(|error| error.to_string())?;
+        if length == 0 {
+            break;
+        }
+        total = total
+            .checked_add(length as u64)
+            .ok_or("Update size overflow")?;
+        if total > maximum {
+            return Err("Update data exceeds its size limit".to_owned());
+        }
+        hasher.update(&buffer[..length]);
+    }
+    Ok((total, format!("{:x}", hasher.finalize())))
+}

--- a/native/opennow-core/src/updater.rs
+++ b/native/opennow-core/src/updater.rs
@@ -1,6 +1,8 @@
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD as BASE64;
-use ed25519_dalek::{Signature, VerifyingKey};
+use crate::update_apply;
+use crate::update_apply::verification::{
+    MAXIMUM_MANIFEST_BYTES, MAXIMUM_UPDATE_BYTES, UpdateManifest, embedded_update_key,
+    safe_asset_name, verify_manifest,
+};
 use reqwest::blocking::{Client, Response};
 use reqwest::header::{ACCEPT, USER_AGENT};
 use semver::Version;
@@ -10,7 +12,6 @@ use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -18,8 +19,6 @@ const RELEASES_URL: &str =
     "https://api.github.com/repos/OpenCloudGaming/OpenNOW/releases?per_page=20";
 const RELEASES_PAGE: &str = "https://github.com/OpenCloudGaming/OpenNOW/releases";
 const RELEASE_ASSET_PREFIX: &str = "https://github.com/OpenCloudGaming/OpenNOW/releases/download/";
-const MAXIMUM_MANIFEST_BYTES: u64 = 64 * 1024;
-const MAXIMUM_UPDATE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 
 #[derive(Clone)]
 struct AvailableUpdate {
@@ -48,6 +47,7 @@ struct State {
     last_checked_at: Option<u128>,
     available: Option<AvailableUpdate>,
     downloaded: Option<DownloadedUpdate>,
+    transaction: Option<update_apply::PreparedUpdate>,
 }
 
 #[derive(Deserialize)]
@@ -67,20 +67,10 @@ struct Asset {
     size: u64,
 }
 
-#[derive(Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct UpdateManifest {
-    schema_version: u32,
-    version: String,
-    asset: String,
-    size: u64,
-    sha256: String,
-    signature: String,
-}
-
 pub struct UpdaterService {
     client: Client,
     staging_dir: PathBuf,
+    data_dir: PathBuf,
     operation: Mutex<()>,
     state: Mutex<State>,
 }
@@ -95,37 +85,85 @@ impl UpdaterService {
         let staging_dir = data_dir.join("updates");
         fs::create_dir_all(&staging_dir)
             .map_err(|error| format!("Could not create the update staging directory: {error}"))?;
+        let (transaction, status, message) = match read_prepared_update(&staging_dir) {
+            Ok(transaction) => (
+                transaction,
+                "idle",
+                "Ready to check GitHub Releases".to_owned(),
+            ),
+            Err(error) => (
+                None,
+                "failed",
+                format!("Could not recover update status: {error}"),
+            ),
+        };
         Ok(Self {
             client,
             staging_dir,
+            data_dir: data_dir.to_path_buf(),
             operation: Mutex::new(()),
             state: Mutex::new(State {
-                status: "idle",
+                status,
                 available_version: None,
                 release_url: None,
                 notes_version: None,
                 notes: None,
-                message: "Ready to check GitHub Releases".to_owned(),
+                message,
                 last_checked_at: None,
                 available: None,
                 downloaded: None,
+                transaction,
             }),
         })
     }
 
     pub fn state(&self) -> Value {
-        state_json(&self.state.lock().expect("updater state poisoned"))
+        let mut state = self.state.lock().expect("updater state poisoned");
+        reconcile_transaction(&mut state, &self.staging_dir);
+        state_json(&state)
+    }
+
+    pub fn installation_pending(&self) -> bool {
+        self.state();
+        matches!(
+            self.state.lock().expect("updater state poisoned").status,
+            "preparing"
+                | "awaiting-exit"
+                | "applying"
+                | "restarting"
+                | "installing"
+                | "managed-pending"
+        )
+    }
+
+    pub fn request_failed(&self, message: &str) {
+        let mut state = self.state.lock().expect("updater state poisoned");
+        if !matches!(
+            state.status,
+            "checking"
+                | "downloading"
+                | "preparing"
+                | "awaiting-exit"
+                | "applying"
+                | "restarting"
+                | "installing"
+        ) {
+            state.message = message.to_owned();
+        }
     }
 
     pub fn check(&self, params: &Value) -> Result<Value, String> {
         let _operation = self.begin_operation()?;
-        let channel = params["channel"].as_str().unwrap_or("stable");
+        let channel = params["channel"]
+            .as_str()
+            .unwrap_or_else(|| crate::version::update_channel(crate::version::APPLICATION_VERSION));
         if !matches!(channel, "stable" | "nightly") {
             return Err("Unsupported update channel".to_owned());
         }
         {
             let mut state = self.state.lock().expect("updater state poisoned");
             state.status = "checking";
+            state.transaction = None;
             state.message = "Checking GitHub Releases…".to_owned();
         }
         let releases = self
@@ -160,7 +198,6 @@ impl UpdaterService {
         let release = select_release(&releases, channel, current);
         let mut state = self.state.lock().expect("updater state poisoned");
         state.last_checked_at = Some(now_ms());
-        state.downloaded = None;
         // Reading release notes is independent of installing a newer version.
         // A development build can be ahead of every published release.
         update_highlights(&mut state, select_latest_release(&releases, channel));
@@ -205,6 +242,7 @@ impl UpdaterService {
             state.available = None;
             state.message = "OpenNOW is up to date.".to_owned();
         }
+        restore_downloaded_status(&mut state);
         Ok(state_json(&state))
     }
 
@@ -218,6 +256,7 @@ impl UpdaterService {
                 .ok_or_else(|| "No signed update package is available".to_owned())?;
             embedded_update_key()?;
             state.status = "downloading";
+            state.transaction = None;
             state.message = format!("Downloading OpenNOW {}…", available.version);
             available
         };
@@ -236,7 +275,6 @@ impl UpdaterService {
                 let mut state = self.state.lock().expect("updater state poisoned");
                 state.status = "available";
                 state.message = format!("Update download failed verification: {error}");
-                state.downloaded = None;
                 Err(error)
             }
         }
@@ -254,12 +292,48 @@ impl UpdaterService {
             .downloaded
             .clone()
             .ok_or_else(|| "No verified update has been downloaded".to_owned())?;
-        verify_downloaded_file(&downloaded)?;
-        let action = launch_verified_update(&downloaded.path)?;
-        let mut state = self.state.lock().expect("updater state poisoned");
-        state.status = "installing";
-        state.message = format!("Verified update launched ({action}). OpenNOW will close.");
-        Ok(state_json(&state))
+        {
+            let mut state = self.state.lock().expect("updater state poisoned");
+            state.status = "preparing";
+            state.message =
+                "Verifying and preparing a complete replacement before shutdown.".to_owned();
+            state.transaction = None;
+        }
+        let result = (|| {
+            verify_downloaded_file(&downloaded)?;
+            let application = std::env::var_os("OPENNOW_APP_EXECUTABLE")
+                .map(PathBuf::from)
+                .ok_or("The Qt application executable identity is unavailable")?;
+            let application_pid = std::env::var("OPENNOW_APP_PID")
+                .map_err(|_| "The Qt application process identity is unavailable")?
+                .parse::<u32>()
+                .map_err(|_| "The Qt application process identity is invalid")?;
+            let kind = update_apply::detect_install_kind(&application, &downloaded.path)?;
+            let prepared = update_apply::prepare_update(update_apply::PrepareRequest {
+                package: downloaded.path.clone(),
+                expected_version: downloaded.version.clone(),
+                application_executable: application,
+                application_pid,
+                core_pid: std::process::id(),
+                kind,
+                data_dir: self.data_dir.clone(),
+            })?;
+            save_prepared_update(&self.staging_dir, &prepared)?;
+            self.state
+                .lock()
+                .expect("updater state poisoned")
+                .transaction = Some(prepared.clone());
+            update_apply::launch_prepared_update(&prepared)?;
+            Ok::<(), String>(())
+        })();
+        if let Err(error) = result {
+            let mut state = self.state.lock().expect("updater state poisoned");
+            state.status = "failed";
+            state.message = format!("Update preparation failed; OpenNOW remains open: {error}");
+            state.transaction = None;
+            return Err(error);
+        }
+        Ok(self.state())
     }
 
     pub fn highlights(&self) -> Value {
@@ -277,8 +351,11 @@ impl UpdaterService {
             .operation
             .try_lock()
             .map_err(|_| "An update operation is already in progress".to_owned())?;
-        if self.state.lock().expect("updater state poisoned").status == "installing" {
+        if self.installation_pending() {
             return Err("Update installation is already in progress".to_owned());
+        }
+        if self.state.lock().expect("updater state poisoned").status == "reboot-required" {
+            return Err("Restart your system before starting another update operation.".to_owned());
         }
         Ok(operation)
     }
@@ -326,6 +403,12 @@ impl UpdaterService {
         }
         fs::rename(&partial_path, &final_path)
             .map_err(|error| format!("Could not finalize the staged update: {error}"))?;
+        fs::write(
+            self.staging_dir
+                .join(format!("{}.manifest.json", manifest.asset)),
+            manifest_bytes,
+        )
+        .map_err(|error| format!("Could not preserve signed update metadata: {error}"))?;
         Ok(DownloadedUpdate {
             version: available.version.clone(),
             asset_name: manifest.asset,
@@ -337,8 +420,15 @@ impl UpdaterService {
 }
 
 fn state_json(state: &State) -> Value {
-    let can_download =
-        state.status == "available" && state.available.is_some() && embedded_update_key().is_ok();
+    let can_download = matches!(state.status, "available" | "error" | "downloaded")
+        && state.available.is_some()
+        && embedded_update_key().is_ok()
+        && state.available.as_ref().is_some_and(|available| {
+            state
+                .downloaded
+                .as_ref()
+                .is_none_or(|downloaded| downloaded.asset_name != available.asset.name)
+        });
     json!({
         "status": state.status,
         "currentVersion": crate::version::APPLICATION_VERSION,
@@ -347,12 +437,185 @@ fn state_json(state: &State) -> Value {
         "releaseUrl": state.release_url,
         "message": state.message,
         "lastCheckedAt": state.last_checked_at.map(|value| value.to_string()),
-        "canCheck": !matches!(state.status, "checking" | "downloading" | "installing"),
+        "canCheck": !matches!(state.status, "checking" | "downloading" | "preparing" | "awaiting-exit" | "applying" | "restarting" | "installing" | "managed-pending" | "reboot-required"),
         "canDownload": can_download,
-        "canInstall": state.status == "downloaded" && state.downloaded.is_some(),
+        "canInstall": matches!(state.status, "downloaded" | "error" | "available" | "not-available" | "failed" | "rolled-back") && state.downloaded.is_some(),
+        "exitRequired": state.status == "awaiting-exit",
+        "installVersion": state.transaction.as_ref().map(|transaction| &transaction.version),
         "updateSource": "github-releases",
         "signaturePolicy": if embedded_update_key().is_ok() { "ed25519-pinned" } else { "unconfigured-fail-closed" }
     })
+}
+
+fn read_prepared_update(directory: &Path) -> Result<Option<update_apply::PreparedUpdate>, String> {
+    let path = directory.join("active-apply.json");
+    let file = match fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("Could not read update transaction: {error}")),
+    };
+    let bytes = read_bounded(file, MAXIMUM_MANIFEST_BYTES)?;
+    let prepared: update_apply::PreparedUpdate =
+        serde_json::from_slice(&bytes).map_err(|_| "Persisted update transaction is malformed")?;
+    if !prepared.plan_path.is_absolute()
+        || !prepared.outcome_path.is_absolute()
+        || prepared
+            .plan_path
+            .file_name()
+            .is_none_or(|name| name != "plan.json")
+        || prepared
+            .outcome_path
+            .file_name()
+            .is_none_or(|name| name != "outcome.json")
+        || prepared.plan_path.parent() != prepared.outcome_path.parent()
+        || parse_version(&prepared.version).is_none()
+    {
+        return Err("Persisted update transaction paths or version are invalid".to_owned());
+    }
+    Ok(Some(prepared))
+}
+
+fn save_prepared_update(
+    directory: &Path,
+    prepared: &update_apply::PreparedUpdate,
+) -> Result<(), String> {
+    let temporary = directory.join(format!(".active-apply-{:016x}.part", rand::random::<u64>()));
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .map_err(|error| error.to_string())?;
+    let result = (|| {
+        file.write_all(&serde_json::to_vec(prepared).map_err(|error| error.to_string())?)
+            .and_then(|_| file.sync_all())
+            .map_err(|error| error.to_string())?;
+        drop(file);
+        let destination = directory.join("active-apply.json");
+        match fs::remove_file(&destination) {
+            Ok(()) => (),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => (),
+            Err(error) => return Err(error.to_string()),
+        }
+        fs::rename(&temporary, destination).map_err(|error| error.to_string())?;
+        #[cfg(unix)]
+        fs::File::open(directory)
+            .and_then(|file| file.sync_all())
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temporary);
+    }
+    result
+}
+
+fn reconcile_transaction(state: &mut State, staging_dir: &Path) {
+    let Some(transaction) = &state.transaction else {
+        return;
+    };
+    let outcome = update_apply::read_outcome(&transaction.outcome_path);
+    let outcome = match outcome {
+        Ok(Some(outcome)) if outcome.version == transaction.version => outcome,
+        Ok(None) | Ok(Some(_)) => {
+            state.status = "failed";
+            state.message =
+                "The update helper outcome is missing or does not match the prepared version."
+                    .to_owned();
+            return;
+        }
+        Err(error) => {
+            state.status = "failed";
+            state.message = error;
+            return;
+        }
+    };
+    use update_apply::OutcomeStatus;
+    if matches!(
+        outcome.status,
+        OutcomeStatus::ManagedPending | OutcomeStatus::RebootRequired
+    ) {
+        match update_apply::recover_managed_update(
+            transaction,
+            &outcome,
+            crate::version::APPLICATION_VERSION,
+        ) {
+            Ok(update_apply::ManagedRecovery::Pending(message)) => {
+                state.status = "managed-pending";
+                state.message = message;
+                return;
+            }
+            Ok(update_apply::ManagedRecovery::RebootRequired(message)) => {
+                state.status = "reboot-required";
+                state.message = message;
+                return;
+            }
+            Ok(update_apply::ManagedRecovery::Finished(result)) => {
+                state.status = if result.status == OutcomeStatus::Completed {
+                    "succeeded"
+                } else {
+                    "failed"
+                };
+                state.message = result.message;
+            }
+            Err(error) => {
+                state.status = "failed";
+                state.message = format!("Could not recover native update completion: {error}");
+            }
+        }
+        state.transaction = None;
+        match fs::remove_file(staging_dir.join("active-apply.json")) {
+            Ok(()) => (),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => (),
+            Err(error) => state.message.push_str(&format!(
+                "; could not remove the completed update transaction: {error}"
+            )),
+        }
+        return;
+    }
+    if matches!(
+        outcome.status,
+        OutcomeStatus::WaitingForExit
+            | OutcomeStatus::BackingUp
+            | OutcomeStatus::Installing
+            | OutcomeStatus::AwaitingStartup
+    ) || (outcome.status == OutcomeStatus::Prepared && state.status != "preparing")
+    {
+        match update_apply::helper_is_running(transaction) {
+            Ok(true) => (),
+            Ok(false) => {
+                state.status = "failed";
+                state.message = "The update helper stopped before completing the transaction. OpenNOW will not close automatically.".to_owned();
+                return;
+            }
+            Err(error) => {
+                state.status = "failed";
+                state.message = format!("Could not confirm update helper ownership: {error}");
+                return;
+            }
+        }
+    }
+    state.status = match outcome.status {
+        OutcomeStatus::Prepared => "preparing",
+        OutcomeStatus::WaitingForExit => "awaiting-exit",
+        OutcomeStatus::BackingUp | OutcomeStatus::Installing => "applying",
+        OutcomeStatus::AwaitingStartup => "restarting",
+        OutcomeStatus::Completed => "succeeded",
+        OutcomeStatus::RolledBack => "rolled-back",
+        OutcomeStatus::Failed => "failed",
+        OutcomeStatus::ManagedPending => "managed-pending",
+        OutcomeStatus::RebootRequired => "reboot-required",
+    };
+    state.message = outcome.message;
+}
+
+fn restore_downloaded_status(state: &mut State) {
+    if let Some(downloaded) = &state.downloaded {
+        state.status = "downloaded";
+        state.message = format!(
+            "OpenNOW {} remains downloaded and verified. Ready to install.",
+            downloaded.version
+        );
+    }
 }
 
 fn select_release<'a>(
@@ -400,6 +663,7 @@ fn update_highlights(state: &mut State, release: Option<&Release>) {
 }
 
 fn compatible_asset(assets: &[Asset]) -> Option<&Asset> {
+    let extension = update_apply::compatible_package_extension().ok()?;
     let os_aliases: &[&str] = if cfg!(target_os = "windows") {
         &["win", "windows"]
     } else if cfg!(target_os = "macos") {
@@ -414,13 +678,9 @@ fn compatible_asset(assets: &[Asset]) -> Option<&Asset> {
     };
     assets.iter().find(|asset| {
         let name = asset.name.to_ascii_lowercase();
-        let package = if cfg!(target_os = "windows") {
-            name.ends_with(".msi") || name.ends_with(".exe")
-        } else if cfg!(target_os = "macos") {
-            name.ends_with(".dmg") || name.ends_with(".pkg")
-        } else {
-            name.ends_with(".appimage") || name.ends_with(".deb")
-        };
+        let package = name
+            .rsplit_once('.')
+            .is_some_and(|(_, suffix)| suffix == extension);
         trusted_asset_url(asset)
             && safe_asset_name(&asset.name)
             && name.contains("qt")
@@ -432,24 +692,6 @@ fn compatible_asset(assets: &[Asset]) -> Option<&Asset> {
     })
 }
 
-fn embedded_update_key() -> Result<VerifyingKey, String> {
-    let encoded = option_env!("OPENNOW_UPDATE_ED25519_PUBLIC_KEY")
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| "This build has no pinned update signing key".to_owned())?;
-    decode_verifying_key(encoded)
-}
-
-fn decode_verifying_key(encoded: &str) -> Result<VerifyingKey, String> {
-    let bytes = BASE64
-        .decode(encoded)
-        .map_err(|_| "Pinned update signing key is not valid base64".to_owned())?;
-    let bytes: [u8; 32] = bytes
-        .try_into()
-        .map_err(|_| "Pinned update signing key has the wrong length".to_owned())?;
-    VerifyingKey::from_bytes(&bytes).map_err(|_| "Pinned update signing key is invalid".to_owned())
-}
-
 fn manifest_matches_release(manifest: &UpdateManifest, available: &AvailableUpdate) -> bool {
     parse_version(&manifest.version)
         .is_some_and(|version| Some(version) == parse_version(&available.version))
@@ -457,39 +699,6 @@ fn manifest_matches_release(manifest: &UpdateManifest, available: &AvailableUpda
         && manifest.size == available.asset.size
         && manifest.size > 0
         && manifest.size <= MAXIMUM_UPDATE_BYTES
-}
-
-fn verify_manifest(manifest: &UpdateManifest, key: &VerifyingKey) -> Result<(), String> {
-    if manifest.schema_version != 1
-        || parse_version(&manifest.version).is_none()
-        || !safe_asset_name(&manifest.asset)
-        || manifest.size == 0
-        || manifest.size > MAXIMUM_UPDATE_BYTES
-        || manifest.sha256.len() != 64
-        || !manifest
-            .sha256
-            .bytes()
-            .all(|value| value.is_ascii_hexdigit())
-    {
-        return Err("Signed update metadata fields are invalid".to_owned());
-    }
-    let signature_bytes = BASE64
-        .decode(&manifest.signature)
-        .map_err(|_| "Update signature is not valid base64".to_owned())?;
-    let signature = Signature::from_slice(&signature_bytes)
-        .map_err(|_| "Update signature has the wrong length".to_owned())?;
-    key.verify_strict(signature_payload(manifest).as_bytes(), &signature)
-        .map_err(|_| "Update manifest signature is invalid".to_owned())
-}
-
-fn signature_payload(manifest: &UpdateManifest) -> String {
-    format!(
-        "OpenNOW update manifest v1\nversion={}\nasset={}\nsize={}\nsha256={}\n",
-        manifest.version.trim_start_matches('v'),
-        manifest.asset,
-        manifest.size,
-        manifest.sha256.to_ascii_lowercase()
-    )
 }
 
 fn write_verified_asset(
@@ -531,113 +740,24 @@ fn write_verified_asset(
 }
 
 fn verify_downloaded_file(downloaded: &DownloadedUpdate) -> Result<(), String> {
-    if !safe_asset_name(&downloaded.asset_name) || !downloaded.path.is_file() {
-        return Err("The verified update package is no longer available".to_owned());
-    }
-    let metadata = fs::metadata(&downloaded.path)
-        .map_err(|_| "The verified update package is unavailable".to_owned())?;
-    if metadata.len() != downloaded.size {
+    let manifest = fs::File::open(
+        downloaded
+            .path
+            .with_file_name(format!("{}.manifest.json", downloaded.asset_name)),
+    )
+    .map_err(|_| "The staged update manifest could not be read".to_owned())?;
+    let manifest = update_apply::verification::verify_signed_manifest(&read_bounded(
+        manifest,
+        MAXIMUM_MANIFEST_BYTES,
+    )?)?;
+    if manifest.version.trim_start_matches('v') != downloaded.version
+        || manifest.asset != downloaded.asset_name
+        || manifest.size != downloaded.size
+        || !manifest.sha256.eq_ignore_ascii_case(&downloaded.sha256)
+    {
         return Err("The staged update package changed after verification".to_owned());
     }
-    let mut input = fs::File::open(&downloaded.path)
-        .map_err(|_| "The staged update package could not be read".to_owned())?;
-    let mut hasher = Sha256::new();
-    std::io::copy(&mut input, &mut hasher)
-        .map_err(|_| "The staged update package could not be verified".to_owned())?;
-    if !format!("{:x}", hasher.finalize()).eq_ignore_ascii_case(&downloaded.sha256) {
-        return Err("The staged update package changed after verification".to_owned());
-    }
-    Ok(())
-}
-
-fn launch_verified_update(path: &Path) -> Result<&'static str, String> {
-    #[cfg(target_os = "windows")]
-    {
-        let extension = path
-            .extension()
-            .and_then(|value| value.to_str())
-            .unwrap_or_default();
-        let child = if extension.eq_ignore_ascii_case("msi") {
-            Command::new("msiexec.exe")
-                .arg("/i")
-                .arg(path)
-                .arg("/passive")
-                .spawn()
-        } else {
-            Command::new(path).spawn()
-        };
-        child.map_err(|error| format!("Could not launch the verified installer: {error}"))?;
-        Ok("installer")
-    }
-    #[cfg(target_os = "macos")]
-    {
-        Command::new("open")
-            .arg(path)
-            .spawn()
-            .map_err(|error| format!("Could not open the verified update package: {error}"))?;
-        Ok("package-opened")
-    }
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        if path
-            .extension()
-            .and_then(|value| value.to_str())
-            .is_some_and(|value| value.eq_ignore_ascii_case("appimage"))
-        {
-            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).map_err(|error| {
-                format!("Could not mark the verified AppImage executable: {error}")
-            })?;
-            if let Some(current) = std::env::var_os("APPIMAGE").map(PathBuf::from) {
-                if current.is_absolute() && current.is_file() {
-                    return replace_running_appimage(&current, path);
-                }
-            }
-            Command::new(path)
-                .spawn()
-                .map_err(|error| format!("Could not launch the verified AppImage: {error}"))?;
-            return Ok("appimage-launched");
-        }
-        Command::new("xdg-open")
-            .arg(path)
-            .spawn()
-            .map_err(|error| format!("Could not open the verified update package: {error}"))?;
-        Ok("package-opened")
-    }
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
-fn replace_running_appimage(current: &Path, staged: &Path) -> Result<&'static str, String> {
-    use std::os::unix::fs::PermissionsExt as _;
-    let parent = current
-        .parent()
-        .ok_or_else(|| "Running AppImage has no parent directory".to_owned())?;
-    let name = current
-        .file_name()
-        .and_then(|value| value.to_str())
-        .ok_or_else(|| "Running AppImage name is invalid".to_owned())?;
-    let replacement = parent.join(format!(".{name}.new"));
-    let backup = parent.join(format!(".{name}.previous"));
-    fs::copy(staged, &replacement)
-        .map_err(|error| format!("Could not stage the AppImage replacement: {error}"))?;
-    fs::set_permissions(&replacement, fs::Permissions::from_mode(0o755))
-        .map_err(|error| format!("Could not set AppImage permissions: {error}"))?;
-    let _ = fs::remove_file(&backup);
-    fs::rename(current, &backup)
-        .map_err(|error| format!("Could not preserve the previous AppImage: {error}"))?;
-    if let Err(error) = fs::rename(&replacement, current) {
-        let _ = fs::rename(&backup, current);
-        return Err(format!("Could not install the AppImage update: {error}"));
-    }
-    if let Err(error) = Command::new(current).spawn() {
-        let failed = parent.join(format!(".{name}.failed"));
-        let _ = fs::rename(current, &failed);
-        let _ = fs::rename(&backup, current);
-        return Err(format!(
-            "Updated AppImage could not restart; rolled back: {error}"
-        ));
-    }
-    Ok("appimage-replaced")
+    update_apply::verification::verify_package(&downloaded.path, &manifest)
 }
 
 fn ensure_asset_response(response: &Response, maximum: u64) -> Result<(), String> {
@@ -656,7 +776,7 @@ fn ensure_asset_response(response: &Response, maximum: u64) -> Result<(), String
     Ok(())
 }
 
-fn read_bounded(mut response: Response, maximum: u64) -> Result<Vec<u8>, String> {
+fn read_bounded(mut response: impl Read, maximum: u64) -> Result<Vec<u8>, String> {
     let mut bytes = Vec::new();
     response
         .by_ref()
@@ -672,16 +792,6 @@ fn read_bounded(mut response: Response, maximum: u64) -> Result<Vec<u8>, String>
 fn trusted_asset_url(asset: &Asset) -> bool {
     asset.browser_download_url.starts_with(RELEASE_ASSET_PREFIX)
         && !asset.browser_download_url[RELEASE_ASSET_PREFIX.len()..].is_empty()
-}
-
-fn safe_asset_name(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= 240
-        && !value.contains(['/', '\\'])
-        && !value.contains("..")
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
 }
 
 fn parse_version(value: &str) -> Option<Version> {
@@ -717,7 +827,291 @@ fn now_ms() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update_apply::verification::{decode_verifying_key, signature_payload};
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as BASE64;
     use ed25519_dalek::{Signer as _, SigningKey};
+
+    fn persisted_managed_fixture(
+        directory: &Path,
+        status: update_apply::OutcomeStatus,
+        installer: Option<update_apply::ProcessIdentity>,
+    ) -> update_apply::PreparedUpdate {
+        let updates = directory.join("updates");
+        fs::create_dir_all(&updates).unwrap();
+        let prepared = update_apply::PreparedUpdate {
+            plan_path: directory.join("plan.json"),
+            outcome_path: directory.join("outcome.json"),
+            version: "1.1.0".to_owned(),
+        };
+        save_prepared_update(&updates, &prepared).unwrap();
+        fs::write(&prepared.plan_path, serde_json::to_vec(&json!({
+            "schemaVersion": 1,
+            "version": prepared.version,
+            "kind": if status == update_apply::OutcomeStatus::RebootRequired || cfg!(windows) { "windowsMsi" } else { "debianPackage" },
+            "package": directory.join("update-package"),
+            "target": directory.join("installed"),
+            "applicationExecutable": directory.join("installed/OpenNOW"),
+            "dataDir": directory.join("data"),
+            "processes": [],
+            "nonce": "a".repeat(64),
+            "managedIdentity": {
+                "package": if cfg!(windows) { "{00000000-0000-0000-0000-000000000000}" } else { "opennow-recovery-test-missing" },
+                "version": "1.1.0", "architecture": "amd64", "installed_product": "opennow-recovery-test-missing"
+            }
+        })).unwrap()).unwrap();
+        fs::write(
+            &prepared.outcome_path,
+            serde_json::to_vec(&update_apply::UpdateOutcome {
+                schema_version: 1,
+                version: prepared.version.clone(),
+                status,
+                message: "Native installation completion is pending".to_owned(),
+                installed_version: None,
+                restarted_process: installer,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        prepared
+    }
+
+    #[test]
+    fn a_live_native_installer_keeps_persisted_updates_blocking() {
+        for status in [
+            update_apply::OutcomeStatus::ManagedPending,
+            update_apply::OutcomeStatus::RebootRequired,
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            persisted_managed_fixture(
+                directory.path(),
+                status,
+                Some(update_apply::ProcessIdentity::capture(std::process::id()).unwrap()),
+            );
+            let updater = UpdaterService::new(directory.path()).unwrap();
+            assert_eq!(updater.state()["status"], "managed-pending");
+            assert_eq!(updater.state()["canCheck"], false);
+            assert!(updater.installation_pending());
+            assert!(directory.path().join("updates/active-apply.json").exists());
+        }
+    }
+
+    #[test]
+    fn a_live_helper_keeps_native_recovery_blocking() {
+        use fs2::FileExt;
+        let directory = tempfile::tempdir().unwrap();
+        let mut installer = update_apply::ProcessIdentity::capture(std::process::id()).unwrap();
+        installer.started = installer.started.wrapping_add(1);
+        persisted_managed_fixture(
+            directory.path(),
+            update_apply::OutcomeStatus::ManagedPending,
+            Some(installer),
+        );
+        let lock = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .read(true)
+            .open(directory.path().join("apply.lock"))
+            .unwrap();
+        lock.try_lock_exclusive().unwrap();
+        let updater = UpdaterService::new(directory.path()).unwrap();
+        assert!(updater.installation_pending());
+        assert_eq!(updater.state()["canCheck"], false);
+        drop(lock);
+        assert!(!updater.installation_pending());
+        assert_eq!(updater.state()["canCheck"], true);
+    }
+
+    #[test]
+    fn finished_native_installer_verification_failure_unblocks_and_clears_persistence() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut installer = update_apply::ProcessIdentity::capture(std::process::id()).unwrap();
+        installer.started = installer.started.wrapping_add(1);
+        let prepared = persisted_managed_fixture(
+            directory.path(),
+            update_apply::OutcomeStatus::ManagedPending,
+            Some(installer),
+        );
+        let updater = UpdaterService::new(directory.path()).unwrap();
+        assert_eq!(updater.state()["status"], "failed");
+        assert_eq!(updater.state()["canCheck"], true);
+        assert!(!updater.installation_pending());
+        assert!(updater.begin_operation().is_ok());
+        assert!(!directory.path().join("updates/active-apply.json").exists());
+        assert_eq!(
+            update_apply::read_outcome(&prepared.outcome_path)
+                .unwrap()
+                .unwrap()
+                .status,
+            update_apply::OutcomeStatus::Failed
+        );
+        let restarted = UpdaterService::new(directory.path()).unwrap();
+        assert!(!restarted.installation_pending());
+        assert_eq!(restarted.state()["canCheck"], true);
+    }
+
+    #[cfg(any(windows, target_os = "linux"))]
+    #[test]
+    fn missing_native_installer_identity_requires_a_proven_reboot_before_recovery() {
+        let directory = tempfile::tempdir().unwrap();
+        persisted_managed_fixture(
+            directory.path(),
+            update_apply::OutcomeStatus::ManagedPending,
+            None,
+        );
+        let updater = UpdaterService::new(directory.path()).unwrap();
+        assert!(updater.installation_pending());
+        assert_eq!(updater.state()["canCheck"], false);
+        assert!(
+            updater.state()["message"]
+                .as_str()
+                .unwrap()
+                .contains("Restart your system")
+        );
+        assert!(directory.path().join("updates/active-apply.json").exists());
+        assert!(directory.path().join("install-boot.json").exists());
+        fs::write(
+            directory.path().join("install-boot.json"),
+            br#"{"schemaVersion":1,"bootId":"previous-boot"}"#,
+        )
+        .unwrap();
+        let restarted = UpdaterService::new(directory.path()).unwrap();
+        assert!(!restarted.installation_pending());
+        assert_eq!(restarted.state()["status"], "failed");
+        assert_eq!(restarted.state()["canCheck"], true);
+        assert!(!directory.path().join("updates/active-apply.json").exists());
+    }
+
+    #[cfg(any(windows, target_os = "linux"))]
+    #[test]
+    fn reboot_warning_allows_sessions_but_blocks_update_operations_until_boot_change() {
+        let directory = tempfile::tempdir().unwrap();
+        persisted_managed_fixture(
+            directory.path(),
+            update_apply::OutcomeStatus::RebootRequired,
+            None,
+        );
+        let updater = UpdaterService::new(directory.path()).unwrap();
+        assert_eq!(updater.state()["status"], "reboot-required");
+        assert_eq!(updater.state()["canCheck"], false);
+        assert!(!updater.installation_pending());
+        assert!(
+            updater
+                .begin_operation()
+                .unwrap_err()
+                .contains("Restart your system")
+        );
+        assert!(directory.path().join("updates/active-apply.json").exists());
+        fs::write(
+            directory.path().join("install-boot.json"),
+            br#"{"schemaVersion":1,"bootId":"previous-boot"}"#,
+        )
+        .unwrap();
+        let restarted = UpdaterService::new(directory.path()).unwrap();
+        assert_eq!(restarted.state()["status"], "failed");
+        assert!(!restarted.installation_pending());
+        assert_eq!(restarted.state()["canCheck"], true);
+        assert!(!directory.path().join("updates/active-apply.json").exists());
+    }
+
+    #[test]
+    fn persisted_apply_outcomes_require_a_live_helper_before_quit() {
+        let directory = tempfile::tempdir().unwrap();
+        let updates = directory.path().join("updates");
+        fs::create_dir(&updates).unwrap();
+        let prepared = update_apply::PreparedUpdate {
+            plan_path: directory.path().join("plan.json"),
+            outcome_path: directory.path().join("outcome.json"),
+            version: "1.1.0".to_owned(),
+        };
+        save_prepared_update(&updates, &prepared).unwrap();
+        assert_eq!(
+            read_prepared_update(&updates).unwrap().unwrap().version,
+            "1.1.0"
+        );
+        for status in [
+            update_apply::OutcomeStatus::Prepared,
+            update_apply::OutcomeStatus::WaitingForExit,
+            update_apply::OutcomeStatus::BackingUp,
+            update_apply::OutcomeStatus::Installing,
+            update_apply::OutcomeStatus::AwaitingStartup,
+        ] {
+            fs::write(
+                &prepared.outcome_path,
+                serde_json::to_vec(&update_apply::UpdateOutcome {
+                    schema_version: 1,
+                    version: prepared.version.clone(),
+                    status,
+                    message: "A stale helper snapshot".to_owned(),
+                    installed_version: None,
+                    restarted_process: None,
+                })
+                .unwrap(),
+            )
+            .unwrap();
+            let updater = UpdaterService::new(directory.path()).unwrap();
+            assert_eq!(updater.state()["status"], "failed");
+            assert_eq!(updater.state()["exitRequired"], false);
+            assert!(!updater.installation_pending());
+        }
+    }
+
+    #[test]
+    fn corrupt_update_status_does_not_prevent_core_startup() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::create_dir(directory.path().join("updates")).unwrap();
+        fs::write(
+            directory.path().join("updates/active-apply.json"),
+            b"partial JSON",
+        )
+        .unwrap();
+        let updater = UpdaterService::new(directory.path()).unwrap();
+        assert_eq!(updater.state()["status"], "failed");
+        assert_eq!(updater.state()["exitRequired"], false);
+        assert_eq!(updater.state()["canCheck"], true);
+    }
+
+    #[test]
+    fn checks_and_errors_preserve_verified_install_capability() {
+        let mut state = notes_state();
+        state.downloaded = Some(DownloadedUpdate {
+            version: "1.1.0".to_owned(),
+            asset_name: "OpenNOW-Qt-linux-x64.AppImage".to_owned(),
+            path: PathBuf::from("/not-read-by-state"),
+            size: 123,
+            sha256: "ab".repeat(32),
+        });
+        for status in ["available", "not-available", "error"] {
+            state.status = status;
+            assert_eq!(state_json(&state)["canInstall"], true);
+            restore_downloaded_status(&mut state);
+            assert_eq!(state.status, "downloaded");
+            assert_eq!(state_json(&state)["downloadedVersion"], "1.1.0");
+        }
+        for status in ["checking", "downloading", "installing"] {
+            state.status = status;
+            assert_eq!(state_json(&state)["canInstall"], false);
+        }
+    }
+
+    #[test]
+    fn install_requires_consent_before_accessing_packages() {
+        let path =
+            std::env::temp_dir().join(format!("opennow-update-consent-{}", rand::random::<u64>()));
+        let updater = UpdaterService::new(&path).unwrap();
+        for params in [
+            json!({}),
+            json!({"confirmed":false}),
+            json!({"confirmed":"true"}),
+        ] {
+            assert_eq!(
+                updater.install(&params).unwrap_err(),
+                "Update installation requires explicit confirmation"
+            );
+        }
+        fs::remove_dir_all(path).unwrap();
+    }
 
     #[test]
     fn overlapping_update_operations_are_rejected_without_mutating_state() {
@@ -798,6 +1192,7 @@ mod tests {
             last_checked_at: None,
             available: None,
             downloaded: None,
+            transaction: None,
         }
     }
 
@@ -1094,37 +1489,5 @@ mod tests {
         verify_manifest(&manifest, &key).unwrap();
         manifest.size += 1;
         assert!(verify_manifest(&manifest, &key).is_err());
-    }
-
-    #[cfg(all(unix, not(target_os = "macos")))]
-    #[test]
-    fn failed_appimage_restart_restores_previous_binary() {
-        use std::os::unix::fs::PermissionsExt as _;
-        use std::time::{SystemTime, UNIX_EPOCH};
-
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let directory = std::env::temp_dir().join(format!(
-            "opennow-update-rollback-{}-{unique}",
-            std::process::id()
-        ));
-        fs::create_dir_all(&directory).unwrap();
-        let current = directory.join("OpenNOW.AppImage");
-        let staged = directory.join("OpenNOW-new.AppImage");
-        fs::write(&current, b"previous release").unwrap();
-        fs::write(&staged, b"not an executable image").unwrap();
-        fs::set_permissions(&current, fs::Permissions::from_mode(0o755)).unwrap();
-        fs::set_permissions(&staged, fs::Permissions::from_mode(0o755)).unwrap();
-
-        let error = replace_running_appimage(&current, &staged).unwrap_err();
-        assert!(error.contains("rolled back"));
-        assert_eq!(fs::read(&current).unwrap(), b"previous release");
-        assert_eq!(
-            fs::read(directory.join(".OpenNOW.AppImage.failed")).unwrap(),
-            b"not an executable image"
-        );
-        fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/native/opennow-core/src/version.rs
+++ b/native/opennow-core/src/version.rs
@@ -3,6 +3,16 @@ pub const APPLICATION_VERSION: &str = match option_env!("OPENNOW_BUILD_VERSION")
     None => env!("CARGO_PKG_VERSION"),
 };
 
+pub fn update_channel(version: &str) -> &'static str {
+    if semver::Version::parse(version)
+        .is_ok_and(|version| version.pre.as_str().split('.').next() == Some("nightly"))
+    {
+        "nightly"
+    } else {
+        "stable"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -10,6 +20,14 @@ mod tests {
     #[test]
     fn application_version_is_semver() {
         semver::Version::parse(APPLICATION_VERSION).expect("application version must be semver");
+    }
+
+    #[test]
+    fn update_channel_follows_build_identity() {
+        assert_eq!(update_channel("1.0.0-nightly.123.2"), "nightly");
+        for version in ["1.0.0", "1.0.0-beta.1", "1.0.0+nightly", "invalid"] {
+            assert_eq!(update_channel(version), "stable");
+        }
     }
 
     #[test]

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -59,9 +59,10 @@ ctest --test-dir build/opennow-qt -C Debug --output-on-failure --no-tests=error 
 ### Manual artifact-only builds
 
 In GitHub **Actions → qt-ci → Run workflow**, select `dev` (or the branch or tag
-to build) and leave **Publish an unsigned nightly prerelease after all checks pass**
-unchecked. The existing workflow uploads build artifacts without creating a release
-or tag. No separate supporter-build workflow is needed.
+to build) and leave **Publish a nightly with signed update manifests after all checks pass**
+unchecked. Leave the `public_key` input empty for a no-key artifact-only build. The workflow
+uploads build artifacts without creating a release, tag, or updater manifests, and requires
+no signing environment. No separate supporter-build workflow is needed.
 
 After a successful run, download
 `opennow-qt-<version>-complete-unsigned` from the run's **Artifacts** section.
@@ -71,9 +72,13 @@ portable ZIPs, Linux x64/ARM64 AppImages and DEBs, the Apple Silicon macOS DMG, 
 and source-commit metadata. The macOS ARM64 validation ZIP is a separate artifact.
 Artifacts expire after 14 days.
 
-These builds are unsigned and require manual downloads for updates. Windows may
-show a SmartScreen warning; macOS packages are not notarized. Windows ARM64 is
-cross-built rather than runtime-tested. Linux DEBs require Qt 6.8+ and SDL3;
+These default no-key builds have no platform publisher signatures and require manual downloads
+for updates. Public publishing instead requires a pinned public key and the protected isolated
+signer described in the [signing setup guide](../docs/update-signing-setup.md); see the
+[nightly release runbook](../docs/qt-nightly-release.md) for the publishing command. Users of
+earlier no-key nightlies must manually install an update-enabled build once before verified
+in-app updates can work. Windows may show a SmartScreen warning; macOS packages are not notarized.
+Windows ARM64 is cross-built rather than runtime-tested. Linux DEBs require Qt 6.8+ and SDL3;
 AppImages are the portable option. Download the files and distribute them through
 your supporter channel. **Actions artifacts in this public repository are not
 private or supporter-access-controlled**, even though they do not appear in Releases.

--- a/opennow-qt/cmake/NativeRuntime.cmake
+++ b/opennow-qt/cmake/NativeRuntime.cmake
@@ -104,6 +104,41 @@ if(WIN32 AND NOT OPENNOW_RUST_EFFECTIVE_TARGET)
     string(REGEX MATCH "host: ([^\r\n]+)" OPENNOW_RUST_HOST_MATCH "${OPENNOW_RUSTC_VERSION}")
     set(OPENNOW_RUST_EFFECTIVE_TARGET "${CMAKE_MATCH_1}")
 endif()
+
+set(OPENNOW_UPDATE_HELPER_TARGET_DIR "${OPENNOW_CORE_TARGET_DIR}")
+set(OPENNOW_UPDATE_HELPER_ARTIFACT_ROOT "${OPENNOW_CORE_ARTIFACT_ROOT}")
+set(OPENNOW_UPDATE_HELPER_TARGET_ARGS ${OPENNOW_RUST_TARGET_ARGS})
+set(OPENNOW_UPDATE_HELPER_ENV)
+if(WIN32)
+    set(OPENNOW_UPDATE_HELPER_TARGET_DIR "${CMAKE_BINARY_DIR}/update-helper-rust-target")
+    set(OPENNOW_UPDATE_HELPER_ARTIFACT_ROOT
+        "${OPENNOW_UPDATE_HELPER_TARGET_DIR}/${OPENNOW_RUST_EFFECTIVE_TARGET}")
+    set(OPENNOW_UPDATE_HELPER_TARGET_ARGS --target "${OPENNOW_RUST_EFFECTIVE_TARGET}")
+    set(OPENNOW_UPDATE_HELPER_ENV --unset=CARGO_ENCODED_RUSTFLAGS
+        "RUSTFLAGS=-C target-feature=+crt-static")
+endif()
+add_custom_target(opennow-update-helper-build ALL
+    COMMAND "${CMAKE_COMMAND}" -E env ${OPENNOW_UPDATE_HELPER_ENV}
+            "OPENNOW_UPDATE_ED25519_PUBLIC_KEY=${OPENNOW_UPDATE_ED25519_PUBLIC_KEY}"
+            "OPENNOW_BUILD_VERSION=${OPENNOW_BUILD_VERSION}"
+            "${CARGO_EXECUTABLE}" build
+            --manifest-path "${CMAKE_CURRENT_SOURCE_DIR}/../native/opennow-core/Cargo.toml"
+            --target-dir "${OPENNOW_UPDATE_HELPER_TARGET_DIR}"
+            --bin opennow-update-helper
+            ${OPENNOW_UPDATE_HELPER_TARGET_ARGS}
+            $<$<CONFIG:Release>:--release>
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+            "${OPENNOW_UPDATE_HELPER_ARTIFACT_ROOT}/${OPENNOW_CORE_PROFILE}/opennow-update-helper${OPENNOW_CORE_SUFFIX}"
+            "$<TARGET_FILE_DIR:opennow-qt>/opennow-update-helper${OPENNOW_CORE_SUFFIX}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../native/opennow-core"
+    COMMAND_EXPAND_LISTS
+    VERBATIM
+)
+if(NOT WIN32)
+    add_dependencies(opennow-update-helper-build opennow-core)
+endif()
+add_dependencies(opennow-qt opennow-update-helper-build)
+
 # The Rust target determines its import-library format, not the Qt compiler.
 # MinGW can consume the MSVC COFF import library for our C-only FFI.
 if(WIN32 AND MINGW AND OPENNOW_RUST_EFFECTIVE_TARGET MATCHES "-msvc$")

--- a/opennow-qt/cmake/Packaging.cmake
+++ b/opennow-qt/cmake/Packaging.cmake
@@ -20,6 +20,7 @@ elseif(NOT APPLE)
     install(PROGRAMS
         "$<TARGET_FILE_DIR:opennow-qt>/opennow-core${OPENNOW_CORE_SUFFIX}"
         "$<TARGET_FILE_DIR:opennow-qt>/opennow-acceptance-verify${OPENNOW_CORE_SUFFIX}"
+        "$<TARGET_FILE_DIR:opennow-qt>/opennow-update-helper${OPENNOW_CORE_SUFFIX}"
         DESTINATION "${CMAKE_INSTALL_BINDIR}"
     )
     install(PROGRAMS "${OPENNOW_STREAMER_FFI_RUNTIME}"
@@ -30,6 +31,7 @@ else()
     install(PROGRAMS
         "${OPENNOW_CORE_ARTIFACT_ROOT}/${OPENNOW_CORE_PROFILE}/opennow-core${OPENNOW_CORE_SUFFIX}"
         "${OPENNOW_CORE_ARTIFACT_ROOT}/${OPENNOW_CORE_PROFILE}/opennow-acceptance-verify${OPENNOW_CORE_SUFFIX}"
+        "${OPENNOW_CORE_ARTIFACT_ROOT}/${OPENNOW_CORE_PROFILE}/opennow-update-helper${OPENNOW_CORE_SUFFIX}"
         DESTINATION "${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS")
     install(FILES "${OPENNOW_STREAMER_FFI_RUNTIME}"
         DESTINATION "${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS")
@@ -63,10 +65,15 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(APPLE)
+    option(OPENNOW_MACOS_ADHOC_SIGN "Ad-hoc seal deployed macOS bundles without a signing identity" OFF)
     set(OPENNOW_QT_DEPLOY_TOOL_ARGS DEPLOY_TOOL_OPTIONS
         "-executable=${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS/opennow-core"
         "-executable=${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS/opennow-acceptance-verify"
+        "-executable=${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS/opennow-update-helper"
         "-executable=${OPENNOW_EXECUTABLE_NAME}.app/Contents/MacOS/opennow-streamer")
+    if(OPENNOW_MACOS_ADHOC_SIGN)
+        list(APPEND OPENNOW_QT_DEPLOY_TOOL_ARGS "-codesign=-")
+    endif()
 endif()
 
 if(WIN32 OR APPLE)
@@ -77,6 +84,15 @@ if(WIN32 OR APPLE)
         ${OPENNOW_QT_DEPLOY_TOOL_ARGS}
     )
     install(SCRIPT "${opennow_deploy_script}")
+    if(APPLE AND OPENNOW_MACOS_ADHOC_SIGN)
+        get_target_property(OPENNOW_MACOS_BUNDLE_IDENTIFIER opennow-qt MACOSX_BUNDLE_GUI_IDENTIFIER)
+        if(NOT OPENNOW_MACOS_BUNDLE_IDENTIFIER)
+            message(FATAL_ERROR "Ad-hoc bundle signing requires a stable macOS bundle identifier")
+        endif()
+        configure_file("${CMAKE_CURRENT_LIST_DIR}/../packaging/macos-adhoc-seal.cmake.in"
+            "${CMAKE_CURRENT_BINARY_DIR}/macos-adhoc-seal.cmake" @ONLY)
+        install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/macos-adhoc-seal.cmake")
+    endif()
 endif()
 
 set(CPACK_PACKAGE_NAME "OpenNOW")

--- a/opennow-qt/packaging/macos-adhoc-seal.cmake.in
+++ b/opennow-qt/packaging/macos-adhoc-seal.cmake.in
@@ -1,0 +1,15 @@
+set(bundle "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@OPENNOW_EXECUTABLE_NAME@.app")
+execute_process(
+    COMMAND /usr/bin/codesign --force --sign - --identifier "@OPENNOW_MACOS_BUNDLE_IDENTIFIER@" "${bundle}"
+    RESULT_VARIABLE sign_result
+    ERROR_VARIABLE sign_error)
+if(NOT sign_result EQUAL 0)
+    message(FATAL_ERROR "Could not seal the deployed macOS bundle: ${sign_error}")
+endif()
+execute_process(
+    COMMAND /usr/bin/codesign --verify --deep --strict "${bundle}"
+    RESULT_VARIABLE verify_result
+    ERROR_VARIABLE verify_error)
+if(NOT verify_result EQUAL 0)
+    message(FATAL_ERROR "The deployed macOS bundle failed signature verification: ${verify_error}")
+endif()

--- a/opennow-qt/packaging/nightly_release.py
+++ b/opennow-qt/packaging/nightly_release.py
@@ -15,7 +15,7 @@ def nightly_version(cmake_file, run, attempt, channel="nightly"):
     return f"{match[1]}-{channel}.{run}.{attempt}"
 
 
-def assemble(source, destination, version, commit, channel="nightly"):
+def expected_packages(version, commit, channel="nightly"):
     if channel not in ("nightly", "supporter"):
         raise ValueError("Invalid unsigned build channel")
     if not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-" + channel + r"\.[1-9][0-9]*\.[1-9][0-9]*", version):
@@ -28,6 +28,11 @@ def assemble(source, destination, version, commit, channel="nightly"):
         for platform, extension in (("Windows", "msi"), ("Windows", "zip"), ("Linux", "AppImage"), ("Linux", "deb"))
     }
     expected.add(f"OpenNOW-Qt-{version}-Darwin-arm64.dmg")
+    return expected
+
+
+def assemble(source, destination, version, commit, channel="nightly"):
+    expected = expected_packages(version, commit, channel)
     files = {}
     for path in source.rglob("*"):
         if path.is_symlink():

--- a/opennow-qt/packaging/sign_nightly_release.py
+++ b/opennow-qt/packaging/sign_nightly_release.py
@@ -1,0 +1,154 @@
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+from nightly_release import expected_packages
+
+
+def decode_key(value):
+    try:
+        key = base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error):
+        raise ValueError("Expected a canonical base64-encoded 32-byte Ed25519 key") from None
+    if len(key) != 32 or base64.b64encode(key).decode() != value:
+        raise ValueError("Expected a canonical base64-encoded 32-byte Ed25519 key")
+    return key
+
+
+def digest(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def payload(manifest):
+    return ("OpenNOW update manifest v1\n"
+            f"version={manifest['version']}\nasset={manifest['asset']}\n"
+            f"size={manifest['size']}\nsha256={manifest['sha256']}\n").encode()
+
+
+def openssl(*args):
+    subprocess.run(["openssl", *map(str, args)], check=True, capture_output=True)
+
+
+def validate_inventory(source, version, commit, signed=False):
+    packages = expected_packages(version, commit)
+    expected = packages | {"RELEASE-INFO.json", "SHA256SUMS"}
+    if signed:
+        expected |= {name + ".manifest.json" for name in packages}
+    if source.is_symlink() or not source.is_dir():
+        raise ValueError("Expected a regular inventory directory")
+    entries = list(source.iterdir())
+    if (any(path.is_symlink() or not path.is_file() or path.stat().st_size == 0 for path in entries)
+            or {path.name for path in entries} != expected):
+        raise ValueError("Unexpected, missing, empty, or linked inventory entry")
+    metadata = json.loads((source / "RELEASE-INFO.json").read_text())
+    inventory = [{"name": name, "size": (source / name).stat().st_size,
+                  "sha256": digest(source / name)} for name in sorted(packages)]
+    if metadata != {
+        "version": version, "sourceCommit": commit, "platformSigning": "unsigned",
+        "updates": "signed-manifest" if signed else "manual-download", "assets": inventory,
+    }:
+        raise ValueError("Release metadata does not match immutable package inventory")
+    lines = (source / "SHA256SUMS").read_text().splitlines()
+    expected_sums = {f"{digest(source / name)}  {name}" for name in expected - {"SHA256SUMS"}}
+    if len(lines) != len(expected_sums) or set(lines) != expected_sums:
+        raise ValueError("SHA256SUMS does not match complete inventory")
+    return metadata
+
+
+def verify(source, version, commit, public_key):
+    key = decode_key(public_key)
+    metadata = validate_inventory(source, version, commit, signed=True)
+    with tempfile.TemporaryDirectory(prefix="opennow-update-verify-") as directory:
+        root = Path(directory)
+        public = root / "public.der"
+        public.write_bytes(bytes.fromhex("302a300506032b6570032100") + key)
+        for asset in metadata["assets"]:
+            manifest = json.loads((source / (asset["name"] + ".manifest.json")).read_text())
+            unsigned = {"schemaVersion": 1, "version": version, "asset": asset["name"],
+                        "size": asset["size"], "sha256": asset["sha256"]}
+            if set(manifest) != set(unsigned) | {"signature"} or any(
+                    type(manifest[name]) is not type(value) or manifest[name] != value
+                    for name, value in unsigned.items()):
+                raise ValueError("Manifest does not match its exact package")
+            signature = base64.b64decode(manifest["signature"], validate=True)
+            if len(signature) != 64:
+                raise ValueError("Expected a 64-byte Ed25519 signature")
+            (root / "payload").write_bytes(payload(manifest))
+            (root / "signature").write_bytes(signature)
+            openssl("pkeyutl", "-verify", "-rawin", "-pubin", "-keyform", "DER",
+                    "-inkey", public, "-in", root / "payload", "-sigfile", root / "signature")
+
+
+def sign(source, destination, version, commit, public_key, private_seed):
+    key = decode_key(public_key)
+    seed = decode_key(private_seed)
+    metadata = validate_inventory(source, version, commit)
+    if destination.exists() or destination.is_symlink():
+        raise ValueError("Signing destination must not exist")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="opennow-update-signing-") as directory, \
+            tempfile.TemporaryDirectory(prefix=".opennow-signed-", dir=destination.parent) as output:
+        root = Path(directory)
+        staged = Path(output) / "release"
+        staged.mkdir()
+        private = root / "private.der"
+        private.write_bytes(bytes.fromhex("302e020100300506032b657004220420") + seed)
+        private.chmod(0o600)
+        openssl("pkey", "-inform", "DER", "-in", private, "-pubout", "-outform", "DER",
+                "-out", root / "public.der")
+        if (root / "public.der").read_bytes() != bytes.fromhex("302a300506032b6570032100") + key:
+            raise ValueError("Signing seed does not match the pinned public key")
+        for asset in metadata["assets"]:
+            target = staged / asset["name"]
+            shutil.copyfile(source / asset["name"], target)
+            if target.stat().st_size != asset["size"] or digest(target) != asset["sha256"]:
+                raise ValueError("Package changed after inventory validation")
+            manifest = {"schemaVersion": 1, "version": version, "asset": asset["name"],
+                        "size": asset["size"], "sha256": asset["sha256"]}
+            (root / "payload").write_bytes(payload(manifest))
+            openssl("pkeyutl", "-sign", "-rawin", "-keyform", "DER", "-inkey", private,
+                    "-in", root / "payload", "-out", root / "signature")
+            manifest["signature"] = base64.b64encode((root / "signature").read_bytes()).decode()
+            (staged / (asset["name"] + ".manifest.json")).write_text(json.dumps(manifest, indent=2) + "\n")
+        metadata["updates"] = "signed-manifest"
+        (staged / "RELEASE-INFO.json").write_text(json.dumps(metadata, indent=2) + "\n")
+        (staged / "SHA256SUMS").write_text("".join(
+            f"{digest(path)}  {path.name}\n" for path in sorted(staged.iterdir())))
+        verify(staged, version, commit, public_key)
+        staged.rename(destination)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("preflight", "sign", "verify"))
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--destination", type=Path)
+    parser.add_argument("--version")
+    parser.add_argument("--commit")
+    args = parser.parse_args()
+    public_key = os.environ.get("OPENNOW_UPDATE_PUBLIC_KEY", "")
+    if args.command == "preflight":
+        if public_key or os.environ.get("PUBLISH_NIGHTLY") == "true":
+            decode_key(public_key)
+        return
+    if not args.source or not args.version or not args.commit:
+        parser.error("sign and verify require --source, --version, and --commit")
+    if args.command == "sign":
+        if not args.destination:
+            parser.error("sign requires --destination")
+        sign(args.source, args.destination, args.version, args.commit, public_key,
+             os.environ.pop("OPENNOW_UPDATE_ED25519_PRIVATE_KEY", ""))
+    else:
+        verify(args.source, args.version, args.commit, public_key)
+
+
+if __name__ == "__main__":
+    main()

--- a/opennow-qt/packaging/verify_linux_package.py
+++ b/opennow-qt/packaging/verify_linux_package.py
@@ -25,6 +25,9 @@ def verify_capabilities(message):
 
 
 def verify_package(bin_dir):
+    helper = bin_dir / "opennow-update-helper"
+    if not helper.is_file() or not os.access(helper, os.X_OK):
+        raise ValueError("The package is missing its executable update helper")
     for name in ("opennow-streamer", "libopennow_streamer_ffi.so"):
         binary = bin_dir / name
         dependencies = subprocess.check_output(["readelf", "-d", binary], text=True)

--- a/opennow-qt/packaging/windows-release-binaries.txt
+++ b/opennow-qt/packaging/windows-release-binaries.txt
@@ -1,5 +1,6 @@
 OpenNOW.exe
 opennow-core.exe
 opennow-acceptance-verify.exe
+opennow-update-helper.exe
 opennow-streamer.exe
 opennow_streamer_ffi.dll

--- a/opennow-qt/packaging/windows-release.ps1
+++ b/opennow-qt/packaging/windows-release.ps1
@@ -17,7 +17,31 @@ function Get-OpenNowReleaseBinaries {
         if ($matches.Count -ne 1) {
             throw "Expected exactly one $name under $Root, found $($matches.Count)"
         }
+        if ($name -eq "opennow-update-helper.exe") {
+            Assert-OpenNowStandaloneUpdateHelper -Path $matches[0].FullName
+        }
         $matches[0]
+    }
+}
+
+function Assert-OpenNowStandaloneUpdateHelper {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $output = & dumpbin /dependents $Path
+    if ($LASTEXITCODE -ne 0) { throw "Could not inspect update helper dependencies" }
+    $dependencies = @($output | ForEach-Object {
+        if ($_ -match '^\s+([A-Za-z0-9_.-]+\.dll)\s*$') { $Matches[1].ToLowerInvariant() }
+    })
+    if ($dependencies.Count -eq 0) { throw "No update helper PE dependencies found" }
+    $systemLibraries = @("advapi32.dll", "bcrypt.dll", "bcryptprimitives.dll", "combase.dll",
+        "crypt32.dll", "gdi32.dll", "iphlpapi.dll", "kernel32.dll", "kernelbase.dll", "msi.dll",
+        "netapi32.dll", "normaliz.dll", "ntdll.dll", "ole32.dll", "oleaut32.dll", "psapi.dll",
+        "rpcrt4.dll", "secur32.dll", "shell32.dll", "shlwapi.dll", "user32.dll", "userenv.dll",
+        "wintrust.dll", "ws2_32.dll")
+    foreach ($dependency in $dependencies) {
+        if ($dependency -notin $systemLibraries -and $dependency -notlike "api-ms-win-core-*.dll") {
+            throw "Update helper must run outside the installation without non-system DLLs: $dependency"
+        }
     }
 }
 

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -419,6 +419,7 @@ ApplicationWindow {
     }
 
     Component.onCompleted: {
+        Qt.callLater(() => CoreClient.markUiReady())
         initializeStartupMode()
         updateSessionWindowMode()
         updateStreamSurfaceLock()

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsAboutPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsAboutPage.qml
@@ -17,7 +17,7 @@ Column {
             leadingIcon: "qrc:/qt/qml/OpenNOW/res/brand/opennow-mark.png"
             title: "OpenNOW " + String(ShellStore.updaterState.currentVersion || qsTr("unknown"))
             description: qsTr("Your games, anywhere.")
-            DesktopSettingsButton { text: ShellStore.updaterState.status === "checking" ? qsTr("Checking…") : qsTr("Check for updates"); primary: true; enabled: ShellStore.updaterState.status !== "checking"; onClicked: ShellStore.checkForUpdates() }
+            DesktopSettingsButton { text: ShellStore.updaterState.status === "checking" ? qsTr("Checking…") : qsTr("Check for updates"); primary: true; enabled: !ShellStore.updaterBusy && ShellStore.updaterState.canCheck === true; onClicked: ShellStore.checkForUpdates() }
         }
         DesktopSettingsRow {
             width: parent.width; paperStyle: true; glyph: "arrows"; title: qsTr("Update channel")
@@ -27,6 +27,26 @@ Column {
                 objectName: "renewUpdateChannel"
                 optionWidth: 96; selectedIndex: options.findIndex(item => item.value === page.settingsScreen.valueSetting("updateChannel","stable"))
                 onSelected: (index,item) => page.settingsScreen.setChoice("updateChannel",item.value)
+            }
+        }
+        DesktopSettingsRow {
+            width: parent.width; paperStyle: true; title: qsTr("Automatically check for updates")
+            description: qsTr("Check every six hours while no streaming session is active.")
+            DesktopSettingsToggle {
+                objectName: "autoCheckUpdatesToggle"
+                Accessible.name: qsTr("Automatically check for updates")
+                checked: page.settingsScreen.boolSetting("autoCheckForUpdates", false)
+                onValueChangedByUser: value => page.settingsScreen.setSetting("autoCheckForUpdates", value)
+            }
+        }
+        DesktopSettingsRow {
+            width: parent.width; paperStyle: true; title: qsTr("Automatically download updates")
+            description: qsTr("Download verified updates while idle. Installation always requires your confirmation.")
+            DesktopSettingsToggle {
+                objectName: "autoDownloadUpdatesToggle"
+                Accessible.name: qsTr("Automatically download updates")
+                checked: page.settingsScreen.boolSetting("autoDownloadUpdates", false)
+                onValueChangedByUser: value => page.settingsScreen.setSetting("autoDownloadUpdates", value)
             }
         }
         DesktopSettingsRow {

--- a/opennow-qt/qml/desktop/updates/DesktopUpdateScreen.qml
+++ b/opennow-qt/qml/desktop/updates/DesktopUpdateScreen.qml
@@ -6,22 +6,25 @@ FocusScope {
     id: root
     objectName: "desktopUpdateScreen"
     readonly property var state: ShellStore.updaterState || ({})
-    readonly property bool busy: state.status === "checking" || state.status === "downloading"
+    readonly property bool busy: ShellStore.updaterBusy
+    Component.onCompleted: ShellStore.acknowledgeUpdateHighlights()
 
     Dialog {
         id: installConfirmation
+        objectName: "updateInstallConfirmation"
         anchors.centerIn: parent
         width: Math.min(parent.width - 48, 440)
         // Bound the dialog independently of the style's header/footer sizing.
         implicitHeight: DesktopTokens.px(220)
         height: Math.min(root.height - 48, implicitHeight)
         modal: true
-        title: qsTr("Install and restart")
+        focus: true
+        title: root.state.downloadedVersion ? qsTr("Install %1 and restart").arg(root.state.downloadedVersion) : qsTr("Install and restart")
         standardButtons: Dialog.Ok | Dialog.Cancel
-        onAccepted: ShellStore.installUpdate()
+        onAccepted: ShellStore.installUpdate(true)
         contentItem: Label {
             wrapMode: Text.WordWrap
-            text: qsTr("OpenNOW will close to install the verified update. Continue?")
+            text: qsTr("OpenNOW will prepare the verified update, close, replace this installation, and restart. Continue?")
         }
     }
 
@@ -67,12 +70,38 @@ FocusScope {
                     }
                     Text {
                         width: parent.width
-                        text: root.state.message || qsTr("Check GitHub Releases for a newer OpenNOW build.")
+                        visible: Boolean(root.state.availableVersion)
+                        text: qsTr("Available version: %1").arg(root.state.availableVersion || "")
+                        color: Theme.textMuted
+                        font.family: Theme.bodyFont
+                        font.pixelSize: DesktopTokens.px(13)
+                        wrapMode: Text.WordWrap
+                    }
+                    Text {
+                        width: parent.width
+                        text: ShellStore.updaterError || root.state.message || qsTr("Check GitHub Releases for a newer OpenNOW build.")
                         textFormat: Text.PlainText
                         color: Theme.label
                         font.family: Theme.bodyFont
                         font.pixelSize: DesktopTokens.px(14)
                         wrapMode: Text.WordWrap
+                        Accessible.role: Accessible.StaticText
+                        Accessible.name: text
+                    }
+                    ProgressBar {
+                        width: parent.width
+                        visible: root.busy
+                        indeterminate: true
+                        Accessible.name: root.state.message || qsTr("Update in progress")
+                    }
+                    Text {
+                        width: parent.width
+                        visible: !ShellStore.updaterSessionSafe
+                        text: qsTr("End your streaming session before installing an update. Background updates will wait.")
+                        color: Theme.textMuted
+                        wrapMode: Text.WordWrap
+                        Accessible.role: Accessible.StaticText
+                        Accessible.name: text
                     }
                     Flow {
                         width: parent.width
@@ -80,7 +109,7 @@ FocusScope {
                         DesktopSettingsButton {
                             text: root.state.status === "checking" ? qsTr("Checking…") : qsTr("Check for updates")
                             primary: true
-                            enabled: !root.busy
+                            enabled: !root.busy && root.state.canCheck === true
                             onClicked: ShellStore.checkForUpdates()
                         }
                         DesktopSettingsButton {
@@ -91,14 +120,15 @@ FocusScope {
                         DesktopSettingsButton {
                             visible: Boolean(root.state.canDownload)
                             text: root.state.status === "downloading" ? qsTr("Downloading…") : qsTr("Download verified update")
-                            enabled: !root.busy
+                            enabled: !root.busy && root.state.canDownload === true
                             onClicked: ShellStore.downloadUpdate()
                         }
                         DesktopSettingsButton {
                             visible: Boolean(root.state.canInstall)
-                            text: qsTr("Install and restart")
+                            text: root.state.downloadedVersion ? qsTr("Install %1 and restart").arg(root.state.downloadedVersion) : qsTr("Install and restart")
                             primary: true
-                            enabled: !root.busy
+                            objectName: "updateInstallButton"
+                            enabled: ShellStore.updaterCanInstall
                             onClicked: installConfirmation.open()
                         }
                     }

--- a/opennow-qt/qml/screens/SettingsScreen.qml
+++ b/opennow-qt/qml/screens/SettingsScreen.qml
@@ -443,6 +443,8 @@ FocusScope {
                 "microphoneMode", ["disabled", "voice-activity"], [qsTr("Disabled"), qsTr("Open microphone")], "segments",
                 ShellStore.microphoneCaptureSupported ? [] : ["voice-activity"]),
             choice("Updates", qsTr("OpenNOW %1 · signed update feed").arg(ShellStore.updaterState.currentVersion || ""), "updateChannel", ["stable","nightly"], ["Stable","Nightly"], "segments"),
+            toggle(qsTr("Automatically check for updates"), qsTr("Check every six hours while no streaming session is active."), "autoCheckForUpdates"),
+            toggle(qsTr("Automatically download updates"), qsTr("Download verified updates while idle. Installation always requires your confirmation."), "autoDownloadUpdates"),
             {t:"Reset all settings", d:"Keeps your account and My games", v:"Reset to defaults", action:"reset", danger:true}
         ]
     }

--- a/opennow-qt/qml/screens/UpdateScreen.qml
+++ b/opennow-qt/qml/screens/UpdateScreen.qml
@@ -6,6 +6,25 @@ FocusScope {
     id: root
     readonly property var state: ShellStore.updaterState || ({})
     readonly property bool available: state.status === "available"
+    Component.onCompleted: ShellStore.acknowledgeUpdateHighlights()
+
+    Dialog {
+        id: installConfirmation
+        objectName: "updateInstallConfirmation"
+        anchors.centerIn: parent
+        width: Math.min(parent.width - 48, 500)
+        implicitHeight: 220
+        height: Math.min(root.height - 48, implicitHeight)
+        modal: true
+        focus: true
+        title: root.state.downloadedVersion ? qsTr("Install %1 and restart").arg(root.state.downloadedVersion) : qsTr("Install and restart")
+        standardButtons: Dialog.Ok | Dialog.Cancel
+        onAccepted: ShellStore.installUpdate(true)
+        contentItem: Label {
+            wrapMode: Text.WordWrap
+            text: qsTr("OpenNOW will prepare the verified update, close, replace this installation, and restart. Continue?")
+        }
+    }
 
     ScreenBackground { tint: "#16263D" }
     GlassPanel {
@@ -16,7 +35,7 @@ FocusScope {
                 width: parent.width; height: 62; spacing: 20
                 Rectangle {
                     width: 62; height: 62; radius: 20; color: root.available ? Theme.mint : Theme.violet
-                    Text { anchors.centerIn: parent; text: root.available ? "↑" : "✓"; color: Theme.contrastText(root.available ? Theme.mint : Theme.violet); font.pixelSize: 30; font.weight: Font.Black }
+                    Text { anchors.centerIn: parent; text: root.state.status === "succeeded" ? "✓" : root.available ? "↑" : "↓"; color: Theme.contrastText(root.available ? Theme.mint : Theme.violet); font.pixelSize: 30; font.weight: Font.Black }
                 }
                 Column {
                     anchors.verticalCenter: parent.verticalCenter; spacing: 3
@@ -26,11 +45,27 @@ FocusScope {
             }
             Text {
                 width: parent.width; wrapMode: Text.WordWrap
-                text: root.state.message || qsTr("Check GitHub Releases for a newer OpenNOW build.")
+                text: ShellStore.updaterError || root.state.message || qsTr("Check GitHub Releases for a newer OpenNOW build.")
                 color: Theme.label; font.family: Theme.bodyFont; font.pixelSize: 17
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
+            }
+            ProgressBar {
+                width: parent.width
+                visible: ShellStore.updaterBusy
+                indeterminate: true
+                Accessible.name: root.state.message || qsTr("Update in progress")
+            }
+            Text {
+                width: parent.width; wrapMode: Text.WordWrap
+                visible: !ShellStore.updaterSessionSafe
+                text: qsTr("End your streaming session before installing an update. Background updates will wait.")
+                color: Theme.textMuted; font.family: Theme.bodyFont; font.pixelSize: 14
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
             }
             GlassPanel {
-                width: parent.width; height: 310; panelRadius: 26
+                width: parent.width; height: 240; panelRadius: 26
                 Flickable {
                     anchors.fill: parent; anchors.margins: 22; contentHeight: notes.height; clip: true
                     ReleaseNotes {
@@ -40,34 +75,37 @@ FocusScope {
                     }
                 }
             }
-            Row {
+            Flow {
+                width: parent.width
                 spacing: 12
                 GlassButton {
-                    id: checkButton; width: 276
+                    id: checkButton; width: 250
                     text: root.state.status === "checking" ? qsTr("Checking…") : qsTr("Check for updates")
-                    primary: true; glyph: "A"; enabled: root.state.status !== "checking"
+                    primary: true; glyph: "A"; enabled: !ShellStore.updaterBusy && root.state.canCheck === true
                     onClicked: ShellStore.checkForUpdates()
                     Component.onCompleted: forceActiveFocus()
                 }
                 GlassButton {
-                    width: 276; text: qsTr("Open releases"); glyph: "↗"
+                    width: 250; text: qsTr("Open releases"); glyph: "↗"
                     enabled: Boolean(root.state.releaseUrl)
                     onClicked: AppController.openExternalUrl(root.state.releaseUrl || "")
                 }
                 GlassButton {
-                    width: 276
+                    width: 250
                     visible: Boolean(root.state.canDownload)
                     text: root.state.status === "downloading" ? qsTr("Downloading…") : qsTr("Download verified update")
                     glyph: "↓"; primary: true
-                    enabled: root.state.status !== "downloading"
+                    enabled: !ShellStore.updaterBusy && root.state.canDownload === true
                     onClicked: ShellStore.downloadUpdate()
                 }
                 GlassButton {
-                    width: 276
+                    width: 250
+                    objectName: "updateInstallButton"
                     visible: Boolean(root.state.canInstall)
-                    text: qsTr("Install and restart")
+                    text: root.state.downloadedVersion ? qsTr("Install %1 and restart").arg(root.state.downloadedVersion) : qsTr("Install and restart")
                     glyph: "↑"; primary: true
-                    onClicked: ShellStore.installUpdate()
+                    enabled: ShellStore.updaterCanInstall
+                    onClicked: installConfirmation.open()
                 }
             }
         }

--- a/opennow-qt/qml/state/ShellStore.qml
+++ b/opennow-qt/qml/state/ShellStore.qml
@@ -212,8 +212,33 @@ QtObject {
     property string mediaMessage: ""
     property var diagnostics: ({entries: []})
     property string diagnosticsMessage: ""
-    property var updaterState: ({status: "idle", currentVersion: Qt.application.version, canCheck: true})
+    property var updaterState: ({status: "idle", currentVersion: Qt.application.version, canCheck: false})
+    property string updaterError: ""
+    property bool updaterInstallConfirmed: false
+    property bool updaterExitScheduled: false
+    property bool updaterReconciling: false
+    property double lastAutoUpdateCheckMs: 0
+    property string autoDownloadAttempt: ""
+    readonly property bool updaterSessionSafe: !activeSession && !streamBusy && !sessionRecoveryPending
+        && activeSessionRequestId === "" && sessionClaimRequestId === "" && streamCreateRequestId === ""
+        && streamerStartRequestId === "" && streamerPrepareRequestId === "" && streamerStopRequestId === ""
+        && !pendingLaunchParams && !pendingDirectLaunch
+        && ["idle", "error"].indexOf(streamState) >= 0
+        && ["stopped", "error"].indexOf(streamerStatus) >= 0
+    readonly property bool updaterBusy: updaterReconciling || updaterCheckRequestId !== ""
+        || updaterDownloadRequestId !== "" || updaterInstallRequestId !== ""
+        || ["checking", "downloading", "preparing", "awaiting-exit", "applying", "restarting"].indexOf(updaterState.status) >= 0
+    readonly property bool updaterCanInstall: ready && updaterSessionSafe && !updaterBusy && updaterState.canInstall === true
+    readonly property bool updaterNeedsReconciliation: updaterReconciling || updaterInstallConfirmed
+        || ["preparing", "awaiting-exit", "applying", "restarting", "managed-pending"].indexOf(updaterState.status) >= 0
+    onUpdaterSessionSafeChanged: {
+        if (updaterSessionSafe && releaseHighlightsPending) {
+            accessibilityMessage = qsTr("Release notes are available in Updates.")
+            releaseHighlightsPending = false
+        }
+    }
     property var releaseHighlights: ({})
+    property bool releaseHighlightsPending: false
     property var socialCapabilities: ({
         friendsAvailable: false,
         presenceAvailable: false,
@@ -513,9 +538,17 @@ QtObject {
     }
 
     property Timer autoUpdateCheckTimer: Timer {
-        interval: 15000
-        repeat: false
-        onTriggered: root.checkForUpdates()
+        interval: root.lastAutoUpdateCheckMs === 0 ? 15000 : 60000
+        repeat: true
+        running: root.ready && (root.settings.autoCheckForUpdates === true || root.settings.autoDownloadUpdates === true)
+        onTriggered: root.runAutomaticUpdates()
+    }
+
+    property Timer updaterReconcileTimer: Timer {
+        interval: 2000
+        repeat: true
+        running: root.ready && root.updaterNeedsReconciliation
+        onTriggered: root.refreshUpdaterState()
     }
 
     function refreshSettings() {
@@ -894,34 +927,87 @@ QtObject {
     }
 
     function checkForUpdates() {
-        if (!ready || updaterCheckRequestId !== "")
+        if (!ready || updaterBusy || updaterState.canCheck !== true)
             return
-        updaterState = Object.assign({}, updaterState, {
-            status: "checking",
-            message: qsTr("Checking GitHub Releases…"),
-            canCheck: false
-        })
+        updaterError = ""
         updaterCheckRequestId = CoreClient.request("updater.check", {
             channel: settings.updateChannel || "stable"
         }, 30000)
     }
 
     function downloadUpdate() {
-        if (!ready || updaterDownloadRequestId !== "" || !updaterState.canDownload)
+        if (!ready || updaterBusy || updaterState.canDownload !== true)
             return
+        updaterError = ""
         updaterDownloadRequestId = CoreClient.request("updater.download", {}, 300000)
-        updaterState = Object.assign({}, updaterState, {
-            status: "downloading",
-            message: qsTr("Downloading and verifying the signed update…"),
-            canDownload: false,
-            canCheck: false
-        })
     }
 
-    function installUpdate() {
-        if (!ready || updaterInstallRequestId !== "" || !updaterState.canInstall)
+    function installUpdate(confirmed) {
+        if (confirmed !== true || !updaterCanInstall)
             return
+        updaterError = ""
+        updaterInstallConfirmed = true
         updaterInstallRequestId = CoreClient.request("updater.install", {confirmed: true}, 30000)
+    }
+
+    function refreshUpdaterState() {
+        if (ready && updaterStateRequestId === "")
+            updaterStateRequestId = CoreClient.request("updater.state.get", {})
+    }
+
+    function acceptUpdaterState(state) {
+        if (state.status !== updaterState.status
+                || ["error", "failed", "rolled-back", "succeeded", "managed-pending", "reboot-required"].indexOf(state.status) >= 0)
+            updaterError = ""
+        updaterState = state
+        updaterReconciling = false
+        if (state.message)
+            accessibilityMessage = state.message
+        if (updaterInstallConfirmed && state.status === "awaiting-exit" && state.exitRequired === true
+                && updaterSessionSafe && !updaterExitScheduled) {
+            updaterExitScheduled = true
+            Qt.callLater(function() {
+                if (updaterInstallConfirmed && updaterState.status === "awaiting-exit"
+                        && updaterState.exitRequired === true && updaterSessionSafe)
+                    AppController.quitApplication()
+                else
+                    updaterExitScheduled = false
+            })
+        } else if (["failed", "rolled-back", "succeeded", "managed-pending", "reboot-required"].indexOf(state.status) >= 0
+                || (state.canInstall === true && updaterInstallRequestId === "")) {
+            updaterInstallConfirmed = false
+        }
+    }
+
+    function reconcileUpdaterFailure(message) {
+        updaterError = message
+        accessibilityMessage = message
+        updaterReconciling = true
+        refreshUpdaterState()
+    }
+
+    function runAutomaticUpdates() {
+        if (!ready || !updaterSessionSafe || updaterBusy)
+            return
+        if (settings.autoDownloadUpdates === true && updaterState.canDownload === true) {
+            const release = String(updaterState.availableVersion || updaterState.releaseUrl || "")
+                + ":" + String(settings.updateChannel || "stable")
+            if (release !== autoDownloadAttempt) {
+                autoDownloadAttempt = release
+                downloadUpdate()
+                return
+            }
+        }
+        if (settings.autoCheckForUpdates === true && updaterState.canCheck === true
+                && (lastAutoUpdateCheckMs === 0 || Date.now() - lastAutoUpdateCheckMs >= 21600000)) {
+            lastAutoUpdateCheckMs = Date.now()
+            checkForUpdates()
+        }
+    }
+
+    function acknowledgeUpdateHighlights() {
+        if (ready && releaseHighlights.version)
+            CoreClient.request("updater.highlights.ack", {version: releaseHighlights.version})
     }
 
     function syncTelemetry() {
@@ -2401,8 +2487,6 @@ QtObject {
                 root.syncTelemetry()
                 root.syncDiscordPresence()
                 root.refreshStreamerDetection()
-                if (result.settings.autoCheckForUpdates && root.updaterCheckRequestId === "")
-                    root.autoUpdateCheckTimer.restart()
             } else if (requestId === root.consoleSurfaceRequestId) {
                 settingsOwner.acceptConsoleSurface(result)
             } else if (requestId === root.providersRequestId) {
@@ -2609,23 +2693,20 @@ QtObject {
                 AppController.openLocalPath(result.path, true)
             } else if (requestId === root.updaterStateRequestId) {
                 root.updaterStateRequestId = ""
-                root.updaterState = result
+                root.acceptUpdaterState(result)
             } else if (requestId === root.updaterCheckRequestId) {
                 root.updaterCheckRequestId = ""
-                root.updaterState = result
+                root.acceptUpdaterState(result)
                 root.updaterHighlightsRequestId = CoreClient.request("updater.highlights.get", {})
             } else if (requestId === root.updaterHighlightsRequestId) {
                 root.updaterHighlightsRequestId = ""
                 root.releaseHighlights = result
             } else if (requestId === root.updaterDownloadRequestId) {
                 root.updaterDownloadRequestId = ""
-                root.updaterState = result
-                root.accessibilityMessage = qsTr("Signed update downloaded and verified")
+                root.acceptUpdaterState(result)
             } else if (requestId === root.updaterInstallRequestId) {
                 root.updaterInstallRequestId = ""
-                root.updaterState = result
-                root.accessibilityMessage = qsTr("Verified update installer launched")
-                Qt.callLater(() => AppController.quitApplication())
+                root.acceptUpdaterState(result)
             } else if (requestId === root.socialCapabilitiesRequestId) {
                 root.socialCapabilitiesRequestId = ""
                 root.socialCapabilities = result
@@ -2837,25 +2918,19 @@ QtObject {
                 root.diagnosticsMessage = message
             } else if (requestId === root.updaterStateRequestId) {
                 root.updaterStateRequestId = ""
+                root.updaterError = message
+                root.updaterReconciling = true
             } else if (requestId === root.updaterCheckRequestId) {
                 root.updaterCheckRequestId = ""
-                root.updaterState = Object.assign({}, root.updaterState, {
-                    status: "error",
-                    message: message,
-                    canCheck: true
-                })
+                root.reconcileUpdaterFailure(message)
             } else if (requestId === root.updaterHighlightsRequestId) {
                 root.updaterHighlightsRequestId = ""
             } else if (requestId === root.updaterDownloadRequestId) {
                 root.updaterDownloadRequestId = ""
-                root.updaterState = Object.assign({}, root.updaterState, {
-                    status: "available", message: message, canCheck: true
-                })
+                root.reconcileUpdaterFailure(message)
             } else if (requestId === root.updaterInstallRequestId) {
                 root.updaterInstallRequestId = ""
-                root.updaterState = Object.assign({}, root.updaterState, {
-                    status: "downloaded", message: message, canInstall: true, canCheck: true
-                })
+                root.reconcileUpdaterFailure(message)
             } else if (requestId === root.socialCapabilitiesRequestId) {
                 root.socialCapabilitiesRequestId = ""
                 root.socialCapabilities = Object.assign({}, root.socialCapabilities, {
@@ -2942,11 +3017,12 @@ QtObject {
             else if (name === "artwork.ready")
                 root.acceptArtworkResult(payload)
             else if (name === "updater.changed")
-                root.updaterState = payload
+                root.acceptUpdaterState(payload)
             else if (name === "updater.highlights.show") {
                 root.releaseHighlights = payload
-                AppController.navigate("updates")
-                CoreClient.request("updater.highlights.ack", {version: payload.version || ""})
+                root.releaseHighlightsPending = !root.updaterSessionSafe
+                if (root.updaterSessionSafe)
+                    root.accessibilityMessage = qsTr("Release notes are available in Updates.")
             }
         }
     }

--- a/opennow-qt/src/core/CoreClient.cpp
+++ b/opennow-qt/src/core/CoreClient.cpp
@@ -7,12 +7,14 @@
 
 #include <QDateTime>
 #include <QElapsedTimer>
+#include <QCoreApplication>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QStandardPaths>
+#include <QProcessEnvironment>
 
 using namespace Qt::StringLiterals;
 
@@ -111,6 +113,25 @@ void CoreClient::logShellDiagnostic(const QString &message)
 CoreClient::CoreClient(QObject *parent)
     : QObject(parent)
 {
+    for (const auto *name : {"OPENNOW_UPDATE_PLAN", "OPENNOW_UPDATE_NONCE"}) {
+        if (qEnvironmentVariableIsSet(name))
+            m_updateStartupEnvironment.insert(QString::fromLatin1(name), qEnvironmentVariable(name));
+        qunsetenv(name);
+    }
+    if (!m_updateStartupEnvironment.isEmpty()) m_updateStartupElapsed.start();
+    connect(this, &CoreClient::responseReceived, this, [this](const QString &id, const QJsonObject &result) {
+        if (id != m_updateStartupRequestId || id.isEmpty()) return;
+        m_updateStartupRequestId.clear();
+        if (result.value(u"acknowledged"_s).toBool())
+            m_updateStartupEnvironment.clear();
+        else
+            QTimer::singleShot(1'000, this, &CoreClient::acknowledgeUpdateStartup);
+    });
+    connect(this, &CoreClient::requestFailed, this, [this](const QString &id, const QString &, const QString &) {
+        if (id != m_updateStartupRequestId || id.isEmpty()) return;
+        m_updateStartupRequestId.clear();
+        QTimer::singleShot(1'000, this, &CoreClient::acknowledgeUpdateStartup);
+    });
     m_process.setProcessChannelMode(QProcess::SeparateChannels);
     connect(&m_process, &QProcess::readyReadStandardOutput, this, &CoreClient::processStdout);
     connect(&m_process, &QProcess::readyReadStandardError, this, &CoreClient::processStderr);
@@ -179,8 +200,31 @@ bool CoreClient::start(const QString &program, const QStringList &arguments)
     m_droppedEvents = 0;
     setLastError({});
     setState(u"starting"_s);
+    auto environment = QProcessEnvironment::systemEnvironment();
+    environment.remove(u"OPENNOW_UPDATE_PLAN"_s);
+    environment.remove(u"OPENNOW_UPDATE_NONCE"_s);
+    environment.insert(m_updateStartupEnvironment);
+    environment.insert(u"OPENNOW_APP_EXECUTABLE"_s,
+                       QFileInfo(QCoreApplication::applicationFilePath()).canonicalFilePath());
+    environment.insert(u"OPENNOW_APP_PID"_s, QString::number(QCoreApplication::applicationPid()));
+    m_process.setProcessEnvironment(environment);
     m_process.start(program, arguments, QIODevice::ReadWrite | QIODevice::Unbuffered);
     return true;
+}
+
+void CoreClient::markUiReady()
+{
+    m_uiReady = true;
+    acknowledgeUpdateStartup();
+}
+
+void CoreClient::acknowledgeUpdateStartup()
+{
+    if (m_updateStartupElapsed.isValid() && m_updateStartupElapsed.hasExpired(90'000))
+        m_updateStartupEnvironment.clear();
+    if (!m_uiReady || m_state != u"ready"_s || m_updateStartupEnvironment.isEmpty()
+        || !m_updateStartupRequestId.isEmpty()) return;
+    m_updateStartupRequestId = request(u"updater.startup.ack"_s, {}, 5'000);
 }
 
 void CoreClient::stop()
@@ -407,6 +451,7 @@ void CoreClient::processLine(const QByteArray &line)
                 }
                 m_restartAttempts = 0;
                 setState(u"ready"_s);
+                acknowledgeUpdateStartup();
             }
             emit responseReceived(id, result);
         } else {

--- a/opennow-qt/src/core/CoreClient.h
+++ b/opennow-qt/src/core/CoreClient.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <QHash>
+#include <QElapsedTimer>
 #include <QJsonObject>
 #include <QObject>
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QQueue>
 #include <QStringList>
 #include <QTimer>
@@ -35,6 +37,7 @@ public:
                                 int timeoutMs = 15'000);
     Q_INVOKABLE bool cancel(const QString &requestId);
     Q_INVOKABLE void logShellDiagnostic(const QString &message);
+    Q_INVOKABLE void markUiReady();
     void setNativeHdrSupported(bool supported) { m_nativeHdrSupported = supported; }
 
 signals:
@@ -67,8 +70,13 @@ private:
     void failAll(const QString &code, const QString &message);
     void protocolFailure(const QString &message);
     void scheduleRestart();
+    void acknowledgeUpdateStartup();
 
     QProcess m_process;
+    QProcessEnvironment m_updateStartupEnvironment;
+    QElapsedTimer m_updateStartupElapsed;
+    QString m_updateStartupRequestId;
+    bool m_uiReady = false;
     QTimer m_timeoutTimer;
     QByteArray m_stdoutBuffer;
     QByteArray m_stderrBuffer;

--- a/opennow-qt/tests/CollectionsAcceptance.qml
+++ b/opennow-qt/tests/CollectionsAcceptance.qml
@@ -11,6 +11,7 @@ QtObject {
         signal responseReceived(string requestId, var result)
         signal requestFailed(string requestId, string code, string message)
         signal eventReceived(string name, var payload)
+        function markUiReady() {}
         function logShellDiagnostic(message) {}
         function request(method, params, timeout) {
             const id = "collections-test-" + (++sequence)

--- a/opennow-qt/tests/QueueDropsAcceptance.qml
+++ b/opennow-qt/tests/QueueDropsAcceptance.qml
@@ -25,6 +25,7 @@ QtObject {
         signal responseReceived(string requestId, var result)
         signal requestFailed(string requestId, string code, string message)
         signal eventReceived(string name, var payload)
+        function markUiReady() {}
         function logShellDiagnostic(message) {}
         function request(method, params, timeout) {
             const id = "drop-fixture-" + (calls.length + 1)

--- a/opennow-qt/tests/RecordingAcceptance.qml
+++ b/opennow-qt/tests/RecordingAcceptance.qml
@@ -22,6 +22,7 @@ QtObject {
         signal responseReceived(string requestId, var result)
         signal requestFailed(string requestId, string code, string message)
         signal eventReceived(string name, var payload)
+        function markUiReady() {}
         function logShellDiagnostic(message) {}
         function request(method, params, timeout) {
             const id = "recording-fixture-" + (calls.length + 1)

--- a/opennow-qt/tests/RegionPingAcceptance.qml
+++ b/opennow-qt/tests/RegionPingAcceptance.qml
@@ -14,6 +14,7 @@ QtObject {
         signal responseReceived(string requestId, var result)
         signal requestFailed(string requestId, string code, string message)
         signal eventReceived(string name, var payload)
+        function markUiReady() {}
         function logShellDiagnostic(message) {} // No filesystem writes from the isolated mock.
         function request(method, params, timeout) {
             const id = "region-test-" + (++sequence)

--- a/opennow-qt/tests/SteamBigPictureAcceptance.qml
+++ b/opennow-qt/tests/SteamBigPictureAcceptance.qml
@@ -10,6 +10,7 @@ QtObject {
         signal responseReceived(string requestId, var result)
         signal requestFailed(string requestId, string code, string message)
         signal eventReceived(string name, var payload)
+        function markUiReady() {}
         function logShellDiagnostic(message) {}
         function request(method, params, timeout) {
             const id = "fixture-" + (calls.length + 1)

--- a/opennow-qt/tests/StorePagingAcceptance.qml
+++ b/opennow-qt/tests/StorePagingAcceptance.qml
@@ -15,6 +15,7 @@ QtObject {
         signal responseReceived(string requestId, var result)
         signal requestFailed(string requestId, string code, string message)
         signal eventReceived(string name, var payload)
+        function markUiReady() {}
         function logShellDiagnostic(message) {} // No filesystem writes from the isolated mock.
         function request(method, params, timeout) {
             const id = "store-test-" + (++sequence)

--- a/opennow-qt/tests/StreamRecoveryAcceptance.qml
+++ b/opennow-qt/tests/StreamRecoveryAcceptance.qml
@@ -12,6 +12,7 @@ QtObject {
         signal responseReceived(string requestId, var result)
         signal requestFailed(string requestId, string code, string message)
         signal eventReceived(string name, var payload)
+        function markUiReady() {}
         function logShellDiagnostic(message) {} // No filesystem writes from the isolated mock.
         function request(method, params, timeout) {
             const id = "fixture-" + (calls.length + 1)

--- a/opennow-qt/tests/fake_core.cpp
+++ b/opennow-qt/tests/fake_core.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <unordered_map>
 #include <cstdlib>
+#include <iomanip>
 
 namespace {
 std::string field(const std::string &json, const std::string &name)
@@ -32,6 +33,7 @@ int main(int argc, char **argv)
     std::string eofMarker;
     bool launchInConsoleMode = false;
     int consoleModeWriteCount = 0;
+    int startupAcknowledgements = 0;
     std::unordered_map<std::string, int> busyAttempts;
     if (argc == 3 && std::string(argv[1]) == "--eof-marker") {
         eofMarker = argv[2];
@@ -43,6 +45,19 @@ int main(int argc, char **argv)
         if (method == "core.hello") {
             std::cout << "{\"type\":\"response\",\"id\":\"" << id
                       << "\",\"ok\":true,\"result\":{\"protocolVersion\":1,\"capabilities\":[\"settings\",\"nativeStreamer.v6\",\"nativeStreamer.ownedNvstNegotiation\"]}}\n" << std::flush;
+        } else if (method == "updater.startup.ack") {
+            ++startupAcknowledgements;
+            std::cout << "{\"type\":\"response\",\"id\":\"" << id
+                      << "\",\"ok\":true,\"result\":{\"acknowledged\":true}}\n" << std::flush;
+        } else if (method == "test.app-context") {
+            const auto executable = std::getenv("OPENNOW_APP_EXECUTABLE");
+            const auto pid = std::getenv("OPENNOW_APP_PID");
+            std::cout << "{\"type\":\"response\",\"id\":\"" << id
+                      << "\",\"ok\":true,\"result\":{\"executable\":" << std::quoted(executable ? executable : "")
+                      << ",\"pid\":" << std::quoted(pid ? pid : "")
+                      << ",\"startupAcknowledgements\":" << startupAcknowledgements
+                      << ",\"hasUpdateEnvironment\":" << (std::getenv("OPENNOW_UPDATE_PLAN") && std::getenv("OPENNOW_UPDATE_NONCE") ? "true" : "false")
+                      << "}}\n" << std::flush;
         } else if (method == "session.create" || method == "streamer.prepare") {
             std::cout << "{\"type\":\"response\",\"id\":\"" << id
                       << "\",\"ok\":true,\"result\":" << line << "}\n" << std::flush;

--- a/opennow-qt/tests/run_update_helper_integration.py
+++ b/opennow-qt/tests/run_update_helper_integration.py
@@ -77,7 +77,10 @@ fn main() {
     if std::env::args().any(|argument| argument == "--hold") {
         std::thread::sleep(std::time::Duration::from_secs(180));
     } else if let Some(directory) = std::env::var_os("OPENNOW_DATA_DIR") {
-        std::fs::write(std::path::Path::new(&directory).join("previous-restarted"), b"1.0.0").unwrap();
+        let path = std::path::Path::new(&directory).join("previous-restarted");
+        let temporary = path.with_extension("tmp");
+        std::fs::write(&temporary, b"1.0.0").unwrap();
+        std::fs::rename(temporary, path).unwrap();
     }
 }
 ''', encoding="utf-8")

--- a/opennow-qt/tests/run_update_helper_integration.py
+++ b/opennow-qt/tests/run_update_helper_integration.py
@@ -1,0 +1,121 @@
+import base64
+import json
+import os
+from pathlib import Path
+import secrets
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "native/opennow-core/Cargo.toml"
+
+
+def run(command, environment):
+    subprocess.run(command, cwd=ROOT, env=environment, check=True, timeout=1200)
+
+
+def build_fixtures(directory, environment):
+    manifest = directory / "Cargo.toml"
+    manifest.write_text('''[package]
+name = "opennow-update-test-fixtures"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "previous"
+path = "previous.rs"
+
+[[bin]]
+name = "candidate"
+path = "candidate.rs"
+
+[dependencies]
+opennow-core = { path = ''' + json.dumps(str(MANIFEST.parent)) + ''' }
+''', encoding="utf-8")
+    shutil.copyfile(MANIFEST.with_name("Cargo.lock"), directory / "Cargo.lock")
+    run(["cargo", "build", "--offline", "--manifest-path", str(manifest), "--bins"], environment)
+
+
+def main():
+    openssl = shutil.which("openssl")
+    if openssl is None and os.name == "nt":
+        candidate = Path(os.environ.get("ProgramFiles", "C:/Program Files")) / "Git/usr/bin/openssl.exe"
+        if candidate.is_file():
+            openssl = str(candidate)
+    if openssl is None:
+        raise RuntimeError("OpenSSL is required to derive the ephemeral Ed25519 public key")
+    with tempfile.TemporaryDirectory(prefix="opennow-signed-helper-") as temporary:
+        directory = Path(temporary).resolve()
+        seed = secrets.token_bytes(32)
+        seed_file = directory / "test-only-signing-seed"
+        seed_file.write_bytes(seed)
+        seed_file.chmod(0o600)
+        public_der = subprocess.run(
+            [openssl, "pkey", "-inform", "DER", "-pubout", "-outform", "DER"],
+            input=bytes.fromhex("302e020100300506032b657004220420") + seed,
+            capture_output=True, check=True, timeout=30,
+        ).stdout
+        if len(public_der) != 44 or public_der[:12] != bytes.fromhex("302a300506032b6570032100"):
+            raise RuntimeError("OpenSSL returned an unexpected Ed25519 public key encoding")
+        environment = os.environ.copy()
+        environment["CARGO_TARGET_DIR"] = str(directory / "target")
+        environment["OPENNOW_UPDATE_ED25519_PUBLIC_KEY"] = base64.b64encode(public_der[12:]).decode("ascii")
+        environment["OPENNOW_TEST_UPDATE_SEED_FILE"] = str(seed_file)
+        for name in ("OPENNOW_UPDATE_PLAN", "OPENNOW_UPDATE_NONCE", "APPIMAGE", "APPDIR", "ARGV0"):
+            environment.pop(name, None)
+        run(["cargo", "build", "--locked", "--manifest-path", str(MANIFEST), "--lib", "--bin", "opennow-update-helper"], environment)
+        suffix = ".exe" if os.name == "nt" else ""
+        debug = directory / "target/debug"
+        previous = debug / ("previous" + suffix)
+        candidate = debug / ("candidate" + suffix)
+        previous_source = directory / "previous.rs"
+        previous_source.write_text('''
+fn main() {
+    if std::env::args().any(|argument| argument == "--hold") {
+        std::thread::sleep(std::time::Duration::from_secs(180));
+    } else if let Some(directory) = std::env::var_os("OPENNOW_DATA_DIR") {
+        std::fs::write(std::path::Path::new(&directory).join("previous-restarted"), b"1.0.0").unwrap();
+    }
+}
+''', encoding="utf-8")
+        candidate_source = directory / "candidate.rs"
+        candidate_source.write_text('''
+fn main() {
+    let executable = std::env::current_exe().unwrap().canonicalize().unwrap();
+    let plan = std::path::PathBuf::from(std::env::var_os("OPENNOW_UPDATE_PLAN").unwrap());
+    let directory = plan.parent().unwrap();
+    std::fs::write(directory.join("candidate-started"), std::process::id().to_string()).unwrap();
+    if directory.join("reject-startup").exists() { std::process::exit(9); }
+    unsafe {
+        std::env::set_var("OPENNOW_APP_PID", std::process::id().to_string());
+        std::env::set_var("OPENNOW_APP_EXECUTABLE", &executable);
+        #[cfg(target_os = "linux")]
+        std::env::set_var("APPIMAGE", &executable);
+    }
+    assert!(opennow_core::update_apply::acknowledge_startup_from_env("1.2.3").unwrap());
+    let start = std::time::Instant::now();
+    while !directory.join("exit-fixture").exists() && start.elapsed().as_secs() < 30 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+''', encoding="utf-8")
+        build_fixtures(directory, environment)
+        environment["OPENNOW_TEST_UPDATE_PREVIOUS"] = str(previous)
+        environment["OPENNOW_TEST_UPDATE_CANDIDATE"] = str(candidate)
+        environment["OPENNOW_TEST_UPDATE_HELPER"] = str(debug / ("opennow-update-helper" + suffix))
+        listed = subprocess.run(
+            ["cargo", "test", "--locked", "--manifest-path", str(MANIFEST), "--lib",
+             "update_apply::integration_tests", "--", "--ignored", "--list"],
+            cwd=ROOT, env=environment, check=True, capture_output=True, text=True, timeout=1200,
+        )
+        if listed.stdout.count(": test") != 4:
+            raise RuntimeError("Expected all four signed helper integration tests to be registered")
+        run(["cargo", "test", "--locked", "--manifest-path", str(MANIFEST), "--lib",
+             "update_apply::integration_tests", "--", "--ignored", "--test-threads=1", "--nocapture"], environment)
+
+
+if __name__ == "__main__":
+    main()

--- a/opennow-qt/tests/test_ci_workflow.py
+++ b/opennow-qt/tests/test_ci_workflow.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import os
 import re
 import subprocess
+import tempfile
+import textwrap
 import unittest
 
 
@@ -32,11 +34,11 @@ class CIWorkflowTest(unittest.TestCase):
     def test_automatic_events_run_checks_without_packages(self):
         ci = (WORKFLOWS / "qt-ci.yml").read_text()
         entries = jobs(ci)
-        self.assertEqual(set(entries), {"contracts", "checks", "build", "publish-nightly"})
+        self.assertEqual(set(entries), {"preflight", "contracts", "checks", "build", "sign-nightly", "publish-nightly"})
         self.assertIn("uses: ./.github/workflows/qt-checks.yml", entries["contracts"])
         self.assertNotIn("    if:", entries["contracts"])
         self.assertIn("    if: github.event_name == 'workflow_dispatch'\n", entries["build"])
-        self.assertIn("    needs: contracts\n", entries["build"])
+        self.assertIn("    needs: [contracts, preflight]\n", entries["build"])
         self.assertIn("uses: ./.github/workflows/qt-build.yml", entries["build"])
         self.assertIn("  pull_request:\n", ci)
         self.assertIn("  push:\n", ci)
@@ -58,6 +60,46 @@ class CIWorkflowTest(unittest.TestCase):
         self.assertIn("name: Package ${{ matrix.label }}", entries["packages"])
         self.assertIn("Create Linux AppImage", entries["packages"])
         self.assertIn("Test relocated bundle without development libraries", entries["packages"])
+
+    def test_windows_packaging_failure_prints_bounded_logs_and_preserves_status(self):
+        workflow = (WORKFLOWS / "qt-build.yml").read_text()
+        step = workflow.split("      - name: Create unsigned package\n", 1)[1].split("      - name:", 1)[0]
+        script = textwrap.dedent(step.split("        run: |\n", 1)[1])
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index in range(6):
+                log = root / f"build/qt-packages/log folder {index}/wix.log"
+                log.parent.mkdir(parents=True)
+                log.write_text("first-line-must-be-truncated\n" + ("x" * 1024 + "\n") * 300 + "WiX failure detail\n")
+            prelude = 'cd() { return 0; }\ncpack() { return "$CPACK_STATUS"; }\n'
+            for platform, status in (("Windows", 37), ("Windows", 0), ("Linux", 37)):
+                with self.subTest(platform=platform, status=status):
+                    result = subprocess.run(["bash", "-euo", "pipefail", "-c", prelude + script],
+                                            cwd=root, env={**os.environ, "RUNNER_OS": platform,
+                                                           "CPACK_STATUS": str(status), "PACKAGE_GENERATOR": "WIX;ZIP"},
+                                            capture_output=True, text=True)
+                    self.assertEqual(result.returncode, status, result.stderr)
+                    if platform == "Windows" and status:
+                        self.assertEqual(result.stdout.count("--- WiX packaging log:"), 4)
+                        self.assertEqual(result.stdout.count("WiX failure detail"), 4)
+                        self.assertNotIn("first-line-must-be-truncated", result.stdout)
+                        self.assertLess(len(result.stdout), 4 * 65536 + 4096)
+                    else:
+                        self.assertEqual(result.stdout, "")
+            result = subprocess.run(["bash", "-euo", "pipefail", "-c",
+                                     prelude + 'tail() { return 11; }\n' + script],
+                                    cwd=root, env={**os.environ, "RUNNER_OS": "Windows",
+                                                   "CPACK_STATUS": "37", "PACKAGE_GENERATOR": "WIX;ZIP"},
+                                    capture_output=True, text=True)
+            self.assertEqual(result.returncode, 37, result.stderr)
+            for log in root.rglob("wix.log"):
+                log.unlink()
+            result = subprocess.run(["bash", "-euo", "pipefail", "-c", prelude + script],
+                                    cwd=root, env={**os.environ, "RUNNER_OS": "Windows",
+                                                   "CPACK_STATUS": "37", "PACKAGE_GENERATOR": "WIX;ZIP"},
+                                    capture_output=True, text=True)
+            self.assertEqual(result.returncode, 37, result.stderr)
+            self.assertIn("No generated WiX logs found.", result.stdout)
 
     def test_all_native_platform_checks_keep_required_status_names(self):
         checks = jobs((WORKFLOWS / "qt-ci.yml").read_text())["checks"]
@@ -97,9 +139,10 @@ class CIWorkflowTest(unittest.TestCase):
 
     def test_manual_packages_overlap_checks_without_bypassing_publication_gates(self):
         entries = jobs((WORKFLOWS / "qt-ci.yml").read_text())
-        self.assertIn("    needs: contracts\n", entries["build"])
+        self.assertIn("    needs: [contracts, preflight]\n", entries["build"])
         self.assertIn("    if: github.event_name == 'workflow_dispatch'\n", entries["build"])
-        self.assertIn("    needs: [contracts, checks, build]\n", entries["publish-nightly"])
+        self.assertIn("    needs: [preflight, contracts, checks, build]\n", entries["sign-nightly"])
+        self.assertIn("    needs: [contracts, checks, build, sign-nightly]\n", entries["publish-nightly"])
         self.assertNotIn("always()", entries["build"])
         self.assertNotIn("always()", entries["publish-nightly"])
         self.assertNotIn("continue-on-error", entries["checks"])
@@ -148,6 +191,29 @@ class CIWorkflowTest(unittest.TestCase):
         self.assertIn("add_custom_target(opennow-ci-unit-tests DEPENDS ${OPENNOW_CI_UNIT_TEST_TARGETS})", cmake)
         self.assertIn('set_tests_properties(${OPENNOW_CI_UNIT_TEST_TARGETS} PROPERTIES LABELS "ci-unit")', cmake)
         self.assertIn('ENVIRONMENT "QT_QPA_PLATFORM=cocoa" RUN_SERIAL TRUE TIMEOUT 30 LABELS "interactive-desktop"', cmake)
+
+    def test_signed_helper_integration_runs_on_every_platform_check_not_signers(self):
+        action = (ROOT / ".github/actions/qt-unit-tests/action.yml").read_text()
+        marker = "    - name: Test signed update helper integration\n"
+        before, after = action.split(marker, 1)
+        step = after.split("    - name:", 1)[0]
+        for setup in ("uses: ilammy/msvc-dev-cmd@v1", "uses: dtolnay/rust-toolchain@stable",
+                      "name: Install Linux test dependencies", "name: Test Rust"):
+            self.assertIn(setup, before)
+        self.assertNotIn("      if:", step)
+        self.assertNotIn("continue-on-error", step)
+        self.assertIn("working-directory: ${{ env.OPENNOW_CHECKOUT }}", step)
+        self.assertIn("CARGO_BUILD_JOBS: ${{ inputs.parallel }}", step)
+        self.assertIn("python opennow-qt/tests/run_update_helper_integration.py", step)
+        self.assertIn("python3 opennow-qt/tests/run_update_helper_integration.py", step)
+        self.assertNotIn("secrets.", step)
+        ci = jobs((WORKFLOWS / "qt-ci.yml").read_text())
+        for label in ("linux-x64", "windows-x64", "macos-arm64"):
+            self.assertIn(f"label: {label}", ci["checks"])
+        self.assertIn("uses: ./.github/actions/qt-unit-tests", ci["checks"])
+        self.assertNotIn("run_update_helper_integration.py", ci["sign-nightly"])
+        candidate = jobs((WORKFLOWS / "qt-release-candidate.yml").read_text())
+        self.assertNotIn("run_update_helper_integration.py", candidate["inventory"])
 
     def test_windows_checks_use_verified_llvm_fallback(self):
         action = (ROOT / ".github/actions/qt-unit-tests/action.yml").read_text()
@@ -202,7 +268,7 @@ class CIWorkflowTest(unittest.TestCase):
         self.assertIn("        type: boolean\n        default: false", ci)
         publish = jobs(ci)["publish-nightly"]
         self.assertIn("if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly", publish)
-        self.assertIn("    needs: [contracts, checks, build]\n", publish)
+        self.assertIn("    needs: [contracts, checks, build, sign-nightly]\n", publish)
 
 
 if __name__ == "__main__":

--- a/opennow-qt/tests/test_linux_package.py
+++ b/opennow-qt/tests/test_linux_package.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packaging"))
-from verify_linux_package import verify_capabilities
+from verify_linux_package import verify_capabilities, verify_package
 
 
 class LinuxPackageDependenciesTest(unittest.TestCase):
@@ -54,6 +54,18 @@ file(WRITE "{source.as_posix()}/architecture.txt" "${{CPACK_DEBIAN_PACKAGE_ARCHI
                 dependencies = (source / "dependencies.txt").read_text().split(",")
                 self.assertIn("qt6-svg-plugins (>= 6.8)", [item.strip() for item in dependencies])
                 self.assertEqual((source / "architecture.txt").read_text(), architecture)
+                self.assertIn("opennow-update-helper", (build / "cmake_install.cmake").read_text())
+
+    def test_missing_or_nonexecutable_helper_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            bin_dir = Path(directory)
+            with self.assertRaisesRegex(ValueError, "executable update helper"):
+                verify_package(bin_dir)
+            helper = bin_dir / "opennow-update-helper"
+            helper.write_bytes(b"test helper")
+            helper.chmod(0o600)
+            with self.assertRaisesRegex(ValueError, "executable update helper"):
+                verify_package(bin_dir)
 
 
 class LinuxPackageCapabilitiesTest(unittest.TestCase):

--- a/opennow-qt/tests/test_macos_build.py
+++ b/opennow-qt/tests/test_macos_build.py
@@ -18,6 +18,8 @@ class MacOSBuildContractTest(unittest.TestCase):
             'ditto "$mount/OpenNOW.app" "$RUNNER_TEMP/dmg-relocated/OpenNOW.app"',
             'hdiutil detach "$mount"\n',
             'for app in "$zip_app" "$RUNNER_TEMP/dmg-relocated/OpenNOW.app"; do',
+            '/usr/bin/codesign --verify --deep --strict "$app"',
+            "grep -Fx 'Identifier=io.github.opencloudgaming.OpenNOW'",
             'mv "$QT_ROOT_DIR" "$QT_ROOT_DIR.unavailable"',
             '[bin_dir / "OpenNOW", "--smoke-test"',
         ]
@@ -37,7 +39,7 @@ class MacOSBuildContractTest(unittest.TestCase):
              ["lipo", "$bin/libopennow_streamer_ffi.dylib", "-verify_arch", "arm64"]],
         )
 
-    def configure(self, arch="arm64", rust_target=""):
+    def configure(self, arch="arm64", rust_target="", adhoc=False):
         directory = tempfile.TemporaryDirectory()
         self.addCleanup(directory.cleanup)
         source = Path(directory.name)
@@ -48,6 +50,7 @@ class MacOSBuildContractTest(unittest.TestCase):
 project(MacOSBuildContract VERSION 1.0.0 LANGUAGES CXX)
 include(GNUInstallDirs)
 add_executable(opennow-qt main.cpp)
+set_target_properties(opennow-qt PROPERTIES MACOSX_BUNDLE_GUI_IDENTIFIER "io.github.opencloudgaming.OpenNOW")
 set(APPLE TRUE)
 set(WIN32 FALSE)
 set(CMAKE_SYSTEM_NAME Darwin)
@@ -55,6 +58,7 @@ set(CMAKE_OSX_ARCHITECTURES "{arch}")
 set(CMAKE_CURRENT_SOURCE_DIR "{QT_SOURCE.as_posix()}")
 set(OPENNOW_RUST_TARGET "{rust_target}")
 set(CARGO_EXECUTABLE cargo)
+set(OPENNOW_MACOS_ADHOC_SIGN {"ON" if adhoc else "OFF"})
 include("{QT_SOURCE.as_posix()}/cmake/BuildMetadata.cmake")
 include("{QT_SOURCE.as_posix()}/cmake/NativeRuntime.cmake")
 set(OPENNOW_EXECUTABLE_NAME OpenNOW)
@@ -115,12 +119,15 @@ file(GENERATE OUTPUT "${{CMAKE_BINARY_DIR}}/contract.txt" CONTENT
     def test_bundle_explicitly_installs_native_helpers(self):
         result, build = self.configure()
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        rule = (build / "CMakeFiles/opennow-update-helper-build.dir/build.make").read_text()
+        self.assertIn("--bin opennow-update-helper", rule)
+        self.assertIn("rust-target/aarch64-apple-darwin/release/opennow-update-helper", rule)
         cpack = (build / "CPackConfig.cmake").read_text()
         self.assertIn('set(CPACK_GENERATOR "DragNDrop;ZIP")', cpack)
         self.assertIn('set(CPACK_PACKAGE_FILE_NAME "OpenNOW-Qt-1.0.0-Darwin-arm64")', cpack)
         install = (build / "cmake_install.cmake").read_text()
         self.assertIn("OpenNOW.app/Contents/MacOS", install)
-        for helper in ("opennow-core", "opennow-acceptance-verify"):
+        for helper in ("opennow-core", "opennow-acceptance-verify", "opennow-update-helper"):
             self.assertIn(f"rust-target/aarch64-apple-darwin/release/{helper}", install)
         for runtime in ("opennow-streamer", "libopennow_streamer_ffi.dylib"):
             self.assertIn(f"streamer-rust-target/aarch64-apple-darwin/release/{runtime}", install)
@@ -129,8 +136,34 @@ file(GENERATE OUTPUT "${{CMAKE_BINARY_DIR}}/contract.txt" CONTENT
         result, build = self.configure()
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         arguments = (build / "deploy-args.txt").read_text().split(";")
-        for helper in ("opennow-core", "opennow-acceptance-verify", "opennow-streamer"):
+        for helper in ("opennow-core", "opennow-acceptance-verify", "opennow-update-helper", "opennow-streamer"):
             self.assertIn(f"-executable=OpenNOW.app/Contents/MacOS/{helper}", arguments)
+
+    def test_nightly_deployment_explicitly_seals_bundle_with_adhoc_identity(self):
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                result, build = self.configure(adhoc=enabled)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                arguments = (build / "deploy-args.txt").read_text().split(";")
+                self.assertEqual("-codesign=-" in arguments, enabled)
+                install = (build / "cmake_install.cmake").read_text()
+                self.assertEqual("macos-adhoc-seal.cmake" in install, enabled)
+                if enabled:
+                    self.assertLess(install.index("/deploy.cmake"), install.index("/macos-adhoc-seal.cmake"))
+                    seal = (build / "macos-adhoc-seal.cmake").read_text()
+                    self.assertIn('--identifier "io.github.opencloudgaming.OpenNOW"', seal)
+                    self.assertIn("--verify --deep --strict", seal)
+                    self.assertIn('$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/OpenNOW.app', seal)
+        workflow = (QT_SOURCE.parent / ".github/workflows/qt-build.yml").read_text()
+        self.assertIn("-DOPENNOW_MACOS_ADHOC_SIGN=ON", workflow)
+        self.assertIn("grep -Fx 'Signature=adhoc'", workflow)
+        self.assertIn("grep -Fx 'TeamIdentifier=not set'", workflow)
+        self.assertIn("Print :CFBundleIdentifier", workflow)
+        main = (QT_SOURCE / "CMakeLists.txt").read_text()
+        self.assertIn('MACOSX_BUNDLE_GUI_IDENTIFIER "io.github.opencloudgaming.OpenNOW"', main)
+        self.assertIn("${MACOSX_BUNDLE_GUI_IDENTIFIER}", (QT_SOURCE / "packaging/Info.plist.in").read_text())
+        candidate = (QT_SOURCE.parent / ".github/workflows/qt-release-candidate.yml").read_text()
+        self.assertNotIn("OPENNOW_MACOS_ADHOC_SIGN", candidate)
 
 
 if __name__ == "__main__":

--- a/opennow-qt/tests/test_release_metadata.py
+++ b/opennow-qt/tests/test_release_metadata.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import subprocess
 import tempfile
 import unittest
+import xml.etree.ElementTree as ET
 
 
 MODULE = Path(__file__).resolve().parents[1] / "cmake" / "BuildMetadata.cmake"
@@ -26,6 +27,12 @@ class BuildMetadataTest(unittest.TestCase):
                 + f'include("{(MODULE.parent / "WindowsInstaller.cmake").as_posix()}")\n'
                 + 'message("MSI=${CPACK_PACKAGE_VERSION}|${CPACK_PACKAGE_NAME}|${CPACK_PACKAGE_INSTALL_DIRECTORY}|${CPACK_WIX_UPGRADE_GUID}")\n'
                 + 'message("LAUNCHER=${CPACK_PACKAGE_EXECUTABLES}")\n'
+                + 'message("WIXPATCH=${CPACK_WIX_PATCH_FILE}")\n'
+                + 'if(DEFINED CPACK_WIX_PROPERTY_ARPINSTALLLOCATION)\n'
+                + 'message("ARPINSTALLLOCATION=OVERRIDDEN")\n'
+                + 'else()\n'
+                + 'message("ARPINSTALLLOCATION=UNSET")\n'
+                + 'endif()\n'
                 + 'if(CPACK_RESOURCE_FILE_LICENSE)\n'
                 + 'file(SHA256 "${CPACK_RESOURCE_FILE_LICENSE}" license_hash)\n'
                 + 'message("LICENSE=${license_hash}")\n'
@@ -94,6 +101,33 @@ class BuildMetadataTest(unittest.TestCase):
                 result = self.metadata(WIN32="TRUE", OPENNOW_BUILD_VERSION=version)
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("MSI", result.stderr)
+
+    def test_existing_upgrade_families_remain_stable_across_architectures(self):
+        families = {
+            "1.0.0": "6E81F7AE-B19D-4E87-A94A-2B2F01EBF762",
+            "1.0.0-nightly.256.1": "9661F4F8-656C-4B64-9035-01B04F4822B1",
+            "1.0.0-supporter.256.1": "B3AF8A40-5F44-445A-AD99-CECE00593601",
+        }
+        for version, guid in families.items():
+            for arch in ("x64", "ARM64"):
+                with self.subTest(version=version, arch=arch):
+                    result = self.metadata(WIN32="TRUE", OPENNOW_BUILD_VERSION=version,
+                                           CMAKE_CXX_COMPILER_ARCHITECTURE_ID=arch)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    identity = next(line for line in result.stderr.splitlines() if line.startswith("MSI="))
+                    self.assertTrue(identity.endswith("|" + guid), identity)
+
+    def test_msi_records_the_resolved_install_root_after_costing(self):
+        result = self.metadata(WIN32="TRUE")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("ARPINSTALLLOCATION=UNSET", result.stderr)
+        patches = next(line.removeprefix("WIXPATCH=") for line in result.stderr.splitlines()
+                       if line.startswith("WIXPATCH="))
+        for patch in filter(None, patches.split(";")):
+            root = ET.parse(patch).getroot()
+            self.assertFalse(root.findall(".//SetProperty[@Id='ARPINSTALLLOCATION']"))
+        policy = (MODULE.parent / "WindowsInstaller.cmake").read_text()
+        self.assertNotIn("CPACK_WIX_PRODUCT_GUID", policy)
 
     def test_msi_launcher_label_and_license_follow_the_package(self):
         license_digest = hashlib.sha256((MODULE.parents[2] / "LICENSE").read_bytes()).hexdigest()

--- a/opennow-qt/tests/test_signed_nightly_release.py
+++ b/opennow-qt/tests/test_signed_nightly_release.py
@@ -1,0 +1,202 @@
+import base64
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packaging"))
+from nightly_release import assemble, expected_packages
+from sign_nightly_release import decode_key, digest, sign, verify
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SignedNightlyReleaseTest(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+        self.version = "1.0.0-nightly.123.2"
+        self.commit = "a" * 40
+        self.packages = expected_packages(self.version, self.commit)
+        raw = self.root / "raw"
+        raw.mkdir()
+        for name in self.packages:
+            (raw / name).write_bytes(f"test package {name}".encode())
+        self.source = self.root / "unsigned"
+        self.destination = self.root / "signed"
+        assemble(raw, self.source, self.version, self.commit)
+        self.seed = base64.b64encode(os.urandom(32)).decode()
+        key = self.root / "test-private.der"
+        key.write_bytes(bytes.fromhex("302e020100300506032b657004220420") + base64.b64decode(self.seed))
+        public = subprocess.check_output([
+            "openssl", "pkey", "-inform", "DER", "-in", str(key), "-pubout", "-outform", "DER"])
+        self.public = base64.b64encode(public[-32:]).decode()
+        key.unlink()
+
+    def sign(self):
+        sign(self.source, self.destination, self.version, self.commit, self.public, self.seed)
+
+    def verify(self):
+        verify(self.destination, self.version, self.commit, self.public)
+
+    def rehash(self, directory):
+        (directory / "SHA256SUMS").write_text("".join(
+            f"{digest(path)}  {path.name}\n" for path in sorted(directory.iterdir())
+            if path.name != "SHA256SUMS"))
+
+    def test_signs_and_verifies_every_exact_package_without_changing_bytes(self):
+        self.sign()
+        self.verify()
+        self.assertEqual(len(list(self.destination.iterdir())), 20)
+        self.assertEqual(len((self.destination / "SHA256SUMS").read_text().splitlines()), 19)
+        info = json.loads((self.destination / "RELEASE-INFO.json").read_text())
+        self.assertEqual(info["updates"], "signed-manifest")
+        self.assertEqual(info["platformSigning"], "unsigned")
+        for name in self.packages:
+            self.assertEqual((self.source / name).read_bytes(), (self.destination / name).read_bytes())
+            manifest = json.loads((self.destination / (name + ".manifest.json")).read_text())
+            self.assertEqual(manifest["asset"], name)
+            self.assertEqual(manifest["version"], self.version)
+
+    def test_mismatched_seed_never_exposes_a_final_inventory(self):
+        self.seed = base64.b64encode(os.urandom(32)).decode()
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            self.sign()
+        self.assertFalse(self.destination.exists())
+
+    def test_each_package_is_required_before_signing(self):
+        for name in self.packages:
+            with self.subTest(name=name):
+                package = self.source / name
+                content = package.read_bytes()
+                package.unlink()
+                with self.assertRaisesRegex(ValueError, "inventory entry"):
+                    self.sign()
+                self.assertFalse(self.destination.exists())
+                package.write_bytes(content)
+
+    def test_rejects_extra_package_validation_zip_and_symbolic_link(self):
+        for name in ("unexpected.zip", f"OpenNOW-Qt-{self.version}-Darwin-arm64.zip"):
+            extra = self.source / name
+            extra.write_bytes(b"not public")
+            with self.assertRaises(ValueError):
+                self.sign()
+            extra.unlink()
+        package = self.source / next(iter(self.packages))
+        package.unlink()
+        package.symlink_to(self.source / "RELEASE-INFO.json")
+        with self.assertRaises(ValueError):
+            self.sign()
+
+    def test_source_commit_and_package_hash_are_immutable(self):
+        self.commit = "b" * 40
+        with self.assertRaisesRegex(ValueError, "immutable package inventory"):
+            self.sign()
+        self.commit = "a" * 40
+        (self.source / next(iter(self.packages))).write_bytes(b"changed")
+        with self.assertRaisesRegex(ValueError, "immutable package inventory"):
+            self.sign()
+
+    def test_rejects_incomplete_or_duplicate_checksums(self):
+        sums = self.source / "SHA256SUMS"
+        lines = sums.read_text().splitlines(keepends=True)
+        for changed in (lines[:-1], lines + lines[:1]):
+            sums.write_text("".join(changed))
+            with self.assertRaisesRegex(ValueError, "SHA256SUMS"):
+                self.sign()
+
+    def test_rejects_rehashed_manifest_tampering_and_wrong_public_key(self):
+        self.sign()
+        public = self.public
+        self.public = base64.b64encode(os.urandom(32)).decode()
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.verify()
+        self.public = public
+        manifest_path = next(self.destination.glob("*.manifest.json"))
+        manifest = json.loads(manifest_path.read_text())
+        manifest["signature"] = base64.b64encode(bytes(64)).decode()
+        manifest_path.write_text(json.dumps(manifest))
+        self.rehash(self.destination)
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.verify()
+
+    def test_rejects_wrong_manifest_identity_even_with_matching_checksums(self):
+        self.sign()
+        manifest_path = next(self.destination.glob("*.manifest.json"))
+        manifest = json.loads(manifest_path.read_text())
+        manifest["asset"] = "different.zip"
+        manifest_path.write_text(json.dumps(manifest))
+        self.rehash(self.destination)
+        with self.assertRaisesRegex(ValueError, "exact package"):
+            self.verify()
+
+    def test_preflight_requires_canonical_key_only_for_publication(self):
+        script = ROOT / "opennow-qt/packaging/sign_nightly_release.py"
+        for key, publish, success in (("", "false", True), ("", "true", False),
+                                      (self.public, "true", True), ("invalid", "false", False),
+                                      (self.public + "\n", "true", False),
+                                      (base64.b64encode(bytes(31)).decode(), "true", False)):
+            with self.subTest(key_length=len(key), publish=publish):
+                result = subprocess.run([sys.executable, str(script), "preflight"],
+                                        env={**os.environ, "OPENNOW_UPDATE_PUBLIC_KEY": key,
+                                             "PUBLISH_NIGHTLY": publish}, capture_output=True)
+                self.assertEqual(result.returncode == 0, success)
+        with self.assertRaises(ValueError):
+            decode_key(self.public[:-1])
+
+    def test_private_seed_is_not_inherited_by_tools_or_written_to_logs(self):
+        tools = self.root / "tools"
+        tools.mkdir()
+        wrapper = tools / "openssl"
+        real_openssl = shutil.which("openssl")
+        self.assertIsNotNone(real_openssl)
+        wrapper.write_text(
+            f"#!{sys.executable}\nimport os, sys\n"
+            "assert 'OPENNOW_UPDATE_ED25519_PRIVATE_KEY' not in os.environ\n"
+            f"os.execv({real_openssl!r}, [{real_openssl!r}, *sys.argv[1:]])\n")
+        wrapper.chmod(0o700)
+        result = subprocess.run([
+            sys.executable, str(ROOT / "opennow-qt/packaging/sign_nightly_release.py"), "sign",
+            "--source", str(self.source), "--destination", str(self.destination),
+            "--version", self.version, "--commit", self.commit,
+        ], env={**os.environ, "PATH": str(tools) + os.pathsep + os.environ["PATH"],
+                "OPENNOW_UPDATE_PUBLIC_KEY": self.public,
+                "OPENNOW_UPDATE_ED25519_PRIVATE_KEY": self.seed}, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertNotIn(self.seed, result.stdout + result.stderr)
+        self.verify()
+
+    def test_workflow_secret_is_isolated_and_publication_uses_only_signed_set(self):
+        workflow = (ROOT / ".github/workflows/qt-ci.yml").read_text()
+        signer = workflow.split("  sign-nightly:\n", 1)[1].split("  publish-nightly:\n", 1)[0]
+        publisher = workflow.split("  publish-nightly:\n", 1)[1]
+        self.assertIn("runs-on: [self-hosted, opennow-release-signer]", signer)
+        self.assertIn("environment: qt-update-signing", signer)
+        self.assertIn("needs: [preflight, contracts, checks, build]", signer)
+        self.assertIn("ref: ${{ github.sha }}", signer)
+        self.assertIn("persist-credentials: false", signer)
+        self.assertEqual(workflow.count("secrets.OPENNOW_UPDATE_ED25519_PRIVATE_KEY"), 1)
+        self.assertNotIn("OPENNOW_UPDATE_ED25519_PRIVATE_KEY", publisher)
+        self.assertNotIn("complete-unsigned", publisher)
+        self.assertIn("complete-update-signed", publisher)
+        self.assertIn("sign_nightly_release.py verify", publisher)
+        for forbidden in ("cargo ", "cmake ", "unsigned-release/", "signed-release/"):
+            self.assertNotIn("run: " + forbidden, signer)
+        self.assertIn("update_public_key: ${{ inputs.public_key }}", workflow)
+        self.assertIn("**Known issue: Alliance Partners are not working correctly in this build.**", publisher)
+        preflight = workflow.split("  preflight:\n", 1)[1].split("  contracts:\n", 1)[0]
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", preflight)
+        outside_signer = workflow.replace(signer, "")
+        self.assertNotIn("OPENNOW_UPDATE_ED25519_PRIVATE_KEY", outside_signer)
+        for path in (ROOT / ".github/workflows/qt-build.yml", ROOT / ".github/actions/qt-unit-tests/action.yml"):
+            self.assertNotIn("OPENNOW_UPDATE_ED25519_PRIVATE_KEY", path.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opennow-qt/tests/test_supporter_build.py
+++ b/opennow-qt/tests/test_supporter_build.py
@@ -108,7 +108,8 @@ class SupporterBuildTest(unittest.TestCase):
         self.assertIn("--channel \"$BUILD_CHANNEL\"", build)
         self.assertIn("uses: ./.github/workflows/qt-build.yml", ci)
         self.assertIn("if: github.event_name == 'workflow_dispatch' && inputs.publish_nightly", ci)
-        self.assertIn("needs: [contracts, checks, build]", ci)
+        self.assertIn("needs: [preflight, contracts, checks, build]", ci)
+        self.assertIn("needs: [contracts, checks, build, sign-nightly]", ci)
         self.assertIn("gh release create", ci)
 
 

--- a/opennow-qt/tests/test_update_helper_driver.py
+++ b/opennow-qt/tests/test_update_helper_driver.py
@@ -1,0 +1,45 @@
+import subprocess
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from run_update_helper_integration import MANIFEST, build_fixtures
+
+
+class UpdateHelperDriverTest(unittest.TestCase):
+    @patch("run_update_helper_integration.run")
+    def test_fixture_compiler_uses_cargo_host_linker(self, run):
+        environment = {
+            "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER": "C:/Program Files/MSVC/link.exe",
+            "CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER": "C:/Program Files/ARM64/link.exe",
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            build_fixtures(directory, environment)
+            run.assert_called_once_with([
+                "cargo", "build", "--offline", "--manifest-path", str(directory / "Cargo.toml"), "--bins",
+            ], environment)
+
+    @patch("run_update_helper_integration.run")
+    def test_fixture_compiler_keeps_default_without_host_override(self, run):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            build_fixtures(directory, {})
+            self.assertEqual(run.call_args.args[1], {})
+            self.assertEqual((directory / "Cargo.lock").read_bytes(), MANIFEST.with_name("Cargo.lock").read_bytes())
+            manifest = (directory / "Cargo.toml").read_text()
+            self.assertIn('path = "candidate.rs"', manifest)
+            self.assertIn('path = "previous.rs"', manifest)
+            self.assertIn("[dependencies]\nopennow-core = { path = ", manifest)
+
+    @patch("run_update_helper_integration.run")
+    def test_fixture_compiler_propagates_cargo_failures(self, run):
+        run.side_effect = subprocess.CalledProcessError(1, ["cargo", "build"])
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaises(subprocess.CalledProcessError):
+                build_fixtures(Path(temporary), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opennow-qt/tests/test_update_helper_packaging.py
+++ b/opennow-qt/tests/test_update_helper_packaging.py
@@ -1,0 +1,101 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGING = ROOT / "opennow-qt/packaging"
+
+
+class UpdateHelperPackagingTest(unittest.TestCase):
+    def test_windows_static_crt_is_scoped_to_separate_helper_build(self):
+        for target in ("x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"):
+            with self.subTest(target=target), tempfile.TemporaryDirectory() as directory:
+                source = Path(directory)
+                build = source / "build"
+                cargo = source / "cargo-fixture"
+                cargo.write_text(f'''#!{sys.executable}
+import json, os, sys
+from pathlib import Path
+args = sys.argv[1:]
+target_dir = Path(args[args.index("--target-dir") + 1])
+target = args[args.index("--target") + 1]
+artifact = target_dir / target / "release/opennow-update-helper.exe"
+artifact.parent.mkdir(parents=True, exist_ok=True)
+artifact.write_bytes(b"helper deployment fixture")
+(target_dir / "environment.json").write_text(json.dumps({{
+    "RUSTFLAGS": os.environ.get("RUSTFLAGS"),
+    "CARGO_ENCODED_RUSTFLAGS": os.environ.get("CARGO_ENCODED_RUSTFLAGS"),
+}}))
+''')
+                cargo.chmod(0o700)
+                (source / "main.cpp").write_text("int main() { return 0; }\n")
+                (source / "CMakeLists.txt").write_text(f'''cmake_minimum_required(VERSION 3.24)
+project(UpdateHelperContract LANGUAGES CXX)
+add_executable(opennow-qt main.cpp)
+set(WIN32 TRUE)
+set(APPLE FALSE)
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_CURRENT_SOURCE_DIR "{(ROOT / 'opennow-qt').as_posix()}")
+set(OPENNOW_RUST_TARGET "{target}")
+set(CARGO_EXECUTABLE "{cargo.as_posix()}")
+include("{(ROOT / 'opennow-qt/cmake/NativeRuntime.cmake').as_posix()}")
+''')
+                result = subprocess.run(["cmake", "-S", str(source), "-B", str(build),
+                                         "-G", "Unix Makefiles", "-DCMAKE_BUILD_TYPE=Release"],
+                                        capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                helper = (build / "CMakeFiles/opennow-update-helper-build.dir/build.make").read_text()
+                self.assertIn("--unset=CARGO_ENCODED_RUSTFLAGS", helper)
+                self.assertIn("target-feature=+crt-static", helper)
+                self.assertIn(f"--target {target}", helper)
+                self.assertIn(f"update-helper-rust-target/{target}/release/opennow-update-helper.exe", helper)
+                self.assertIn("--bin opennow-update-helper", helper)
+                for name in ("opennow-core", "opennow-streamer-ffi-build", "opennow-streamer-bin-build"):
+                    rule = (build / f"CMakeFiles/{name}.dir/build.make").read_text()
+                    self.assertNotIn("crt-static", rule)
+                    self.assertNotIn("update-helper-rust-target", rule)
+                result = subprocess.run(["cmake", "--build", str(build), "--target", "opennow-update-helper-build"],
+                                        env={**os.environ, "RUSTFLAGS": "parent-flags",
+                                             "CARGO_ENCODED_RUSTFLAGS": "encoded-parent-flags"},
+                                        capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertEqual(json.loads((build / "update-helper-rust-target/environment.json").read_text()), {
+                    "RUSTFLAGS": "-C target-feature=+crt-static", "CARGO_ENCODED_RUSTFLAGS": None,
+                })
+                self.assertEqual((build / "opennow-update-helper.exe").read_bytes(), b"helper deployment fixture")
+
+    def test_windows_authoritative_list_drives_installation_and_both_package_checks(self):
+        names = (PACKAGING / "windows-release-binaries.txt").read_text().splitlines()
+        self.assertEqual(names.count("opennow-update-helper.exe"), 1)
+        install = (PACKAGING / "WindowsReleaseBinaries.cmake").read_text()
+        self.assertIn('file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/windows-release-binaries.txt"', install)
+        self.assertIn('"$<TARGET_FILE_DIR:opennow-qt>/${OPENNOW_WINDOWS_RELEASE_BINARY}"', install)
+        validation = (PACKAGING / "windows-release.ps1").read_text()
+        self.assertIn('Get-Content (Join-Path $PSScriptRoot "windows-release-binaries.txt")', validation)
+        self.assertIn('Assert-OpenNowStandaloneUpdateHelper -Path $matches[0].FullName', validation)
+        self.assertIn('dumpbin /dependents $Path', validation)
+        for function in ("Assert-OpenNowSignedPackage", "Assert-OpenNowPackagePayload"):
+            body = validation.split(f"function {function} {{", 1)[1].split("\nfunction ", 1)[0]
+            self.assertIn("Get-OpenNowReleaseBinaries -Root $Root", body)
+            self.assertIn("Get-FileHash $file.FullName -Algorithm SHA256", body)
+        workflow = (ROOT / ".github/workflows/qt-build.yml").read_text()
+        for root in ("$msiExpanded", "$zipExpanded"):
+            self.assertIn(f"Assert-OpenNowPackagePayload -Root {root}", workflow)
+        candidate = (ROOT / ".github/workflows/qt-release-candidate.yml").read_text()
+        self.assertEqual(candidate.count("Assert-OpenNowSignedPackage -Root"), 2)
+
+    def test_final_macos_dmg_validates_helper_architecture_and_dependencies(self):
+        workflow = (ROOT / ".github/workflows/qt-build.yml").read_text()
+        validation = workflow.split("      - name: Test relocated bundle without development libraries", 1)[1]
+        self.assertIn('for app in "$zip_app" "$RUNNER_TEMP/dmg-relocated/OpenNOW.app"; do', validation)
+        self.assertIn("opennow-acceptance-verify opennow-update-helper opennow-streamer; do", validation)
+        self.assertIn('"opennow-update-helper", "opennow-streamer", "libopennow_streamer_ffi.dylib"', validation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opennow-qt/tests/test_windows_helper_dependencies.ps1
+++ b/opennow-qt/tests/test_windows_helper_dependencies.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = "Stop"
+. "$PSScriptRoot/../packaging/windows-release.ps1"
+
+$script:dumpbinExitCode = 0
+$script:dependencies = @("    KERNEL32.dll", "    msi.dll", "    bcryptprimitives.dll")
+function dumpbin {
+    $global:LASTEXITCODE = $script:dumpbinExitCode
+    $script:dependencies
+}
+
+Assert-OpenNowStandaloneUpdateHelper -Path "test-helper.exe"
+foreach ($library in @("VCRUNTIME140.dll", "VCRUNTIME140D.dll", "msvcp140.dll", "ucrtbase.dll",
+                       "api-ms-win-crt-runtime-l1-1-0.dll", "Qt6Core.dll", "unexpected.dll")) {
+    $script:dependencies = @("    KERNEL32.dll", "    $library")
+    $rejected = $false
+    try {
+        Assert-OpenNowStandaloneUpdateHelper -Path "test-helper.exe"
+    } catch {
+        if ($_.Exception.Message -notlike "Update helper must run outside*") { throw }
+        $rejected = $true
+    }
+    if (-not $rejected) { throw "Unexpectedly allowed helper dependency $library" }
+}
+
+$script:dependencies = @("No import table")
+try {
+    Assert-OpenNowStandaloneUpdateHelper -Path "test-helper.exe"
+    throw "Unexpectedly accepted an unparsed import table"
+} catch {
+    if ($_.Exception.Message -ne "No update helper PE dependencies found") { throw }
+}
+
+$script:dumpbinExitCode = 1
+try {
+    Assert-OpenNowStandaloneUpdateHelper -Path "test-helper.exe"
+    throw "Unexpectedly accepted a failing PE inspector"
+} catch {
+    if ($_.Exception.Message -ne "Could not inspect update helper dependencies") { throw }
+}
+
+$global:LASTEXITCODE = 0
+Write-Host "Windows helper system-only PE dependency policy tests passed"

--- a/opennow-qt/tests/test_windows_installer.ps1
+++ b/opennow-qt/tests/test_windows_installer.ps1
@@ -5,6 +5,47 @@ $testNamespace = [Guid]::NewGuid().ToString()
 $metadata = (Resolve-Path "$PSScriptRoot/../cmake/BuildMetadata.cmake").Path.Replace('\', '/')
 $policy = (Resolve-Path "$PSScriptRoot/../cmake/WindowsInstaller.cmake").Path.Replace('\', '/')
 
+function Assert-Registration {
+    param([string]$Package, [string]$Destination)
+
+    $installer = New-Object -ComObject WindowsInstaller.Installer
+    $objects = [Collections.Generic.List[object]]::new()
+    $objects.Add($installer)
+    try {
+        $database = $installer.GetType().InvokeMember("OpenDatabase", "InvokeMethod", $null, $installer, @($Package, 0))
+        $objects.Add($database)
+        $properties = @{}
+        foreach ($property in @("ProductCode", "UpgradeCode")) {
+            $view = $database.GetType().InvokeMember("OpenView", "InvokeMethod", $null, $database,
+                @("SELECT ``Value`` FROM ``Property`` WHERE ``Property`` = '$property'"))
+            $objects.Add($view)
+            $view.GetType().InvokeMember("Execute", "InvokeMethod", $null, $view, $null)
+            $record = $view.GetType().InvokeMember("Fetch", "InvokeMethod", $null, $view, $null)
+            $objects.Add($record)
+            $properties[$property] = $record.GetType().InvokeMember("StringData", "GetProperty", $null, $record, @(1))
+            $view.GetType().InvokeMember("Close", "InvokeMethod", $null, $view, $null)
+        }
+        $location = $installer.GetType().InvokeMember("ProductInfo", "GetProperty", $null, $installer,
+            @($properties.ProductCode, "InstallLocation"))
+        if ([string]::IsNullOrWhiteSpace($location) -or
+            [IO.Path]::GetFullPath($location).TrimEnd('\') -ne [IO.Path]::GetFullPath($Destination).TrimEnd('\')) {
+            throw "MSI InstallLocation does not match the resolved installation root"
+        }
+        $related = $installer.GetType().InvokeMember("RelatedProducts", "GetProperty", $null, $installer,
+            @($properties.UpgradeCode))
+        $objects.Add($related)
+        $count = $related.GetType().InvokeMember("Count", "GetProperty", $null, $related, $null)
+        if ($count -ne 1) { throw "Expected one registered product after a channel upgrade, found $count" }
+        $product = $related.GetType().InvokeMember("Item", "GetProperty", $null, $related, @(0))
+        if ($product -ne $properties.ProductCode) { throw "The registered product is not the newly installed MSI" }
+    } finally {
+        $objects.Reverse()
+        foreach ($instance in $objects) {
+            [Runtime.InteropServices.Marshal]::FinalReleaseComObject($instance) | Out-Null
+        }
+    }
+}
+
 function Invoke-Installer {
     param([string]$Package, [string]$Destination, [int]$Expected = 0)
 
@@ -18,6 +59,7 @@ function Invoke-Installer {
     if ($Expected -ne 0 -and -not (Select-String -Path $log -SimpleMatch "A later version")) {
         throw "Older MSI failed without the expected downgrade rejection"
     }
+    if ($Expected -eq 0) { Assert-Registration $Package $Destination }
 }
 
 function Assert-Payload {
@@ -73,6 +115,31 @@ include(CPack)
                 Get-Content $_.FullName | Write-Host
             }
             throw "MSI fixture packaging failed"
+        }
+        $propertiesFiles = @(Get-ChildItem "$source/packages" -Recurse -Filter properties.wxi)
+        if ($propertiesFiles.Count -ne 1) { throw "Expected one generated WiX properties include" }
+        $wixDirectory = $propertiesFiles[0].Directory.FullName
+        [xml]$propertiesXml = Get-Content $propertiesFiles[0].FullName -Raw
+        [xml]$fragmentXml = Get-Content (Join-Path $wixDirectory "product_fragment.wxi") -Raw
+        $actionQuery = "//*[local-name()='SetProperty' and @Id='ARPINSTALLLOCATION']"
+        $actions = @($propertiesXml.SelectNodes($actionQuery)) + @($fragmentXml.SelectNodes($actionQuery))
+        if ($actions.Count -ne 1 -or $propertiesXml.SelectNodes($actionQuery).Count -ne 1) {
+            throw "CPack must own exactly one ARPINSTALLLOCATION action"
+        }
+        if ($actions[0].GetAttribute("Value") -ne "[INSTALL_ROOT]" -or
+            $actions[0].GetAttribute("After") -ne "CostFinalize" -or
+            $actions[0].GetAttribute("Sequence") -notin @("", "both", "execute")) {
+            throw "Install-location registration must use the resolved root in the execute sequence"
+        }
+        $installRoot = $propertiesXml.SelectSingleNode("//*[local-name()='Property' and @Id='INSTALL_ROOT']")
+        $previousLocation = $propertiesXml.SelectSingleNode("//*[local-name()='RegistrySearch' and @Id='FindInstallLocation']")
+        if ($null -eq $installRoot -or $installRoot.GetAttribute("Secure") -ne "yes" -or
+            $null -eq $previousLocation -or $previousLocation.ParentNode -ne $installRoot -or
+            $previousLocation.GetAttribute("Root") -ne "HKLM" -or
+            $previousLocation.GetAttribute("Key") -ne 'Software\Microsoft\Windows\CurrentVersion\Uninstall\[WIX_UPGRADE_DETECTED]' -or
+            $previousLocation.GetAttribute("Name") -ne "InstallLocation" -or
+            $previousLocation.GetAttribute("Type") -ne "raw") {
+            throw "CPack must preserve the previous product's registered installation root during upgrades"
         }
         $license = @(Get-ChildItem "$source/packages" -Recurse -Filter License.rtf)
         if ($license.Count -ne 1 -or

--- a/opennow-qt/tests/test_windows_release.ps1
+++ b/opennow-qt/tests/test_windows_release.ps1
@@ -14,9 +14,16 @@ function Assert-Fails {
 
 $script:SignToolExitCode = 0
 $script:Verified = @()
+$script:Inspected = @()
 function signtool {
     $script:Verified += $args[-1]
     & (Join-Path $PSHOME "pwsh") -NoProfile -Command "exit $script:SignToolExitCode"
+}
+
+function dumpbin {
+    $script:Inspected += $args[-1]
+    $global:LASTEXITCODE = 0
+    "    KERNEL32.dll"
 }
 
 $root = Join-Path ([IO.Path]::GetTempPath()) "opennow-package-test-$([Guid]::NewGuid())"
@@ -24,7 +31,7 @@ try {
     $deployment = New-Item -ItemType Directory "$root/deployment"
     $package = New-Item -ItemType Directory "$root/package/bin"
     $names = @(Get-Content "$PSScriptRoot/../packaging/windows-release-binaries.txt")
-    $expected = @("OpenNOW.exe", "opennow-core.exe", "opennow-acceptance-verify.exe", "opennow-streamer.exe", "opennow_streamer_ffi.dll")
+    $expected = @("OpenNOW.exe", "opennow-core.exe", "opennow-acceptance-verify.exe", "opennow-update-helper.exe", "opennow-streamer.exe", "opennow_streamer_ffi.dll")
     if (Compare-Object $names $expected) { throw "Unexpected first-party binary contract" }
     foreach ($name in $names) {
         Set-Content "$deployment/$name" "signed $name"
@@ -32,6 +39,10 @@ try {
     }
     Assert-OpenNowSignedPackage -Root "$root/package" -SignedRoot $deployment
     Assert-OpenNowPackagePayload -Root "$root/package" -DeploymentRoot $deployment
+    if ($script:Inspected.Count -eq 0 -or
+        @($script:Inspected | Where-Object { [IO.Path]::GetFileName($_) -ne "opennow-update-helper.exe" }).Count -ne 0) {
+        throw "Package validation did not inspect the update helper dependencies"
+    }
     foreach ($name in $names) {
         if (-not ($script:Verified | Where-Object { [IO.Path]::GetFileName($_) -eq $name })) {
             throw "$name was not signature-verified"
@@ -93,4 +104,5 @@ include(CPack)
 } finally {
     Remove-Item $root -Recurse -Force
     Remove-Item Function:signtool
+    Remove-Item Function:dumpbin
 }

--- a/opennow-qt/tests/tst_coreclient.cpp
+++ b/opennow-qt/tests/tst_coreclient.cpp
@@ -9,6 +9,7 @@
 #include <QRegularExpression>
 #include <QTemporaryDir>
 #include <QTest>
+#include <algorithm>
 
 namespace {
 QString fakeCorePath()
@@ -63,6 +64,68 @@ private slots:
         qunsetenv("OPENNOW_TEST_GPU_BOOTSTRAP");
         QVERIFY(preference.isEmpty());
         QVERIFY(elapsed.elapsed() < 4'000);
+    }
+
+    void acknowledgesUpdateOnlyAfterUiAndCoreAreReady_data()
+    {
+        QTest::addColumn<bool>("uiFirst");
+        QTest::newRow("ui-first") << true;
+        QTest::newRow("core-first") << false;
+    }
+
+    void acknowledgesUpdateOnlyAfterUiAndCoreAreReady()
+    {
+        QFETCH(bool, uiFirst);
+        qputenv("OPENNOW_UPDATE_PLAN", "/fixture/update/plan.json");
+        qputenv("OPENNOW_UPDATE_NONCE", "fixture-nonce");
+        CoreClient client;
+        QVERIFY(!qEnvironmentVariableIsSet("OPENNOW_UPDATE_PLAN"));
+        QVERIFY(!qEnvironmentVariableIsSet("OPENNOW_UPDATE_NONCE"));
+        QSignalSpy responses(&client, &CoreClient::responseReceived);
+        if (uiFirst) client.markUiReady();
+        QVERIFY(client.start(fakeCorePath()));
+        QTRY_COMPARE_WITH_TIMEOUT(client.state(), QStringLiteral("ready"), 2'000);
+        if (!uiFirst) {
+            responses.clear();
+            const auto id = client.request(QStringLiteral("test.app-context"));
+            QTRY_COMPARE_WITH_TIMEOUT(responses.size(), 1, 2'000);
+            QCOMPARE(responses.first().at(0).toString(), id);
+            const auto context = qvariant_cast<QJsonObject>(responses.first().at(1));
+            QCOMPARE(context.value(QStringLiteral("startupAcknowledgements")).toInt(), 0);
+            QVERIFY(context.value(QStringLiteral("hasUpdateEnvironment")).toBool());
+            client.markUiReady();
+        }
+        QTRY_VERIFY_WITH_TIMEOUT(std::any_of(responses.begin(), responses.end(), [](const auto &response) {
+            return qvariant_cast<QJsonObject>(response.at(1)).value(QStringLiteral("acknowledged")).toBool();
+        }), 2'000);
+        client.stop();
+        QVERIFY(client.start(fakeCorePath()));
+        QTRY_COMPARE_WITH_TIMEOUT(client.state(), QStringLiteral("ready"), 2'000);
+        responses.clear();
+        client.request(QStringLiteral("test.app-context"));
+        QTRY_COMPARE_WITH_TIMEOUT(responses.size(), 1, 2'000);
+        const auto context = qvariant_cast<QJsonObject>(responses.first().at(1));
+        QCOMPARE(context.value(QStringLiteral("startupAcknowledgements")).toInt(), 0);
+        QVERIFY(!context.value(QStringLiteral("hasUpdateEnvironment")).toBool());
+    }
+
+    void passesCanonicalApplicationIdentityToCore()
+    {
+        CoreClient client;
+        client.markUiReady();
+        QSignalSpy responses(&client, &CoreClient::responseReceived);
+        QVERIFY(client.start(fakeCorePath()));
+        QTRY_COMPARE_WITH_TIMEOUT(client.state(), QStringLiteral("ready"), 2'000);
+        responses.clear();
+        const auto id = client.request(QStringLiteral("test.app-context"));
+        QTRY_COMPARE_WITH_TIMEOUT(responses.size(), 1, 2'000);
+        QCOMPARE(responses.first().at(0).toString(), id);
+        const auto context = qvariant_cast<QJsonObject>(responses.first().at(1));
+        QCOMPARE(context.value(QStringLiteral("executable")).toString(),
+                 QFileInfo(QCoreApplication::applicationFilePath()).canonicalFilePath());
+        QCOMPARE(context.value(QStringLiteral("pid")).toString(),
+                 QString::number(QCoreApplication::applicationPid()));
+        QCOMPARE(context.value(QStringLiteral("startupAcknowledgements")).toInt(), 0);
     }
 
     void retriesAdmissionRejectionsWithoutFailingTheCaller()

--- a/opennow-qt/tests/tst_embeddedorchestration.cpp
+++ b/opennow-qt/tests/tst_embeddedorchestration.cpp
@@ -44,6 +44,157 @@ private slots:
         }
     }
 
+    void updaterPollsManagedPendingWithoutRequiringAnotherApplicationRestart()
+    {
+        QJSEngine engine;
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'managed-pending',canCheck:false})")).isError());
+        QVERIFY(engine.evaluate(QStringLiteral("updaterNeedsReconciliation")).toBool());
+        QVERIFY(!engine.evaluate(QStringLiteral("updaterInstallConfirmed")).toBool());
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'failed',canCheck:true})")).isError());
+        QVERIFY(!engine.evaluate(QStringLiteral("updaterNeedsReconciliation")).toBool());
+        QVERIFY(engine.evaluate(QStringLiteral("updaterState.canCheck")).toBool());
+        QCOMPARE(engine.evaluate(QStringLiteral("callbacks.length")).toInt(), 0);
+    }
+
+    void updaterFreshStartupPollsUntilHelperReportsItsOutcome()
+    {
+        QJSEngine engine;
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'restarting',canCheck:false})")).isError());
+        QVERIFY(!engine.evaluate(QStringLiteral("updaterInstallConfirmed")).toBool());
+        QVERIFY(engine.evaluate(QStringLiteral("updaterNeedsReconciliation")).toBool());
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'succeeded',canCheck:true})")).isError());
+        QVERIFY(!engine.evaluate(QStringLiteral("updaterNeedsReconciliation")).toBool());
+        QCOMPARE(engine.evaluate(QStringLiteral("callbacks.length")).toInt(), 0);
+    }
+
+    void updaterReconciliationPreservesRejectedOperationFeedback()
+    {
+        QJSEngine engine;
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            reconcileUpdaterFailure('End your active session first');
+            acceptUpdaterState({status:'downloaded',canInstall:true,canCheck:true});
+        )JS")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("updaterError")).toString(), QStringLiteral("End your active session first"));
+        QVERIFY(!engine.evaluate(QStringLiteral("installUpdate(true)")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("updaterError")).toString(), QString{});
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            reconcileUpdaterFailure('Preparation timed out');
+            acceptUpdaterState({status:'awaiting-exit',exitRequired:true});
+        )JS")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("updaterError")).toString(), QString{});
+    }
+
+    void updaterRequiresConsentAndAuthoritativeExit()
+    {
+        QJSEngine engine;
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(QStringLiteral("installUpdate(); installUpdate(false)")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests.length")).toInt(), 0);
+        QVERIFY(!engine.evaluate(QStringLiteral("installUpdate(true)")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests[0].method")).toString(), QStringLiteral("updater.install"));
+        QVERIFY(engine.evaluate(QStringLiteral("requests[0].params.confirmed")).toBool());
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'preparing',exitRequired:true})")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("callbacks.length")).toInt(), 0);
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'awaiting-exit',exitRequired:false})")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("callbacks.length")).toInt(), 0);
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'awaiting-exit',exitRequired:true}); callbacks.shift()()")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("quits")).toInt(), 1);
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'awaiting-exit',exitRequired:true})")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("callbacks.length")).toInt(), 0);
+        QVERIFY(!engine.evaluate(QStringLiteral("updaterInstallConfirmed = true; acceptUpdaterState({status:'awaiting-exit',exitRequired:true}); activeSession = {sessionId:'new'}; callbacks.shift()()")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("quits")).toInt(), 0);
+    }
+
+    void updaterDefersForSessions_data()
+    {
+        QTest::addColumn<QString>("sessionState");
+        QTest::newRow("active") << QStringLiteral("activeSession = {sessionId:'live'}");
+        QTest::newRow("starting") << QStringLiteral("streamerStartRequestId = 'start'");
+        QTest::newRow("recovering") << QStringLiteral("sessionRecoveryPending = true");
+        QTest::newRow("discovering") << QStringLiteral("activeSessionRequestId = 'discover'");
+        QTest::newRow("queued-launch") << QStringLiteral("pendingLaunchParams = {appId:'1'}");
+        QTest::newRow("streaming") << QStringLiteral("streamerStatus = 'streaming'");
+        QTest::newRow("negotiating-streamer") << QStringLiteral("streamerStatus = 'negotiating'");
+        QTest::newRow("recovering-streamer") << QStringLiteral("streamerStatus = 'recovering'");
+        QTest::newRow("unknown-streamer") << QStringLiteral("streamerStatus = 'unknown'");
+    }
+
+    void updaterDefersForSessions()
+    {
+        QFETCH(QString, sessionState);
+        QJSEngine engine;
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(sessionState).isError());
+        QVERIFY(!engine.evaluate(QStringLiteral("installUpdate(true); runAutomaticUpdates()")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests.length")).toInt(), 0);
+        QVERIFY(!engine.evaluate(QStringLiteral("updaterInstallConfirmed = true; acceptUpdaterState({status:'awaiting-exit',exitRequired:true})")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("callbacks.length")).toInt(), 0);
+    }
+
+    void updaterReconcilesTimeoutWithoutInventingCapabilities()
+    {
+        QJSEngine engine;
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            installUpdate(true);
+            acceptUpdaterState({status:'preparing',canInstall:false,canCheck:false});
+            updaterInstallRequestId = '';
+            reconcileUpdaterFailure('Timed out');
+            installUpdate(true);
+        )JS")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests.length")).toInt(), 2);
+        QCOMPARE(engine.evaluate(QStringLiteral("requests[1].method")).toString(), QStringLiteral("updater.state.get"));
+        QVERIFY(engine.evaluate(QStringLiteral("updaterInstallConfirmed")).toBool());
+        QVERIFY(!engine.evaluate(QStringLiteral("updaterState.canInstall")).toBool());
+        QVERIFY(!engine.evaluate(QStringLiteral("acceptUpdaterState({status:'awaiting-exit',exitRequired:true}); callbacks.shift()()")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("quits")).toInt(), 1);
+
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            installUpdate(true); updaterInstallRequestId = '';
+            reconcileUpdaterFailure('Failed');
+            acceptUpdaterState({status:'failed',canCheck:true,canDownload:false,canInstall:true});
+            installUpdate(true);
+        )JS")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests.length")).toInt(), 3);
+        QCOMPARE(engine.evaluate(QStringLiteral("requests[2].method")).toString(), QStringLiteral("updater.install"));
+        QCOMPARE(engine.evaluate(QStringLiteral("quits")).toInt(), 0);
+    }
+
+    void updaterBackgroundPreferencesAreIndependent()
+    {
+        QJSEngine engine;
+        QVERIFY(initializeUpdaterEngine(engine));
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            settings = {autoCheckForUpdates:false,autoDownloadUpdates:true};
+            updaterState = {status:'available',canCheck:true,canDownload:true,availableVersion:'2'};
+            runAutomaticUpdates();
+        )JS")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests[0].method")).toString(), QStringLiteral("updater.download"));
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            updaterDownloadRequestId = ''; runAutomaticUpdates();
+        )JS")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests.length")).toInt(), 1);
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            settings = {autoCheckForUpdates:true,autoDownloadUpdates:false};
+            runAutomaticUpdates(); updaterCheckRequestId = ''; runAutomaticUpdates();
+        )JS")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests.length")).toInt(), 2);
+        QCOMPARE(engine.evaluate(QStringLiteral("requests[1].method")).toString(), QStringLiteral("updater.check"));
+        const auto shell = source(QStringLiteral("qml/state/ShellStore.qml"));
+        const auto highlights = shell.mid(shell.indexOf(QStringLiteral("else if (name === \"updater.highlights.show\")")));
+        QVERIFY(!highlights.contains(QStringLiteral("AppController.navigate")));
+        for (const auto &path : {"qml/screens/UpdateScreen.qml", "qml/desktop/updates/DesktopUpdateScreen.qml"}) {
+            const auto screen = source(QString::fromLatin1(path));
+            QVERIFY(screen.contains(QStringLiteral("onAccepted: ShellStore.installUpdate(true)")));
+            QVERIFY(screen.contains(QStringLiteral("onClicked: installConfirmation.open()")));
+        }
+    }
+
     void premiumGamesRequirePaidMembershipBeforeLaunch_data()
     {
         QTest::addColumn<QString>("requiredTier");
@@ -712,6 +863,43 @@ private slots:
             "if (!m_captureActive || m_relativeMouse)")));
         QVERIFY(implementation.contains(QStringLiteral(
             "submitAbsoluteMouse(event->position());")));
+    }
+private:
+    static bool initializeUpdaterEngine(QJSEngine &engine)
+    {
+        engine.installExtensions(QJSEngine::TranslationExtension);
+        const auto shell = source(QStringLiteral("qml/state/ShellStore.qml"));
+        const auto setup = engine.evaluate(QStringLiteral(R"JS(
+            var ready = true, activeSession = null, streamBusy = false, sessionRecoveryPending = false;
+            var activeSessionRequestId = '', sessionClaimRequestId = '', streamCreateRequestId = '';
+            var streamerStartRequestId = '', streamerPrepareRequestId = '', streamerStopRequestId = '';
+            var pendingLaunchParams = null, pendingDirectLaunch = null, streamState = 'idle', streamerStatus = 'stopped';
+            var updaterCheckRequestId = '', updaterDownloadRequestId = '', updaterInstallRequestId = '', updaterStateRequestId = '';
+            var updaterError = '', accessibilityMessage = '', updaterInstallConfirmed = false, updaterExitScheduled = false, updaterReconciling = false;
+            var lastAutoUpdateCheckMs = 0, autoDownloadAttempt = '';
+            var updaterState = {status:'downloaded',canInstall:true,canCheck:true};
+            var settings = {autoCheckForUpdates:true,autoDownloadUpdates:true};
+            var requests = [], callbacks = [], quits = 0;
+            var CoreClient = {request:function(method,params) { requests.push({method:method,params:params}); return 'request-' + requests.length; }};
+            var AppController = {quitApplication:function() { ++quits; }};
+            var Qt = {callLater:function(callback) { callbacks.push(callback); }};
+        )JS"));
+        if (setup.isError()) return false;
+        for (const auto *name : {"updaterSessionSafe", "updaterBusy", "updaterCanInstall", "updaterNeedsReconciliation"}) {
+            const auto match = QRegularExpression(QStringLiteral(
+                "    readonly property bool %1: (.*?)(?=\\n    (?:property|readonly|on[A-Z]))").arg(QString::fromLatin1(name)),
+                QRegularExpression::DotMatchesEverythingOption).match(shell);
+            if (!match.hasMatch()) return false;
+            if (engine.evaluate(QStringLiteral("Object.defineProperty(this,'%1',{configurable:true,get:function(){return %2;}})")
+                    .arg(QString::fromLatin1(name), match.captured(1))).isError()) return false;
+        }
+        for (const auto *name : {"installUpdate", "acceptUpdaterState", "refreshUpdaterState", "reconcileUpdaterFailure", "runAutomaticUpdates", "checkForUpdates", "downloadUpdate"}) {
+            const auto match = QRegularExpression(QStringLiteral(
+                "    function %1\\([^\\n]*\\) \\{.*?\\n    \\}").arg(QString::fromLatin1(name)),
+                QRegularExpression::DotMatchesEverythingOption).match(shell);
+            if (!match.hasMatch() || engine.evaluate(match.captured()).isError()) return false;
+        }
+        return true;
     }
 };
 


### PR DESCRIPTION
Stacked on #887. Adds confirmed in-place updates to the Qt/native application, including Windows portable copies and macOS app bundles.

## Apply and recover

- A separately deployed native helper independently verifies the pinned Ed25519 signature and package, prepares bounded replacements, waits for the identified app/core processes to exit, and applies complete portable-directory, macOS bundle, or AppImage updates.
- Restart success requires acknowledgement from the initialized Qt application and core. Failed unmanaged replacements/startups restore the previous installation; native MSI/DEB transactions report their actual outcomes without claiming filesystem rollback for committed package-manager changes.
- Preserve portable user data and permissions, validate archive/bundle paths and processor identity, and keep the helper outside the installation being replaced. FAT/exFAT portable installations fail before shutdown because private ACL-backed staging is required.

## Consent and release trust

- Require explicit installation confirmation and no active or recovering session. Automatic downloads are independently opt-in; periodic checks and downloads defer during gameplay. Reconcile late RPC/helper outcomes and retain verified downloads and retry capabilities.
- Fresh nightly profiles default to the nightly channel without overwriting saved choices. Background release notes no longer navigate away from gameplay.
- Public nightly publication now requires a pinned public key and a protected isolated signer. Verify and sign all nine packages, then independently verify the final 20-file release inventory before publication. No-key artifact-only builds remain available. Preserve the Alliance Partners warning.

## Verification

[Artifact-only run 34588708205](https://github.com/OpenCloudGaming/OpenNOW/actions/runs/34588708205) and [PR workflow 34588653095](https://github.com/OpenCloudGaming/OpenNOW/actions/runs/34588653095) passed on current head `283ab0ca`, with no failing, pending or cancelled current checks. Signing and publication were intentionally skipped. The complete nine-package artifact is `opennow-qt-1.0.0-nightly.449.1-complete-unsigned` (artifact ID `10195145286`). The stack includes dev `fb810667`, retaining GPU selection and updater startup tests.

- All four signed helper integration cases passed natively on Windows x64, macOS ARM64 and Linux x64: verified replacement with candidate self-acknowledgement, failed-startup rollback, wrong package/bundle identity rejection, and tamper rejection. These use native test packages and executable fixtures.
- Windows x64/ARM64 MSI and ZIP builds passed payload and standalone-helper dependency checks. Real x64 MSI fixture tests passed run/retry/downgrade, stable isolation and launcher checks. macOS DMG and validation ZIP passed final ad-hoc-seal and relocated-bundle checks. Linux x64/ARM64 packages and AppImage smoke checks passed. The complete nine-package unsigned inventory passed checksum verification.
- Local checks passed 264 Rust tests, all-target Clippy with warnings denied, all four signed helper integrations, 65 Qt orchestration cases, 25 CoreClient cases, seven graphics-device-selection cases, 108 Python contracts and actionlint. The local full Qt configure was blocked by Qt 6.4.2; supported-version CI passed the full 23-test Linux/macOS and 22-test Windows CTest suites, plus the native Rust, packaging and localization checks.

Both review issues are resolved. No actual Windows reboot or full live managed-package updater transaction was performed; native MSI fixture coverage does not claim that broader end-to-end validation.

Public activation still requires the production environment, isolated runner and key setup in `docs/update-signing-setup.md`. Existing no-key nightlies need one manual upgrade. This PR has not published a release, and ad-hoc macOS signing is not Developer ID signing or notarization.

## Qt verification fixtures

![Confirmed installation and restart](https://api-nightly.capy.ai/pr-assets/_gNIz4K-hu5JDMIxgtGVGoMT6mKkpzpCLqgN17uyFqw)

![Independent automatic update preferences](https://api-nightly.capy.ai/pr-assets/ZBga-GdBOhK6Rt9-Vs5WFVNe-ZKuKAZReI3YIjmL-4g)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M269PQTAPJFEBTJKTM5AAEZ0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->