### PR TITLE
fix(streamer): correct NVST QoS bitrate feedback accounting

### DIFF
--- a/docs/streamer-comparison/features.md
+++ b/docs/streamer-comparison/features.md
@@ -210,6 +210,23 @@ These are QoS and recovery. Same header rule. Tests in `nvst_control.rs`.
 | `0x0204` | frame ack | 102-byte payload. Full hex in `frame_ack_places_only_source_pinned_fields` |
 | `0x0207` | QoS report | 52-byte payload. Full hex in `qos_report_matches_the_source_test_layout` |
 
+QoS reports run at approximately 18 Hz. The cumulative completed-frame byte count at `+16`
+and the previous successfully queued report's byte count at `+48` are separate samples.
+After the 1.9-second warm-up, `+44` carries their wrapping difference in bits, saturated to
+the field's u32 range. This follows OpenNOW-mac's `NvstQosReport` rate-field interpretation;
+it is not a measurement of total wire traffic including FEC. Failed SCTP queue attempts do
+not advance the report baseline. A new session starts with a fresh baseline.
+
+The timestamp at `+36` tracks the newest authenticated video RTP timestamp, including
+packets whose frames are still incomplete. Reordered packets cannot move it backward,
+and sender clock wrap is preserved. The delay fields at `+20` and `+24` remain unavailable
+zeros; RTP interarrival jitter is not substituted for one-way delay. The captured `+34`
+constant remains unchanged because interpreting it as a configurable link capability is
+not established. Regression coverage in `nvst_qos_tests.rs` exercises encrypted packet
+reception at synthetic 50/75 Mbps byte volumes, partial frames, rejected packets, wrapping
+counters, warm-up, and report baselines. These tests do not reproduce the remote server's
+congestion controller or prove that a live-session bitrate oscillation is resolved.
+
 IDR is the recovery command OpenNOW already sends. Official also sends a reference-invalidation request. That invalidation frame is **not** in this tree and is not guessed here.
 
 ## Inbound cursor examples

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -387,6 +387,7 @@ struct ReceptionTiming {
     first_arrival: Option<Instant>,
     first_rtp_timestamp: u32,
     last_rtp_timestamp: u32,
+    latest_rtp_timestamp: Option<u32>,
     last_transit: i64,
     jitter: f64,
 }
@@ -436,7 +437,6 @@ pub struct NvstFeedbackState {
     pending_nacks: Mutex<VecDeque<PendingNackRange>>,
     completed_frames: AtomicU32,
     completed_frame_bytes: AtomicU64,
-    last_completed_rtp_timestamp: AtomicU32,
     pending_frame_acks: Mutex<VecDeque<CompletedFrameFeedback>>,
 }
 
@@ -457,7 +457,6 @@ impl Default for NvstFeedbackState {
             pending_nacks: Mutex::new(VecDeque::new()),
             completed_frames: AtomicU32::new(0),
             completed_frame_bytes: AtomicU64::new(0),
-            last_completed_rtp_timestamp: AtomicU32::new(0),
             pending_frame_acks: Mutex::new(VecDeque::new()),
         }
     }
@@ -526,6 +525,12 @@ impl NvstFeedbackState {
             .reception_timing
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if timing
+            .latest_rtp_timestamp
+            .is_none_or(|latest| rtp_timestamp.wrapping_sub(latest) as i32 > 0)
+        {
+            timing.latest_rtp_timestamp = Some(rtp_timestamp);
+        }
         let Some(first_arrival) = timing.first_arrival else {
             timing.first_arrival = Some(now);
             timing.first_rtp_timestamp = rtp_timestamp;
@@ -625,8 +630,6 @@ impl NvstFeedbackState {
             u64::try_from(frame.bytes.len()).unwrap_or(u64::MAX),
             Ordering::AcqRel,
         );
-        self.last_completed_rtp_timestamp
-            .store(frame.timestamp, Ordering::Release);
         if frame.keyframe && self.keyframe_needed.swap(false, Ordering::AcqRel) {
             opennow_streamer_protocol::log::log_async(
                 "INFO",
@@ -666,8 +669,24 @@ impl NvstFeedbackState {
         (
             self.completed_frames.load(Ordering::Acquire),
             self.completed_frame_bytes.load(Ordering::Acquire) as u32,
-            self.last_completed_rtp_timestamp.load(Ordering::Acquire),
+            self.reception_timing
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .latest_rtp_timestamp
+                .unwrap_or(0),
         )
+    }
+
+    fn qos_report(&self, previous: &QosReport, warmed_up: bool) -> QosReport {
+        let (frames_received, bytes_received, rtp_timestamp) = self.completed_frame_snapshot();
+        QosReport {
+            sequence: previous.sequence.wrapping_add(1),
+            frames_received,
+            bytes_received,
+            rtp_timestamp,
+            previous_bytes_received: previous.bytes_received,
+            warmed_up,
+        }
     }
 
     /// SSRC + highest sequence for the next Receiver Report, if a stream is bound.
@@ -5267,7 +5286,7 @@ fn run_nvst_webrtc_bundle(
     let mut keyframe_attempts = 0_u64;
     let mut last_keyframe_attempt_log: Option<Instant> = None;
     let mut rtcp_reports_sent = 0_u64;
-    let mut qos_sequence = 0_u32;
+    let mut last_qos_report = QosReport::default();
     let mut last_qos_send = Instant::now() - QOS_REPORT_INTERVAL;
     let mut last_frame_pacing_send = Instant::now() - QOS_REPORT_INTERVAL;
     let control_stats_origin = Instant::now();
@@ -5527,20 +5546,13 @@ fn run_nvst_webrtc_bundle(
             && now.duration_since(last_qos_send) >= QOS_REPORT_INTERVAL
             && let Some(channels) = input_channels
         {
-            let (frames_received, bytes_received, rtp_timestamp) =
-                feedback.completed_frame_snapshot();
-            qos_sequence = qos_sequence.wrapping_add(1);
-            let command = QosReport {
-                sequence: qos_sequence,
-                frames_received,
-                bytes_received,
-                rtp_timestamp,
-                previous_bytes_received: bytes_received,
-                warmed_up: now.saturating_duration_since(transport_origin) >= QOS_WARM_UP,
-            }
-            .command()
-            .encoded();
+            let report = feedback.qos_report(
+                &last_qos_report,
+                now.saturating_duration_since(transport_origin) >= QOS_WARM_UP,
+            );
+            let command = report.command().encoded();
             if channels.send_partial_control(&mut rtc, &command) {
+                last_qos_report = report;
                 qos_reports_sent = qos_reports_sent.saturating_add(1);
             }
             last_qos_send = now;
@@ -6464,6 +6476,9 @@ mod tests {
     }
     mod recovery_tests {
         include!("nvst_recovery_tests.rs");
+    }
+    mod qos_tests {
+        include!("nvst_qos_tests.rs");
     }
     use super::*;
     use serde_json::json;

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_control.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_control.rs
@@ -78,6 +78,7 @@ pub(crate) fn frame_pacing_report(
     }
 }
 
+#[derive(Debug, Default)]
 pub(crate) struct QosReport {
     pub(crate) sequence: u32,
     pub(crate) frames_received: u32,
@@ -99,6 +100,15 @@ impl QosReport {
         put_u16(&mut payload, 32, 1_000);
         put_u16(&mut payload, 34, 12_708);
         put_u32(&mut payload, 36, self.rtp_timestamp);
+        if self.warmed_up {
+            put_u32(
+                &mut payload,
+                44,
+                self.bytes_received
+                    .wrapping_sub(self.previous_bytes_received)
+                    .saturating_mul(8),
+            );
+        }
         put_u32(&mut payload, 48, self.previous_bytes_received);
         NvstControlCommand {
             code: QOS_REPORT_CODE,

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_qos_tests.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_qos_tests.rs
@@ -1,0 +1,220 @@
+use super::*;
+
+fn word(report: &QosReport, offset: usize) -> u32 {
+    u32::from_le_bytes(
+        report.command().payload[offset..offset + 4]
+            .try_into()
+            .unwrap(),
+    )
+}
+
+#[test]
+fn qos_reports_measure_successive_intervals_at_50_and_75_mbps() {
+    for bitrate_mbps in [50_u32, 75] {
+        let mut config = config();
+        config.max_access_unit_bytes = DEFAULT_MAX_ACCESS_UNIT_BYTES;
+        let feedback = config.feedback();
+        let crypto = test_srtp(&config);
+        let mut receiver = NvstVideoReceiver::new(config);
+        let mut previous = QosReport::default();
+        let mut sequence = 10_u16;
+        let interval_bytes = bitrate_mbps * 1_000_000 / 8 / 18;
+        let mut media = vec![0x55; interval_bytes as usize];
+        media[..5].copy_from_slice(&[0, 0, 0, 1, 0x65]);
+        let origin = Instant::now();
+
+        for frame_index in 1..=4 {
+            let timestamp = 90_000 + frame_index * 5_000;
+            let now = origin + QOS_REPORT_INTERVAL * frame_index;
+            let mut emitted = 0;
+            let chunk_count = media.len().div_ceil(1_200);
+            for (index, chunk) in media.chunks(1_200).enumerate() {
+                let mut flags = FLAG_CONTAINS_PIC_DATA;
+                if index == 0 {
+                    flags |= FLAG_SOF;
+                }
+                if index + 1 == chunk_count {
+                    flags |= FLAG_EOF;
+                }
+                let mut packet = build_plaintext_rtp(sequence, flags, frame_index, chunk);
+                packet[4..8].copy_from_slice(&timestamp.to_be_bytes());
+                let encrypted = protect_for_test(&crypto, packet, 0);
+                for event in receiver.process_datagram(peer(), &encrypted, now) {
+                    let NvstReceiveEvent::Frame(frame) = event else {
+                        panic!("unexpected receive event: {event:?}");
+                    };
+                    assert_eq!(frame.bytes, media);
+                    emitted += 1;
+                }
+                sequence += 1;
+            }
+            assert_eq!(emitted, 1);
+            let report = feedback.qos_report(&previous, true);
+            assert_eq!(report.sequence, frame_index);
+            assert_eq!(report.frames_received, frame_index);
+            assert_eq!(word(&report, 16), frame_index * interval_bytes);
+            assert_eq!(word(&report, 48), (frame_index - 1) * interval_bytes);
+            assert_eq!(word(&report, 44), interval_bytes * 8);
+            assert_eq!(word(&report, 36), timestamp);
+            assert_eq!(report.command().encoded().len(), 56);
+            previous = report;
+        }
+
+        let idle = feedback.qos_report(&previous, true);
+        assert_eq!(word(&idle, 16), word(&idle, 48));
+        assert_eq!(word(&idle, 44), 0);
+        assert_eq!(idle.rtp_timestamp, previous.rtp_timestamp);
+    }
+}
+
+#[test]
+fn qos_receive_progress_advances_before_frame_completion_but_not_on_invalid_packets() {
+    let config = config();
+    let feedback = config.feedback();
+    let crypto = test_srtp(&config);
+    let mut receiver = NvstVideoReceiver::new(config);
+    let mut first = build_plaintext_rtp(10, FLAG_SOF, 1, &[0, 0, 0, 1, 0x65]);
+    first[4..8].copy_from_slice(&90_000_u32.to_be_bytes());
+    let first = protect_for_test(&crypto, first, 0);
+    let now = Instant::now();
+    assert!(receiver.process_datagram(peer(), &first, now).is_empty());
+    let first_report = feedback.qos_report(&QosReport::default(), true);
+    assert_eq!(first_report.rtp_timestamp, 90_000);
+    assert_eq!(first_report.frames_received, 0);
+    assert_eq!(first_report.bytes_received, 0);
+
+    let mut later = build_plaintext_rtp(12, FLAG_SOF, 2, &[0, 0, 0, 1, 0x61]);
+    later[4..8].copy_from_slice(&93_000_u32.to_be_bytes());
+    let later = protect_for_test(&crypto, later, 0);
+    let mut corrupted = later.clone();
+    corrupted[4] ^= 1;
+    assert!(matches!(
+        receiver
+            .process_datagram(peer(), &corrupted, now)
+            .as_slice(),
+        [NvstReceiveEvent::Dropped(
+            NvstDropReason::AuthenticationFailed
+        )]
+    ));
+    assert_eq!(
+        feedback.qos_report(&first_report, true).rtp_timestamp,
+        90_000
+    );
+    let wrong_peer = SocketAddr::new(peer().ip(), peer().port() + 1);
+    assert!(matches!(
+        receiver
+            .process_datagram(wrong_peer, &later, now)
+            .as_slice(),
+        [NvstReceiveEvent::Dropped(
+            NvstDropReason::UnexpectedSource { .. }
+        )]
+    ));
+    assert_eq!(
+        feedback.qos_report(&first_report, true).rtp_timestamp,
+        90_000
+    );
+    assert!(receiver.process_datagram(peer(), &later, now).is_empty());
+    let later_report = feedback.qos_report(&first_report, true);
+    assert_eq!(later_report.rtp_timestamp, 93_000);
+    assert_eq!(later_report.frames_received, 0);
+    assert_eq!(word(&later_report, 44), 0);
+    assert!(matches!(
+        receiver.process_datagram(peer(), &first, now).as_slice(),
+        [NvstReceiveEvent::Dropped(NvstDropReason::ReplayRejected)]
+    ));
+    assert_eq!(
+        feedback.qos_report(&later_report, true).rtp_timestamp,
+        93_000
+    );
+}
+
+#[test]
+fn qos_receive_timestamp_handles_reordering_and_sender_clock_wrap() {
+    let feedback = NvstFeedbackState::default();
+    let previous = QosReport::default();
+    let now = Instant::now();
+    feedback.publish_stream(7, 10, u32::MAX - 2_000, now);
+    assert_eq!(
+        feedback.qos_report(&previous, true).rtp_timestamp,
+        u32::MAX - 2_000
+    );
+    feedback.publish_stream(7, 12, 1_000, now + Duration::from_millis(33));
+    assert_eq!(feedback.qos_report(&previous, true).rtp_timestamp, 1_000);
+    feedback.publish_stream(7, 12, u32::MAX - 500, now + Duration::from_millis(34));
+    assert_eq!(feedback.qos_report(&previous, true).rtp_timestamp, 1_000);
+    feedback.publish_stream(7, 13, 4_000, now + Duration::from_millis(66));
+    assert_eq!(feedback.qos_report(&previous, true).rtp_timestamp, 4_000);
+}
+
+#[test]
+fn qos_unsent_samples_do_not_advance_the_successful_report_baseline() {
+    let feedback = NvstFeedbackState::default();
+    feedback
+        .completed_frame_bytes
+        .store(1_000, Ordering::Release);
+    let sent = feedback.qos_report(&QosReport::default(), true);
+    feedback
+        .completed_frame_bytes
+        .store(2_000, Ordering::Release);
+    let unsent = feedback.qos_report(&sent, true);
+    assert_eq!(word(&unsent, 44), 8_000);
+    feedback
+        .completed_frame_bytes
+        .store(3_000, Ordering::Release);
+    let retry = feedback.qos_report(&sent, true);
+    assert_eq!(retry.sequence, unsent.sequence);
+    assert_eq!(word(&retry, 48), 1_000);
+    assert_eq!(word(&retry, 44), 16_000);
+    let next = feedback.qos_report(&retry, true);
+    assert_eq!(next.sequence, retry.sequence + 1);
+    assert_eq!(word(&next, 44), 0);
+}
+
+#[test]
+fn qos_counters_wrap_without_zeroing_or_overflowing_interval_bits() {
+    let feedback = NvstFeedbackState::default();
+    feedback
+        .completed_frame_bytes
+        .store(u64::from(u32::MAX) + 101, Ordering::Release);
+    let previous = QosReport {
+        sequence: u32::MAX,
+        bytes_received: u32::MAX - 99,
+        ..QosReport::default()
+    };
+    let report = feedback.qos_report(&previous, true);
+    assert_eq!(report.sequence, 0);
+    assert_eq!(word(&report, 16), 100);
+    assert_eq!(word(&report, 48), u32::MAX - 99);
+    assert_eq!(word(&report, 44), 1_600);
+
+    feedback
+        .completed_frame_bytes
+        .store(u64::from(u32::MAX), Ordering::Release);
+    let saturated = feedback.qos_report(&QosReport::default(), true);
+    assert_eq!(word(&saturated, 44), u32::MAX);
+}
+
+#[test]
+fn qos_warmup_and_new_sessions_keep_independent_baselines() {
+    let feedback = NvstFeedbackState::default();
+    feedback
+        .completed_frame_bytes
+        .store(500_000, Ordering::Release);
+    let warmup = feedback.qos_report(&QosReport::default(), false);
+    assert_eq!(word(&warmup, 44), 0);
+    feedback
+        .completed_frame_bytes
+        .store(1_000_000, Ordering::Release);
+    let warmed_up = feedback.qos_report(&warmup, true);
+    assert_eq!(word(&warmed_up, 48), 500_000);
+    assert_eq!(word(&warmed_up, 44), 4_000_000);
+
+    let next_session = NvstFeedbackState::default();
+    let report = next_session.qos_report(&QosReport::default(), false);
+    assert_eq!(report.sequence, 1);
+    assert_eq!(report.frames_received, 0);
+    assert_eq!(word(&report, 16), 0);
+    assert_eq!(word(&report, 48), 0);
+    assert_eq!(word(&report, 44), 0);
+    assert_eq!(word(&report, 36), 0);
+}


### PR DESCRIPTION
Correct the native streamer's QoS accounting that could contribute to repeated bitrate drops and recovery stalls near the configured ceiling.

- Keep current and previous successfully queued byte samples separate instead of sending identical counters. Populate interval bits after warm-up, handle counter wrap and saturation, and preserve the baseline when SCTP queue admission fails.
- Report the newest authenticated video RTP timestamp without waiting for frame completion. Preserve sender clock wrap and prevent reordered packets from moving receive progress backward.
- Add encrypted receiver-path regression coverage at synthetic 50 and 75 Mbps byte volumes, plus partial frames, rejected packets, idle intervals, warm-up, session resets, counter wrap, and unsent samples.
- Document the QoS field interpretation and its limits. Leave the bitrate ceiling, FEC settings, inferred delay fields, and captured capability constant unchanged.

Validation: **173 transport tests pass**; the complete native streamer workspace passes with **605 passed and 9 ignored** on Linux. Transport Clippy passes with `--all-targets -- -D warnings`, changed Rust files pass rustfmt, and `git diff --check` is clean.

The tests verify receive-to-QoS behavior, not the remote server's congestion controller. A live GFN comparison at 50 and 75 Mbps is still needed to establish whether this resolves the reported lag spikes.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2904BF8FCCEJTVQP33QMP3T"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->