### PR TITLE
fix(qt): allow choosing the game store before launch

### DIFF
--- a/native/opennow-core/src/gfn.rs
+++ b/native/opennow-core/src/gfn.rs
@@ -3224,7 +3224,8 @@ mod tests {
                     {"id":"1001","appStore":"Steam","gfn":{"library":{"status":"NOT_OWNED"}}},
                     {"id":"1003","appStore":"Xbox","gfn":{"library":{"status":status}}}
                 ]
-            })).unwrap();
+            }))
+            .unwrap();
             assert_eq!(game["selectedVariantIndex"], 1);
             assert_eq!(game["launchAppId"], "1003");
         }
@@ -3253,7 +3254,8 @@ mod tests {
                 {"id":"1001","appStore":"Steam"},
                 {"id":"1003","appStore":"Xbox"}
             ]
-        })).unwrap();
+        }))
+        .unwrap();
         assert_eq!(game["selectedVariantIndex"], 0);
         assert_eq!(game["launchAppId"], "1001");
     }

--- a/native/opennow-core/src/gfn.rs
+++ b/native/opennow-core/src/gfn.rs
@@ -2091,6 +2091,11 @@ fn app_to_game(app: &Value) -> Option<Value> {
     let selected_index = variants
         .iter()
         .position(|variant| variant["librarySelected"].as_bool() == Some(true))
+        .or_else(|| {
+            variants
+                .iter()
+                .position(|variant| variant["inLibrary"].as_bool() == Some(true))
+        })
         .unwrap_or(0);
     let launch_id = variants
         .get(selected_index)
@@ -3208,6 +3213,49 @@ mod tests {
         assert_eq!(game["variants"][0]["inLibrary"], true);
         assert_eq!(game["variants"][1]["inLibrary"], false);
         assert_eq!(game["variants"][2]["inLibrary"], true);
+    }
+
+    #[test]
+    fn account_library_mapping_prefers_owned_variant_without_saved_selection() {
+        for status in ["MANUAL", "PLATFORM_SYNC", "IN_LIBRARY"] {
+            let game = app_to_game(&json!({
+                "id":"cms-multi-store", "title":"Multi Store Game",
+                "variants":[
+                    {"id":"1001","appStore":"Steam","gfn":{"library":{"status":"NOT_OWNED"}}},
+                    {"id":"1003","appStore":"Xbox","gfn":{"library":{"status":status}}}
+                ]
+            })).unwrap();
+            assert_eq!(game["selectedVariantIndex"], 1);
+            assert_eq!(game["launchAppId"], "1003");
+        }
+    }
+
+    #[test]
+    fn account_library_mapping_preserves_saved_selection_over_ownership() {
+        for selected in [false, true] {
+            let game = app_to_game(&json!({
+                "id":"cms-multi-store", "title":"Multi Store Game",
+                "variants":[
+                    {"id":"1001","appStore":"Steam","gfn":{"library":{"status":"NOT_OWNED","selected":selected}}},
+                    {"id":"1003","appStore":"Xbox","gfn":{"library":{"status":"MANUAL"}}}
+                ]
+            })).unwrap();
+            assert_eq!(game["selectedVariantIndex"], if selected { 0 } else { 1 });
+            assert_eq!(game["launchAppId"], if selected { "1001" } else { "1003" });
+        }
+    }
+
+    #[test]
+    fn account_library_mapping_keeps_first_variant_when_none_owned() {
+        let game = app_to_game(&json!({
+            "id":"cms-multi-store", "title":"Multi Store Game",
+            "variants":[
+                {"id":"1001","appStore":"Steam"},
+                {"id":"1003","appStore":"Xbox"}
+            ]
+        })).unwrap();
+        assert_eq!(game["selectedVariantIndex"], 0);
+        assert_eq!(game["launchAppId"], "1001");
     }
 
     #[test]

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -197,7 +197,7 @@ if(BUILD_TESTING)
         OPENNOW_QML_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qml")
     qt_add_resources(opennow-theme-tests "theme-test-assets"
         PREFIX "/qt/qml/OpenNOW" FILES ${OPENNOW_KEYBOARD_ICON_FILES}
-        res/brand/opennow-mark.png)
+        res/brand/opennow-mark.png res/icons/desktop-play.svg)
     add_test(NAME opennow-theme-tests COMMAND opennow-theme-tests
         -input "${CMAKE_CURRENT_SOURCE_DIR}/tests/theme")
     set_tests_properties(opennow-theme-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 30)

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -197,7 +197,8 @@ if(BUILD_TESTING)
         OPENNOW_QML_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qml")
     qt_add_resources(opennow-theme-tests "theme-test-assets"
         PREFIX "/qt/qml/OpenNOW" FILES ${OPENNOW_KEYBOARD_ICON_FILES}
-        res/brand/opennow-mark.png res/icons/desktop-play.svg)
+        res/brand/opennow-mark.png res/icons/desktop-play.svg
+        res/icons/store-steam.svg res/icons/store-epic.svg res/icons/store-xbox.svg)
     add_test(NAME opennow-theme-tests COMMAND opennow-theme-tests
         -input "${CMAKE_CURRENT_SOURCE_DIR}/tests/theme")
     set_tests_properties(opennow-theme-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 30)

--- a/opennow-qt/qml/desktop/components/DesktopGameModal.qml
+++ b/opennow-qt/qml/desktop/components/DesktopGameModal.qml
@@ -8,6 +8,7 @@ FocusScope {
     property var game: ShellStore.selectedGame
     signal closeRequested()
     signal playRequested()
+    signal variantSelected(int index)
     objectName: "desktopGameModal"
     property bool opened: false
     visible: reveal.present
@@ -271,6 +272,46 @@ FocusScope {
                         }
                     }
                 }
+                Column {
+                    x: DesktopTokens.px(24)
+                    width: parent.width - DesktopTokens.px(48)
+                    spacing: DesktopTokens.px(8)
+                    visible: storeVariants.count > 1
+                    height: visible ? implicitHeight + DesktopTokens.px(16) : 0
+                    Text {
+                        text: qsTr("PLATFORM")
+                        color: Theme.textMuted
+                        font.family: Theme.bodyFont
+                        font.pixelSize: DesktopTokens.smallSize
+                        font.weight: Font.Bold
+                    }
+                    Flow {
+                        width: parent.width
+                        spacing: DesktopTokens.px(8)
+                        Repeater {
+                            id: storeVariants
+                            model: root.game ? root.game.variants || [] : []
+                            DesktopButton {
+                                required property var modelData
+                                required property int index
+                                objectName: "desktopStoreVariant" + index
+                                text: String(modelData.store || qsTr("Unknown"))
+                                height: DesktopTokens.px(36)
+                                leftPadding: DesktopTokens.px(14)
+                                rightPadding: DesktopTokens.px(14)
+                                font.pixelSize: DesktopTokens.captionSize
+                                checkable: true
+                                autoExclusive: true
+                                checked: root.game ? index === Number(root.game.selectedVariantIndex || 0) : false
+                                primary: checked
+                                Accessible.description: modelData.inLibrary ? qsTr("Owned") : qsTr("Not owned")
+                                onClicked: root.variantSelected(index)
+                                Keys.onReturnPressed: root.variantSelected(index)
+                                Keys.onEnterPressed: root.variantSelected(index)
+                            }
+                        }
+                    }
+                }
                 Item {
                     width: parent.width; height: actionRow.height + 24
                     RowLayout {
@@ -278,6 +319,7 @@ FocusScope {
                         x: 24; y: 4; width: parent.width - 48; spacing: 10
                         DesktopButton {
                             id: primaryAction
+                            objectName: "desktopGamePlay"
                             Layout.fillWidth: true; Layout.preferredHeight: 52
                             primary: true; glyph: "desktop-play.svg"; text: qsTr("Play"); shortcutText: qsTr("ENTER"); shortcutSequence: "Enter"
                             enabled: root.game !== null && root.gameAvailable

--- a/opennow-qt/qml/desktop/components/DesktopGameModal.qml
+++ b/opennow-qt/qml/desktop/components/DesktopGameModal.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Window
 import OpenNOW
 
 FocusScope {
@@ -292,6 +293,7 @@ FocusScope {
                             id: storeVariants
                             model: root.game ? root.game.variants || [] : []
                             DesktopButton {
+                                id: platformButton
                                 required property var modelData
                                 required property int index
                                 objectName: "desktopStoreVariant" + index
@@ -300,6 +302,7 @@ FocusScope {
                                 leftPadding: DesktopTokens.px(14)
                                 rightPadding: DesktopTokens.px(14)
                                 font.pixelSize: DesktopTokens.captionSize
+                                implicitWidth: platformContents.implicitWidth + leftPadding + rightPadding
                                 checkable: true
                                 autoExclusive: true
                                 checked: root.game ? index === Number(root.game.selectedVariantIndex || 0) : false
@@ -308,6 +311,34 @@ FocusScope {
                                 onClicked: root.variantSelected(index)
                                 Keys.onReturnPressed: root.variantSelected(index)
                                 Keys.onEnterPressed: root.variantSelected(index)
+                                contentItem: Row {
+                                    id: platformContents
+                                    spacing: DesktopTokens.px(8)
+                                    Rectangle {
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        width: DesktopTokens.px(26)
+                                        height: width
+                                        radius: DesktopTokens.px(5)
+                                        visible: platformLogo.source.toString() !== ""
+                                        color: platformButton.checked || Theme.lightMode ? "#202634" : "transparent"
+                                        Image {
+                                            id: platformLogo
+                                            objectName: "desktopStoreLogo" + platformButton.index
+                                            anchors.centerIn: parent
+                                            width: DesktopTokens.px(20)
+                                            height: width
+                                            source: DesktopTokens.storeIconUrl(platformButton.modelData.store)
+                                            sourceSize: Qt.size(width * Screen.devicePixelRatio, height * Screen.devicePixelRatio)
+                                            fillMode: Image.PreserveAspectFit
+                                        }
+                                    }
+                                    Text {
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        text: platformButton.text
+                                        font: platformButton.font
+                                        color: platformButton.checked ? "#0A0D14" : Theme.label
+                                    }
+                                }
                             }
                         }
                     }

--- a/opennow-qt/qml/desktop/shell/DesktopApp.qml
+++ b/opennow-qt/qml/desktop/shell/DesktopApp.qml
@@ -181,6 +181,7 @@ FocusScope {
         z: 100
         onCloseRequested: AppController.goBack()
         onPlayRequested: ShellStore.launchSelectedGame(false)
+        onVariantSelected: index => ShellStore.selectGameVariant(index)
     }
     DesktopCommandPalette {
         opened: root.commandOpen && root.shellVisible

--- a/opennow-qt/tests/theme/tst_storeselection.qml
+++ b/opennow-qt/tests/theme/tst_storeselection.qml
@@ -1,0 +1,100 @@
+import QtQuick
+import QtTest
+import OpenNOW
+
+TestCase {
+    id: testCase
+    name: "DesktopStoreSelection"
+    width: 1100
+    height: 900
+    visible: true
+    when: windowShown
+
+    DesktopGameModal {
+        id: modal
+        anchors.fill: parent
+        opened: true
+        onVariantSelected: index => {
+            game = Object.assign({}, game, {selectedVariantIndex: index})
+        }
+    }
+
+    SignalSpy { id: selection; target: modal; signalName: "variantSelected" }
+    SignalSpy { id: launches; target: modal; signalName: "playRequested" }
+
+    function init() {
+        DesktopTokens.uiScale = 1
+        modal.game = {title: "Multi Store Game", isAvailable: true, selectedVariantIndex: 0,
+            variants: [{id: "1001", store: "Steam", inLibrary: false},
+                       {id: "1003", store: "Xbox", inLibrary: true}]}
+        selection.clear()
+        launches.clear()
+        waitForRendering(modal)
+    }
+
+    function cleanup() {
+        DesktopTokens.uiScale = 1
+    }
+
+    function test_chooseStore_data() {
+        return [{tag: "mouse", key: 0}, {tag: "return", key: Qt.Key_Return},
+                {tag: "enter", key: Qt.Key_Enter}, {tag: "space", key: Qt.Key_Space}]
+    }
+
+    function test_chooseStore(data) {
+        const xbox = findChild(modal, "desktopStoreVariant1")
+        const steam = findChild(modal, "desktopStoreVariant0")
+        verify(xbox !== null)
+        verify(steam.checked)
+        if (data.key) {
+            xbox.forceActiveFocus()
+            keyClick(data.key)
+        } else {
+            mouseClick(xbox)
+        }
+        compare(selection.count, 1)
+        compare(selection.signalArguments[0][0], 1)
+        compare(modal.selectedVariant.id, "1003")
+        verify(xbox.checked)
+        verify(!steam.checked)
+        compare(modal.ownershipText, "OWNED ON XBOX")
+        compare(launches.count, 0)
+        waitForRendering(modal)
+        mouseClick(findChild(modal, "desktopGamePlay"))
+        compare(launches.count, 1)
+        mouseClick(findChild(modal, "desktopStoreVariant0"))
+        compare(modal.selectedVariant.id, "1001")
+        verify(findChild(modal, "desktopStoreVariant0").checked)
+        verify(!findChild(modal, "desktopStoreVariant1").checked)
+    }
+
+    function test_singleStoreHidesPicker() {
+        modal.game = {title: "Xbox Game", isAvailable: true,
+            variants: [{id: "1003", store: "Xbox", inLibrary: true}]}
+        tryVerify(() => findChild(modal, "desktopStoreVariant1") === null)
+        verify(!findChild(modal, "desktopStoreVariant0").visible)
+        compare(modal.selectedVariant.id, "1003")
+    }
+
+    function test_clearingGameRemovesPicker() {
+        modal.game = null
+        tryVerify(() => findChild(modal, "desktopStoreVariant0") === null)
+        compare(modal.selectedVariant, null)
+        verify(!findChild(modal, "desktopGamePlay").enabled)
+    }
+
+    function test_scaledPicker_data() {
+        return [{tag: "default", scale: 1}, {tag: "125-percent", scale: 1.25},
+                {tag: "150-percent", scale: 1.5}]
+    }
+
+    function test_scaledPicker(data) {
+        DesktopTokens.uiScale = data.scale
+        waitForRendering(modal)
+        const xbox = findChild(modal, "desktopStoreVariant1")
+        tryCompare(xbox, "height", DesktopTokens.px(36))
+        verify(xbox.x + xbox.width <= xbox.parent.width)
+        mouseClick(xbox)
+        compare(modal.selectedVariant.id, "1003")
+    }
+}

--- a/opennow-qt/tests/theme/tst_storeselection.qml
+++ b/opennow-qt/tests/theme/tst_storeselection.qml
@@ -24,6 +24,7 @@ TestCase {
 
     function init() {
         DesktopTokens.uiScale = 1
+        ShellStore.settings = {appTheme: "dark"}
         modal.game = {title: "Multi Store Game", isAvailable: true, selectedVariantIndex: 0,
             variants: [{id: "1001", store: "Steam", inLibrary: false},
                        {id: "1003", store: "Xbox", inLibrary: true}]}
@@ -81,6 +82,26 @@ TestCase {
         tryVerify(() => findChild(modal, "desktopStoreVariant0") === null)
         compare(modal.selectedVariant, null)
         verify(!findChild(modal, "desktopGamePlay").enabled)
+    }
+
+    function test_storeLogos_data() {
+        return [{tag: "dark", theme: "dark"}, {tag: "light", theme: "light"}]
+    }
+
+    function test_storeLogos(data) {
+        ShellStore.settings = {appTheme: data.theme}
+        modal.game = {title: "Multi Store Game", isAvailable: true, selectedVariantIndex: 2,
+            variants: [{id: "1001", store: "Steam"}, {id: "1002", store: "Epic Games Store"},
+                       {id: "1003", store: "Xbox", inLibrary: true}]}
+        waitForRendering(modal)
+        for (let index = 0; index < 3; ++index) {
+            const logo = findChild(modal, "desktopStoreLogo" + index)
+            verify(logo.visible)
+            tryCompare(logo, "status", Image.Ready)
+            compare(logo.source.toString(), DesktopTokens.storeIconUrl(modal.game.variants[index].store))
+            if (index === 2 || data.theme === "light")
+                compare(logo.parent.color, Qt.color("#202634"))
+        }
     }
 
     function test_scaledPicker_data() {

--- a/opennow-qt/tests/tst_embeddedorchestration.cpp
+++ b/opennow-qt/tests/tst_embeddedorchestration.cpp
@@ -17,6 +17,43 @@ class EmbeddedOrchestrationTest final : public QObject
     Q_OBJECT
 
 private slots:
+    void desktopStoreSelectionUsesTheSelectedLaunchVariant()
+    {
+        const auto desktop = source(QStringLiteral("qml/desktop/shell/DesktopApp.qml"));
+        QVERIFY(desktop.contains(QStringLiteral("onVariantSelected: index => ShellStore.selectGameVariant(index)")));
+        const auto shell = source(QStringLiteral("qml/state/ShellStore.qml"));
+        const auto catalog = source(QStringLiteral("qml/state/catalog/CatalogState.qml"));
+        QJSEngine engine;
+        engine.installExtensions(QJSEngine::TranslationExtension);
+        for (const auto &name : {"selectGameVariant", "selectedLaunchAppId", "selectedGameMembershipError", "launchSelectedGame"}) {
+            const auto match = QRegularExpression(QStringLiteral(
+                "    function %1\\([^\\n]*\\) \\{.*?\\n    \\}").arg(QString::fromLatin1(name)),
+                QRegularExpression::DotMatchesEverythingOption).match(
+                    QString::fromLatin1(name) == "selectGameVariant" ? catalog : shell);
+            QVERIFY(match.hasMatch());
+            QVERIFY(!engine.evaluate(match.captured()).isError());
+        }
+        QVERIFY(!engine.evaluate(QStringLiteral(R"JS(
+            var signedIn = true, ready = true, streamBusy = false, onboardingReplaying = false;
+            var selectedGame = {launchAppId: '1001', title: 'Multi Store Game', selectedVariantIndex: 0,
+                variants: [{id: '1001', store: 'Steam', inLibrary: false},
+                           {id: '1003', store: 'Xbox', inLibrary: true}]};
+            var settings = {}, regions = [], requests = [], pendingLaunchParams = null;
+            var CoreClient = {request: function(method, params) {
+                requests.push({method: method, params: params}); return 'request';
+            }};
+            var AppController = {navigate: function(route) {}};
+            function accessibilityAnnounced(message) {}
+            selectGameVariant(1);
+            launchSelectedGame(false);
+        )JS")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests[0].params.appId")).toString(), QStringLiteral("1003"));
+        QVERIFY(engine.evaluate(QStringLiteral("requests[0].params.accountLinked")).toBool());
+        QVERIFY(!engine.evaluate(QStringLiteral("selectGameVariant(0); launchSelectedGame(false);")).isError());
+        QCOMPARE(engine.evaluate(QStringLiteral("requests[1].params.appId")).toString(), QStringLiteral("1001"));
+        QVERIFY(!engine.evaluate(QStringLiteral("requests[1].params.accountLinked")).toBool());
+    }
+
     void existingSessionLaunchFlow_data()
     {
         QTest::addColumn<QString>("sessions");

--- a/opennow-qt/tests/tst_theme.cpp
+++ b/opennow-qt/tests/tst_theme.cpp
@@ -13,6 +13,7 @@ public:
     ThemeTestShell() : QQmlPropertyMap(this, nullptr) {}
 
     Q_INVOKABLE QString artworkUrl(const QString &source) const { return source; }
+    Q_INVOKABLE bool isFavorite(const QVariant &) const { return false; }
     Q_INVOKABLE bool streamOverlayBlocksGameplayInput(const QString &overlay) const { return !overlay.isEmpty(); }
 
 signals:
@@ -37,6 +38,9 @@ public slots:
             qmlRegisterSingletonType(QUrl::fromLocalFile(source + "/" + entry.second), "OpenNOW", 1, 0, entry.first);
         }
         for (const auto &entry : {std::pair{"DesktopSessionStarting", "desktop/stream/DesktopSessionStarting.qml"},
+                                 {"DesktopGameModal", "desktop/components/DesktopGameModal.qml"},
+                                 {"MotionProgress", "components/MotionProgress.qml"},
+                                 {"RoundedArtwork", "components/RoundedArtwork.qml"},
                                  {"DesktopButton", "desktop/components/DesktopButton.qml"},
                                  {"DesktopGlyph", "desktop/components/DesktopGlyph.qml"},
                                  {"DesktopSettingsIcon", "desktop/settings/controls/DesktopSettingsIcon.qml"},
@@ -56,6 +60,10 @@ public slots:
         m_shell.insert("selectedGame", QVariantMap{{"title", "Dead by Daylight"}});
         m_shell.insert("activeSession", QVariantMap{{"queuePosition", 21}});
         m_shell.insert("streamer", QVariantMap{});
+        m_shell.insert("subscription", QVariantMap{});
+        m_shell.insert("authSession", QVariantMap{});
+        m_shell.insert("socialCapabilities", QVariantMap{});
+        m_shell.insert("regions", QVariantList{});
         m_shell.insert("streamState", "preparing");
         m_shell.insert("streamerRestartAttempts", 0);
         m_shell.insert("sessionReconnectAttempts", 0);


### PR DESCRIPTION
Adds platform buttons with store logos to the desktop game dialog, wired through the existing catalog selection action. Players can select Xbox instead of being stuck with the first or previously selected store. Enter or Space selects a platform without launching the game, and the ownership badge follows the selection. Existing logo assets remain legible on selected buttons and in light mode.

When the catalog has no saved selection, prefer the first owned variant. Keep saved selections authoritative and retain the first-variant fallback when none are owned.

Verification:
- Full Qt application build passed.
- All 26 Qt CI unit-test targets and all three desktop/console game-detail acceptance checks passed. The local HDR test initially needed the missing Mesa Vulkan driver installed; it passed after installation.
- All 26 GFN core tests passed, including owned Xbox fallback, saved-selection precedence, and unowned fallback. Rust formatting and strict core Clippy passed.
- New QML coverage exercises mouse/keyboard selection, switching stores, single/cleared games, 100–150% UI scale, and logo loading/contrast backgrounds in dark and light modes. Launch regression checks the selected variant ID and ownership passed to the core.
- Visually checked the actual Qt picker with logos at 125% UI scale using synthetic catalog data. A live Xbox/GFN session has not been tested.

![Desktop platform picker with Xbox selected](https://api-nightly.capy.ai/pr-assets/xfYlSGmaa9_-NX2C0lAMh8tlIWEx_8_WX2RzppjxeXg)