### PR TITLE
test(qt): complete session responses in Big Picture acceptance

### DIFF
--- a/opennow-qt/tests/SteamBigPictureAcceptance.qml
+++ b/opennow-qt/tests/SteamBigPictureAcceptance.qml
@@ -69,11 +69,12 @@ QtObject {
                         check(request.method === "session.remote.list", "launch checks existing sessions first")
                         check(request.params.appLaunchMode === (enabled === true ? "gamepadFriendly" : "default"),
                             "only explicit Big Picture opt-in selects gamepad-friendly mode")
-                        ShellStore.createPendingSession()
+                        client.responseReceived(request.id, {sessions:[]})
                         const create = client.calls[client.calls.length - 1]
                         check(create.method === "session.create" && create.params.appLaunchMode === request.params.appLaunchMode,
                             "session creation preserves the selected launch mode")
-                        ShellStore.streamCreateRequestId = ""
+                        client.responseReceived(create.id, {session:null})
+                        check(!ShellStore.streamBusy, "completed requests allow the next launch")
                     }
                 }
             }


### PR DESCRIPTION
The Steam Big Picture acceptance loop left `session.remote.list` pending, so the session-busy guard introduced in #898 rejected the next launch. Both Linux nightly package jobs failed on this fixture.

Deliver the empty lookup and session-creation results through the fixture client's normal response signals. Preserve all launch-mode assertions and assert that completed requests leave the shell ready for the next launch. No production behavior changes.

Validation: `git diff --check` passes. Local CMake configuration is blocked by the missing Qt 6.8+ SDK; the full manual packaging workflow will validate this branch, including the Linux acceptance suites, before merge.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M28F4KAG16R6B2P8YKG3S5ZR"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->