### PR TITLE
fix(input): preserve Windows keyboard mappings and report lost transitions

### DIFF
--- a/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
+++ b/native/opennow-streamer/crates/opennow-streamer-transport/src/nvst.rs
@@ -44,8 +44,9 @@ use super::nvst_control::{
 };
 use super::nvst_cursor::{CursorCommand, NvstCursorCapture, valid_cursor_channel_message};
 use super::nvst_input::{
-    NvstInputChannelState, NvstInputChannels, NvstInputCodec, native_input_type_is_motion,
-    native_input_type_name, native_input_types, next_control_keepalive, server_cursor_messages,
+    NvstEncodedInput, NvstInputChannelState, NvstInputChannels, NvstInputCodec,
+    native_input_type_is_motion, native_input_type_name, native_input_types,
+    next_control_keepalive, server_cursor_messages,
 };
 use super::{
     EncodedMediaFrame, MediaConsumer, TransportError, deliver_media_frame, install_crypto,
@@ -5222,6 +5223,53 @@ fn finish_nvst_input_handshake(
     true
 }
 
+fn send_nvst_captured_input(
+    codec: &mut NvstInputCodec,
+    bytes: &[u8],
+    timestamp_us: u64,
+    reply: Option<mpsc::SyncSender<Result<(), TransportError>>>,
+    input_ready: &AtomicBool,
+    event_sender: &Sender<NvstReceiveEvent>,
+    mut send: impl FnMut(&NvstEncodedInput) -> bool,
+) -> bool {
+    let previous_codec = codec.clone();
+    let result = codec
+        .encode(bytes, timestamp_us)
+        .map_err(|error| error.to_string())
+        .and_then(|messages| {
+            for message in messages {
+                if !send(&message) {
+                    return Err(format!(
+                        "input packet could not be queued on {:?}",
+                        message.route
+                    ));
+                }
+            }
+            Ok(())
+        });
+    let failed = result.is_err();
+    if let Err(error) = &result {
+        *codec = previous_codec;
+        eprintln!("NVST input packet rejected: {error}");
+    }
+    if let Some(reply) = reply {
+        let _ = reply.send(result.map_err(|_| TransportError::InputNotReady));
+        return true;
+    }
+    if !failed
+        || native_input_types(bytes).is_ok_and(|types| {
+            !types.is_empty() && types.into_iter().all(native_input_type_is_motion)
+        })
+    {
+        return true;
+    }
+    input_ready.store(false, Ordering::Release);
+    let _ = event_sender.send(NvstReceiveEvent::InputUnavailable(
+        "discrete input delivery failed; stopping to prevent stuck input".to_owned(),
+    ));
+    false
+}
+
 fn run_nvst_webrtc_bundle(
     socket: UdpSocket,
     config: NvstVideoConfig,
@@ -5325,7 +5373,6 @@ fn run_nvst_webrtc_bundle(
                     }
                 }
                 Ok(UdpReceiverCommand::SendInput { bytes, reply }) => {
-                    let mut sent = true;
                     if input_state.is_ready()
                         && let Some(channels) = input_channels
                     {
@@ -5379,43 +5426,31 @@ fn run_nvst_webrtc_bundle(
                             .as_micros()
                             .try_into()
                             .unwrap_or(u64::MAX);
-                        let previous_input_codec = input_codec.clone();
-                        match input_codec.encode(&bytes, timestamp_us) {
-                            Ok(messages) => {
-                                for message in messages {
-                                    if should_log {
-                                        eprintln!(
-                                            "NVST encoded input tx: route={:?} bytes={} raw={}",
-                                            message.route,
-                                            message.bytes.len(),
-                                            diagnostic_hex(&message.bytes, 128),
-                                        );
-                                    }
-                                    if !channels.send_encoded(&mut rtc, &message) {
-                                        sent = false;
-                                        input_codec = previous_input_codec;
-                                        eprintln!(
-                                            "NVST input packet could not be queued on {:?}",
-                                            message.route
-                                        );
-                                        break;
-                                    }
+                        if !send_nvst_captured_input(
+                            &mut input_codec,
+                            &bytes,
+                            timestamp_us,
+                            reply,
+                            &input_ready,
+                            &event_sender,
+                            |message| {
+                                if should_log {
+                                    eprintln!(
+                                        "NVST encoded input tx: route={:?} bytes={} raw={}",
+                                        message.route,
+                                        message.bytes.len(),
+                                        diagnostic_hex(&message.bytes, 128),
+                                    );
                                 }
-                            }
-                            Err(error) => {
-                                sent = false;
-                                eprintln!("NVST input packet rejected: {error}");
-                            }
+                                channels.send_encoded(&mut rtc, message)
+                            },
+                        ) {
+                            rtc.disconnect();
+                            forward_optional(&event_sender, receiver.stop());
+                            return;
                         }
-                    } else {
-                        sent = false;
-                    }
-                    if let Some(reply) = reply {
-                        let _ = reply.send(if sent {
-                            Ok(())
-                        } else {
-                            Err(TransportError::InputNotReady)
-                        });
+                    } else if let Some(reply) = reply {
+                        let _ = reply.send(Err(TransportError::InputNotReady));
                     }
                 }
                 Ok(UdpReceiverCommand::Stop) | Err(TryRecvError::Disconnected) => {
@@ -6486,6 +6521,202 @@ mod tests {
     const TEST_KEY: &str = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";
     const TEST_SALT: &str = "000102030405060708090A0B0C0D";
     const TEST_PEER: &str = "192.0.2.20";
+
+    #[test]
+    fn asynchronous_discrete_input_write_rejection_requests_terminal_shutdown() {
+        for input_type in [3_u32, 4, 8, 9, 10] {
+            let mut packet = vec![0; if input_type == 10 { 22 } else { 18 }];
+            packet[..4].copy_from_slice(&input_type.to_le_bytes());
+            let mut codec = NvstInputCodec::default();
+            let ready = AtomicBool::new(true);
+            let (events, received) = mpsc::channel();
+            let mut writes = 0;
+            assert!(!send_nvst_captured_input(
+                &mut codec,
+                &packet,
+                1,
+                None,
+                &ready,
+                &events,
+                |message| {
+                    writes += 1;
+                    assert_eq!(
+                        message.route,
+                        super::super::nvst_input::NvstInputRoute::ControlReliable
+                    );
+                    false
+                },
+            ));
+            assert_eq!(writes, 1);
+            assert!(!ready.load(Ordering::Acquire));
+            assert!(
+                matches!(received.try_recv().unwrap(), NvstReceiveEvent::InputUnavailable(reason)
+                if reason.contains("discrete input delivery failed"))
+            );
+            assert!(received.try_recv().is_err());
+        }
+    }
+
+    #[test]
+    fn asynchronous_motion_write_rejection_remains_nonterminal() {
+        for (input_type, length) in [(5_u32, 26), (7, 22)] {
+            let mut packet = vec![0; length];
+            packet[..4].copy_from_slice(&input_type.to_le_bytes());
+            let ready = AtomicBool::new(true);
+            let (events, received) = mpsc::channel();
+            let mut writes = 0;
+            assert!(send_nvst_captured_input(
+                &mut NvstInputCodec::default(),
+                &packet,
+                1,
+                None,
+                &ready,
+                &events,
+                |_| {
+                    writes += 1;
+                    false
+                },
+            ));
+            assert_eq!(writes, 1);
+            assert!(ready.load(Ordering::Acquire));
+            assert!(received.try_recv().is_err());
+        }
+    }
+
+    #[test]
+    fn synchronous_input_write_rejection_preserves_error_reply() {
+        let mut packet = vec![0; 18];
+        packet[..4].copy_from_slice(&4_u32.to_le_bytes());
+        let ready = AtomicBool::new(true);
+        let (events, received) = mpsc::channel();
+        let (reply, result) = mpsc::sync_channel(1);
+        assert!(send_nvst_captured_input(
+            &mut NvstInputCodec::default(),
+            &packet,
+            1,
+            Some(reply),
+            &ready,
+            &events,
+            |_| false,
+        ));
+        assert!(matches!(
+            result.try_recv().unwrap(),
+            Err(TransportError::InputNotReady)
+        ));
+        assert!(ready.load(Ordering::Acquire));
+        assert!(received.try_recv().is_err());
+    }
+
+    #[test]
+    fn asynchronous_discrete_input_success_keeps_session_ready() {
+        let mut packet = vec![0; 18];
+        packet[..4].copy_from_slice(&4_u32.to_le_bytes());
+        let ready = AtomicBool::new(true);
+        let (events, received) = mpsc::channel();
+        let mut writes = 0;
+        assert!(send_nvst_captured_input(
+            &mut NvstInputCodec::default(),
+            &packet,
+            1,
+            None,
+            &ready,
+            &events,
+            |_| {
+                writes += 1;
+                true
+            },
+        ));
+        assert_eq!(writes, 1);
+        assert!(ready.load(Ordering::Acquire));
+        assert!(received.try_recv().is_err());
+    }
+
+    #[test]
+    fn asynchronous_malformed_input_requests_shutdown_without_channel_write() {
+        let ready = AtomicBool::new(true);
+        let (events, received) = mpsc::channel();
+        assert!(!send_nvst_captured_input(
+            &mut NvstInputCodec::default(),
+            &[4, 0, 0, 0],
+            1,
+            None,
+            &ready,
+            &events,
+            |_| panic!("malformed input must not reach the channel"),
+        ));
+        assert!(!ready.load(Ordering::Acquire));
+        assert!(matches!(
+            received.try_recv().unwrap(),
+            NvstReceiveEvent::InputUnavailable(_)
+        ));
+    }
+
+    #[test]
+    fn input_write_rejection_restores_gamepad_codec_after_partial_batch() {
+        let mut packet = vec![0; 38];
+        packet[..4].copy_from_slice(&12_u32.to_le_bytes());
+        packet[4..6].copy_from_slice(&26_u16.to_le_bytes());
+        packet[8..10].copy_from_slice(&0x0101_u16.to_le_bytes());
+        let expected = NvstInputCodec::default().encode(&packet, 1).unwrap();
+        assert_eq!(expected.len(), 2);
+        let mut codec = NvstInputCodec::default();
+        let ready = AtomicBool::new(true);
+        let (events, received) = mpsc::channel();
+        let mut writes = 0;
+        assert!(!send_nvst_captured_input(
+            &mut codec,
+            &packet,
+            1,
+            None,
+            &ready,
+            &events,
+            |_| {
+                writes += 1;
+                writes == 1
+            },
+        ));
+        assert_eq!(writes, 2);
+        assert!(!ready.load(Ordering::Acquire));
+        assert!(matches!(
+            received.try_recv().unwrap(),
+            NvstReceiveEvent::InputUnavailable(_)
+        ));
+        assert_eq!(codec.encode(&packet, 1).unwrap(), expected);
+    }
+
+    #[test]
+    fn input_encoding_rejection_restores_gamepad_codec_after_partial_mutation() {
+        let mut gamepad = vec![0; 38];
+        gamepad[..4].copy_from_slice(&12_u32.to_le_bytes());
+        gamepad[4..6].copy_from_slice(&26_u16.to_le_bytes());
+        gamepad[8..10].copy_from_slice(&0x0101_u16.to_le_bytes());
+        let expected = NvstInputCodec::default().encode(&gamepad, 1).unwrap();
+        let mut packet = vec![0x23];
+        packet.extend_from_slice(&1_u64.to_be_bytes());
+        for event in [&gamepad[..], &4_u32.to_le_bytes()[..]] {
+            packet.push(0x21);
+            packet.extend_from_slice(&(event.len() as u16).to_be_bytes());
+            packet.extend_from_slice(event);
+        }
+        let mut codec = NvstInputCodec::default();
+        let ready = AtomicBool::new(true);
+        let (events, received) = mpsc::channel();
+        assert!(!send_nvst_captured_input(
+            &mut codec,
+            &packet,
+            1,
+            None,
+            &ready,
+            &events,
+            |_| panic!("invalid batch must not reach the channel"),
+        ));
+        assert!(!ready.load(Ordering::Acquire));
+        assert!(matches!(
+            received.try_recv().unwrap(),
+            NvstReceiveEvent::InputUnavailable(_)
+        ));
+        assert_eq!(codec.encode(&gamepad, 1).unwrap(), expected);
+    }
 
     #[test]
     fn startup_keyframe_control_request_does_not_wait_for_video_ssrc() {

--- a/opennow-qt/src/streaming/StreamVideoItem.h
+++ b/opennow-qt/src/streaming/StreamVideoItem.h
@@ -109,7 +109,8 @@ public:
                                                         const QSize &videoSize,
                                                         const QSizeF &itemSize);
     [[nodiscard]] static quint16 windowsVirtualKey(
-        int key, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
+        int key, Qt::KeyboardModifiers modifiers = Qt::NoModifier,
+        quint32 nativeVirtualKey = 0);
     [[nodiscard]] static quint16 inputModifiers(Qt::KeyboardModifiers modifiers, int key);
     [[nodiscard]] static QString shortcutActionForInput(
         const QVariantMap &bindings, int key, Qt::KeyboardModifiers modifiers);
@@ -168,6 +169,7 @@ private:
     [[nodiscard]] static QRect cursorConfinementRect(const QRect &viewport, bool rawRelative);
     void releaseCursorConfinement();
     void submitAbsoluteMouse(const QPointF &position);
+    [[nodiscard]] static quint16 eventVirtualKey(const QKeyEvent *event);
     [[nodiscard]] quint32 keyIdentity(const QKeyEvent *event) const;
     [[nodiscard]] static quint8 mouseButton(Qt::MouseButton button);
 

--- a/opennow-qt/src/streaming/StreamVideoItemInput.cpp
+++ b/opennow-qt/src/streaming/StreamVideoItemInput.cpp
@@ -30,8 +30,17 @@
 #include <windows.h>
 #endif
 
-quint16 StreamVideoItem::windowsVirtualKey(int key, Qt::KeyboardModifiers modifiers)
+quint16 StreamVideoItem::windowsVirtualKey(int key, Qt::KeyboardModifiers modifiers,
+                                          quint32 nativeVirtualKey)
 {
+    if (nativeVirtualKey > 0 && nativeVirtualKey < 0xff) {
+        switch (nativeVirtualKey) {
+        case 0x10: return 0xa0;
+        case 0x11: return 0xa2;
+        case 0x12: return 0xa4;
+        default: return static_cast<quint16>(nativeVirtualKey);
+        }
+    }
     if (key >= Qt::Key_A && key <= Qt::Key_Z) return static_cast<quint16>(key);
     if (key >= Qt::Key_0 && key <= Qt::Key_9) return static_cast<quint16>(key);
     if (key >= Qt::Key_F1 && key <= Qt::Key_F24)
@@ -152,10 +161,19 @@ void StreamVideoItem::focusOutEvent(QFocusEvent *event)
     QQuickItem::focusOutEvent(event);
 }
 
+quint16 StreamVideoItem::eventVirtualKey(const QKeyEvent *event)
+{
+#if defined(Q_OS_WIN)
+    return windowsVirtualKey(event->key(), event->modifiers(), event->nativeVirtualKey());
+#else
+    return windowsVirtualKey(event->key(), event->modifiers());
+#endif
+}
+
 quint32 StreamVideoItem::keyIdentity(const QKeyEvent *event) const
 {
     if (event->nativeScanCode() != 0) return event->nativeScanCode();
-    const auto virtualKey = windowsVirtualKey(event->key(), event->modifiers());
+    const auto virtualKey = eventVirtualKey(event);
     return virtualKey != 0 ? virtualKey : static_cast<quint32>(event->key());
 }
 
@@ -173,8 +191,15 @@ void StreamVideoItem::keyPressEvent(QKeyEvent *event)
         return;
     }
     const auto identity = keyIdentity(event);
-    const auto shortcutAction = shortcutActionForInput(
+    const auto virtualKey = eventVirtualKey(event);
+    const QKeyEvent shortcutEvent(QEvent::KeyPress,
+        virtualKey >= 0x41 && virtualKey <= 0x5a ? virtualKey : event->key(), event->modifiers());
+    auto shortcutAction = shortcutActionForInput(
         m_shortcutBindings, event->key(), event->modifiers());
+    if (shortcutAction.isEmpty() && shortcutEvent.key() != event->key()) {
+        shortcutAction = shortcutActionForInput(
+            m_shortcutBindings, shortcutEvent.key(), event->modifiers());
+    }
     if (!shortcutAction.isEmpty()) {
         // A fullscreen transition can prevent Windows from delivering the key-up
         // that belongs to the key which initiated it.  Keep the identity only so
@@ -190,7 +215,8 @@ void StreamVideoItem::keyPressEvent(QKeyEvent *event)
         event->ignore();
         return;
     }
-    if (m_clipboardPaste && event->matches(QKeySequence::Paste)) {
+    if (m_clipboardPaste && (event->matches(QKeySequence::Paste)
+                            || shortcutEvent.matches(QKeySequence::Paste))) {
         m_pressedShortcuts.insert(identity);
         event->accept();
         const auto *clipboard = QGuiApplication::clipboard();
@@ -207,7 +233,7 @@ void StreamVideoItem::keyPressEvent(QKeyEvent *event)
         }
         for (auto key = m_pressedKeys.begin(); key != m_pressedKeys.end();) {
             const auto vk = key->virtualKey;
-            if (vk == 0xa0 || vk == 0xa2 || vk == 0xa4 || vk == 0x5b) {
+            if ((vk >= 0xa0 && vk <= 0xa5) || vk == 0x5b || vk == 0x5c) {
                 s_nativeRuntime->submitKey(vk, 0, false);
                 key = m_pressedKeys.erase(key);
             } else {
@@ -218,7 +244,6 @@ void StreamVideoItem::keyPressEvent(QKeyEvent *event)
             emit clipboardPasteFailed();
         return;
     }
-    const auto virtualKey = windowsVirtualKey(event->key(), event->modifiers());
     if (virtualKey == 0) {
         event->ignore();
         return;

--- a/opennow-qt/tests/tst_streamvideoitem.cpp
+++ b/opennow-qt/tests/tst_streamvideoitem.cpp
@@ -851,6 +851,152 @@ private slots:
         QCOMPARE(StreamVideoItem::inputModifiers(Qt::ShiftModifier, Qt::Key_Shift), quint16(0));
     }
 
+    void preservesWindowsVirtualKeysAcrossLayouts_data()
+    {
+        QTest::addColumn<int>("key");
+        QTest::addColumn<quint32>("nativeKey");
+        QTest::addColumn<quint16>("expected");
+        QTest::newRow("cyrillic-w") << 0x0426 << quint32(0x57) << quint16(0x57);
+        QTest::newRow("cyrillic-a") << 0x0424 << quint32(0x41) << quint16(0x41);
+        QTest::newRow("cyrillic-s") << 0x042b << quint32(0x53) << quint16(0x53);
+        QTest::newRow("cyrillic-d") << 0x0412 << quint32(0x44) << quint16(0x44);
+        QTest::newRow("french-number-row") << int(Qt::Key_Eacute) << quint32(0x32) << quint16(0x32);
+        QTest::newRow("numpad-one") << int(Qt::Key_1) << quint32(0x61) << quint16(0x61);
+        QTest::newRow("right-shift") << int(Qt::Key_Shift) << quint32(0xa1) << quint16(0xa1);
+        QTest::newRow("generic-control") << int(Qt::Key_Control) << quint32(0x11) << quint16(0xa2);
+        QTest::newRow("synthetic-w") << int(Qt::Key_W) << quint32(0) << quint16(0x57);
+        QTest::newRow("invalid-native") << int(Qt::Key_W) << quint32(0x10057) << quint16(0x57);
+    }
+
+    void preservesWindowsVirtualKeysAcrossLayouts()
+    {
+        QFETCH(int, key);
+        QFETCH(quint32, nativeKey);
+        QFETCH(quint16, expected);
+        QCOMPARE(StreamVideoItem::windowsVirtualKey(key, Qt::NoModifier, nativeKey), expected);
+    }
+
+    void nativeKeyboardEventsPreserveGameplayKeys_data()
+    {
+        QTest::addColumn<bool>("fullscreen");
+        QTest::newRow("windowed") << false;
+        QTest::newRow("fullscreen") << true;
+    }
+
+    void nativeKeyboardEventsPreserveGameplayKeys()
+    {
+        QFETCH(bool, fullscreen);
+        static QList<QList<quint16>> inputCalls;
+        static QList<QByteArray> textCalls;
+        inputCalls.clear();
+        textCalls.clear();
+        auto api = CursorSession::api();
+        api.submitKey = [](const OpenNowStreamer *, std::uint16_t vk,
+                           std::uint16_t modifiers, bool pressed) {
+            inputCalls.append(QList<quint16>{vk, modifiers, quint16(pressed)});
+            return OPENNOW_STREAMER_OK;
+        };
+        api.submitText = [](const OpenNowStreamer *, const std::uint8_t *text, std::size_t size) {
+            textCalls.append(QByteArray(reinterpret_cast<const char *>(text), qsizetype(size)));
+            return OPENNOW_STREAMER_OK;
+        };
+        NativeStreamRuntime runtime(api);
+        QVERIFY(runtime.start());
+        StreamVideoItem::setNativeStreamRuntime(&runtime);
+        const auto reset = qScopeGuard([] { StreamVideoItem::setNativeStreamRuntime(nullptr); });
+        QVERIFY(runtime.send({{QStringLiteral("type"), QStringLiteral("start")},
+                              {QStringLiteral("id"), QStringLiteral("native-keyboard")}}));
+        const QByteArray ready = R"({"id":"native-keyboard","type":"ok"})";
+        CursorSession::callbacks.response_callback(
+            reinterpret_cast<const std::uint8_t *>(ready.constData()), ready.size(),
+            CursorSession::callbacks.user_data);
+        QTRY_VERIFY(runtime.inputAllowed());
+        QQuickWindow window;
+        window.resize(640, 480);
+        auto *item = new StreamVideoItem(window.contentItem());
+        item->setRenderCallback({});
+        item->setSize(window.size());
+        auto *overlay = new QQuickItem(window.contentItem());
+        if (fullscreen) window.showFullScreen();
+        else window.showNormal();
+        window.requestActivate();
+        QTRY_VERIFY(window.isActive());
+        item->forceActiveFocus();
+        QTRY_VERIFY(item->captureActive());
+        const struct {
+            int key;
+            quint32 scanCode;
+            quint32 nativeKey;
+            quint16 expected;
+        } keys[] = {
+#if defined(Q_OS_WIN)
+            {0x0426, 0x11, 0x57, 0x57},
+            {0x0424, 0x1e, 0x41, 0x41},
+            {0x042b, 0x1f, 0x53, 0x53},
+            {0x0412, 0x20, 0x44, 0x44},
+#else
+            {Qt::Key_W, 25, 0x77, 0x57},
+            {Qt::Key_A, 38, 0x61, 0x41},
+            {Qt::Key_S, 39, 0x73, 0x53},
+            {Qt::Key_D, 40, 0x64, 0x44},
+#endif
+        };
+        for (const auto &key : keys) {
+            inputCalls.clear();
+            QKeyEvent press(QEvent::KeyPress, key.key, Qt::NoModifier,
+                            key.scanCode, key.nativeKey, 0);
+            QCoreApplication::sendEvent(&window, &press);
+            QCOMPARE(inputCalls, (QList<QList<quint16>>{{key.expected, 0, 1}}));
+            QKeyEvent release(QEvent::KeyRelease, Qt::Key_unknown, Qt::NoModifier,
+                              key.scanCode, 0, 0);
+            QCoreApplication::sendEvent(&window, &release);
+            QCOMPARE(inputCalls, (QList<QList<quint16>>{
+                {key.expected, 0, 1}, {key.expected, 0, 0}}));
+            QCoreApplication::sendEvent(&window, &press);
+            item->setInputEnabled(false);
+            overlay->forceActiveFocus();
+            QCOMPARE(inputCalls.last(), (QList<quint16>{key.expected, 0, 0}));
+            inputCalls.clear();
+            QCoreApplication::sendEvent(&window, &press);
+            QCoreApplication::sendEvent(&window, &release);
+            QVERIFY(inputCalls.isEmpty());
+            item->setInputEnabled(true);
+            item->forceActiveFocus();
+            QTRY_VERIFY(item->captureActive());
+            QCoreApplication::sendEvent(&window, &press);
+            QCoreApplication::sendEvent(&window, &release);
+            QCOMPARE(inputCalls, (QList<QList<quint16>>{
+                {key.expected, 0, 1}, {key.expected, 0, 0}}));
+        }
+#if defined(Q_OS_WIN)
+        item->setShortcutBindings({{QStringLiteral("menu"), QStringLiteral("Ctrl+G")}});
+        QSignalSpy shortcuts(item, &StreamVideoItem::localShortcutRequested);
+        inputCalls.clear();
+        QKeyEvent shortcutPress(QEvent::KeyPress, 0x041f, Qt::ControlModifier, 0x22, 0x47, 0);
+        QKeyEvent shortcutRelease(QEvent::KeyRelease, 0x041f, Qt::ControlModifier, 0x22, 0x47, 0);
+        QCoreApplication::sendEvent(&window, &shortcutPress);
+        QCoreApplication::sendEvent(&window, &shortcutRelease);
+        QCOMPARE(shortcuts.size(), 1);
+        QCOMPARE(shortcuts.first().first().toString(), QStringLiteral("menu"));
+        QVERIFY(inputCalls.isEmpty());
+        auto *clipboard = QGuiApplication::clipboard();
+        const auto previousText = clipboard->text();
+        const auto restoreClipboard = qScopeGuard([&] { clipboard->setText(previousText); });
+        clipboard->setText(QStringLiteral("native keyboard paste"));
+        item->setClipboardPaste(true);
+        QKeyEvent controlPress(QEvent::KeyPress, Qt::Key_Control, Qt::ControlModifier,
+                               0x11d, 0xa3, 0);
+        QCoreApplication::sendEvent(&window, &controlPress);
+        QKeyEvent pastePress(QEvent::KeyPress, 0x041c, Qt::ControlModifier, 0x2f, 0x56, 0);
+        QKeyEvent pasteRelease(QEvent::KeyRelease, 0x041c, Qt::ControlModifier, 0x2f, 0x56, 0);
+        QCoreApplication::sendEvent(&window, &pastePress);
+        QCoreApplication::sendEvent(&window, &pasteRelease);
+        QCOMPARE(textCalls, (QList<QByteArray>{"native keyboard paste"}));
+        QCOMPARE(inputCalls, (QList<QList<quint16>>{{0xa3, 0, 1}, {0xa3, 0, 0}}));
+        QVERIFY(item->m_pressedKeys.isEmpty());
+#endif
+    }
+
     void tabDoesNotStealGameplayFocus_data()
     {
         QTest::addColumn<int>("key");


### PR DESCRIPTION
## Keyboard routing

Preserve Windows-native virtual keys instead of deriving gameplay input solely from Qt's layout-dependent character. The original mapping returns zero for all four Cyrillic-layout WASD characters even when the event carries the correct Windows VK. Keep the existing mapping for synthetic events and other platforms, and preserve scan-code-based release tracking across layout changes.

Resolve local letter shortcuts and clipboard paste using the native key as a fallback, so Ctrl+G and Ctrl+V do not become remote gameplay input on those layouts. Release either side of held modifiers before clipboard text submission.

## Input delivery failures

Report failed asynchronous discrete-input encoding/channel admission through the existing input-unavailable and stopped lifecycle path instead of silently losing key/button transitions. Preserve synchronous error replies, nonterminal mouse-motion drops, and encoder rollback after partial batches. This is a separate audit finding, not a demonstrated cause in the supplied diagnostics.

## Verification

- Compiled the original and patched keyboard mapper: Cyrillic WASD returned `00/00/00/00` before and `57/41/53/44` after.
- Added native-key mapping and windowed/fullscreen event regressions, including overlay handoff, layout-changing releases, Windows local shortcuts, and clipboard modifier release.
- Qt Debug application and all test targets build. Full CTest run passed 271/276; the five Vulkan-initialization failures all passed after installing the missing Mesa Vulkan driver. Stream-video tests also passed on rerun.
- Focused keyboard tests passed using both offscreen Qt and XCB under Xvfb. Windows-specific event branches require Windows CI; no live GFN account/gameplay validation was performed here.
- Native streamer workspace: 619 passed, 9 ignored, 0 failed. Transport suite: 180 passed. Strict all-target transport Clippy and diff whitespace checks pass.

The supplied logs establish Windows/input-ready v3 and later transport idle timeouts, but contain no individual key events or keyboard-layout metadata. The layout defect is reproduced independently; these changes do not claim to resolve the separately logged network timeouts.

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M2AHW2R1PXNRNR56QV92BY4R"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->