### PR TITLE
fix(qt): keep session launch text readable in light mode

### DIFF
--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -195,6 +195,9 @@ if(BUILD_TESTING)
     target_link_libraries(opennow-theme-tests PRIVATE Qt6::QuickTest Qt6::Quick)
     target_compile_definitions(opennow-theme-tests PRIVATE
         OPENNOW_QML_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qml")
+    qt_add_resources(opennow-theme-tests "theme-test-assets"
+        PREFIX "/qt/qml/OpenNOW" FILES ${OPENNOW_KEYBOARD_ICON_FILES}
+        res/brand/opennow-mark.png)
     add_test(NAME opennow-theme-tests COMMAND opennow-theme-tests
         -input "${CMAKE_CURRENT_SOURCE_DIR}/tests/theme")
     set_tests_properties(opennow-theme-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 30)

--- a/opennow-qt/qml/desktop/components/DesktopButton.qml
+++ b/opennow-qt/qml/desktop/components/DesktopButton.qml
@@ -6,6 +6,7 @@ Button {
     id: root
     property bool primary: false
     property bool danger: false
+    property bool onMediaBackground: false
     property string shortcutText: ""
     property string shortcutSequence: shortcutText
     property string glyph: ""
@@ -36,7 +37,7 @@ Button {
             radius: parent.radius + 2
             color: "transparent"
             border.width: 2
-            border.color: DesktopTokens.focus
+            border.color: root.onMediaBackground ? Theme.mediaAccent : DesktopTokens.focus
             visible: root.activeFocus
         }
     }
@@ -61,14 +62,15 @@ Button {
                 width: root.glyphSize; height: root.glyphSize
                 sourceComponent: DesktopSettingsIcon {
                     glyph: root.themedGlyph
-                    ink: root.primary ? "#0A0D14" : Theme.label
+                    ink: root.primary ? "#0A0D14" : root.onMediaBackground ? Theme.mediaForeground : Theme.label
                 }
             }
             Text {
                 visible: root.text !== ""
                 anchors.verticalCenter: parent.verticalCenter
                 text: root.text
-                color: root.primary ? "#0A0D14" : root.danger ? "#FFB4AE" : DesktopTokens.textHigh
+                color: root.primary ? "#0A0D14" : root.danger ? "#FFB4AE"
+                    : root.onMediaBackground ? Theme.mediaForeground : DesktopTokens.textHigh
                 font: root.font
             }
             KeyboardGlyph {
@@ -77,7 +79,7 @@ Button {
                 shortcut: root.shortcutSequence
                 Accessible.name: root.shortcutText
                 keySize: 20
-                ink: root.primary ? "#0B0F1A" : DesktopTokens.textMuted
+                ink: root.primary ? "#0B0F1A" : root.onMediaBackground ? Theme.mediaMuted : DesktopTokens.textMuted
             }
         }
     }

--- a/opennow-qt/qml/desktop/stream/DesktopSessionStarting.qml
+++ b/opennow-qt/qml/desktop/stream/DesktopSessionStarting.qml
@@ -94,7 +94,7 @@ FocusScope {
         }
         Text {
             text: "OpenNOW"
-            color: DesktopTokens.text
+            color: Theme.mediaForeground
             font.family: DesktopTokens.displayFont
             font.pixelSize: 16
             font.weight: Font.Black
@@ -109,7 +109,7 @@ FocusScope {
         Text {
             text: root.stopping ? qsTr("ENDING SESSION")
                 : root.failed ? qsTr("SESSION INTERRUPTED") : qsTr("STARTING SESSION")
-            color: root.failed ? DesktopTokens.danger : DesktopTokens.focus
+            color: root.failed ? DesktopTokens.danger : Theme.mediaAccent
             font.family: DesktopTokens.monoFont
             font.pixelSize: 11
             font.weight: Font.Bold
@@ -119,7 +119,7 @@ FocusScope {
             width: parent.width
             topPadding: 10
             text: String(root.game.title || qsTr("GeForce NOW"))
-            color: DesktopTokens.text
+            color: Theme.mediaForeground
             font.family: DesktopTokens.displayFont
             font.pixelSize: root.width < 800 ? 34 : 44
             font.weight: Font.Black
@@ -145,7 +145,7 @@ FocusScope {
                         anchors.horizontalCenter: parent.horizontalCenter
                         y: -1
                         width: 6; height: 6; radius: 3
-                        color: DesktopTokens.focus
+                        color: Theme.mediaAccent
                     }
                     RotationAnimation on rotation {
                         from: 0; to: 360; duration: 1400; loops: Animation.Infinite
@@ -157,7 +157,7 @@ FocusScope {
                 objectName: "sessionLaunchStatus"
                 width: parent.width - (root.failed ? 0 : 32)
                 text: root.statusText
-                color: root.failed ? DesktopTokens.danger : DesktopTokens.text
+                color: root.failed ? DesktopTokens.danger : Theme.mediaForeground
                 font.family: DesktopTokens.bodyFont
                 font.pixelSize: 19
                 font.weight: Font.DemiBold
@@ -168,7 +168,7 @@ FocusScope {
             width: parent.width
             topPadding: 10
             text: root.detailText
-            color: DesktopTokens.textBody
+            color: Theme.mediaMuted
             font.family: DesktopTokens.bodyFont
             font.pixelSize: 14
             lineHeight: 1.4
@@ -181,6 +181,7 @@ FocusScope {
             width: parent.width
             spacing: 12
             DesktopButton {
+                onMediaBackground: true
                 visible: root.failed && (root.connecting || ShellStore.activeSession !== null
                     || ShellStore.pendingLaunchParams !== null || ShellStore.conflictSession !== null)
                 enabled: !ShellStore.streamBusy
@@ -190,6 +191,7 @@ FocusScope {
             }
             DesktopButton {
                 id: cancelButton
+                onMediaBackground: true
                 enabled: !root.stopping
                 text: root.failed && !ShellStore.activeSession ? qsTr("Back") : qsTr("Cancel session")
                 shortcutText: qsTr("Esc")

--- a/opennow-qt/qml/theme/Theme.qml
+++ b/opennow-qt/qml/theme/Theme.qml
@@ -29,14 +29,16 @@ QtObject {
     // Artwork scrims and dark store-color fallbacks always need a light foreground,
     // independently of the shell's light/dark mode.
     readonly property color mediaForeground: "#FFFFFF"
+    readonly property color mediaMuted: Qt.rgba(mediaForeground.r, mediaForeground.g, mediaForeground.b, 0.64)
+    readonly property color mediaAccent: accentOverridden ? accentColor(accent, false) : (pack.darkAccent || pack.accent)
     readonly property color seam: lightMode ? Qt.rgba(0.04, 0.06, 0.10, 0.14) : Qt.rgba(1, 1, 1, 0.14)
     readonly property color label: lightMode ? "#111827" : "#FFFFFF"
     readonly property color textMuted: lightMode ? Qt.rgba(0.04, 0.06, 0.10, 0.64) : Qt.rgba(1, 1, 1, 0.64)
     readonly property var accentChoices: ["green", "blue", "violet", "rose", "coral", "amber", "white"]
-    function accentColor(value) {
+    function accentColor(value, forLightMode = lightMode) {
         const dark = {green:"#6EE7B7", blue:"#7FD4FF", violet:"#A78BFA", rose:"#FF8A9A", coral:"#FF8A80", amber:"#FFD166", white:"#FFFFFF"}
         const light = {green:"#126B4E", blue:"#12638C", violet:"#7042BA", rose:"#AA285B", coral:"#A9362C", amber:"#806017", white:"#374151"}
-        return (lightMode ? light : dark)[value] || (lightMode ? light.blue : dark.blue)
+        return (forLightMode ? light : dark)[value] || (forLightMode ? light.blue : dark.blue)
     }
     readonly property color customAccent: accentColor(accent)
     readonly property color packAccent: lightMode ? (pack.lightAccent || pack.accent) : (pack.darkAccent || pack.accent)

--- a/opennow-qt/tests/theme/tst_sessionstarting.qml
+++ b/opennow-qt/tests/theme/tst_sessionstarting.qml
@@ -1,0 +1,103 @@
+import QtQuick
+import QtTest
+import OpenNOW
+
+TestCase {
+    id: testCase
+    name: "SessionStartingContrast"
+    width: 1000
+    height: 700
+    when: windowShown
+    visible: true
+
+    DesktopSessionStarting {
+        id: screen
+        anchors.fill: parent
+    }
+
+    DesktopButton {
+        id: shellButton
+        visible: false
+        text: "Shell button"
+    }
+
+    function init() {
+        ShellStore.previewThemePack = ""
+        ShellStore.streamState = "preparing"
+        AppController.route = "inserting"
+        AppController.overlay = ""
+    }
+
+    function descendants(item) {
+        let result = []
+        for (const child of item.children || [])
+            result = result.concat([child], descendants(child))
+        return result
+    }
+
+    function textItem(text) {
+        const item = descendants(screen).find(item => item.text === text && item.color !== undefined)
+        verify(item !== undefined, "Missing text: " + text)
+        return item
+    }
+
+    function contrastOnDark(color) {
+        const background = Qt.color("#04060A")
+        const linear = value => value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4)
+        const luminance = value => linear(value.r) * 0.2126 + linear(value.g) * 0.7152 + linear(value.b) * 0.0722
+        const composited = Qt.rgba(color.r * color.a + background.r * (1 - color.a),
+                                  color.g * color.a + background.g * (1 - color.a),
+                                  color.b * color.a + background.b * (1 - color.a), 1)
+        return (luminance(composited) + 0.05) / (luminance(background) + 0.05)
+    }
+
+    function test_launchPalette_data() {
+        const rows = []
+        for (const pack of Theme.packs) {
+            for (const mode of ["light", "dark", "auto"]) {
+                for (const accent of ["pack"].concat(Theme.accentChoices))
+                    rows.push({tag: pack.id + "-" + mode + "-" + accent, pack: pack.id, mode: mode, accent: accent})
+            }
+        }
+        return rows
+    }
+
+    function test_launchPalette(data) {
+        ShellStore.settings = {themePack: data.pack, appTheme: data.mode,
+            appAccentColor: data.accent, themeAccentOverride: data.accent !== "pack"}
+        compare(textItem("Dead by Daylight").color, Theme.mediaForeground)
+        compare(textItem("Queue position 21").color, Theme.mediaForeground)
+        compare(textItem("OpenNOW").color, Theme.mediaForeground)
+        compare(textItem(screen.detailText).color.toString(), Theme.mediaMuted.toString())
+        compare(textItem("STARTING SESSION").color, Theme.mediaAccent)
+        compare(textItem("Cancel session").color, Theme.mediaForeground)
+        for (const text of ["Dead by Daylight", "Queue position 21", "OpenNOW",
+                            screen.detailText, "STARTING SESSION", "Cancel session"])
+            verify(contrastOnDark(textItem(text).color) >= 4.5, "Insufficient contrast: " + text)
+
+        const shortcut = descendants(screen).find(item => item.shortcut === "Esc")
+        verify(shortcut !== undefined)
+        compare(shortcut.ink, Theme.mediaMuted)
+        verify(contrastOnDark(shortcut.ink) >= 4.5)
+
+        const cancel = descendants(screen).find(item => item.text === "Cancel session" && item.onMediaBackground !== undefined)
+        cancel.forceActiveFocus()
+        verify(descendants(cancel.background).some(item => item.visible && item.border
+            && item.border.width === 2 && item.border.color.toString() === Theme.mediaAccent.toString()))
+
+        const shellText = descendants(shellButton).find(item => item.text === shellButton.text && item.color !== undefined)
+        compare(shellText.color, DesktopTokens.textHigh)
+    }
+
+    function test_failureAndReconnect() {
+        ShellStore.settings = {themePack: "nocturne", appTheme: "light"}
+        ShellStore.streamState = "failed"
+        compare(textItem("Session could not start").color, DesktopTokens.danger)
+        compare(textItem("Try again").color, Qt.color("#0A0D14"))
+        compare(textItem("Cancel session").color, Theme.mediaForeground)
+        ShellStore.streamState = "reconnecting"
+        compare(textItem("Reconnecting to your session").color, Theme.mediaForeground)
+        ShellStore.streamState = "stopping"
+        compare(textItem("Closing your session").color, Theme.mediaForeground)
+    }
+}

--- a/opennow-qt/tests/tst_theme.cpp
+++ b/opennow-qt/tests/tst_theme.cpp
@@ -1,7 +1,23 @@
+#include <QFontDatabase>
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QQmlPropertyMap>
 #include <QtQuickTest/quicktest.h>
+#include <utility>
+
+class ThemeTestShell final : public QQmlPropertyMap
+{
+    Q_OBJECT
+
+public:
+    ThemeTestShell() : QQmlPropertyMap(this, nullptr) {}
+
+    Q_INVOKABLE QString artworkUrl(const QString &source) const { return source; }
+    Q_INVOKABLE bool streamOverlayBlocksGameplayInput(const QString &overlay) const { return !overlay.isEmpty(); }
+
+signals:
+    void readyChanged();
+};
 
 class ThemeTestSetup final : public QObject
 {
@@ -11,21 +27,52 @@ public slots:
     void applicationAvailable()
     {
         const auto source = QStringLiteral(OPENNOW_QML_SOURCE_DIR);
+        QFontDatabase::addApplicationFont(source + "/../res/fonts/Nunito-Variable.ttf");
+        QFontDatabase::addApplicationFont(source + "/../res/fonts/IBMPlexMono-Medium.ttf");
         qmlRegisterSingletonType(QUrl::fromLocalFile(source + "/theme/Theme.qml"), "OpenNOW.ThemeTests", 1, 0, "Theme");
         qmlRegisterType(QUrl::fromLocalFile(source + "/state/settings/SettingsState.qml"), "OpenNOW.ThemeTests", 1, 0, "SettingsState");
+        for (const auto &entry : {std::pair{"Theme", "theme/Theme.qml"},
+                                 {"DesktopTokens", "desktop/components/DesktopTokens.qml"},
+                                 {"InputPromptIcons", "components/InputPromptIcons.qml"}}) {
+            qmlRegisterSingletonType(QUrl::fromLocalFile(source + "/" + entry.second), "OpenNOW", 1, 0, entry.first);
+        }
+        for (const auto &entry : {std::pair{"DesktopSessionStarting", "desktop/stream/DesktopSessionStarting.qml"},
+                                 {"DesktopButton", "desktop/components/DesktopButton.qml"},
+                                 {"DesktopGlyph", "desktop/components/DesktopGlyph.qml"},
+                                 {"DesktopSettingsIcon", "desktop/settings/controls/DesktopSettingsIcon.qml"},
+                                 {"KeyboardGlyph", "components/KeyboardGlyph.qml"},
+                                 {"ArtworkSource", "components/ArtworkSource.qml"}}) {
+            qmlRegisterType(QUrl::fromLocalFile(source + "/" + entry.second), "OpenNOW", 1, 0, entry.first);
+        }
     }
 
     void qmlEngineAvailable(QQmlEngine *engine)
     {
+        auto paths = engine->importPathList();
+        paths.removeAll(QCoreApplication::applicationDirPath());
+        engine->setImportPathList(paths);
         m_shell.insert("settings", QVariantMap{});
         m_shell.insert("previewThemePack", QString{});
+        m_shell.insert("selectedGame", QVariantMap{{"title", "Dead by Daylight"}});
+        m_shell.insert("activeSession", QVariantMap{{"queuePosition", 21}});
+        m_shell.insert("streamer", QVariantMap{});
+        m_shell.insert("streamState", "preparing");
+        m_shell.insert("streamerRestartAttempts", 0);
+        m_shell.insert("sessionReconnectAttempts", 0);
+        m_shell.insert("launchConflictDetected", false);
+        m_shell.insert("streamMessage", QString{});
+        m_shell.insert("streamBusy", false);
+        m_shell.insert("pendingLaunchParams", QVariantMap{});
+        m_shell.insert("conflictSession", QVariantMap{});
         m_controller.insert("reducedMotion", true);
+        m_controller.insert("route", "inserting");
+        m_controller.insert("overlay", QString{});
         engine->rootContext()->setContextProperty("ShellStore", &m_shell);
         engine->rootContext()->setContextProperty("AppController", &m_controller);
     }
 
 private:
-    QQmlPropertyMap m_shell;
+    ThemeTestShell m_shell;
     QQmlPropertyMap m_controller;
 };
 


### PR DESCRIPTION
The session launch screen always uses a dark artwork scrim, but its text and secondary buttons inherited the light shell palette and became nearly black.

- Use the media foreground and muted colors for the launch title, status, details, and cancel action.
- Resolve launch accents and button focus rings from the selected theme's dark palette, including custom accents, without changing the shell theme.
- Add launch-screen regression coverage to the existing theme test target for all 192 combinations of theme pack, light/dark/auto mode, and accent selection, plus failure/reconnect/stopping states and unchanged shell-button colors.

Verified with Qt 6.8.3: all five related Qt suites pass (`theme`, `consolelayout`, `consoleactions`, `controllericons`, `streamtoasts`), and all production QML parses with the CI `qmlformat` check. Reverting the launch-screen fix makes the regression fail with actual `#111827` versus expected `#ffffff`. Inspected native Qt fixture renders in light and dark modes at 679×534 and 1000×700; no live account or gameplay session was used.

Light-mode launch screen, using the account-free fixture without artwork:

![Light-mode launch screen](https://api-nightly.capy.ai/pr-assets/x7V6xW_7Yn4fXOkn7HgiXtSokDnZk_Pa99khq83S4Sg)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2ABH27CS10E9921362MBAA3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->