### PR TITLE
fix(streamer): respect command boundaries when decoding cursor updates

### DIFF
--- a/docs/streamer-comparison/features.md
+++ b/docs/streamer-comparison/features.md
@@ -240,6 +240,16 @@ id 0 lock-style  0f 01 04 00 00 00 00 00
 
 Normalized extract for id 1 is `00 01 00 00 00 00 00 0c 80 16 80`. OpenNOW treats type 0 and cursor id 0 as hidden relative.
 
+Cursor extraction walks the little-endian command code and payload length at each
+command boundary, as the Mac reference's `NvstControlCommand.parse` does. It skips
+non-cursor payloads intact and stops at a truncated command. It must not scan inside
+those payloads for cursor-looking bytes: doing so can manufacture lock/unlock
+notifications from unrelated traffic. Complete cursor commands before a truncated
+tail, and cursor commands following an unrelated complete command, still dispatch.
+The `unrelated_control_payloads_cannot_toggle_cursor_lock` and
+`truncated_control_payloads_cannot_invent_cursor_notifications` transport tests
+exercise these boundaries without a live session.
+
 ## What is missing on purpose
 
 - Feature type 10 on-wire bytes. Logs and DLL names prove it is mouse accel/speed. They do not dump the frame.

--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_input.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst_input.rs
@@ -421,10 +421,6 @@ pub(crate) struct NvstServerCursorMessage {
     pub(crate) normalized: Option<Vec<u8>>,
 }
 
-/// Scans a data-channel message for cursor commands instead of assuming that
-/// the host always places them at byte zero on `control_channel_reliable`.
-/// This is deliberately cursor-specific: arbitrary custom-channel payloads
-/// must not be interpreted as general NVST control traffic.
 pub(crate) fn server_cursor_messages(bytes: &[u8]) -> Vec<NvstServerCursorMessage> {
     let mut updates = Vec::new();
     let mut offset = 0_usize;
@@ -436,12 +432,10 @@ pub(crate) fn server_cursor_messages(bytes: &[u8]) -> Vec<NvstServerCursorMessag
             break;
         };
         if payload_end > bytes.len() {
-            offset += 1;
-            continue;
+            break;
         }
         let payload = &bytes[payload_start..payload_end];
         match code {
-            super::nvst_haptics::HAPTIC_COMMAND_CODE => {}
             COMMAND_SYSTEM_CURSOR if payload.len() >= 4 => {
                 let cursor_id =
                     u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
@@ -490,10 +484,7 @@ pub(crate) fn server_cursor_messages(bytes: &[u8]) -> Vec<NvstServerCursorMessag
                     normalized: None,
                 });
             }
-            _ => {
-                offset += 1;
-                continue;
-            }
+            _ => {}
         }
         offset = payload_end;
     }
@@ -1388,6 +1379,63 @@ mod tests {
         assert_eq!(cursors.len(), 1);
         assert_eq!(cursors[0].offset, 16);
         assert_eq!(cursors[0].cursor_id, Some(1));
+    }
+
+    #[test]
+    fn unrelated_control_payloads_cannot_toggle_cursor_lock() {
+        for code in [0x010a, 0x0111, 0x0200, 0xffff] {
+            let mut bytes = control_command(COMMAND_SYSTEM_CURSOR, &0_u32.to_le_bytes());
+            let unrelated = control_command(
+                code,
+                &hex("0f010400010000000f01040000000000100108000000000000000000"),
+            );
+            bytes.extend_from_slice(&unrelated);
+            let visible_offset = bytes.len();
+            bytes.extend_from_slice(&control_command(
+                COMMAND_SYSTEM_CURSOR,
+                &12_u32.to_le_bytes(),
+            ));
+
+            let cursors = server_cursor_messages(&bytes);
+            assert_eq!(cursors.len(), 2, "outer command {code:#06x}");
+            assert_eq!(cursors[0].offset, 0);
+            assert_eq!(cursors[0].normalized, Some(hex("00000000000000")));
+            assert_eq!(cursors[1].offset, visible_offset);
+            assert_eq!(cursors[1].normalized, Some(hex("000c0000000000")));
+        }
+    }
+
+    #[test]
+    fn truncated_control_payloads_cannot_invent_cursor_notifications() {
+        for code in [0x010a, COMMAND_SYSTEM_CURSOR, COMMAND_BITMAP_CURSOR] {
+            let mut bytes = control_command(COMMAND_SYSTEM_CURSOR, &0_u32.to_le_bytes());
+            bytes.extend_from_slice(&code.to_le_bytes());
+            bytes.extend_from_slice(&100_u16.to_le_bytes());
+            bytes.extend_from_slice(&hex("0f01040001000000100108000000000000000000"));
+
+            let cursors = server_cursor_messages(&bytes);
+            assert_eq!(cursors.len(), 1, "truncated command {code:#06x}");
+            assert_eq!(cursors[0].offset, 0);
+            assert_eq!(cursors[0].normalized, Some(hex("00000000000000")));
+        }
+    }
+
+    #[test]
+    fn short_cursor_payloads_do_not_consume_following_commands() {
+        for (code, minimum_length) in [(COMMAND_SYSTEM_CURSOR, 4), (COMMAND_BITMAP_CURSOR, 8)] {
+            for length in 0..minimum_length {
+                let mut bytes = control_command(code, &vec![0x0f; length]);
+                let visible_offset = bytes.len();
+                bytes.extend_from_slice(&control_command(
+                    COMMAND_SYSTEM_CURSOR,
+                    &1_u32.to_le_bytes(),
+                ));
+                let cursors = server_cursor_messages(&bytes);
+                assert_eq!(cursors.len(), 1);
+                assert_eq!(cursors[0].offset, visible_offset);
+                assert_eq!(cursors[0].normalized, Some(hex("00010000000000")));
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Changes

Stop scanning inside unrelated or truncated NVST control payloads for cursor commands. Those bytes could be mistaken for system-cursor notifications and forwarded to Qt as real lock/unlock changes. Parse command boundaries instead, matching the Mac reference's `NvstControlCommand.parse` and the native haptics receiver.

Complete cursor commands still dispatch in order, including commands after unknown complete messages. The cursor wire format, system-ID mode mapping, manual pointer override, and cursor-composition watchdog are unchanged.

Add regression coverage for embedded fake lock/unlock/bitmap commands, truncated payloads, and short cursor messages followed by valid commands. Document the framing contract.

## Verification

- Before the fix, the new regressions failed: unrelated payload contents produced five cursor notifications instead of two; a truncated command produced three instead of one.
- Transport suite: 176 passed.
- Default-feature streamer workspace suite on Linux: 615 passed, 9 ignored.
- Transport Clippy with `--all-targets -- -D warnings`, formatting, and `git diff --check` passed.

The parser defect is reproduced with synthetic protocol fixtures. The original user's live lock/unlock loop has not been reproduced with an authenticated GFN session, so this is a verified source-level cause of false mode changes, not confirmation that it explains every instance of that report.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2AHHXVN71MX7Y1RVF519CDJ"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->