### PR TITLE
feat(qt): expose persistent in-game settings

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,8 @@
 {
+  "persistentInGameSettings": {
+    "title": "Persistent in-game settings",
+    "description": "Keep your in-game graphics settings between sessions for supported games and memberships. Applies to new sessions."
+  },
   "graphicsProcessor": {
     "title": "Graphics processor",
     "restartHint": "Uses the same GPU for decoding and display. Changes apply after restarting OpenNOW.",

--- a/native/opennow-core/src/cloudmatch.rs
+++ b/native/opennow-core/src/cloudmatch.rs
@@ -901,7 +901,7 @@ fn build_create_body(app_id: &str, params: &Value, settings: &Value, device_id: 
     };
     let cloud_gsync = resolved_cloud_gsync(settings);
     let reflex = cloud_gsync || fps >= 120;
-    let persistence = setting_bool(settings, "enablePersistingInGameSettings", false)
+    let persistence = setting_bool(settings, "enablePersistingInGameSettings", true)
         && params["supportsInGameSettingsPersistence"].as_bool() == Some(true);
     let physical_resolution = json!({
         "horizontalPixels": width,
@@ -2561,7 +2561,7 @@ mod tests {
     }
 
     #[test]
-    fn in_game_settings_persistence_requires_opt_in_and_game_support() {
+    fn in_game_settings_persistence_defaults_on_and_requires_game_support() {
         for preference in [Value::Null, json!(false), json!(true)] {
             for support in [Value::Null, json!(false), json!(true)] {
                 let mut params = json!({});
@@ -2575,7 +2575,7 @@ mod tests {
                 let body = build_create_body("123", &params, &settings, "stable-device");
                 assert_eq!(
                     body["sessionRequestData"]["enablePersistingInGameSettings"],
-                    preference == true && support == true
+                    preference != false && support == true
                 );
             }
         }

--- a/native/opennow-core/src/cloudmatch.rs
+++ b/native/opennow-core/src/cloudmatch.rs
@@ -2561,6 +2561,46 @@ mod tests {
     }
 
     #[test]
+    fn in_game_settings_persistence_requires_opt_in_and_game_support() {
+        for preference in [Value::Null, json!(false), json!(true)] {
+            for support in [Value::Null, json!(false), json!(true)] {
+                let mut params = json!({});
+                let mut settings = json!({});
+                if !support.is_null() {
+                    params["supportsInGameSettingsPersistence"] = support.clone();
+                }
+                if !preference.is_null() {
+                    settings["enablePersistingInGameSettings"] = preference.clone();
+                }
+                let body = build_create_body("123", &params, &settings, "stable-device");
+                assert_eq!(
+                    body["sessionRequestData"]["enablePersistingInGameSettings"],
+                    preference == true && support == true
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn resume_preserves_in_game_settings_persistence_despite_preference_changes() {
+        for enabled in [false, true] {
+            let original = json!({"sessionRequestData": {
+                "enablePersistingInGameSettings": enabled
+            }});
+            let body = build_resume_body(
+                "123",
+                &original,
+                &json!({"enablePersistingInGameSettings": !enabled}),
+                "stable-device",
+            );
+            assert_eq!(
+                body["sessionRequestData"]["enablePersistingInGameSettings"],
+                enabled
+            );
+        }
+    }
+
+    #[test]
     fn resume_does_not_renegotiate_allocated_video_parameters() {
         let original = json!({"sessionRequestData": {
             "appLaunchMode":2, "enablePersistingInGameSettings":true,

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -895,7 +895,7 @@ fn defaults() -> Map<String, Value> {
         "showSessionReport":true, "showSessionTimeRemainingInStatsOverlay":false,
         "sessionClockShowEveryMinutes":60, "sessionClockShowDurationSeconds":30,
         "windowWidth":1400, "windowHeight":900, "keyboardLayout":"en-US",
-        "gameLanguage":"en_US", "enablePersistingInGameSettings":false, "enableL4S":false,
+        "gameLanguage":"en_US", "enablePersistingInGameSettings":true, "enableL4S":false,
         "identifyAsSteamDeck":false, "steamBigPictureMode":false,
         "enableCloudGsync":false, "discordRichPresence":false,
         "autoCheckForUpdates":true, "autoDownloadUpdates":false,
@@ -1310,7 +1310,10 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let load = || SettingsStore::load(Some(directory.path().to_owned())).unwrap();
         let mut store = load();
-        assert_eq!(store.all()["enablePersistingInGameSettings"], false);
+        assert_eq!(store.all()["enablePersistingInGameSettings"], true);
+        fs::write(directory.path().join("settings.json"), br#"{"fps":120}"#).unwrap();
+        store = load();
+        assert_eq!(store.all()["enablePersistingInGameSettings"], true);
         for enabled in [true, false, true] {
             store
                 .set("enablePersistingInGameSettings", json!(enabled))
@@ -1330,8 +1333,11 @@ mod tests {
         assert_eq!(store.all()["enablePersistingInGameSettings"], true);
         assert_eq!(load().all()["enablePersistingInGameSettings"], true);
         fs::remove_dir(directory.path().join("settings.json.tmp")).unwrap();
+        store
+            .set("enablePersistingInGameSettings", json!(false))
+            .unwrap();
         store.reset().unwrap();
-        assert_eq!(load().all()["enablePersistingInGameSettings"], false);
+        assert_eq!(load().all()["enablePersistingInGameSettings"], true);
     }
 
     #[test]

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -1306,6 +1306,35 @@ mod tests {
     }
 
     #[test]
+    fn in_game_settings_persistence_survives_restart_and_resets() {
+        let directory = tempfile::tempdir().unwrap();
+        let load = || SettingsStore::load(Some(directory.path().to_owned())).unwrap();
+        let mut store = load();
+        assert_eq!(store.all()["enablePersistingInGameSettings"], false);
+        for enabled in [true, false, true] {
+            store
+                .set("enablePersistingInGameSettings", json!(enabled))
+                .unwrap();
+            store = load();
+            assert_eq!(store.all()["enablePersistingInGameSettings"], enabled);
+            store.set("fps", json!(120)).unwrap();
+            store = load();
+            assert_eq!(store.all()["enablePersistingInGameSettings"], enabled);
+        }
+        fs::create_dir(directory.path().join("settings.json.tmp")).unwrap();
+        assert!(
+            store
+                .set("enablePersistingInGameSettings", json!(false))
+                .is_err()
+        );
+        assert_eq!(store.all()["enablePersistingInGameSettings"], true);
+        assert_eq!(load().all()["enablePersistingInGameSettings"], true);
+        fs::remove_dir(directory.path().join("settings.json.tmp")).unwrap();
+        store.reset().unwrap();
+        assert_eq!(load().all()["enablePersistingInGameSettings"], false);
+    }
+
+    #[test]
     fn steam_big_picture_is_opt_in_and_persists_independently() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -272,7 +272,7 @@ if(BUILD_TESTING)
     endif()
     set_tests_properties(opennow-streamcolor-tests PROPERTIES TIMEOUT 60)
     qt_add_resources(opennow-qt "region-ping-acceptance"
-        PREFIX "/acceptance" BASE tests FILES tests/RegionPingAcceptance.qml tests/RegionChoicesAcceptance.qml tests/StorePagingAcceptance.qml tests/BackendAvailabilityAcceptance.qml tests/StreamRecoveryAcceptance.qml tests/IdleModeAcceptance.qml tests/FrameGenerationAcceptance.qml tests/AudioOutputAcceptance.qml tests/CollectionsAcceptance.qml tests/SteamBigPictureAcceptance.qml tests/ControllerMetadataAcceptance.qml tests/MicrophoneAcceptance.qml tests/RecordingAcceptance.qml)
+        PREFIX "/acceptance" BASE tests FILES tests/RegionPingAcceptance.qml tests/RegionChoicesAcceptance.qml tests/StorePagingAcceptance.qml tests/BackendAvailabilityAcceptance.qml tests/StreamRecoveryAcceptance.qml tests/IdleModeAcceptance.qml tests/FrameGenerationAcceptance.qml tests/AudioOutputAcceptance.qml tests/CollectionsAcceptance.qml tests/SteamBigPictureAcceptance.qml tests/PersistentInGameSettingsAcceptance.qml tests/ControllerMetadataAcceptance.qml tests/MicrophoneAcceptance.qml tests/RecordingAcceptance.qml)
     add_test(NAME qml-recording
         COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
             --route settings --smoke-recording --reduced-motion)
@@ -348,6 +348,10 @@ if(BUILD_TESTING)
         COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
             --route settings-streaming --smoke-steam-big-picture --reduced-motion)
     set_tests_properties(qml-steam-big-picture PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
+    add_test(NAME qml-persistent-in-game-settings
+        COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
+            --route settings-streaming --smoke-persistent-in-game-settings --reduced-motion)
+    set_tests_properties(qml-persistent-in-game-settings PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 10)
     add_test(NAME qml-frame-generation
         COMMAND opennow-qt --smoke-test --allow-multiple-instances --desktop
             --route settings-streaming --smoke-frame-generation --reduced-motion)

--- a/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
+++ b/opennow-qt/qml/desktop/settings/DesktopSettingsScreen.qml
@@ -24,7 +24,7 @@ FocusScope {
     signal requestConsoleMode(bool enabled)
 
     readonly property var sections: [
-        {label: qsTr("Stream"), detail: qsTr("Picture, codec, bitrate"), icon: "monitor", page: 3, keywords: "resolution fps hdr color audio stats overlay bitrate codec reflex backend gpu directx vulkan steam big picture launch gamepad fullscreen session ready"},
+        {label: qsTr("Stream"), detail: qsTr("Picture, codec, bitrate"), icon: "monitor", page: 3, keywords: "resolution fps hdr color audio stats overlay bitrate codec reflex backend gpu directx vulkan steam big picture launch gamepad fullscreen session ready persistent in-game graphics settings"},
         {label: qsTr("Audio"), detail: qsTr("Output and stream audio"), icon: "wave", page: 4, keywords: "sound audio volume output microphone"},
         {label: qsTr("Recording"), detail: qsTr("Capture, replay, shortcuts"), icon: "image", page: 12, keywords: "recording capture clip replay buffer memory duration folder resolution fps quality shortcuts F12"},
         {label: qsTr("Controls"), detail: qsTr("Pads, mouse, shortcuts"), icon: "controller", page: 5, keywords: "controller gyroscope steam sensitivity keyboard language shortcuts"},

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
@@ -24,11 +24,21 @@ Column {
         DesktopSettingsRow {
             width: parent.width; paperStyle: true; glyph: "controller"; title: qsTr("Steam Big Picture mode")
             description: qsTr("Request gamepad-friendly launchers such as Steam Big Picture. Applies to new GeForce NOW sessions only.")
-            showDivider: false
             DesktopSettingsToggle {
                 objectName: "steamBigPictureToggle"
                 checked: page.settingsScreen.boolSetting("steamBigPictureMode", false)
                 onValueChangedByUser: value => page.settingsScreen.setSetting("steamBigPictureMode", value)
+            }
+        }
+        DesktopSettingsRow {
+            width: parent.width; paperStyle: true; glyph: "controller"; title: qsTr("Persistent in-game settings")
+            description: qsTr("Keep your in-game graphics settings between sessions for supported games and memberships. Applies to new sessions.")
+            showDivider: false
+            DesktopSettingsToggle {
+                objectName: "persistentInGameSettingsToggle"
+                checked: page.settingsScreen.boolSetting("enablePersistingInGameSettings", false)
+                Accessible.name: qsTr("Persistent in-game settings")
+                onValueChangedByUser: value => page.settingsScreen.setSetting("enablePersistingInGameSettings", value)
             }
         }
     }

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
@@ -36,7 +36,7 @@ Column {
             showDivider: false
             DesktopSettingsToggle {
                 objectName: "persistentInGameSettingsToggle"
-                checked: page.settingsScreen.boolSetting("enablePersistingInGameSettings", false)
+                checked: page.settingsScreen.boolSetting("enablePersistingInGameSettings", true)
                 Accessible.name: qsTr("Persistent in-game settings")
                 onValueChangedByUser: value => page.settingsScreen.setSetting("enablePersistingInGameSettings", value)
             }

--- a/opennow-qt/qml/screens/SettingsScreen.qml
+++ b/opennow-qt/qml/screens/SettingsScreen.qml
@@ -266,7 +266,7 @@ FocusScope {
                 {t:"Profile", control:"profile", height:121, initial:accountName.slice(0,1).toUpperCase(), name:accountName, tier:membership.toUpperCase(), subtitle:ShellStore.signedIn ? qsTr("NVIDIA account · signed in on this PC") : qsTr("Connect securely with NVIDIA"), meta:ShellStore.sessionPersistence === "os-credential-store" ? qsTr("Protected by the operating system credential store") : qsTr("Session-only profile"), v:ShellStore.signedIn ? qsTr("Manage on nvidia.com") : qsTr("Sign in"), route:ShellStore.signedIn ? "accounts" : "sign-in"},
                 {t:"Profiles", d:"Each profile has its own My games shelf and settings", v:qsTr("%1 saved").arg(ShellStore.savedAccounts.length), route:"accounts"},
                 {t:"Profile PIN", d:"Ask for a 4-digit PIN when switching to this profile", v:"Set up", route:"profile-pin"},
-                toggle("Cloud saves", "Sync Steam / Epic / Ubisoft saves before each session", "enablePersistingInGameSettings"),
+                toggle(qsTr("Persistent in-game settings"), qsTr("Keep your in-game graphics settings between sessions for supported games and memberships. Applies to new sessions."), "enablePersistingInGameSettings"),
                 toggle("Discord Rich Presence", "Show what you're playing on Discord", "discordRichPresence"),
                 choice("Error reporting", "Send anonymous crash reports to help fix OpenNOW", "errorReportingConsent", ["denied","granted"], ["Off","Anonymous"], "segments"),
                 {t:"Sign out", d:"Removes the NVIDIA token from this PC; My games stay", v:"Sign out of NVIDIA", action:"sign-out", danger:true},

--- a/opennow-qt/src/acceptance/SmokeAcceptance.cpp
+++ b/opennow-qt/src/acceptance/SmokeAcceptance.cpp
@@ -201,6 +201,7 @@ int AcceptanceSession::startSmokeWorkload()
                      || m_arguments.contains(u"--smoke-recording"_s)
                      || m_arguments.contains(u"--smoke-collections"_s)
                      || m_arguments.contains(u"--smoke-steam-big-picture"_s)
+                     || m_arguments.contains(u"--smoke-persistent-in-game-settings"_s)
                      || m_arguments.contains(u"--smoke-idle-mode"_s)
                      || m_arguments.contains(u"--smoke-queue-drops"_s)
                      || m_arguments.contains(u"--smoke-stream-recovery"_s))) {
@@ -216,6 +217,8 @@ int AcceptanceSession::startSmokeWorkload()
             ? u"qrc:/acceptance/CollectionsAcceptance.qml"_s
             : m_arguments.contains(u"--smoke-steam-big-picture"_s)
             ? u"qrc:/acceptance/SteamBigPictureAcceptance.qml"_s
+            : m_arguments.contains(u"--smoke-persistent-in-game-settings"_s)
+            ? u"qrc:/acceptance/PersistentInGameSettingsAcceptance.qml"_s
             : m_arguments.contains(u"--smoke-idle-mode"_s)
             ? u"qrc:/acceptance/IdleModeAcceptance.qml"_s
             : m_arguments.contains(u"--smoke-stream-recovery"_s)
@@ -235,7 +238,8 @@ int AcceptanceSession::startSmokeWorkload()
             || m_arguments.contains(u"--smoke-recording"_s)
             || m_arguments.contains(u"--smoke-queue-drops"_s)
             || m_arguments.contains(u"--smoke-collections"_s)
-            || m_arguments.contains(u"--smoke-steam-big-picture"_s)) {
+            || m_arguments.contains(u"--smoke-steam-big-picture"_s)
+            || m_arguments.contains(u"--smoke-persistent-in-game-settings"_s)) {
             auto *client = fixture->property("client").value<QObject *>();
             if (!client) return EXIT_FAILURE;
             m_engine.rootContext()->setContextProperty(u"CoreClient"_s, client);

--- a/opennow-qt/tests/PersistentInGameSettingsAcceptance.qml
+++ b/opennow-qt/tests/PersistentInGameSettingsAcceptance.qml
@@ -32,12 +32,13 @@ QtObject {
         client.state = "ready"
         ShellStore.settings = ({})
         const toggle = find(parent, "persistentInGameSettingsToggle")
-        check(toggle && !toggle.checked, "desktop preference defaults off")
+        check(toggle && toggle.checked, "desktop preference defaults on")
+        ShellStore.settings = {enablePersistingInGameSettings:true}
         const consolePage = consoleSettings.createObject(parent)
         const row = consolePage.settingsModel().find(item => item.key === "enablePersistingInGameSettings")
-        check(row && row.toggle && row.v === "Off" && row.t === "Persistent in-game settings",
+        check(row && row.toggle && row.v === "On" && row.t === "Persistent in-game settings",
             "console exposes in-game settings rather than cloud saves")
-        for (const enabled of [true, false]) {
+        for (const enabled of [false, true, false]) {
             toggle.clicked()
             const write = client.calls[client.calls.length - 1]
             check(write.method === "settings.set" && write.params.key === "enablePersistingInGameSettings"

--- a/opennow-qt/tests/PersistentInGameSettingsAcceptance.qml
+++ b/opennow-qt/tests/PersistentInGameSettingsAcceptance.qml
@@ -1,0 +1,89 @@
+import QtQuick
+import OpenNOW
+
+QtObject {
+    property Component consoleSettings: Component { SettingsScreen { visible: false; selectedSection: 0 } }
+    property QtObject client: QtObject {
+        property string state: "stopped"
+        property string lastError: ""
+        property var calls: []
+        signal responseReceived(string requestId, var result)
+        signal requestFailed(string requestId, string code, string message)
+        signal eventReceived(string name, var payload)
+        function markUiReady() {}
+        function logShellDiagnostic(message) {}
+        function request(method, params, timeout) {
+            const id = "fixture-" + (calls.length + 1)
+            calls = calls.concat([{id:id, method:method, params:params}])
+            return id
+        }
+        function cancel(id) { return true }
+    }
+    function check(ok, message) { if (!ok) throw new Error("Persistent in-game settings: " + message) }
+    function find(item, name) {
+        if (item.objectName === name) return item
+        for (const child of item.children || []) {
+            const found = find(child, name)
+            if (found) return found
+        }
+        return null
+    }
+    function run(parent) {
+        client.state = "ready"
+        ShellStore.settings = ({})
+        const toggle = find(parent, "persistentInGameSettingsToggle")
+        check(toggle && !toggle.checked, "desktop preference defaults off")
+        const consolePage = consoleSettings.createObject(parent)
+        const row = consolePage.settingsModel().find(item => item.key === "enablePersistingInGameSettings")
+        check(row && row.toggle && row.v === "Off" && row.t === "Persistent in-game settings",
+            "console exposes in-game settings rather than cloud saves")
+        for (const enabled of [true, false]) {
+            toggle.clicked()
+            const write = client.calls[client.calls.length - 1]
+            check(write.method === "settings.set" && write.params.key === "enablePersistingInGameSettings"
+                && write.params.value === enabled, "desktop requests the persisted preference")
+            client.eventReceived("settings.changed", {key:"enablePersistingInGameSettings", value:enabled})
+            check(toggle.checked === enabled && ShellStore.settings.enablePersistingInGameSettings === enabled,
+                "desktop reflects the saved value")
+            check(consolePage.settingsModel().find(item => item.key === "enablePersistingInGameSettings").v
+                === (enabled ? "On" : "Off"), "console reflects desktop changes")
+        }
+        consolePage.activate(consolePage.settingsModel().find(item => item.key === "enablePersistingInGameSettings"))
+        const write = client.calls[client.calls.length - 1]
+        check(write.method === "settings.set" && write.params.key === "enablePersistingInGameSettings"
+            && write.params.value === true, "console writes the same preference")
+        client.eventReceived("settings.changed", {key:"enablePersistingInGameSettings", value:true})
+        check(toggle.checked, "desktop reflects console changes")
+        consolePage.destroy()
+
+        ShellStore.nativeRuntimeReady = true
+        ShellStore.authSession = {accountId:"fixture"}
+        for (const support of [undefined, false, true]) {
+            for (const selectedIndex of [0, 1]) {
+                for (const directConsoleMode of [false, true]) {
+                    ShellStore.selectedGame = {
+                        title:"Fixture", launchAppId:"12345", selectedVariantIndex:selectedIndex,
+                        variants:[
+                            {appId:"12345", supportsInGameSettingsPersistence:support},
+                            {appId:"67890", supportsInGameSettingsPersistence:!support}
+                        ]
+                    }
+                    ShellStore.launchSelectedGame(directConsoleMode)
+                    const request = client.calls[client.calls.length - 1]
+                    const expectedSupport = selectedIndex === 0 ? support === true : !support
+                    check(request.method === "session.remote.list"
+                        && request.params.supportsInGameSettingsPersistence === expectedSupport,
+                        "launch uses the selected storefront's support flag")
+                    client.responseReceived(request.id, {sessions:[]})
+                    const create = client.calls[client.calls.length - 1]
+                    check(create.method === "session.create"
+                        && create.params.supportsInGameSettingsPersistence === expectedSupport,
+                        "session creation preserves game support")
+                    client.responseReceived(create.id, {session:null})
+                    check(!ShellStore.streamBusy, "launch requests settle")
+                }
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
Expose **Persistent in-game settings** in desktop Settings → Stream and correct the console Account setting previously mislabeled as “Cloud saves.” Both controls use the existing saved `enablePersistingInGameSettings` preference and CloudMatch request path, matching the flag used by OpenNOW-Mac. The preference defaults to enabled for new installations and settings files without the key. Explicit saved choices are preserved, and resetting settings restores enabled. It applies to supported games and memberships and affects new sessions only. Add settings-search keywords and English source translations.

Add regression coverage for desktop/console synchronization, selected storefront capability forwarding, on/off persistence across reloads, reset and failed writes, default-enabled launches and explicit opt-out gating, and preserving the allocated session's flag on resume.

### Verification
- Full Debug Qt/native build passed.
- Rust core suite passed: 277 tests, 4 existing ignored tests. Clippy with `-D warnings` and rustfmt passed.
- All 25 Qt `ci-unit` tests passed.
- New persistence acceptance, 4 settings windowed/fullscreen motion checks, and 8 desktop/console/compact settings route checks passed.
- QML syntax and localization checks passed.
- Real core JSON requests verified setting reads/writes and persistence across three process launches.
- Inspected desktop and console screenshots from the built Qt smoke harness. Live NVIDIA retention of in-game graphics settings was not tested without a GFN account.

### Desktop
![Persistent in-game settings in desktop Stream settings](https://api-nightly.capy.ai/pr-assets/2BLkt4qMEgimT21dIMYlT7XxjAvslAVT2m5uqEqL3KA)

### Console
![Persistent in-game settings in console Account settings](https://api-nightly.capy.ai/pr-assets/0Y9Er4IgJBcsaGviC247rHoErPLnjl5bV4zK0xPnbo0)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M290C4RMAD54VW62G05DC4HF"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->