### PR TITLE
fix(packaging): bundle Qt and SDL3 in Linux release DEBs

### DIFF
--- a/.github/workflows/qt-build.yml
+++ b/.github/workflows/qt-build.yml
@@ -366,7 +366,7 @@ jobs:
         run: ctest --test-dir build/opennow-qt-release -C Release --output-on-failure --parallel 4 --no-tests=error -LE interactive-desktop
 
       - name: Create unsigned package
-        if: runner.os != 'macOS'
+        if: runner.os == 'Windows'
         shell: bash
         env:
           PACKAGE_GENERATOR: ${{ matrix.package-generator }}
@@ -424,10 +424,10 @@ jobs:
           APPIMAGE_RUNTIME_SHA256: ${{ matrix.appimage-runtime-sha256 }}
         run: |
           export LD_LIBRARY_PATH="$RUNNER_TEMP/SDL-install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          mkdir -p build/qt-packages
           cmake --install build/opennow-qt-release --config Release \
             --prefix "$PWD/build/AppDir/usr"
-          deb=$(find build/qt-packages -maxdepth 1 -type f -name '*.deb' -print -quit)
-          python3 opennow-qt/packaging/verify_linux_package.py build/AppDir/usr/bin --deb "$deb"
+          python3 opennow-qt/packaging/verify_linux_package.py build/AppDir/usr/bin
           curl --fail --location --retry 3 \
             "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage" \
             --output "build/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage"
@@ -463,6 +463,18 @@ jobs:
           LD_LIBRARY_PATH="$PWD/build/AppDir/usr/lib:$LD_LIBRARY_PATH" \
             python3 opennow-qt/packaging/verify_linux_package.py build/AppDir/usr/bin
           mv OpenNOW-Qt-*.AppImage build/qt-packages/
+
+      - name: Create bundled Linux DEB
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          cpack --config build/opennow-qt-release/CPackConfig.cmake \
+            -D "CPACK_PROJECT_CONFIG_FILE=$PWD/opennow-qt/packaging/LinuxBundledDeb.cmake" \
+            -D "OPENNOW_APPDIR=$PWD/build/AppDir" \
+            -C Release -G DEB -B build/qt-packages
+          debs=(build/qt-packages/*.deb)
+          [[ ${#debs[@]} -eq 1 && -f "${debs[0]}" ]]
+          bash opennow-qt/packaging/verify_bundled_deb.sh "${debs[0]}"
 
       - name: Smoke-test Linux AppImage
         if: runner.os == 'Linux'

--- a/.github/workflows/qt-release-candidate.yml
+++ b/.github/workflows/qt-release-candidate.yml
@@ -170,14 +170,10 @@ jobs:
         run: |
           export LD_LIBRARY_PATH="$RUNNER_TEMP/SDL-install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
           mkdir -p build/release-artifacts
-          cpack --config build/qt-release/CPackConfig.cmake -C Release -G DEB -B build/release-artifacts
           cmake --install build/qt-release --config Release --prefix "$PWD/build/AppDir/usr"
           test -f build/AppDir/usr/bin/libopennow_streamer_ffi.so
           test -x build/AppDir/usr/bin/opennow-streamer
-          deb=$(find build/release-artifacts -maxdepth 1 -type f -name '*.deb' -print -quit)
-          dpkg-deb --fsys-tarfile "$deb" | tar -tf - | grep -Fx './usr/bin/libopennow_streamer_ffi.so'
-          dpkg-deb --fsys-tarfile "$deb" | tar -tf - | grep -Fx './usr/bin/opennow-streamer'
-          python3 opennow-qt/packaging/verify_linux_package.py build/AppDir/usr/bin --deb "$deb"
+          python3 opennow-qt/packaging/verify_linux_package.py build/AppDir/usr/bin
           curl --fail --location --retry 3 \
             "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage" \
             --output "build/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage"
@@ -205,6 +201,13 @@ jobs:
           LD_LIBRARY_PATH="$PWD/build/AppDir/usr/lib:$LD_LIBRARY_PATH" \
             python3 opennow-qt/packaging/verify_linux_package.py build/AppDir/usr/bin
           mv OpenNOW-Qt-*.AppImage build/release-artifacts/
+          cpack --config build/qt-release/CPackConfig.cmake \
+            -D "CPACK_PROJECT_CONFIG_FILE=$PWD/opennow-qt/packaging/LinuxBundledDeb.cmake" \
+            -D "OPENNOW_APPDIR=$PWD/build/AppDir" \
+            -C Release -G DEB -B build/release-artifacts
+          debs=(build/release-artifacts/*.deb)
+          [[ ${#debs[@]} -eq 1 && -f "${debs[0]}" ]]
+          bash opennow-qt/packaging/verify_bundled_deb.sh "${debs[0]}"
 
       - name: Smoke release artifacts and record checksums
         shell: bash

--- a/docs/qt-nightly-release.md
+++ b/docs/qt-nightly-release.md
@@ -65,8 +65,11 @@ Each release contains nine packages with distinct version/platform/architecture 
   Newer runs and retries upgrade the nightly installation; older nightlies are rejected.
 - `OpenNOW-Qt-<version>-Linux-x64.AppImage` and `...-Linux-arm64.AppImage` are the recommended
   portable Linux downloads. Make the downloaded file executable before starting it.
-- `OpenNOW-Qt-<version>-Linux-x64.deb` and `...-Linux-arm64.deb` require distribution-provided
-  Qt 6.8+ and SDL3. Stock Ubuntu 24.04 does not provide those versions; use the AppImage there.
+- `OpenNOW-Qt-<version>-Linux-x64.deb` and `...-Linux-arm64.deb` bundle the AppImage's deployed
+  Qt, QML plugins, SDL3, and media runtime privately under `/opt/opennow`. Ubuntu 24.04 and
+  Linux Mint 22.x do not need a Qt upgrade or third-party repositories. Install the downloaded
+  package with `sudo apt install ./OpenNOW-Qt-<version>-Linux-x64.deb` so APT installs the
+  remaining system dependencies. The desktop entry and `opennow-qt` command use that private runtime.
   The internal Debian version uses `1.0.0~nightly.<run>.<attempt>` so a later stable `1.0.0`
   correctly supersedes it.
 - `OpenNOW-Qt-<version>-Darwin-arm64.dmg` contains the Apple Silicon application for macOS 13+.
@@ -84,6 +87,12 @@ missing platforms, duplicate basenames, wrong versions, empty files, and unexpec
 before any release upload.
 AppImage smoke tests use the packaged offscreen plugin with host Qt plugin, QML, and library
 search paths removed, so the installed CI toolkit cannot hide missing bundled dependencies.
+Release DEBs are assembled from that same deployed AppDir, then installed in a clean Ubuntu 24.04
+container on each native architecture. Checks reject distribution Qt/SDL3 dependencies, check
+library resolution before adding test tools, run offscreen and X11 smoke tests and native capability
+probes, and exercise reinstall/removal. Run `bash opennow-qt/packaging/verify_bundled_deb.sh <package.deb>`
+to repeat these checks locally with Docker. Direct developer CPack builds without the
+`LinuxBundledDeb.cmake` project configuration still require distribution Qt 6.8+ and SDL3.
 macOS checks mount the actual DMG, copy the app out, detach the image, and smoke both that app
 and the validation ZIP with development Qt, SDL3, and build directories hidden. Windows checks
 extract MSI and ZIP payloads and compare every binary in the

--- a/docs/qt-release-candidate.md
+++ b/docs/qt-release-candidate.md
@@ -56,10 +56,11 @@ ephemeral or reset after each approved release operation.
 - Linux x64/ARM64 DEB and checksum-pinned AppImage builds use native runners. Both the probe and
   embedded streamer enable `linux-vaapi` and `linux-ffmpeg-bundled`. Native VAAPI supports H.264
   only; HEVC/AV1 remain available through other backends, including bundled FFmpeg software decode.
-  Builds require libva/libva-drm development headers and libclang for generated bindings. DEBs
-  require `libva2` and `libva-drm2`; usable GPU hardware and a host VAAPI driver are still required
-  for hardware decode. Package checks validate dependency resolution and capabilities without
-  requiring a GPU on the build runner.
+  Builds require libva/libva-drm development headers and libclang for generated bindings. Release
+  DEBs reuse the deployed AppImage runtime, including Qt, SDL3, libva, and libva-drm, under
+  `/opt/opennow`; usable GPU hardware and a host VAAPI driver are still required for hardware decode.
+  Clean Ubuntu 24.04 container checks install the DEB without distribution Qt/SDL3, verify
+  offscreen/X11 startup and capabilities, and exercise reinstall/removal without a GPU.
 - Every installable artifact receives a sibling Ed25519 update manifest after platform signing.
 - The inventory job fails unless it finds both Windows MSI/ZIP pairs, both Linux AppImage/DEB pairs,
   no macOS DMGs, and exactly one manifest per artifact (eight artifacts total). It records the immutable commit and

--- a/opennow-qt/README.md
+++ b/opennow-qt/README.md
@@ -78,8 +78,8 @@ signer described in the [signing setup guide](../docs/update-signing-setup.md); 
 [nightly release runbook](../docs/qt-nightly-release.md) for the publishing command. Users of
 earlier no-key nightlies must manually install an update-enabled build once before verified
 in-app updates can work. Windows may show a SmartScreen warning; macOS packages are not notarized.
-Windows ARM64 is cross-built rather than runtime-tested. Linux DEBs require Qt 6.8+ and SDL3;
-AppImages are the portable option. Download the files and distribute them through
+Windows ARM64 is cross-built rather than runtime-tested. Release Linux DEBs bundle Qt and SDL3
+for Ubuntu 24.04 / Linux Mint 22.x; AppImages are the portable option. Download the files and distribute them through
 your supporter channel. **Actions artifacts in this public repository are not
 private or supporter-access-controlled**, even though they do not appear in Releases.
 

--- a/opennow-qt/packaging/LinuxBundledDeb.cmake
+++ b/opennow-qt/packaging/LinuxBundledDeb.cmake
@@ -1,0 +1,47 @@
+if(NOT DEFINED OPENNOW_APPDIR OR NOT IS_ABSOLUTE "${OPENNOW_APPDIR}")
+    message(FATAL_ERROR "OPENNOW_APPDIR must be an absolute path")
+endif()
+if(NOT CPACK_DEBIAN_PACKAGE_ARCHITECTURE MATCHES "^(amd64|arm64)$")
+    message(FATAL_ERROR "Bundled DEBs require an amd64 or arm64 Linux build")
+endif()
+
+foreach(required IN ITEMS
+    AppRun AppRun.wrapped apprun-hooks/linuxdeploy-plugin-qt-hook.sh
+    usr/bin/opennow-qt usr/bin/opennow-core usr/bin/opennow-update-helper
+    usr/bin/opennow-acceptance-verify usr/bin/opennow-streamer
+    usr/bin/libopennow_streamer_ffi.so usr/bin/qt.conf
+    usr/lib/libQt6Core.so.6 usr/lib/libSDL3.so.0
+    usr/lib/libva.so.2 usr/lib/libva-drm.so.2
+    usr/plugins/imageformats/libqsvg.so
+    usr/plugins/platforms/libqxcb.so usr/plugins/platforms/libqoffscreen.so
+    usr/plugins/platforms/libqwayland-egl.so usr/plugins/platforms/libqwayland-generic.so
+    usr/plugins/wayland-shell-integration/libxdg-shell.so
+    usr/qml/QtQuick/qmldir usr/qml/QtQuick/Controls/qmldir)
+    if(NOT EXISTS "${OPENNOW_APPDIR}/${required}")
+        message(FATAL_ERROR "The deployed Linux runtime is missing ${required}")
+    endif()
+endforeach()
+
+set(integration "${OPENNOW_APPDIR}/../deb-integration")
+file(REMOVE_RECURSE "${integration}")
+file(MAKE_DIRECTORY "${integration}/usr/bin")
+file(WRITE "${integration}/usr/bin/opennow-qt"
+    "#!/bin/sh\nexec /opt/opennow/AppRun \"$@\"\n")
+file(CHMOD "${integration}/usr/bin/opennow-qt"
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+foreach(directory IN ITEMS applications metainfo icons)
+    file(COPY "${OPENNOW_APPDIR}/usr/share/${directory}" DESTINATION "${integration}/usr/share")
+endforeach()
+file(COPY "${OPENNOW_APPDIR}/usr/share/doc/opennow" DESTINATION "${integration}/usr/share/doc")
+
+set(CPACK_GENERATOR DEB)
+set(CPACK_INSTALL_CMAKE_PROJECTS "")
+set(CPACK_INSTALLED_DIRECTORIES "${OPENNOW_APPDIR};/opt/opennow;${integration};/")
+set(CPACK_PACKAGING_INSTALL_PREFIX "/")
+set(CPACK_SET_DESTDIR OFF)
+set(CPACK_STRIP_FILES OFF)
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "ca-certificates, libssl3t64, libvulkan1, libasound2t64, libudev1")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS TRUE)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS
+    "${OPENNOW_APPDIR}/usr/lib;${OPENNOW_APPDIR}/usr/bin")
+find_program(OPENNOW_DPKG_SHLIBDEPS dpkg-shlibdeps REQUIRED)

--- a/opennow-qt/packaging/verify_bundled_deb.sh
+++ b/opennow-qt/packaging/verify_bundled_deb.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+deb=$(realpath "${1:?Usage: verify_bundled_deb.sh PACKAGE.deb}")
+verification=$(cd "$(dirname "$0")" && pwd)
+test -f "$deb"
+docker run --rm -i \
+  --mount "type=bind,source=$(dirname "$deb"),target=/packages,readonly" \
+  --mount "type=bind,source=$verification,target=/verification,readonly" \
+  -e "OPENNOW_DEB=/packages/$(basename "$deb")" \
+  ubuntu:24.04 bash -s <<'VERIFY'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+export LC_ALL=C.UTF-8
+printf 'path-include=/usr/share/doc/opennow/*\n' > /etc/dpkg/dpkg.cfg.d/zz-opennow-test
+apt-get update
+apt-get install -y --no-install-recommends "$OPENNOW_DEB"
+test "$(dpkg-query -W -f='${db:Status-Status}' opennow)" = installed
+if dpkg-query -W -f='${binary:Package}\t${db:Status-Status}\n' \
+    | grep -E '^(libqt6|qt6-|qml6-|libsdl3).*installed$'; then
+  echo 'The bundled DEB must not install distribution Qt or SDL3 packages' >&2
+  exit 1
+fi
+test "$(dpkg-query -S /opt/opennow/usr/bin/opennow-qt)" = 'opennow: /opt/opennow/usr/bin/opennow-qt'
+test -f /usr/share/applications/io.github.opencloudgaming.OpenNOW.desktop
+test -f /usr/share/icons/hicolor/scalable/apps/io.github.opencloudgaming.OpenNOW.svg
+test -f /usr/share/metainfo/io.github.opencloudgaming.OpenNOW.metainfo.xml
+test -f /usr/share/doc/opennow/THIRD_PARTY_NOTICES
+while IFS= read -r -d '' binary; do
+  dependencies=$(ldd "$binary" 2>&1) || {
+    if [[ "$dependencies" == *'statically linked'* ]]; then
+      continue
+    fi
+    printf '%s\n%s\n' "$binary" "$dependencies" >&2
+    exit 1
+  }
+  if [[ "$dependencies" == *'not found'* ]]; then
+    printf '%s\n%s\n' "$binary" "$dependencies" >&2
+    exit 1
+  fi
+done < <(find /opt/opennow/usr/bin /opt/opennow/usr/lib /opt/opennow/usr/plugins /opt/opennow/usr/qml \
+    -type f \( -name '*.so*' -o -name 'opennow-*' \) -print0)
+useradd --create-home opennow-test
+install -d -m 700 -o opennow-test -g opennow-test /tmp/opennow-runtime
+runuser -u opennow-test -- env QT_QPA_PLATFORM=offscreen XDG_RUNTIME_DIR=/tmp/opennow-runtime \
+  timeout 60 /usr/bin/opennow-qt --smoke-test --allow-multiple-instances --route home --reduced-motion
+apt-get install -y --no-install-recommends python3 binutils xvfb xauth mesa-vulkan-drivers
+runuser -u opennow-test -- python3 /verification/verify_linux_package.py /opt/opennow/usr/bin
+runuser -u opennow-test -- env QT_QPA_PLATFORM=xcb XDG_RUNTIME_DIR=/tmp/opennow-runtime \
+  timeout 60 xvfb-run -a /usr/bin/opennow-qt --smoke-test --allow-multiple-instances --route home --reduced-motion
+apt-get install -y --reinstall --no-install-recommends "$OPENNOW_DEB"
+apt-get purge -y opennow
+test ! -e /usr/bin/opennow-qt
+test ! -e /opt/opennow
+test ! -e /usr/share/applications/io.github.opencloudgaming.OpenNOW.desktop
+echo 'Bundled DEB install, dependency, offscreen/X11 smoke, capability, reinstall and removal checks passed'
+VERIFY

--- a/opennow-qt/tests/test_bundled_deb.py
+++ b/opennow-qt/tests/test_bundled_deb.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGING = ROOT / "opennow-qt/packaging"
+
+
+@unittest.skipUnless(os.name == "posix" and shutil.which("dpkg-shlibdeps"), "Requires Debian packaging tools")
+class BundledDebTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.appdir = self.root / "AppDir"
+        files = (
+            "AppRun", "AppRun.wrapped", "apprun-hooks/linuxdeploy-plugin-qt-hook.sh",
+            "usr/bin/opennow-core", "usr/bin/opennow-update-helper", "usr/bin/opennow-streamer",
+            "usr/bin/opennow-acceptance-verify", "usr/bin/libopennow_streamer_ffi.so", "usr/bin/qt.conf",
+            "usr/lib/libSDL3.so.0", "usr/lib/libva.so.2", "usr/lib/libva-drm.so.2",
+            "usr/plugins/imageformats/libqsvg.so", "usr/plugins/platforms/libqxcb.so",
+            "usr/plugins/platforms/libqoffscreen.so", "usr/plugins/platforms/libqwayland-egl.so",
+            "usr/plugins/platforms/libqwayland-generic.so",
+            "usr/plugins/wayland-shell-integration/libxdg-shell.so",
+            "usr/qml/QtQuick/qmldir", "usr/qml/QtQuick/Controls/qmldir",
+            "usr/share/doc/opennow/THIRD_PARTY_NOTICES", "usr/share/doc/libva2/copyright",
+        )
+        for name in files:
+            path = self.appdir / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("package fixture\n")
+        for name, directory in (
+            ("io.github.opencloudgaming.OpenNOW.desktop", "applications"),
+            ("io.github.opencloudgaming.OpenNOW.metainfo.xml", "metainfo"),
+            ("io.github.opencloudgaming.OpenNOW.svg", "icons/hicolor/scalable/apps"),
+        ):
+            destination = self.appdir / "usr/share" / directory / name
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(PACKAGING / name, destination)
+        (self.root / "library.c").write_text("int package_fixture(void) { return 0; }\n")
+        (self.root / "main.c").write_text(
+            "int package_fixture(void); int main(void) { return package_fixture(); }\n"
+        )
+        self.run_command([
+            "cc", "-shared", "-fPIC", "-Wl,-soname,libQt6Core.so.6", str(self.root / "library.c"),
+            "-o", str(self.appdir / "usr/lib/libQt6Core.so.6"),
+        ])
+        self.run_command([
+            "cc", str(self.root / "main.c"), f"-L{self.appdir}/usr/lib", "-l:libQt6Core.so.6",
+            "-Wl,-rpath,$ORIGIN/../lib", "-o", str(self.appdir / "usr/bin/opennow-qt"),
+        ])
+        architecture = self.run_command(["dpkg", "--print-architecture"]).stdout.strip()
+        (self.root / "CMakeLists.txt").write_text(f'''
+cmake_minimum_required(VERSION 3.24)
+project(BundledDebContract VERSION 1.2.3 LANGUAGES NONE)
+install(FILES main.c DESTINATION bin)
+set(CPACK_PACKAGE_NAME OpenNOW)
+set(CPACK_PACKAGE_CONTACT "OpenCloudGaming <support@opennow.app>")
+set(CPACK_PACKAGE_FILE_NAME bundled)
+set(CPACK_DEBIAN_FILE_NAME bundled.deb)
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "{architecture}")
+set(CPACK_DEBIAN_PACKAGE_VERSION "1.2.3~nightly.4.1")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt6core6 (>= 6.8), libsdl3-0")
+include(CPack)
+''')
+        self.run_command(["cmake", "-S", str(self.root), "-B", str(self.root / "build")])
+
+    def run_command(self, command):
+        result = subprocess.run(command, capture_output=True, text=True, timeout=120)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result
+
+    def package(self):
+        return subprocess.run([
+            "cpack", "--config", str(self.root / "build/CPackConfig.cmake"),
+            "-D", f"CPACK_PROJECT_CONFIG_FILE={PACKAGING}/LinuxBundledDeb.cmake",
+            "-D", f"OPENNOW_APPDIR={self.appdir}", "-G", "DEB", "-B", str(self.root / "packages"),
+        ], capture_output=True, text=True, timeout=120)
+
+    def test_bundles_private_libraries_without_distribution_qt_or_file_conflicts(self):
+        for attempt in range(2):
+            with self.subTest(attempt=attempt):
+                result = self.package()
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        deb = self.root / "packages/bundled.deb"
+        dependencies = self.run_command(["dpkg-deb", "-f", str(deb), "Depends"]).stdout
+        self.assertNotIn("qt6", dependencies.lower())
+        self.assertNotIn("sdl3", dependencies.lower())
+        self.assertIn("libc6", dependencies)
+        self.assertIn("libvulkan1", dependencies)
+        self.assertEqual(self.run_command(["dpkg-deb", "-f", str(deb), "Version"]).stdout.strip(),
+                         "1.2.3~nightly.4.1")
+        extracted = self.root / "extracted"
+        self.run_command(["dpkg-deb", "-x", str(deb), str(extracted)])
+        launcher = extracted / "usr/bin/opennow-qt"
+        self.assertTrue(os.access(launcher, os.X_OK))
+        self.assertEqual(launcher.read_text(), '#!/bin/sh\nexec /opt/opennow/AppRun "$@"\n')
+        self.assertFalse((extracted / "usr/bin/main.c").exists())
+        self.assertFalse((extracted / "usr/share/doc/libva2").exists())
+        self.assertTrue((extracted / "opt/opennow/usr/share/doc/libva2/copyright").is_file())
+        self.assertTrue((extracted / "usr/share/doc/opennow/THIRD_PARTY_NOTICES").is_file())
+        self.assertTrue((extracted / "usr/share/applications/io.github.opencloudgaming.OpenNOW.desktop").is_file())
+        self.run_command([str(extracted / "opt/opennow/usr/bin/opennow-qt")])
+
+    def test_incomplete_runtime_fails_before_creating_a_deb(self):
+        (self.appdir / "usr/plugins/imageformats/libqsvg.so").unlink()
+        result = self.package()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing usr/plugins/imageformats/libqsvg.so", result.stdout + result.stderr)
+        self.assertFalse((self.root / "packages/bundled.deb").exists())
+
+
+class BundledDebWorkflowTest(unittest.TestCase):
+    def test_every_release_deb_uses_and_tests_the_deployed_runtime(self):
+        for name in ("qt-build.yml", "qt-release-candidate.yml"):
+            with self.subTest(workflow=name):
+                workflow = (ROOT / ".github/workflows" / name).read_text()
+                self.assertIn('CPACK_PROJECT_CONFIG_FILE=$PWD/opennow-qt/packaging/LinuxBundledDeb.cmake', workflow)
+                self.assertIn('OPENNOW_APPDIR=$PWD/build/AppDir', workflow)
+                self.assertIn('bash opennow-qt/packaging/verify_bundled_deb.sh "${debs[0]}"', workflow)
+                self.assertLess(workflow.index("--plugin qt"), workflow.index("LinuxBundledDeb.cmake"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The published 1.0.0 DEB cannot install on Linux Mint 22.x / Ubuntu 24.04: it requires Qt >= 6.8 while Noble provides 6.4.2, plus SDL3 and QML/plugin packages that are not available there. Reproduced with APT against the published x64 DEB in a clean Ubuntu 24.04 container.

Release DEBs now reuse the fully deployed AppImage runtime under `/opt/opennow`, with the existing `opennow-qt` command and desktop integration. Qt, QML plugins, SDL3 and media libraries stay private; CPack calculates remaining host-library dependencies, with explicit dependencies for dynamically loaded system runtimes and TLS certificates. Package identity, architecture and Debian version ordering stay unchanged. Direct developer CPack builds retain their distribution-runtime contract.

Both release workflows build the DEB after AppImage deployment and test it in a clean Ubuntu 24.04 container. The check verifies dependency resolution without distribution Qt/SDL3, native capabilities, non-root offscreen/X11 startup, reinstall and removal. Regression tests cover private-library packaging, metadata, missing plugins, repeated generation and avoiding ownership conflicts with system documentation.

Validation:
- All 111 Python build/packaging contract tests pass.
- Repository-pinned actionlint 1.7.12, ShellCheck, shell syntax and diff checks pass.
- Repackaged the published 1.0.0 x64 AppImage payload with the new CPack configuration. The resulting DEB installs, resolves its libraries, passes offscreen/X11 smoke and VAAPI/FFmpeg capability checks, reinstalls and removes successfully in clean Ubuntu 24.04. Used the matching 1.0.0 protocol verifier for that released payload.
- ARM64 uses the same configuration and native-architecture container gate in release workflows; it was not run locally. No live GFN session or Mint desktop validation was performed.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2AF6GWCZ3MZCGVYPVE3WCV3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->