### PR TITLE
fix(streamer): separate bundle and video NAT routing identities

### DIFF
--- a/docs/native-streamer-no-video.md
+++ b/docs/native-streamer-no-video.md
@@ -90,6 +90,45 @@ in the same session. Denying access must still produce a bounded timeout.
 After playback starts, a video delivery failure should still enter recovery
 after eight seconds rather than receiving another startup allowance.
 
+## Separate bundle and video NATT identities
+
+The 2026-09-11 Pi 5 capture from `1.0.0-nightly.413.1` completed PLAY,
+DTLS, SCTP, and audio reception. The video socket received zero datagrams
+through both eight-second timeouts. The advertised video port range was already
+preserved, so the earlier port-range correction does not explain this capture.
+
+The Rust bundle worker sent the raw VIDEO SETUP `X-Nv-Ping-Payload` in its
+authenticated NATT keepalive, just like the separate video worker. Both sockets
+therefore advertised the video identity to the server. This violates the role
+separation in the Mac reference:
+
+- [The production Mac bundle](https://github.com/OpenCloudGaming/openNOW-Mac/blob/f95fde8ed79cedd8f7e4333e195ecfd7a701a04b/OPN/Stream/NvstWebRtcBundle.swift#L10-L15)
+  uses the incremented remote ICE identity, while video uses the raw SETUP payload.
+- [The Mac bundle probe](https://github.com/OpenCloudGaming/openNOW-Mac/blob/f95fde8ed79cedd8f7e4333e195ecfd7a701a04b/GFN/NVST/BifrostFree/NvstBundleIceProbe.swift#L137-L155)
+  sends the additional NATT keepalive as `PING:<localUfrag>`, never as the video
+  payload. This is an authenticated STUN request, not a plaintext `PING` datagram.
+
+Rust now uses `PING` for the bundle NATT identity. Its bundle ICE identity,
+video SETUP payload, authentication, negotiated endpoints, and timeout policy
+remain unchanged. Startup diagnostics report the payload length for each role.
+The Android branch at `d8e509e64818` contains the same duplicate-identity behavior,
+so it is not an independent reference for this part of the protocol.
+
+The `bundle_keepalives_do_not_claim_the_video_routing_identity` regression test
+runs both real UDP workers against one loopback server endpoint. It checks
+repeated authenticated probes from each socket and delivery of an authenticated
+video frame. It fails before the correction because the bundle claims the video
+identity. This proves the wire correction, not a server-side routing overwrite
+or recovery on the affected Pi and Windows machines. A fresh-session retest must
+show incoming authenticated video, assembled frames, and visible playback.
+
+Startup ordering remains a separate lead. Android starts its UDP workers before
+ANNOUNCE. Mac also explicitly starts video punches before PLAY and records a
+[late-punch failure on high-RTT seats](https://github.com/OpenCloudGaming/openNOW-Mac/blob/f95fde8ed79cedd8f7e4333e195ecfd7a701a04b/OPN/Stream/NvstBifrostFreeVideo.swift#L274-L284).
+Rust starts the workers after ANNOUNCE and before PLAY, but does not wait for
+their first send. The supplied logs do not timestamp that first send, so they
+cannot establish whether this race occurred. No timing delay is added by this fix.
+
 ## Verification
 
 Run the native streamer workspace tests and `opennow-embedded-orchestration-tests`.

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -4732,6 +4732,7 @@ fn log_udp_receiver_start(
     socket: &UdpSocket,
     peer: SocketAddr,
     config: &NvstVideoConfig,
+    ping_payload: &[u8],
 ) {
     opennow_streamer_protocol::log::log_async(
         "INFO",
@@ -4742,7 +4743,7 @@ fn log_udp_receiver_start(
             peer.port(),
             peer.is_ipv4(),
             config.ping_version,
-            config.ping_payload.len(),
+            ping_payload.len(),
             config.stun_credentials.is_some(),
             config.video_peer.ip() == config.bundle_peer().ip()
         ),
@@ -5218,9 +5219,9 @@ fn run_nvst_webrtc_bundle(
     } = outputs;
     let bundle_peer = config.bundle_peer();
     let local_port = socket.local_addr().map_or(0, |addr| addr.port());
-    log_udp_receiver_start("bundle", &socket, bundle_peer, &config);
+    let ping_payload = b"PING";
+    log_udp_receiver_start("bundle", &socket, bundle_peer, &config, ping_payload);
     let stun_credentials = config.stun_credentials.clone();
-    let ping_payload = config.ping_payload.clone();
     // Feedback plane shared with the Mjolnir video receiver: it publishes the
     // stream SSRC/sequence and recovery requests; this bundle sends the RTCP
     // Receiver Reports / NACK / PLI over the `rtcp1` SCTP data channel.
@@ -5461,7 +5462,7 @@ fn run_nvst_webrtc_bundle(
             let natt = if getrandom::fill(&mut natt_tid).is_ok() {
                 let natt = build_natt_hole_punch_request(
                     &credentials.local_username_fragment,
-                    &ping_payload,
+                    ping_payload,
                     &credentials.remote_password,
                     &natt_tid,
                 );
@@ -6120,7 +6121,13 @@ fn run_nvst_udp_receiver(
         return;
     }
     let local_port = socket.local_addr().map_or(0, |addr| addr.port());
-    log_udp_receiver_start("video", &socket, config.video_peer, &config);
+    log_udp_receiver_start(
+        "video",
+        &socket,
+        config.video_peer,
+        &config,
+        &config.ping_payload,
+    );
     let NvstReceiverOutputs {
         media_consumer,
         event_sender,
@@ -9331,6 +9338,86 @@ mod tests {
                 session.stop();
             }
         }
+    }
+
+    #[test]
+    fn bundle_keepalives_do_not_claim_the_video_routing_identity() {
+        let server = UdpSocket::bind("127.0.0.1:0").unwrap();
+        server
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let bundle = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let video = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let bundle_address = bundle.local_addr().unwrap();
+        let video_address = video.local_addr().unwrap();
+        let mut remote = create_nvst_bundle_rtc(&server).unwrap();
+        let mut config = config();
+        config.client_udp_port = bundle_address.port();
+        config.mjolnir_udp_port = Some(video_address.port());
+        config.video_peer = server.local_addr().unwrap();
+        config.remote_dtls_fingerprint =
+            Some(nvst_local_bundle_identity(&mut remote).dtls_fingerprint);
+        config.stun_credentials = Some(stun_credentials());
+        config.ping_payload = b"setup-ping".to_vec();
+        let packet = protect_for_test(
+            &test_srtp(&config),
+            build_plaintext_rtp(
+                1,
+                FLAG_SOF | FLAG_EOF | FLAG_CONTAINS_PIC_DATA,
+                42,
+                &[0, 0, 1, 0x65],
+            ),
+            0,
+        );
+        let (media_consumer, media_receiver) = mpsc::sync_channel(1);
+        let (event_sender, _event_receiver) = mpsc::channel();
+        let bundle_session = spawn_nvst_udp_receiver_with_socket(
+            config.clone(),
+            media_consumer.clone(),
+            event_sender.clone(),
+            Some(bundle),
+            None,
+        )
+        .unwrap();
+        let video_session =
+            spawn_nvst_mjolnir_receiver(video, config, media_consumer, event_sender).unwrap();
+        let mut datagram = [0_u8; 2048];
+        let mut bundle_keepalives = 0;
+        let mut bundle_ice_checks = 0;
+        let mut video_keepalives = 0;
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while bundle_keepalives < 3 || bundle_ice_checks < 3 || video_keepalives < 3 {
+            assert!(
+                Instant::now() < deadline,
+                "both socket roles must send probes"
+            );
+            let (length, source) = server.recv_from(&mut datagram).unwrap();
+            let packet = &datagram[..length];
+            assert!(valid_stun_fingerprint(packet));
+            assert!(valid_stun_message_integrity(
+                packet,
+                stun_credentials().remote_password.as_bytes()
+            ));
+            let (_, username) = find_stun_attribute(packet, STUN_ATTR_USERNAME).unwrap();
+            if source == video_address {
+                assert_eq!(username, b"setup-ping:loc1");
+                video_keepalives += 1;
+            } else {
+                assert_eq!(source, bundle_address);
+                assert_ne!(username, b"setup-ping:loc1", "bundle must not claim video");
+                match username {
+                    b"remote01:loc1" => bundle_ice_checks += 1,
+                    b"PING:loc1" => bundle_keepalives += 1,
+                    _ => panic!("unexpected bundle probe identity"),
+                }
+            }
+        }
+        server.send_to(&packet, video_address).unwrap();
+        let frame = media_receiver.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(frame.frame_index, Some(42));
+        assert!(frame.keyframe);
+        video_session.stop();
+        bundle_session.stop();
     }
 
     #[test]

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_ping_tests.rs
@@ -380,7 +380,7 @@ fn bundle_receiver_publishes_ping_from_its_real_udp_keepalive_reply() {
     while Instant::now() < deadline {
         let (length, source) = server.recv_from(&mut packet).unwrap();
         if find_stun_attribute(&packet[..length], STUN_ATTR_USERNAME)
-            .is_some_and(|(_, username)| username == b"ping-fixture:loc1")
+            .is_some_and(|(_, username)| username == b"PING:loc1")
         {
             let transaction_id = packet[8..20].try_into().unwrap();
             server.send_to(&success(transaction_id), source).unwrap();


### PR DESCRIPTION
The Pi 5 capture from nightly.413.1 completes PLAY, DTLS, SCTP, and audio reception, but the separate video socket receives zero datagrams through both eight-second timeouts. Comparison with OpenNOW-Mac found that Rust sends the raw VIDEO SETUP NATT identity from both UDP sockets. The Mac production bundle uses its separate ICE identity, and its bundle probe uses `PING:<localUfrag>` for the additional authenticated NATT keepalive.

Use `PING` for bundle NATT while retaining the raw SETUP payload exclusively for video. This remains an authenticated STUN packet, not a plaintext PING. Preserve bundle ICE negotiation, credentials, endpoints, packet sizing, and recovery limits. Report each socket's actual ping payload length in startup diagnostics.

Add a two-socket loopback regression that runs the real bundle and video workers against one server endpoint, verifies repeated authenticated role-specific probes, and receives an authenticated video frame. It fails on the original code because the bundle claims the video identity. Update the existing bundle RTT fixture to answer the corrected identity without changing its timing or source-selection assertions. Document the Mac/Android comparison and remaining startup-ordering lead.

Validation on Linux:
- Native streamer workspace: **597 passed, 9 ignored, 0 failed**.
- Transport crate: **167 passed**.
- Transport Clippy with `--all-targets -- -D warnings`: passed.
- Workspace formatting and `git diff --check`: passed.

This verifies the client wire correction, not a server-side routing overwrite or resolution of every reported timeout. Live Pi/Windows GFN playback is unverified and needs a fresh-session retest. Android contains the same duplicate identity behavior; its branch and the Mac repository are unchanged. Startup ordering is documented separately rather than changed using an unverified timing delay.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M28DB51F4XBAZWFQMAMVK1GD"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->