### PR TITLE
feat(qt): show Windows HEVC installation guidance in settings

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -5,6 +5,13 @@
     "reminderTitle": "Background stream reminder",
     "reminderDescription": "Request taskbar or dock attention every 5 minutes while a stream runs in the background. Availability depends on your desktop. Does not prevent AFK timeouts."
   },
+  "windowsHevcHelp": {
+    "title": "H.265 / HEVC is unavailable",
+    "description": "If Microsoft's HEVC extension is missing, install it to use H.265. Try the free version first. If it is unavailable for you, Microsoft also offers a paid version.",
+    "free": "Free HEVC extension",
+    "paid": "Paid HEVC extension",
+    "hardwareRequirement": "Your GPU still needs hardware HEVC decoding support. Installing the extension will not make H.265 work on hardware that cannot decode it. Restart OpenNOW after installation to check again."
+  },
   "tenBitWarning": {
     "title": "10-bit color",
     "description": "10-bit color may cause stuttering on some systems. If you notice stuttering, switch back to 8-bit.",

--- a/opennow-qt/cmake/QmlModule.cmake
+++ b/opennow-qt/cmake/QmlModule.cmake
@@ -268,6 +268,7 @@ qt_add_qml_module(opennow-qt
         qml/desktop/onboarding/DesktopOnboardingNetwork.qml
         qml/desktop/settings/controls/DesktopSettingsAdvanced.qml
         qml/desktop/settings/controls/DesktopSettingsButton.qml
+        qml/desktop/settings/controls/DesktopSettingsHevcHelp.qml
         qml/desktop/settings/controls/DesktopSettingsChoice.qml
         qml/desktop/settings/controls/DesktopSettingsDisclosure.qml
         qml/desktop/settings/controls/DesktopSettingsDropdown.qml

--- a/opennow-qt/cmake/Tests.cmake
+++ b/opennow-qt/cmake/Tests.cmake
@@ -42,6 +42,14 @@ if(BUILD_TESTING)
     qt_add_shaders(opennow-hdrcolor-tests "opennow-hdrchrome-test-shaders"
         BATCHABLE PREFIX "/opennow/shaders" BASE "shaders" FILES ${OPENNOW_CHROME_SHADERS})
     find_package(Qt6 6.8 REQUIRED COMPONENTS QuickTest)
+    qt_add_executable(opennow-hevchelp-tests tests/tst_hevchelp.cpp)
+    target_link_libraries(opennow-hevchelp-tests PRIVATE Qt6::QuickTest Qt6::Quick)
+    target_compile_definitions(opennow-hevchelp-tests PRIVATE
+        OPENNOW_QML_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qml")
+    add_test(NAME opennow-hevchelp-tests COMMAND opennow-hevchelp-tests
+        -input "${CMAKE_CURRENT_SOURCE_DIR}/tests/hevchelp")
+    set_tests_properties(opennow-hevchelp-tests PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen" TIMEOUT 30)
     qt_add_executable(opennow-tenbitwarning-tests tests/tst_tenbitwarning.cpp)
     target_link_libraries(opennow-tenbitwarning-tests PRIVATE Qt6::QuickTest Qt6::Quick)
     target_compile_definitions(opennow-tenbitwarning-tests PRIVATE

--- a/opennow-qt/qml/desktop/settings/controls/DesktopSettingsHevcHelp.qml
+++ b/opennow-qt/qml/desktop/settings/controls/DesktopSettingsHevcHelp.qml
@@ -1,0 +1,89 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import OpenNOW
+
+Item {
+    id: help
+    required property bool runtimeReady
+    required property var capabilities
+    property string platformName: Qt.platform.os
+    signal openStoreRequested(string url)
+
+    objectName: "windowsHevcHelp"
+    visible: platformName === "windows" && runtimeReady
+        && (capabilities.videoBackends || []).some(backend => backend.backend === "d3d11"
+            && backend.available && (backend.codecs || []).some(codec => codec.codec === "h265"
+                && codec.available === false))
+    implicitHeight: visible ? content.implicitHeight + DesktopTokens.px(32) : 0
+
+    Column {
+        id: content
+        x: DesktopTokens.px(20)
+        y: DesktopTokens.px(16)
+        width: Math.max(0, parent.width - x * 2)
+        spacing: DesktopTokens.px(12)
+
+        Text {
+            width: parent.width
+            text: qsTr("H.265 / HEVC is unavailable")
+            color: Theme.label
+            font.family: Theme.bodyFont
+            font.pixelSize: DesktopTokens.px(14)
+            font.weight: Font.Bold
+            wrapMode: Text.WordWrap
+        }
+        Text {
+            width: parent.width
+            text: qsTr("If Microsoft's HEVC extension is missing, install it to use H.265. Try the free version first. If it is unavailable for you, Microsoft also offers a paid version.")
+            color: Theme.textMuted
+            font.family: Theme.bodyFont
+            font.pixelSize: DesktopTokens.px(13)
+            font.weight: Font.DemiBold
+            wrapMode: Text.WordWrap
+        }
+        Repeater {
+            model: [
+                {productId: "9N4WGH0Z6VHQ", label: qsTr("Free HEVC extension")},
+                {productId: "9NMZLZ57R3T7", label: qsTr("Paid HEVC extension")}
+            ]
+            delegate: Flow {
+                id: offer
+                required property var modelData
+                width: content.width
+                spacing: DesktopTokens.px(12)
+
+                DesktopSettingsButton {
+                    objectName: "hevcStore-" + offer.modelData.productId
+                    text: offer.modelData.label
+                    onClicked: help.openStoreRequested("https://apps.microsoft.com/detail/" + offer.modelData.productId.toLowerCase())
+                }
+                TextEdit {
+                    objectName: "hevcCommand-" + offer.modelData.productId
+                    width: Math.min(implicitWidth, content.width)
+                    text: "winget install " + offer.modelData.productId
+                    readOnly: true
+                    selectByMouse: true
+                    activeFocusOnTab: true
+                    color: Theme.label
+                    selectionColor: Theme.focus
+                    selectedTextColor: Theme.focusText
+                    font.family: Theme.monoFont
+                    font.pixelSize: DesktopTokens.px(13)
+                    font.weight: Font.Medium
+                    topPadding: DesktopTokens.px(10)
+                    wrapMode: TextEdit.Wrap
+                    Accessible.name: text
+                }
+            }
+        }
+        Text {
+            width: parent.width
+            text: qsTr("Your GPU still needs hardware HEVC decoding support. Installing the extension will not make H.265 work on hardware that cannot decode it. Restart OpenNOW after installation to check again.")
+            color: Theme.textMuted
+            font.family: Theme.bodyFont
+            font.pixelSize: DesktopTokens.px(13)
+            font.weight: Font.DemiBold
+            wrapMode: Text.WordWrap
+        }
+    }
+}

--- a/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
+++ b/opennow-qt/qml/desktop/settings/pages/DesktopSettingsStreamPage.qml
@@ -178,6 +178,12 @@ Column {
                 onSelected: (index,item) => page.settingsScreen.setChoice("codec",item.value)
             }
         }
+        DesktopSettingsHevcHelp {
+            width: parent.width
+            runtimeReady: ShellStore.nativeRuntimeReady
+            capabilities: ShellStore.nativeRuntimeCapabilities
+            onOpenStoreRequested: url => Qt.openUrlExternally(url)
+        }
         DesktopSettingsRow {
             id: bitrateRow
             width: parent.width; paperStyle: true; glyph: "wave"; title: qsTr("Bitrate"); description: qsTr("Maximum requested bitrate")

--- a/opennow-qt/tests/hevchelp/tst_hevchelp.qml
+++ b/opennow-qt/tests/hevchelp/tst_hevchelp.qml
@@ -1,0 +1,106 @@
+import QtQuick
+import QtTest
+import OpenNOW
+
+TestCase {
+    id: testCase
+    name: "HevcHelp"
+    visible: true
+    width: 960
+    height: 900
+    when: windowShown
+
+    Component {
+        id: helpComponent
+        DesktopSettingsHevcHelp {
+            width: testCase.width
+            runtimeReady: true
+            platformName: "windows"
+            capabilities: ({videoBackends: [{backend: "d3d11", available: true,
+                codecs: [{codec: "h265", available: false}]}]})
+        }
+    }
+    SignalSpy { id: storeSpy; signalName: "openStoreRequested" }
+    property var help
+
+    function init() {
+        help = createTemporaryObject(helpComponent, testCase)
+        verify(help)
+        storeSpy.target = help
+        storeSpy.clear()
+    }
+
+    function cleanup() {
+        DesktopTokens.uiScale = 1
+    }
+
+    function test_detection_data() {
+        return [
+            {tag: "windows-missing", platform: "windows", ready: true, backends: [{backend: "d3d11", available: true, codecs: [{codec: "h265", available: false}]}], shown: true},
+            {tag: "windows-supported", platform: "windows", ready: true, backends: [{backend: "d3d11", available: true, codecs: [{codec: "h265", available: true}]}], shown: false},
+            {tag: "pending-probe", platform: "windows", ready: false, backends: [{backend: "d3d11", available: true, codecs: [{codec: "h265", available: false}]}], shown: false},
+            {tag: "linux", platform: "linux", ready: true, backends: [{backend: "d3d11", available: true, codecs: [{codec: "h265", available: false}]}], shown: false},
+            {tag: "macos", platform: "osx", ready: true, backends: [{backend: "d3d11", available: true, codecs: [{codec: "h265", available: false}]}], shown: false},
+            {tag: "empty-probe", platform: "windows", ready: true, backends: [], shown: false},
+            {tag: "backend-failed", platform: "windows", ready: true, backends: [{backend: "d3d11", available: false, codecs: [{codec: "h265", available: false}]}], shown: false},
+            {tag: "unknown-codec", platform: "windows", ready: true, backends: [{backend: "d3d11", available: true, codecs: [{codec: "h264", available: true}]}], shown: false},
+            {tag: "other-backend", platform: "windows", ready: true, backends: [{backend: "vulkan", available: true, codecs: [{codec: "h265", available: false}]}], shown: false}
+        ]
+    }
+
+    function test_detection(data) {
+        help.platformName = data.platform
+        help.runtimeReady = data.ready
+        help.capabilities = {videoBackends: data.backends}
+        compare(help.visible, data.shown)
+        compare(help.implicitHeight > 0, data.shown)
+    }
+
+    function test_reprobe() {
+        verify(help.visible)
+        help.runtimeReady = false
+        verify(!help.visible)
+        help.capabilities = {videoBackends: [{backend: "d3d11", available: true,
+            codecs: [{codec: "h265", available: true}]}]}
+        help.runtimeReady = true
+        verify(!help.visible)
+        help.capabilities = {}
+        verify(!help.visible)
+    }
+
+    function test_storeLinks_data() {
+        return [{tag: "free", productId: "9N4WGH0Z6VHQ"}, {tag: "paid", productId: "9NMZLZ57R3T7"}]
+    }
+
+    function test_storeLinks(data) {
+        const button = findChild(help, "hevcStore-" + data.productId)
+        verify(button)
+        mouseClick(button)
+        compare(storeSpy.count, 1)
+        compare(storeSpy.signalArguments[0][0], "https://apps.microsoft.com/detail/" + data.productId.toLowerCase())
+        const command = findChild(help, "hevcCommand-" + data.productId)
+        compare(command.text, "winget install " + data.productId)
+        verify(command.readOnly && command.selectByMouse)
+        command.selectAll()
+        compare(command.selectedText, command.text)
+    }
+
+    function test_scaledLayout_data() {
+        return [{tag: "normal", scale: 1, width: 900}, {tag: "scaled", scale: 1.5, width: 600}]
+    }
+
+    function test_scaledLayout(data) {
+        DesktopTokens.uiScale = data.scale
+        help.width = data.width
+        waitForRendering(help)
+        verify(help.implicitHeight > 0)
+        for (const productId of ["9N4WGH0Z6VHQ", "9NMZLZ57R3T7"]) {
+            for (const prefix of ["hevcStore-", "hevcCommand-"]) {
+                const item = findChild(help, prefix + productId)
+                const position = item.mapToItem(help, 0, 0)
+                verify(position.x >= 0 && position.x + item.width <= help.width)
+                verify(position.y >= 0 && position.y + item.height <= help.height)
+            }
+        }
+    }
+}

--- a/opennow-qt/tests/tst_hevchelp.cpp
+++ b/opennow-qt/tests/tst_hevchelp.cpp
@@ -1,0 +1,43 @@
+#include <QFontDatabase>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QQmlPropertyMap>
+#include <QtQuickTest/quicktest.h>
+
+class HevcHelpTestSetup final : public QObject
+{
+    Q_OBJECT
+
+public slots:
+    void applicationAvailable()
+    {
+        const auto source = QStringLiteral(OPENNOW_QML_SOURCE_DIR);
+        qmlRegisterSingletonType(QUrl::fromLocalFile(source + "/theme/Theme.qml"), "OpenNOW", 1, 0, "Theme");
+        qmlRegisterSingletonType(QUrl::fromLocalFile(source + "/desktop/components/DesktopTokens.qml"), "OpenNOW", 1, 0, "DesktopTokens");
+        qmlRegisterSingletonType(QUrl::fromLocalFile(source + "/components/InputPromptIcons.qml"), "OpenNOW", 1, 0, "InputPromptIcons");
+        qmlRegisterType(QUrl::fromLocalFile(source + "/components/KeyboardGlyph.qml"), "OpenNOW", 1, 0, "KeyboardGlyph");
+        for (const auto *name : {"DesktopSettingsHevcHelp", "DesktopSettingsButton", "DesktopSettingsIcon"}) {
+            qmlRegisterType(QUrl::fromLocalFile(source + "/desktop/settings/controls/" + name + ".qml"), "OpenNOW", 1, 0, name);
+        }
+        QFontDatabase::addApplicationFont(source + "/../res/fonts/Nunito-Variable.ttf");
+    }
+
+    void qmlEngineAvailable(QQmlEngine *engine)
+    {
+        auto paths = engine->importPathList();
+        paths.removeAll(QCoreApplication::applicationDirPath());
+        engine->setImportPathList(paths);
+        m_shell.insert("settings", QVariantMap{{"appTheme", "dark"}});
+        m_shell.insert("previewThemePack", QString{});
+        m_controller.insert("reducedMotion", true);
+        engine->rootContext()->setContextProperty("ShellStore", &m_shell);
+        engine->rootContext()->setContextProperty("AppController", &m_controller);
+    }
+
+private:
+    QQmlPropertyMap m_shell;
+    QQmlPropertyMap m_controller;
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(hevchelp, HevcHelpTestSetup)
+#include "tst_hevchelp.moc"


### PR DESCRIPTION
## Summary
- Show HEVC installation guidance below the desktop Streaming codec selector when the Windows DX11 capability probe completes with an available backend but no H.265 decoder. Keep it hidden on other platforms, during probing, when HEVC works, and on generic backend failures.
- Provide the free and paid Microsoft Store links and selectable `winget install` commands. Explain that the extension cannot replace GPU hardware decoding support and that OpenNOW must be restarted after installation. No automatic installs or documentation changes.
- Register the QML component, add English localization sources, and cover visibility, reprobes, Store requests, command selection, and scaled layouts with Qt Quick tests.

## Validation
- Built the Qt application and `opennow-hevchelp-tests` with Qt 6.8.3 on Linux.
- Passed all six tests selected by `ctest --test-dir build/opennow-qt -R 'settings-streaming|backend-availability|hevchelp' --output-on-failure`.
- The repository QML lint target completed with existing warnings; the final new component passes focused `qmllint` without warnings.
- `npm run locales:check` and `git diff --cached --check` passed.
- Visually checked the real QML component at 150% UI scale using a Windows capability fixture. Real Windows hardware probing and extension installation were not exercised on this Linux machine.

## UI preview
Qt component preview with simulated Windows HEVC-unavailable capabilities, at 150% scale.

![Windows HEVC installation guidance](https://api-nightly.capy.ai/pr-assets/0dU2Uo1LKhyGaUmmDB9re6axAYcXEthD0Jj2RYrJEbo)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2AF4A2WYTMB5GDCBYHVT8CK"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->