### PR TITLE
fix(streamer): prevent duplicate ICE replies from inflating ping

### DIFF
--- a/native/opennow-streamer/README.md
+++ b/native/opennow-streamer/README.md
@@ -184,6 +184,11 @@ message integrity. Each receiver tracks at most 64 probes. ICE statistics only r
 the sample when the pair's response count changes; rereading old statistics cannot keep
 an old measurement alive.
 
+The bundle remembers up to 64 emitted ICE transactions and forwards each authenticated
+success response to the ICE library only once. Delayed duplicate replies must not overwrite
+the original completion time and turn the age of an old probe into the displayed network RTT.
+This does not cap genuine network latency or filter first replies based on their timing.
+
 Session liveness follows [OpenNOW-Mac's live-tested keepalive method](https://github.com/OpenCloudGaming/OpenNOW-Mac/blob/90627114383501dd18ef165baa005d9ea603fdf3/GFN/NVST/Rtsp/NvstRtspConnection.swift#L161-L234):
 send `GET_PARAMETER` with the RTSP Session header every two seconds over the existing
 RTSPS WebSocket, and match the response. A `551 Option Not Supported` response

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -87,6 +87,51 @@ struct StreamPingTracker {
     pending: VecDeque<([u8; 12], Instant)>,
 }
 
+#[derive(Default)]
+struct IceResponseTracker {
+    requests: VecDeque<([u8; 12], bool)>,
+}
+
+impl IceResponseTracker {
+    fn sent(&mut self, packet: &[u8]) {
+        if !looks_like_stun(packet) || packet[..2] != STUN_BINDING_REQUEST.to_be_bytes() {
+            return;
+        }
+        let transaction_id = packet[8..20].try_into().expect("STUN header checked");
+        if self.requests.iter().any(|(id, _)| *id == transaction_id) {
+            return;
+        }
+        if self.requests.len() == MAX_PENDING_STREAM_PINGS {
+            self.requests.pop_front();
+        }
+        self.requests.push_back((transaction_id, false));
+    }
+
+    fn accept(&mut self, packet: &[u8], remote_password: &str) -> bool {
+        if !looks_like_stun(packet)
+            || packet[..2] != STUN_BINDING_SUCCESS_RESPONSE.to_be_bytes()
+            || STUN_HEADER_LEN + usize::from(u16::from_be_bytes([packet[2], packet[3]]))
+                != packet.len()
+        {
+            return true;
+        }
+        let Some((_, completed)) = self
+            .requests
+            .iter_mut()
+            .find(|(id, _)| id.as_slice() == &packet[8..20])
+        else {
+            return true;
+        };
+        if !valid_stun_message_integrity(packet, remote_password.as_bytes())
+            || (find_stun_attribute(packet, STUN_ATTR_FINGERPRINT).is_some()
+                && !valid_stun_fingerprint(packet))
+        {
+            return true;
+        }
+        !std::mem::replace(completed, true)
+    }
+}
+
 impl StreamPingTracker {
     fn sent(&mut self, transaction_id: [u8; 12], now: Instant) {
         self.pending
@@ -5202,6 +5247,7 @@ fn run_nvst_webrtc_bundle(
     let mut outbound_datagrams = 0_u64;
     let mut hole_punch_pings = 0_u64;
     let mut ping_tracker = StreamPingTracker::default();
+    let mut ice_responses = IceResponseTracker::default();
     let mut ice_ping_responses = 0;
     let mut last_hole_punch = Instant::now() - PING_INTERVAL_BEFORE_CONNECTION;
     let mut seen_ssrcs = HashSet::new();
@@ -5666,6 +5712,7 @@ fn run_nvst_webrtc_bundle(
                         forward_optional(&event_sender, receiver.stop());
                         return;
                     }
+                    ice_responses.sent(&transmit.contents);
                     // Official ICE-on WebRtcTransport skips setupDtls until a real
                     // inbound STUN. Do not synthesize Binding Success — that only
                     // unblocks str0m and sends ClientHello before GFN has a pair.
@@ -6011,6 +6058,11 @@ fn run_nvst_webrtc_bundle(
                             continue;
                         }
                     };
+                    if let Some(credentials) = stun_credentials.as_ref()
+                        && !ice_responses.accept(&datagram[..length], &credentials.remote_password)
+                    {
+                        continue;
+                    }
                     if let Err(error) = rtc.handle_input(Input::Receive(
                         Instant::now(),
                         Receive {

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
@@ -1,5 +1,174 @@
 use super::*;
 
+#[test]
+fn selected_ice_ping_does_not_count_duplicate_replies_as_new_round_trips() {
+    let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut rtc = create_nvst_bundle_rtc(&socket).unwrap();
+    let local: SocketAddr = "192.0.2.1:1000".parse().unwrap();
+    let remote: SocketAddr = "192.0.2.2:2000".parse().unwrap();
+    let credentials = stun_credentials();
+    rtc.add_local_candidate(Candidate::host(local, "udp").unwrap());
+    rtc.add_remote_candidate(Candidate::host(remote, "udp").unwrap());
+    rtc.direct_api().set_remote_ice_credentials(IceCreds {
+        ufrag: credentials.remote_username_fragment.clone(),
+        pass: credentials.remote_password.clone(),
+    });
+    rtc.direct_api().set_ice_controlling(true);
+    let feedback = NvstFeedbackState::default();
+    let mut previous_responses = 0;
+    let start = Instant::now();
+    let mut last_response = None;
+    let mut samples = Vec::new();
+    let mut ice_responses = IceResponseTracker::default();
+
+    for tick in 0..=350 {
+        let now = start + Duration::from_millis(tick * 10);
+        rtc.handle_input(Input::Timeout(now)).unwrap();
+        loop {
+            match rtc.poll_output().unwrap() {
+                Output::Timeout(_) => break,
+                Output::Transmit(packet)
+                    if packet.contents.get(..2) == Some(&STUN_BINDING_REQUEST.to_be_bytes()) =>
+                {
+                    ice_responses.sent(&packet.contents);
+                    if tick >= 50 {
+                        continue;
+                    }
+                    let transaction_id = packet.contents[8..20].try_into().unwrap();
+                    let response = synthesize_ice_binding_success(
+                        &transaction_id,
+                        local,
+                        &credentials.remote_password,
+                    );
+                    assert!(ice_responses.accept(&response, &credentials.remote_password));
+                    rtc.handle_input(Input::Receive(
+                        now + Duration::from_millis(5),
+                        Receive {
+                            proto: RtcProtocol::Udp,
+                            source: remote,
+                            destination: local,
+                            contents: response.as_slice().try_into().unwrap(),
+                        },
+                    ))
+                    .unwrap();
+                    last_response = Some(response);
+                }
+                Output::Event(Event::PeerStats(stats)) => {
+                    feedback.update_ice_ping(
+                        stats.selected_candidate_pair.as_ref(),
+                        &mut previous_responses,
+                        now,
+                    );
+                    if let Some(sample) = feedback.ping_ms(now) {
+                        samples.push(sample);
+                    }
+                }
+                _ => {}
+            }
+        }
+        if tick == 100 || tick == 200 {
+            let response = last_response.as_ref().unwrap();
+            if !ice_responses.accept(response, &credentials.remote_password) {
+                continue;
+            }
+            rtc.handle_input(Input::Receive(
+                now,
+                Receive {
+                    proto: RtcProtocol::Udp,
+                    source: remote,
+                    destination: local,
+                    contents: response.as_slice().try_into().unwrap(),
+                },
+            ))
+            .unwrap();
+        }
+    }
+    assert_eq!(samples.len(), 3);
+    assert!(samples.iter().all(|sample| *sample <= 5.0), "{samples:?}");
+}
+
+#[test]
+fn ice_response_tracking_ignores_only_authenticated_duplicates_of_sent_requests() {
+    let credentials = stun_credentials();
+    let request = build_stun_binding_request(&credentials, &[1; 12]);
+    let response = success([1; 12]);
+    let mut tracker = IceResponseTracker::default();
+    assert!(tracker.accept(&response, &credentials.remote_password));
+    tracker.sent(&request);
+    let invalid_integrity = build_authenticated_stun_packet(
+        STUN_BINDING_SUCCESS_RESPONSE,
+        &[1; 12],
+        b"wrong-password",
+        &[],
+    );
+    let mut invalid_fingerprint = response.clone();
+    *invalid_fingerprint.last_mut().unwrap() ^= 1;
+    for packet in [vec![], request.clone(), invalid_integrity, invalid_fingerprint] {
+        assert!(tracker.accept(&packet, &credentials.remote_password));
+        assert!(!tracker.requests.front().unwrap().1);
+    }
+    assert!(tracker.accept(&response, &credentials.remote_password));
+    assert!(!tracker.accept(&response, &credentials.remote_password));
+    tracker.sent(&request);
+    assert!(!tracker.accept(&response, &credentials.remote_password));
+    assert_eq!(tracker.requests.len(), 1);
+    assert!(tracker.accept(&success([2; 12]), &credentials.remote_password));
+}
+
+#[test]
+fn ice_response_tracking_handles_optional_fingerprints_and_resets_per_session() {
+    let credentials = stun_credentials();
+    let mut tracker = IceResponseTracker::default();
+    tracker.sent(&build_stun_binding_request(&credentials, &[1; 12]));
+    let mut response = success([1; 12]);
+    response.truncate(response.len() - 8);
+    let length = (response.len() - STUN_HEADER_LEN) as u16;
+    response[2..4].copy_from_slice(&length.to_be_bytes());
+    assert!(tracker.accept(&response, &credentials.remote_password));
+    assert!(!tracker.accept(&response, &credentials.remote_password));
+    let mut restarted = IceResponseTracker::default();
+    restarted.sent(&build_stun_binding_request(&credentials, &[1; 12]));
+    assert!(restarted.accept(&response, &credentials.remote_password));
+}
+
+#[test]
+fn ice_response_tracking_is_bounded_without_tracking_non_ice_traffic() {
+    let credentials = stun_credentials();
+    let mut tracker = IceResponseTracker::default();
+    for packet in [vec![], b"PING".to_vec(), success([0; 12])] {
+        tracker.sent(&packet);
+    }
+    assert!(tracker.requests.is_empty());
+    for id in 0..=MAX_PENDING_STREAM_PINGS {
+        tracker.sent(&build_stun_binding_request(&credentials, &[id as u8; 12]));
+    }
+    assert_eq!(tracker.requests.len(), MAX_PENDING_STREAM_PINGS);
+    assert_eq!(tracker.requests.front().unwrap().0, [1; 12]);
+    assert!(tracker.accept(&success([1; 12]), &credentials.remote_password));
+    assert!(!tracker.accept(&success([1; 12]), &credentials.remote_password));
+}
+
+#[test]
+fn ice_response_tracking_preserves_reordering_and_genuinely_slow_first_replies() {
+    let credentials = stun_credentials();
+    let mut ice_responses = IceResponseTracker::default();
+    let mut ping = StreamPingTracker::default();
+    let start = Instant::now();
+    for id in [1, 2] {
+        ice_responses.sent(&build_stun_binding_request(&credentials, &[id; 12]));
+        ping.sent([id; 12], start);
+    }
+    for (id, elapsed) in [(2, Duration::from_millis(5)), (1, Duration::from_secs(2))] {
+        let response = success([id; 12]);
+        assert!(ice_responses.accept(&response, &credentials.remote_password));
+        assert_eq!(
+            ping.receive(&response, peer(), &credentials, start + elapsed),
+            Some(elapsed)
+        );
+        assert!(!ice_responses.accept(&response, &credentials.remote_password));
+    }
+}
+
 fn success(transaction_id: [u8; 12]) -> Vec<u8> {
     build_authenticated_stun_packet(
         STUN_BINDING_SUCCESS_RESPONSE,


### PR DESCRIPTION
The current ICE dependency records repeated Binding Success responses as new completions of the original transaction. A deterministic test against the real `Rtc` reproduces a 995 ms ping after replaying a reply on a simulated 0–5 ms connection.

Track the last 64 ICE requests actually emitted by the bundle and pass each authenticated success response to the ICE library once. Validate integrity and any supplied fingerprint before recording completion, so an invalid packet cannot consume a request. The tracker is local to the receiver and resets with the session. Unrelated traffic and first replies remain unchanged, including genuinely slow first replies; there is no latency cap or smoothing.

Add regression coverage for real ICE statistics after one- and two-second replays, authentication, optional fingerprints, retransmission, reordering, bounded state, session reset, and genuine two-second first replies. Document the measurement behavior. Existing network source selection, Qt presentation, and keepalives remain unchanged.

Validation on Linux:
- Native streamer workspace: 595 passed, 9 ignored, 0 failed.
- Transport crate: 166 passed.
- Transport Clippy with all targets and warnings denied: passed.
- Workspace formatting and `git diff --check`: passed.

Live GFN gameplay was not verified. The duplicate-response defect is reproduced, but no capture from the reported session is available to confirm it as the cause of that session's high readings.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M28B10G281JFBWSCB3Q65WGH"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->