### PR TITLE
fix(qt): default both controller stick dead zones to 5%

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -61,8 +61,8 @@
   "controllerTuning": {
     "leftDeadzone": "Left stick dead zone",
     "rightDeadzone": "Right stick dead zone",
-    "leftDeadzoneDescription": "Ignore stick drift during gameplay. Default: 24%. The remaining travel is rescaled to full range.",
-    "rightDeadzoneDescription": "Ignore stick drift during gameplay. Default: 27%. Set to 0% to leave dead zones to the game.",
+    "leftDeadzoneDescription": "Ignore stick drift during gameplay. Default: 5%. The remaining travel is rescaled to full range.",
+    "rightDeadzoneDescription": "Ignore stick drift during gameplay. Default: 5%. Set to 0% to leave dead zones to the game.",
     "vibration": "Controller vibration",
     "vibrationDescription": "Scale game vibration on supported controllers. Set to 0% to disable."
   },

--- a/native/opennow-core/src/settings.rs
+++ b/native/opennow-core/src/settings.rs
@@ -369,8 +369,8 @@ impl SettingsStore {
             crate::version::update_channel(crate::version::APPLICATION_VERSION),
         );
         clamp_integer(&mut self.values, "mouseAcceleration", 1, 150, 1);
-        clamp_integer(&mut self.values, "controllerLeftStickDeadzone", 0, 50, 24);
-        clamp_integer(&mut self.values, "controllerRightStickDeadzone", 0, 50, 27);
+        clamp_integer(&mut self.values, "controllerLeftStickDeadzone", 0, 50, 5);
+        clamp_integer(&mut self.values, "controllerRightStickDeadzone", 0, 50, 5);
         clamp_integer(
             &mut self.values,
             "controllerVibrationIntensity",
@@ -884,7 +884,7 @@ fn defaults() -> Map<String, Value> {
         "appAccentColor":"green", "appTheme":"auto", "appLanguage":"system", "themePack":"nocturne", "translucentUI":false,
         "showTileLabels":true,
         "controllerMode":true, "controllerModePromptDismissed":false,
-        "controllerLeftStickDeadzone":24, "controllerRightStickDeadzone":27,
+        "controllerLeftStickDeadzone":5, "controllerRightStickDeadzone":5,
         "controllerVibrationIntensity":100,
         "reducedMotion":false,
         "launchInConsoleMode":false, "consoleProfilePickerOnLaunch":true,
@@ -2276,8 +2276,8 @@ mod tests {
         let directory = env::temp_dir().join(format!("opennow-controller-tuning-{unique}"));
         let mut store = SettingsStore::load(Some(directory.clone())).unwrap();
         for (key, default, maximum) in [
-            ("controllerLeftStickDeadzone", 24, 50),
-            ("controllerRightStickDeadzone", 27, 50),
+            ("controllerLeftStickDeadzone", 5, 50),
+            ("controllerRightStickDeadzone", 5, 50),
             ("controllerVibrationIntensity", 100, 100),
         ] {
             assert_eq!(store.all()[key], json!(default));

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -581,7 +581,7 @@ they also duplicate input.
 **Settings → Input & controllers** includes independent left/right stick dead zones
 (0–50%) and controller vibration intensity (0–100%) in both desktop and console mode.
 These global preferences are saved and apply without restarting the session. Defaults
-are 24% left and 27% right, rounded from the XInput-style thresholds used by OpenNOW-Mac.
+are 5% for both sticks. Existing saved preferences are preserved.
 The radial filter suppresses resting drift and rescales the remaining travel, preserving
 full axis and diagonal output. Set either stick to 0% to leave its dead zone to the game;
 shell navigation retains its separate press/release thresholds.

--- a/opennow-qt/qml/Main.qml
+++ b/opennow-qt/qml/Main.qml
@@ -175,12 +175,12 @@ ApplicationWindow {
     Binding {
         target: ControllerInput
         property: "leftStickDeadzone"
-        value: Number(ShellStore.settings.controllerLeftStickDeadzone ?? 24)
+        value: Number(ShellStore.settings.controllerLeftStickDeadzone ?? 5)
     }
     Binding {
         target: ControllerInput
         property: "rightStickDeadzone"
-        value: Number(ShellStore.settings.controllerRightStickDeadzone ?? 27)
+        value: Number(ShellStore.settings.controllerRightStickDeadzone ?? 5)
     }
     Binding {
         target: ControllerInput

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsControlsPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsControlsPage.qml
@@ -71,21 +71,21 @@ Column {
         }
         DesktopSettingsRow {
             width: parent.width; paperStyle: true; glyph: "controller"; title: qsTr("Left stick dead zone")
-            description: qsTr("Ignore stick drift during gameplay. Default: 24%. The remaining travel is rescaled to full range.")
+            description: qsTr("Ignore stick drift during gameplay. Default: 5%. The remaining travel is rescaled to full range.")
             DesktopSettingsSlider {
                 objectName: "controllerLeftStickDeadzoneSlider"
                 from: 0; to: 50; stepSize: 1
-                value: Number(controlsRoot.settingsScreen.valueSetting("controllerLeftStickDeadzone", 24))
+                value: Number(controlsRoot.settingsScreen.valueSetting("controllerLeftStickDeadzone", 5))
                 onCommitted: value => controlsRoot.settingsScreen.setSetting("controllerLeftStickDeadzone", value)
             }
         }
         DesktopSettingsRow {
             width: parent.width; paperStyle: true; glyph: "controller"; title: qsTr("Right stick dead zone")
-            description: qsTr("Ignore stick drift during gameplay. Default: 27%. Set to 0% to leave dead zones to the game.")
+            description: qsTr("Ignore stick drift during gameplay. Default: 5%. Set to 0% to leave dead zones to the game.")
             DesktopSettingsSlider {
                 objectName: "controllerRightStickDeadzoneSlider"
                 from: 0; to: 50; stepSize: 1
-                value: Number(controlsRoot.settingsScreen.valueSetting("controllerRightStickDeadzone", 27))
+                value: Number(controlsRoot.settingsScreen.valueSetting("controllerRightStickDeadzone", 5))
                 onCommitted: value => controlsRoot.settingsScreen.setSetting("controllerRightStickDeadzone", value)
             }
         }

--- a/opennow-qt/qml/screens/SettingsScreen.qml
+++ b/opennow-qt/qml/screens/SettingsScreen.qml
@@ -354,8 +354,8 @@ FocusScope {
             rows.push(toggle("Gyroscope", "Forward motion data to the rig", "enableGyroscopeControls"))
             rows.push(toggle(qsTr("Clipboard paste"), qsTr("Paste local text into the stream with Ctrl+V (Command+V on macOS). Up to 64 KiB per paste. No automatic clipboard sync."), "clipboardPaste"))
             for (const setting of [
-                {key:"controllerLeftStickDeadzone", title:qsTr("Left stick dead zone"), description:qsTr("Ignore stick drift during gameplay. Default: 24%. The remaining travel is rescaled to full range."), maximum:50, fallback:24},
-                {key:"controllerRightStickDeadzone", title:qsTr("Right stick dead zone"), description:qsTr("Ignore stick drift during gameplay. Default: 27%. Set to 0% to leave dead zones to the game."), maximum:50, fallback:27},
+                {key:"controllerLeftStickDeadzone", title:qsTr("Left stick dead zone"), description:qsTr("Ignore stick drift during gameplay. Default: 5%. The remaining travel is rescaled to full range."), maximum:50, fallback:5},
+                {key:"controllerRightStickDeadzone", title:qsTr("Right stick dead zone"), description:qsTr("Ignore stick drift during gameplay. Default: 5%. Set to 0% to leave dead zones to the game."), maximum:50, fallback:5},
                 {key:"controllerVibrationIntensity", title:qsTr("Controller vibration"), description:qsTr("Scale game vibration on supported controllers. Set to 0% to disable."), maximum:100, fallback:100}
             ]) {
                 const value = Number(settings[setting.key] ?? setting.fallback)

--- a/opennow-qt/src/input/ControllerInput.h
+++ b/opennow-qt/src/input/ControllerInput.h
@@ -127,8 +127,8 @@ private:
     bool m_sdlReady = false;
     bool m_shellCaptureEnabled = true;
     bool m_inputSuspended = false;
-    int m_leftStickDeadzone = 24;
-    int m_rightStickDeadzone = 27;
+    int m_leftStickDeadzone = 5;
+    int m_rightStickDeadzone = 5;
     int m_vibrationIntensity = 100;
     qint64 m_lastControllerMetadataAt = 0;
     qint64 m_lastGamepadSnapshotAt = 0;

--- a/opennow-qt/tests/ControllerMetadataAcceptance.qml
+++ b/opennow-qt/tests/ControllerMetadataAcceptance.qml
@@ -15,8 +15,8 @@ QtObject {
         property int controllerCount: controllers.length
         property bool shellCaptureEnabled: true
         property bool inputSuspended: false
-        property int leftStickDeadzone: 24
-        property int rightStickDeadzone: 27
+        property int leftStickDeadzone: 5
+        property int rightStickDeadzone: 5
         property int vibrationIntensity: 100
         signal controllerActivity()
         signal controllerActivityDetailed(string device, string control, int value)
@@ -39,8 +39,8 @@ QtObject {
             "disabled shell navigation must not transfer controller input or rumble to gameplay")
         ShellStore.applySetting("controllerMode", true)
         for (const setting of [
-            ["controllerLeftStickDeadzone", "leftStickDeadzone", 24, 50],
-            ["controllerRightStickDeadzone", "rightStickDeadzone", 27, 50],
+            ["controllerLeftStickDeadzone", "leftStickDeadzone", 5, 50],
+            ["controllerRightStickDeadzone", "rightStickDeadzone", 5, 50],
             ["controllerVibrationIntensity", "vibrationIntensity", 100, 100]
         ]) {
             const slider = find(page, setting[0] + "Slider")

--- a/opennow-qt/tests/tst_controllertuning.cpp
+++ b/opennow-qt/tests/tst_controllertuning.cpp
@@ -98,8 +98,10 @@ private slots:
         TuningPad pad;
         QVERIFY(pad.id);
         QTRY_COMPARE(input.controllerCount(), 1);
-        QCOMPARE(input.leftStickDeadzone(), 24);
-        QCOMPARE(input.rightStickDeadzone(), 27);
+        QCOMPARE(input.leftStickDeadzone(), 5);
+        QCOMPARE(input.rightStickDeadzone(), 5);
+        input.setLeftStickDeadzone(24);
+        input.setRightStickDeadzone(27);
         QVERIFY(pad.axis(SDL_GAMEPAD_AXIS_LEFTX, 8192));
         QVERIFY(pad.axis(SDL_GAMEPAD_AXIS_RIGHTX, 8192));
         SDL_UpdateJoysticks();


### PR DESCRIPTION
Set the left and right controller stick dead-zone defaults to 5% in core settings, invalid-value fallbacks, Qt input initialization, and desktop/console settings bindings. Existing saved preferences remain unchanged.

Update English settings descriptions, controller acceptance fixtures, and documentation. Keep the independent-stick test's original 24%/27% behavior coverage by setting those values explicitly after checking the new defaults.

Validation:
- `cargo test --manifest-path native/opennow-core/Cargo.toml settings::tests`: 37 passed.
- `cargo fmt --manifest-path native/opennow-core/Cargo.toml --check`: passed.
- `npm run locales:check`: passed.
- `node --test scripts/check-translations.test.mjs`: 6 passed.
- `git diff --check`: passed.
- Qt configuration blocked at `find_package(Qt6 6.8)` because the local machine has no Qt SDK. Qt controller tests and visual verification were not run.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M291Y85P2TDW6YX6459X64CB"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->