### PR TITLE
fix(ci): use generated changelogs for release notes

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -190,29 +190,12 @@ jobs:
         with:
           name: opennow-qt-${{ needs.build.outputs.version }}-complete-update-signed
           path: nightly-release
-      - name: Verify signed inventory and prepare release notes
+      - name: Verify signed inventory
         shell: bash
         run: |
           python3 opennow-qt/packaging/sign_nightly_release.py verify \
             --source nightly-release --version "$RELEASE_VERSION" --commit "$SOURCE_SHA"
           (cd nightly-release && sha256sum --check --strict SHA256SUMS)
-          cat > nightly-notes.md <<EOF
-          Experimental OpenNOW Qt/native nightly from commit \`$SOURCE_SHA\`.
-
-          **Platform packages remain unsigned; update manifests are Ed25519-signed.** Windows may display a SmartScreen or unknown-publisher warning.
-          Windows x64 and ARM64 downloads include MSI installers and portable ZIPs.
-          The MSI installs OpenNOW Nightly separately from stable OpenNOW. For the portable ZIP, extract the entire archive and run \`bin/OpenNOW.exe\`.
-          The macOS DMG supports Apple Silicon on macOS 13+: open it and drag OpenNOW into Applications.
-          The Mac app is not notarized and Gatekeeper may block it. Use System Settings → Privacy & Security → Open Anyway if macOS offers it; do not disable Gatekeeper globally.
-          Linux AppImages are the recommended portable download; mark the file executable before launching it.
-          DEBs require a distribution providing Qt 6.8+ and SDL3; stock Ubuntu 24.04 does not satisfy those requirements.
-
-          These builds pin the update-signing public key and include a verified manifest for every package.
-          If your installed nightly has no pinned key, manually install this release once; that older build cannot securely bootstrap trust from the update feed.
-          SHA256SUMS detects corrupted downloads; it is not a cryptographic publisher signature.
-          Intel macOS is not included. Windows ARM64 is cross-built, not runtime-tested by CI.
-          **Known issue: Alliance Partners are not working correctly in this build.**
-          EOF
       - name: Publish only after the complete upload succeeds
         shell: bash
         env:
@@ -220,7 +203,7 @@ jobs:
         run: |
           gh release create "v$RELEASE_VERSION" nightly-release/* \
             --repo "$GITHUB_REPOSITORY" --target "$SOURCE_SHA" \
-            --title "OpenNOW v$RELEASE_VERSION" --notes-file nightly-notes.md \
+            --title "OpenNOW v$RELEASE_VERSION" --generate-notes \
             --draft --prerelease --latest=false
           gh release edit "v$RELEASE_VERSION" --repo "$GITHUB_REPOSITORY" \
             --draft=false --prerelease --latest=false

--- a/docs/update-signing-setup.md
+++ b/docs/update-signing-setup.md
@@ -57,9 +57,10 @@ learn a trust key from release metadata. Do not bypass signature checks to boots
 Later updates require manifests signed by the already pinned key.
 
 Update-manifest signing does not remove Windows publisher warnings or macOS Gatekeeper
-warnings. The platform packages remain unsigned. Keep the Alliance Partners release
-warning: **Known issue: Alliance Partners are not working correctly in this build.**
-Update signing does not fix partner authentication or streaming compatibility.
+warnings. The platform packages remain unsigned. Nightly release notes use GitHub-generated
+changelogs; installation guidance and known limitations are documented in
+[`qt-nightly-release.md`](qt-nightly-release.md). Update signing does not fix partner
+authentication or streaming compatibility.
 
 ## Verify the repository contract without production credentials
 

--- a/docs/update-signing.md
+++ b/docs/update-signing.md
@@ -89,7 +89,8 @@ and the rewritten release metadata. The validation-only macOS ZIP is never publi
 The production `qt-release-candidate.yml` contract remains separate: eight Linux and
 Windows packages, platform signing, isolated update signing, and a candidate artifact.
 This nightly follow-up does not add a macOS production candidate or alter that contract.
-Nightly release notes retain the Alliance Partners warning and do not claim a compatibility fix.
+Nightly release notes use GitHub-generated changelogs. Installation guidance and known
+limitations are documented in [`qt-nightly-release.md`](qt-nightly-release.md).
 
 Nightly macOS packaging enables `OPENNOW_MACOS_ADHOC_SIGN`. Qt deployment signs nested
 code with `macdeployqt -codesign=-`, then the final install script seals the complete

--- a/opennow-qt/tests/test_signed_nightly_release.py
+++ b/opennow-qt/tests/test_signed_nightly_release.py
@@ -189,7 +189,9 @@ class SignedNightlyReleaseTest(unittest.TestCase):
         for forbidden in ("cargo ", "cmake ", "unsigned-release/", "signed-release/"):
             self.assertNotIn("run: " + forbidden, signer)
         self.assertIn("update_public_key: ${{ inputs.public_key }}", workflow)
-        self.assertIn("**Known issue: Alliance Partners are not working correctly in this build.**", publisher)
+        self.assertIn('--title "OpenNOW v$RELEASE_VERSION" --generate-notes', publisher)
+        self.assertNotIn("--notes-file", publisher)
+        self.assertNotIn("nightly-notes.md", publisher)
         preflight = workflow.split("  preflight:\n", 1)[1].split("  contracts:\n", 1)[0]
         self.assertIn("if: github.event_name == 'workflow_dispatch'", preflight)
         outside_signer = workflow.replace(signer, "")


### PR DESCRIPTION
Replace the nightly release’s installation instructions, signing explanations, and static warnings with GitHub-generated “What’s Changed” notes. Keep package verification, signed uploads, and draft-first prerelease publication unchanged. Existing releases are unchanged.

Update the release workflow contract and signing guides to match. Installation guidance and known limitations remain in the nightly release documentation.

Verified with all 108 Python build/packaging contract tests, actionlint v1.7.12 across the Qt workflows, and `git diff --check`. No release was published during validation.